### PR TITLE
fix: project url

### DIFF
--- a/.github/workflows/assign-issue-to-project.yaml
+++ b/.github/workflows/assign-issue-to-project.yaml
@@ -13,5 +13,5 @@ jobs:
       - name: Assign to basic project
         uses: srggrs/assign-one-project-github-action@1.3.1
         with:
-          project: 'https://github.com/eclipse-edc/Connector/projects/1'
+          project: 'https://github.com/orgs/eclipse-edc/projects/3'
           column_name: 'Open'

--- a/.github/workflows/assign-pr-to-project.yaml
+++ b/.github/workflows/assign-pr-to-project.yaml
@@ -15,5 +15,5 @@ jobs:
       - name: Assign to basic project
         uses: srggrs/assign-one-project-github-action@1.3.1
         with:
-          project: 'https://github.com/eclipse-edc/Connector/projects/1'
+          project: 'https://github.com/orgs/eclipse-edc/projects/3'
           column_name: 'In progress'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,7 +207,7 @@ the relations and progresses.
 
 The [GitHub Projects page](https://github.com/eclipse-edc/Connector/projects)
 provides a general overview of the project's working items. Every new issue is automatically assigned
-to the ["Dataspace Connector" project](https://github.com/eclipse-edc/Connector/projects/1).
+to the ["Dataspace Connector" project](https://github.com/orgs/eclipse-edc/projects/3).
 It can be unassigned or moved to any other project that is provided.
 
 In every project, an issue passes four stages: `Backlog`, `In progress`, `Review in progress`, and `Done`,


### PR DESCRIPTION
## What this PR changes/adds

updates references to the new project URL: https://github.com/orgs/eclipse-edc/projects/3

## Why it does that

Fix CI

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
