### PR TITLE
feat(dataPlane): register a different resolve strategy when working with embedded data-plane

### DIFF
--- a/extensions/control-plane/data-plane-transfer/data-plane-transfer-sync/README.md
+++ b/extensions/control-plane/data-plane-transfer/data-plane-transfer-sync/README.md
@@ -63,6 +63,7 @@ The token is first created on provider side within `ProviderDataPlaneProxyDataFl
 having _HttpProxy_ as destination type. This data flow controller encrypts the content address and builds a signed token
 containing this encrypted address as claim along with the contract id. This token is wrapped into an `EndpointDataReference` (EDR) object along with the
 URL of Data Plane to be used as proxy for querying the data. The Data Plane instance to be used is determined through the `DataPlaneSelectorService`.
+If the extension is provided in a runtime with an embedded Data Plane and it exposes the `public` API, the embedded Data Plane will be used as proxy.
 
 > **_NOTE:_**  For a Data Plane instance to be eligible for the transfer, it must:
 >  - contains `HttpProxy` in the `allowedDestTypes`

--- a/extensions/control-plane/data-plane-transfer/data-plane-transfer-sync/src/main/java/org/eclipse/edc/connector/dataplane/transfer/sync/proxy/EmbeddedDataPlaneTransferProxyResolve.java
+++ b/extensions/control-plane/data-plane-transfer/data-plane-transfer-sync/src/main/java/org/eclipse/edc/connector/dataplane/transfer/sync/proxy/EmbeddedDataPlaneTransferProxyResolve.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2020-2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.transfer.sync.proxy;
+
+import org.eclipse.edc.connector.dataplane.spi.DataPlanePublicApiUrl;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+
+public class EmbeddedDataPlaneTransferProxyResolve implements DataPlaneTransferProxyResolver {
+
+
+    private final DataPlanePublicApiUrl embeddedUrl;
+
+    public EmbeddedDataPlaneTransferProxyResolve(DataPlanePublicApiUrl embeddedUrl) {
+        this.embeddedUrl = embeddedUrl;
+    }
+
+    @Override
+    public Result<String> resolveProxyUrl(DataAddress source) {
+        return Result.success(embeddedUrl.get().toString());
+    }
+}

--- a/extensions/control-plane/data-plane-transfer/data-plane-transfer-sync/src/test/java/org/eclipse/edc/connector/dataplane/transfer/sync/proxy/EmbeddedPlaneTransferProxyResolverTest.java
+++ b/extensions/control-plane/data-plane-transfer/data-plane-transfer-sync/src/test/java/org/eclipse/edc/connector/dataplane/transfer/sync/proxy/EmbeddedPlaneTransferProxyResolverTest.java
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.transfer.sync.proxy;
+
+import org.eclipse.edc.connector.dataplane.spi.DataPlanePublicApiUrl;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class EmbeddedPlaneTransferProxyResolverTest {
+
+
+    private DataPlanePublicApiUrl dataPlanePublicApiUrl;
+    private DataPlaneTransferProxyResolver resolver;
+
+    @BeforeEach
+    public void setUp() {
+        dataPlanePublicApiUrl = mock(DataPlanePublicApiUrl.class);
+        resolver = new EmbeddedDataPlaneTransferProxyResolve(dataPlanePublicApiUrl);
+    }
+
+    @Test
+    void verifyResolveSuccess() throws MalformedURLException {
+        var address = DataAddress.Builder.newInstance().type(UUID.randomUUID().toString()).build();
+        var proxyUrl = new URL("http://test.proxy.url");
+
+        when(dataPlanePublicApiUrl.get()).thenReturn(proxyUrl);
+
+        var result = resolver.resolveProxyUrl(address);
+
+        assertThat(result.succeeded()).isTrue();
+        assertThat(result.getContent()).isEqualTo(proxyUrl.toString());
+    }
+
+
+}

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/DataPlanePublicApiUrl.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/DataPlanePublicApiUrl.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (c) 2020-2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.spi;
+
+
+import java.net.URL;
+
+@FunctionalInterface
+public interface DataPlanePublicApiUrl {
+
+    /**
+     * gets the URL which the HTTP Data Plane API provides.
+     */
+    URL get();
+}


### PR DESCRIPTION
## What this PR changes/adds

Registers a different DataPlane proxy when working with embedded data-plane which points
to the data plane `/public` api of the same runtime .
 

## Why it does that

simplify test environments and samples

## Linked Issue(s)

Closes #2226 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
