### PR TITLE
fix: make negotiation api launch a `decline` command

### DIFF
--- a/core/common/state-machine/src/main/java/org/eclipse/edc/statemachine/retry/SendRetryManager.java
+++ b/core/common/state-machine/src/main/java/org/eclipse/edc/statemachine/retry/SendRetryManager.java
@@ -14,28 +14,31 @@
 
 package org.eclipse.edc.statemachine.retry;
 
+import org.eclipse.edc.spi.entity.StatefulEntity;
+
 /**
  * Service enabling a "long retry" mechanism when sending entities across applications.
  * Implementations may support a retry strategy (e.g. an exponential wait mechanism
  * so as not to overflow the remote service when it becomes available again).
  *
- * @param <T> entity type
  */
-public interface SendRetryManager<T> {
+public interface SendRetryManager {
     /**
      * Determines whether the given entity may be sent at this time, or the system
      * should wait and send the entity later.
      *
      * @param entity entity to be evaluated.
      * @return {@code true} if the entity should not be sent at this time.
+     * @param <T> stateful entity type
      */
-    boolean shouldDelay(T entity);
+    <T extends StatefulEntity<T>> boolean shouldDelay(T entity);
 
     /**
      * Determines whether retries for sending the given entity have been exhausted.
      *
      * @param entity entity to be evaluated.
      * @return {@code true} if the entity should not be sent anymore.
+     * @param <T> stateful entity type
      */
-    boolean retriesExhausted(T entity);
+    <T extends StatefulEntity<T>> boolean retriesExhausted(T entity);
 }

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/ContractNegotiationCommandExtension.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/ContractNegotiationCommandExtension.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.connector.contract;
 
 import org.eclipse.edc.connector.contract.negotiation.command.handlers.CancelNegotiationCommandHandler;
+import org.eclipse.edc.connector.contract.negotiation.command.handlers.DeclineNegotiationCommandHandler;
 import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.runtime.metamodel.annotation.CoreExtension;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
@@ -44,6 +45,7 @@ public class ContractNegotiationCommandExtension implements ServiceExtension {
 
     private void registerDefaultCommandHandlers(CommandHandlerRegistry registry) {
         registry.register(new CancelNegotiationCommandHandler(store));
+        registry.register(new DeclineNegotiationCommandHandler(store));
     }
 
 }

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/AbstractContractNegotiationManager.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/AbstractContractNegotiationManager.java
@@ -24,7 +24,6 @@ import org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore;
 import org.eclipse.edc.spi.command.CommandProcessor;
 import org.eclipse.edc.spi.command.CommandQueue;
 import org.eclipse.edc.spi.command.CommandRunner;
-import org.eclipse.edc.spi.entity.StatefulEntity;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.retry.WaitStrategy;
@@ -57,7 +56,7 @@ public abstract class AbstractContractNegotiationManager {
     protected int batchSize = DEFAULT_BATCH_SIZE;
     protected WaitStrategy waitStrategy = () -> DEFAULT_ITERATION_WAIT;
     protected PolicyDefinitionStore policyStore;
-    protected SendRetryManager<StatefulEntity> sendRetryManager;
+    protected SendRetryManager sendRetryManager;
 
     /**
      * Gives the name of the manager
@@ -142,7 +141,7 @@ public abstract class AbstractContractNegotiationManager {
             return this;
         }
 
-        public Builder<T> sendRetryManager(SendRetryManager<StatefulEntity> sendRetryManager) {
+        public Builder<T> sendRetryManager(SendRetryManager sendRetryManager) {
             manager.sendRetryManager = sendRetryManager;
             return this;
         }

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/command/handlers/DeclineNegotiationCommandHandler.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/command/handlers/DeclineNegotiationCommandHandler.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.contract.negotiation.command.handlers;
+
+import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
+import org.eclipse.edc.connector.contract.spi.types.command.DeclineNegotiationCommand;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
+
+/**
+ * Handler for {@link DeclineNegotiationCommand}s. Transitions the specified ContractNegotiation to the DECLINING state.
+ */
+public class DeclineNegotiationCommandHandler extends SingleContractNegotiationCommandHandler<DeclineNegotiationCommand> {
+
+    public DeclineNegotiationCommandHandler(ContractNegotiationStore store) {
+        super(store);
+    }
+
+    @Override
+    public Class<DeclineNegotiationCommand> getType() {
+        return DeclineNegotiationCommand.class;
+    }
+
+    /**
+     * Transitions a {@link ContractNegotiation} to the DECLINING state.
+     *
+     * @param negotiation the ContractNegotiation to modify.
+     * @return true
+     */
+    @Override
+    protected boolean modify(ContractNegotiation negotiation) {
+        negotiation.transitionDeclining();
+        return true;
+    }
+
+}

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/command/handlers/DeclineNegotiationCommandHandler.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/command/handlers/DeclineNegotiationCommandHandler.java
@@ -41,6 +41,7 @@ public class DeclineNegotiationCommandHandler extends SingleContractNegotiationC
     @Override
     protected boolean modify(ContractNegotiation negotiation) {
         negotiation.transitionDeclining();
+        negotiation.setErrorDetail("Declined");
         return true;
     }
 

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
@@ -30,7 +30,6 @@ import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.command.CommandQueue;
 import org.eclipse.edc.spi.command.CommandRunner;
-import org.eclipse.edc.spi.entity.StatefulEntity;
 import org.eclipse.edc.spi.iam.ClaimToken;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.monitor.Monitor;
@@ -80,7 +79,7 @@ class ConsumerContractNegotiationManagerImplTest {
     private final RemoteMessageDispatcherRegistry dispatcherRegistry = mock(RemoteMessageDispatcherRegistry.class);
     private final PolicyDefinitionStore policyStore = mock(PolicyDefinitionStore.class);
     private final ContractNegotiationListener listener = mock(ContractNegotiationListener.class);
-    private final SendRetryManager<StatefulEntity> sendRetryManager = mock(SendRetryManager.class);
+    private final SendRetryManager sendRetryManager = mock(SendRetryManager.class);
     private ConsumerContractNegotiationManagerImpl negotiationManager;
 
     @BeforeEach

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -34,7 +34,6 @@ import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.policy.model.PolicyType;
 import org.eclipse.edc.spi.command.CommandQueue;
 import org.eclipse.edc.spi.command.CommandRunner;
-import org.eclipse.edc.spi.entity.StatefulEntity;
 import org.eclipse.edc.spi.iam.ClaimToken;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.monitor.ConsoleMonitor;
@@ -104,7 +103,7 @@ class ContractNegotiationIntegrationTest {
 
         CommandRunner<ContractNegotiationCommand> runner = (CommandRunner<ContractNegotiationCommand>) mock(CommandRunner.class);
 
-        SendRetryManager<StatefulEntity> sendRetryManager = mock(SendRetryManager.class);
+        var sendRetryManager = mock(SendRetryManager.class);
 
         providerManager = ProviderContractNegotiationManagerImpl.Builder.newInstance()
                 .dispatcherRegistry(providerDispatcherRegistry)

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
@@ -33,7 +33,6 @@ import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.command.CommandQueue;
 import org.eclipse.edc.spi.command.CommandRunner;
-import org.eclipse.edc.spi.entity.StatefulEntity;
 import org.eclipse.edc.spi.iam.ClaimToken;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.monitor.Monitor;
@@ -81,7 +80,7 @@ class ProviderContractNegotiationManagerImplTest {
     private final ContractValidationService validationService = mock(ContractValidationService.class);
     private final RemoteMessageDispatcherRegistry dispatcherRegistry = mock(RemoteMessageDispatcherRegistry.class);
     private final PolicyDefinitionStore policyStore = mock(PolicyDefinitionStore.class);
-    private final SendRetryManager<StatefulEntity> sendRetryManager = mock(SendRetryManager.class);
+    private final SendRetryManager sendRetryManager = mock(SendRetryManager.class);
     private final ContractNegotiationListener listener = mock(ContractNegotiationListener.class);
     private ProviderContractNegotiationManagerImpl negotiationManager;
 

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/command/ContractNegotiationCommandQueueIntegrationTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/command/ContractNegotiationCommandQueueIntegrationTest.java
@@ -29,7 +29,6 @@ import org.eclipse.edc.spi.command.BoundedCommandQueue;
 import org.eclipse.edc.spi.command.CommandHandlerRegistry;
 import org.eclipse.edc.spi.command.CommandQueue;
 import org.eclipse.edc.spi.command.CommandRunner;
-import org.eclipse.edc.spi.entity.StatefulEntity;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.statemachine.retry.SendRetryManager;
@@ -55,7 +54,7 @@ class ContractNegotiationCommandQueueIntegrationTest {
     private String negotiationId;
     private ContractNegotiation negotiation;
     private TestCommand command;
-    private SendRetryManager<StatefulEntity> sendRetryManager = mock(SendRetryManager.class);
+    private SendRetryManager sendRetryManager = mock(SendRetryManager.class);
 
     @BeforeEach
     void setUp() {

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/command/handlers/DeclineNegotiationCommandHandlerTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/command/handlers/DeclineNegotiationCommandHandlerTest.java
@@ -57,6 +57,7 @@ class DeclineNegotiationCommandHandlerTest {
         commandHandler.handle(command);
 
         assertThat(negotiation.getState()).isEqualTo(ContractNegotiationStates.DECLINING.code());
+        assertThat(negotiation.getErrorDetail()).isNotBlank();
         assertThat(negotiation.getUpdatedAt()).isNotEqualTo(originalTime);
     }
 

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/command/handlers/DeclineNegotiationCommandHandlerTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/command/handlers/DeclineNegotiationCommandHandlerTest.java
@@ -30,13 +30,12 @@ import static org.mockito.Mockito.when;
 
 class DeclineNegotiationCommandHandlerTest {
 
-    private DeclineNegotiationCommandHandler commandHandler;
+    private final ContractNegotiationStore store = mock(ContractNegotiationStore.class);
 
-    private ContractNegotiationStore store;
+    private DeclineNegotiationCommandHandler commandHandler;
 
     @BeforeEach
     public void setUp() {
-        store = mock(ContractNegotiationStore.class);
         commandHandler = new DeclineNegotiationCommandHandler(store);
     }
 

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/command/handlers/DeclineNegotiationCommandHandlerTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/command/handlers/DeclineNegotiationCommandHandlerTest.java
@@ -1,0 +1,81 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.contract.negotiation.command.handlers;
+
+import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
+import org.eclipse.edc.connector.contract.spi.types.command.DeclineNegotiationCommand;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates;
+import org.eclipse.edc.spi.EdcException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DeclineNegotiationCommandHandlerTest {
+
+    private DeclineNegotiationCommandHandler commandHandler;
+
+    private ContractNegotiationStore store;
+
+    @BeforeEach
+    public void setUp() {
+        store = mock(ContractNegotiationStore.class);
+        commandHandler = new DeclineNegotiationCommandHandler(store);
+    }
+
+    @Test
+    void handle_negotiationExists_declineNegotiation() {
+        var negotiationId = "test";
+        var negotiation = ContractNegotiation.Builder.newInstance()
+                .id(negotiationId)
+                .counterPartyId("counter-party")
+                .counterPartyAddress("https://counter-party")
+                .protocol("test-protocol")
+                .state(ContractNegotiationStates.REQUESTED.code())
+                .build();
+        var originalTime = negotiation.getUpdatedAt();
+        var command = new DeclineNegotiationCommand(negotiationId);
+
+        when(store.find(negotiationId)).thenReturn(negotiation);
+
+        commandHandler.handle(command);
+
+        assertThat(negotiation.getState()).isEqualTo(ContractNegotiationStates.DECLINING.code());
+        assertThat(negotiation.getUpdatedAt()).isNotEqualTo(originalTime);
+    }
+
+    @Test
+    void handle_negotiationDoesNotExist_throwEdcException() {
+        var negotiationId = "test";
+        var command = new DeclineNegotiationCommand(negotiationId);
+
+        when(store.find(negotiationId)).thenReturn(null);
+
+        assertThatThrownBy(() -> commandHandler.handle(command))
+                .isInstanceOf(EdcException.class)
+                .hasMessage(format("Could not find ContractNegotiation with ID [%s]", negotiationId));
+    }
+
+    @Test
+    void getType_returnType() {
+        assertThat(commandHandler.getType()).isEqualTo(DeclineNegotiationCommand.class);
+    }
+
+}

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
@@ -40,7 +40,6 @@ import org.eclipse.edc.spi.asset.DataAddressResolver;
 import org.eclipse.edc.spi.command.CommandProcessor;
 import org.eclipse.edc.spi.command.CommandQueue;
 import org.eclipse.edc.spi.command.CommandRunner;
-import org.eclipse.edc.spi.entity.StatefulEntity;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.response.StatusResult;
@@ -123,7 +122,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
     private StateMachineManager stateMachineManager;
     private DataAddressResolver addressResolver;
     private PolicyArchive policyArchive;
-    private SendRetryManager<StatefulEntity> sendRetryManager;
+    private SendRetryManager sendRetryManager;
     private Clock clock;
 
     private TransferProcessManagerImpl() {

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/transfer/TransferProcessManagerImplTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/transfer/TransferProcessManagerImplTest.java
@@ -46,7 +46,6 @@ import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.asset.DataAddressResolver;
 import org.eclipse.edc.spi.command.CommandQueue;
 import org.eclipse.edc.spi.command.CommandRunner;
-import org.eclipse.edc.spi.entity.StatefulEntity;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.response.ResponseStatus;
@@ -118,7 +117,7 @@ class TransferProcessManagerImplTest {
     private final PolicyArchive policyArchive = mock(PolicyArchive.class);
     private final DataFlowManager dataFlowManager = mock(DataFlowManager.class);
     private final Vault vault = mock(Vault.class);
-    private final SendRetryManager<StatefulEntity<?>> sendRetryManager = mock(SendRetryManager.class);
+    private final SendRetryManager sendRetryManager = mock(SendRetryManager.class);
     private final TransferProcessListener listener = mock(TransferProcessListener.class);
 
     private TransferProcessManagerImpl manager;

--- a/extensions/control-plane/api/management-api/catalog-api/src/test/java/org/eclipse/edc/connector/api/management/catalog/CatalogApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/test/java/org/eclipse/edc/connector/api/management/catalog/CatalogApiControllerIntegrationTest.java
@@ -78,7 +78,6 @@ class CatalogApiControllerIntegrationTest {
                 "web.http.management.path", "/api/v1/management",
                 "edc.api.auth.key", authKey
         ));
-
     }
 
     @Test

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/command/DeclineNegotiationCommand.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/command/DeclineNegotiationCommand.java
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.contract.spi.types.command;
+
+/**
+ * Command for declining a specific ContractNegotiation.
+ */
+public class DeclineNegotiationCommand extends SingleContractNegotiationCommand {
+    public DeclineNegotiationCommand(String negotiationId) {
+        super(negotiationId);
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

Introduce a `decline` command and make the `ContractNegotiationApiController` launch it.

## Why it does that

The current `/decline` endpoint is not declining the negotiation on both sides.

## Further notes

- improved the `SendRetryManager` interface, as it caused a lot of warnings due to bad design.

## Linked Issue(s)

Closes #2259

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
