### PR TITLE
fix: make logical constraint serdes work

### DIFF
--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/edc/protocol/ids/serialization/IdsTypeManagerUtil.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/edc/protocol/ids/serialization/IdsTypeManagerUtil.java
@@ -15,7 +15,6 @@
 package org.eclipse.edc.protocol.ids.serialization;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import de.fraunhofer.iais.eis.AbstractConstraint;
 import de.fraunhofer.iais.eis.Action;
 import de.fraunhofer.iais.eis.Artifact;
 import de.fraunhofer.iais.eis.ArtifactRequestMessage;
@@ -111,7 +110,6 @@ public final class IdsTypeManagerUtil {
         typeManager.registerSerializer("ids", Duty.class, new JsonLdSerializer<>(Duty.class, IdsConstants.CONTEXT));
         typeManager.registerSerializer("ids", Action.class, new JsonLdSerializer<>(Action.class, IdsConstants.CONTEXT));
         typeManager.registerSerializer("ids", LogicalConstraint.class, new JsonLdSerializer<>(LogicalConstraint.class, IdsConstants.CONTEXT));
-        typeManager.registerSerializer("ids", AbstractConstraint.class, new JsonLdSerializer<>(AbstractConstraint.class, IdsConstants.CONTEXT));
         typeManager.registerSerializer("ids", Constraint.class, new JsonLdSerializer<>(Constraint.class, IdsConstants.CONTEXT));
 
         // connector/offer

--- a/data-protocols/ids/ids-jsonld-serdes/src/test/java/org/eclipse/edc/protocol/ids/jsonld/SerializationTest.java
+++ b/data-protocols/ids/ids-jsonld-serdes/src/test/java/org/eclipse/edc/protocol/ids/jsonld/SerializationTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.protocol.ids.jsonld;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.fraunhofer.iais.eis.Action;
@@ -37,6 +38,8 @@ import de.fraunhofer.iais.eis.DynamicAttributeTokenBuilder;
 import de.fraunhofer.iais.eis.Frequency;
 import de.fraunhofer.iais.eis.Language;
 import de.fraunhofer.iais.eis.LeftOperand;
+import de.fraunhofer.iais.eis.LogicalConstraint;
+import de.fraunhofer.iais.eis.LogicalConstraintBuilder;
 import de.fraunhofer.iais.eis.PaymentModality;
 import de.fraunhofer.iais.eis.Permission;
 import de.fraunhofer.iais.eis.PermissionBuilder;
@@ -356,6 +359,27 @@ class SerializationTest {
         assertThat(((IdsConstraintImpl) constraint).getUnit()).isEqualTo(uri);
 
         assertEquals(resultString, objectMapper.writeValueAsString(resultObj));
+    }
+
+    @Test
+    void logicalConstraint() throws JsonProcessingException {
+        var resource = new RdfResource();
+        resource.setValue(string);
+        resource.setType(string);
+
+        var constraint = new IdsConstraintBuilder(uri)
+                .leftOperand(leftOperand.name())
+                .operator(binaryOperator)
+                .rightOperand(resource)
+                .unit(uri)
+                .pipEndpoint(uri)
+                .build();
+        var orConstraint = new LogicalConstraintBuilder()._or_(constraint).build();
+
+        var resultString = objectMapper.writeValueAsString(orConstraint);
+        var logicalConstraint = objectMapper.readValue(resultString, LogicalConstraint.class);
+
+        assertThat(logicalConstraint.getOr()).hasSize(1);
     }
 
     // build objects

--- a/spi/common/transaction-spi/src/test/java/org/eclipse/edc/transaction/spi/NoopTransactionContextTest.java
+++ b/spi/common/transaction-spi/src/test/java/org/eclipse/edc/transaction/spi/NoopTransactionContextTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
 package org.eclipse.edc.transaction.spi;
 
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
## What this PR changes/adds

Remove the `AbstractConstraint.class` serializer, that in fact was making the `LogicalOperator` not working.

## Why it does that

To make logical constraints (or, and) work through ids.

## Further notes

-

## Linked Issue(s)

Closes #2334 

## Checklist

- [x] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
