### PR TITLE
fix: set correct `consumer` and `provider` ids on `ContractOffer`

### DIFF
--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/handler/DescriptionRequestHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/handler/DescriptionRequestHandler.java
@@ -37,10 +37,10 @@ import org.eclipse.edc.spi.asset.AssetIndex;
 import org.eclipse.edc.spi.iam.ClaimToken;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.query.Criterion;
-import org.eclipse.edc.spi.query.QuerySpec;
-import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
 
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
@@ -49,6 +49,11 @@ import static org.eclipse.edc.protocol.ids.api.multipart.util.ResponseUtil.badPa
 import static org.eclipse.edc.protocol.ids.api.multipart.util.ResponseUtil.createMultipartResponse;
 import static org.eclipse.edc.protocol.ids.api.multipart.util.ResponseUtil.descriptionResponse;
 import static org.eclipse.edc.protocol.ids.api.multipart.util.ResponseUtil.notFound;
+import static org.eclipse.edc.protocol.ids.spi.types.IdsType.ARTIFACT;
+import static org.eclipse.edc.protocol.ids.spi.types.IdsType.CATALOG;
+import static org.eclipse.edc.protocol.ids.spi.types.IdsType.CONNECTOR;
+import static org.eclipse.edc.protocol.ids.spi.types.IdsType.REPRESENTATION;
+import static org.eclipse.edc.protocol.ids.spi.types.IdsType.RESOURCE;
 
 public class DescriptionRequestHandler implements Handler {
     private final Monitor monitor;
@@ -59,6 +64,14 @@ public class DescriptionRequestHandler implements Handler {
     private final ContractOfferResolver contractOfferResolver;
     private final ConnectorService connectorService;
     private final ObjectMapper objectMapper;
+
+    private final Map<IdsType, DescriptionHandler<?>> descriptionHandlers = Map.of(
+            ARTIFACT, new ArtifactDescriptionHandler(),
+            REPRESENTATION, new RepresentationDescriptionHandler(),
+            CONNECTOR, new ConnectorDescriptionHandler(),
+            CATALOG, new CatalogDescriptionHandler(),
+            RESOURCE, new ResourceDescriptionHandler()
+    );
 
     public DescriptionRequestHandler(
             @NotNull Monitor monitor,
@@ -86,31 +99,23 @@ public class DescriptionRequestHandler implements Handler {
 
     @Override
     public @NotNull MultipartResponse handleRequest(@NotNull MultipartRequest multipartRequest) {
-        var claimToken = multipartRequest.getClaimToken();
         var message = (DescriptionRequestMessage) multipartRequest.getHeader();
 
-        // Get ID of requested element
-        var requestedElement = IdsId.from(message.getRequestedElement());
+        var idsId = IdsId.from(message.getRequestedElement()).asOptional()
+                .orElse(IdsId.Builder.newInstance().type(CONNECTOR).value("fallback").build());
 
-        var querySpec = getQuerySpec(message, objectMapper);
+        var descriptionHandler = descriptionHandlers.get(idsId.getType());
 
-        // Retrieve and transform requested element
-        Result<? extends ModelClass> result;
-        if (requestedElement.failed() || requestedElement.getContent() == null ||
-                (requestedElement.getContent().getType() == IdsType.CONNECTOR)) {
-            result = getConnector(claimToken, querySpec);
-        } else {
-            var retrievedObject = retrieveRequestedElement(requestedElement.getContent(), claimToken, querySpec);
-            if (retrievedObject == null) {
-                return createMultipartResponse(notFound(message, connectorId));
-            }
-            result = transformRequestedElement(retrievedObject, requestedElement.getContent().getType());
+        if (descriptionHandler == null) {
+            monitor.warning("Cannot handle DescriptionRequest with type " + idsId.getType());
+            return createMultipartResponse(notFound(message, connectorId));
         }
 
+        var object = descriptionHandler.getObject(message, idsId, multipartRequest.getClaimToken());
+        var result = transformerRegistry.transform(object, descriptionHandler.getType());
         if (result.failed()) {
             monitor.warning(String.format("Could not retrieve requested element with ID %s:%s: [%s]",
-                    requestedElement.getContent().getType(), requestedElement.getContent().getValue(),
-                    String.join(", ", result.getFailureMessages())));
+                    idsId.getType(), idsId.getValue(), result.getFailureDetail()));
 
             return createMultipartResponse(badParameters(message, connectorId));
         }
@@ -118,69 +123,87 @@ public class DescriptionRequestHandler implements Handler {
         return createMultipartResponse(descriptionResponse(message, connectorId), result.getContent());
     }
 
-    private Result<Connector> getConnector(ClaimToken claimToken, QuerySpec querySpec) {
-        return transformerRegistry.transform(connectorService.getConnector(claimToken, querySpec), Connector.class);
+    private interface DescriptionHandler<T extends ModelClass> {
+        Class<T> getType();
+
+        Object getObject(DescriptionRequestMessage requestMessage, IdsId idsId, ClaimToken claimToken);
     }
 
-    /**
-     * Retrieves the requested element specified by the IdsId. If the requested element is a
-     * catalog or resource, the given range is used.
-     *
-     * @param idsId the ID.
-     * @param claimToken the claim token of the requesting connector.
-     * @param querySpec the QuerySpec containing Range and/or filtering criteria.
-     * @return the requested element.
-     */
-    private Object retrieveRequestedElement(IdsId idsId, ClaimToken claimToken, QuerySpec querySpec) {
-        var type = idsId.getType();
-        switch (type) {
-            case ARTIFACT:
-            case REPRESENTATION:
-                return assetIndex.findById(idsId.getValue());
-            case CATALOG:
-                return catalogService.getDataCatalog(claimToken, querySpec);
-            case RESOURCE:
-                var assetId = idsId.getValue();
-                var asset = assetIndex.findById(assetId);
-                if (asset == null) {
-                    return Result.failure(format("Asset with ID %s does not exist.", assetId));
-                }
+    private class ArtifactDescriptionHandler implements DescriptionHandler<Artifact> {
+        @Override
+        public Class<Artifact> getType() {
+            return Artifact.class;
+        }
 
-                var contractOfferQuery = ContractOfferQuery.Builder.newInstance()
-                        .claimToken(claimToken)
-                        .assetsCriterion(new Criterion(Asset.PROPERTY_ID, "=", assetId))
-                        .build();
+        @Override
+        public Object getObject(DescriptionRequestMessage requestMessage, IdsId idsId, ClaimToken claimToken) {
+            return assetIndex.findById(idsId.getValue());
+        }
+    }
 
-                try (var stream = contractOfferResolver.queryContractOffers(contractOfferQuery)) {
-                    var targetingContractOffers = stream.collect(toList());
+    private class RepresentationDescriptionHandler implements DescriptionHandler<Representation> {
+        @Override
+        public Class<Representation> getType() {
+            return Representation.class;
+        }
 
-                    return new OfferedAsset(asset, targetingContractOffers);
-                }
+        @Override
+        public Object getObject(DescriptionRequestMessage requestMessage, IdsId idsId, ClaimToken claimToken) {
+            return assetIndex.findById(idsId.getValue());
+        }
+    }
 
-            default:
+    private class ConnectorDescriptionHandler implements DescriptionHandler<Connector> {
+        @Override
+        public Class<Connector> getType() {
+            return Connector.class;
+        }
+
+        @Override
+        public Object getObject(DescriptionRequestMessage requestMessage, IdsId idsId, ClaimToken claimToken) {
+            return connectorService.getConnector(claimToken, getQuerySpec(requestMessage, objectMapper));
+        }
+    }
+
+    private class CatalogDescriptionHandler implements DescriptionHandler<ResourceCatalog> {
+        @Override
+        public Class<ResourceCatalog> getType() {
+            return ResourceCatalog.class;
+        }
+
+        @Override
+        public Object getObject(DescriptionRequestMessage requestMessage, IdsId idsId, ClaimToken claimToken) {
+            return catalogService.getDataCatalog(claimToken, getQuerySpec(requestMessage, objectMapper));
+        }
+    }
+
+    private class ResourceDescriptionHandler implements DescriptionHandler<Resource> {
+        @Override
+        public Class<Resource> getType() {
+            return Resource.class;
+        }
+
+        @Override
+        public Object getObject(DescriptionRequestMessage requestMessage, IdsId idsId, ClaimToken claimToken) {
+            var assetId = idsId.getValue();
+            var asset = assetIndex.findById(assetId);
+            if (asset == null) {
+                monitor.warning(format("Asset with ID %s does not exist.", assetId));
                 return null;
+            }
+
+            var contractOfferQuery = ContractOfferQuery.Builder.newInstance()
+                    .claimToken(claimToken)
+                    .assetsCriterion(new Criterion(Asset.PROPERTY_ID, "=", assetId))
+                    .build();
+
+            try (var stream = contractOfferResolver.queryContractOffers(contractOfferQuery)) {
+                var targetingContractOffers = stream.collect(toList());
+
+                return new OfferedAsset(asset, targetingContractOffers);
+            }
         }
     }
 
-    /**
-     * Transforms the requested element as defined by the IdsType.
-     *
-     * @param object the object to transform.
-     * @param type the IDS target type.
-     * @return the transformation result,
-     */
-    private Result<? extends ModelClass> transformRequestedElement(Object object, IdsType type) {
-        switch (type) {
-            case ARTIFACT:
-                return transformerRegistry.transform(object, Artifact.class);
-            case CATALOG:
-                return transformerRegistry.transform(object, ResourceCatalog.class);
-            case REPRESENTATION:
-                return transformerRegistry.transform(object, Representation.class);
-            case RESOURCE:
-                return transformerRegistry.transform(object, Resource.class);
-            default:
-                return Result.failure(format("Unknown requested element type: %s", type));
-        }
-    }
+
 }

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/edc/protocol/ids/IdsCoreServiceExtension.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/edc/protocol/ids/IdsCoreServiceExtension.java
@@ -100,7 +100,7 @@ public class IdsCoreServiceExtension implements ServiceExtension {
         var dataCatalogService = new CatalogServiceImpl(dataCatalogId, contractOfferResolver);
         context.registerService(CatalogService.class, dataCatalogService);
 
-        var connectorService = new ConnectorServiceImpl(monitor, connectorServiceSettings, dataCatalogService);
+        var connectorService = new ConnectorServiceImpl(connectorServiceSettings, dataCatalogService);
         context.registerService(ConnectorService.class, connectorService);
 
         context.registerService(DynamicAttributeTokenService.class, new DynamicAttributeTokenServiceImpl(identityService));

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/edc/protocol/ids/service/CatalogServiceImpl.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/edc/protocol/ids/service/CatalogServiceImpl.java
@@ -20,8 +20,7 @@ import org.eclipse.edc.catalog.spi.Catalog;
 import org.eclipse.edc.connector.contract.spi.offer.ContractOfferQuery;
 import org.eclipse.edc.connector.contract.spi.offer.ContractOfferResolver;
 import org.eclipse.edc.protocol.ids.spi.service.CatalogService;
-import org.eclipse.edc.spi.iam.ClaimToken;
-import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.protocol.ids.spi.types.container.DescriptionRequest;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
@@ -39,19 +38,17 @@ public class CatalogServiceImpl implements CatalogService {
         this.contractOfferResolver = Objects.requireNonNull(contractOfferResolver);
     }
 
-    /**
-     * Provides the dataCatalog object, which may be used by the IDS self-description of the connector.
-     *
-     * @return data catalog
-     */
     @Override
-    @NotNull
-    public Catalog getDataCatalog(ClaimToken claimToken, QuerySpec querySpec) {
+    public @NotNull Catalog getDataCatalog(@NotNull DescriptionRequest descriptionRequest) {
+        var querySpec = descriptionRequest.getQuerySpec();
 
         var query = ContractOfferQuery.Builder.newInstance()
-                .claimToken(claimToken)
+                .claimToken(descriptionRequest.getClaimToken())
                 .assetsCriteria(querySpec.getFilterExpression())
-                .range(querySpec.getRange()).build();
+                .range(querySpec.getRange())
+                .provider(descriptionRequest.getProvider())
+                .consumer(descriptionRequest.getConsumer())
+                .build();
 
         try (var offers = contractOfferResolver.queryContractOffers(query)) {
             return Catalog.Builder.newInstance()

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/edc/protocol/ids/service/ConnectorServiceImpl.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/edc/protocol/ids/service/ConnectorServiceImpl.java
@@ -19,9 +19,7 @@ package org.eclipse.edc.protocol.ids.service;
 import org.eclipse.edc.protocol.ids.spi.domain.connector.Connector;
 import org.eclipse.edc.protocol.ids.spi.service.CatalogService;
 import org.eclipse.edc.protocol.ids.spi.service.ConnectorService;
-import org.eclipse.edc.spi.iam.ClaimToken;
-import org.eclipse.edc.spi.monitor.Monitor;
-import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.protocol.ids.spi.types.container.DescriptionRequest;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collections;
@@ -30,25 +28,19 @@ import java.util.Objects;
 public class ConnectorServiceImpl implements ConnectorService {
     private static final String SYSTEM_VERSION = "0.0.1-SNAPSHOT"; // TODO update before/during build
 
-    private final Monitor monitor;
     private final ConnectorServiceSettings connectorServiceSettings;
     private final CatalogService dataCatalogService;
 
     public ConnectorServiceImpl(
-            @NotNull Monitor monitor,
             @NotNull ConnectorServiceSettings connectorServiceSettings,
             @NotNull CatalogService dataCatalogService) {
-        this.monitor = Objects.requireNonNull(monitor);
         this.connectorServiceSettings = Objects.requireNonNull(connectorServiceSettings);
         this.dataCatalogService = Objects.requireNonNull(dataCatalogService);
     }
 
-    @NotNull
     @Override
-    public Connector getConnector(@NotNull ClaimToken claimToken, QuerySpec querySpec) {
-        Objects.requireNonNull(claimToken);
-
-        var catalog = dataCatalogService.getDataCatalog(claimToken, querySpec);
+    public Connector getConnector(@NotNull DescriptionRequest descriptionRequest) {
+        var catalog = dataCatalogService.getDataCatalog(descriptionRequest);
 
         return Connector.Builder
                 .newInstance()

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/edc/protocol/ids/util/ConnectorIdUtil.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/edc/protocol/ids/util/ConnectorIdUtil.java
@@ -53,7 +53,7 @@ public class ConnectorIdUtil {
         }
 
         var message = "IDS Settings: Expected valid URN for setting '%s', but was %s'. Expected format: 'urn:connector:[id]'";
-        throw new EdcException(String.format(message, EDC_IDS_ID, DEFAULT_EDC_IDS_ID));
+        throw new EdcException(String.format(message, EDC_IDS_ID, value));
     }
 
 }

--- a/data-protocols/ids/ids-core/src/test/java/org/eclipse/edc/protocol/ids/service/CatalogServiceImplTest.java
+++ b/data-protocols/ids/ids-core/src/test/java/org/eclipse/edc/protocol/ids/service/CatalogServiceImplTest.java
@@ -18,6 +18,7 @@ import org.eclipse.edc.connector.contract.spi.offer.ContractOfferQuery;
 import org.eclipse.edc.connector.contract.spi.offer.ContractOfferResolver;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.protocol.ids.spi.types.container.DescriptionRequest;
 import org.eclipse.edc.spi.iam.ClaimToken;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
@@ -50,8 +51,12 @@ class CatalogServiceImplTest {
 
         var offers = Arrays.asList(createContractOffer("1"), createContractOffer("2"));
         when(contractOfferResolver.queryContractOffers(any(ContractOfferQuery.class))).thenReturn(offers.stream());
+        var descriptionRequest = DescriptionRequest.Builder.newInstance()
+                .claimToken(claimToken)
+                .querySpec(QuerySpec.none())
+                .build();
 
-        var result = dataCatalogService.getDataCatalog(claimToken, QuerySpec.none());
+        var result = dataCatalogService.getDataCatalog(descriptionRequest);
 
         assertThat(result).isNotNull();
         assertThat(result.getId()).isEqualTo(CATALOG_ID);

--- a/data-protocols/ids/ids-core/src/test/java/org/eclipse/edc/protocol/ids/service/ConnectorServiceImplTest.java
+++ b/data-protocols/ids/ids-core/src/test/java/org/eclipse/edc/protocol/ids/service/ConnectorServiceImplTest.java
@@ -19,8 +19,8 @@ import org.eclipse.edc.catalog.spi.Catalog;
 import org.eclipse.edc.protocol.ids.spi.domain.connector.SecurityProfile;
 import org.eclipse.edc.protocol.ids.spi.service.CatalogService;
 import org.eclipse.edc.protocol.ids.spi.types.IdsId;
+import org.eclipse.edc.protocol.ids.spi.types.container.DescriptionRequest;
 import org.eclipse.edc.spi.iam.ClaimToken;
-import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -49,12 +49,12 @@ class ConnectorServiceImplTest {
 
     @BeforeEach
     void setUp() {
-        connectorService = new ConnectorServiceImpl(mock(Monitor.class), connectorServiceSettings, dataCatalogService);
+        connectorService = new ConnectorServiceImpl(connectorServiceSettings, dataCatalogService);
     }
 
     @Test
     void getConnector() {
-        when(dataCatalogService.getDataCatalog(any(), any())).thenReturn(mock(Catalog.class));
+        when(dataCatalogService.getDataCatalog(any())).thenReturn(mock(Catalog.class));
         when(connectorServiceSettings.getId()).thenReturn(CONNECTOR_ID);
         when(connectorServiceSettings.getTitle()).thenReturn(CONNECTOR_TITLE);
         when(connectorServiceSettings.getDescription()).thenReturn(CONNECTOR_DESCRIPTION);
@@ -63,8 +63,13 @@ class ConnectorServiceImplTest {
         when(connectorServiceSettings.getMaintainer()).thenReturn(CONNECTOR_MAINTAINER);
         when(connectorServiceSettings.getCurator()).thenReturn(CONNECTOR_CURATOR);
         var claimToken = ClaimToken.Builder.newInstance().build();
+        var descriptionRequest = DescriptionRequest.Builder.newInstance()
+                .id(IdsId.from("urn:connector:any").getContent())
+                .claimToken(claimToken)
+                .querySpec(QuerySpec.none())
+                .build();
 
-        var result = connectorService.getConnector(claimToken, QuerySpec.none());
+        var result = connectorService.getConnector(descriptionRequest);
 
         assertThat(result).isNotNull();
         assertThat(result.getId()).isEqualTo(CONNECTOR_ID);
@@ -75,7 +80,7 @@ class ConnectorServiceImplTest {
         assertThat(result.getMaintainer()).isEqualTo(CONNECTOR_MAINTAINER);
         assertThat(result.getCurator()).isEqualTo(CONNECTOR_CURATOR);
         assertThat(result.getConnectorVersion()).isEqualTo(CONNECTOR_VERSION);
-        verify(dataCatalogService).getDataCatalog(any(), any());
+        verify(dataCatalogService).getDataCatalog(any());
         verify(connectorServiceSettings).getId();
         verify(connectorServiceSettings).getTitle();
         verify(connectorServiceSettings).getDescription();

--- a/data-protocols/ids/ids-spi/src/main/java/org/eclipse/edc/protocol/ids/spi/service/CatalogService.java
+++ b/data-protocols/ids/ids-spi/src/main/java/org/eclipse/edc/protocol/ids/spi/service/CatalogService.java
@@ -16,9 +16,8 @@
 package org.eclipse.edc.protocol.ids.spi.service;
 
 import org.eclipse.edc.catalog.spi.Catalog;
+import org.eclipse.edc.protocol.ids.spi.types.container.DescriptionRequest;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
-import org.eclipse.edc.spi.iam.ClaimToken;
-import org.eclipse.edc.spi.query.QuerySpec;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -33,5 +32,5 @@ public interface CatalogService {
      * @return data catalog
      */
     @NotNull
-    Catalog getDataCatalog(ClaimToken claimToken, QuerySpec querySpec);
+    Catalog getDataCatalog(@NotNull DescriptionRequest descriptionRequest);
 }

--- a/data-protocols/ids/ids-spi/src/main/java/org/eclipse/edc/protocol/ids/spi/service/CatalogService.java
+++ b/data-protocols/ids/ids-spi/src/main/java/org/eclipse/edc/protocol/ids/spi/service/CatalogService.java
@@ -27,7 +27,7 @@ import org.jetbrains.annotations.NotNull;
 public interface CatalogService {
 
     /**
-     * Provides the data catalog
+     * Provides the data catalog, which may be used by the IDS self-description of the connector.
      *
      * @return data catalog
      */

--- a/data-protocols/ids/ids-spi/src/main/java/org/eclipse/edc/protocol/ids/spi/service/ConnectorService.java
+++ b/data-protocols/ids/ids-spi/src/main/java/org/eclipse/edc/protocol/ids/spi/service/ConnectorService.java
@@ -16,9 +16,8 @@
 package org.eclipse.edc.protocol.ids.spi.service;
 
 import org.eclipse.edc.protocol.ids.spi.domain.connector.Connector;
+import org.eclipse.edc.protocol.ids.spi.types.container.DescriptionRequest;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
-import org.eclipse.edc.spi.iam.ClaimToken;
-import org.eclipse.edc.spi.query.QuerySpec;
 import org.jetbrains.annotations.NotNull;
 
 
@@ -35,5 +34,5 @@ public interface ConnectorService {
      * @return connector description
      */
     @NotNull
-    Connector getConnector(@NotNull ClaimToken claimToken, QuerySpec querySpec);
+    Connector getConnector(@NotNull DescriptionRequest descriptionRequest);
 }

--- a/data-protocols/ids/ids-spi/src/main/java/org/eclipse/edc/protocol/ids/spi/types/container/DescriptionRequest.java
+++ b/data-protocols/ids/ids-spi/src/main/java/org/eclipse/edc/protocol/ids/spi/types/container/DescriptionRequest.java
@@ -1,0 +1,96 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.ids.spi.types.container;
+
+import org.eclipse.edc.protocol.ids.spi.types.IdsId;
+import org.eclipse.edc.spi.iam.ClaimToken;
+import org.eclipse.edc.spi.query.QuerySpec;
+
+import java.net.URI;
+
+public class DescriptionRequest {
+
+    private IdsId id;
+    private ClaimToken claimToken;
+    private QuerySpec querySpec = QuerySpec.none();
+    private URI provider;
+    private URI consumer;
+
+    private DescriptionRequest() {
+
+    }
+
+    public IdsId getId() {
+        return id;
+    }
+
+    public ClaimToken getClaimToken() {
+        return claimToken;
+    }
+
+    public QuerySpec getQuerySpec() {
+        return querySpec;
+    }
+
+    public URI getProvider() {
+        return provider;
+    }
+
+    public URI getConsumer() {
+        return consumer;
+    }
+
+    public static final class Builder {
+        private final DescriptionRequest instance;
+
+        private Builder() {
+            instance = new DescriptionRequest();
+        }
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder id(IdsId id) {
+            instance.id = id;
+            return this;
+        }
+
+        public Builder claimToken(ClaimToken claimToken) {
+            instance.claimToken = claimToken;
+            return this;
+        }
+
+        public Builder querySpec(QuerySpec querySpec) {
+            instance.querySpec = querySpec;
+            return this;
+        }
+
+        public Builder provider(URI provider) {
+            instance.provider = provider;
+            return this;
+        }
+
+        public Builder consumer(URI consumer) {
+            instance.consumer = consumer;
+            return this;
+        }
+
+        public DescriptionRequest build() {
+            return instance;
+        }
+    }
+
+}

--- a/spi/common/transaction-spi/src/test/java/org/eclipse/edc/transaction/spi/NoopTransactionContextTest.java
+++ b/spi/common/transaction-spi/src/test/java/org/eclipse/edc/transaction/spi/NoopTransactionContextTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
 package org.eclipse.edc.transaction.spi;
 
 import org.junit.jupiter.api.BeforeEach;

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/offer/ContractOfferQuery.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/offer/ContractOfferQuery.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.spi.iam.ClaimToken;
 import org.eclipse.edc.spi.message.Range;
 import org.eclipse.edc.spi.query.Criterion;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -30,6 +31,8 @@ public class ContractOfferQuery {
     private final List<Criterion> assetsCriteria = new ArrayList<>();
     private ClaimToken claimToken;
     private Range range = new Range();
+    private URI provider;
+    private URI consumer;
 
     private ContractOfferQuery() {
     }
@@ -48,6 +51,14 @@ public class ContractOfferQuery {
 
     public Range getRange() {
         return range;
+    }
+
+    public URI getProvider() {
+        return provider;
+    }
+
+    public URI getConsumer() {
+        return consumer;
     }
 
     public static final class Builder {
@@ -78,6 +89,16 @@ public class ContractOfferQuery {
 
         public Builder range(Range range) {
             instance.range = range;
+            return this;
+        }
+
+        public Builder provider(URI provider) {
+            instance.provider = provider;
+            return this;
+        }
+
+        public Builder consumer(URI consumer) {
+            instance.consumer = consumer;
             return this;
         }
 

--- a/system-tests/e2e-transfer-test/backend-service/src/main/java/org/eclipse/edc/test/e2e/BackendServiceTestExtension.java
+++ b/system-tests/e2e-transfer-test/backend-service/src/main/java/org/eclipse/edc/test/e2e/BackendServiceTestExtension.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.spi.http.EdcHttpClient;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.web.jersey.mapper.EdcApiExceptionMapper;
 import org.eclipse.edc.web.spi.WebService;
 
 public class BackendServiceTestExtension implements ServiceExtension {
@@ -44,5 +45,6 @@ public class BackendServiceTestExtension implements ServiceExtension {
         webService.registerResource(new ConsumerBackendServiceController(context.getMonitor()));
         webService.registerResource(new BackendServiceHttpProvisionerController(context.getMonitor(), httpClient, typeManager, exposedHttpPort));
         webService.registerResource(new Oauth2TokenController(context.getMonitor()));
+        webService.registerResource(new EdcApiExceptionMapper());
     }
 }

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/AbstractEndToEndTransfer.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/AbstractEndToEndTransfer.java
@@ -48,8 +48,7 @@ public abstract class AbstractEndToEndTransfer {
         var assetId = UUID.randomUUID().toString();
         createResourcesOnProvider(assetId, noConstraintPolicy(), UUID.randomUUID().toString(), httpDataAddressProperties());
 
-        var catalog = CONSUMER.getCatalog(PROVIDER.idsEndpoint());
-        assertThat(catalog.getContractOffers()).hasSizeGreaterThan(0);
+        var catalog = CONSUMER.getCatalog(PROVIDER);
 
         var contractOffer = catalog
                 .getContractOffers()
@@ -89,11 +88,7 @@ public abstract class AbstractEndToEndTransfer {
                 "proxyQueryParams", "true"
         ));
 
-        await().atMost(timeout).untilAsserted(() -> {
-            var catalog = CONSUMER.getCatalog(PROVIDER.idsEndpoint());
-            assertThat(catalog.getContractOffers()).hasSizeGreaterThan(0);
-        });
-        var catalog = CONSUMER.getCatalog(PROVIDER.idsEndpoint());
+        var catalog = CONSUMER.getCatalog(PROVIDER);
 
         var contractOffer = catalog
                 .getContractOffers()
@@ -121,8 +116,7 @@ public abstract class AbstractEndToEndTransfer {
         var assetId = UUID.randomUUID().toString();
         createResourcesOnProvider(assetId, noConstraintPolicy(), UUID.randomUUID().toString(), httpDataAddressProperties());
 
-        var catalog = CONSUMER.getCatalog(PROVIDER.idsEndpoint());
-        assertThat(catalog.getContractOffers()).hasSizeGreaterThan(0);
+        var catalog = CONSUMER.getCatalog(PROVIDER);
 
         var contractOffer = catalog
                 .getContractOffers()
@@ -160,8 +154,7 @@ public abstract class AbstractEndToEndTransfer {
         var assetId = UUID.randomUUID().toString();
         createResourcesOnProvider(assetId, noConstraintPolicy(), UUID.randomUUID().toString(), httpDataAddressOauth2Properties());
 
-        var catalog = CONSUMER.getCatalog(PROVIDER.idsEndpoint());
-        assertThat(catalog.getContractOffers()).hasSizeGreaterThan(0);
+        var catalog = CONSUMER.getCatalog(PROVIDER);
 
         var contractOffer = catalog
                 .getContractOffers()


### PR DESCRIPTION
## What this PR changes/adds

Set the correct `provider` (connector id) and `consumer` (issuer connector) fields on the `ContractOffer`

## Why it does that

likely these fields will be removed from the contract offer in the future, but in the meantime better value them correctly since they are provided
Fix bug #753 

## Further notes
- introduced a `DescriptionRequest` data class that contains some fields necessary for the description request
- refactored `DescriptionRequestHandler` because it was hard to read with those 2 switch-case blocks.

## Linked Issue(s)

Closes #753 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
