### PR TITLE
feat(build): add workflow_dispatch event trigger

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,6 +1,7 @@
 name: Test Code (Style, Tests)
 
 on:
+  workflow_dispatch:
   push:
   pull_request:
     branches: [ main ]


### PR DESCRIPTION
## What this PR changes/adds

Adds the `workflow_dispatch` event trigger to `verify.yaml`

## Why it does that

to be able to trigger the build from external systems through the Github API (e.g. Jenkins).

## Linked Issue(s)

Closes https://github.com/eclipse-edc/Connector/issues/2281

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
