### PR TITLE
feat(assetApi): adds endpoint for getting a DataAddress of an Asset

### DIFF
--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApi.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApi.java
@@ -26,6 +26,7 @@ import org.eclipse.edc.api.model.IdResponseDto;
 import org.eclipse.edc.api.query.QuerySpecDto;
 import org.eclipse.edc.connector.api.management.asset.model.AssetEntryDto;
 import org.eclipse.edc.connector.api.management.asset.model.AssetResponseDto;
+import org.eclipse.edc.connector.api.management.asset.model.DataAddressDto;
 import org.eclipse.edc.web.spi.ApiErrorDetail;
 
 import java.util.List;
@@ -88,5 +89,17 @@ public interface AssetApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
             })
     void removeAsset(String id);
+
+
+    @Operation(description = "Gets a data address of an asset with the given ID",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The data address",
+                            content = @Content(schema = @Schema(implementation = DataAddressDto.class))),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))),
+                    @ApiResponse(responseCode = "404", description = "An asset with the given ID does not exist",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
+            })
+    DataAddressDto getAssetDataAddress(String id);
 }
 

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApiExtension.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApiExtension.java
@@ -20,10 +20,12 @@ import org.eclipse.edc.api.transformer.DtoTransformerRegistry;
 import org.eclipse.edc.connector.api.management.asset.transform.AssetRequestDtoToAssetTransformer;
 import org.eclipse.edc.connector.api.management.asset.transform.AssetToAssetResponseDtoTransformer;
 import org.eclipse.edc.connector.api.management.asset.transform.DataAddressDtoToDataAddressTransformer;
+import org.eclipse.edc.connector.api.management.asset.transform.DataAddressToDataAddressDtoTransformer;
 import org.eclipse.edc.connector.api.management.configuration.ManagementApiConfiguration;
 import org.eclipse.edc.connector.spi.asset.AssetService;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.asset.DataAddressResolver;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.web.spi.WebService;
@@ -45,6 +47,9 @@ public class AssetApiExtension implements ServiceExtension {
     @Inject
     private AssetService assetService;
 
+    @Inject
+    private DataAddressResolver dataAddressResolver;
+
     @Override
     public String name() {
         return NAME;
@@ -55,10 +60,11 @@ public class AssetApiExtension implements ServiceExtension {
         var monitor = context.getMonitor();
 
         transformerRegistry.register(new AssetRequestDtoToAssetTransformer());
-        transformerRegistry.register(new DataAddressDtoToDataAddressTransformer());
         transformerRegistry.register(new AssetToAssetResponseDtoTransformer());
+        transformerRegistry.register(new DataAddressDtoToDataAddressTransformer());
+        transformerRegistry.register(new DataAddressToDataAddressDtoTransformer());
 
-        webService.registerResource(config.getContextAlias(), new AssetApiController(monitor, assetService, transformerRegistry));
+        webService.registerResource(config.getContextAlias(), new AssetApiController(monitor, assetService, dataAddressResolver, transformerRegistry));
     }
 
 }

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/transform/DataAddressToDataAddressDtoTransformer.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/transform/DataAddressToDataAddressDtoTransformer.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.asset.transform;
+
+import org.eclipse.edc.api.transformer.DtoTransformer;
+import org.eclipse.edc.connector.api.management.asset.model.DataAddressDto;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class DataAddressToDataAddressDtoTransformer implements DtoTransformer<DataAddress, DataAddressDto> {
+
+    @Override
+    public Class<DataAddress> getInputType() {
+        return DataAddress.class;
+    }
+
+    @Override
+    public Class<DataAddressDto> getOutputType() {
+        return DataAddressDto.class;
+    }
+
+    @Override
+    public @Nullable DataAddressDto transform(@NotNull DataAddress object, @NotNull TransformerContext context) {
+        return DataAddressDto.Builder.newInstance().properties(object.getProperties()).build();
+    }
+
+}

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/AssetApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/AssetApiControllerIntegrationTest.java
@@ -283,6 +283,28 @@ public class AssetApiControllerIntegrationTest {
                 .statusCode(409);
     }
 
+    @Test
+    void getAssetAddress(AssetIndex assetIndex) {
+        var asset = Asset.Builder.newInstance().id("id").build();
+        var dataAddress = DataAddress.Builder.newInstance().type("type").build();
+        assetIndex.accept(asset, dataAddress);
+
+        baseRequest()
+                .get("/assets/id/address")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .body("properties.size()", greaterThan(0));
+    }
+
+    @Test
+    void getAssetAddress_notFound() {
+        baseRequest()
+                .get("/assets/not-existent-id/address")
+                .then()
+                .statusCode(404);
+    }
+
     private ContractNegotiation createContractNegotiation(Asset asset) {
         return ContractNegotiation.Builder.newInstance()
                 .id(UUID.randomUUID().toString())

--- a/resources/openapi/yaml/management-api/asset-api.yaml
+++ b/resources/openapi/yaml/management-api/asset-api.yaml
@@ -207,6 +207,44 @@ paths:
           description: An asset with the given ID does not exist
       tags:
       - Asset
+  /assets/{id}/address:
+    get:
+      description: Gets a data address of an asset with the given ID
+      operationId: getAssetDataAddress
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+          example: null
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataAddressDto'
+          description: The data address
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: "Request was malformed, e.g. id was null"
+        "404":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: An asset with the given ID does not exist
+      tags:
+      - Asset
 components:
   schemas:
     ApiErrorDetail:


### PR DESCRIPTION
## What this PR changes/adds

Adds `/assets/{id}/address` endpoint to asset mgmt for getting the data address of an asset by the asset id

## Why it does that
api enhancement


## Linked Issue(s)

Closes #2363 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
