### PR TITLE
refactor: Rename `ids` api context to `protocol`

### DIFF
--- a/data-protocols/ids/ids-api-configuration/build.gradle.kts
+++ b/data-protocols/ids/ids-api-configuration/build.gradle.kts
@@ -19,6 +19,8 @@ plugins {
 dependencies {
     api(project(":spi:common:core-spi"))
     api(project(":spi:common:web-spi"))
+
+    testImplementation(project(":core:common:junit"))
 }
 
 publishing {

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/IdsMultipartApiServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/IdsMultipartApiServiceExtension.java
@@ -22,7 +22,6 @@ import org.eclipse.edc.connector.contract.spi.negotiation.ConsumerContractNegoti
 import org.eclipse.edc.connector.contract.spi.negotiation.ProviderContractNegotiationManager;
 import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.connector.contract.spi.offer.ContractOfferResolver;
-import org.eclipse.edc.connector.contract.spi.validation.ContractValidationService;
 import org.eclipse.edc.connector.spi.transferprocess.TransferProcessService;
 import org.eclipse.edc.connector.transfer.spi.edr.EndpointDataReferenceReceiverRegistry;
 import org.eclipse.edc.connector.transfer.spi.edr.EndpointDataReferenceTransformerRegistry;
@@ -91,9 +90,6 @@ public final class IdsMultipartApiServiceExtension implements ServiceExtension {
 
     @Inject
     private ProviderContractNegotiationManager providerNegotiationManager;
-
-    @Inject
-    private ContractValidationService contractValidationService;
 
     @Inject
     private EndpointDataReferenceReceiverRegistry endpointDataReferenceReceiverRegistry;


### PR DESCRIPTION
## What this PR changes/adds

Rename `ids` api context to `protocol`

## Why it does that

Api restructure

## Further notes

- the  `ids` context name is deprecated, to be removed in the next releases

## Linked Issue(s)

Closes #2187 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
