### PR TITLE
feat(dataPlaneS3): adds support for vault on data source address

### DIFF
--- a/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/DataPlaneS3Extension.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/DataPlaneS3Extension.java
@@ -52,7 +52,7 @@ public class DataPlaneS3Extension implements ServiceExtension {
 
         var monitor = context.getMonitor();
 
-        var sourceFactory = new S3DataSourceFactory(awsClientProvider);
+        var sourceFactory = new S3DataSourceFactory(awsClientProvider, vault, typeManager);
         pipelineService.registerFactory(sourceFactory);
 
         var sinkFactory = new S3DataSinkFactory(awsClientProvider, executorService, monitor, vault, typeManager);

--- a/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSourceFactory.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSourceFactory.java
@@ -24,9 +24,12 @@ import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSourceFactory;
 import org.eclipse.edc.connector.dataplane.util.validation.ValidationRule;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
 import org.jetbrains.annotations.NotNull;
+import software.amazon.awssdk.services.s3.S3Client;
 
 import static org.eclipse.edc.aws.s3.S3BucketSchema.ACCESS_KEY_ID;
 import static org.eclipse.edc.aws.s3.S3BucketSchema.BUCKET_NAME;
@@ -38,9 +41,14 @@ public class S3DataSourceFactory implements DataSourceFactory {
     private final ValidationRule<DataAddress> validation = new S3DataAddressValidationRule();
     private final ValidationRule<DataAddress> credentialsValidation = new S3DataAddressCredentialsValidationRule();
     private final AwsClientProvider clientProvider;
+    private final Vault vault;
 
-    public S3DataSourceFactory(AwsClientProvider clientProvider) {
+    private final TypeManager typeManager;
+
+    public S3DataSourceFactory(AwsClientProvider clientProvider, Vault vault, TypeManager typeManager) {
         this.clientProvider = clientProvider;
+        this.vault = vault;
+        this.typeManager = typeManager;
     }
 
     @Override
@@ -64,11 +72,17 @@ public class S3DataSourceFactory implements DataSourceFactory {
 
         var source = request.getSourceDataAddress();
 
-        var secretToken = new AwsSecretToken(source.getProperty(ACCESS_KEY_ID), source.getProperty(SECRET_ACCESS_KEY));
-
-        var client = credentialsValidation.apply(source).succeeded()
-                ? clientProvider.s3Client(source.getProperty(REGION), secretToken)
-                : clientProvider.s3Client(source.getProperty(REGION));
+        S3Client client;
+        var secret = vault.resolveSecret(source.getKeyName());
+        if (secret != null) {
+            var secretToken = typeManager.readValue(secret, AwsSecretToken.class);
+            client = clientProvider.s3Client(source.getProperty(REGION), secretToken);
+        } else if (credentialsValidation.apply(source).succeeded()) {
+            var secretToken = new AwsSecretToken(source.getProperty(ACCESS_KEY_ID), source.getProperty(SECRET_ACCESS_KEY));
+            client = clientProvider.s3Client(source.getProperty(REGION), secretToken);
+        } else {
+            client = clientProvider.s3Client(source.getProperty(REGION));
+        }
 
         return S3DataSource.Builder.newInstance()
                 .bucketName(source.getProperty(BUCKET_NAME))

--- a/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataPlaneIntegrationTest.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataPlaneIntegrationTest.java
@@ -65,8 +65,11 @@ public class S3DataPlaneIntegrationTest extends AbstractS3Test {
         var key = UUID.randomUUID().toString();
         putStringOnBucket(sourceBucketName, key, body);
 
-        var sinkFactory = new S3DataSinkFactory(clientProvider, Executors.newSingleThreadExecutor(), mock(Monitor.class), mock(Vault.class), new TypeManager());
-        var sourceFactory = new S3DataSourceFactory(clientProvider);
+        var vault = mock(Vault.class);
+        var typeManager = new TypeManager();
+
+        var sinkFactory = new S3DataSinkFactory(clientProvider, Executors.newSingleThreadExecutor(), mock(Monitor.class), vault, typeManager);
+        var sourceFactory = new S3DataSourceFactory(clientProvider, vault, typeManager);
         var sourceAddress = DataAddress.Builder.newInstance()
                 .type(S3BucketSchema.TYPE)
                 .keyName(key)


### PR DESCRIPTION
## What this PR changes/adds

Adds the support for key and secret from the vault

## Why it does that

security improvement

## Linked Issue(s)

Closes #2364 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
