### PR TITLE
fix(build): only the upstream project may trigger jenkins

### DIFF
--- a/.github/workflows/trigger_snapshot.yml
+++ b/.github/workflows/trigger_snapshot.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   Trigger-Snapshot:
     runs-on: ubuntu-latest
+    # forks cannot trigger Jenkins
+    if: github.repository == 'eclipse-edc/Connector'
     steps:
       # Trigger EF Jenkins. This job waits for Jenkins to complete the publishing, which may take a long time, because every
       # module is signed individually, and parallelism is not available. Hence, the increased timeout of 3600 seconds.


### PR DESCRIPTION
## What this PR changes/adds

Adds a condition to the Jenkins Snapshot trigger Job, so that only the upstream project may execute the job.

## Why it does that

Forks may not trigger our EDC Jenkins.

## Further notes

- contrary to my solution proposal in the issue, I opted for flat-out disallowing forks to trigger the job _in general_ because forks may not use our EDC Jenkins instance, even if there are credentials present.

## Linked Issue(s)

Closes #2256 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
