### PR TITLE
docs: provide decision record for EdcHttpClient

### DIFF
--- a/docs/developer/decision-records/2022-12-05-edc-http-client/README.md
+++ b/docs/developer/decision-records/2022-12-05-edc-http-client/README.md
@@ -1,0 +1,35 @@
+# EDC Http Client
+
+## Decision
+
+An `EdcHttpClient` will be introduced to wrap `OkHttpClient` and `Failsafe` functionalities.
+
+## Rationale
+
+At the moment, everytime the `Failsafe` retry mechanism is needed there's the need to inject the relative `RetryPolicy` 
+service and explicitly use it everytime we need to call an http endpoint.
+Retry mechanism is something we definitely want to have out-of-the-box as in fact it is something we expect to see used
+in every http call.
+
+## Approach
+
+An `EdcHttpClient` interface will be introduced in a `http-spi` module:
+```java
+public interface EdcHttpClient {
+
+    Response execute(Request request) throws IOException;
+
+    <T> CompletableFuture<T> executeAsync(Request request, Function<Response, T> mappingFunction);
+
+    EdcHttpClient withDns(String dnsServer);
+
+}
+```
+
+The implementation will use `okhttp` and `failsafe-okttp` to provide retry mechanism using the registered `RetryPolicy`.
+The implementation service will be provided by the `CoreDefaultServicesExtension`.
+
+This service would be used instead of `OkHttpClient` and `RetryPolicy`, and in the future it could provide other features
+or, also, provide a more okhttp-agnostic interface.
+
+The `withDns` method is necessary for the `WebDidExtension`.

--- a/docs/developer/decision-records/README.md
+++ b/docs/developer/decision-records/README.md
@@ -45,3 +45,4 @@
 - [2022-10-31 Service Layer](2022-10-31-aggregate-service-layer/)
 - [2022-11-09 API Restructuring](2022-11-09-api-refactoring/)
 - [2022-11-28 Release Management](2022-11-28-release-management/)
+- [2022-12-05 EDC Http Client](2022-12-05-edc-http-client/)


### PR DESCRIPTION
## What this PR changes/adds

Add decision record for `EdcHttpClient` that's a wrapper around `OkHttpClient` and `Failsafe` that will provide retry mechanism out-of-the-box. Ref. #1566 

## Why it does that

document

## Further notes

-

## Linked Issue(s)

Ref #1566

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
