### PR TITLE
test: add unit tests for S3CoreExtension

### DIFF
--- a/extensions/common/aws/aws-s3-core/build.gradle.kts
+++ b/extensions/common/aws/aws-s3-core/build.gradle.kts
@@ -24,6 +24,8 @@ dependencies {
     api(libs.aws.iam)
     api(libs.aws.s3)
     api(libs.aws.sts)
+
+    testImplementation(project(":core:common:junit"))
 }
 
 publishing {

--- a/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/S3CoreExtension.java
+++ b/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/S3CoreExtension.java
@@ -38,13 +38,13 @@ public class S3CoreExtension implements ServiceExtension {
 
     public static final String NAME = "S3";
     @Setting(value = "The key of the secret where the AWS Access Key Id is stored")
-    private static final String AWS_ACCESS_KEY = "edc.aws.access.key";
+    static final String AWS_ACCESS_KEY = "edc.aws.access.key";
     @Setting(value = "The key of the secret where the AWS Secret Access Key is stored")
-    private static final String AWS_SECRET_KEY = "edc.aws.secret.access.key";
+    static final String AWS_SECRET_KEY = "edc.aws.secret.access.key";
     @Setting(value = "If valued, the AWS clients will point to the specified endpoint")
-    private static final String AWS_ENDPOINT_OVERRIDE = "edc.aws.endpoint.override";
+    static final String AWS_ENDPOINT_OVERRIDE = "edc.aws.endpoint.override";
     @Setting(value = "The size of the thread pool used for the async clients")
-    private static final String AWS_ASYNC_CLIENT_THREAD_POOL_SIZE = "edc.aws.client.async.thread-pool-size";
+    static final String AWS_ASYNC_CLIENT_THREAD_POOL_SIZE = "edc.aws.client.async.thread-pool-size";
     @Inject
     private Vault vault;
 
@@ -75,7 +75,7 @@ public class S3CoreExtension implements ServiceExtension {
     }
 
     @NotNull
-    private AwsCredentialsProvider createCredentialsProvider(ServiceExtensionContext context) {
+    AwsCredentialsProvider createCredentialsProvider(ServiceExtensionContext context) {
         var accessKey = vault.resolveSecret(context.getSetting(AWS_ACCESS_KEY, AWS_ACCESS_KEY));
         var secretKey = vault.resolveSecret(context.getSetting(AWS_SECRET_KEY, AWS_SECRET_KEY));
 

--- a/extensions/common/aws/aws-s3-core/src/test/java/org/eclipse/edc/aws/s3/AwsClientProviderImplTest.java
+++ b/extensions/common/aws/aws-s3-core/src/test/java/org/eclipse/edc/aws/s3/AwsClientProviderImplTest.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2023 NTT DATA Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Masatake Iwasaki (NTT DATA) - Initial implementation
+ *
+ */
+
+package org.eclipse.edc.aws.s3;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AwsClientProviderImplTest {
+    @Test
+    void testClientCaching() {
+        var configuration = AwsClientProviderConfiguration.Builder.newInstance()
+                .credentialsProvider(() -> AwsBasicCredentials.create("dummy", "dummy"))
+                .build();
+        var provider = new AwsClientProviderImpl(configuration);
+        var client1 = provider.s3Client("us-east-1");
+        var client2 = provider.s3Client("us-west-1");
+        var client3 = provider.s3Client("us-west-1");
+        assertThat(client3).isSameAs(client2).isNotSameAs(client1);
+
+        var asyncClient1 = provider.s3AsyncClient("us-east-1");
+        var asyncClient2 = provider.s3AsyncClient("us-west-1");
+        var asyncClient3 = provider.s3AsyncClient("us-west-1");
+        assertThat(client3).isSameAs(client2).isNotSameAs(client1);
+    }
+}

--- a/extensions/common/aws/aws-s3-core/src/test/java/org/eclipse/edc/aws/s3/S3CoreExtensionTest.java
+++ b/extensions/common/aws/aws-s3-core/src/test/java/org/eclipse/edc/aws/s3/S3CoreExtensionTest.java
@@ -1,0 +1,98 @@
+/*
+ *  Copyright (c) 2023 NTT DATA Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Masatake Iwasaki (NTT DATA) - Initial implementation
+ *
+ */
+
+package org.eclipse.edc.aws.s3;
+
+import org.eclipse.edc.junit.extensions.EdcExtension;
+import org.eclipse.edc.junit.testfixtures.MockVault;
+import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(EdcExtension.class)
+public class S3CoreExtensionTest {
+    private static final String VAULT_KEY_ACCESS_KEY_ID = "key of access key id";
+    private static final String VAULT_KEY_SECRET_ACCESS_KEY = "key of secret access key";
+    private static final String EDC_AWS_ACCESS_KEY_ID = "access key id in vault";
+    private static final String EDC_AWS_SECRET_ACCESS_KEY = "secret access key in vault";
+    private static final String AWS_ACCESS_KEY_ID = "access key id via AWS SDK settings";
+    private static final String AWS_SECRET_ACCESS_KEY = "secret access key via AWS SDK settings";
+
+    private Properties savedProperties;
+    private S3CoreExtension s3;
+
+    @BeforeEach
+    void setUp(EdcExtension edc) {
+        savedProperties = (Properties) System.getProperties().clone();
+
+        // AWS SDK settings via system properties
+        System.setProperty("aws.accessKeyId", AWS_ACCESS_KEY_ID);
+        System.setProperty("aws.secretAccessKey", AWS_SECRET_ACCESS_KEY);
+
+        edc.setConfiguration(Map.of(
+                S3CoreExtension.AWS_ACCESS_KEY, VAULT_KEY_ACCESS_KEY_ID,
+                S3CoreExtension.AWS_SECRET_KEY, VAULT_KEY_SECRET_ACCESS_KEY));
+        edc.registerServiceMock(Vault.class, new MockVault());
+        s3 = new S3CoreExtension();
+        edc.registerSystemExtension(ServiceExtension.class, s3);
+    }
+
+    @AfterEach
+    void afterEach() {
+        System.setProperties(savedProperties);
+    }
+
+    @Test
+    void testCredentialsFromVault(EdcExtension edc, Vault vault) {
+        vault.storeSecret(VAULT_KEY_ACCESS_KEY_ID, EDC_AWS_ACCESS_KEY_ID);
+        vault.storeSecret(VAULT_KEY_SECRET_ACCESS_KEY, EDC_AWS_SECRET_ACCESS_KEY);
+
+        // EDC configurations have higher precedence than AWS SDK settings
+        var credentials = s3.createCredentialsProvider(edc.getContext()).resolveCredentials();
+        assertEquals(EDC_AWS_ACCESS_KEY_ID, credentials.accessKeyId());
+        assertEquals(EDC_AWS_SECRET_ACCESS_KEY, credentials.secretAccessKey());
+    }
+
+    @Test
+    void testCredentialsFromAwsSdk(EdcExtension edc) {
+        var credentials = s3.createCredentialsProvider(edc.getContext()).resolveCredentials();
+        assertEquals(AWS_ACCESS_KEY_ID, credentials.accessKeyId());
+        assertEquals(AWS_SECRET_ACCESS_KEY, credentials.secretAccessKey());
+    }
+
+    @Test
+    void testAwsClientProviderCaching(EdcExtension edc) {
+        var provider = s3.awsClientProvider(edc.getContext());
+        var client1 = provider.s3Client("us-east-1");
+        var client2 = provider.s3Client("us-west-1");
+        var client3 = provider.s3Client("us-west-1");
+        assertTrue(client1 != client2);
+        assertTrue(client2 == client3);
+
+        var asyncClient1 = provider.s3AsyncClient("us-east-1");
+        var asyncClient2 = provider.s3AsyncClient("us-west-1");
+        var asyncClient3 = provider.s3AsyncClient("us-west-1");
+        assertTrue(asyncClient1 != asyncClient2);
+        assertTrue(asyncClient2 == asyncClient3);
+    }
+}

--- a/extensions/common/aws/aws-s3-core/src/test/java/org/eclipse/edc/aws/s3/S3CoreExtensionTest.java
+++ b/extensions/common/aws/aws-s3-core/src/test/java/org/eclipse/edc/aws/s3/S3CoreExtensionTest.java
@@ -78,18 +78,4 @@ public class S3CoreExtensionTest {
         assertThat(credentials.accessKeyId()).isEqualTo(AWS_ACCESS_KEY_ID);
         assertThat(credentials.secretAccessKey()).isEqualTo(AWS_SECRET_ACCESS_KEY);
     }
-
-    @Test
-    void testAwsClientProviderCaching(EdcExtension edc) {
-        var provider = s3.awsClientProvider(edc.getContext());
-        var client1 = provider.s3Client("us-east-1");
-        var client2 = provider.s3Client("us-west-1");
-        var client3 = provider.s3Client("us-west-1");
-        assertThat(client3).isSameAs(client2).isNotSameAs(client1);
-
-        var asyncClient1 = provider.s3AsyncClient("us-east-1");
-        var asyncClient2 = provider.s3AsyncClient("us-west-1");
-        var asyncClient3 = provider.s3AsyncClient("us-west-1");
-        assertThat(client3).isSameAs(client2).isNotSameAs(client1);
-    }
 }

--- a/extensions/common/aws/aws-s3-core/src/test/java/org/eclipse/edc/aws/s3/S3CoreExtensionTest.java
+++ b/extensions/common/aws/aws-s3-core/src/test/java/org/eclipse/edc/aws/s3/S3CoreExtensionTest.java
@@ -26,8 +26,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.util.Map;
 import java.util.Properties;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(EdcExtension.class)
 public class S3CoreExtensionTest {
@@ -69,15 +68,15 @@ public class S3CoreExtensionTest {
 
         // EDC configurations have higher precedence than AWS SDK settings
         var credentials = s3.createCredentialsProvider(edc.getContext()).resolveCredentials();
-        assertEquals(EDC_AWS_ACCESS_KEY_ID, credentials.accessKeyId());
-        assertEquals(EDC_AWS_SECRET_ACCESS_KEY, credentials.secretAccessKey());
+        assertThat(credentials.accessKeyId()).isEqualTo(EDC_AWS_ACCESS_KEY_ID);
+        assertThat(credentials.secretAccessKey()).isEqualTo(EDC_AWS_SECRET_ACCESS_KEY);
     }
 
     @Test
     void testCredentialsFromAwsSdk(EdcExtension edc) {
         var credentials = s3.createCredentialsProvider(edc.getContext()).resolveCredentials();
-        assertEquals(AWS_ACCESS_KEY_ID, credentials.accessKeyId());
-        assertEquals(AWS_SECRET_ACCESS_KEY, credentials.secretAccessKey());
+        assertThat(credentials.accessKeyId()).isEqualTo(AWS_ACCESS_KEY_ID);
+        assertThat(credentials.secretAccessKey()).isEqualTo(AWS_SECRET_ACCESS_KEY);
     }
 
     @Test
@@ -86,13 +85,11 @@ public class S3CoreExtensionTest {
         var client1 = provider.s3Client("us-east-1");
         var client2 = provider.s3Client("us-west-1");
         var client3 = provider.s3Client("us-west-1");
-        assertTrue(client1 != client2);
-        assertTrue(client2 == client3);
+        assertThat(client3).isSameAs(client2).isNotSameAs(client1);
 
         var asyncClient1 = provider.s3AsyncClient("us-east-1");
         var asyncClient2 = provider.s3AsyncClient("us-west-1");
         var asyncClient3 = provider.s3AsyncClient("us-west-1");
-        assertTrue(asyncClient1 != asyncClient2);
-        assertTrue(asyncClient2 == asyncClient3);
+        assertThat(client3).isSameAs(client2).isNotSameAs(client1);
     }
 }

--- a/extensions/common/aws/aws-s3-core/src/test/java/org/eclipse/edc/aws/s3/S3CoreExtensionTest.java
+++ b/extensions/common/aws/aws-s3-core/src/test/java/org/eclipse/edc/aws/s3/S3CoreExtensionTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.services.s3.model.GetUrlRequest;
 
 import java.util.Map;
@@ -77,14 +78,14 @@ public class S3CoreExtensionTest {
 
     @Test
     void testCredentialsFromAwsSdk(EdcExtension edc) {
-        var credentials = s3.createCredentialsProvider(edc.getContext()).resolveCredentials();
-        assertThat(credentials.accessKeyId()).isEqualTo(AWS_ACCESS_KEY_ID);
-        assertThat(credentials.secretAccessKey()).isEqualTo(AWS_SECRET_ACCESS_KEY);
+        var provider = s3.createCredentialsProvider(edc.getContext());
+        assertThat(provider).isInstanceOf(DefaultCredentialsProvider.class);
     }
 
+    @Test
     void testEndpointOverride(EdcExtension edc) {
         var utilities = s3.awsClientProvider(edc.getContext()).s3Client("us-east-1").utilities();
         var request = GetUrlRequest.builder().bucket("test-bucket").key("test-key").build();
-        assertThat(utilities.getUrl(request).toString()).contains("hoge");
+        assertThat(utilities.getUrl(request).toString()).contains(EDC_AWS_ENDPOINT_OVERRIDE);
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

* add unit tests for S3CoreExtension.
* make configuration keys and internal method package private

## Why it does that

While integration tests for AWS S3 exist, there is no unit test for basic feature of S3CoreExtension.
Unit tests for the extension should be useful as a foundation for further improvement.

## Linked Issue(s)

Closes #2423

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [n/a] documented public classes/methods?
- [n/a] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
