### PR TITLE
feat(oauth): renames  edc.oauth.public.key.alias to edc.oauth.certificate.alias

### DIFF
--- a/extensions/common/iam/oauth2/oauth2-core/README.md
+++ b/extensions/common/iam/oauth2/oauth2-core/README.md
@@ -10,7 +10,7 @@ This extension provides an `IdentityService` implementation based on the OAuth2 
 | `edc.oauth.provider.audience`     | Provider audience to be put in the outgoing token as 'aud' claim                           | false     | id of the connector                 |
 | `edc.oauth.endpoint.audience`     | Endpoint audience to verify incoming token 'aud' claim                                     | false     | `edc.oauth.provider.audience` value |
 | `edc.oauth.provider.jwks.url`     | URL from which well-known public keys of Authorization server can be fetched               | false     | http://localhost/empty_jwks_url     | 
-| `edc.oauth.public.key.alias`      | Alias of public associated with client certificate                                         | true      | null                                |
+| `edc.oauth.certificate.alias`     | Alias of public associated with client certificate                                         | true      | null                                |
 | `edc.oauth.private.key.alias`     | Alias of private key (used to sign the token)                                              | true      | null                                |
 | `edc.oauth.provider.jwks.refresh` | Interval at which public keys are refreshed from Authorization server (in minutes)         | false     | 5                                   |
 | `edc.oauth.client.id`             | Public identifier of the client                                                            | true      | null                                |

--- a/extensions/common/iam/oauth2/oauth2-core/src/test/java/org/eclipse/edc/iam/oauth2/Oauth2ExtensionTest.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/test/java/org/eclipse/edc/iam/oauth2/Oauth2ExtensionTest.java
@@ -1,0 +1,112 @@
+/*
+ *  Copyright (c) 2020-2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.iam.oauth2;
+
+import dev.failsafe.RetryPolicy;
+import okhttp3.OkHttpClient;
+import org.eclipse.edc.iam.oauth2.spi.CredentialsRequestAdditionalParametersProvider;
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.spi.security.CertificateResolver;
+import org.eclipse.edc.spi.security.PrivateKeyResolver;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.system.configuration.Config;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+import org.eclipse.edc.spi.system.injection.ObjectFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.security.PrivateKey;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(DependencyInjectionExtension.class)
+public class Oauth2ExtensionTest {
+
+    private ServiceExtensionContext context;
+    private Oauth2Extension extension;
+
+    private CertificateResolver certificateResolver;
+    private PrivateKeyResolver privateKeyResolver;
+
+    @BeforeEach
+    void setup(ServiceExtensionContext context, ObjectFactory factory) {
+        certificateResolver = mock(CertificateResolver.class);
+        privateKeyResolver = mock(PrivateKeyResolver.class);
+        context.registerService(RetryPolicy.class, mock(RetryPolicy.class));
+        context.registerService(CertificateResolver.class, certificateResolver);
+        context.registerService(CredentialsRequestAdditionalParametersProvider.class, mock(CredentialsRequestAdditionalParametersProvider.class));
+        context.registerService(PrivateKeyResolver.class, privateKeyResolver);
+        context.registerService(OkHttpClient.class, mock(OkHttpClient.class));
+        extension = factory.constructInstance(Oauth2Extension.class);
+        this.context = spy(context);
+    }
+
+    @Test
+    void verifyExtensionWithPublicKeyDeprecatedAlias() throws CertificateEncodingException {
+
+        var config = spy(ConfigFactory.fromMap(Map.of(
+                "edc.oauth.client.id", "id",
+                "edc.oauth.token.url", "url",
+                "edc.oauth.public.key.alias", "alias",
+                "edc.oauth.private.key.alias", "p_alias")));
+
+        setupMocks(config);
+
+        extension.initialize(context);
+
+        verify(config, times(1)).getString("edc.oauth.public.key.alias");
+        verify(config, never()).getString("edc.oauth.certificate.alias");
+
+    }
+
+    @Test
+    void verifyExtensionWithCertificateAlias() throws CertificateEncodingException {
+
+        var config = spy(ConfigFactory.fromMap(Map.of(
+                "edc.oauth.client.id", "id",
+                "edc.oauth.token.url", "url",
+                "edc.oauth.certificate.alias", "alias",
+                "edc.oauth.private.key.alias", "p_alias")));
+
+        setupMocks(config);
+
+        extension.initialize(context);
+
+        verify(config, times(1)).getString("edc.oauth.certificate.alias");
+        verify(config, never()).getString("edc.oauth.public.key.alias");
+
+    }
+
+    private void setupMocks(Config config) throws CertificateEncodingException {
+        when(context.getConfig()).thenReturn(config);
+
+        var certificate = mock(X509Certificate.class);
+        var privateKey = mock(PrivateKey.class);
+
+        when(privateKey.getAlgorithm()).thenReturn("RSA");
+        when(certificate.getEncoded()).thenReturn(new byte[]{});
+        when(certificateResolver.resolveCertificate("alias")).thenReturn(certificate);
+        when(privateKeyResolver.resolvePrivateKey("p_alias", PrivateKey.class)).thenReturn(privateKey);
+    }
+}

--- a/extensions/common/iam/oauth2/oauth2-daps/src/test/java/org/eclipse/edc/iam/oauth2/daps/DapsIntegrationTest.java
+++ b/extensions/common/iam/oauth2/oauth2-daps/src/test/java/org/eclipse/edc/iam/oauth2/daps/DapsIntegrationTest.java
@@ -43,7 +43,7 @@ class DapsIntegrationTest {
             "edc.oauth.provider.audience", AUDIENCE_IDS_CONNECTORS_ALL,
             "edc.oauth.endpoint.audience", AUDIENCE_IDS_CONNECTORS_ALL,
             "edc.oauth.provider.jwks.url", DAPS_URL + "/.well-known/jwks.json",
-            "edc.oauth.public.key.alias", CLIENT_KEYSTORE_KEY_ALIAS,
+            "edc.oauth.certificate.alias", CLIENT_KEYSTORE_KEY_ALIAS,
             "edc.oauth.private.key.alias", CLIENT_KEYSTORE_KEY_ALIAS
     );
 

--- a/launchers/ids-connector/README.md
+++ b/launchers/ids-connector/README.md
@@ -64,7 +64,7 @@ this launcher's directory. Please adjust this for your setup as follows:
   supported by the DAPS. Therefore, this property has to be set to `idsc:IDS_CONNECTORS_ALL`.
 * `edc.oauth.provider.jwks.url`: Set this to the URL of the DAPS you want to use followed by 
   `/.well-known/jwks.json`.
-* `edc.oauth.public.key.alias`: Set this to your certificate's `alias` in the keystore.
+* `edc.oauth.certificate.alias`: Set this to your certificate's `alias` in the keystore.
 * `edc.oauth.private.key.alias`: Set this to your certificate's `alias` in the keystore.
 
 ### Getting the Certificate Identifier

--- a/launchers/ids-connector/config.properties
+++ b/launchers/ids-connector/config.properties
@@ -4,14 +4,12 @@ web.http.path=/api
 web.http.ids.port=8282
 web.http.ids.path=/api/v1/ids
 ids.webhook.address=http://localhost:8282
-
 ### Authentication for Dat Management API endpoints ###
 edc.api.auth.key=password
-
 ### OAuth2 ###
 edc.oauth.token.url=<daps-url>/token
 edc.oauth.client.id=<identifier-from-certificate>
 edc.oauth.provider.audience=idsc:IDS_CONNECTORS_ALL
 edc.oauth.provider.jwks.url=<daps-url>/.well-known/jwks.json
-edc.oauth.public.key.alias=<alias-of-certificate-in-keystore>
+edc.oauth.certificate.alias=<alias-of-certificate-in-keystore>
 edc.oauth.private.key.alias=<alias-of-certificate-in-keystore>


### PR DESCRIPTION
## What this PR changes/adds

Renames ` edc.oauth.public.key.alias` to `edc.oauth.certificate.alias`

## Why it does that

clarity


## Linked Issue(s)

Closes #2257 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
