### PR TITLE
fix(docs): resolve markdown syntax errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <h1 align="center">
-  <br>
+  <br/>
     <img alt="Logo" width="100" src="resources/media/logo.png"/>
-  <br>
+  <br/>
       Eclipse Dataspace Connector
-  <br>
+  <br/>
 </h1>
 
 <div align="center">

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <br/>
     <img alt="Logo" width="100" src="resources/media/logo.png"/>
   <br/>
-      Eclipse Dataspace Connector
+      EDC Connector
   <br/>
 </h1>
 

--- a/docs/developer/architecture/README.md
+++ b/docs/developer/architecture/README.md
@@ -28,4 +28,4 @@ transferProcessObservable = context.getService(TransferProcessObservable.class);
 transferProcessObservable.registerListener(myTransferProcessListener);
 ```
 
-A sample is available at [04.1-file-transfer-listener](../../../samples/04.1-file-transfer-listener/).
+A sample is available at [04.1-file-transfer-listener](../../../samples/04.1-file-transfer-listener/README.md).

--- a/docs/developer/architecture/terminology.md
+++ b/docs/developer/architecture/terminology.md
@@ -1,34 +1,34 @@
 # Terminology
 
-| Name                                   | Description                                         |
-|:---                                    |:---                                                 |
-| **Artifact**                           |
-| **Asset**                              | **Assets**<p>* have one content type<p>* can be a finite as a (set of) file(s) or non finite as a service, stream</br>* are the _unit of sharing_<p>* can point to one or more (physical) asset elements
-| **Asset Element**                      |
-| **Asset Index**                        | **Asset Index**<p>* manages assets<p>* provided by an extension<p>* may support external catalogs<p>* can be queried 
-| **Broker**                             | see **IDS Broker**
-| **Connector**                          |
-| **Connector Directory**                |
-| **Contract**                           |
-| **Contract Agreement**                 | **Contract Agreement**<p>* points to a **Contract Offer**<p>* results from a **Contract Negotiation Process**<p>* has a start date and may have a expiry date and a cancellation date
-| **Contract Negotiation**               | * MVP: only possible to accept already offered contracts. Counter offers are rejected automatically.
-| **Contract Offer**                     | **Contract Offer**<p>* set of obligations and permissions<p>* generated on the fly on provider side (see **Contract Offer Framework**)<p>* are immutable<p>* persisted in **Contract Negotiation Process** once the negotiation has started<p>
-| **Contract Offer Framework**           | **Contract Offer Framework**<p>* generates **Contract Offer Templates**<p>* provided by **Extensions**<p>* may be implemented in custom extensions to created contract offers based on existing systems
-| **Contract Offer Template**            | Blueprint of a **Contract Offer**
-| **Consumer**                           |
-| **Data**                               |
-| **Dataspace**                          |
-| **EDC Extension**                      |
-| **Element**                            | see **Asset Element**
-| **Extension**                          | see **EDC Extension**
-| **Framework**                          | see **Contract Offer Framework**
-| **Identity Provider**                  |
-| **IDS Broker**                         | IDS version of the **Connector Directory**
-| **Offer**                              | see **Contract Offer**
-| **Offer Framework**                    | see **Contract Offer Framework**
-| **Policy**                             | logical collection of rules
-| **Provider**                           |
-| **Resource**                           |
-| **Resource Manifest**                  |
-| **Rule**                               | **Rules**<p>* bound to a **Contract Offer**, **Contract Agreement** or **Contract Offer Framework**<p>* exist independent from an **Asset**
-| **Transfer Process**                   | **Transfer Process**<p>* based on a **Contract Agreement**
+| Name                                   | Description                                                                                                                                                                                                                                         |
+|:---                                    |:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Artifact**                           |                                                                                                                                                                                                                                                     |
+| **Asset**                              | **Assets**<br/>* have one content type<br/>* can be a finite as a (set of) file(s) or non finite as a service, stream<br/>* are the _unit of sharing_<br/>* can point to one or more (physical) asset elements                                      |
+| **Asset Element**                      |                                                                                                                                                                                                                                                     |
+| **Asset Index**                        | **Asset Index**<br/>* manages assets<br/>* provided by an extension<br/>* may support external catalogs<br/>* can be queried                                                                                                                        |
+| **Broker**                             | see **IDS Broker**                                                                                                                                                                                                                                  |
+| **Connector**                          |                                                                                                                                                                                                                                                     |
+| **Connector Directory**                |                                                                                                                                                                                                                                                     |
+| **Contract**                           |                                                                                                                                                                                                                                                     |
+| **Contract Agreement**                 | **Contract Agreement**<br/>* points to a **Contract Offer**<br/>* results from a **Contract Negotiation Process**<br/>* has a start date and may have a expiry date and a cancellation date                                                         |
+| **Contract Negotiation**               | * MVP: only possible to accept already offered contracts. Counter offers are rejected automatically.                                                                                                                                                |
+| **Contract Offer**                     | **Contract Offer**<br/>* set of obligations and permissions<br/>* generated on the fly on provider side (see **Contract Offer Framework**)<br/>* are immutable<br/>* persisted in **Contract Negotiation Process** once the negotiation has started |
+| **Contract Offer Framework**           | **Contract Offer Framework**<br/>* generates **Contract Offer Templates**<br/>* provided by **Extensions**<br/>* may be implemented in custom extensions to created contract offers based on existing systems                                       |
+| **Contract Offer Template**            | Blueprint of a **Contract Offer**                                                                                                                                                                                                                   |
+| **Consumer**                           |                                                                                                                                                                                                                                                     |
+| **Data**                               |                                                                                                                                                                                                                                                     |
+| **Dataspace**                          |                                                                                                                                                                                                                                                     |
+| **EDC Extension**                      |                                                                                                                                                                                                                                                     |
+| **Element**                            | see **Asset Element**                                                                                                                                                                                                                               |
+| **Extension**                          | see **EDC Extension**                                                                                                                                                                                                                               |
+| **Framework**                          | see **Contract Offer Framework**                                                                                                                                                                                                                    |
+| **Identity Provider**                  |                                                                                                                                                                                                                                                     |
+| **IDS Broker**                         | IDS version of the **Connector Directory**                                                                                                                                                                                                          |
+| **Offer**                              | see **Contract Offer**                                                                                                                                                                                                                              |
+| **Offer Framework**                    | see **Contract Offer Framework**                                                                                                                                                                                                                    |
+| **Policy**                             | logical collection of rules                                                                                                                                                                                                                         |
+| **Provider**                           |                                                                                                                                                                                                                                                     |
+| **Resource**                           |                                                                                                                                                                                                                                                     |
+| **Resource Manifest**                  |                                                                                                                                                                                                                                                     |
+| **Rule**                               | **Rules**<br/>* bound to a **Contract Offer**, **Contract Agreement** or **Contract Offer Framework**<br/>* exist independent from an **Asset**                                                                                                     |
+| **Transfer Process**                   | **Transfer Process**<br/>* based on a **Contract Agreement**                                                                                                                                                                                        |

--- a/docs/developer/decision-records/2022-02-10-code-coverage/README.md
+++ b/docs/developer/decision-records/2022-02-10-code-coverage/README.md
@@ -24,8 +24,8 @@ We evaluated the following options:
 
 ## Comparison of selected options
 
-| Tool                       | Project coverage report                | Coverage on PR in Github                                     | Additional comments                                          |
-| -------------------------- | -------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
-| JaCoCo with Codecov        | ✅ Detailed report on Codecov dashboard | ✅ Github bot messages on every PR (coverage after the PR is merged, total project coverage, code complexity) | ✅ Reports on code complexity<p> ✅ Easy configuration       |
+| Tool                       | Project coverage report                | Coverage on PR in Github                                     | Additional comments                                                                                               |
+| -------------------------- | -------------------------------------- | ------------------------------------------------------------ |-------------------------------------------------------------------------------------------------------------------|
+| JaCoCo with Codecov        | ✅ Detailed report on Codecov dashboard | ✅ Github bot messages on every PR (coverage after the PR is merged, total project coverage, code complexity) | ✅ Reports on code complexity<br/> ✅ Easy configuration                                                             |
 | JaCoCo with Github Actions | ✅ Basic report (percentage)            | ✅ Github bot messages on every PR (coverage on changed files and total project coverage) | ⚠️ [Minor issue] Manual configuration (JaCoCo Report Github Action requires a property to path to JaCoCo reports) |
-| JaCoCo with Codacy         | ✅ Report available on Codacy dashboard | ⚠️ Not supported                                              | ⚠️ Delays in reports showing up in the dashboard              |
+| JaCoCo with Codacy         | ✅ Report available on Codacy dashboard | ⚠️ Not supported                                              | ⚠️ Delays in reports showing up in the dashboard                                                                  |

--- a/docs/developer/decision-records/2022-04-21-dpf-blob-data-transfer/README.md
+++ b/docs/developer/decision-records/2022-04-21-dpf-blob-data-transfer/README.md
@@ -27,7 +27,7 @@ This sequence diagram describes the flow if the 2 participants are using Azure b
 
 The sequence starts from the client triggering the transfer on the consumer side and finishes when the consumer deprovisions its resources.
 
-![blob-transfer](developer/architecture/data-transfer/diagrams/blob-transfer.png)
+![blob-transfer](../../architecture/data-transfer/diagrams/blob-transfer.png)
 
 1. The client calls the data management API to trigger a transfer process. The requested asset is identified by the `assetId` and the `contractId` from previous contract negotiation. The client get the `PROCESS_ID` corresponding to the `transferProcess`. This `PROCESS_ID` will be used to get the transfer status. For now, `managedResources` needs to be set to true, to make sure that the consumer provisions the blob container. `managedResources=false` would be used if the client wants to use a pre-existing container without creating a new one, but this feature is not supported yet.  
 2. Consumer gets the destination storage account access key in its Vault.  

--- a/docs/developer/metrics.md
+++ b/docs/developer/metrics.md
@@ -2,7 +2,7 @@
 
 EDC provides extensions for instrumentation with the [Micrometer](https://micrometer.io/) metrics library to automatically collect metrics from the host system, JVM, and frameworks and libraries used in EDC (including OkHttp, Jetty, Jersey and ExecutorService).
 
-See [sample 04.3](../../samples/04.3-open-telemetry) for an example of an instrumented EDC consumer. 
+See [sample 04.3](../../samples/04.3-open-telemetry/README.md) for an example of an instrumented EDC consumer. 
 
 ## Micrometer Extension
 

--- a/extensions/common/events/events-cloud-http/README.md
+++ b/extensions/common/events/events-cloud-http/README.md
@@ -7,4 +7,4 @@ respecting the [CloudEvents HTTP spec v1.0.2](https://github.com/cloudevents/spe
 
 | Parameter name                    | Description                                       | Default value       |
 |-----------------------------------|---------------------------------------------------|---------------------|
-| `edc.events.cloudevents.endpoint` | The http endpoint where the events will be pushed | <mandatory setting> |
+| `edc.events.cloudevents.endpoint` | The http endpoint where the events will be pushed | _mandatory setting_ |

--- a/launchers/ids-connector/README.md
+++ b/launchers/ids-connector/README.md
@@ -233,16 +233,24 @@ To do so, follow these steps:
 
 1. Checkout the [Omejdn DAPS repository](https://github.com/International-Data-Spaces-Association/omejdn-daps)
 2. Retrieve the submodules: 
-   > git submodule update --init --remote
+   ```bash
+   git submodule update --init --remote
+   ```
 3. Generate a key and a certificate for the DAPS instance:
-   > openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 -keyout keys/omejdn/omejdn.key -out daps.cert
+   ```bash
+    openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 -keyout keys/omejdn/omejdn.key -out daps.cert
+   ```
 4. Modify `.env` in the project root: set `DAPS_DOMAIN` to the URL your DAPS instance will be running at.
 5. Register a connector (the security profile is optional and will default to *idsc:BASE_SECURITY_PROFILE* if not
    specified):
-   > scripts/register_connector.sh <client-name-for-connector> <security-profile>
+   ```bash
+   scripts/register_connector.sh <client-name-for-connector> <security-profile>
+   ```
 6. Optionally, you can register more connectors by running step 5 multiple times with different client names.
 7. Run the DAPS:
-   > docker compose -f compose-development.yml up
+   ```bash
+   docker compose -f compose-development.yml up
+   ```
 8. When you see `omejdn-server_1  | == Sinatra (v2.1.0) has taken the stage on 4567 for development with backup from Thin`
    in the logs, the DAPS is ready to accept requests.
    

--- a/samples/04.1-file-transfer-listener/README.md
+++ b/samples/04.1-file-transfer-listener/README.md
@@ -1,8 +1,8 @@
 # Implement a simple transfer listener
 
-In this sample, we build upon the [file transfer sample](../04.0-file-transfer/) to add functionality to react to transfer completion on the consumer connector side.
+In this sample, we build upon the [file transfer sample](../04.0-file-transfer/README.md) to add functionality to react to transfer completion on the consumer connector side.
 
-We will use the provider from the [file transfer sample](../04.0-file-transfer/), and the consumer built on the consumer from that sample, with a transfer process listener added.
+We will use the provider from the [file transfer sample](../04.0-file-transfer/README.md), and the consumer built on the consumer from that sample, with a transfer process listener added.
 
 Also, in order to keep things organized, the code in this example has been separated into several Java modules:
 

--- a/samples/04.3-open-telemetry/README.md
+++ b/samples/04.3-open-telemetry/README.md
@@ -1,6 +1,6 @@
 # Telemetry with OpenTelemetry and Micrometer
 
-This sample builds on top of [sample 04.0-file-transfer](../04.0-file-transfer/) to show how you can:
+This sample builds on top of [sample 04.0-file-transfer](../04.0-file-transfer/README.md) to show how you can:
 
 - generate traces with [OpenTelemetry](https://opentelemetry.io) and collect and visualize them with [Jaeger](https://www.jaegertracing.io/).
 - automatically collect metrics from infrastructure, server endpoints and client libraries with [Micrometer](https://micrometer.io) and visualize them with [Prometheus](https://prometheus.io).

--- a/samples/README.md
+++ b/samples/README.md
@@ -2,14 +2,14 @@
 
 Each sample provides a detailed documentation that guides you step by step and addresses major capabilities of the connector.
 
-- [1 Run the Connector](01-basic-connector/)
-- [2 Write a First Extension](02-health-endpoint/)
-- [3 Apply Custom Configurations](03-configuration/)
-- [4.0 Perform a Contract Negotiation](04.0-file-transfer/)
-- [4.1 Implement a Simple Transfer Listener](04.1-file-transfer-listener/)
-- [4.2 Modify a Transfer Process](04.2-modify-transferprocess/)
-- [4.3 Work with Open Telemetry](04.3-open-telemetry/)
-- [5 Run a Cloud Deployment](05-file-transfer-cloud/)
+- [1 Run the Connector](01-basic-connector/README.md)
+- [2 Write a First Extension](02-health-endpoint/README.md)
+- [3 Apply Custom Configurations](03-configuration/README.md)
+- [4.0 Perform a Contract Negotiation](04.0-file-transfer/README.md)
+- [4.1 Implement a Simple Transfer Listener](04.1-file-transfer-listener/README.md)
+- [4.2 Modify a Transfer Process](04.2-modify-transferprocess/README.md)
+- [4.3 Work with Open Telemetry](04.3-open-telemetry/README.md)
+- [5 Run a Cloud Deployment](05-file-transfer-cloud/README.md)
 
 For an extended introduction and information about prerequisites, please take a look at the
 [on-boarding guide](../onboarding.md).


### PR DESCRIPTION
## What this PR changes/adds

Fixes markdown errors. 

## Why it does that

Allow any frameworks to interpret markdown files correctly.

## Further notes

Changed "Eclipse Dataspace Connector" in `README.md` to "EDC Connector" to follow the renaming

## Linked Issue(s)

Closes #2337 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
