### PR TITLE
feat: support `/public` endpoint without trailing slash

### DIFF
--- a/.github/workflows/assign-pr-to-project.yaml
+++ b/.github/workflows/assign-pr-to-project.yaml
@@ -15,5 +15,5 @@ jobs:
       - name: Assign to basic project
         uses: srggrs/assign-one-project-github-action@1.3.1
         with:
-          project: 'https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/projects/1'
+          project: 'https://github.com/eclipse-edc/Connector/projects/1'
           column_name: 'In progress'

--- a/extensions/common/http/jersey-core/src/main/java/org/eclipse/edc/web/jersey/JerseyRestService.java
+++ b/extensions/common/http/jersey-core/src/main/java/org/eclipse/edc/web/jersey/JerseyRestService.java
@@ -97,7 +97,6 @@ public class JerseyRestService implements WebService {
 
         additionalInstances.forEach(supplier -> resourceConfig.registerInstances(supplier.get()));
 
-
         if (configuration.isCorsEnabled()) {
             resourceConfig.register(new CorsFilter(configuration));
         }

--- a/extensions/common/http/jersey-core/src/test/java/org/eclipse/edc/web/jersey/mapper/ExceptionMappersIntegrationTest.java
+++ b/extensions/common/http/jersey-core/src/test/java/org/eclipse/edc/web/jersey/mapper/ExceptionMappersIntegrationTest.java
@@ -18,7 +18,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.MessageInterpolator;
 import jakarta.validation.Valid;
 import jakarta.validation.Validation;
-import jakarta.validation.ValidatorFactory;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 import jakarta.ws.rs.Consumes;
@@ -54,26 +53,22 @@ import static org.mockito.Mockito.mock;
 @ExtendWith(EdcExtension.class)
 public class ExceptionMappersIntegrationTest {
 
-
-    public static final String POSITIVE_TEMPLATE = "{jakarta.validation.constraints.Positive.message}";
-    public static final String NOT_BLANK_TEMPLATE = "{jakarta.validation.constraints.NotBlank.message}";
+    private static final String POSITIVE_TEMPLATE = "{jakarta.validation.constraints.Positive.message}";
+    private static final String NOT_BLANK_TEMPLATE = "{jakarta.validation.constraints.NotBlank.message}";
     private final int port = getFreePort();
     private final Runnable runnable = mock(Runnable.class);
-
 
     private MessageInterpolator interpolator;
 
     @BeforeEach
     void setUp(EdcExtension extension) {
         extension.setConfiguration(Map.of(
-                "web.http.port", String.valueOf(getFreePort()),
-                "web.http.path", "/api",
-                "web.http.test.port", String.valueOf(port),
-                "web.http.test.path", "/"
+                "web.http.port", String.valueOf(port),
+                "web.http.path", "/api"
         ));
         extension.registerSystemExtension(ServiceExtension.class, new MyServiceExtension());
 
-        try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+        try (var factory = Validation.buildDefaultValidatorFactory()) {
             interpolator = factory.getMessageInterpolator();
         }
     }
@@ -85,7 +80,7 @@ public class ExceptionMappersIntegrationTest {
         given()
                 .port(port)
                 .accept(JSON)
-                .get("/test")
+                .get("/api/test")
                 .then()
                 .statusCode(404)
                 .contentType(JSON)
@@ -101,7 +96,7 @@ public class ExceptionMappersIntegrationTest {
                 .accept(JSON)
                 .contentType(JSON)
                 .body(Map.of("data", "", "number", "-1"))
-                .post("/test")
+                .post("/api/test")
                 .then()
                 .statusCode(400)
                 .body("size()", is(2))
@@ -126,7 +121,7 @@ public class ExceptionMappersIntegrationTest {
         given()
                 .port(port)
                 .accept(JSON)
-                .get("/test")
+                .get("/api/test")
                 .then()
                 .statusCode(500);
     }
@@ -164,7 +159,7 @@ public class ExceptionMappersIntegrationTest {
 
         @Override
         public void initialize(ServiceExtensionContext context) {
-            webService.registerResource("test", new TestController());
+            webService.registerResource(new TestController());
         }
     }
 }

--- a/extensions/common/http/jetty-core/src/main/java/org/eclipse/edc/web/jetty/JettyService.java
+++ b/extensions/common/http/jetty-core/src/main/java/org/eclipse/edc/web/jetty/JettyService.java
@@ -29,9 +29,7 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.servlet.ServletContextHandler;
-import org.eclipse.jetty.servlet.ServletHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
-import org.eclipse.jetty.servlet.ServletMapping;
 import org.eclipse.jetty.servlet.Source;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.jetbrains.annotations.NotNull;
@@ -79,6 +77,9 @@ public class JettyService implements WebServer {
             server = new Server();
             //create a connector for every port mapping
             configuration.getPortMappings().forEach(mapping -> {
+                if (!mapping.getPath().startsWith("/")) {
+                    throw new IllegalArgumentException("A context path must start with /: " + mapping.getPath());
+                }
 
                 ServerConnector connector;
                 if (Arrays.stream(server.getConnectors()).anyMatch(c -> ((ServerConnector) c).getPort() == mapping.getPort())) {

--- a/extensions/common/http/jetty-core/src/test/java/org/eclipse/edc/web/jetty/JettyServiceTest.java
+++ b/extensions/common/http/jetty-core/src/test/java/org/eclipse/edc/web/jetty/JettyServiceTest.java
@@ -45,6 +45,7 @@ import static org.eclipse.edc.junit.testfixtures.TestUtils.testOkHttpClient;
 import static org.mockito.Mockito.mock;
 
 class JettyServiceTest {
+
     private JettyService jettyService;
     private Monitor monitor;
     private TestController testController;
@@ -126,20 +127,17 @@ class JettyServiceTest {
     }
 
     @Test
-    @DisplayName("Verifies that an invalid path spec causes 404")
-    void verifyInvalidPathSpecCauses404() {
+    void verifyInvalidPathSpecThrowsException() {
         var config = ConfigFactory.fromMap(Map.of(
                 "web.http.port", "7171",
                 "web.http.another.port", "9191",
-                "web.http.another.name", "another",
                 "web.http.another.path", "another")); //misses leading slash
         jettyService = new JettyService(JettyConfiguration.createFromConfig(null, null, config), monitor);
 
-        jettyService.start();
-
-        jettyService.registerServlet("another", new ServletContainer(createTestResource()));
-
-        assertThat(executeRequest("http://localhost:9191/another/test/resource").code()).isEqualTo(404);
+        assertThatThrownBy(() -> jettyService.start()).isInstanceOf(EdcException.class)
+                .hasMessage("Error starting Jetty service")
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasRootCauseMessage("A context path must start with /: another");
     }
 
     @Test

--- a/extensions/data-plane/data-plane-api/src/test/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlaneApiIntegrationTest.java
+++ b/extensions/data-plane/data-plane-api/src/test/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlaneApiIntegrationTest.java
@@ -57,6 +57,7 @@ import static java.util.concurrent.CompletableFuture.failedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.junit.testfixtures.TestUtils.getFreePort;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
@@ -162,6 +163,15 @@ class DataPlaneApiIntegrationTest {
                 .then()
                 .statusCode(Response.Status.BAD_REQUEST.getStatusCode())
                 .body("errors[0]", is("Missing bearer token"));
+    }
+
+    @Test
+    void publicApi_shouldNotReturn302_whenUrlWithoutTrailingSlash() {
+        given().port(PUBLIC_API_PORT)
+                .when()
+                .post("/public")
+                .then()
+                .statusCode(not(302));
     }
 
     @Test


### PR DESCRIPTION
## What this PR changes/adds

Avoid setting `contextPath` on the `ServletContextHandler`, setting it as a servlet mapping

## Why it does that

Currently the `/public` endpoint of the dataplane returns 302

## Further notes

-

## Linked Issue(s)

Closes #2242

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/pr_etiquette.md) for details_)
