### PR TITLE
chore(dependabot): customize labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
     schedule:
       interval: "weekly" # default = monday
     open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github_actions"
+      - "no-changelog"
 
   # maintain dependencies for Gradle
   - package-ecosystem: "gradle" # checks build.gradle(.kts) and settings.gradle(.kts)
@@ -13,3 +17,7 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "java"
+      - "no-changelog"


### PR DESCRIPTION
## What this PR changes/adds

Set labels that will be added to a PR by dependabot.

## Why it does that

Currently, the `no-changelog` label is missing an causes a failed workflow.

## Further notes

-- 

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
