### PR TITLE
feat: add scope parameter to oauth2 provisioner

### DIFF
--- a/extensions/common/iam/oauth2/oauth2-client/src/main/java/org/eclipse/edc/iam/oauth2/client/Oauth2ClientImpl.java
+++ b/extensions/common/iam/oauth2/oauth2-client/src/main/java/org/eclipse/edc/iam/oauth2/client/Oauth2ClientImpl.java
@@ -70,7 +70,9 @@ public class Oauth2ClientImpl implements Oauth2Client {
 
     private static FormBody createRequestBody(Oauth2CredentialsRequest request) {
         var builder = new FormBody.Builder();
-        request.getParams().forEach(builder::add);
+        request.getParams().entrySet().stream()
+                .filter(entry -> entry.getValue() != null)
+                .forEach(entry -> builder.add(entry.getKey(), entry.getValue()));
         return builder.build();
     }
 

--- a/extensions/control-plane/provision/provision-oauth2/provision-oauth2-core/README.md
+++ b/extensions/control-plane/provision/provision-oauth2/provision-oauth2-core/README.md
@@ -29,14 +29,17 @@ The extension works for all the `HttpData` addresses that contain the "oauth2" p
 It supports [both types of client credential](https://connect2id.com/products/server/docs/guides/oauth-client-authentication#credential-types):
 shared secret and private-key based.
 
+### Common properties
+
+- `oauth2:tokenUrl`: the url where the token will be requested
+- `oauth2:scope`: (optional) the requested scope
+
 ### Private-key based client credential
 
 This type of client credential is used when the `HttpData` address contains the `oauth2:privateKeyName` property. This type of client
 credential is considered as more secured as described [here](https://connect2id.com/products/server/docs/guides/oauth-client-authentication#private-key-auth-is-more-secure).
 The mandatory for working with type of client credentials are:
 
-- `oauth2:clientId`: the client id
-- `oauth2:tokenUrl`: the url where the token will be requested
 - `oauth2:privateKeyName`: the name of the private key used to sign the JWT sent to the Oauth2 server
   `oauth2:validity`: the validity of the JWT token sent to the Oauth2 server (in seconds)
 
@@ -46,6 +49,5 @@ This type of client credential is used when the `HttpData` address DOES not cont
 The mandatory for working with type of client credentials are:
 
 - `oauth2:clientId`: the client id
-- `oauth2:tokenUrl`: the url where the token will be requested
 - `oauth2:clientSecret`: shared secret for authenticating to the Oauth2 server
 

--- a/extensions/control-plane/provision/provision-oauth2/provision-oauth2-core/src/main/java/org/eclipse/edc/connector/provision/oauth2/Oauth2CredentialsRequestFactory.java
+++ b/extensions/control-plane/provision/provision-oauth2/provision-oauth2-core/src/main/java/org/eclipse/edc/connector/provision/oauth2/Oauth2CredentialsRequestFactory.java
@@ -1,0 +1,89 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.provision.oauth2;
+
+import org.eclipse.edc.iam.oauth2.spi.Oauth2AssertionDecorator;
+import org.eclipse.edc.iam.oauth2.spi.client.Oauth2CredentialsRequest;
+import org.eclipse.edc.iam.oauth2.spi.client.PrivateKeyOauth2CredentialsRequest;
+import org.eclipse.edc.iam.oauth2.spi.client.SharedSecretOauth2CredentialsRequest;
+import org.eclipse.edc.jwt.TokenGenerationServiceImpl;
+import org.eclipse.edc.spi.iam.TokenRepresentation;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.security.PrivateKeyResolver;
+import org.jetbrains.annotations.NotNull;
+
+import java.security.PrivateKey;
+import java.time.Clock;
+
+/**
+ * Factory class that provides methods to build {@link Oauth2CredentialsRequest} instances
+ */
+public class Oauth2CredentialsRequestFactory {
+
+    private static final String GRANT_CLIENT_CREDENTIALS = "client_credentials";
+    private final PrivateKeyResolver privateKeyResolver;
+    private final Clock clock;
+
+    public Oauth2CredentialsRequestFactory(PrivateKeyResolver privateKeyResolver, Clock clock) {
+        this.privateKeyResolver = privateKeyResolver;
+        this.clock = clock;
+    }
+
+    /**
+     * Create an {@link Oauth2CredentialsRequest} given a {@link Oauth2ResourceDefinition}
+     *
+     * @param resourceDefinition the resource definition
+     * @return a {@link Result} containing the {@link Oauth2CredentialsRequest} object
+     */
+    public Result<Oauth2CredentialsRequest> create(Oauth2ResourceDefinition resourceDefinition) {
+        var keySecret = resourceDefinition.getPrivateKeyName();
+        return keySecret != null
+                ? createPrivateKeyBasedRequest(keySecret, resourceDefinition)
+                : createSharedSecretRequest(resourceDefinition);
+    }
+
+    @NotNull
+    private Result<Oauth2CredentialsRequest> createPrivateKeyBasedRequest(String pkSecret, Oauth2ResourceDefinition resourceDefinition) {
+        return createAssertion(pkSecret, resourceDefinition)
+                .map(assertion -> PrivateKeyOauth2CredentialsRequest.Builder.newInstance()
+                        .clientAssertion(assertion.getToken())
+                        .url(resourceDefinition.getTokenUrl())
+                        .grantType(GRANT_CLIENT_CREDENTIALS)
+                        .scope(resourceDefinition.getScope())
+                        .build());
+    }
+
+    @NotNull
+    private Result<Oauth2CredentialsRequest> createSharedSecretRequest(Oauth2ResourceDefinition resourceDefinition) {
+        return Result.success(SharedSecretOauth2CredentialsRequest.Builder.newInstance()
+                .url(resourceDefinition.getTokenUrl())
+                .grantType(GRANT_CLIENT_CREDENTIALS)
+                .clientId(resourceDefinition.getClientId())
+                .clientSecret(resourceDefinition.getClientSecret())
+                .scope(resourceDefinition.getScope())
+                .build());
+    }
+
+    @NotNull
+    private Result<TokenRepresentation> createAssertion(String pkSecret, Oauth2ResourceDefinition resourceDefinition) {
+        var privateKey = privateKeyResolver.resolvePrivateKey(pkSecret, PrivateKey.class);
+        if (privateKey == null) {
+            return Result.failure("Failed to resolve private key with alias: " + pkSecret);
+        }
+        var decorator = new Oauth2AssertionDecorator(resourceDefinition.getTokenUrl(), resourceDefinition.getClientId(), clock, resourceDefinition.getValidity());
+        var service = new TokenGenerationServiceImpl(privateKey);
+        return service.generate(decorator);
+    }
+}

--- a/extensions/control-plane/provision/provision-oauth2/provision-oauth2-core/src/main/java/org/eclipse/edc/connector/provision/oauth2/Oauth2DataAddressSchema.java
+++ b/extensions/control-plane/provision/provision-oauth2/provision-oauth2-core/src/main/java/org/eclipse/edc/connector/provision/oauth2/Oauth2DataAddressSchema.java
@@ -20,4 +20,5 @@ public interface Oauth2DataAddressSchema {
     String TOKEN_URL = "oauth2:tokenUrl";
     String VALIDITY = "oauth2:validity";
     String PRIVATE_KEY_NAME = "oauth2:privateKeyName";
+    String SCOPE = "oauth2:scope";
 }

--- a/extensions/control-plane/provision/provision-oauth2/provision-oauth2-core/src/main/java/org/eclipse/edc/connector/provision/oauth2/Oauth2ProvisionExtension.java
+++ b/extensions/control-plane/provision/provision-oauth2/provision-oauth2-core/src/main/java/org/eclipse/edc/connector/provision/oauth2/Oauth2ProvisionExtension.java
@@ -57,7 +57,8 @@ public class Oauth2ProvisionExtension implements ServiceExtension {
         resourceManifestGenerator.registerGenerator(new Oauth2ProviderResourceDefinitionGenerator());
         resourceManifestGenerator.registerGenerator(new Oauth2ConsumerResourceDefinitionGenerator());
 
-        provisionManager.register(new Oauth2Provisioner(client, privateKeyResolver, clock));
+        var requestFactory = new Oauth2CredentialsRequestFactory(privateKeyResolver, clock);
+        provisionManager.register(new Oauth2Provisioner(client, requestFactory));
     }
 
 }

--- a/extensions/control-plane/provision/provision-oauth2/provision-oauth2-core/src/main/java/org/eclipse/edc/connector/provision/oauth2/Oauth2Provisioner.java
+++ b/extensions/control-plane/provision/provision-oauth2/provision-oauth2-core/src/main/java/org/eclipse/edc/connector/provision/oauth2/Oauth2Provisioner.java
@@ -19,22 +19,11 @@ import org.eclipse.edc.connector.transfer.spi.types.DeprovisionedResource;
 import org.eclipse.edc.connector.transfer.spi.types.ProvisionResponse;
 import org.eclipse.edc.connector.transfer.spi.types.ProvisionedResource;
 import org.eclipse.edc.connector.transfer.spi.types.ResourceDefinition;
-import org.eclipse.edc.iam.oauth2.spi.Oauth2AssertionDecorator;
 import org.eclipse.edc.iam.oauth2.spi.client.Oauth2Client;
-import org.eclipse.edc.iam.oauth2.spi.client.Oauth2CredentialsRequest;
-import org.eclipse.edc.iam.oauth2.spi.client.PrivateKeyOauth2CredentialsRequest;
-import org.eclipse.edc.iam.oauth2.spi.client.SharedSecretOauth2CredentialsRequest;
-import org.eclipse.edc.jwt.TokenGenerationServiceImpl;
 import org.eclipse.edc.policy.model.Policy;
-import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.response.StatusResult;
-import org.eclipse.edc.spi.result.Result;
-import org.eclipse.edc.spi.security.PrivateKeyResolver;
 import org.eclipse.edc.spi.types.domain.HttpDataAddress;
-import org.jetbrains.annotations.NotNull;
 
-import java.security.PrivateKey;
-import java.time.Clock;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
@@ -46,16 +35,12 @@ import static org.eclipse.edc.spi.response.ResponseStatus.FATAL_ERROR;
  */
 class Oauth2Provisioner implements Provisioner<Oauth2ResourceDefinition, Oauth2ProvisionedResource> {
 
-    private static final String GRANT_CLIENT_CREDENTIALS = "client_credentials";
-
     private final Oauth2Client client;
-    private final PrivateKeyResolver privateKeyResolver;
-    private final Clock clock;
+    private final Oauth2CredentialsRequestFactory requestFactory;
 
-    Oauth2Provisioner(Oauth2Client client, PrivateKeyResolver privateKeyResolver, Clock clock) {
+    Oauth2Provisioner(Oauth2Client client, Oauth2CredentialsRequestFactory requestFactory) {
         this.client = client;
-        this.privateKeyResolver = privateKeyResolver;
-        this.clock = clock;
+        this.requestFactory = requestFactory;
     }
 
     @Override
@@ -70,7 +55,7 @@ class Oauth2Provisioner implements Provisioner<Oauth2ResourceDefinition, Oauth2P
 
     @Override
     public CompletableFuture<StatusResult<ProvisionResponse>> provision(Oauth2ResourceDefinition resourceDefinition, Policy policy) {
-        var request = createRequest(resourceDefinition);
+        var request = requestFactory.create(resourceDefinition);
         if (request.failed()) {
             return completedFuture(StatusResult.failure(FATAL_ERROR, request.getFailureDetail()));
         }
@@ -109,39 +94,4 @@ class Oauth2Provisioner implements Provisioner<Oauth2ResourceDefinition, Oauth2P
         return completedFuture(StatusResult.success(deprovisionedResource));
     }
 
-    @NotNull
-    private Result<Oauth2CredentialsRequest> createRequest(Oauth2ResourceDefinition rd) {
-        var keySecret = rd.getPrivateKeyName();
-        return keySecret != null ? createPrivateKeyBasedRequest(keySecret, rd) : createSharedSecretRequest(rd);
-    }
-
-    @NotNull
-    private Result<Oauth2CredentialsRequest> createPrivateKeyBasedRequest(String pkSecret, Oauth2ResourceDefinition rd) {
-        return createAssertion(pkSecret, rd)
-                .map(assertion -> PrivateKeyOauth2CredentialsRequest.Builder.newInstance()
-                        .clientAssertion(assertion.getToken())
-                        .url(rd.getTokenUrl())
-                        .grantType(GRANT_CLIENT_CREDENTIALS)
-                        .build());
-    }
-
-    @NotNull
-    private Result<Oauth2CredentialsRequest> createSharedSecretRequest(Oauth2ResourceDefinition rd) {
-        return Result.success(SharedSecretOauth2CredentialsRequest.Builder.newInstance()
-                .url(rd.getTokenUrl())
-                .grantType(GRANT_CLIENT_CREDENTIALS)
-                .clientId(rd.getClientId())
-                .clientSecret(rd.getClientSecret())
-                .build());
-    }
-
-    private Result<TokenRepresentation> createAssertion(String pkSecret, Oauth2ResourceDefinition rd) {
-        var privateKey = privateKeyResolver.resolvePrivateKey(pkSecret, PrivateKey.class);
-        if (privateKey == null) {
-            return Result.failure("Failed to resolve private key with alias: " + pkSecret);
-        }
-        var decorator = new Oauth2AssertionDecorator(rd.getTokenUrl(), rd.getClientId(), clock, rd.getValidity());
-        var service = new TokenGenerationServiceImpl(privateKey);
-        return service.generate(decorator);
-    }
 }

--- a/extensions/control-plane/provision/provision-oauth2/provision-oauth2-core/src/main/java/org/eclipse/edc/connector/provision/oauth2/Oauth2ResourceDefinition.java
+++ b/extensions/control-plane/provision/provision-oauth2/provision-oauth2-core/src/main/java/org/eclipse/edc/connector/provision/oauth2/Oauth2ResourceDefinition.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import static org.eclipse.edc.connector.provision.oauth2.Oauth2DataAddressSchema.CLIENT_ID;
 import static org.eclipse.edc.connector.provision.oauth2.Oauth2DataAddressSchema.CLIENT_SECRET;
 import static org.eclipse.edc.connector.provision.oauth2.Oauth2DataAddressSchema.PRIVATE_KEY_NAME;
+import static org.eclipse.edc.connector.provision.oauth2.Oauth2DataAddressSchema.SCOPE;
 import static org.eclipse.edc.connector.provision.oauth2.Oauth2DataAddressSchema.TOKEN_URL;
 import static org.eclipse.edc.connector.provision.oauth2.Oauth2DataAddressSchema.VALIDITY;
 
@@ -68,6 +69,11 @@ public class Oauth2ResourceDefinition extends ResourceDefinition {
     @Nullable
     public String getPrivateKeyName() {
         return dataAddress.getProperty(PRIVATE_KEY_NAME);
+    }
+
+    @Nullable
+    public String getScope() {
+        return dataAddress.getProperty(SCOPE);
     }
 
     public long getValidity() {

--- a/extensions/control-plane/provision/provision-oauth2/provision-oauth2-core/src/test/java/org/eclipse/edc/connector/provision/oauth2/Oauth2CredentialsRequestFactoryTest.java
+++ b/extensions/control-plane/provision/provision-oauth2/provision-oauth2-core/src/test/java/org/eclipse/edc/connector/provision/oauth2/Oauth2CredentialsRequestFactoryTest.java
@@ -1,0 +1,151 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.provision.oauth2;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.crypto.RSASSAVerifier;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jwt.SignedJWT;
+import org.eclipse.edc.iam.oauth2.spi.client.PrivateKeyOauth2CredentialsRequest;
+import org.eclipse.edc.iam.oauth2.spi.client.SharedSecretOauth2CredentialsRequest;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.security.PrivateKeyResolver;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.HttpDataAddress;
+import org.junit.jupiter.api.Test;
+
+import java.security.PrivateKey;
+import java.sql.Date;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.UUID;
+
+import static java.time.ZoneOffset.UTC;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
+import static org.eclipse.edc.connector.provision.oauth2.Oauth2DataAddressSchema.CLIENT_ID;
+import static org.eclipse.edc.connector.provision.oauth2.Oauth2DataAddressSchema.CLIENT_SECRET;
+import static org.eclipse.edc.connector.provision.oauth2.Oauth2DataAddressSchema.PRIVATE_KEY_NAME;
+import static org.eclipse.edc.connector.provision.oauth2.Oauth2DataAddressSchema.SCOPE;
+import static org.eclipse.edc.connector.provision.oauth2.Oauth2DataAddressSchema.TOKEN_URL;
+import static org.eclipse.edc.connector.provision.oauth2.Oauth2DataAddressSchema.VALIDITY;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class Oauth2CredentialsRequestFactoryTest {
+
+    private final Instant now = Instant.now();
+    private final Clock clock = Clock.fixed(now, UTC);
+    private final PrivateKeyResolver privateKeyResolver = mock(PrivateKeyResolver.class);
+    private final Oauth2CredentialsRequestFactory factory = new Oauth2CredentialsRequestFactory(privateKeyResolver, clock);
+
+    @Test
+    void shouldCreateSharedSecretRequest_whenPrivateKeyNameIsAbsent() {
+        var address = defaultAddress()
+                .property(CLIENT_SECRET, "clientSecret")
+                .property(SCOPE, "scope")
+                .build();
+
+        var result = factory.create(createResourceDefinition(address));
+
+        assertThat(result).matches(Result::succeeded).extracting(Result::getContent)
+                .asInstanceOf(type(SharedSecretOauth2CredentialsRequest.class))
+                .satisfies(request -> {
+                    assertThat(request.getGrantType()).isEqualTo("client_credentials");
+                    assertThat(request.getClientId()).isEqualTo("clientId");
+                    assertThat(request.getClientSecret()).isEqualTo("clientSecret");
+                    assertThat(request.getUrl()).isEqualTo("http://oauth2-server.com/token");
+                    assertThat(request.getScope()).isEqualTo("scope");
+                });
+        verifyNoInteractions(privateKeyResolver);
+    }
+
+    @Test
+    void shouldCreatePrivateKeyRequest_whenPrivateKeyNameIsPresent() throws JOSEException {
+        var keyPair = generateKeyPair();
+        when(privateKeyResolver.resolvePrivateKey("pk-test", PrivateKey.class)).thenReturn(keyPair.toPrivateKey());
+
+        var address = defaultAddress()
+                .property(PRIVATE_KEY_NAME, "pk-test")
+                .property(VALIDITY, "600")
+                .build();
+
+        var result = factory.create(createResourceDefinition(address));
+
+        assertThat(result).matches(Result::succeeded).extracting(Result::getContent)
+                .asInstanceOf(type(PrivateKeyOauth2CredentialsRequest.class))
+                .satisfies(request -> {
+                    assertThat(request.getGrantType()).isEqualTo("client_credentials");
+                    assertThat(request.getUrl()).isEqualTo("http://oauth2-server.com/token");
+                    assertThat(request.getClientAssertionType()).isEqualTo("urn:ietf:params:oauth:client-assertion-type:jwt-bearer");
+                    assertThat(request.getScope()).isEqualTo(null);
+                })
+                .extracting(PrivateKeyOauth2CredentialsRequest::getClientAssertion)
+                .satisfies(assertion -> {
+                    var assertionToken = SignedJWT.parse(assertion);
+                    var now = clock.instant().truncatedTo(ChronoUnit.SECONDS);
+                    assertThat(assertionToken.verify(new RSASSAVerifier(keyPair.toRSAPublicKey()))).isTrue();
+                    assertThat(assertionToken.getJWTClaimsSet().getClaims())
+                            .hasFieldOrPropertyWithValue("sub", "clientId")
+                            .hasFieldOrPropertyWithValue("iss", "clientId")
+                            .hasFieldOrPropertyWithValue("aud", List.of(address.getProperty(TOKEN_URL)))
+                            .hasFieldOrProperty("jti")
+                            .hasFieldOrPropertyWithValue("iat", Date.from(now))
+                            .hasFieldOrPropertyWithValue("exp", Date.from(now.plusSeconds(600)));
+                });
+    }
+
+    @Test
+    void shouldFailIfPrivateKeySecretNotFound() {
+        when(privateKeyResolver.resolvePrivateKey("pk-test", PrivateKey.class)).thenReturn(null);
+
+        var address = defaultAddress()
+                .property(PRIVATE_KEY_NAME, "pk-test")
+                .property(VALIDITY, "600")
+                .build();
+
+        var result = factory.create(createResourceDefinition(address));
+
+        assertThat(result).matches(Result::failed)
+                .extracting(Result::getFailureDetail).asString().contains("pk-test");
+    }
+
+    private Oauth2ResourceDefinition createResourceDefinition(DataAddress address) {
+        return Oauth2ResourceDefinition.Builder.newInstance()
+                .id(UUID.randomUUID().toString())
+                .transferProcessId(UUID.randomUUID().toString())
+                .dataAddress(address)
+                .build();
+    }
+
+    private HttpDataAddress.Builder defaultAddress() {
+        return HttpDataAddress.Builder.newInstance()
+                .property(CLIENT_ID, "clientId")
+                .property(TOKEN_URL, "http://oauth2-server.com/token");
+    }
+
+    private RSAKey generateKeyPair() throws JOSEException {
+        return new RSAKeyGenerator(2048)
+                .keyUse(KeyUse.SIGNATURE) // indicate the intended use of the key
+                .keyID(UUID.randomUUID().toString()) // give the key a unique ID
+                .generate();
+    }
+
+}


### PR DESCRIPTION
## What this PR changes/adds

Permits to add a `scope` parameter to the token request in the `provision-oauth2` extension

## Why it does that

Some cases require it

## Further notes

- extracted a `Factory` that takes care of building the request object, this permitted to simplify the provisioner logic

## Linked Issue(s)

Closes #2406 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
