### PR TITLE
fix(javadoc): removed erronous tag

### DIFF
--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/AbstractResult.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/AbstractResult.java
@@ -102,7 +102,7 @@ public abstract class AbstractResult<T, F extends Failure> {
      * Execute an action if this {@link Result} is not successful.
      *
      * @param failureAction The function that maps a {@link Failure} into the content.
-     * @return T the success value if successful, otherwise the object returned by the {@param failureAction}
+     * @return T the success value if successful, otherwise the object returned by the failureAction
      */
     public T orElse(Function<F, T> failureAction) {
         if (failed()) {


### PR DESCRIPTION
## What this PR changes/adds

removes an `{@param ....}` tag from the javadoc.

## Why it does that

Gradle's `javadoc` task complained, causing the CI build to fail.
https://ci.eclipse.org/edc/job/Playground/job/Build-Component-Template/19/console

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
