### PR TITLE
feat: make endpointOverride configurable by DataAddress (#1903)

### DIFF
--- a/extensions/common/aws/s3-core/src/main/java/org/eclipse/dataspaceconnector/aws/s3/core/AwsClientProvider.java
+++ b/extensions/common/aws/s3-core/src/main/java/org/eclipse/dataspaceconnector/aws/s3/core/AwsClientProvider.java
@@ -65,4 +65,6 @@ public interface AwsClientProvider {
      * Releases resources used by the provider.
      */
     void shutdown();
+
+    void configureEndpointOverride(String endpointOverride);
 }

--- a/extensions/common/aws/s3-core/src/main/java/org/eclipse/dataspaceconnector/aws/s3/core/AwsClientProviderConfiguration.java
+++ b/extensions/common/aws/s3-core/src/main/java/org/eclipse/dataspaceconnector/aws/s3/core/AwsClientProviderConfiguration.java
@@ -17,6 +17,7 @@ package org.eclipse.dataspaceconnector.aws.s3.core;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Objects;
 
 public class AwsClientProviderConfiguration {
@@ -37,6 +38,13 @@ public class AwsClientProviderConfiguration {
 
     public URI getEndpointOverride() {
         return endpointOverride;
+    }
+    public void setEndpointOverride(String endpointOverride) {
+        try {
+            this.endpointOverride = new URI(endpointOverride);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(String.format("Cannot set endpointOverride (%s) as URI",endpointOverride));
+        }
     }
 
     public int getThreadPoolSize() {

--- a/extensions/common/aws/s3-core/src/main/java/org/eclipse/dataspaceconnector/aws/s3/core/AwsClientProviderImpl.java
+++ b/extensions/common/aws/s3-core/src/main/java/org/eclipse/dataspaceconnector/aws/s3/core/AwsClientProviderImpl.java
@@ -100,6 +100,13 @@ public class AwsClientProviderImpl implements AwsClientProvider {
         stsAsyncClients.values().forEach(SdkAutoCloseable::close);
     }
 
+    @Override
+    public void configureEndpointOverride(String endpointOverride) {
+        if(endpointOverride == null || endpointOverride.equals(""))
+            return;
+        configuration.setEndpointOverride(endpointOverride);
+    }
+
     private S3Client createS3Client(AwsCredentials credentials, String region) {
         var credentialsProvider = StaticCredentialsProvider.create(credentials);
         var builder = S3Client.builder()

--- a/extensions/common/aws/s3-core/src/main/java/org/eclipse/dataspaceconnector/aws/s3/core/S3BucketSchema.java
+++ b/extensions/common/aws/s3-core/src/main/java/org/eclipse/dataspaceconnector/aws/s3/core/S3BucketSchema.java
@@ -19,5 +19,6 @@ public interface S3BucketSchema {
     String REGION = "region";
     String BUCKET_NAME = "bucketName";
     String ACCESS_KEY_ID = "accessKeyId";
+    String ENDPOINT_OVERRIDE = "endpointOverride";
     String SECRET_ACCESS_KEY = "secretAccessKey";
 }


### PR DESCRIPTION
## What this PR changes/adds

see eclipse-edc/Technology-Aws#24 

## Why it does that

see eclipse-edc/Technology-Aws#24 

## Further notes

IMHO, further refactoring for the creation of the S3Client in `S3DataSourceFactory.createSource()` and `S3DataSinkFactory.createSink()` is required. 

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

eclipse-edc/Technology-Aws#24 


## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
