### PR TITLE
chore: update sample links

### DIFF
--- a/docs/developer/architecture/README.md
+++ b/docs/developer/architecture/README.md
@@ -28,4 +28,4 @@ transferProcessObservable = context.getService(TransferProcessObservable.class);
 transferProcessObservable.registerListener(myTransferProcessListener);
 ```
 
-A sample is available at [04.1-file-transfer-listener](https://github.com/eclipse-edc/Samples/blob/main/04.1-file-transfer-listener/README.md).
+A sample is available at [04.1-file-transfer-listener](https://github.com/eclipse-edc/Samples/blob/main/transfer/transfer-02-file-transfer-listener/README.md).

--- a/docs/developer/command-queue.md
+++ b/docs/developer/command-queue.md
@@ -76,4 +76,4 @@ violate the serializability principle.
 
 ## Further reading
 
-A complete sample with additional explanation can be found in the [samples](https://github.com/eclipse-edc/Samples/blob/main/04.2-modify-transferprocess/README.md).
+A complete sample with additional explanation can be found in the [samples](https://github.com/eclipse-edc/Samples/blob/main/transfer/transfer-03-modify-transferprocess/README.md).

--- a/docs/developer/metrics.md
+++ b/docs/developer/metrics.md
@@ -2,7 +2,7 @@
 
 EDC provides extensions for instrumentation with the [Micrometer](https://micrometer.io/) metrics library to automatically collect metrics from the host system, JVM, and frameworks and libraries used in EDC (including OkHttp, Jetty, Jersey and ExecutorService).
 
-See [sample 04.3](https://github.com/eclipse-edc/Samples/blob/main/04.3-open-telemetry/README.md) for an example of an instrumented EDC consumer. 
+See [sample 04.3](https://github.com/eclipse-edc/Samples/blob/main/transfer/transfer-04-open-telemetry/README.md) for an example of an instrumented EDC consumer. 
 
 ## Micrometer Extension
 


### PR DESCRIPTION
## What this PR changes/adds

Updates the links to samples in the documentation.

## Why it does that

The links to samples have changed after the restructuring of the samples repository.

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
