### PR TITLE
feat: Introduce `Fallback` mechanism to `EdcHttpClient`

### DIFF
--- a/core/common/connector-core/build.gradle.kts
+++ b/core/common/connector-core/build.gradle.kts
@@ -28,13 +28,13 @@ dependencies {
     implementation(project(":core:common:policy-engine"))
     implementation(project(":core:common:util"))
 
-    api(libs.failsafe.okhttp)
     implementation(libs.dnsOverHttps)
     implementation(libs.bouncyCastle.bcpkix)
 
     testImplementation(project(":core:common:junit"))
     testImplementation(libs.awaitility)
     testImplementation(libs.junit.jupiter.api)
+    testImplementation(libs.mockserver.netty)
 }
 
 publishing {

--- a/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/CoreDefaultServicesExtension.java
+++ b/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/CoreDefaultServicesExtension.java
@@ -102,7 +102,8 @@ public class CoreDefaultServicesExtension implements ServiceExtension {
     public EdcHttpClient edcHttpClient(ServiceExtensionContext context) {
         return new EdcHttpClientImpl(
                 okHttpClient(context),
-                retryPolicy(context)
+                retryPolicy(context),
+                context.getMonitor()
         );
     }
 

--- a/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/security/DefaultPrivateKeyParseFunction.java
+++ b/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/security/DefaultPrivateKeyParseFunction.java
@@ -33,9 +33,8 @@ public class DefaultPrivateKeyParseFunction implements Function<String, PrivateK
 
     @Override
     public PrivateKey apply(String encoded) {
-        var pemParser = new PEMParser(new StringReader(encoded));
-        var converter = new JcaPEMKeyConverter();
-        try {
+        try (var pemParser = new PEMParser(new StringReader(encoded))) {
+            var converter = new JcaPEMKeyConverter();
             var o = pemParser.readObject();
             if (o instanceof PEMKeyPair) {
                 var keyPair = (PEMKeyPair) o;

--- a/core/common/connector-core/src/test/java/org/eclipse/edc/connector/core/base/EdcHttpClientImplTest.java
+++ b/core/common/connector-core/src/test/java/org/eclipse/edc/connector/core/base/EdcHttpClientImplTest.java
@@ -1,0 +1,174 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.core.base;
+
+import dev.failsafe.RetryPolicy;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.model.HttpResponse;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.eclipse.edc.junit.testfixtures.TestUtils.getFreePort;
+import static org.eclipse.edc.junit.testfixtures.TestUtils.testOkHttpClient;
+import static org.eclipse.edc.spi.http.FallbackFactories.statusMustBe;
+import static org.eclipse.edc.spi.http.FallbackFactories.statusMustBeSuccessful;
+import static org.mockito.Mockito.mock;
+import static org.mockserver.matchers.Times.once;
+import static org.mockserver.matchers.Times.unlimited;
+import static org.mockserver.model.HttpError.error;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.JsonBody.json;
+import static org.mockserver.stop.Stop.stopQuietly;
+import static org.mockserver.verify.VerificationTimes.exactly;
+
+class EdcHttpClientImplTest {
+
+    private final int port = getFreePort();
+
+    private final TypeManager typeManager = new TypeManager();
+    private ClientAndServer server;
+
+    @BeforeEach
+    public void startServer() {
+        server = ClientAndServer.startClientAndServer(port);
+    }
+
+    @AfterEach
+    public void stopServer() {
+        stopQuietly(server);
+    }
+
+    @Test
+    void execute_fallback_shouldMapResultWhenResponseIsSuccessful() {
+        var client = clientWith(RetryPolicy.ofDefaults());
+        server.when(request(), once()).respond(new HttpResponse().withStatusCode(200).withBody(json(Map.of("message", "data"))));
+
+        var request = new Request.Builder()
+                .url("http://localhost:" + port)
+                .build();
+
+        var result = client.execute(request, handleResponse());
+
+        assertThat(result).matches(Result::succeeded).extracting(Result::getContent).isEqualTo("data");
+    }
+
+    @Test
+    void execute_fallback_shouldRetry() {
+        var client = clientWith(RetryPolicy.<Response>builder().withMaxAttempts(2).build());
+        server.when(request(), once()).error(error().withDropConnection(true));
+        server.when(request(), once()).respond(new HttpResponse().withStatusCode(200).withBody(json(Map.of("message", "data"))));
+
+        var request = new Request.Builder()
+                .url("http://localhost:" + port)
+                .build();
+
+        var result = client.execute(request, handleResponse());
+
+        assertThat(result).matches(Result::succeeded).extracting(Result::getContent).isEqualTo("data");
+        server.verify(request(), exactly(2));
+    }
+
+    @Test
+    void execute_fallback_shouldFailAfterAttemptsExpired_whenResponseFails() {
+        var client = clientWith(RetryPolicy.<Response>builder().withMaxAttempts(2).build());
+        server.when(request(), unlimited()).error(error().withDropConnection(true));
+
+        var request = new Request.Builder()
+                .url("http://localhost:" + port)
+                .build();
+
+        var result = client.execute(request, handleResponse());
+
+        assertThat(result).matches(Result::failed).extracting(Result::getFailureMessages).asList()
+                .first().asString().matches(it -> it.startsWith("unexpected end of stream on"));
+    }
+
+    @Test
+    void execute_fallback_shouldRetryIfStatusIsNotSuccessful() {
+        var client = clientWith(RetryPolicy.<Response>builder().withMaxAttempts(2).build());
+
+        var request = new Request.Builder()
+                .url("http://localhost:" + port)
+                .build();
+
+        server.when(request(), unlimited()).respond(new HttpResponse().withStatusCode(500));
+
+        var result = client.execute(request, List.of(statusMustBeSuccessful()), handleResponse());
+
+        assertThat(result).matches(Result::failed).extracting(Result::getFailureMessages).asList()
+                .first().asString().matches(it -> it.startsWith("Server response to"));
+        server.verify(request(), exactly(2));
+    }
+
+    @Test
+    void execute_fallback_shouldRetryIfStatusIsNotAsExpected() {
+        var client = clientWith(RetryPolicy.<Response>builder().withMaxAttempts(2).build());
+
+        var request = new Request.Builder()
+                .url("http://localhost:" + port)
+                .build();
+        server.when(request(), unlimited()).respond(new HttpResponse().withStatusCode(200));
+
+        var result = client.execute(request, List.of(statusMustBe(204)), handleResponse());
+
+        assertThat(result).matches(Result::failed).extracting(Result::getFailureMessages).asList()
+                .first().asString().matches(it -> it.startsWith("Server response to"));
+        server.verify(request(), exactly(2));
+    }
+
+    @Test
+    void execute_fallback_shouldFailAfterAttemptsExpired_whenServerIsDown() {
+        var client = clientWith(RetryPolicy.<Response>builder().withMaxAttempts(2).build());
+        server.stop();
+
+        var request = new Request.Builder()
+                .url("http://localhost:" + port)
+                .build();
+
+        var result = client.execute(request, handleResponse());
+
+        assertThat(result).matches(Result::failed).extracting(Result::getFailureMessages).asList()
+                .first().asString().matches(it -> it.startsWith("Failed to connect to"));
+    }
+
+    @NotNull
+    private static EdcHttpClientImpl clientWith(RetryPolicy<Response> retryPolicy) {
+        return new EdcHttpClientImpl(testOkHttpClient(), retryPolicy, mock(Monitor.class));
+    }
+
+    @NotNull
+    private Function<Response, Result<String>> handleResponse() {
+        return r -> {
+            try {
+                return Result.success(typeManager.readValue(r.body().string(), Map.class).get("message").toString());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+}

--- a/core/common/connector-core/src/test/java/org/eclipse/edc/connector/core/security/DefaultPrivateKeyParseFunctionTest.java
+++ b/core/common/connector-core/src/test/java/org/eclipse/edc/connector/core/security/DefaultPrivateKeyParseFunctionTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import java.io.IOException;
+import java.security.Security;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -29,11 +30,12 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class DefaultPrivateKeyParseFunctionTest {
 
-
     private DefaultPrivateKeyParseFunction parseFunction;
 
     @BeforeEach
     public void setUp() {
+        Security.removeProvider("BC"); // TODO: this is to make this test working on the CI
+        // because there's a test in this module that uses mockserver, that seems to add the BC provider, making this test break.
         parseFunction = new DefaultPrivateKeyParseFunction();
     }
 
@@ -59,10 +61,8 @@ class DefaultPrivateKeyParseFunctionTest {
      * Load content from a resource file.
      */
     private String loadResourceFile(String file) throws IOException {
-        return new String(
-                Objects.requireNonNull(
-                                DefaultPrivateKeyParseFunctionTest.class.getClassLoader().getResourceAsStream(file)
-                        )
-                        .readAllBytes());
+        try (var resourceAsStream = DefaultPrivateKeyParseFunctionTest.class.getClassLoader().getResourceAsStream(file)) {
+            return new String(Objects.requireNonNull(resourceAsStream).readAllBytes());
+        }
     }
 }

--- a/core/common/junit/src/main/java/org/eclipse/edc/junit/testfixtures/TestUtils.java
+++ b/core/common/junit/src/main/java/org/eclipse/edc/junit/testfixtures/TestUtils.java
@@ -19,6 +19,7 @@ import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import org.eclipse.edc.connector.core.base.EdcHttpClientImpl;
 import org.eclipse.edc.spi.http.EdcHttpClient;
+import org.eclipse.edc.spi.monitor.Monitor;
 
 import java.io.File;
 import java.io.IOException;
@@ -33,6 +34,7 @@ import java.util.concurrent.TimeUnit;
 
 import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
 
 public class TestUtils {
     public static final int MAX_TCP_PORT = 65_535;
@@ -161,7 +163,7 @@ public class TestUtils {
      * @return an {@link OkHttpClient.Builder}.
      */
     public static EdcHttpClient testHttpClient(Interceptor... interceptors) {
-        return new EdcHttpClientImpl(testOkHttpClient(interceptors), RetryPolicy.ofDefaults());
+        return new EdcHttpClientImpl(testOkHttpClient(interceptors), RetryPolicy.ofDefaults(), mock(Monitor.class));
     }
 
     /**

--- a/extensions/common/iam/oauth2/oauth2-client/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2ClientExtension.java
+++ b/extensions/common/iam/oauth2/oauth2-client/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2ClientExtension.java
@@ -26,7 +26,7 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 @Extension(value = Oauth2ClientExtension.NAME)
 public class Oauth2ClientExtension implements ServiceExtension {
 
-    public static final String NAME = "OAuth2 Core";
+    public static final String NAME = "OAuth2 Client";
 
     @Inject
     private EdcHttpClient httpClient;
@@ -38,6 +38,6 @@ public class Oauth2ClientExtension implements ServiceExtension {
 
     @Provider
     public Oauth2Client oauth2Client(ServiceExtensionContext context) {
-        return new Oauth2ClientImpl(httpClient, context.getTypeManager(), context.getMonitor());
+        return new Oauth2ClientImpl(httpClient, context.getTypeManager());
     }
 }

--- a/extensions/common/iam/oauth2/oauth2-client/src/test/java/org/eclipse/edc/iam/oauth2/client/Oauth2ClientImplTest.java
+++ b/extensions/common/iam/oauth2/oauth2-client/src/test/java/org/eclipse/edc/iam/oauth2/client/Oauth2ClientImplTest.java
@@ -16,7 +16,6 @@ package org.eclipse.edc.iam.oauth2.client;
 
 import org.eclipse.edc.iam.oauth2.spi.client.Oauth2CredentialsRequest;
 import org.eclipse.edc.iam.oauth2.spi.client.SharedSecretOauth2CredentialsRequest;
-import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,7 +32,6 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.junit.testfixtures.TestUtils.getFreePort;
 import static org.eclipse.edc.junit.testfixtures.TestUtils.testHttpClient;
-import static org.mockito.Mockito.mock;
 import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 import static org.mockserver.model.MediaType.APPLICATION_JSON;
 
@@ -47,7 +45,7 @@ class Oauth2ClientImplTest {
 
     @BeforeEach
     public void setUp() {
-        client = new Oauth2ClientImpl(testHttpClient(), typeManager, mock(Monitor.class));
+        client = new Oauth2ClientImpl(testHttpClient(), typeManager);
     }
 
     @Test
@@ -78,9 +76,8 @@ class Oauth2ClientImplTest {
         var result = client.requestToken(request);
 
         assertThat(result.failed()).isTrue();
-        assertThat(result.getFailureDetail()).contains("Server responded 400");
+        assertThat(result.getFailureDetail()).startsWith("Server response");
     }
-
 
     @Test
     void verifyFailureIfServerIsNotReachable() {
@@ -91,9 +88,8 @@ class Oauth2ClientImplTest {
         var result = client.requestToken(request);
 
         assertThat(result.failed()).isTrue();
-        assertThat(result.getFailureDetail()).contains("client_credentials request failed");
+        assertThat(result.getFailureDetail()).startsWith("Failed to connect to");
     }
-
 
     private Oauth2CredentialsRequest createRequest() {
         return SharedSecretOauth2CredentialsRequest.Builder.newInstance()

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/identity/Oauth2ServiceImpl.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/identity/Oauth2ServiceImpl.java
@@ -97,4 +97,5 @@ public class Oauth2ServiceImpl implements IdentityService {
                 .params(credentialsRequestAdditionalParametersProvider.provide(parameters))
                 .build();
     }
+
 }

--- a/extensions/common/iam/oauth2/oauth2-core/src/test/java/org/eclipse/edc/iam/oauth2/identity/Oauth2ServiceImplTest.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/test/java/org/eclipse/edc/iam/oauth2/identity/Oauth2ServiceImplTest.java
@@ -48,7 +48,6 @@ import org.mockito.ArgumentCaptor;
 
 import java.time.Clock;
 import java.time.Instant;
-import java.util.Collections;
 import java.util.Date;
 import java.util.Map;
 import java.util.UUID;
@@ -240,10 +239,6 @@ class Oauth2ServiceImplTest {
                 .scope("scope")
                 .params(additional)
                 .build();
-    }
-
-    private PrivateKeyOauth2CredentialsRequest createRequest() {
-        return createRequest(Collections.emptyMap());
     }
 
     private RSAKey testKey() throws JOSEException {

--- a/spi/common/http-spi/src/main/java/org/eclipse/edc/spi/http/EdcHttpClient.java
+++ b/spi/common/http-spi/src/main/java/org/eclipse/edc/spi/http/EdcHttpClient.java
@@ -16,8 +16,10 @@ package org.eclipse.edc.spi.http;
 
 import okhttp3.Request;
 import okhttp3.Response;
+import org.eclipse.edc.spi.result.Result;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
@@ -34,6 +36,25 @@ public interface EdcHttpClient {
      * @throws IOException on connection error.
      */
     Response execute(Request request) throws IOException;
+
+    /**
+     * Executes the specified request synchronously applying the mapping function to the response.
+     *
+     * @param request the {@link Request}.
+     *                @param mappingFunction the function that will be applied to the {@link Response}.
+     * @return a {@link Result}, containing the object returned by the mappingFunction
+     */
+    <T> Result<T> execute(Request request, Function<Response, Result<T>> mappingFunction);
+
+    /**
+     * Executes the specified request synchronously applying the mapping function to the response.
+     * Accepts a list of {@link FallbackFactories} that could apply retry in particular occasions.
+     *
+     * @param request the {@link Request}.
+     *                @param mappingFunction the function that will be applied to the {@link Response}.
+     * @return a {@link Result}, containing the object returned by the mappingFunction
+     */
+    <T> Result<T> execute(Request request, List<FallbackFactory> fallbacks, Function<Response, Result<T>> mappingFunction);
 
     /**
      * Executes the specified request asynchronously, maps the response with the mappingFunction.

--- a/spi/common/http-spi/src/main/java/org/eclipse/edc/spi/http/EdcHttpClientException.java
+++ b/spi/common/http-spi/src/main/java/org/eclipse/edc/spi/http/EdcHttpClientException.java
@@ -12,22 +12,13 @@
  *
  */
 
-plugins {
-    `java-library`
-    `maven-publish`
-}
+package org.eclipse.edc.spi.http;
 
-dependencies {
-    api(project(":spi:common:core-spi"))
+import org.eclipse.edc.spi.EdcException;
 
-    api(libs.okhttp)
-    api(libs.failsafe.okhttp)
-}
+public class EdcHttpClientException extends EdcException {
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
+    public EdcHttpClientException(String message) {
+        super(message);
     }
 }

--- a/spi/common/http-spi/src/main/java/org/eclipse/edc/spi/http/FallbackFactories.java
+++ b/spi/common/http-spi/src/main/java/org/eclipse/edc/spi/http/FallbackFactories.java
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.spi.http;
+
+import dev.failsafe.Fallback;
+import dev.failsafe.event.ExecutionAttemptedEvent;
+import dev.failsafe.function.CheckedFunction;
+import okhttp3.Response;
+
+import static java.lang.String.format;
+
+/**
+ * A set of global defined {@link FallbackFactory} that can be used with {@link EdcHttpClient}
+ */
+public interface FallbackFactories {
+
+    /**
+     * Verifies that the response is successful, otherwise it should be retried
+     *
+     * @return the {@link FallbackFactory}
+     */
+    static FallbackFactory statusMustBeSuccessful() {
+        return request -> {
+            CheckedFunction<ExecutionAttemptedEvent<? extends Response>, Exception> exceptionSupplier = event -> {
+                var response = event.getLastResult();
+                if (response == null) {
+                    return new EdcHttpClientException(event.getLastException().getMessage());
+                } else {
+                    return new EdcHttpClientException(format("Server response to %s was not successful but was %s: %s", request, response.code(), response.body().string()));
+                }
+            };
+            return Fallback.builderOfException(exceptionSupplier)
+                    .handleResultIf(r -> !r.isSuccessful())
+                    .build();
+        };
+    }
+
+    /**
+     * Verifies that the response has a specific status, otherwise it should be retried
+     *
+     * @return the {@link FallbackFactory}
+     */
+    static FallbackFactory statusMustBe(int status) {
+        return request -> {
+            CheckedFunction<ExecutionAttemptedEvent<? extends Response>, Exception> exceptionSupplier = event -> {
+                var response = event.getLastResult();
+                if (response == null) {
+                    return new EdcHttpClientException(event.getLastException().getMessage());
+                } else {
+                    return new EdcHttpClientException(format("Server response to %s was not %s but was %s: %s", request, status, response.code(), response.body().string()));
+                }
+            };
+            return Fallback.builderOfException(exceptionSupplier)
+                    .handleResultIf(r -> r.code() != status)
+                    .build();
+        };
+    }
+}

--- a/spi/common/http-spi/src/main/java/org/eclipse/edc/spi/http/FallbackFactory.java
+++ b/spi/common/http-spi/src/main/java/org/eclipse/edc/spi/http/FallbackFactory.java
@@ -12,22 +12,21 @@
  *
  */
 
-plugins {
-    `java-library`
-    `maven-publish`
-}
+package org.eclipse.edc.spi.http;
 
-dependencies {
-    api(project(":spi:common:core-spi"))
+import dev.failsafe.Fallback;
+import okhttp3.Request;
+import okhttp3.Response;
 
-    api(libs.okhttp)
-    api(libs.failsafe.okhttp)
-}
-
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
+/**
+ * Factory for {@link Fallback} instances given a {@link Request}
+ */
+public interface FallbackFactory {
+    /**
+     * Create a {@link Fallback} from a {@link Request}
+     *
+     * @param request the {@link Request}
+     * @return a {@link Fallback} instance
+     */
+    Fallback<Response> create(Request request);
 }


### PR DESCRIPTION
## What this PR changes/adds

Adds two methods to `EdcHttpClient`:
```
<T> Result<T> execute(Request request, Function<Response, Result<T>> mappingFunction)
<T> Result<T> execute(Request request, List<FallbackFactory> fallbacks, Function<Response, Result<T>> mappingFunction)
```

First one is just a shortcut to call the second one without `fallbacks`.
In `Failsafe`, a `Fallback` is an object that permits to apply retry also after a `Response` is received from the `OkHttpClient`, in particular it can be used to retry when the status result is not "successful" (not contained between 200 and 299) or is not a specific state. This is useful to retry calls when flaky statuses as `503 - service unavailable` are returned.

## Why it does that

Improve resiliency

## Further notes

- the methods accept a `mappingFunction` that will apply on the `Response`, so it will be up to the client to close the `Response` and catch unexpected exceptions and map them to `Result.failure`
- made `Oauth2ClientImpl` use these methods as a showcase.

## Linked Issue(s)

Closes #2368

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
