### PR TITLE
chore: make CommandHandler.handle return a Result

### DIFF
--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/command/handlers/SingleContractNegotiationCommandHandler.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/command/handlers/SingleContractNegotiationCommandHandler.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.connector.contract.spi.types.command.SingleContractNegoti
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.command.CommandHandler;
+import org.eclipse.edc.spi.result.Result;
 
 import static java.lang.String.format;
 
@@ -44,7 +45,7 @@ public abstract class SingleContractNegotiationCommandHandler<T extends SingleCo
      * @param command the command.
      */
     @Override
-    public void handle(SingleContractNegotiationCommand command) {
+    public Result<Void> handle(SingleContractNegotiationCommand command) {
         var negotiationId = command.getNegotiationId();
         var negotiation = store.find(negotiationId);
         if (negotiation == null) {
@@ -53,7 +54,9 @@ public abstract class SingleContractNegotiationCommandHandler<T extends SingleCo
             if (modify(negotiation)) {
                 negotiation.setModified();
                 store.save(negotiation);
+                return Result.success();
             }
+            return Result.failure("The ContractNegotiation could not be modified ");
         }
     }
 

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/command/handlers/CancelNegotiationCommandHandlerTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/command/handlers/CancelNegotiationCommandHandlerTest.java
@@ -55,11 +55,12 @@ class CancelNegotiationCommandHandlerTest {
 
         when(store.find(negotiationId)).thenReturn(negotiation);
 
-        commandHandler.handle(command);
+        var result = commandHandler.handle(command);
 
         assertThat(negotiation.getState()).isEqualTo(ContractNegotiationStates.ERROR.code());
         assertThat(negotiation.getErrorDetail()).isEqualTo("Cancelled");
         assertThat(negotiation.getUpdatedAt()).isNotEqualTo(originalTime);
+        assertThat(result.succeeded()).isTrue();
     }
 
     @Test

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/command/handlers/DeclineNegotiationCommandHandlerTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/command/handlers/DeclineNegotiationCommandHandlerTest.java
@@ -46,25 +46,18 @@ class DeclineNegotiationCommandHandlerTest {
     @Test
     void handle_negotiationExists_declineNegotiation() {
         var negotiationId = "test";
-        var negotiation = ContractNegotiation.Builder.newInstance()
-                .id(negotiationId)
-                .counterPartyId("counter-party")
-                .counterPartyAddress("https://counter-party")
-                .protocol("test-protocol")
-                .state(ContractNegotiationStates.REQUESTED.code())
-                .clock(future)
-                .updatedAt(now.millis())
-                .build();
+        var negotiation = ContractNegotiation.Builder.newInstance().id(negotiationId).counterPartyId("counter-party").counterPartyAddress("https://counter-party").protocol("test-protocol").state(ContractNegotiationStates.REQUESTED.code()).clock(future).updatedAt(now.millis()).build();
         var originalTime = negotiation.getUpdatedAt();
         var command = new DeclineNegotiationCommand(negotiationId);
 
         when(store.find(negotiationId)).thenReturn(negotiation);
 
-        commandHandler.handle(command);
+        var result = commandHandler.handle(command);
 
         assertThat(negotiation.getState()).isEqualTo(ContractNegotiationStates.DECLINING.code());
         assertThat(negotiation.getErrorDetail()).isNotBlank();
         assertThat(negotiation.getUpdatedAt()).isGreaterThan(originalTime);
+        assertThat(result.succeeded()).isTrue();
     }
 
     @Test
@@ -74,9 +67,7 @@ class DeclineNegotiationCommandHandlerTest {
 
         when(store.find(negotiationId)).thenReturn(null);
 
-        assertThatThrownBy(() -> commandHandler.handle(command))
-                .isInstanceOf(EdcException.class)
-                .hasMessage(format("Could not find ContractNegotiation with ID [%s]", negotiationId));
+        assertThatThrownBy(() -> commandHandler.handle(command)).isInstanceOf(EdcException.class).hasMessage(format("Could not find ContractNegotiation with ID [%s]", negotiationId));
     }
 
     @Test

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/command/handlers/AddProvisionedResourceCommandHandler.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/command/handlers/AddProvisionedResourceCommandHandler.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.connector.transfer.spi.TransferProcessManager;
 import org.eclipse.edc.connector.transfer.spi.types.command.AddProvisionedResourceCommand;
 import org.eclipse.edc.spi.command.CommandHandler;
 import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.result.Result;
 
 import java.util.List;
 
@@ -35,8 +36,8 @@ public class AddProvisionedResourceCommandHandler implements CommandHandler<AddP
     }
 
     @Override
-    public void handle(AddProvisionedResourceCommand command) {
-        delegate.handleProvisionResult(command.getTransferProcessId(), List.of(StatusResult.success(command.getProvisionResponse())));
+    public Result<Void> handle(AddProvisionedResourceCommand command) {
+        return delegate.handleProvisionResult(command.getTransferProcessId(), List.of(StatusResult.success(command.getProvisionResponse())));
     }
 
     @Override

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/command/handlers/DeprovisionCompleteCommandHandler.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/command/handlers/DeprovisionCompleteCommandHandler.java
@@ -18,6 +18,7 @@ import org.eclipse.edc.connector.transfer.process.ProvisionCallbackDelegate;
 import org.eclipse.edc.connector.transfer.spi.types.command.DeprovisionCompleteCommand;
 import org.eclipse.edc.spi.command.CommandHandler;
 import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.result.Result;
 
 import java.util.List;
 
@@ -33,8 +34,8 @@ public class DeprovisionCompleteCommandHandler implements CommandHandler<Deprovi
     }
 
     @Override
-    public void handle(DeprovisionCompleteCommand command) {
-        delegate.handleDeprovisionResult(command.getTransferProcessId(), List.of(StatusResult.success(command.getResource())));
+    public Result<Void> handle(DeprovisionCompleteCommand command) {
+        return delegate.handleDeprovisionResult(command.getTransferProcessId(), List.of(StatusResult.success(command.getResource())));
     }
 
     @Override

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/command/handlers/SingleTransferProcessCommandHandler.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/command/handlers/SingleTransferProcessCommandHandler.java
@@ -20,6 +20,7 @@ import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.connector.transfer.spi.types.command.SingleTransferProcessCommand;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.command.CommandHandler;
+import org.eclipse.edc.spi.result.Result;
 
 import static java.lang.String.format;
 
@@ -36,7 +37,7 @@ public abstract class SingleTransferProcessCommandHandler<T extends SingleTransf
     }
 
     @Override
-    public void handle(T command) {
+    public Result<Void> handle(T command) {
         var transferProcessId = command.getTransferProcessId();
         var transferProcess = store.find(transferProcessId);
         if (transferProcess == null) {
@@ -46,7 +47,9 @@ public abstract class SingleTransferProcessCommandHandler<T extends SingleTransf
                 transferProcess.setModified();
                 store.save(transferProcess);
                 postAction(transferProcess);
+                return Result.success();
             }
+            return Result.failure("The TransferProcess could not be modified");
         }
     }
 

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/ProvisionCallbackDelegate.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/ProvisionCallbackDelegate.java
@@ -18,6 +18,7 @@ import org.eclipse.edc.connector.transfer.spi.provision.ProvisionManager;
 import org.eclipse.edc.connector.transfer.spi.types.DeprovisionedResource;
 import org.eclipse.edc.connector.transfer.spi.types.ProvisionResponse;
 import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.result.Result;
 
 import java.util.List;
 
@@ -28,10 +29,10 @@ public interface ProvisionCallbackDelegate {
     /**
      * Called when the {@link ProvisionManager} completes provisioning.
      */
-    void handleProvisionResult(String transferProcessId, List<StatusResult<ProvisionResponse>> provisionResponse);
+    Result<Void> handleProvisionResult(String transferProcessId, List<StatusResult<ProvisionResponse>> provisionResponse);
 
     /**
      * Called when the {@link ProvisionManager} completes deprovisioning.
      */
-    void handleDeprovisionResult(String transferProcessId, List<StatusResult<DeprovisionedResource>> provisionResponse);
+    Result<Void> handleDeprovisionResult(String transferProcessId, List<StatusResult<DeprovisionedResource>> provisionResponse);
 }

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/command/handlers/DeprovisionCommandHandlerTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/command/handlers/DeprovisionCommandHandlerTest.java
@@ -49,11 +49,12 @@ class DeprovisionCommandHandlerTest {
         var originalDate = tp.getUpdatedAt();
 
         when(storeMock.find(anyString())).thenReturn(tp);
-        handler.handle(cmd);
+        var result = handler.handle(cmd);
 
         assertThat(tp.getState()).isEqualTo(TransferProcessStates.DEPROVISIONING.code());
         assertThat(tp.getErrorDetail()).isNull();
         assertThat(tp.getUpdatedAt()).isNotEqualTo(originalDate);
+        assertThat(result.succeeded()).isTrue();
     }
 
     @Test

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/command/CommandHandler.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/command/CommandHandler.java
@@ -15,6 +15,8 @@
 
 package org.eclipse.edc.spi.command;
 
+import org.eclipse.edc.spi.result.Result;
+
 /**
  * CommandHandlers receive a {@link Command} object and act on it. If possible, command handlers should
  * not perform lengthy operations as this could block the command queue.
@@ -31,6 +33,6 @@ public interface CommandHandler<T extends Command> {
     /**
      * Processes the command.
      */
-    void handle(T command);
+    Result<Void> handle(T command);
 
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/command/CommandRunner.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/command/CommandRunner.java
@@ -45,8 +45,7 @@ public class CommandRunner<C extends Command> {
             return Result.failure("No command handler found for command type " + commandClass);
         }
         try {
-            handler.handle(command);
-            return Result.success();
+            return handler.handle(command);
         } catch (RuntimeException ex) {
             command.increaseErrorCount();
             monitor.severe("Error when processing a command", ex);


### PR DESCRIPTION
## What this PR changes/adds

the CommandHandler.handle returns a Result instead of void
## Why it does that

to make it easier to detect the errors and improve the reposrting of them
## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #2340 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
