### PR TITLE
feat: Add basic HttpDataAddress validation

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/ControlPlaneServicesExtension.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/ControlPlaneServicesExtension.java
@@ -28,6 +28,7 @@ import org.eclipse.edc.connector.service.contractagreement.ContractAgreementServ
 import org.eclipse.edc.connector.service.contractdefinition.ContractDefinitionEventListener;
 import org.eclipse.edc.connector.service.contractdefinition.ContractDefinitionServiceImpl;
 import org.eclipse.edc.connector.service.contractnegotiation.ContractNegotiationServiceImpl;
+import org.eclipse.edc.connector.service.dataaddress.DataAddressValidatorImpl;
 import org.eclipse.edc.connector.service.policydefinition.PolicyDefinitionEventListener;
 import org.eclipse.edc.connector.service.policydefinition.PolicyDefinitionServiceImpl;
 import org.eclipse.edc.connector.service.transferprocess.TransferProcessServiceImpl;
@@ -44,6 +45,7 @@ import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.spi.asset.AssetIndex;
+import org.eclipse.edc.spi.dataaddress.DataAddressValidator;
 import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.observe.asset.AssetObservableImpl;
@@ -137,5 +139,10 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     @Provider
     public TransferProcessService transferProcessService() {
         return new TransferProcessServiceImpl(transferProcessStore, transferProcessManager, transactionContext, contractNegotiationStore, contractValidationService);
+    }
+
+    @Provider
+    public DataAddressValidator dataAddressValidator() {
+        return new DataAddressValidatorImpl();
     }
 }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/ControlPlaneServicesExtension.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/ControlPlaneServicesExtension.java
@@ -59,6 +59,8 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
 
     public static final String NAME = "Control Plane Services";
 
+    private final DataAddressValidator dataAddressValidator = new DataAddressValidatorImpl();
+
     @Inject
     private Clock clock;
 
@@ -104,7 +106,7 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     public AssetService assetService() {
         var assetObservable = new AssetObservableImpl();
         assetObservable.registerListener(new AssetEventListener(clock, eventRouter));
-        return new AssetServiceImpl(assetIndex, contractNegotiationStore, transactionContext, assetObservable);
+        return new AssetServiceImpl(assetIndex, contractNegotiationStore, transactionContext, assetObservable, dataAddressValidator);
     }
 
     @Provider
@@ -139,11 +141,11 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     @Provider
     public TransferProcessService transferProcessService() {
         return new TransferProcessServiceImpl(transferProcessStore, transferProcessManager, transactionContext,
-                contractNegotiationStore, contractValidationService, new DataAddressValidatorImpl());
+                contractNegotiationStore, contractValidationService, dataAddressValidator);
     }
 
     @Provider // TODO: remove it and inject directly to the asset service
     public DataAddressValidator dataAddressValidator() {
-        return new DataAddressValidatorImpl();
+        return dataAddressValidator;
     }
 }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/ControlPlaneServicesExtension.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/ControlPlaneServicesExtension.java
@@ -138,10 +138,11 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
 
     @Provider
     public TransferProcessService transferProcessService() {
-        return new TransferProcessServiceImpl(transferProcessStore, transferProcessManager, transactionContext, contractNegotiationStore, contractValidationService);
+        return new TransferProcessServiceImpl(transferProcessStore, transferProcessManager, transactionContext,
+                contractNegotiationStore, contractValidationService, new DataAddressValidatorImpl());
     }
 
-    @Provider
+    @Provider // TODO: remove it and inject directly to the asset service
     public DataAddressValidator dataAddressValidator() {
         return new DataAddressValidatorImpl();
     }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/ControlPlaneServicesExtension.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/ControlPlaneServicesExtension.java
@@ -143,9 +143,4 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
         return new TransferProcessServiceImpl(transferProcessStore, transferProcessManager, transactionContext,
                 contractNegotiationStore, contractValidationService, dataAddressValidator);
     }
-
-    @Provider // TODO: remove it and inject directly to the asset service
-    public DataAddressValidator dataAddressValidator() {
-        return dataAddressValidator;
-    }
 }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/dataaddress/DataAddressValidatorImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/dataaddress/DataAddressValidatorImpl.java
@@ -23,6 +23,7 @@ import org.jetbrains.annotations.NotNull;
 import java.net.MalformedURLException;
 import java.net.URL;
 
+import static java.lang.String.format;
 import static org.eclipse.edc.spi.types.domain.HttpDataAddress.HTTP_DATA;
 
 public class DataAddressValidatorImpl implements DataAddressValidator {
@@ -46,7 +47,7 @@ public class DataAddressValidatorImpl implements DataAddressValidator {
             new URL(baseUrl);
             return Result.success();
         } catch (MalformedURLException e) {
-            return Result.failure("BaseUrl is not a valid URL: " + baseUrl);
+            return Result.failure(format("DataAddress of type %s must contain a valid baseUrl: %s", HTTP_DATA, baseUrl));
         }
     }
 }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/dataaddress/DataAddressValidatorImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/dataaddress/DataAddressValidatorImpl.java
@@ -26,7 +26,6 @@ public class DataAddressValidatorImpl implements DataAddressValidator {
     @Override
     public Result<DataAddress> validate(DataAddress dataAddress) {
         if (dataAddress.getType().equals("HttpData")) {
-            // TODO: fix builder, to avoid explicit casting
             var httpDataAddress = HttpDataAddress.Builder.newInstance()
                     .properties(dataAddress.getProperties())
                     .build();

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/dataaddress/DataAddressValidatorImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/dataaddress/DataAddressValidatorImpl.java
@@ -18,26 +18,35 @@ import org.eclipse.edc.spi.dataaddress.DataAddressValidator;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.HttpDataAddress;
+import org.jetbrains.annotations.NotNull;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 
+import static org.eclipse.edc.spi.types.domain.HttpDataAddress.HTTP_DATA;
+
 public class DataAddressValidatorImpl implements DataAddressValidator {
+
     @Override
-    public Result<DataAddress> validate(DataAddress dataAddress) {
-        if (dataAddress.getType().equals("HttpData")) {
-            var httpDataAddress = HttpDataAddress.Builder.newInstance()
-                    .properties(dataAddress.getProperties())
-                    .build();
-            var baseUrl = httpDataAddress.getBaseUrl();
-            try {
-                new URL(baseUrl);
-                return Result.success(httpDataAddress);
-            } catch (MalformedURLException e) {
-                return Result.failure("BaseUrl is not a valid URL: " + baseUrl);
-            }
+    public Result<Void> validate(DataAddress dataAddress) {
+        if (HTTP_DATA.equals(dataAddress.getType())) {
+            return validateHttpDataAddress(dataAddress);
         } else {
-            return Result.success(dataAddress);
+            return Result.success();
+        }
+    }
+
+    @NotNull
+    private Result<Void> validateHttpDataAddress(DataAddress dataAddress) {
+        var httpDataAddress = HttpDataAddress.Builder.newInstance()
+                .properties(dataAddress.getProperties())
+                .build();
+        var baseUrl = httpDataAddress.getBaseUrl();
+        try {
+            new URL(baseUrl);
+            return Result.success();
+        } catch (MalformedURLException e) {
+            return Result.failure("BaseUrl is not a valid URL: " + baseUrl);
         }
     }
 }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/dataaddress/DataAddressValidatorImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/dataaddress/DataAddressValidatorImpl.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
+ *
+ */
+
+package org.eclipse.edc.connector.service.dataaddress;
+
+import org.eclipse.edc.spi.dataaddress.DataAddressValidator;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.HttpDataAddress;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class DataAddressValidatorImpl implements DataAddressValidator {
+    @Override
+    public Result<DataAddress> validate(DataAddress dataAddress) {
+        if (dataAddress.getType().equals("HttpData")) {
+            // TODO: fix builder, to avoid explicit casting
+            var httpDataAddress = HttpDataAddress.Builder.newInstance()
+                    .properties(dataAddress.getProperties())
+                    .build();
+            var baseUrl = httpDataAddress.getBaseUrl();
+            try {
+                new URL(baseUrl);
+                return Result.success(httpDataAddress);
+            } catch (MalformedURLException e) {
+                return Result.failure("BaseUrl is not a valid URL: " + baseUrl);
+            }
+        } else {
+            return Result.success(dataAddress);
+        }
+    }
+}

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/asset/AssetServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/asset/AssetServiceImplTest.java
@@ -118,7 +118,7 @@ class AssetServiceImplTest {
 
     @Test
     void createAsset_shouldCreateAssetIfItDoesNotAlreadyExist() {
-        when(dataAddressValidator.validate(any())).thenAnswer(i -> Result.success(i.getArgument(0)));
+        when(dataAddressValidator.validate(any())).thenReturn(Result.success());
         var assetId = "assetId";
         var asset = createAsset(assetId);
         when(index.findById(assetId)).thenReturn(null);
@@ -135,7 +135,7 @@ class AssetServiceImplTest {
 
     @Test
     void createAsset_shouldNotCreateAssetIfItAlreadyExists() {
-        when(dataAddressValidator.validate(any())).thenAnswer(i -> Result.success(i.getArgument(0)));
+        when(dataAddressValidator.validate(any())).thenReturn(Result.success());
         var asset = createAsset("assetId");
         when(index.findById("assetId")).thenReturn(asset);
         var dataAddress = DataAddress.Builder.newInstance().type("addressType").build();

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/asset/AssetServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/asset/AssetServiceImplTest.java
@@ -18,9 +18,12 @@ import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiat
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.service.spi.result.ServiceResult;
 import org.eclipse.edc.spi.asset.AssetIndex;
+import org.eclipse.edc.spi.dataaddress.DataAddressValidator;
 import org.eclipse.edc.spi.observe.asset.AssetObservable;
 import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.eclipse.edc.transaction.spi.NoopTransactionContext;
@@ -37,12 +40,14 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.service.spi.result.ServiceFailure.Reason.BAD_REQUEST;
 import static org.eclipse.edc.service.spi.result.ServiceFailure.Reason.CONFLICT;
 import static org.eclipse.edc.service.spi.result.ServiceFailure.Reason.NOT_FOUND;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class AssetServiceImplTest {
@@ -51,8 +56,10 @@ class AssetServiceImplTest {
     private final ContractNegotiationStore contractNegotiationStore = mock(ContractNegotiationStore.class);
     private final TransactionContext dummyTransactionContext = new NoopTransactionContext();
     private final AssetObservable observable = mock(AssetObservable.class);
+    private final DataAddressValidator dataAddressValidator = mock(DataAddressValidator.class);
 
-    private final AssetServiceImpl service = new AssetServiceImpl(index, contractNegotiationStore, dummyTransactionContext, observable);
+    private final AssetServiceImpl service = new AssetServiceImpl(index, contractNegotiationStore, dummyTransactionContext,
+            observable, dataAddressValidator);
 
     @Test
     void findById_shouldRelyOnAssetIndex() {
@@ -111,6 +118,7 @@ class AssetServiceImplTest {
 
     @Test
     void createAsset_shouldCreateAssetIfItDoesNotAlreadyExist() {
+        when(dataAddressValidator.validate(any())).thenAnswer(i -> Result.success(i.getArgument(0)));
         var assetId = "assetId";
         var asset = createAsset(assetId);
         when(index.findById(assetId)).thenReturn(null);
@@ -127,6 +135,7 @@ class AssetServiceImplTest {
 
     @Test
     void createAsset_shouldNotCreateAssetIfItAlreadyExists() {
+        when(dataAddressValidator.validate(any())).thenAnswer(i -> Result.success(i.getArgument(0)));
         var asset = createAsset("assetId");
         when(index.findById("assetId")).thenReturn(asset);
         var dataAddress = DataAddress.Builder.newInstance().type("addressType").build();
@@ -134,6 +143,20 @@ class AssetServiceImplTest {
         var inserted = service.create(asset, dataAddress);
 
         assertThat(inserted.succeeded()).isFalse();
+    }
+
+    @Test
+    void createAsset_shouldNotCreateAssetIfDataAddressInvalid() {
+        var asset = createAsset("assetId");
+        var dataAddress = DataAddress.Builder.newInstance().type("addressType").build();
+        when(dataAddressValidator.validate(any())).thenReturn(Result.failure("Data address is invalid"));
+
+        var result = service.create(asset, dataAddress);
+
+        assertThat(result).satisfies(ServiceResult::failed)
+                .extracting(ServiceResult::reason)
+                .isEqualTo(BAD_REQUEST);
+        verifyNoInteractions(index);
     }
 
     @Test

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/dataaddress/DataAddressValidatorImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/dataaddress/DataAddressValidatorImplTest.java
@@ -33,11 +33,7 @@ class DataAddressValidatorImplTest {
 
         var result = validator.validate(dataAddress);
 
-        assertThat(result).satisfies(Result::succeeded)
-                .extracting(Result::getContent)
-                .satisfies(actual -> {
-                    assertThat(actual.getProperties()).isEqualTo(dataAddress.getProperties());
-                });
+        assertThat(result).satisfies(Result::succeeded);
     }
 
     @Test

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/dataaddress/DataAddressValidatorImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/dataaddress/DataAddressValidatorImplTest.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
+ *
+ */
+
+package org.eclipse.edc.connector.service.dataaddress;
+
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DataAddressValidatorImplTest {
+
+    @Test
+    void shouldFail_whenHttpDataBaseUrlNotValid() {
+        var validator = new DataAddressValidatorImpl();
+
+        var dataAddress = DataAddress.Builder.newInstance().property("type", "HttpData").property("baseUrl", "not-a-valid-url").build();
+
+        var result = validator.validate(dataAddress);
+
+        assertThat(result.failed()).isTrue();
+    }
+}

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessServiceImplTest.java
@@ -175,7 +175,7 @@ class TransferProcessServiceImplTest {
     void initiateTransfer() {
         var dataRequest = dataRequest();
         String processId = "processId";
-        when(dataAddressValidator.validate(any())).thenAnswer(i -> Result.success(i.getArgument(0)));
+        when(dataAddressValidator.validate(any())).thenReturn(Result.success());
         when(manager.initiateConsumerRequest(dataRequest)).thenReturn(StatusResult.success(processId));
 
         var result = service.initiateTransfer(dataRequest);
@@ -205,7 +205,7 @@ class TransferProcessServiceImplTest {
         when(negotiationStore.findContractAgreement(any())).thenReturn(contractAgreement());
         when(validationService.validateAgreement(any(), any())).thenReturn(true);
         when(manager.initiateProviderRequest(any())).thenReturn(StatusResult.success(processId));
-        when(dataAddressValidator.validate(any())).thenAnswer(i -> Result.success(i.getArgument(0)));
+        when(dataAddressValidator.validate(any())).thenReturn(Result.success());
 
         var result = service.initiateTransfer(dataRequest, claimToken);
 
@@ -220,7 +220,7 @@ class TransferProcessServiceImplTest {
         var claimToken = claimToken();
         when(negotiationStore.findContractAgreement(any())).thenReturn(contractAgreement());
         when(validationService.validateAgreement(any(), any())).thenReturn(false);
-        when(dataAddressValidator.validate(any())).thenAnswer(i -> Result.success(i.getArgument(0)));
+        when(dataAddressValidator.validate(any())).thenReturn(Result.success());
 
         var result = service.initiateTransfer(dataRequest, claimToken);
 

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApiExtension.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApiExtension.java
@@ -24,6 +24,7 @@ import org.eclipse.edc.connector.api.management.configuration.ManagementApiConfi
 import org.eclipse.edc.connector.spi.asset.AssetService;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.dataaddress.DataAddressValidator;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.web.spi.WebService;
@@ -45,6 +46,9 @@ public class AssetApiExtension implements ServiceExtension {
     @Inject
     private AssetService assetService;
 
+    @Inject
+    private DataAddressValidator dataAddressValidator;
+
     @Override
     public String name() {
         return NAME;
@@ -55,7 +59,7 @@ public class AssetApiExtension implements ServiceExtension {
         var monitor = context.getMonitor();
 
         transformerRegistry.register(new AssetRequestDtoToAssetTransformer());
-        transformerRegistry.register(new DataAddressDtoToDataAddressTransformer());
+        transformerRegistry.register(new DataAddressDtoToDataAddressTransformer(dataAddressValidator));
         transformerRegistry.register(new AssetToAssetResponseDtoTransformer());
 
         webService.registerResource(config.getContextAlias(), new AssetApiController(monitor, assetService, transformerRegistry));

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApiExtension.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApiExtension.java
@@ -24,7 +24,6 @@ import org.eclipse.edc.connector.api.management.configuration.ManagementApiConfi
 import org.eclipse.edc.connector.spi.asset.AssetService;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
-import org.eclipse.edc.spi.dataaddress.DataAddressValidator;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.web.spi.WebService;

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApiExtension.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApiExtension.java
@@ -46,9 +46,6 @@ public class AssetApiExtension implements ServiceExtension {
     @Inject
     private AssetService assetService;
 
-    @Inject
-    private DataAddressValidator dataAddressValidator;
-
     @Override
     public String name() {
         return NAME;
@@ -59,7 +56,7 @@ public class AssetApiExtension implements ServiceExtension {
         var monitor = context.getMonitor();
 
         transformerRegistry.register(new AssetRequestDtoToAssetTransformer());
-        transformerRegistry.register(new DataAddressDtoToDataAddressTransformer(dataAddressValidator));
+        transformerRegistry.register(new DataAddressDtoToDataAddressTransformer());
         transformerRegistry.register(new AssetToAssetResponseDtoTransformer());
 
         webService.registerResource(config.getContextAlias(), new AssetApiController(monitor, assetService, transformerRegistry));

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/transform/DataAddressDtoToDataAddressTransformer.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/transform/DataAddressDtoToDataAddressTransformer.java
@@ -16,19 +16,12 @@ package org.eclipse.edc.connector.api.management.asset.transform;
 
 import org.eclipse.edc.api.transformer.DtoTransformer;
 import org.eclipse.edc.connector.api.management.asset.model.DataAddressDto;
-import org.eclipse.edc.spi.dataaddress.DataAddressValidator;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class DataAddressDtoToDataAddressTransformer implements DtoTransformer<DataAddressDto, DataAddress> {
-
-    private final DataAddressValidator validator;
-
-    public DataAddressDtoToDataAddressTransformer(DataAddressValidator validator) {
-        this.validator = validator;
-    }
 
     @Override
     public Class<DataAddressDto> getInputType() {
@@ -42,13 +35,7 @@ public class DataAddressDtoToDataAddressTransformer implements DtoTransformer<Da
 
     @Override
     public @Nullable DataAddress transform(@Nullable DataAddressDto object, @NotNull TransformerContext context) {
-        var dataAddress = DataAddress.Builder.newInstance().properties(object.getProperties()).build();
-
-        return validator.validate(dataAddress)
-                .orElse(failure -> {
-                    failure.getMessages().forEach(context::reportProblem);
-                    return null;
-                });
+        return DataAddress.Builder.newInstance().properties(object.getProperties()).build();
     }
 
 }

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/transform/DataAddressDtoToDataAddressTransformerTest.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/transform/DataAddressDtoToDataAddressTransformerTest.java
@@ -15,24 +15,17 @@
 package org.eclipse.edc.connector.api.management.asset.transform;
 
 import org.eclipse.edc.connector.api.management.asset.model.DataAddressDto;
-import org.eclipse.edc.spi.dataaddress.DataAddressValidator;
-import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 class DataAddressDtoToDataAddressTransformerTest {
 
-    private final DataAddressValidator validator = mock(DataAddressValidator.class);
-    private final DataAddressDtoToDataAddressTransformer transformer = new DataAddressDtoToDataAddressTransformer(validator);
+    private final DataAddressDtoToDataAddressTransformer transformer = new DataAddressDtoToDataAddressTransformer();
 
     @Test
     void inputOutputType() {
@@ -42,7 +35,6 @@ class DataAddressDtoToDataAddressTransformerTest {
 
     @Test
     void shouldTransform() {
-        when(validator.validate(any())).thenAnswer(i -> Result.success(i.getArgument(0)));
         var context = mock(TransformerContext.class);
         var dataAddressDto = DataAddressDto.Builder.newInstance()
                 .properties(Map.of("type", "any"))
@@ -51,20 +43,5 @@ class DataAddressDtoToDataAddressTransformerTest {
         var dataAddress = transformer.transform(dataAddressDto, context);
 
         assertThat(dataAddress.getProperties()).containsExactlyEntriesOf(dataAddressDto.getProperties());
-    }
-
-    @Test
-    void shouldReturnNull_whenValidationFails() {
-        when(validator.validate(any())).thenReturn(Result.failure(List.of("an error", "another error")));
-        var context = mock(TransformerContext.class);
-        var dataAddressDto = DataAddressDto.Builder.newInstance()
-                .properties(Map.of("type", "any"))
-                .build();
-
-        var dataAddress = transformer.transform(dataAddressDto, context);
-
-        assertThat(dataAddress).isNull();
-        verify(context).reportProblem("an error");
-        verify(context).reportProblem("another error");
     }
 }

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/transform/DataAddressDtoToDataAddressTransformerTest.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/transform/DataAddressDtoToDataAddressTransformerTest.java
@@ -15,17 +15,24 @@
 package org.eclipse.edc.connector.api.management.asset.transform;
 
 import org.eclipse.edc.connector.api.management.asset.model.DataAddressDto;
+import org.eclipse.edc.spi.dataaddress.DataAddressValidator;
+import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class DataAddressDtoToDataAddressTransformerTest {
 
-    private final DataAddressDtoToDataAddressTransformer transformer = new DataAddressDtoToDataAddressTransformer();
+    private final DataAddressValidator validator = mock(DataAddressValidator.class);
+    private final DataAddressDtoToDataAddressTransformer transformer = new DataAddressDtoToDataAddressTransformer(validator);
 
     @Test
     void inputOutputType() {
@@ -34,7 +41,8 @@ class DataAddressDtoToDataAddressTransformerTest {
     }
 
     @Test
-    void transform() {
+    void shouldTransform() {
+        when(validator.validate(any())).thenAnswer(i -> Result.success(i.getArgument(0)));
         var context = mock(TransformerContext.class);
         var dataAddressDto = DataAddressDto.Builder.newInstance()
                 .properties(Map.of("type", "any"))
@@ -43,5 +51,20 @@ class DataAddressDtoToDataAddressTransformerTest {
         var dataAddress = transformer.transform(dataAddressDto, context);
 
         assertThat(dataAddress.getProperties()).containsExactlyEntriesOf(dataAddressDto.getProperties());
+    }
+
+    @Test
+    void shouldReturnNull_whenValidationFails() {
+        when(validator.validate(any())).thenReturn(Result.failure(List.of("an error", "another error")));
+        var context = mock(TransformerContext.class);
+        var dataAddressDto = DataAddressDto.Builder.newInstance()
+                .properties(Map.of("type", "any"))
+                .build();
+
+        var dataAddress = transformer.transform(dataAddressDto, context);
+
+        assertThat(dataAddress).isNull();
+        verify(context).reportProblem("an error");
+        verify(context).reportProblem("another error");
     }
 }

--- a/extensions/control-plane/data-plane-transfer/data-plane-transfer-sync/src/test/java/org/eclipse/edc/connector/dataplane/transfer/sync/proxy/DataPlaneTransferConsumerProxyTransformerTest.java
+++ b/extensions/control-plane/data-plane-transfer/data-plane-transfer-sync/src/test/java/org/eclipse/edc/connector/dataplane/transfer/sync/proxy/DataPlaneTransferConsumerProxyTransformerTest.java
@@ -88,7 +88,7 @@ class DataPlaneTransferConsumerProxyTransformerTest {
         assertThat(proxyCreationRequest.getProxyEndpoint()).isEqualTo(proxyUrl);
         assertThat(proxyCreationRequest.getProperties()).containsExactlyInAnyOrderEntriesOf(inputEdr.getProperties());
         assertThat(proxyCreationRequest.getContentAddress()).satisfies(address -> {
-            assertThat(address.getType()).isEqualTo(HttpDataAddress.DATA_TYPE);
+            assertThat(address.getType()).isEqualTo(HttpDataAddress.HTTP_DATA);
             var httpAddress = (HttpDataAddress) address;
             assertThat(httpAddress.getBaseUrl()).isEqualTo(inputEdr.getEndpoint());
             assertThat(httpAddress.getAuthKey()).isEqualTo(inputEdr.getAuthKey());

--- a/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSinkFactory.java
+++ b/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSinkFactory.java
@@ -26,10 +26,10 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.concurrent.ExecutorService;
 
-import static org.eclipse.edc.spi.types.domain.HttpDataAddress.DATA_TYPE;
+import static org.eclipse.edc.spi.types.domain.HttpDataAddress.HTTP_DATA;
 
 /**
- * Instantiates {@link HttpDataSink}s for requests whose source data type is {@link HttpDataAddress#DATA_TYPE}.
+ * Instantiates {@link HttpDataSink}s for requests whose source data type is {@link HttpDataAddress#HTTP_DATA}.
  */
 public class HttpDataSinkFactory implements DataSinkFactory {
     private final OkHttpClient httpClient;
@@ -52,7 +52,7 @@ public class HttpDataSinkFactory implements DataSinkFactory {
 
     @Override
     public boolean canHandle(DataFlowRequest request) {
-        return DATA_TYPE.equals(request.getDestinationDataAddress().getType());
+        return HTTP_DATA.equals(request.getDestinationDataAddress().getType());
     }
 
     @Override

--- a/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSourceFactory.java
+++ b/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSourceFactory.java
@@ -24,10 +24,10 @@ import org.eclipse.edc.spi.types.domain.HttpDataAddress;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
 import org.jetbrains.annotations.NotNull;
 
-import static org.eclipse.edc.spi.types.domain.HttpDataAddress.DATA_TYPE;
+import static org.eclipse.edc.spi.types.domain.HttpDataAddress.HTTP_DATA;
 
 /**
- * Instantiates {@link HttpDataSource}s for requests whose source data type is {@link HttpDataAddress#DATA_TYPE}.
+ * Instantiates {@link HttpDataSource}s for requests whose source data type is {@link HttpDataAddress#HTTP_DATA}.
  */
 public class HttpDataSourceFactory implements DataSourceFactory {
 
@@ -43,7 +43,7 @@ public class HttpDataSourceFactory implements DataSourceFactory {
 
     @Override
     public boolean canHandle(DataFlowRequest request) {
-        return DATA_TYPE.equals(request.getSourceDataAddress().getType());
+        return HTTP_DATA.equals(request.getSourceDataAddress().getType());
     }
 
     @Override

--- a/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSinkFactoryTest.java
+++ b/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSinkFactoryTest.java
@@ -41,7 +41,7 @@ import java.util.concurrent.Executors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.dataplane.http.testfixtures.HttpTestFixtures.createHttpResponse;
-import static org.eclipse.edc.spi.types.domain.HttpDataAddress.DATA_TYPE;
+import static org.eclipse.edc.spi.types.domain.HttpDataAddress.HTTP_DATA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -72,7 +72,7 @@ class HttpDataSinkFactoryTest {
 
     @Test
     void verifyCanHandle() {
-        assertThat(factory.canHandle(HttpTestFixtures.createRequest(DATA_TYPE).build())).isTrue();
+        assertThat(factory.canHandle(HttpTestFixtures.createRequest(HTTP_DATA).build())).isTrue();
     }
 
     @Test

--- a/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSourceFactoryTest.java
+++ b/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSourceFactoryTest.java
@@ -31,7 +31,7 @@ import java.util.Arrays;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.spi.types.domain.HttpDataAddress.DATA_TYPE;
+import static org.eclipse.edc.spi.types.domain.HttpDataAddress.HTTP_DATA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -60,7 +60,7 @@ class HttpDataSourceFactoryTest {
 
     @Test
     void verifyCanHandle() {
-        assertThat(factory.canHandle(HttpTestFixtures.createRequest(DATA_TYPE).build())).isTrue();
+        assertThat(factory.canHandle(HttpTestFixtures.createRequest(HTTP_DATA).build())).isTrue();
     }
 
     @Test

--- a/spi/common/aggregate-service-spi/src/main/java/org/eclipse/edc/service/spi/result/ServiceResult.java
+++ b/spi/common/aggregate-service-spi/src/main/java/org/eclipse/edc/service/spi/result/ServiceResult.java
@@ -41,7 +41,11 @@ public class ServiceResult<T> extends AbstractResult<T, ServiceFailure> {
     }
 
     public static <T> ServiceResult<T> badRequest(String... message) {
-        return new ServiceResult<>(null, new ServiceFailure(List.of(message), BAD_REQUEST));
+        return badRequest(List.of(message));
+    }
+
+    public static <T> ServiceResult<T> badRequest(List<String> messages) {
+        return new ServiceResult<>(null, new ServiceFailure(messages, BAD_REQUEST));
     }
 
     public ServiceFailure.Reason reason() {

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/dataaddress/DataAddressValidator.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/dataaddress/DataAddressValidator.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
+ *
+ */
+
+package org.eclipse.edc.spi.dataaddress;
+
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+
+/**
+ * Validate a DataAddress
+ */
+public interface DataAddressValidator {
+
+    /**
+     * Validate a DataAddress
+     *
+     * @param dataAddress the {@link DataAddress} to be validated.
+     * @return Successful {@link Result} if the {@link DataAddress} is valid, failure otherwise.
+     */
+    Result<DataAddress> validate(DataAddress dataAddress);
+
+}

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/dataaddress/DataAddressValidator.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/dataaddress/DataAddressValidator.java
@@ -28,6 +28,6 @@ public interface DataAddressValidator {
      * @param dataAddress the {@link DataAddress} to be validated.
      * @return Successful {@link Result} if the {@link DataAddress} is valid, failure otherwise.
      */
-    Result<DataAddress> validate(DataAddress dataAddress);
+    Result<Void> validate(DataAddress dataAddress);
 
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/AbstractResult.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/AbstractResult.java
@@ -17,7 +17,6 @@ package org.eclipse.edc.spi.result;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/AbstractResult.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/AbstractResult.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.spi.result;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -98,6 +99,19 @@ public abstract class AbstractResult<T, F extends Failure> {
         return onFailure(failureAction);
     }
 
+    /**
+     * Execute an action if this {@link Result} is not successful.
+     *
+     * @param exceptionMapper The function that maps a {@link Failure} into the content.
+     * @return T the success value if successful, otherwise the object returned by the {@param failureAction}
+     */
+    public T orElse(Function<F, T> failureAction) {
+        if (failed()) {
+            return failureAction.apply(getFailure());
+        } else {
+            return getContent();
+        }
+    }
 
     /**
      * Throws an exception returned by the mapper {@link Function} if this {@link Result} is not successful.

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/AbstractResult.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/AbstractResult.java
@@ -101,7 +101,7 @@ public abstract class AbstractResult<T, F extends Failure> {
     /**
      * Execute an action if this {@link Result} is not successful.
      *
-     * @param exceptionMapper The function that maps a {@link Failure} into the content.
+     * @param failureAction The function that maps a {@link Failure} into the content.
      * @return T the success value if successful, otherwise the object returned by the {@param failureAction}
      */
     public T orElse(Function<F, T> failureAction) {

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/DataAddress.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/DataAddress.java
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import javax.xml.crypto.Data;
 
 /**
  * An address that can be used resolve a data location. Data addresses are used throughout the system. For example, an asset has a data address used to resolve its contents,
@@ -37,7 +38,7 @@ import java.util.Objects;
 public class DataAddress {
     public static final String TYPE = "type";
     public static final String KEY_NAME = "keyName";
-    private final Map<String, String> properties = new HashMap<>();
+    protected final Map<String, String> properties = new HashMap<>();
 
     protected DataAddress() {
     }
@@ -91,42 +92,47 @@ public class DataAddress {
     }
 
     @JsonPOJOBuilder(withPrefix = "")
-    public static class Builder {
-        protected final DataAddress address;
+    public static class Builder<DA extends DataAddress, B extends Builder<DA, B>> {
+        protected final DA address;
 
-        protected Builder(DataAddress address) {
+        protected Builder(DA address) {
             this.address = address;
         }
 
         @JsonCreator()
-        public static Builder newInstance() {
-            return new Builder(new DataAddress());
+        public static <B extends Builder<DataAddress, B>> Builder<DataAddress, B> newInstance() {
+            return new Builder<>(new DataAddress());
         }
 
-        public Builder type(String type) {
+        public B type(String type) {
             address.properties.put(TYPE, Objects.requireNonNull(type));
-            return this;
+            return self();
         }
 
-        public Builder property(String key, String value) {
+        public B property(String key, String value) {
             Objects.requireNonNull(key, "Property key null.");
             address.properties.put(key, value);
-            return this;
+            return self();
         }
 
-        public Builder properties(Map<String, String> properties) {
+        public B properties(Map<String, String> properties) {
             properties.forEach(this::property);
-            return this;
+            return self();
         }
 
-        public Builder keyName(String keyName) {
+        public B keyName(String keyName) {
             address.getProperties().put(KEY_NAME, Objects.requireNonNull(keyName));
-            return this;
+            return self();
         }
 
         public DataAddress build() {
             Objects.requireNonNull(address.getType(), "DataAddress builder missing Type property.");
             return address;
+        }
+
+        @SuppressWarnings("unchecked")
+        private B self() {
+            return (B) this;
         }
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/DataAddress.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/DataAddress.java
@@ -24,7 +24,6 @@ import org.jetbrains.annotations.NotNull;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import javax.xml.crypto.Data;
 
 /**
  * An address that can be used resolve a data location. Data addresses are used throughout the system. For example, an asset has a data address used to resolve its contents,

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/HttpDataAddress.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/HttpDataAddress.java
@@ -37,7 +37,7 @@ import static java.util.Collections.emptyMap;
 @JsonDeserialize(builder = DataAddress.Builder.class)
 public class HttpDataAddress extends DataAddress {
 
-    public static final String DATA_TYPE = "HttpData";
+    public static final String HTTP_DATA = "HttpData";
 
     private static final String NAME = "name";
     private static final String PATH = "path";
@@ -137,11 +137,11 @@ public class HttpDataAddress extends DataAddress {
     }
 
     @JsonPOJOBuilder(withPrefix = "")
-    public static final class Builder extends DataAddress.Builder {
+    public static final class Builder extends DataAddress.Builder<HttpDataAddress, Builder> {
 
         private Builder() {
             super(new HttpDataAddress());
-            this.type(DATA_TYPE);
+            this.type(HTTP_DATA);
         }
 
         @JsonCreator
@@ -230,8 +230,8 @@ public class HttpDataAddress extends DataAddress {
 
         @Override
         public HttpDataAddress build() {
-            this.type(DATA_TYPE);
-            return (HttpDataAddress) address;
+            this.type(HTTP_DATA);
+            return address;
         }
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/HttpDataAddress.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/HttpDataAddress.java
@@ -58,6 +58,7 @@ public class HttpDataAddress extends DataAddress {
 
     private HttpDataAddress() {
         super();
+        this.setType(HTTP_DATA);
     }
 
     @JsonIgnore
@@ -141,7 +142,6 @@ public class HttpDataAddress extends DataAddress {
 
         private Builder() {
             super(new HttpDataAddress());
-            this.type(HTTP_DATA);
         }
 
         @JsonCreator


### PR DESCRIPTION
## What this PR changes/adds

Introduce a new `DataAddressValidator` component, that takes case of validate any `DataAddress` that is going to be ingested by the system, currently in two different points: on `Asset` creation and on `TransferProcess` initialization.

Currently it validates the `baseUrl` field of `HttpData` data address, that must be a valid 

## Why it does that

To fail fast in case of not well formatted data addresses.

## Further notes

- this is a simple version, but it could be made extensible if needed to give the opportunity to add validation for other types of `DataAddress` (e.g. s3, gcs, ...)

## Linked Issue(s)

Closes #2235

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/pr_etiquette.md) for details_)
