### PR TITLE
fix: correctly transform assetId back from IDS infomodel

### DIFF
--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -214,9 +214,16 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
      * @return a {@link StatusResult}: OK
      */
     private StatusResult<ContractNegotiation> processIncomingOffer(ContractNegotiation negotiation, ClaimToken token, ContractOffer offer) {
-        var result = validateLastOffer(negotiation, token, offer);
+        // TODO: why we validate offer in a different way if it is the initial one?
+        Result<ContractOffer> result;
+        if (negotiation.getContractOffers().isEmpty()) {
+            result = validationService.validateInitialOffer(token, offer);
+        } else {
+            var lastOffer = negotiation.getLastContractOffer();
+            result = validationService.validate(token, offer, lastOffer);
+        }
 
-        negotiation.addContractOffer(offer); // TODO persist unchecked offer of consumer?
+        negotiation.addContractOffer(offer);
 
         if (result.failed()) {
             monitor.debug("[Provider] Contract offer received. Will be rejected: " + result.getFailureDetail());
@@ -230,7 +237,6 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
         }
 
         monitor.debug("[Provider] Contract offer received. Will be approved.");
-        negotiation.addContractOffer(result.getContent());
         negotiation.transitionConfirming();
         negotiationStore.save(negotiation);
         monitor.debug(String.format("[Provider] ContractNegotiation %s is now in state %s.",
@@ -249,14 +255,6 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
 
     private boolean processCommand(ContractNegotiationCommand command) {
         return commandProcessor.processCommandQueue(command);
-    }
-
-    private Result<ContractOffer> validateLastOffer(ContractNegotiation negotiation, ClaimToken token, ContractOffer offer) {
-        if (negotiation.getContractOffers().isEmpty()) {
-            return validationService.validateInitialOffer(token, offer);
-        }
-        var lastOffer = negotiation.getLastContractOffer();
-        return validationService.validate(token, offer, lastOffer);
     }
 
     /**

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -214,11 +214,11 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
      * @return a {@link StatusResult}: OK
      */
     private StatusResult<ContractNegotiation> processIncomingOffer(ContractNegotiation negotiation, ClaimToken token, ContractOffer offer) {
-        // TODO: why we validate offer in a different way if it is the initial one?
         Result<ContractOffer> result;
         if (negotiation.getContractOffers().isEmpty()) {
             result = validationService.validateInitialOffer(token, offer);
         } else {
+            // TODO: this is actually dead code because "counter-offers" are not supported.
             var lastOffer = negotiation.getLastContractOffer();
             result = validationService.validate(token, offer, lastOffer);
         }

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -174,7 +174,7 @@ class ContractNegotiationIntegrationTest {
 
                     // Assert that provider and consumer have the same offers and agreement stored
                     assertThat(consumerNegotiation.getContractOffers()).hasSize(1);
-                    assertThat(providerNegotiation.getContractOffers()).hasSize(2);
+                    assertThat(providerNegotiation.getContractOffers()).hasSize(1);
                     assertThat(consumerNegotiation.getContractOffers().get(0)).isEqualTo(offer);
                     assertThat(consumerNegotiation.getState()).isEqualTo(CONFIRMED.code());
                     assertThat(consumerNegotiation.getLastContractOffer()).isEqualTo(providerNegotiation.getLastContractOffer());
@@ -188,11 +188,12 @@ class ContractNegotiationIntegrationTest {
 
     @Test
     void testNegotiation_initialOfferDeclined() {
+        when(providerDispatcherRegistry.send(any(), isA(ContractRejection.class), any())).then(onProviderSentRejection());
         when(consumerDispatcherRegistry.send(any(), isA(ContractOfferRequest.class), any())).then(onConsumerSentOfferRequest());
         consumerNegotiationId = null;
         ContractOffer offer = getContractOffer();
 
-        when(validationService.validateInitialOffer(token, offer)).thenReturn(Result.success(offer));
+        when(validationService.validateInitialOffer(token, offer)).thenReturn(Result.failure("must be declined"));
 
         // Start provider and consumer negotiation managers
         providerManager.start();
@@ -219,7 +220,7 @@ class ContractNegotiationIntegrationTest {
 
                     // Assert that provider and consumer have the same offers stored
                     assertThat(consumerNegotiation.getContractOffers()).hasSize(1);
-                    assertThat(providerNegotiation.getContractOffers()).hasSize(2);
+                    assertThat(providerNegotiation.getContractOffers()).hasSize(1);
                     assertThat(consumerNegotiation.getLastContractOffer()).isEqualTo(providerNegotiation.getLastContractOffer());
 
                     // Assert that no agreement has been stored on either side
@@ -265,7 +266,7 @@ class ContractNegotiationIntegrationTest {
 
                     // Assert that provider and consumer have the same offers stored
                     assertThat(consumerNegotiation.getContractOffers()).hasSize(1);
-                    assertThat(providerNegotiation.getContractOffers()).hasSize(2);
+                    assertThat(providerNegotiation.getContractOffers()).hasSize(1);
                     assertThat(consumerNegotiation.getLastContractOffer()).isEqualTo(providerNegotiation.getLastContractOffer());
 
                     // Assert that no agreement has been stored on either side
@@ -534,6 +535,15 @@ class ContractNegotiationIntegrationTest {
         return i -> {
             ContractAgreementRequest request = i.getArgument(1);
             var result = consumerManager.confirmed(token, request.getCorrelationId(), request.getContractAgreement(), request.getPolicy());
+            return toFuture(result);
+        };
+    }
+
+    @NotNull
+    private Answer<Object> onProviderSentRejection() {
+        return i -> {
+            ContractRejection request = i.getArgument(1);
+            var result = consumerManager.declined(token, request.getCorrelationId());
             return toFuture(result);
         };
     }

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
@@ -130,7 +130,7 @@ class ProviderContractNegotiationManagerImplTest {
                         n.getCounterPartyAddress().equals(request.getConnectorAddress()) &&
                         n.getProtocol().equals(request.getProtocol()) &&
                         n.getCorrelationId().equals(request.getCorrelationId()) &&
-                        n.getContractOffers().size() == 2 &&
+                        n.getContractOffers().size() == 1 &&
                         n.getLastContractOffer().equals(contractOffer)
         ));
         verify(validationService).validateInitialOffer(token, contractOffer);
@@ -224,9 +224,8 @@ class ProviderContractNegotiationManagerImplTest {
         assertThat(result.succeeded()).isTrue();
         verify(store, atLeastOnce()).save(argThat(n ->
                 n.getState() == ContractNegotiationStates.CONFIRMING.code() &&
-                        n.getContractOffers().size() == 3 &&
-                        n.getContractOffers().get(1).equals(contractOffer) &&
-                        n.getContractOffers().get(2).equals(validatedOffer)
+                n.getContractOffers().size() == 2 &&
+                n.getLastContractOffer().equals(contractOffer)
         ));
 
         verify(validationService).validate(eq(token), eq(contractOffer), any(ContractOffer.class));

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/handler/ContractAgreementHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/handler/ContractAgreementHandler.java
@@ -21,11 +21,9 @@ import org.eclipse.edc.connector.contract.spi.negotiation.ConsumerContractNegoti
 import org.eclipse.edc.protocol.ids.api.multipart.message.MultipartRequest;
 import org.eclipse.edc.protocol.ids.api.multipart.message.MultipartResponse;
 import org.eclipse.edc.protocol.ids.spi.transform.ContractAgreementTransformerOutput;
-import org.eclipse.edc.protocol.ids.spi.transform.ContractTransformerInput;
 import org.eclipse.edc.protocol.ids.spi.transform.IdsTransformerRegistry;
 import org.eclipse.edc.protocol.ids.spi.types.IdsId;
 import org.eclipse.edc.spi.monitor.Monitor;
-import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
@@ -83,21 +81,9 @@ public class ContractAgreementHandler implements Handler {
             return createMultipartResponse(badParameters(message, connectorId));
         }
 
-        // search for matching asset
-        // TODO remove fake asset (description request to fetch original metadata --> store/cache)
-        var assetId = IdsId.from(permission.getTarget()).getContent().getValue();
-        var asset = Asset.Builder.newInstance().id(assetId).build();
-
-        // Create contract offer request
-        var input = ContractTransformerInput.Builder.newInstance()
-                .contract(contractAgreement)
-                .asset(asset)
-                .build();
-
-        var result = transformerRegistry.transform(input, ContractAgreementTransformerOutput.class);
+        var result = transformerRegistry.transform(contractAgreement, ContractAgreementTransformerOutput.class);
         if (result.failed()) {
-            monitor.debug(String.format("Could not transform contract agreement: [%s]",
-                    String.join(", ", result.getFailureMessages())));
+            monitor.debug(String.format("Could not transform contract agreement: [%s]", result.getFailureDetail()));
             return createMultipartResponse(badParameters(message, connectorId));
         }
 

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/handler/ContractAgreementHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/handler/ContractAgreementHandler.java
@@ -85,7 +85,8 @@ public class ContractAgreementHandler implements Handler {
 
         // search for matching asset
         // TODO remove fake asset (description request to fetch original metadata --> store/cache)
-        var asset = Asset.Builder.newInstance().id(String.valueOf(permission.getTarget())).build();
+        var assetId = IdsId.from(permission.getTarget()).getContent().getValue();
+        var asset = Asset.Builder.newInstance().id(assetId).build();
 
         // Create contract offer request
         var input = ContractTransformerInput.Builder.newInstance()

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/MultipartControllerIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/MultipartControllerIntegrationTest.java
@@ -92,7 +92,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.junit.testfixtures.TestUtils.getFreePort;
 import static org.eclipse.edc.protocol.ids.spi.domain.IdsConstants.IDS_WEBHOOK_ADDRESS_PROPERTY;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ComponentTest
@@ -666,7 +668,7 @@ class MultipartControllerIntegrationTest {
 
         assertThat(response).isNotNull().extracting(Response::code).isEqualTo(200);
 
-        List<NamedMultipartContent> content = extractNamedMultipartContent(response);
+        var content = extractNamedMultipartContent(response);
 
         assertThat(content)
                 .hasSize(1)
@@ -692,6 +694,7 @@ class MultipartControllerIntegrationTest {
         });
         jsonHeader.inPath("$.ids:issuerConnector.@id").isString().isEqualTo("urn:connector:" + CONNECTOR_ID);
         jsonHeader.inPath("$.ids:senderAgent.@id").isString().isEqualTo("urn:connector:" + CONNECTOR_ID);
+        verify(consumerContractNegotiationManager).confirmed(any(), any(), argThat(agreement -> assetId.equals(agreement.getAssetId())), any());
     }
 
     @Test

--- a/data-protocols/ids/ids-transform-v1/src/main/java/org/eclipse/edc/protocol/ids/transform/type/policy/PermissionToIdsPermissionTransformer.java
+++ b/data-protocols/ids/ids-transform-v1/src/main/java/org/eclipse/edc/protocol/ids/transform/type/policy/PermissionToIdsPermissionTransformer.java
@@ -67,7 +67,7 @@ public class PermissionToIdsPermissionTransformer implements IdsTypeTransformer<
         }
 
         var assigner = object.getAssigner();
-            if (assigner != null) {
+        if (assigner != null) {
             builder._assigner_(List.of(URI.create(assigner)));
         }
 

--- a/data-protocols/ids/ids-transform-v1/src/main/java/org/eclipse/edc/protocol/ids/transform/type/policy/PermissionToIdsPermissionTransformer.java
+++ b/data-protocols/ids/ids-transform-v1/src/main/java/org/eclipse/edc/protocol/ids/transform/type/policy/PermissionToIdsPermissionTransformer.java
@@ -67,7 +67,7 @@ public class PermissionToIdsPermissionTransformer implements IdsTypeTransformer<
         }
 
         var assigner = object.getAssigner();
-        if (assigner != null) {
+            if (assigner != null) {
             builder._assigner_(List.of(URI.create(assigner)));
         }
 

--- a/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/edc/protocol/ids/transform/ContractAgreementFromIdsContractAgreementTransformerTest.java
+++ b/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/edc/protocol/ids/transform/ContractAgreementFromIdsContractAgreementTransformerTest.java
@@ -14,103 +14,76 @@
 
 package org.eclipse.edc.protocol.ids.transform;
 
+import de.fraunhofer.iais.eis.ContractAgreementBuilder;
 import org.eclipse.edc.policy.model.Duty;
 import org.eclipse.edc.policy.model.Permission;
 import org.eclipse.edc.policy.model.Prohibition;
-import org.eclipse.edc.protocol.ids.spi.transform.ContractTransformerInput;
 import org.eclipse.edc.protocol.ids.transform.type.contract.ContractAgreementFromIdsContractAgreementTransformer;
-import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.eclipse.edc.transform.spi.TransformerContext;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Calendar;
-import java.util.Collections;
 import java.util.GregorianCalendar;
+import java.util.List;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class ContractAgreementFromIdsContractAgreementTransformerTest {
+
     private static final URI AGREEMENT_ID = URI.create("urn:contractagreement:456uz984390236s");
     private static final URI PROVIDER_URI = URI.create("https://provider.com/");
-
     private static final URI CONSUMER_URI = URI.create("https://provider.com/");
     private static final XMLGregorianCalendar CONTRACT_START = DatatypeFactory.newDefaultInstance().newXMLGregorianCalendar(new GregorianCalendar(2021, Calendar.JANUARY, 1));
     private static final XMLGregorianCalendar CONTRACT_END = DatatypeFactory.newDefaultInstance().newXMLGregorianCalendar(new GregorianCalendar(2021, Calendar.FEBRUARY, 2));
     private static final XMLGregorianCalendar SIGNING_DATE = DatatypeFactory.newDefaultInstance().newXMLGregorianCalendar(new GregorianCalendar(2021, Calendar.FEBRUARY, 2));
 
-    private ContractAgreementFromIdsContractAgreementTransformer transformer;
-
     private de.fraunhofer.iais.eis.Permission idsPermission;
     private de.fraunhofer.iais.eis.Prohibition idsProhibition;
     private de.fraunhofer.iais.eis.Duty idsDuty;
-    private TransformerContext context;
-    private ContractTransformerInput input;
+    private final TransformerContext context = mock(TransformerContext.class);
+
+    private ContractAgreementFromIdsContractAgreementTransformer transformer;
 
     @BeforeEach
     void setUp() {
         transformer = new ContractAgreementFromIdsContractAgreementTransformer();
-        idsPermission = new de.fraunhofer.iais.eis.PermissionBuilder().build();
+        idsPermission = new de.fraunhofer.iais.eis.PermissionBuilder()._target_(URI.create("urn:artifact:assetId")).build();
         idsProhibition = new de.fraunhofer.iais.eis.ProhibitionBuilder().build();
         idsDuty = new de.fraunhofer.iais.eis.DutyBuilder().build();
-        var idsContractAgreement = new de.fraunhofer.iais.eis.ContractAgreementBuilder(AGREEMENT_ID)
-                ._provider_(PROVIDER_URI)
-                ._consumer_(CONSUMER_URI)
-                ._permission_(new ArrayList<>(Collections.singletonList(idsPermission)))
-                ._prohibition_(new ArrayList<>(Collections.singletonList(idsProhibition)))
-                ._obligation_(new ArrayList<>(Collections.singletonList(idsDuty)))
-                ._contractStart_(CONTRACT_START)
-                ._contractEnd_(CONTRACT_END)
-                ._contractDate_(SIGNING_DATE)
-                .build();
-        var asset = Asset.Builder.newInstance().build();
-        input = ContractTransformerInput.Builder.newInstance().contract(idsContractAgreement).asset(asset).build();
-        context = mock(TransformerContext.class);
     }
 
     @Test
-    void testThrowsNullPointerExceptionForAll() {
-        Assertions.assertThrows(NullPointerException.class, () -> {
-            transformer.transform(null, null);
-        });
-    }
-
-    @Test
-    void testThrowsNullPointerExceptionForContext() {
-        Assertions.assertThrows(NullPointerException.class, () -> {
-            transformer.transform(input, null);
-        });
-    }
-
-    @Test
-    void testReturnsNull() {
+    void shouldReturnNull_ifInputIsNull() {
         var result = transformer.transform(null, context);
 
-        Assertions.assertNull(result);
+        assertThat(result).isNull();
     }
 
     @Test
-    void testSuccessfulSimple() {
-        var edcPermission = mock(Permission.class);
+    void shouldTransform() {
+        var edcPermission = Permission.Builder.newInstance().target("assetId").build();
         var edcProhibition = mock(Prohibition.class);
         var edcObligation = mock(Duty.class);
-
         when(context.transform(eq(idsPermission), eq(Permission.class))).thenReturn(edcPermission);
         when(context.transform(eq(idsProhibition), eq(Prohibition.class))).thenReturn(edcProhibition);
         when(context.transform(eq(idsDuty), eq(Duty.class))).thenReturn(edcObligation);
 
-        var result = transformer.transform(input, context);
+        var contractAgreement = createFullContractAgreementBuilder().build();
+
+        var result = transformer.transform(contractAgreement, context);
 
         assertThat(result).isNotNull();
+        assertThat(result.getContractAgreement().getAssetId()).isEqualTo("assetId");
         assertThat(result.getPolicy()).isNotNull().satisfies(policy -> {
             assertThat(policy.getObligations()).hasSize(1).containsExactly(edcObligation);
             assertThat(policy.getPermissions()).hasSize(1).containsExactly(edcPermission);
@@ -120,5 +93,29 @@ public class ContractAgreementFromIdsContractAgreementTransformerTest {
         verify(context).transform(eq(idsPermission), eq(Permission.class));
         verify(context).transform(eq(idsProhibition), eq(Prohibition.class));
         verify(context).transform(eq(idsDuty), eq(Duty.class));
+    }
+
+    @Test
+    void shouldReportProblem_whenThereAreNoPermissions() {
+        var contractAgreement = createFullContractAgreementBuilder()
+                ._permission_(emptyList())
+                .build();
+
+        var result = transformer.transform(contractAgreement, context);
+
+        assertThat(result).isNull();
+        verify(context).reportProblem(any());
+    }
+
+    private ContractAgreementBuilder createFullContractAgreementBuilder() {
+        return new de.fraunhofer.iais.eis.ContractAgreementBuilder(AGREEMENT_ID)
+                ._provider_(PROVIDER_URI)
+                ._consumer_(CONSUMER_URI)
+                ._permission_(List.of(idsPermission))
+                ._prohibition_(List.of(idsProhibition))
+                ._obligation_(List.of(idsDuty))
+                ._contractStart_(CONTRACT_START)
+                ._contractEnd_(CONTRACT_END)
+                ._contractDate_(SIGNING_DATE);
     }
 }

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/AbstractEndToEndTransfer.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/AbstractEndToEndTransfer.java
@@ -57,10 +57,7 @@ public abstract class AbstractEndToEndTransfer {
                 .filter(o -> o.getAsset().getId().equals(assetId))
                 .findFirst()
                 .get();
-        var negotiationId = CONSUMER.negotiateContract(PROVIDER, contractOffer);
-        var contractAgreementId = CONSUMER.getContractAgreementId(negotiationId);
-        var contractAgreement = CONSUMER.getContractAgreement(contractAgreementId);
-        assertThat(contractAgreement.get("assetId")).isEqualTo(assetId);
+        var contractAgreementId = CONSUMER.negotiateContract(PROVIDER, contractOffer);
 
         var dataRequestId = UUID.randomUUID().toString();
         var transferProcessId = CONSUMER.dataRequest(dataRequestId, contractAgreementId, assetId, PROVIDER, sync());
@@ -104,8 +101,7 @@ public abstract class AbstractEndToEndTransfer {
                 .filter(o -> o.getAsset().getId().equals(assetId))
                 .findFirst()
                 .get();
-        var negotiationId = CONSUMER.negotiateContract(PROVIDER, contractOffer);
-        var contractAgreementId = CONSUMER.getContractAgreementId(negotiationId);
+        var contractAgreementId = CONSUMER.negotiateContract(PROVIDER, contractOffer);
 
         var dataRequestId = UUID.randomUUID().toString();
         var transferProcessId = CONSUMER.dataRequest(dataRequestId, contractAgreementId, assetId, PROVIDER, sync());
@@ -134,8 +130,7 @@ public abstract class AbstractEndToEndTransfer {
                 .filter(o -> o.getAsset().getId().equals(assetId))
                 .findFirst()
                 .get();
-        var negotiationId = CONSUMER.negotiateContract(PROVIDER, contractOffer);
-        var contractAgreementId = CONSUMER.getContractAgreementId(negotiationId);
+        var contractAgreementId = CONSUMER.negotiateContract(PROVIDER, contractOffer);
 
         var destination = HttpDataAddress.Builder.newInstance()
                 .baseUrl(CONSUMER.backendService() + "/api/consumer/store")
@@ -174,8 +169,7 @@ public abstract class AbstractEndToEndTransfer {
                 .filter(o -> o.getAsset().getId().equals(assetId))
                 .findFirst()
                 .get();
-        var negotiationId = CONSUMER.negotiateContract(PROVIDER, contractOffer);
-        var contractAgreementId = CONSUMER.getContractAgreementId(negotiationId);
+        var contractAgreementId = CONSUMER.negotiateContract(PROVIDER, contractOffer);
 
         var destination = HttpDataAddress.Builder.newInstance()
                 .baseUrl(CONSUMER.backendService() + "/api/consumer/store")

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/AbstractEndToEndTransfer.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/AbstractEndToEndTransfer.java
@@ -59,8 +59,8 @@ public abstract class AbstractEndToEndTransfer {
                 .get();
         var negotiationId = CONSUMER.negotiateContract(PROVIDER, contractOffer);
         var contractAgreementId = CONSUMER.getContractAgreementId(negotiationId);
-
-        assertThat(contractAgreementId).isNotEmpty();
+        var contractAgreement = CONSUMER.getContractAgreement(contractAgreementId);
+        assertThat(contractAgreement.get("assetId")).isEqualTo(assetId);
 
         var dataRequestId = UUID.randomUUID().toString();
         var transferProcessId = CONSUMER.dataRequest(dataRequestId, contractAgreementId, assetId, PROVIDER, sync());
@@ -107,8 +107,6 @@ public abstract class AbstractEndToEndTransfer {
         var negotiationId = CONSUMER.negotiateContract(PROVIDER, contractOffer);
         var contractAgreementId = CONSUMER.getContractAgreementId(negotiationId);
 
-        assertThat(contractAgreementId).isNotEmpty();
-
         var dataRequestId = UUID.randomUUID().toString();
         var transferProcessId = CONSUMER.dataRequest(dataRequestId, contractAgreementId, assetId, PROVIDER, sync());
 
@@ -138,8 +136,6 @@ public abstract class AbstractEndToEndTransfer {
                 .get();
         var negotiationId = CONSUMER.negotiateContract(PROVIDER, contractOffer);
         var contractAgreementId = CONSUMER.getContractAgreementId(negotiationId);
-
-        assertThat(contractAgreementId).isNotEmpty();
 
         var destination = HttpDataAddress.Builder.newInstance()
                 .baseUrl(CONSUMER.backendService() + "/api/consumer/store")
@@ -180,8 +176,6 @@ public abstract class AbstractEndToEndTransfer {
                 .get();
         var negotiationId = CONSUMER.negotiateContract(PROVIDER, contractOffer);
         var contractAgreementId = CONSUMER.getContractAgreementId(negotiationId);
-
-        assertThat(contractAgreementId).isNotEmpty();
 
         var destination = HttpDataAddress.Builder.newInstance()
                 .baseUrl(CONSUMER.backendService() + "/api/consumer/store")

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/Participant.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/Participant.java
@@ -119,6 +119,9 @@ public class Participant {
                 .contentType(JSON).contentType(JSON);
     }
 
+    /**
+     * Start contract negotiation, waits for agreement, check asset id and returns the agreement id
+     */
     public String negotiateContract(Participant provider, ContractOffer contractOffer) {
         var request = Map.of(
                 "connectorId", "provider",
@@ -131,7 +134,7 @@ public class Participant {
                 )
         );
 
-        return given()
+        var negotiationId = given()
                 .baseUri(controlPlaneManagement.toString())
                 .contentType(JSON)
                 .body(typeManager.writeValueAsString(request))
@@ -140,6 +143,13 @@ public class Participant {
                 .then()
                 .statusCode(200)
                 .extract().body().jsonPath().getString("id");
+
+        var contractAgreementId = getContractAgreementId(negotiationId);
+
+        var assetId = getContractAgreementField(contractAgreementId, "assetId");
+        assertThat(assetId).isEqualTo(contractOffer.getAsset().getId());
+
+        return contractAgreementId;
     }
 
     public String getContractAgreementId(String negotiationId) {
@@ -155,29 +165,6 @@ public class Participant {
         var id = contractAgreementId.get();
         assertThat(id).isNotEmpty();
         return id;
-    }
-
-    public Map<String, Object> getContractAgreement(String contractAgreementId) {
-        return given()
-                .baseUri(controlPlaneManagement.toString())
-                .contentType(JSON)
-                .when()
-                .get("/contractagreements/{id}", contractAgreementId)
-                .then()
-                .statusCode(200)
-                .extract().body().as(Map.class);
-    }
-
-    private String getContractNegotiationField(String negotiationId, String fieldName) {
-        return given()
-                .baseUri(controlPlaneManagement.toString())
-                .contentType(JSON)
-                .when()
-                .get("/contractnegotiations/{id}", negotiationId)
-                .then()
-                .statusCode(200)
-                .extract().body().jsonPath()
-                .getString(fieldName);
     }
 
     public String dataRequest(String id, String contractAgreementId, String assetId, Participant provider, DataAddress dataAddress) {
@@ -408,6 +395,30 @@ public class Participant {
 
     public String getName() {
         return name;
+    }
+
+    private String getContractAgreementField(String contractAgreementId, String fieldName) {
+        return given()
+                .baseUri(controlPlaneManagement.toString())
+                .contentType(JSON)
+                .when()
+                .get("/contractagreements/{id}", contractAgreementId)
+                .then()
+                .statusCode(200)
+                .extract().body().jsonPath()
+                .getString(fieldName);
+    }
+
+    private String getContractNegotiationField(String negotiationId, String fieldName) {
+        return given()
+                .baseUri(controlPlaneManagement.toString())
+                .contentType(JSON)
+                .when()
+                .get("/contractnegotiations/{id}", negotiationId)
+                .then()
+                .statusCode(200)
+                .extract().body().jsonPath()
+                .getString(fieldName);
     }
 
     @NotNull

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/Participant.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/Participant.java
@@ -152,7 +152,20 @@ public class Participant {
             contractAgreementId.set(agreementId);
         });
 
-        return contractAgreementId.get();
+        var id = contractAgreementId.get();
+        assertThat(id).isNotEmpty();
+        return id;
+    }
+
+    public Map<String, Object> getContractAgreement(String contractAgreementId) {
+        return given()
+                .baseUri(controlPlaneManagement.toString())
+                .contentType(JSON)
+                .when()
+                .get("/contractagreements/{id}", contractAgreementId)
+                .then()
+                .statusCode(200)
+                .extract().body().as(Map.class);
     }
 
     private String getContractNegotiationField(String negotiationId, String fieldName) {


### PR DESCRIPTION
## What this PR changes/adds

Set the `ContractAgreement.assetId` field with the value coming out from the "IDS to EDC" model transformation, so it won't report the `urn:artifact` prefix

## Why it does that

Bugfix

## Further notes

- moved some transformation logic that was in the `ContractAgreementHandler` to the `ContractAgreementFromIdsContractAgreementTransformer`
- these `ContractNegotiationIntegrationTest` are pure evil! I think they deserve some love.
- What's the point of having the logic for "counter offers" that's actually dead code? (`ConsumerContractNegotiationManager.offerReceived` is only called by tests). I would propose to remove all that logic since it will need to be re-engineered when actual use-cases will come. Follow-up issue will come (#2326)

## Linked Issue(s)

Closes #2318 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
