### PR TITLE
build(deps): bump BouncyCastle to 1.72 Jdk18on

### DIFF
--- a/core/common/connector-core/build.gradle.kts
+++ b/core/common/connector-core/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     implementation(project(":core:common:util"))
 
     implementation(libs.dnsOverHttps)
-    implementation(libs.bouncyCastle.bcpkix)
+    implementation(libs.bouncyCastle.bcpkixJdk18on)
 
     testImplementation(project(":core:common:junit"))
     testImplementation(libs.awaitility)

--- a/extensions/common/vault/vault-filesystem/build.gradle.kts
+++ b/extensions/common/vault/vault-filesystem/build.gradle.kts
@@ -19,11 +19,11 @@ plugins {
 dependencies {
     api(project(":spi:common:core-spi"))
     implementation(project(":core:common:util"))
-    implementation(libs.bouncyCastle.bcpkix)
+    implementation(libs.bouncyCastle.bcpkixJdk18on)
 
     testImplementation(project(":extensions:common:iam:decentralized-identity:identity-did-crypto"))
     testImplementation(libs.nimbus.jwt)
-    testImplementation(libs.bouncyCastle.bcprov)
+    testImplementation(libs.bouncyCastle.bcprovJdk18on)
 }
 
 publishing {

--- a/extensions/control-plane/transfer/transfer-data-plane/build.gradle.kts
+++ b/extensions/control-plane/transfer/transfer-data-plane/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
     api(libs.nimbus.jwt)
     // Note: nimbus requires bouncycastle as mentioned in documentation:
     // https://www.javadoc.io/doc/com.nimbusds/nimbus-jose-jwt/7.2.1/com/nimbusds/jose/jwk/JWK.html#parseFromPEMEncodedObjects-java.lang.String-
-    api(libs.bouncyCastle.bcpkix)
+    api(libs.bouncyCastle.bcpkixJdk18on)
 
     testImplementation(project(":core:common:junit"))
     testImplementation(libs.jersey.multipart)

--- a/extensions/data-plane/data-plane-azure-data-factory/build.gradle.kts
+++ b/extensions/data-plane/data-plane-azure-data-factory/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
 
     testImplementation(project(":core:common:junit"))
     testImplementation(libs.awaitility)
-    testImplementation(libs.bouncyCastle.bcprov)
+    testImplementation(libs.bouncyCastle.bcprovJdk18on)
 }
 
 publishing {


### PR DESCRIPTION
## What this PR changes/adds

Bumps BouncyCastle to 1.72 Jdk18on

## Why it does that

dependency update


## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
