### PR TITLE
chore(ContractValidationService): change return type of validateAgreement from boolean to Result

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessServiceImpl.java
@@ -144,7 +144,7 @@ public class TransferProcessServiceImpl implements TransferProcessService {
 
         return transactionContext.execute(() ->
                 Optional.ofNullable(negotiationStore.findContractAgreement(request.getContractId()))
-                        .filter(agreement -> contractValidationService.validateAgreement(claimToken, agreement))
+                        .filter(agreement -> contractValidationService.validateAgreement(claimToken, agreement).succeeded())
                         .map(agreement -> manager.initiateProviderRequest(request))
                         .filter(AbstractResult::succeeded)
                         .map(AbstractResult::getContent)

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessServiceImplTest.java
@@ -202,8 +202,9 @@ class TransferProcessServiceImplTest {
         var dataRequest = dataRequest();
         var claimToken = claimToken();
         var processId = "processId";
+
         when(negotiationStore.findContractAgreement(any())).thenReturn(contractAgreement());
-        when(validationService.validateAgreement(any(), any())).thenReturn(true);
+        when(validationService.validateAgreement(any(), any())).thenReturn(Result.success(null));
         when(manager.initiateProviderRequest(any())).thenReturn(StatusResult.success(processId));
         when(dataAddressValidator.validate(any())).thenReturn(Result.success());
 
@@ -219,7 +220,7 @@ class TransferProcessServiceImplTest {
         var dataRequest = dataRequest();
         var claimToken = claimToken();
         when(negotiationStore.findContractAgreement(any())).thenReturn(contractAgreement());
-        when(validationService.validateAgreement(any(), any())).thenReturn(false);
+        when(validationService.validateAgreement(any(), any())).thenReturn(Result.failure("error"));
         when(dataAddressValidator.validate(any())).thenReturn(Result.success());
 
         var result = service.initiateTransfer(dataRequest, claimToken);

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/client/MultipartDispatcherIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/client/MultipartDispatcherIntegrationTest.java
@@ -128,7 +128,7 @@ class MultipartDispatcherIntegrationTest {
                 .contractStartDate(Instant.now().getEpochSecond())
                 .contractEndDate(Instant.now().plus(1, ChronoUnit.DAYS).getEpochSecond())
                 .id("1:2").build());
-        when(validationService.validateAgreement(any(), any(ContractAgreement.class))).thenReturn(true);
+        when(validationService.validateAgreement(any(), any(ContractAgreement.class))).thenReturn(Result.success(null));
 
         var request = DataRequest.Builder.newInstance()
                 .connectorId(CONNECTOR_ID)

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/validation/ContractValidationService.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/validation/ContractValidationService.java
@@ -60,7 +60,7 @@ public interface ContractValidationService {
      * @param agreement The {@link ContractAgreement} between consumer and provider to validate
      * @return the result of the validation
      */
-    boolean validateAgreement(ClaimToken token, ContractAgreement agreement);
+    Result<ContractAgreement> validateAgreement(ClaimToken token, ContractAgreement agreement);
 
     /**
      * When the negotiation has been confirmed by the provider, the consumer must validate it ensuring that is the same
@@ -70,4 +70,5 @@ public interface ContractValidationService {
      * @param latestOffer The last {@link ContractOffer}
      */
     Result<Void> validateConfirmed(ContractAgreement agreement, ContractOffer latestOffer);
+
 }


### PR DESCRIPTION
…onding unit tests

## What this PR changes/adds

change the ValidateAgremment() return Type from boolean to Result<ContractAgreement>.

## Why it does that

The change was to get the corresponding information as a user during the validation of the agreement.
## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #2211

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/pr_etiquette.md) for details_)
