### PR TITLE
refactor: deprecate contract negotiation cancel endpoint

### DIFF
--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/command/handlers/CancelNegotiationCommandHandler.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/command/handlers/CancelNegotiationCommandHandler.java
@@ -21,7 +21,10 @@ import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiat
 /**
  * Handler for {@link CancelNegotiationCommand}s. Transitions the specified ContractNegotiation
  * to the error state.
+ *
+ * @deprecated please decline the negotiation instead.
  */
+@Deprecated(since = "milestone8")
 public class CancelNegotiationCommandHandler extends SingleContractNegotiationCommandHandler<CancelNegotiationCommand> {
 
     public CancelNegotiationCommandHandler(ContractNegotiationStore store) {

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApi.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApi.java
@@ -46,7 +46,7 @@ public interface ContractNegotiationApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))) },
             deprecated = true
     )
-    @Deprecated
+    @Deprecated(since = "milestone8")
     List<ContractNegotiationDto> getNegotiations(@Valid QuerySpecDto querySpecDto);
 
     @Operation(description = "Returns all contract negotiations according to a query",
@@ -110,6 +110,11 @@ public interface ContractNegotiationApi {
     IdResponseDto initiateContractNegotiation(@Valid NegotiationInitiateRequestDto initiateDto);
 
 
+    /**
+     * This is deprecated as the current implementation transit the negotiation to ERRROR. Please use "declineNegotiation" instead.
+     * @param id negotiation id
+     * @deprecated please use /decline to terminate negotiation
+     */
     @Operation(description = "Requests aborting the contract negotiation. Due to the asynchronous nature of contract negotiations, a successful " +
             "response only indicates that the request was successfully received. Clients must poll the /{id}/state endpoint to track the state.",
             responses = {
@@ -120,6 +125,7 @@ public interface ContractNegotiationApi {
                     @ApiResponse(responseCode = "404", description = "A contract negotiation with the given ID does not exist",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
             })
+    @Deprecated(since = "milestone8")
     void cancelNegotiation(String id);
 
     @Operation(description = "Requests cancelling the contract negotiation. Due to the asynchronous nature of contract negotiations, a successful " +

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiController.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiController.java
@@ -67,7 +67,7 @@ public class ContractNegotiationApiController implements ContractNegotiationApi 
 
     @GET
     @Override
-    @Deprecated
+    @Deprecated(since = "milestone8")
     public List<ContractNegotiationDto> getNegotiations(@Valid @BeanParam QuerySpecDto querySpecDto) {
         return queryContractNegotiations(querySpecDto);
     }
@@ -138,6 +138,7 @@ public class ContractNegotiationApiController implements ContractNegotiationApi 
     @POST
     @Path("/{id}/cancel")
     @Override
+    @Deprecated(since = "milestone8")
     public void cancelNegotiation(@PathParam("id") String id) {
         monitor.debug(format("Attempting to cancel contract definition with id %s", id));
         var result = service.cancel(id).orElseThrow(exceptionMapper(ContractNegotiation.class, id));

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/command/CancelNegotiationCommand.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/command/CancelNegotiationCommand.java
@@ -16,7 +16,9 @@ package org.eclipse.edc.connector.contract.spi.types.command;
 
 /**
  * Command for cancelling a specific ContractNegotiation.
+ * @deprecated please decline the negotiation instead.
  */
+@Deprecated(since = "milestone8")
 public class CancelNegotiationCommand extends SingleContractNegotiationCommand {
     public CancelNegotiationCommand(String negotiationId) {
         super(negotiationId);

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/contractnegotiation/ContractNegotiationService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/contractnegotiation/ContractNegotiationService.java
@@ -70,7 +70,9 @@ public interface ContractNegotiationService {
      *
      * @param negotiationId the id of the contract negotiation to be canceled
      * @return successful result if the contract negotiation is canceled correctly, failure otherwise
+     * @deprecated please use "decline" instead
      */
+    @Deprecated(since = "milestone8")
     ServiceResult<ContractNegotiation> cancel(String negotiationId);
 
     /**


### PR DESCRIPTION
## What this PR changes/adds

Deprecate `ContractNegotiation` `cancel` api endpoint and command.

## Why it does that

It transit the contract to "error", that should be an internal state to handle unexpected failures.

## Further notes

- The endpoint and the command will be removed in 2 milestones

## Linked Issue(s)

Closes #2268 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
