### PR TITLE
refactor: move `control` api endpoints under `control` context

### DIFF
--- a/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/CoreServicesExtension.java
+++ b/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/CoreServicesExtension.java
@@ -54,7 +54,6 @@ import java.time.Duration;
 
 @BaseExtension
 @Provides({
-        HealthCheckService.class,
         Monitor.class,
         TypeManager.class,
         Clock.class,

--- a/core/control-plane/control-plane-api-client/src/test/java/org/eclipse/edc/connector/api/client/transferprocess/TransferProcessHttpClientIntegrationTest.java
+++ b/core/control-plane/control-plane-api-client/src/test/java/org/eclipse/edc/connector/api/client/transferprocess/TransferProcessHttpClientIntegrationTest.java
@@ -43,7 +43,6 @@ import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.eclipse.edc.connector.api.ControlPlaneApiExtension.DEFAULT_CONTROL_PLANE_API_CONTEXT_PATH;
 import static org.eclipse.edc.connector.transfer.spi.types.TransferProcessStates.COMPLETED;
 import static org.eclipse.edc.connector.transfer.spi.types.TransferProcessStates.ERROR;
 import static org.eclipse.edc.junit.testfixtures.TestUtils.getFreePort;
@@ -54,23 +53,18 @@ import static org.mockito.Mockito.when;
 @ExtendWith(EdcExtension.class)
 public class TransferProcessHttpClientIntegrationTest {
 
-    private final String authKey = "123456";
     private final int port = getFreePort();
-
-    private TransferService service;
+    private final TransferService service = mock(TransferService.class);
 
     @BeforeEach
     void setUp(EdcExtension extension) {
-
-        service = mock(TransferService.class);
         when(service.canHandle(any())).thenReturn(true);
-
 
         extension.setConfiguration(Map.of(
                 "web.http.port", String.valueOf(getFreePort()),
                 "web.http.path", "/api",
-                "web.http.controlplane.port", String.valueOf(port),
-                "web.http.controlplane.path", DEFAULT_CONTROL_PLANE_API_CONTEXT_PATH
+                "web.http.control.port", String.valueOf(port),
+                "web.http.control.path", "/control"
         ));
 
         extension.registerSystemExtension(ServiceExtension.class, new TransferServiceMockExtension(service));
@@ -89,7 +83,6 @@ public class TransferProcessHttpClientIntegrationTest {
                     .extracting(StatefulEntity::getState).isEqualTo(COMPLETED.code());
         });
     }
-
 
     @Test
     void shouldCallTransferProcessApiWithFailed(TransferProcessStore store, DataPlaneManager manager, ControlPlaneApiUrl callbackUrl) {

--- a/core/control-plane/control-plane-api/build.gradle.kts
+++ b/core/control-plane/control-plane-api/build.gradle.kts
@@ -23,12 +23,11 @@ dependencies {
     api(project(":spi:control-plane:control-plane-api-client-spi"))
     api(project(":spi:common:web-spi"))
     api(project(":spi:common:auth-spi"))
-
+    implementation(project(":extensions:common:api:control-api-configuration"))
 
     implementation(libs.jakarta.rsApi)
     implementation(libs.jakarta.validation)
     implementation(libs.jersey.beanvalidation) //for validation
-
 
     testImplementation(project(":core:control-plane:control-plane-core"))
     testImplementation(project(":extensions:common:http"))
@@ -36,9 +35,7 @@ dependencies {
     testImplementation(project(":extensions:common:auth:auth-tokenbased"))
     testImplementation(libs.restAssured)
     testImplementation(libs.awaitility)
-
 }
-
 
 publishing {
     publications {

--- a/core/control-plane/control-plane-api/src/main/java/org/eclipse/edc/connector/api/ControlPlaneApiExtension.java
+++ b/core/control-plane/control-plane-api/src/main/java/org/eclipse/edc/connector/api/ControlPlaneApiExtension.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.connector.api;
 
+import org.eclipse.edc.connector.api.control.configuration.ControlApiConfiguration;
 import org.eclipse.edc.connector.api.transferprocess.TransferProcessControlApiController;
 import org.eclipse.edc.connector.api.transferprocess.model.TransferProcessFailStateDto;
 import org.eclipse.edc.connector.spi.transferprocess.TransferProcessService;
@@ -35,6 +36,8 @@ import org.jetbrains.annotations.NotNull;
 import java.net.MalformedURLException;
 import java.net.URL;
 
+import static java.lang.String.format;
+
 /**
  * {@link ControlPlaneApiExtension } exposes HTTP endpoints for internal interaction with the Control Plane
  */
@@ -43,13 +46,29 @@ public class ControlPlaneApiExtension implements ServiceExtension {
 
     public static final String NAME = "Control Plane API";
 
-    public static final String CONTROL_PLANE_API_CONFIG = "web.http.controlplane";
-    public static final String CONTROL_PLANE_CONTEXT_ALIAS = "controlplane";
-    public static final int DEFAULT_CONTROL_PLANE_API_PORT = 8384;
-    public static final String DEFAULT_CONTROL_PLANE_API_CONTEXT_PATH = "/api/v1/controlplane";
+    private static final String DEPRECATED_CONTROLPANE_CONFIG_GROUP = "web.http.controlplane";
+    private static final String CONTROL_PLANE_CONTEXT_ALIAS = "controlplane";
+    private static final int DEFAULT_CONTROL_PLANE_API_PORT = 8384;
+    private static final String DEFAULT_CONTROL_PLANE_API_CONTEXT_PATH = "/api/v1/controlplane";
+
+    /**
+     * This deprecation is used to permit a softer transition from the deprecated `web.http.controlpane` config group to
+     * the current `web.http.control`
+     *
+     * @deprecated "web.http.control" config should be used instead of "web.http.controlplane"
+     */
+    @Deprecated(since = "milestone8")
+    public static final WebServiceSettings DEPRECATED_SETTINGS = WebServiceSettings.Builder.newInstance()
+            .apiConfigKey(DEPRECATED_CONTROLPANE_CONFIG_GROUP)
+            .contextAlias(CONTROL_PLANE_CONTEXT_ALIAS)
+            .defaultPath(DEFAULT_CONTROL_PLANE_API_CONTEXT_PATH)
+            .defaultPort(DEFAULT_CONTROL_PLANE_API_PORT)
+            .name(NAME)
+            .build();
 
     @Inject
     private WebServer webServer;
+
     @Inject
     private WebService webService;
 
@@ -62,7 +81,10 @@ public class ControlPlaneApiExtension implements ServiceExtension {
     @Inject
     private TransferProcessService transferProcessService;
 
-    private WebServiceConfiguration configuration;
+    @Inject
+    private ControlApiConfiguration controlApiConfiguration;
+
+    private WebServiceConfiguration webServiceConfiguration;
 
     @Override
     public String name() {
@@ -71,20 +93,19 @@ public class ControlPlaneApiExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var settings = WebServiceSettings.Builder.newInstance()
-                .apiConfigKey(CONTROL_PLANE_API_CONFIG)
-                .contextAlias(CONTROL_PLANE_CONTEXT_ALIAS)
-                .defaultPath(DEFAULT_CONTROL_PLANE_API_CONTEXT_PATH)
-                .defaultPort(DEFAULT_CONTROL_PLANE_API_PORT)
-                .name(NAME)
-                .build();
+        if (context.getConfig().hasPath(DEPRECATED_CONTROLPANE_CONFIG_GROUP)) {
+            webServiceConfiguration = configurator.configure(context, webServer, DEPRECATED_SETTINGS);
+            context.getMonitor().warning(
+                    format("Deprecated settings group %s is being used for Control API configuration, please switch to the new group %s",
+                            DEPRECATED_SETTINGS.apiConfigKey(), "web.http." + controlApiConfiguration.getContextAlias()));
+        } else {
+            webServiceConfiguration = controlApiConfiguration;
+        }
 
-        configuration = configurator.configure(context, webServer, settings);
         context.getTypeManager().registerTypes(TransferProcessFailStateDto.class);
 
-        webService.registerResource(configuration.getContextAlias(), new TransferProcessControlApiController(transferProcessService));
+        webService.registerResource(webServiceConfiguration.getContextAlias(), new TransferProcessControlApiController(transferProcessService));
     }
-
 
     @Provider
     public ControlPlaneApiUrl controlPlaneApiUrl(ServiceExtensionContext context) {
@@ -100,8 +121,7 @@ public class ControlPlaneApiExtension implements ServiceExtension {
 
     @NotNull
     private String getApiUrl() {
-        return String.format("http://%s:%s%s", hostname.get(), configuration.getPort(), configuration.getPath());
+        return String.format("http://%s:%s%s", hostname.get(), webServiceConfiguration.getPort(), webServiceConfiguration.getPath());
     }
-
 
 }

--- a/core/control-plane/control-plane-api/src/test/java/org/eclipse/edc/connector/api/ControlPlaneApiExtensionTest.java
+++ b/core/control-plane/control-plane-api/src/test/java/org/eclipse/edc/connector/api/ControlPlaneApiExtensionTest.java
@@ -1,0 +1,108 @@
+/*
+ *  Copyright (c) 2020 - 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api;
+
+import org.eclipse.edc.api.auth.spi.AuthenticationRequestFilter;
+import org.eclipse.edc.api.auth.spi.AuthenticationService;
+import org.eclipse.edc.connector.api.control.configuration.ControlApiConfiguration;
+import org.eclipse.edc.connector.api.transferprocess.TransferProcessControlApiController;
+import org.eclipse.edc.connector.spi.transferprocess.TransferProcessService;
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.system.Hostname;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+import org.eclipse.edc.spi.system.injection.ObjectFactory;
+import org.eclipse.edc.web.spi.WebServer;
+import org.eclipse.edc.web.spi.WebService;
+import org.eclipse.edc.web.spi.configuration.WebServiceConfiguration;
+import org.eclipse.edc.web.spi.configuration.WebServiceConfigurer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.net.URL;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(DependencyInjectionExtension.class)
+class ControlPlaneApiExtensionTest {
+
+    private ServiceExtensionContext context;
+    private final WebServer webServer = mock(WebServer.class);
+    private final WebService webService = mock(WebService.class);
+    private final Monitor monitor = mock(Monitor.class);
+    private final WebServiceConfigurer webServiceConfigurer = mock(WebServiceConfigurer.class);
+
+    private ControlPlaneApiExtension extension;
+
+    @BeforeEach
+    void setup(ServiceExtensionContext context, ObjectFactory factory) {
+        var webServiceConfiguration = WebServiceConfiguration.Builder.newInstance()
+                .contextAlias("control")
+                .path("/control")
+                .port(8888)
+                .build();
+        context.registerService(WebServer.class, webServer);
+        context.registerService(WebService.class, webService);
+        context.registerService(Hostname.class, () -> "localhost");
+        context.registerService(TransferProcessService.class, mock(TransferProcessService.class));
+        context.registerService(AuthenticationService.class, mock(AuthenticationService.class));
+        context.registerService(WebServiceConfigurer.class, webServiceConfigurer);
+        context.registerService(ControlApiConfiguration.class, new ControlApiConfiguration(webServiceConfiguration));
+
+        this.context = spy(context); //used to inject the config
+        when(this.context.getMonitor()).thenReturn(monitor);
+
+        extension = factory.constructInstance(ControlPlaneApiExtension.class);
+    }
+
+    @Test
+    void initialize_shouldBeRegisteredAsControlApiService() {
+        when(context.getConfig()).thenReturn(ConfigFactory.empty());
+
+        extension.initialize(context);
+
+        verify(webService).registerResource(eq("control"), isA(TransferProcessControlApiController.class));
+        verifyNoInteractions(webServiceConfigurer);
+        verifyNoMoreInteractions(webServer, webService);
+    }
+
+    @Test
+    void initialize_shouldUseDeprecatedSettings_whenProvisionerSettingsGroupExists() {
+        var config = ConfigFactory.fromMap(Map.of("web.http.controlplane.path", "/api/v1/someotherpath/webhook"));
+        when(context.getConfig()).thenReturn(config);
+        when(context.getConfig("web.http.controlplane")).thenReturn(config.getConfig("web.http.controlplane"));
+        var webServiceConfiguration = WebServiceConfiguration.Builder.newInstance().contextAlias("controlplane").port(9999).path("/any").build();
+        when(webServiceConfigurer.configure(any(), any(), any())).thenReturn(webServiceConfiguration);
+
+        extension.initialize(context);
+
+        verify(webService).registerResource(eq("controlplane"), isA(TransferProcessControlApiController.class));
+        verify(monitor).warning(anyString());
+    }
+}

--- a/core/control-plane/control-plane-api/src/test/java/org/eclipse/edc/connector/api/ControlPlaneApiExtensionTest.java
+++ b/core/control-plane/control-plane-api/src/test/java/org/eclipse/edc/connector/api/ControlPlaneApiExtensionTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.connector.api;
 
-import org.eclipse.edc.api.auth.spi.AuthenticationRequestFilter;
 import org.eclipse.edc.api.auth.spi.AuthenticationService;
 import org.eclipse.edc.connector.api.control.configuration.ControlApiConfiguration;
 import org.eclipse.edc.connector.api.transferprocess.TransferProcessControlApiController;
@@ -33,11 +32,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.net.URL;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;

--- a/core/control-plane/control-plane-api/src/test/java/org/eclipse/edc/connector/api/TransferProcessControlApiControllerIntegrationTest.java
+++ b/core/control-plane/control-plane-api/src/test/java/org/eclipse/edc/connector/api/TransferProcessControlApiControllerIntegrationTest.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.eclipse.edc.connector.api.ControlPlaneApiExtension.DEFAULT_CONTROL_PLANE_API_CONTEXT_PATH;
 import static org.eclipse.edc.connector.transfer.spi.types.TransferProcessStates.COMPLETED;
 import static org.eclipse.edc.connector.transfer.spi.types.TransferProcessStates.ERROR;
 import static org.eclipse.edc.junit.testfixtures.TestUtils.getFreePort;
@@ -49,16 +48,14 @@ class TransferProcessControlApiControllerIntegrationTest {
         extension.setConfiguration(Map.of(
                 "web.http.port", String.valueOf(getFreePort()),
                 "web.http.path", "/api",
-                "web.http.controlplane.port", String.valueOf(port),
-                "web.http.controlplane.path", DEFAULT_CONTROL_PLANE_API_CONTEXT_PATH
+                "web.http.control.port", String.valueOf(port),
+                "web.http.control.path", "/"
         ));
     }
 
     @Test
     void callTransferProcessHookWithComplete(TransferProcessStore store) {
-
         store.save(createTransferProcess());
-
 
         baseRequest()
                 .contentType("application/json")
@@ -77,7 +74,6 @@ class TransferProcessControlApiControllerIntegrationTest {
 
     @Test
     void callTransferProcessHookWithError(TransferProcessStore store) {
-
         store.save(createTransferProcess());
 
         var rq = TransferProcessFailStateDto.Builder.newInstance()
@@ -147,7 +143,6 @@ class TransferProcessControlApiControllerIntegrationTest {
 
     @Test
     void callCompleteTransferProcessHook_invalidState(TransferProcessStore store) {
-
         store.save(createTransferProcessBuilder().state(ERROR.code()).build());
 
         var rq = TransferProcessFailStateDto.Builder.newInstance()
@@ -160,7 +155,6 @@ class TransferProcessControlApiControllerIntegrationTest {
                 .then()
                 .statusCode(409);
     }
-
 
     private TransferProcess createTransferProcess() {
         return createTransferProcessBuilder().build();
@@ -179,9 +173,7 @@ class TransferProcessControlApiControllerIntegrationTest {
     private RequestSpecification baseRequest() {
         return given()
                 .baseUri("http://localhost:" + port)
-                .basePath(DEFAULT_CONTROL_PLANE_API_CONTEXT_PATH)
                 .when();
     }
-
 
 }

--- a/extensions/common/api/control-api-configuration/README.md
+++ b/extensions/common/api/control-api-configuration/README.md
@@ -1,0 +1,13 @@
+# Control API Configuration
+
+This module provides central configuration for all Control APIs, i.e. the `ControlApiConfiguration`, which
+currently only contains the context alias, which all the Control API controllers should be registered under.
+
+## Configurations
+
+Exemplary configuration:
+
+```properties
+web.http.control.port=9191
+web.http.control.path=/api/v1/control
+```

--- a/extensions/common/api/control-api-configuration/build.gradle.kts
+++ b/extensions/common/api/control-api-configuration/build.gradle.kts
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation and others
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *       ZF Friedrichshafen AG - Remove token-based default auth mechanism
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    implementation(project(":extensions:common:api:api-core"))
+
+    testImplementation(project(":core:common:junit"))
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("management-api-configuration") {
+            artifactId = "management-api-configuration"
+            from(components["java"])
+        }
+    }
+}

--- a/extensions/common/api/control-api-configuration/build.gradle.kts
+++ b/extensions/common/api/control-api-configuration/build.gradle.kts
@@ -25,8 +25,8 @@ dependencies {
 
 publishing {
     publications {
-        create<MavenPublication>("management-api-configuration") {
-            artifactId = "management-api-configuration"
+        create<MavenPublication>("control-api-configuration") {
+            artifactId = "control-api-configuration"
             from(components["java"])
         }
     }

--- a/extensions/common/api/control-api-configuration/src/main/java/org/eclipse/edc/connector/api/control/configuration/ControlApiConfiguration.java
+++ b/extensions/common/api/control-api-configuration/src/main/java/org/eclipse/edc/connector/api/control/configuration/ControlApiConfiguration.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2020 - 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.control.configuration;
+
+import org.eclipse.edc.web.spi.configuration.WebServiceConfiguration;
+
+public class ControlApiConfiguration extends WebServiceConfiguration {
+
+    public ControlApiConfiguration(String contextAlias) {
+        super();
+        this.contextAlias = contextAlias;
+    }
+
+    public ControlApiConfiguration(WebServiceConfiguration webServiceConfiguration) {
+        this.contextAlias = webServiceConfiguration.getContextAlias();
+        this.path = webServiceConfiguration.getPath();
+        this.port = webServiceConfiguration.getPort();
+    }
+
+}

--- a/extensions/common/api/control-api-configuration/src/main/java/org/eclipse/edc/connector/api/control/configuration/ControlApiConfigurationExtension.java
+++ b/extensions/common/api/control-api-configuration/src/main/java/org/eclipse/edc/connector/api/control/configuration/ControlApiConfigurationExtension.java
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (c) 2020 - 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.control.configuration;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.runtime.metamodel.annotation.Provides;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.web.spi.WebServer;
+import org.eclipse.edc.web.spi.configuration.WebServiceConfigurer;
+import org.eclipse.edc.web.spi.configuration.WebServiceSettings;
+
+/**
+ * Tells all the Control API controllers under which context alias they need to register their resources: either
+ * `default` or `control`
+ */
+@Provides(ControlApiConfiguration.class)
+@Extension(value = ControlApiConfigurationExtension.NAME)
+public class ControlApiConfigurationExtension implements ServiceExtension {
+
+    public static final String NAME = "Control API configuration";
+
+    private static final String WEB_SERVICE_NAME = "Control API";
+    private static final String CONTROL_CONTEXT_ALIAS = "control";
+    private static final int DEFAULT_CONTROL_API_PORT = 9191;
+    private static final String DEFAULT_CONTROL_API_CONTEXT_PATH = "/api/v1/control";
+
+    @Inject
+    private WebServer webServer;
+
+    @Inject
+    private WebServiceConfigurer configurator;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Provider
+    public ControlApiConfiguration controlApiConfiguration(ServiceExtensionContext context) {
+        var settings = WebServiceSettings.Builder.newInstance()
+                .apiConfigKey("web.http." + CONTROL_CONTEXT_ALIAS)
+                .contextAlias(CONTROL_CONTEXT_ALIAS)
+                .defaultPath(DEFAULT_CONTROL_API_CONTEXT_PATH)
+                .defaultPort(DEFAULT_CONTROL_API_PORT)
+                .useDefaultContext(true)
+                .name(WEB_SERVICE_NAME)
+                .build();
+
+        var webServiceConfiguration = configurator.configure(context, webServer, settings);
+
+        return new ControlApiConfiguration(webServiceConfiguration);
+    }
+}

--- a/extensions/common/api/control-api-configuration/src/main/java/org/eclipse/edc/connector/api/control/configuration/ControlApiConfigurationExtension.java
+++ b/extensions/common/api/control-api-configuration/src/main/java/org/eclipse/edc/connector/api/control/configuration/ControlApiConfigurationExtension.java
@@ -17,7 +17,6 @@ package org.eclipse.edc.connector.api.control.configuration;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
-import org.eclipse.edc.runtime.metamodel.annotation.Provides;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.web.spi.WebServer;
@@ -28,7 +27,6 @@ import org.eclipse.edc.web.spi.configuration.WebServiceSettings;
  * Tells all the Control API controllers under which context alias they need to register their resources: either
  * `default` or `control`
  */
-@Provides(ControlApiConfiguration.class)
 @Extension(value = ControlApiConfigurationExtension.NAME)
 public class ControlApiConfigurationExtension implements ServiceExtension {
 

--- a/extensions/common/api/control-api-configuration/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/common/api/control-api-configuration/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2020 - 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+#
+#
+
+org.eclipse.edc.connector.api.control.configuration.ControlApiConfigurationExtension

--- a/extensions/common/http/jetty-core/src/main/java/org/eclipse/edc/web/jetty/JettyService.java
+++ b/extensions/common/http/jetty-core/src/main/java/org/eclipse/edc/web/jetty/JettyService.java
@@ -69,7 +69,7 @@ public class JettyService implements WebServer {
         this.monitor = monitor;
         System.setProperty(LOG_ANNOUNCE, "false");
         // for websocket endpoints
-        handlers.put("/", new ServletContextHandler(null, "/", NO_SESSIONS));
+//        handlers.put("/", new ServletContextHandler(null, "/", NO_SESSIONS));
     }
 
     public void start() {
@@ -136,7 +136,9 @@ public class JettyService implements WebServer {
 
         var servletHandler = getOrCreate(actualPath).getServletHandler();
         servletHandler.addServletWithMapping(servletHolder, actualPath);
-        servletHandler.addServletWithMapping(servletHolder, actualPath + "/*");
+
+        var allPathSpec = actualPath.endsWith("/") ? "*" : "/*";
+        servletHandler.addServletWithMapping(servletHolder, actualPath + allPathSpec);
     }
 
     /**

--- a/extensions/common/http/jetty-core/src/main/java/org/eclipse/edc/web/jetty/JettyService.java
+++ b/extensions/common/http/jetty-core/src/main/java/org/eclipse/edc/web/jetty/JettyService.java
@@ -69,7 +69,7 @@ public class JettyService implements WebServer {
         this.monitor = monitor;
         System.setProperty(LOG_ANNOUNCE, "false");
         // for websocket endpoints
-//        handlers.put("/", new ServletContextHandler(null, "/", NO_SESSIONS));
+        handlers.put("/", new ServletContextHandler(null, "/", NO_SESSIONS));
     }
 
     public void start() {

--- a/extensions/common/http/jetty-core/src/test/java/org/eclipse/edc/web/jetty/JettyServiceTest.java
+++ b/extensions/common/http/jetty-core/src/test/java/org/eclipse/edc/web/jetty/JettyServiceTest.java
@@ -127,6 +127,20 @@ class JettyServiceTest {
     }
 
     @Test
+    void verifyCustomPathRoot() {
+        var config = ConfigFactory.fromMap(Map.of(
+                "web.http.port", "7171",
+                "web.http.path", "/"));
+        jettyService = new JettyService(JettyConfiguration.createFromConfig(null, null, config), monitor);
+
+        jettyService.start();
+
+        jettyService.registerServlet("default", new ServletContainer(createTestResource()));
+
+        assertThat(executeRequest("http://localhost:7171/test/resource").code()).isEqualTo(200);
+    }
+
+    @Test
     void verifyInvalidPathSpecThrowsException() {
         var config = ConfigFactory.fromMap(Map.of(
                 "web.http.port", "7171",

--- a/extensions/control-plane/data-plane-transfer/data-plane-transfer-sync/build.gradle.kts
+++ b/extensions/control-plane/data-plane-transfer/data-plane-transfer-sync/build.gradle.kts
@@ -22,12 +22,12 @@ dependencies {
     api(project(":spi:control-plane:contract-spi"))
     api(project(":spi:control-plane:transfer-spi"))
     api(project(":spi:common:web-spi"))
-
     api(project(":spi:control-plane:data-plane-transfer-spi"))
     api(project(":spi:data-plane:data-plane-spi"))
     api(project(":spi:data-plane-selector:data-plane-selector-spi"))
 
     implementation(project(":core:common:jwt-core"))
+    implementation(project(":extensions:common:api:control-api-configuration"))
 
     api(libs.jakarta.rsApi)
     api(libs.nimbus.jwt)
@@ -35,6 +35,7 @@ dependencies {
     // https://www.javadoc.io/doc/com.nimbusds/nimbus-jose-jwt/7.2.1/com/nimbusds/jose/jwk/JWK.html#parseFromPEMEncodedObjects-java.lang.String-
     api(libs.bouncyCastle.bcpkix)
 
+    testImplementation(project(":core:common:junit"))
     testImplementation(libs.jersey.multipart)
 }
 

--- a/extensions/data-plane/data-plane-api/build.gradle.kts
+++ b/extensions/data-plane/data-plane-api/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     api(project(":spi:common:web-spi"))
     api(project(":spi:data-plane:data-plane-spi"))
     implementation(project(":core:data-plane:data-plane-util"))
+    implementation(project(":extensions:common:api:control-api-configuration"))
 
     implementation(libs.okhttp)
     implementation(libs.jakarta.rsApi)

--- a/extensions/data-plane/data-plane-api/src/main/java/org/eclipse/edc/connector/dataplane/api/DataPlaneApiExtension.java
+++ b/extensions/data-plane/data-plane-api/src/main/java/org/eclipse/edc/connector/dataplane/api/DataPlaneApiExtension.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.connector.dataplane.api;
 
 import okhttp3.OkHttpClient;
+import org.eclipse.edc.connector.api.control.configuration.ControlApiConfiguration;
 import org.eclipse.edc.connector.dataplane.api.controller.DataPlaneControlApiController;
 import org.eclipse.edc.connector.dataplane.api.controller.DataPlanePublicApiController;
 import org.eclipse.edc.connector.dataplane.api.validation.TokenValidationClientImpl;
@@ -39,7 +40,6 @@ public class DataPlaneApiExtension implements ServiceExtension {
     public static final String NAME = "Data Plane API";
     @Setting
     private static final String CONTROL_PLANE_VALIDATION_ENDPOINT = "edc.dataplane.token.validation.endpoint";
-    private static final String CONTROL = "control";
     private static final String PUBLIC = "public";
     @Inject
     private DataPlaneManager dataPlaneManager;
@@ -49,6 +49,9 @@ public class DataPlaneApiExtension implements ServiceExtension {
 
     @Inject
     private OkHttpClient httpClient;
+
+    @Inject
+    private ControlApiConfiguration controlApiConfiguration;
 
     @Override
     public String name() {
@@ -67,7 +70,7 @@ public class DataPlaneApiExtension implements ServiceExtension {
         var executorService = context.getService(ExecutorInstrumentation.class)
                 .instrument(Executors.newSingleThreadExecutor(), DataPlanePublicApiController.class.getSimpleName());
 
-        webService.registerResource(CONTROL, new DataPlaneControlApiController(dataPlaneManager));
+        webService.registerResource(controlApiConfiguration.getContextAlias(), new DataPlaneControlApiController(dataPlaneManager));
 
         var publicApiController = new DataPlanePublicApiController(dataPlaneManager, tokenValidationClient, monitor, executorService);
         webService.registerResource(PUBLIC, publicApiController);

--- a/resources/openapi/openapi.yaml
+++ b/resources/openapi/openapi.yaml
@@ -22,6 +22,250 @@ tags:
     \ path parameters and request body are supported (in the limits fixed by the HTTP\
     \ server) and can also conveyed to the actual data source."
 paths:
+  /check/health:
+    get:
+      tags:
+      - Application Observability
+      description: Performs a liveness probe to determine whether the runtime is working
+        properly.
+      operationId: checkHealth
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HealthStatus'
+  /check/liveness:
+    get:
+      tags:
+      - Application Observability
+      description: Performs a liveness probe to determine whether the runtime is working
+        properly.
+      operationId: getLiveness
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HealthStatus'
+  /check/readiness:
+    get:
+      tags:
+      - Application Observability
+      description: Performs a readiness probe to determine whether the runtime is
+        able to accept requests.
+      operationId: getReadiness
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HealthStatus'
+  /check/startup:
+    get:
+      tags:
+      - Application Observability
+      description: Performs a startup probe to determine whether the runtime has completed
+        startup.
+      operationId: getStartup
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HealthStatus'
+  /contractagreements:
+    get:
+      tags:
+      - Contract Agreement
+      description: Gets all contract agreements according to a particular query
+      operationId: getAllAgreements
+      parameters:
+      - name: offset
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: limit
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: filter
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      - name: sort
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+          enum:
+          - ASC
+          - DESC
+      - name: sortField
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ContractAgreementDto'
+        "400":
+          description: Request body was malformed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+      deprecated: true
+  /contractagreements/request:
+    post:
+      tags:
+      - Contract Agreement
+      description: Gets all contract agreements according to a particular query
+      operationId: queryAllAgreements
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: '#/components/schemas/QuerySpecDto'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ContractAgreementDto'
+        "400":
+          description: Request body was malformed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /contractagreements/{id}:
+    get:
+      tags:
+      - Contract Agreement
+      description: Gets an contract agreement with the given ID
+      operationId: getContractAgreement
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: The contract agreement
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContractAgreementDto'
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "404":
+          description: An contract agreement with the given ID does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /transferprocess/{processId}/complete:
+    post:
+      tags:
+      - Transfer Process Control Api
+      description: "Requests completion of the transfer process. Due to the asynchronous\
+        \ nature of transfers, a successful response only indicates that the request\
+        \ was successfully received"
+      operationId: complete
+      parameters:
+      - name: processId
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /transferprocess/{processId}/fail:
+    post:
+      tags:
+      - Transfer Process Control Api
+      description: "Requests completion of the transfer process. Due to the asynchronous\
+        \ nature of transfers, a successful response only indicates that the request\
+        \ was successfully received"
+      operationId: fail
+      parameters:
+      - name: processId
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TransferProcessFailStateDto'
+        required: true
+      responses:
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
   /catalog:
     get:
       tags:
@@ -419,6 +663,170 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ApiErrorDetail'
+  /callback/{processId}/deprovision:
+    post:
+      tags:
+      - HTTP Provisioner Webhook
+      operationId: callDeprovisionWebhook
+      parameters:
+      - name: processId
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeprovisionedResource'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /callback/{processId}/provision:
+    post:
+      tags:
+      - HTTP Provisioner Webhook
+      operationId: callProvisionWebhook
+      parameters:
+      - name: processId
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProvisionerWebhookRequest'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /token:
+    get:
+      tags:
+      - Token Validation
+      description: "Checks that the provided token has been signed by the present\
+        \ entity and asserts its validity. If token is valid, then the data address\
+        \ contained in its claims is decrypted and returned back to the caller."
+      operationId: validate
+      parameters:
+      - name: Authorization
+        in: header
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Token is valid
+        "400":
+          description: Request was malformed
+        "403":
+          description: Token is invalid
+  /transfer:
+    post:
+      tags:
+      - Data Plane control API
+      description: Initiates a data transfer for the given request. The transfer will
+        be performed asynchronously.
+      operationId: initiateTransfer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DataFlowRequest'
+      responses:
+        "200":
+          description: Data transfer initiated
+        "400":
+          description: Failed to validate request
+  /transfer/{processId}:
+    get:
+      tags:
+      - Data Plane control API
+      description: Get the current state of a data transfer.
+      operationId: getTransferState
+      parameters:
+      - name: processId
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Missing access token
+  /{any}:
+    get:
+      tags:
+      - Data Plane public API
+      description: Send `GET` data query to the Data Plane.
+      operationId: get
+      responses:
+        "400":
+          description: Missing access token
+        "403":
+          description: Access token is expired or invalid
+        "500":
+          description: Failed to transfer data
+    put:
+      tags:
+      - Data Plane public API
+      description: Send `PUT` data query to the Data Plane.
+      operationId: put
+      responses:
+        "400":
+          description: Missing access token
+        "403":
+          description: Access token is expired or invalid
+        "500":
+          description: Failed to transfer data
+    post:
+      tags:
+      - Data Plane public API
+      description: Send `POST` data query to the Data Plane.
+      operationId: post
+      responses:
+        "400":
+          description: Missing access token
+        "403":
+          description: Access token is expired or invalid
+        "500":
+          description: Failed to transfer data
+    delete:
+      tags:
+      - Data Plane public API
+      description: Send `DELETE` data query to the Data Plane.
+      operationId: delete
+      responses:
+        "400":
+          description: Missing access token
+        "403":
+          description: Access token is expired or invalid
+        "500":
+          description: Failed to transfer data
+    patch:
+      tags:
+      - Data Plane public API
+      description: Send `PATCH` data query to the Data Plane.
+      operationId: patch
+      responses:
+        "400":
+          description: Missing access token
+        "403":
+          description: Access token is expired or invalid
+        "500":
+          description: Failed to transfer data
   /contractdefinitions:
     get:
       tags:
@@ -617,58 +1025,12 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ApiErrorDetail'
-  /callback/{processId}/deprovision:
-    post:
-      tags:
-      - HTTP Provisioner Webhook
-      operationId: callDeprovisionWebhook
-      parameters:
-      - name: processId
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DeprovisionedResource'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /callback/{processId}/provision:
-    post:
-      tags:
-      - HTTP Provisioner Webhook
-      operationId: callProvisionWebhook
-      parameters:
-      - name: processId
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ProvisionerWebhookRequest'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /contractagreements:
+  /policydefinitions:
     get:
       tags:
-      - Contract Agreement
-      description: Gets all contract agreements according to a particular query
-      operationId: getAllAgreements
+      - Policy
+      description: Returns all policy definitions according to a query
+      operationId: getAllPolicies
       parameters:
       - name: offset
         in: query
@@ -717,7 +1079,34 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ContractAgreementDto'
+                  $ref: '#/components/schemas/PolicyDefinitionResponseDto'
+        "400":
+          description: Request was malformed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+      deprecated: true
+    post:
+      tags:
+      - Policy
+      description: Creates a new policy definition
+      operationId: createPolicy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PolicyDefinitionRequestDto'
+      responses:
+        "200":
+          description: policy definition was created successfully. Returns the Policy
+            Definition Id and created timestamp
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdResponseDto'
         "400":
           description: Request body was malformed
           content:
@@ -726,16 +1115,24 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ApiErrorDetail'
-      deprecated: true
-  /contractagreements/request:
+        "409":
+          description: "Could not create policy definition, because a contract definition\
+            \ with that ID already exists"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /policydefinitions/request:
     post:
       tags:
-      - Contract Agreement
-      description: Gets all contract agreements according to a particular query
-      operationId: queryAllAgreements
+      - Policy
+      description: Returns all policy definitions according to a query
+      operationId: queryAllPolicies
       requestBody:
         content:
-          '*/*':
+          application/json:
             schema:
               $ref: '#/components/schemas/QuerySpecDto'
       responses:
@@ -745,21 +1142,21 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ContractAgreementDto'
+                  $ref: '#/components/schemas/PolicyDefinitionResponseDto'
         "400":
-          description: Request body was malformed
+          description: Request was malformed
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/ApiErrorDetail'
-  /contractagreements/{id}:
+  /policydefinitions/{id}:
     get:
       tags:
-      - Contract Agreement
-      description: Gets an contract agreement with the given ID
-      operationId: getContractAgreement
+      - Policy
+      description: Gets a policy definition with the given ID
+      operationId: getPolicy
       parameters:
       - name: id
         in: path
@@ -770,11 +1167,11 @@ paths:
           type: string
       responses:
         "200":
-          description: The contract agreement
+          description: The  policy definition
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ContractAgreementDto'
+                $ref: '#/components/schemas/PolicyDefinitionResponseDto'
         "400":
           description: "Request was malformed, e.g. id was null"
           content:
@@ -784,7 +1181,260 @@ paths:
                 items:
                   $ref: '#/components/schemas/ApiErrorDetail'
         "404":
-          description: An contract agreement with the given ID does not exist
+          description: An  policy definition with the given ID does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+    delete:
+      tags:
+      - Policy
+      description: "Removes a policy definition with the given ID if possible. Deleting\
+        \ a policy definition is only possible if that policy definition is not yet\
+        \ referenced by a contract definition, in which case an error is returned.\
+        \ DANGER ZONE: Note that deleting policy definitions can have unexpected results,\
+        \ do this at your own risk!"
+      operationId: deletePolicy
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Policy definition was deleted successfully
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "404":
+          description: An policy definition with the given ID does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "409":
+          description: "The policy definition cannot be deleted, because it is referenced\
+            \ by a contract definition"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /assets:
+    get:
+      tags:
+      - Asset
+      description: Gets all assets according to a particular query
+      operationId: getAllAssets
+      parameters:
+      - name: offset
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: limit
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: filter
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      - name: sort
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+          enum:
+          - ASC
+          - DESC
+      - name: sortField
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AssetResponseDto'
+        "400":
+          description: Request body was malformed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+      deprecated: true
+    post:
+      tags:
+      - Asset
+      description: Creates a new asset together with a data address
+      operationId: createAsset
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssetEntryDto'
+      responses:
+        "200":
+          description: Asset was created successfully. Returns the asset Id and created
+            timestamp
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdResponseDto'
+        "400":
+          description: Request body was malformed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "409":
+          description: "Could not create asset, because an asset with that ID already\
+            \ exists"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /assets/request:
+    post:
+      tags:
+      - Asset
+      description: ' all assets according to a particular query'
+      operationId: requestAssets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QuerySpecDto'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AssetResponseDto'
+        "400":
+          description: Request body was malformed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /assets/{id}:
+    get:
+      tags:
+      - Asset
+      description: Gets an asset with the given ID
+      operationId: getAsset
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: The asset
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetResponseDto'
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "404":
+          description: An asset with the given ID does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+    delete:
+      tags:
+      - Asset
+      description: "Removes an asset with the given ID if possible. Deleting an asset\
+        \ is only possible if that asset is not yet referenced by a contract agreement,\
+        \ in which case an error is returned. DANGER ZONE: Note that deleting assets\
+        \ can have unexpected results, especially for contract offers that have been\
+        \ sent out or ongoing or contract negotiations."
+      operationId: removeAsset
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Asset was deleted successfully
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "404":
+          description: An asset with the given ID does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "409":
+          description: "The asset cannot be deleted, because it is referenced by a\
+            \ contract agreement"
           content:
             application/json:
               schema:
@@ -836,101 +1486,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DataPlaneInstance'
-  /transfer:
-    post:
-      tags:
-      - Data Plane control API
-      description: Initiates a data transfer for the given request. The transfer will
-        be performed asynchronously.
-      operationId: initiateTransfer
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DataFlowRequest'
-      responses:
-        "200":
-          description: Data transfer initiated
-        "400":
-          description: Failed to validate request
-  /transfer/{processId}:
-    get:
-      tags:
-      - Data Plane control API
-      description: Get the current state of a data transfer.
-      operationId: getTransferState
-      parameters:
-      - name: processId
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        "200":
-          description: Missing access token
-  /{any}:
-    get:
-      tags:
-      - Data Plane public API
-      description: Send `GET` data query to the Data Plane.
-      operationId: get
-      responses:
-        "400":
-          description: Missing access token
-        "403":
-          description: Access token is expired or invalid
-        "500":
-          description: Failed to transfer data
-    put:
-      tags:
-      - Data Plane public API
-      description: Send `PUT` data query to the Data Plane.
-      operationId: put
-      responses:
-        "400":
-          description: Missing access token
-        "403":
-          description: Access token is expired or invalid
-        "500":
-          description: Failed to transfer data
-    post:
-      tags:
-      - Data Plane public API
-      description: Send `POST` data query to the Data Plane.
-      operationId: post
-      responses:
-        "400":
-          description: Missing access token
-        "403":
-          description: Access token is expired or invalid
-        "500":
-          description: Failed to transfer data
-    delete:
-      tags:
-      - Data Plane public API
-      description: Send `DELETE` data query to the Data Plane.
-      operationId: delete
-      responses:
-        "400":
-          description: Missing access token
-        "403":
-          description: Access token is expired or invalid
-        "500":
-          description: Failed to transfer data
-    patch:
-      tags:
-      - Data Plane public API
-      description: Send `PATCH` data query to the Data Plane.
-      operationId: patch
-      responses:
-        "400":
-          description: Missing access token
-        "403":
-          description: Access token is expired or invalid
-        "500":
-          description: Failed to transfer data
   /transferprocess:
     get:
       tags:
@@ -1209,561 +1764,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ApiErrorDetail'
-  /check/health:
-    get:
-      tags:
-      - Application Observability
-      description: Performs a liveness probe to determine whether the runtime is working
-        properly.
-      operationId: checkHealth
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/HealthStatus'
-  /check/liveness:
-    get:
-      tags:
-      - Application Observability
-      description: Performs a liveness probe to determine whether the runtime is working
-        properly.
-      operationId: getLiveness
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/HealthStatus'
-  /check/readiness:
-    get:
-      tags:
-      - Application Observability
-      description: Performs a readiness probe to determine whether the runtime is
-        able to accept requests.
-      operationId: getReadiness
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/HealthStatus'
-  /check/startup:
-    get:
-      tags:
-      - Application Observability
-      description: Performs a startup probe to determine whether the runtime has completed
-        startup.
-      operationId: getStartup
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/HealthStatus'
-  /assets:
-    get:
-      tags:
-      - Asset
-      description: Gets all assets according to a particular query
-      operationId: getAllAssets
-      parameters:
-      - name: offset
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: limit
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: filter
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      - name: sort
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          enum:
-          - ASC
-          - DESC
-      - name: sortField
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/AssetResponseDto'
-        "400":
-          description: Request body was malformed
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-      deprecated: true
-    post:
-      tags:
-      - Asset
-      description: Creates a new asset together with a data address
-      operationId: createAsset
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AssetEntryDto'
-      responses:
-        "200":
-          description: Asset was created successfully. Returns the asset Id and created
-            timestamp
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/IdResponseDto'
-        "400":
-          description: Request body was malformed
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "409":
-          description: "Could not create asset, because an asset with that ID already\
-            \ exists"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-  /assets/request:
-    post:
-      tags:
-      - Asset
-      description: ' all assets according to a particular query'
-      operationId: requestAssets
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/QuerySpecDto'
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/AssetResponseDto'
-        "400":
-          description: Request body was malformed
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-  /assets/{id}:
-    get:
-      tags:
-      - Asset
-      description: Gets an asset with the given ID
-      operationId: getAsset
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        "200":
-          description: The asset
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AssetResponseDto'
-        "400":
-          description: "Request was malformed, e.g. id was null"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "404":
-          description: An asset with the given ID does not exist
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-    delete:
-      tags:
-      - Asset
-      description: "Removes an asset with the given ID if possible. Deleting an asset\
-        \ is only possible if that asset is not yet referenced by a contract agreement,\
-        \ in which case an error is returned. DANGER ZONE: Note that deleting assets\
-        \ can have unexpected results, especially for contract offers that have been\
-        \ sent out or ongoing or contract negotiations."
-      operationId: removeAsset
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        "200":
-          description: Asset was deleted successfully
-        "400":
-          description: "Request was malformed, e.g. id was null"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "404":
-          description: An asset with the given ID does not exist
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "409":
-          description: "The asset cannot be deleted, because it is referenced by a\
-            \ contract agreement"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-  /policydefinitions:
-    get:
-      tags:
-      - Policy
-      description: Returns all policy definitions according to a query
-      operationId: getAllPolicies
-      parameters:
-      - name: offset
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: limit
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: filter
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      - name: sort
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          enum:
-          - ASC
-          - DESC
-      - name: sortField
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/PolicyDefinitionResponseDto'
-        "400":
-          description: Request was malformed
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-      deprecated: true
-    post:
-      tags:
-      - Policy
-      description: Creates a new policy definition
-      operationId: createPolicy
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PolicyDefinitionRequestDto'
-      responses:
-        "200":
-          description: policy definition was created successfully. Returns the Policy
-            Definition Id and created timestamp
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/IdResponseDto'
-        "400":
-          description: Request body was malformed
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "409":
-          description: "Could not create policy definition, because a contract definition\
-            \ with that ID already exists"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-  /policydefinitions/request:
-    post:
-      tags:
-      - Policy
-      description: Returns all policy definitions according to a query
-      operationId: queryAllPolicies
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/QuerySpecDto'
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/PolicyDefinitionResponseDto'
-        "400":
-          description: Request was malformed
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-  /policydefinitions/{id}:
-    get:
-      tags:
-      - Policy
-      description: Gets a policy definition with the given ID
-      operationId: getPolicy
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        "200":
-          description: The  policy definition
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PolicyDefinitionResponseDto'
-        "400":
-          description: "Request was malformed, e.g. id was null"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "404":
-          description: An  policy definition with the given ID does not exist
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-    delete:
-      tags:
-      - Policy
-      description: "Removes a policy definition with the given ID if possible. Deleting\
-        \ a policy definition is only possible if that policy definition is not yet\
-        \ referenced by a contract definition, in which case an error is returned.\
-        \ DANGER ZONE: Note that deleting policy definitions can have unexpected results,\
-        \ do this at your own risk!"
-      operationId: deletePolicy
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        "200":
-          description: Policy definition was deleted successfully
-        "400":
-          description: "Request was malformed, e.g. id was null"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "404":
-          description: An policy definition with the given ID does not exist
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "409":
-          description: "The policy definition cannot be deleted, because it is referenced\
-            \ by a contract definition"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-  /transferprocess/{processId}/complete:
-    post:
-      tags:
-      - Transfer Process Control Api
-      description: "Requests completion of the transfer process. Due to the asynchronous\
-        \ nature of transfers, a successful response only indicates that the request\
-        \ was successfully received"
-      operationId: complete
-      parameters:
-      - name: processId
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        "400":
-          description: "Request was malformed, e.g. id was null"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-  /transferprocess/{processId}/fail:
-    post:
-      tags:
-      - Transfer Process Control Api
-      description: "Requests completion of the transfer process. Due to the asynchronous\
-        \ nature of transfers, a successful response only indicates that the request\
-        \ was successfully received"
-      operationId: fail
-      parameters:
-      - name: processId
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/TransferProcessFailStateDto'
-        required: true
-      responses:
-        "400":
-          description: "Request was malformed, e.g. id was null"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-  /token:
-    get:
-      tags:
-      - Token Validation
-      description: "Checks that the provided token has been signed by the present\
-        \ entity and asserts its validity. If token is valid, then the data address\
-        \ contained in its claims is decrypted and returned back to the caller."
-      operationId: validate
-      parameters:
-      - name: Authorization
-        in: header
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        "200":
-          description: Token is valid
-        "400":
-          description: Request was malformed
-        "403":
-          description: Token is invalid
 components:
   schemas:
     Action:

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -121,8 +121,10 @@ include(":extensions:common:vault:vault-azure")
 include(":extensions:common:vault:vault-filesystem")
 include(":extensions:common:vault:vault-hashicorp")
 
-include(":extensions:control-plane:api:management-api")
+include(":extensions:common:api:control-api-configuration")
 include(":extensions:common:api:management-api-configuration")
+
+include(":extensions:control-plane:api:management-api")
 include(":extensions:control-plane:api:management-api:asset-api")
 include(":extensions:control-plane:api:management-api:catalog-api")
 include(":extensions:control-plane:api:management-api:contract-agreement-api")

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/Participant.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/Participant.java
@@ -48,9 +48,8 @@ public class Participant {
     private final Duration timeout = Duration.ofSeconds(30);
 
     private final URI controlPlane = URI.create("http://localhost:" + getFreePort());
-    private final URI controlPlaneValidation = URI.create("http://localhost:" + getFreePort() + "/validation");
+    private final URI controlPlaneControl = URI.create("http://localhost:" + getFreePort() + "/control");
     private final URI controlPlaneManagement = URI.create("http://localhost:" + getFreePort() + "/api/management");
-    private final URI controlPlaneProvisioner = URI.create("http://localhost:" + getFreePort() + "/provisioner");
     private final URI dataPlane = URI.create("http://localhost:" + getFreePort());
     private final URI dataPlaneControl = URI.create("http://localhost:" + getFreePort() + "/control");
     private final URI dataPlanePublic = URI.create("http://localhost:" + getFreePort() + "/public");
@@ -288,10 +287,8 @@ public class Participant {
                 put("web.http.ids.path", IDS_PATH);
                 put("web.http.management.port", String.valueOf(controlPlaneManagement.getPort()));
                 put("web.http.management.path", controlPlaneManagement.getPath());
-                put("web.http.provisioner.port", String.valueOf(controlPlaneProvisioner.getPort()));
-                put("web.http.provisioner.path", controlPlaneProvisioner.getPath());
-                put("web.http.validation.port", String.valueOf(controlPlaneValidation.getPort()));
-                put("web.http.validation.path", controlPlaneValidation.getPath());
+                put("web.http.control.port", String.valueOf(controlPlaneControl.getPort()));
+                put("web.http.control.path", controlPlaneControl.getPath());
                 put("edc.vault", resourceAbsolutePath(name + "-vault.properties"));
                 put("edc.keystore", resourceAbsolutePath("certs/cert.pfx"));
                 put("edc.keystore.password", "123456");
@@ -374,7 +371,6 @@ public class Participant {
         return baseConfiguration;
     }
 
-
     @NotNull
     public String jdbcUrl() {
         return PostgresqlLocalInstance.JDBC_URL_PREFIX + name;
@@ -392,7 +388,7 @@ public class Participant {
                 put("edc.vault", resourceAbsolutePath(name + "-vault.properties"));
                 put("edc.keystore", resourceAbsolutePath("certs/cert.pfx"));
                 put("edc.keystore.password", "123456");
-                put("edc.dataplane.token.validation.endpoint", controlPlaneValidation + "/token");
+                put("edc.dataplane.token.validation.endpoint", controlPlaneControl + "/token");
             }
         };
     }


### PR DESCRIPTION
## What this PR changes/adds

Moves all the `control` APIs under the `control` context

## Why it does that

Api restructure

## Further notes

-

## Linked Issue(s)

Closes #2186 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/pr_etiquette.md) for details_)
