### PR TITLE
fix: publish to swaggerhub only on upstream main branch pushes

### DIFF
--- a/.github/workflows/apidoc.yaml
+++ b/.github/workflows/apidoc.yaml
@@ -56,8 +56,8 @@ jobs:
           diff -r git-sorted git-regen
 
   Publish-To-SwaggerHub:
-    # do NOT run on forks. The Org ("edc") is unique all across SwaggerHub
-    if: github.repository == 'eclipse-edc/Connector' && github.event_name != 'pull_request'
+    # do NOT run on forks or on PRs. The Org ("edc") is unique all across SwaggerHub
+    if: github.repository == 'eclipse-edc/Connector' && github.event_name == 'push' && github.ref_name == 'main'
     runs-on: ubuntu-latest
     needs: [ Verify-OpenAPI-Definitions ]
     strategy:


### PR DESCRIPTION
## What this PR changes/adds

Run the publish job only when the event is a `push` on the upstream `main` branch

## Why it does that

To avoid failures

## Linked Issue(s)

Closes #2397

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
