### PR TITLE
refactor(TransferProcessStore): replaces create and update api with save with support of upsert

### DIFF
--- a/core/control-plane/control-plane-api-client/src/test/java/org/eclipse/edc/connector/api/client/transferprocess/TransferProcessHttpClientIntegrationTest.java
+++ b/core/control-plane/control-plane-api-client/src/test/java/org/eclipse/edc/connector/api/client/transferprocess/TransferProcessHttpClientIntegrationTest.java
@@ -80,7 +80,7 @@ public class TransferProcessHttpClientIntegrationTest {
     void shouldCallTransferProcessApiWithComplete(TransferProcessStore store, DataPlaneManager manager, ControlPlaneApiUrl callbackUrl) {
         when(service.transfer(any())).thenReturn(CompletableFuture.completedFuture(StatusResult.success()));
         var id = "tp-id";
-        store.create(createTransferProcess(id));
+        store.save(createTransferProcess(id));
         manager.initiateTransfer(createDataFlowRequest(id, callbackUrl.get()));
 
         await().untilAsserted(() -> {
@@ -95,7 +95,7 @@ public class TransferProcessHttpClientIntegrationTest {
     void shouldCallTransferProcessApiWithFailed(TransferProcessStore store, DataPlaneManager manager, ControlPlaneApiUrl callbackUrl) {
         when(service.transfer(any())).thenReturn(CompletableFuture.completedFuture(StatusResult.failure(ResponseStatus.FATAL_ERROR, "error")));
         var id = "tp-id";
-        store.create(createTransferProcess(id));
+        store.save(createTransferProcess(id));
         manager.initiateTransfer(createDataFlowRequest(id, callbackUrl.get()));
 
         await().untilAsserted(() -> {
@@ -111,7 +111,7 @@ public class TransferProcessHttpClientIntegrationTest {
     void shouldCallTransferProcessApiWithException(TransferProcessStore store, DataPlaneManager manager, ControlPlaneApiUrl callbackUrl) {
         when(service.transfer(any())).thenReturn(CompletableFuture.failedFuture(new EdcException("error")));
         var id = "tp-id";
-        store.create(createTransferProcess(id));
+        store.save(createTransferProcess(id));
         manager.initiateTransfer(createDataFlowRequest(id, callbackUrl.get()));
 
         await().untilAsserted(() -> {

--- a/core/control-plane/control-plane-api/src/test/java/org/eclipse/edc/connector/api/TransferProcessControlApiControllerIntegrationTest.java
+++ b/core/control-plane/control-plane-api/src/test/java/org/eclipse/edc/connector/api/TransferProcessControlApiControllerIntegrationTest.java
@@ -57,7 +57,7 @@ class TransferProcessControlApiControllerIntegrationTest {
     @Test
     void callTransferProcessHookWithComplete(TransferProcessStore store) {
 
-        store.create(createTransferProcess());
+        store.save(createTransferProcess());
 
 
         baseRequest()
@@ -78,7 +78,7 @@ class TransferProcessControlApiControllerIntegrationTest {
     @Test
     void callTransferProcessHookWithError(TransferProcessStore store) {
 
-        store.create(createTransferProcess());
+        store.save(createTransferProcess());
 
         var rq = TransferProcessFailStateDto.Builder.newInstance()
                 .errorMessage("error")
@@ -148,7 +148,7 @@ class TransferProcessControlApiControllerIntegrationTest {
     @Test
     void callCompleteTransferProcessHook_invalidState(TransferProcessStore store) {
 
-        store.create(createTransferProcessBuilder().state(ERROR.code()).build());
+        store.save(createTransferProcessBuilder().state(ERROR.code()).build());
 
         var rq = TransferProcessFailStateDto.Builder.newInstance()
                 .errorMessage("error")

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/transferprocess/InMemoryTransferProcessStore.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/transferprocess/InMemoryTransferProcessStore.java
@@ -61,12 +61,7 @@ public class InMemoryTransferProcessStore implements TransferProcessStore {
     }
 
     @Override
-    public void create(TransferProcess process) {
-        store.upsert(process);
-    }
-
-    @Override
-    public void update(TransferProcess process) {
+    public void save(TransferProcess process) {
         store.upsert(process);
     }
 

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/command/handlers/SingleTransferProcessCommandHandler.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/command/handlers/SingleTransferProcessCommandHandler.java
@@ -44,7 +44,7 @@ public abstract class SingleTransferProcessCommandHandler<T extends SingleTransf
         } else {
             if (modify(transferProcess, command)) {
                 transferProcess.setModified();
-                store.update(transferProcess);
+                store.save(transferProcess);
                 postAction(transferProcess);
             }
         }

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
@@ -271,7 +271,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
             process.transitionInitial();
         }
         observable.invokeForEach(l -> l.preCreated(process));
-        transferProcessStore.create(process);
+        transferProcessStore.save(process);
         observable.invokeForEach(l -> l.initiated(process));
         monitor.debug("Process " + process.getId() + " is now " + TransferProcessStates.from(process.getState()));
 
@@ -511,14 +511,14 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
         if (transferProcess.provisioningComplete()) {
             transferProcess.transitionProvisioned();
             observable.invokeForEach(l -> l.preProvisioned(transferProcess));
-            transferProcessStore.update(transferProcess);
+            transferProcessStore.save(transferProcess);
             observable.invokeForEach(l -> l.provisioned(transferProcess));
         } else if (responses.stream().anyMatch(ProvisionResponse::isInProcess)) {
             transferProcess.transitionProvisioningRequested();
-            transferProcessStore.update(transferProcess);
+            transferProcessStore.save(transferProcess);
             observable.invokeForEach(l -> l.provisioningRequested(transferProcess));
         } else {
-            transferProcessStore.update(transferProcess);
+            transferProcessStore.save(transferProcess);
         }
     }
 
@@ -542,14 +542,14 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
         if (transferProcess.deprovisionComplete()) {
             transferProcess.transitionDeprovisioned();
             observable.invokeForEach(l -> l.preDeprovisioned(transferProcess));
-            transferProcessStore.update(transferProcess);
+            transferProcessStore.save(transferProcess);
             observable.invokeForEach(l -> l.deprovisioned(transferProcess));
         } else if (results.stream().anyMatch(DeprovisionedResource::isInProcess)) {
             transferProcess.transitionDeprovisioningRequested();
-            transferProcessStore.update(transferProcess);
+            transferProcessStore.save(transferProcess);
             observable.invokeForEach(l -> l.deprovisioningRequested(transferProcess));
         } else {
-            transferProcessStore.update(transferProcess);
+            transferProcessStore.save(transferProcess);
         }
     }
 
@@ -707,17 +707,17 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
                 TransferProcessStates.from(transferProcess.getState())), e);
         // update state count and timestamp
         transferProcess.transitionRequesting();
-        transferProcessStore.update(transferProcess);
+        transferProcessStore.save(transferProcess);
     }
 
     private void updateTransferProcess(TransferProcess transferProcess, Consumer<TransferProcessListener> observe) {
         observable.invokeForEach(observe);
-        transferProcessStore.update(transferProcess);
+        transferProcessStore.save(transferProcess);
         monitor.debug("Process " + transferProcess.getId() + " is now " + TransferProcessStates.from(transferProcess.getState()));
     }
 
     private void breakLease(TransferProcess process) {
-        transferProcessStore.update(process);
+        transferProcessStore.save(process);
     }
 
     public static class Builder {

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/command/handlers/CancelTransferCommandHandlerTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/command/handlers/CancelTransferCommandHandlerTest.java
@@ -65,7 +65,7 @@ class CancelTransferCommandHandlerTest {
         assertThat(tp.getUpdatedAt()).isNotEqualTo(originalDate);
 
         verify(store).find(anyString());
-        verify(store).update(tp);
+        verify(store).save(tp);
         verifyNoMoreInteractions(store);
         verify(listener).cancelled(tp);
     }

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/command/handlers/CompleteTransferCommandHandlerTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/command/handlers/CompleteTransferCommandHandlerTest.java
@@ -65,7 +65,7 @@ class CompleteTransferCommandHandlerTest {
         assertThat(tp.getUpdatedAt()).isNotEqualTo(originalDate);
 
         verify(store).find(anyString());
-        verify(store).update(tp);
+        verify(store).save(tp);
         verifyNoMoreInteractions(store);
         verify(listener).completed(tp);
     }

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/command/handlers/FailTransferCommandHandlerTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/command/handlers/FailTransferCommandHandlerTest.java
@@ -65,7 +65,7 @@ class FailTransferCommandHandlerTest {
         assertThat(tp.getUpdatedAt()).isNotEqualTo(originalDate);
 
         verify(store).find(anyString());
-        verify(store).update(tp);
+        verify(store).save(tp);
         verifyNoMoreInteractions(store);
         verify(listener).failed(tp);
     }

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/transfer/TransferProcessManagerImplIntegrationTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/transfer/TransferProcessManagerImplIntegrationTest.java
@@ -116,7 +116,7 @@ class TransferProcessManagerImplIntegrationTest {
                 .mapToObj(i -> provisionedResourceSet())
                 .map(resourceSet -> createUnsavedTransferProcess().resourceManifest(manifest).provisionedResourceSet(resourceSet).build())
                 .peek(TransferProcess::transitionInitial)
-                .peek(store::create)
+                .peek(store::save)
                 .collect(Collectors.toList());
 
         transferProcessManager.start();

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/transfer/TransferProcessManagerImplTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/transfer/TransferProcessManagerImplTest.java
@@ -162,7 +162,7 @@ class TransferProcessManagerImplTest {
         manager.initiateProviderRequest(dataRequest); // repeat request
         manager.stop();
 
-        verify(transferProcessStore, times(1)).create(isA(TransferProcess.class));
+        verify(transferProcessStore, times(1)).save(isA(TransferProcess.class));
         verify(transferProcessStore, times(2)).processIdForDataRequestId(anyString());
     }
 
@@ -175,7 +175,7 @@ class TransferProcessManagerImplTest {
         manager.initiateProviderRequest(dataRequest);
         manager.stop();
 
-        verify(transferProcessStore, times(1)).create(argThat(p -> p.getCreatedAt() == currentTime));
+        verify(transferProcessStore, times(1)).save(argThat(p -> p.getCreatedAt() == currentTime));
         verify(listener).initiated(any());
     }
 
@@ -194,7 +194,7 @@ class TransferProcessManagerImplTest {
         await().untilAsserted(() -> {
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
             verifyNoInteractions(provisionManager);
-            verify(transferProcessStore).update(argThat(p -> p.getState() == PROVISIONING.code()));
+            verify(transferProcessStore).save(argThat(p -> p.getState() == PROVISIONING.code()));
         });
     }
 
@@ -212,7 +212,7 @@ class TransferProcessManagerImplTest {
         await().untilAsserted(() -> {
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
             verifyNoInteractions(provisionManager);
-            verify(transferProcessStore).update(argThat(p -> p.getState() == ERROR.code()));
+            verify(transferProcessStore).save(argThat(p -> p.getState() == ERROR.code()));
         });
     }
 
@@ -235,7 +235,7 @@ class TransferProcessManagerImplTest {
         await().untilAsserted(() -> {
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
             verify(transferProcessStore).find(process.getId());
-            verify(transferProcessStore).update(argThat(p -> p.getState() == PROVISIONED.code()));
+            verify(transferProcessStore).save(argThat(p -> p.getState() == PROVISIONED.code()));
             verify(listener).provisioned(process);
         });
     }
@@ -264,7 +264,7 @@ class TransferProcessManagerImplTest {
 
         await().untilAsserted(() -> {
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
-            verify(transferProcessStore).update(argThat(p -> p.getState() == PROVISIONED.code()));
+            verify(transferProcessStore).save(argThat(p -> p.getState() == PROVISIONED.code()));
             verify(vault).storeSecret(any(), any());
             verify(listener).provisioned(process);
         });
@@ -288,7 +288,7 @@ class TransferProcessManagerImplTest {
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore).update(argThat(p -> p.getState() == PROVISIONING_REQUESTED.code()));
+            verify(transferProcessStore).save(argThat(p -> p.getState() == PROVISIONING_REQUESTED.code()));
             verify(listener).provisioningRequested(any());
         });
     }
@@ -308,7 +308,7 @@ class TransferProcessManagerImplTest {
 
         await().untilAsserted(() -> {
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
-            verify(transferProcessStore).update(argThat(p -> p.getState() == ERROR.code()));
+            verify(transferProcessStore).save(argThat(p -> p.getState() == ERROR.code()));
             verify(listener).failed(process);
         });
     }
@@ -329,7 +329,7 @@ class TransferProcessManagerImplTest {
 
         await().untilAsserted(() -> {
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
-            verify(transferProcessStore).update(argThat(p -> p.getState() == ERROR.code()));
+            verify(transferProcessStore).save(argThat(p -> p.getState() == ERROR.code()));
             verify(listener).failed(process);
         });
     }
@@ -350,7 +350,7 @@ class TransferProcessManagerImplTest {
 
         await().untilAsserted(() -> {
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
-            verify(transferProcessStore).update(argThat(p -> p.getState() == PROVISIONING.code()));
+            verify(transferProcessStore).save(argThat(p -> p.getState() == PROVISIONING.code()));
         });
     }
 
@@ -363,7 +363,7 @@ class TransferProcessManagerImplTest {
 
         await().untilAsserted(() -> {
             verify(transferProcessStore, atLeastOnce()).nextForState(eq(PROVISIONED.code()), anyInt());
-            verify(transferProcessStore).update(argThat(p -> p.getState() == REQUESTING.code()));
+            verify(transferProcessStore).save(argThat(p -> p.getState() == REQUESTING.code()));
         });
     }
 
@@ -378,7 +378,7 @@ class TransferProcessManagerImplTest {
 
         await().untilAsserted(() -> {
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
-            verify(transferProcessStore).update(argThat(p -> p.getState() == IN_PROGRESS.code()));
+            verify(transferProcessStore).save(argThat(p -> p.getState() == IN_PROGRESS.code()));
         });
     }
 
@@ -392,7 +392,7 @@ class TransferProcessManagerImplTest {
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore).update(argThat(p -> p.getState() == ERROR.code()));
+            verify(transferProcessStore).save(argThat(p -> p.getState() == ERROR.code()));
             verify(listener).failed(any());
         });
     }
@@ -407,7 +407,7 @@ class TransferProcessManagerImplTest {
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore, times(1)).update(argThat(p -> p.getState() == PROVISIONED.code()));
+            verify(transferProcessStore, times(1)).save(argThat(p -> p.getState() == PROVISIONED.code()));
         });
     }
 
@@ -422,7 +422,7 @@ class TransferProcessManagerImplTest {
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore, times(1)).update(argThat(p -> p.getState() == ERROR.code()));
+            verify(transferProcessStore, times(1)).save(argThat(p -> p.getState() == ERROR.code()));
             verify(listener).failed(process);
         });
     }
@@ -439,7 +439,7 @@ class TransferProcessManagerImplTest {
 
         await().untilAsserted(() -> {
             verifyNoInteractions(dataFlowManager);
-            verify(transferProcessStore, times(1)).update(argThat(p -> p.getState() == PROVISIONED.code()));
+            verify(transferProcessStore, times(1)).save(argThat(p -> p.getState() == PROVISIONED.code()));
         });
     }
 
@@ -453,7 +453,7 @@ class TransferProcessManagerImplTest {
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore, times(1)).update(argThat(p -> p.getState() == REQUESTED.code()));
+            verify(transferProcessStore, times(1)).save(argThat(p -> p.getState() == REQUESTED.code()));
             verify(listener).requested(process);
         });
     }
@@ -468,7 +468,7 @@ class TransferProcessManagerImplTest {
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore, times(1)).update(argThat(p -> p.getState() == REQUESTING.code()));
+            verify(transferProcessStore, times(1)).save(argThat(p -> p.getState() == REQUESTING.code()));
         });
     }
 
@@ -483,7 +483,7 @@ class TransferProcessManagerImplTest {
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore, times(1)).update(argThat(p -> p.getState() == ERROR.code()));
+            verify(transferProcessStore, times(1)).save(argThat(p -> p.getState() == ERROR.code()));
             verify(listener).failed(process);
         });
     }
@@ -500,7 +500,7 @@ class TransferProcessManagerImplTest {
 
         await().untilAsserted(() -> {
             verifyNoInteractions(dispatcherRegistry);
-            verify(transferProcessStore, times(1)).update(argThat(p -> p.getState() == REQUESTING.code()));
+            verify(transferProcessStore, times(1)).save(argThat(p -> p.getState() == REQUESTING.code()));
         });
     }
 
@@ -513,7 +513,7 @@ class TransferProcessManagerImplTest {
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore).update(argThat(p -> p.getState() == IN_PROGRESS.code()));
+            verify(transferProcessStore).save(argThat(p -> p.getState() == IN_PROGRESS.code()));
         });
     }
 
@@ -527,7 +527,7 @@ class TransferProcessManagerImplTest {
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore).update(argThat(p -> p.getState() == STREAMING.code()));
+            verify(transferProcessStore).save(argThat(p -> p.getState() == STREAMING.code()));
         });
     }
 
@@ -536,12 +536,12 @@ class TransferProcessManagerImplTest {
         var process = createTransferProcess(REQUESTED);
         when(transferProcessStore.nextForState(eq(REQUESTED.code()), anyInt())).thenReturn(List.of(process));
         doThrow(new AssertionError("update() should not be called as process was not updated"))
-                .when(transferProcessStore).update(process);
+                .when(transferProcessStore).save(process);
 
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore, never()).update(any());
+            verify(transferProcessStore, never()).save(any());
         });
     }
 
@@ -559,7 +559,7 @@ class TransferProcessManagerImplTest {
 
         await().untilAsserted(() -> {
             verify(statusCheckerRegistry, atLeastOnce()).resolve(any());
-            verify(transferProcessStore).update(argThat(p -> p.getState() == COMPLETED.code()));
+            verify(transferProcessStore).save(argThat(p -> p.getState() == COMPLETED.code()));
             verify(listener).completed(process);
         });
     }
@@ -578,7 +578,7 @@ class TransferProcessManagerImplTest {
 
         await().untilAsserted(() -> {
             verify(statusCheckerRegistry, atLeastOnce()).resolve(any());
-            verify(transferProcessStore).update(argThat(p -> p.getState() == COMPLETED.code()));
+            verify(transferProcessStore).save(argThat(p -> p.getState() == COMPLETED.code()));
             verify(listener).completed(process);
         });
     }
@@ -596,7 +596,7 @@ class TransferProcessManagerImplTest {
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore).update(argThat(p -> p.getState() == IN_PROGRESS.code()));
+            verify(transferProcessStore).save(argThat(p -> p.getState() == IN_PROGRESS.code()));
         });
     }
 
@@ -608,12 +608,12 @@ class TransferProcessManagerImplTest {
         process.getProvisionedResourceSet().addResource(provisionedDataDestinationResource());
         when(transferProcessStore.nextForState(eq(IN_PROGRESS.code()), anyInt())).thenReturn(List.of(process));
         doThrow(new AssertionError("update() should not be called as process was not updated"))
-                .when(transferProcessStore).update(process);
+                .when(transferProcessStore).save(process);
 
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore, never()).update(any());
+            verify(transferProcessStore, never()).save(any());
         });
     }
 
@@ -631,7 +631,7 @@ class TransferProcessManagerImplTest {
 
         await().untilAsserted(() -> {
             verify(statusCheckerRegistry, atLeastOnce()).resolve(any());
-            verify(transferProcessStore).update(argThat(p -> p.getState() == COMPLETED.code()));
+            verify(transferProcessStore).save(argThat(p -> p.getState() == COMPLETED.code()));
             verify(listener).completed(process);
         });
     }
@@ -666,7 +666,7 @@ class TransferProcessManagerImplTest {
         await().untilAsserted(() -> {
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
             verify(transferProcessStore).find(process.getId());
-            verify(transferProcessStore).update(argThat(p -> p.getState() == DEPROVISIONED.code()));
+            verify(transferProcessStore).save(argThat(p -> p.getState() == DEPROVISIONED.code()));
             verify(vault).deleteSecret(any());
             verify(listener).deprovisioned(process);
         });
@@ -701,7 +701,7 @@ class TransferProcessManagerImplTest {
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore).update(argThat(p -> p.getState() == DEPROVISIONING_REQUESTED.code()));
+            verify(transferProcessStore).save(argThat(p -> p.getState() == DEPROVISIONING_REQUESTED.code()));
             verify(listener).deprovisioningRequested(any());
         });
     }
@@ -732,7 +732,7 @@ class TransferProcessManagerImplTest {
 
         await().untilAsserted(() -> {
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
-            verify(transferProcessStore).update(argThat(p -> p.getState() == ERROR.code()));
+            verify(transferProcessStore).save(argThat(p -> p.getState() == ERROR.code()));
             verify(listener).failed(process);
         });
     }
@@ -762,7 +762,7 @@ class TransferProcessManagerImplTest {
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore).update(argThat(p -> p.getState() == DEPROVISIONING.code()));
+            verify(transferProcessStore).save(argThat(p -> p.getState() == DEPROVISIONING.code()));
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
         });
     }
@@ -781,7 +781,7 @@ class TransferProcessManagerImplTest {
 
         await().untilAsserted(() -> {
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
-            verify(transferProcessStore).update(argThat(p -> p.getState() == ERROR.code()));
+            verify(transferProcessStore).save(argThat(p -> p.getState() == ERROR.code()));
             verify(listener).failed(process);
         });
     }
@@ -794,7 +794,7 @@ class TransferProcessManagerImplTest {
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore).update(argThat(p -> p.getState() == ENDED.code()));
+            verify(transferProcessStore).save(argThat(p -> p.getState() == ENDED.code()));
             verify(listener).ended(process);
         });
     }

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/api/management/transferprocess/TransferProcessApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/api/management/transferprocess/TransferProcessApiControllerIntegrationTest.java
@@ -66,7 +66,7 @@ class TransferProcessApiControllerIntegrationTest {
 
     @Test
     void getAllTransferProcesses(TransferProcessStore store) {
-        store.create(createTransferProcess(PROCESS_ID));
+        store.save(createTransferProcess(PROCESS_ID));
 
         baseRequest()
                 .get("/transferprocess")
@@ -87,7 +87,7 @@ class TransferProcessApiControllerIntegrationTest {
 
     @Test
     void queryAllTransferProcesses(TransferProcessStore store) {
-        store.create(createTransferProcess(PROCESS_ID));
+        store.save(createTransferProcess(PROCESS_ID));
 
         baseRequest()
                 .contentType(JSON)
@@ -101,7 +101,7 @@ class TransferProcessApiControllerIntegrationTest {
     @Test
     void queryAllTransferProcesses_withPaging(TransferProcessStore store) {
         IntStream.range(0, 10)
-                .forEach(i -> store.create(createTransferProcess(PROCESS_ID + i)));
+                .forEach(i -> store.save(createTransferProcess(PROCESS_ID + i)));
 
         baseRequest()
                 .contentType(JSON)
@@ -116,7 +116,7 @@ class TransferProcessApiControllerIntegrationTest {
     @Test
     void queryAllTransferProcesses_withFilter(TransferProcessStore store) {
         IntStream.range(0, 10)
-                .forEach(i -> store.create(createTransferProcess(PROCESS_ID + i)));
+                .forEach(i -> store.save(createTransferProcess(PROCESS_ID + i)));
 
         baseRequest()
                 .contentType(JSON)
@@ -131,7 +131,7 @@ class TransferProcessApiControllerIntegrationTest {
 
     @Test
     void getSingleTransferProcess(TransferProcessStore store) {
-        store.create(createTransferProcess(PROCESS_ID));
+        store.save(createTransferProcess(PROCESS_ID));
         baseRequest()
                 .get("/transferprocess/" + PROCESS_ID)
                 .then()
@@ -152,7 +152,7 @@ class TransferProcessApiControllerIntegrationTest {
 
     @Test
     void getSingleTransferProcessState(TransferProcessStore store) {
-        store.create(createTransferProcess(PROCESS_ID, PROVISIONING.code()));
+        store.save(createTransferProcess(PROCESS_ID, PROVISIONING.code()));
 
         var state = baseRequest()
                 .get("/transferprocess/" + PROCESS_ID + "/state")
@@ -174,7 +174,7 @@ class TransferProcessApiControllerIntegrationTest {
 
     @Test
     void cancel(TransferProcessStore store) {
-        store.create(createTransferProcess(PROCESS_ID, IN_PROGRESS.code()));
+        store.save(createTransferProcess(PROCESS_ID, IN_PROGRESS.code()));
 
         baseRequest()
                 .contentType(JSON)
@@ -194,7 +194,7 @@ class TransferProcessApiControllerIntegrationTest {
 
     @Test
     void cancel_conflict(TransferProcessStore store) {
-        store.create(createTransferProcess(PROCESS_ID, COMPLETED.code()));
+        store.save(createTransferProcess(PROCESS_ID, COMPLETED.code()));
         baseRequest()
                 .contentType(JSON)
                 .post("/transferprocess/" + PROCESS_ID + "/cancel")
@@ -204,7 +204,7 @@ class TransferProcessApiControllerIntegrationTest {
 
     @Test
     void deprovision(TransferProcessStore store) {
-        store.create(createTransferProcess(PROCESS_ID, COMPLETED.code()));
+        store.save(createTransferProcess(PROCESS_ID, COMPLETED.code()));
 
         baseRequest()
                 .contentType(JSON)
@@ -224,7 +224,7 @@ class TransferProcessApiControllerIntegrationTest {
 
     @Test
     void deprovision_conflict(TransferProcessStore store) {
-        store.create(createTransferProcess(PROCESS_ID, INITIAL.code()));
+        store.save(createTransferProcess(PROCESS_ID, INITIAL.code()));
 
         baseRequest()
                 .contentType(JSON)

--- a/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/webhook/HttpProvisionerWebhookApiControllerIntegrationTest.java
+++ b/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/webhook/HttpProvisionerWebhookApiControllerIntegrationTest.java
@@ -87,7 +87,7 @@ class HttpProvisionerWebhookApiControllerIntegrationTest {
     @Test
     void callProvisionWebhook(TransferProcessStore store) {
 
-        store.create(createTransferProcess());
+        store.save(createTransferProcess());
 
         var rq = ProvisionerWebhookRequest.Builder.newInstance()
                 .assetId("test-asset")
@@ -137,7 +137,7 @@ class HttpProvisionerWebhookApiControllerIntegrationTest {
     @Test
     void callDeprovisionWebhook(TransferProcessStore store) {
 
-        store.create(createTransferProcess());
+        store.save(createTransferProcess());
 
         var rq = DeprovisionedResource.Builder.newInstance()
                 .provisionedResourceId("resource-id")

--- a/extensions/control-plane/store/cosmos/transfer-process-store-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/transferprocess/CosmosTransferProcessStore.java
+++ b/extensions/control-plane/store/cosmos/transfer-process-store-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/transferprocess/CosmosTransferProcessStore.java
@@ -117,20 +117,11 @@ public class CosmosTransferProcessStore implements TransferProcessStore {
     }
 
     @Override
-    public void create(TransferProcess process) {
+    public void save(TransferProcess process) {
         Objects.requireNonNull(process.getId(), "TransferProcesses must have an ID!");
-
-        //todo: configure indexing
-        var document = new TransferProcessDocument(process, partitionKey);
-        failsafeExecutor.run(() -> cosmosDbApi.saveItem(document));
-    }
-
-    @Override
-    public void update(TransferProcess process) {
-        var document = new TransferProcessDocument(process, partitionKey);
         try {
             leaseContext.acquireLease(process.getId());
-            failsafeExecutor.run(() -> cosmosDbApi.saveItem(document));
+            failsafeExecutor.run(() -> cosmosDbApi.saveItem(new TransferProcessDocument(process, partitionKey)));
             leaseContext.breakLease(process.getId());
         } catch (BadRequestException ex) {
             throw new EdcException(ex);

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/transferprocess/PostgresTransferProcessStoreTest.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/transferprocess/PostgresTransferProcessStoreTest.java
@@ -85,8 +85,8 @@ class PostgresTransferProcessStoreTest extends TransferProcessStoreTestBase {
         var tp = createTransferProcessBuilder("testprocess1")
                 .dataRequest(da)
                 .build();
-        store.create(tp);
-        store.create(createTransferProcess("testprocess2"));
+        store.save(tp);
+        store.save(createTransferProcess("testprocess2"));
 
         var query = QuerySpec.Builder.newInstance()
                 .filter(List.of(new Criterion("dataRequest.notexist", "=", "somevalue")))
@@ -104,8 +104,8 @@ class PostgresTransferProcessStoreTest extends TransferProcessStoreTestBase {
         var tp = createTransferProcessBuilder("testprocess1")
                 .resourceManifest(rm)
                 .build();
-        store.create(tp);
-        store.create(createTransferProcess("testprocess2"));
+        store.save(tp);
+        store.save(createTransferProcess("testprocess2"));
 
         // throws exception when an explicit mapping exists
         var query = QuerySpec.Builder.newInstance()
@@ -137,8 +137,8 @@ class PostgresTransferProcessStoreTest extends TransferProcessStoreTestBase {
         var tp = createTransferProcessBuilder("testprocess1")
                 .provisionedResourceSet(prs)
                 .build();
-        store.create(tp);
-        store.create(createTransferProcess("testprocess2"));
+        store.save(tp);
+        store.save(createTransferProcess("testprocess2"));
 
         // throws exception when an explicit mapping exists
         var query = QuerySpec.Builder.newInstance()
@@ -158,7 +158,7 @@ class PostgresTransferProcessStoreTest extends TransferProcessStoreTestBase {
 
     @Test
     void find_queryByLease() {
-        store.create(createTransferProcess("testprocess1"));
+        store.save(createTransferProcess("testprocess1"));
 
         var query = QuerySpec.Builder.newInstance()
                 .filter(List.of(new Criterion("lease.leasedBy", "=", "foobar")))
@@ -174,13 +174,13 @@ class PostgresTransferProcessStoreTest extends TransferProcessStoreTestBase {
         var t1 = TestFunctions.createTransferProcessBuilder("id1")
                 .dataRequest(null)
                 .build();
-        assertThatIllegalArgumentException().isThrownBy(() -> getTransferProcessStore().create(t1));
+        assertThatIllegalArgumentException().isThrownBy(() -> getTransferProcessStore().save(t1));
     }
 
     @Override
     @Test
     protected void findAll_verifySorting_invalidProperty() {
-        IntStream.range(0, 10).forEach(i -> getTransferProcessStore().create(createTransferProcess("test-neg-" + i)));
+        IntStream.range(0, 10).forEach(i -> getTransferProcessStore().save(createTransferProcess("test-neg-" + i)));
 
         var query = QuerySpec.Builder.newInstance().sortField("notexist").sortOrder(SortOrder.DESC).build();
 

--- a/samples/04.2-modify-transferprocess/simulator/src/main/java/org/eclipse/edc/sample/extension/transfer/TransferSimulationExtension.java
+++ b/samples/04.2-modify-transferprocess/simulator/src/main/java/org/eclipse/edc/sample/extension/transfer/TransferSimulationExtension.java
@@ -56,7 +56,7 @@ public class TransferSimulationExtension implements ServiceExtension {
                         tp.addProvisionedResource(createDummyResource());
 
                         context.getMonitor().info("Insert Dummy TransferProcess");
-                        store.update(tp);
+                        store.save(tp);
                     }
                 },
                 5000

--- a/samples/04.2-modify-transferprocess/watchdog/src/main/java/org/eclipse/edc/sample/extension/watchdog/CheckTimeoutCommandHandler.java
+++ b/samples/04.2-modify-transferprocess/watchdog/src/main/java/org/eclipse/edc/sample/extension/watchdog/CheckTimeoutCommandHandler.java
@@ -36,6 +36,11 @@ public class CheckTimeoutCommandHandler implements CommandHandler<CheckTransferP
     }
 
     @Override
+    public Class<CheckTransferProcessTimeoutCommand> getType() {
+        return CheckTransferProcessTimeoutCommand.class;
+    }
+
+    @Override
     public void handle(CheckTransferProcessTimeoutCommand command) {
 
         var states = store.nextForState(command.getTargetState().code(), command.getBatchSize());
@@ -44,13 +49,8 @@ public class CheckTimeoutCommandHandler implements CommandHandler<CheckTransferP
                     monitor.info(format("will retire TP with id [%s] due to timeout", tp.getId()));
 
                     tp.transitionError("timeout by watchdog");
-                    store.update(tp);
+                    store.save(tp);
                 });
-    }
-
-    @Override
-    public Class<CheckTransferProcessTimeoutCommand> getType() {
-        return CheckTransferProcessTimeoutCommand.class;
     }
 
     private boolean isExpired(long stateTimestamp, Duration maxAge) {

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/store/TransferProcessStore.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/store/TransferProcessStore.java
@@ -41,14 +41,11 @@ public interface TransferProcessStore extends StateEntityStore<TransferProcess> 
     String processIdForDataRequestId(String id);
 
     /**
-     * Creates a transfer process.
+     * Persists a transfer process. This follows UPSERT semantics, so if the object didn't exit before, it's
+     * created.
      */
-    void create(TransferProcess process);
+    void save(TransferProcess process);
 
-    /**
-     * Updates a transfer process.
-     */
-    void update(TransferProcess process);
 
     /**
      * Deletes a transfer process.


### PR DESCRIPTION
## What this PR changes/adds

Replace `create` and `update` methods with `save` method that has upsert semantics

## Why it does that

Consistency with other stores.

## Linked Issue(s)

Closes #2224 

## Checklist

- [ ] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/pr_etiquette.md) for details_)
