### PR TITLE
chore: remove publications

### DIFF
--- a/core/common/boot/build.gradle.kts
+++ b/core/common/boot/build.gradle.kts
@@ -25,10 +25,4 @@ dependencies {
     testImplementation(libs.junit.jupiter.api)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/core/common/connector-core/build.gradle.kts
+++ b/core/common/connector-core/build.gradle.kts
@@ -37,10 +37,4 @@ dependencies {
     testImplementation(libs.mockserver.netty)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/core/common/junit/build.gradle.kts
+++ b/core/common/junit/build.gradle.kts
@@ -32,10 +32,4 @@ dependencies {
     implementation("org.junit-pioneer:junit-pioneer:1.9.1")
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/core/common/jwt-core/build.gradle.kts
+++ b/core/common/jwt-core/build.gradle.kts
@@ -23,10 +23,4 @@ dependencies {
     implementation(libs.nimbus.jwt)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/core/common/policy-engine/build.gradle.kts
+++ b/core/common/policy-engine/build.gradle.kts
@@ -23,10 +23,4 @@ dependencies {
     implementation(project(":core:common:policy-evaluator"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/core/common/policy-evaluator/build.gradle.kts
+++ b/core/common/policy-evaluator/build.gradle.kts
@@ -21,10 +21,4 @@ dependencies {
     api(project(":spi:common:policy-model"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/core/common/state-machine/build.gradle.kts
+++ b/core/common/state-machine/build.gradle.kts
@@ -24,10 +24,4 @@ dependencies {
 
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/core/common/util/build.gradle.kts
+++ b/core/common/util/build.gradle.kts
@@ -21,10 +21,4 @@ dependencies {
     testImplementation("org.junit-pioneer:junit-pioneer:1.9.1")
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/core/control-plane/contract-core/build.gradle.kts
+++ b/core/control-plane/contract-core/build.gradle.kts
@@ -29,10 +29,4 @@ dependencies {
     testImplementation(libs.awaitility)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/core/control-plane/control-plane-aggregate-services/build.gradle.kts
+++ b/core/control-plane/control-plane-aggregate-services/build.gradle.kts
@@ -25,10 +25,4 @@ dependencies {
     testImplementation(libs.awaitility)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/core/control-plane/control-plane-api-client/build.gradle.kts
+++ b/core/control-plane/control-plane-api-client/build.gradle.kts
@@ -31,10 +31,4 @@ dependencies {
 
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/core/control-plane/control-plane-api/build.gradle.kts
+++ b/core/control-plane/control-plane-api/build.gradle.kts
@@ -44,10 +44,4 @@ edcBuild {
 }
 
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/core/control-plane/control-plane-core/build.gradle.kts
+++ b/core/control-plane/control-plane-core/build.gradle.kts
@@ -34,10 +34,4 @@ dependencies {
     testImplementation(testFixtures(project(":spi:control-plane:transfer-spi")))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/core/control-plane/transfer-core/build.gradle.kts
+++ b/core/control-plane/transfer-core/build.gradle.kts
@@ -28,10 +28,4 @@ dependencies {
 }
 
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/core/data-plane-selector/data-plane-selector-core/build.gradle.kts
+++ b/core/data-plane-selector/data-plane-selector-core/build.gradle.kts
@@ -26,10 +26,4 @@ dependencies {
 
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/core/data-plane/data-plane-core/build.gradle.kts
+++ b/core/data-plane/data-plane-core/build.gradle.kts
@@ -24,10 +24,4 @@ dependencies {
     api(project(":core:data-plane:data-plane-framework"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/core/data-plane/data-plane-framework/build.gradle.kts
+++ b/core/data-plane/data-plane-framework/build.gradle.kts
@@ -32,10 +32,4 @@ dependencies {
 }
 
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/core/data-plane/data-plane-util/build.gradle.kts
+++ b/core/data-plane/data-plane-util/build.gradle.kts
@@ -24,10 +24,4 @@ dependencies {
     implementation(libs.opentelemetry.annotations)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/data-protocols/ids/build.gradle.kts
+++ b/data-protocols/ids/build.gradle.kts
@@ -27,10 +27,4 @@ dependencies {
     api(project(":data-protocols:ids:ids-api-configuration"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/data-protocols/ids/ids-api-configuration/build.gradle.kts
+++ b/data-protocols/ids/ids-api-configuration/build.gradle.kts
@@ -23,10 +23,4 @@ dependencies {
     testImplementation(project(":core:common:junit"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/build.gradle.kts
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/build.gradle.kts
@@ -32,10 +32,4 @@ dependencies {
     testImplementation(project(":core:common:junit"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/build.gradle.kts
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/build.gradle.kts
@@ -38,10 +38,4 @@ dependencies {
 
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/data-protocols/ids/ids-core/build.gradle.kts
+++ b/data-protocols/ids/ids-core/build.gradle.kts
@@ -28,10 +28,4 @@ dependencies {
     implementation(project(":data-protocols:ids:ids-jsonld-serdes"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/data-protocols/ids/ids-jsonld-serdes/build.gradle.kts
+++ b/data-protocols/ids/ids-jsonld-serdes/build.gradle.kts
@@ -21,10 +21,4 @@ dependencies {
     testImplementation(project(":data-protocols:ids:ids-core"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/data-protocols/ids/ids-spi/build.gradle.kts
+++ b/data-protocols/ids/ids-spi/build.gradle.kts
@@ -24,10 +24,4 @@ dependencies {
     implementation(libs.jakarta.rsApi)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/data-protocols/ids/ids-token-validation/build.gradle.kts
+++ b/data-protocols/ids/ids-token-validation/build.gradle.kts
@@ -26,10 +26,4 @@ dependencies {
     api(libs.fraunhofer.infomodel)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/data-protocols/ids/ids-transform-v1/build.gradle.kts
+++ b/data-protocols/ids/ids-transform-v1/build.gradle.kts
@@ -29,10 +29,4 @@ dependencies {
 
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/api/api-core/build.gradle.kts
+++ b/extensions/common/api/api-core/build.gradle.kts
@@ -33,10 +33,4 @@ dependencies {
     testImplementation(project(":core:common:junit"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/api/api-observability/build.gradle.kts
+++ b/extensions/common/api/api-observability/build.gradle.kts
@@ -34,10 +34,4 @@ edcBuild {
     }
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/api/control-api-configuration/build.gradle.kts
+++ b/extensions/common/api/control-api-configuration/build.gradle.kts
@@ -23,10 +23,4 @@ dependencies {
     testImplementation(project(":core:common:junit"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/api/management-api-configuration/build.gradle.kts
+++ b/extensions/common/api/management-api-configuration/build.gradle.kts
@@ -29,10 +29,4 @@ edcBuild {
     }
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/auth/auth-basic/build.gradle.kts
+++ b/extensions/common/auth/auth-basic/build.gradle.kts
@@ -23,10 +23,4 @@ dependencies {
     implementation(libs.jakarta.rsApi)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/auth/auth-tokenbased/build.gradle.kts
+++ b/extensions/common/auth/auth-tokenbased/build.gradle.kts
@@ -23,10 +23,4 @@ dependencies {
     testImplementation(project(":core:common:junit"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/aws/aws-s3-core/build.gradle.kts
+++ b/extensions/common/aws/aws-s3-core/build.gradle.kts
@@ -26,10 +26,4 @@ dependencies {
     api(libs.aws.sts)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/aws/aws-s3-test/build.gradle.kts
+++ b/extensions/common/aws/aws-s3-test/build.gradle.kts
@@ -29,10 +29,4 @@ dependencies {
     testFixturesApi(libs.aws.s3)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/azure/azure-blob-core/build.gradle.kts
+++ b/extensions/common/azure/azure-blob-core/build.gradle.kts
@@ -30,10 +30,4 @@ dependencies {
     testFixturesRuntimeOnly(libs.junit.jupiter.engine)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/azure/azure-cosmos-core/build.gradle.kts
+++ b/extensions/common/azure/azure-cosmos-core/build.gradle.kts
@@ -30,10 +30,4 @@ dependencies {
     testFixturesImplementation(libs.azure.cosmos)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/azure/azure-eventgrid/build.gradle.kts
+++ b/extensions/common/azure/azure-eventgrid/build.gradle.kts
@@ -23,10 +23,4 @@ dependencies {
     implementation(libs.azure.eventgrid)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/azure/azure-resource-manager/build.gradle.kts
+++ b/extensions/common/azure/azure-resource-manager/build.gradle.kts
@@ -28,10 +28,4 @@ dependencies {
     testImplementation(project(":core:common:junit"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/azure/azure-test/build.gradle.kts
+++ b/extensions/common/azure/azure-test/build.gradle.kts
@@ -28,10 +28,4 @@ dependencies {
     testFixturesApi(libs.junit.jupiter.api)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/configuration/configuration-filesystem/build.gradle.kts
+++ b/extensions/common/configuration/configuration-filesystem/build.gradle.kts
@@ -22,10 +22,4 @@ dependencies {
     implementation(project(":core:common:util"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/events/events-cloud-http/build.gradle.kts
+++ b/extensions/common/events/events-cloud-http/build.gradle.kts
@@ -29,10 +29,4 @@ dependencies {
     testImplementation(libs.awaitility)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/gcp/gcp-core/build.gradle.kts
+++ b/extensions/common/gcp/gcp-core/build.gradle.kts
@@ -25,10 +25,4 @@ dependencies {
     implementation(libs.googlecloud.iam.credentials)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/http/build.gradle.kts
+++ b/extensions/common/http/build.gradle.kts
@@ -22,10 +22,4 @@ dependencies {
     api(project(":extensions:common:http:jetty-core"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/http/jersey-core/build.gradle.kts
+++ b/extensions/common/http/jersey-core/build.gradle.kts
@@ -29,10 +29,4 @@ dependencies {
     testImplementation(libs.jersey.beanvalidation) //for validation
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/http/jersey-micrometer/build.gradle.kts
+++ b/extensions/common/http/jersey-micrometer/build.gradle.kts
@@ -21,10 +21,4 @@ dependencies {
     implementation(libs.micrometer)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/http/jetty-core/build.gradle.kts
+++ b/extensions/common/http/jetty-core/build.gradle.kts
@@ -29,10 +29,4 @@ dependencies {
     testImplementation(project(":core:common:junit"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/http/jetty-micrometer/build.gradle.kts
+++ b/extensions/common/http/jetty-micrometer/build.gradle.kts
@@ -25,10 +25,4 @@ dependencies {
 
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/iam/decentralized-identity/build.gradle.kts
+++ b/extensions/common/iam/decentralized-identity/build.gradle.kts
@@ -24,10 +24,4 @@ dependencies {
     api(project(":extensions:common:iam:decentralized-identity:identity-did-test"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/iam/decentralized-identity/identity-did-core/build.gradle.kts
+++ b/extensions/common/iam/decentralized-identity/identity-did-core/build.gradle.kts
@@ -13,10 +13,4 @@ dependencies {
     testImplementation(project(":core:common:junit"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/iam/decentralized-identity/identity-did-crypto/build.gradle.kts
+++ b/extensions/common/iam/decentralized-identity/identity-did-crypto/build.gradle.kts
@@ -10,10 +10,4 @@ dependencies {
     testImplementation(project(":core:common:junit"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/iam/decentralized-identity/identity-did-service/build.gradle.kts
+++ b/extensions/common/iam/decentralized-identity/identity-did-service/build.gradle.kts
@@ -11,10 +11,4 @@ dependencies {
     testImplementation(project(":core:common:junit"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/iam/decentralized-identity/identity-did-test/build.gradle.kts
+++ b/extensions/common/iam/decentralized-identity/identity-did-test/build.gradle.kts
@@ -10,10 +10,4 @@ dependencies {
 
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/iam/decentralized-identity/identity-did-web/build.gradle.kts
+++ b/extensions/common/iam/decentralized-identity/identity-did-web/build.gradle.kts
@@ -11,10 +11,4 @@ dependencies {
     testImplementation(project(":core:common:junit"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/iam/iam-mock/build.gradle.kts
+++ b/extensions/common/iam/iam-mock/build.gradle.kts
@@ -21,10 +21,4 @@ dependencies {
     implementation("com.auth0:java-jwt:4.2.2")
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/iam/oauth2/oauth2-client/build.gradle.kts
+++ b/extensions/common/iam/oauth2/oauth2-client/build.gradle.kts
@@ -26,10 +26,4 @@ dependencies {
     testImplementation(libs.mockserver.client)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/iam/oauth2/oauth2-core/build.gradle.kts
+++ b/extensions/common/iam/oauth2/oauth2-core/build.gradle.kts
@@ -30,10 +30,4 @@ dependencies {
     testImplementation(libs.mockserver.client)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/iam/oauth2/oauth2-daps/build.gradle.kts
+++ b/extensions/common/iam/oauth2/oauth2-daps/build.gradle.kts
@@ -25,10 +25,4 @@ dependencies {
     testImplementation(project(":core:common:junit"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/iam/oauth2/oauth2-service/build.gradle.kts
+++ b/extensions/common/iam/oauth2/oauth2-service/build.gradle.kts
@@ -21,10 +21,4 @@ dependencies {
     implementation(project(":extensions:common:iam:oauth2:oauth2-core"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/metrics/micrometer-core/build.gradle.kts
+++ b/extensions/common/metrics/micrometer-core/build.gradle.kts
@@ -41,10 +41,4 @@ tasks.withType<Test> {
     }
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/monitor/monitor-jdk-logger/build.gradle.kts
+++ b/extensions/common/monitor/monitor-jdk-logger/build.gradle.kts
@@ -21,10 +21,4 @@ dependencies {
     api(project(":spi:common:core-spi"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/sql/sql-core/build.gradle.kts
+++ b/extensions/common/sql/sql-core/build.gradle.kts
@@ -34,10 +34,4 @@ dependencies {
 
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/sql/sql-lease/build.gradle.kts
+++ b/extensions/common/sql/sql-lease/build.gradle.kts
@@ -32,10 +32,4 @@ dependencies {
     testImplementation(libs.assertj)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/sql/sql-pool/sql-pool-apache-commons/build.gradle.kts
+++ b/extensions/common/sql/sql-pool/sql-pool-apache-commons/build.gradle.kts
@@ -32,10 +32,4 @@ dependencies {
     testImplementation(libs.mockito.inline)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/transaction/transaction-atomikos/build.gradle.kts
+++ b/extensions/common/transaction/transaction-atomikos/build.gradle.kts
@@ -29,10 +29,4 @@ dependencies {
     testImplementation(libs.h2)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/transaction/transaction-local/build.gradle.kts
+++ b/extensions/common/transaction/transaction-local/build.gradle.kts
@@ -23,10 +23,4 @@ dependencies {
     implementation(project(":spi:common:transaction-datasource-spi"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/vault/vault-azure/build.gradle.kts
+++ b/extensions/common/vault/vault-azure/build.gradle.kts
@@ -32,10 +32,4 @@ dependencies {
     testImplementation(libs.mockito.inline)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/vault/vault-filesystem/build.gradle.kts
+++ b/extensions/common/vault/vault-filesystem/build.gradle.kts
@@ -26,10 +26,4 @@ dependencies {
     testImplementation(libs.bouncyCastle.bcprovJdk18on)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/common/vault/vault-hashicorp/build.gradle.kts
+++ b/extensions/common/vault/vault-hashicorp/build.gradle.kts
@@ -24,10 +24,4 @@ dependencies {
     testImplementation(project(":core:common:junit"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/control-plane/api/management-api/asset-api/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/asset-api/build.gradle.kts
@@ -38,10 +38,4 @@ edcBuild {
     }
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/control-plane/api/management-api/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/build.gradle.kts
@@ -28,10 +28,4 @@ dependencies {
     api(project(":extensions:control-plane:api:management-api:transfer-process-api"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/control-plane/api/management-api/catalog-api/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/catalog-api/build.gradle.kts
@@ -38,10 +38,4 @@ edcBuild {
     }
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/control-plane/api/management-api/contract-agreement-api/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/contract-agreement-api/build.gradle.kts
@@ -38,10 +38,4 @@ edcBuild {
     }
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/control-plane/api/management-api/contract-definition-api/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/contract-definition-api/build.gradle.kts
@@ -38,10 +38,4 @@ edcBuild {
     }
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/build.gradle.kts
@@ -38,10 +38,4 @@ edcBuild {
     }
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/control-plane/api/management-api/policy-definition-api/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/policy-definition-api/build.gradle.kts
@@ -44,10 +44,4 @@ edcBuild {
     }
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/control-plane/api/management-api/transfer-process-api/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/transfer-process-api/build.gradle.kts
@@ -40,10 +40,4 @@ edcBuild {
     }
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/control-plane/provision/provision-aws-s3/build.gradle.kts
+++ b/extensions/control-plane/provision/provision-aws-s3/build.gradle.kts
@@ -23,10 +23,4 @@ dependencies {
     testImplementation(testFixtures(project(":extensions:common:aws:aws-s3-test")))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/control-plane/provision/provision-blob/build.gradle.kts
+++ b/extensions/control-plane/provision/provision-blob/build.gradle.kts
@@ -26,10 +26,4 @@ dependencies {
     testImplementation(testFixtures(project(":extensions:common:azure:azure-test")))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/control-plane/provision/provision-gcs/build.gradle.kts
+++ b/extensions/control-plane/provision/provision-gcs/build.gradle.kts
@@ -27,10 +27,4 @@ dependencies {
     implementation(libs.googlecloud.iam.credentials)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/control-plane/provision/provision-http/build.gradle.kts
+++ b/extensions/control-plane/provision/provision-http/build.gradle.kts
@@ -42,10 +42,4 @@ edcBuild {
 }
 
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/control-plane/provision/provision-oauth2/provision-oauth2-core/build.gradle.kts
+++ b/extensions/control-plane/provision/provision-oauth2/provision-oauth2-core/build.gradle.kts
@@ -34,10 +34,4 @@ dependencies {
     testImplementation(libs.mockserver.netty)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/control-plane/provision/provision-oauth2/provision-oauth2/build.gradle.kts
+++ b/extensions/control-plane/provision/provision-oauth2/provision-oauth2/build.gradle.kts
@@ -21,10 +21,4 @@ dependencies {
     implementation(project(":extensions:control-plane:provision:provision-oauth2:provision-oauth2-core"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/control-plane/store/cosmos/asset-index-cosmos/build.gradle.kts
+++ b/extensions/control-plane/store/cosmos/asset-index-cosmos/build.gradle.kts
@@ -29,10 +29,4 @@ dependencies {
 
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/control-plane/store/cosmos/contract-definition-store-cosmos/build.gradle.kts
+++ b/extensions/control-plane/store/cosmos/contract-definition-store-cosmos/build.gradle.kts
@@ -28,10 +28,4 @@ dependencies {
     testImplementation(testFixtures(project(":extensions:common:azure:azure-test")))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/control-plane/store/cosmos/contract-negotiation-store-cosmos/build.gradle.kts
+++ b/extensions/control-plane/store/cosmos/contract-negotiation-store-cosmos/build.gradle.kts
@@ -32,10 +32,4 @@ dependencies {
 
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/control-plane/store/cosmos/control-plane-cosmos/build.gradle.kts
+++ b/extensions/control-plane/store/cosmos/control-plane-cosmos/build.gradle.kts
@@ -26,10 +26,4 @@ dependencies {
     api(project(":extensions:control-plane:store:cosmos:transfer-process-store-cosmos"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/control-plane/store/cosmos/policy-definition-store-cosmos/build.gradle.kts
+++ b/extensions/control-plane/store/cosmos/policy-definition-store-cosmos/build.gradle.kts
@@ -31,10 +31,4 @@ dependencies {
 
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/control-plane/store/cosmos/transfer-process-store-cosmos/build.gradle.kts
+++ b/extensions/control-plane/store/cosmos/transfer-process-store-cosmos/build.gradle.kts
@@ -31,10 +31,4 @@ dependencies {
     testImplementation(testFixtures(project(":spi:control-plane:transfer-spi")))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/control-plane/store/sql/asset-index-sql/build.gradle.kts
+++ b/extensions/control-plane/store/sql/asset-index-sql/build.gradle.kts
@@ -33,10 +33,4 @@ dependencies {
 
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/control-plane/store/sql/contract-definition-store-sql/build.gradle.kts
+++ b/extensions/control-plane/store/sql/contract-definition-store-sql/build.gradle.kts
@@ -32,10 +32,4 @@ dependencies {
     testImplementation(libs.postgres)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/build.gradle.kts
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/build.gradle.kts
@@ -34,10 +34,4 @@ dependencies {
     testImplementation(libs.postgres)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/control-plane/store/sql/control-plane-sql/build.gradle.kts
+++ b/extensions/control-plane/store/sql/control-plane-sql/build.gradle.kts
@@ -27,10 +27,4 @@ dependencies {
     implementation(project(":extensions:control-plane:store:sql:transfer-process-store-sql"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/control-plane/store/sql/policy-definition-store-sql/build.gradle.kts
+++ b/extensions/control-plane/store/sql/policy-definition-store-sql/build.gradle.kts
@@ -31,10 +31,4 @@ dependencies {
     testImplementation(testFixtures(project(":extensions:common:sql:sql-core")))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/build.gradle.kts
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/build.gradle.kts
@@ -36,10 +36,4 @@ dependencies {
 
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/control-plane/transfer/transfer-data-plane/build.gradle.kts
+++ b/extensions/control-plane/transfer/transfer-data-plane/build.gradle.kts
@@ -48,10 +48,4 @@ edcBuild {
 }
 
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/control-plane/transfer/transfer-pull-http-dynamic-receiver/build.gradle.kts
+++ b/extensions/control-plane/transfer/transfer-pull-http-dynamic-receiver/build.gradle.kts
@@ -33,10 +33,4 @@ dependencies {
 }
 
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/control-plane/transfer/transfer-pull-http-receiver/build.gradle.kts
+++ b/extensions/control-plane/transfer/transfer-pull-http-receiver/build.gradle.kts
@@ -27,10 +27,4 @@ dependencies {
     testImplementation(project(":core:common:junit"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/data-plane-selector/data-plane-selector-api/build.gradle.kts
+++ b/extensions/data-plane-selector/data-plane-selector-api/build.gradle.kts
@@ -37,10 +37,4 @@ edcBuild {
 }
 
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/data-plane-selector/data-plane-selector-client/build.gradle.kts
+++ b/extensions/data-plane-selector/data-plane-selector-client/build.gradle.kts
@@ -27,10 +27,4 @@ dependencies {
     testImplementation(project(":core:common:junit"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/data-plane-selector/store/cosmos/data-plane-instance-store-cosmos/build.gradle.kts
+++ b/extensions/data-plane-selector/store/cosmos/data-plane-instance-store-cosmos/build.gradle.kts
@@ -14,10 +14,4 @@ dependencies {
     testImplementation(testFixtures(project(":extensions:common:azure:azure-test")))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/build.gradle.kts
+++ b/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/build.gradle.kts
@@ -18,10 +18,4 @@ dependencies {
 
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/data-plane/data-plane-api/build.gradle.kts
+++ b/extensions/data-plane/data-plane-api/build.gradle.kts
@@ -41,10 +41,4 @@ edcBuild {
     }
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/data-plane/data-plane-aws-s3/build.gradle.kts
+++ b/extensions/data-plane/data-plane-aws-s3/build.gradle.kts
@@ -30,10 +30,4 @@ dependencies {
     testImplementation(project(":core:common:junit"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/data-plane/data-plane-azure-data-factory/build.gradle.kts
+++ b/extensions/data-plane/data-plane-azure-data-factory/build.gradle.kts
@@ -38,10 +38,4 @@ dependencies {
     testImplementation(libs.bouncyCastle.bcprovJdk18on)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/data-plane/data-plane-azure-storage/build.gradle.kts
+++ b/extensions/data-plane/data-plane-azure-storage/build.gradle.kts
@@ -29,10 +29,4 @@ dependencies {
     testImplementation(testFixtures(project(":extensions:common:azure:azure-blob-core")))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/data-plane/data-plane-client/build.gradle.kts
+++ b/extensions/data-plane/data-plane-client/build.gradle.kts
@@ -32,10 +32,4 @@ dependencies {
     testImplementation(libs.mockserver.client)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/data-plane/data-plane-google-storage/build.gradle.kts
+++ b/extensions/data-plane/data-plane-google-storage/build.gradle.kts
@@ -28,10 +28,4 @@ dependencies {
     testImplementation(project(":core:common:junit"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/data-plane/data-plane-http/build.gradle.kts
+++ b/extensions/data-plane/data-plane-http/build.gradle.kts
@@ -27,10 +27,4 @@ dependencies {
     testImplementation(libs.mockserver.netty)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/data-plane/store/cosmos/data-plane-store-cosmos/build.gradle.kts
+++ b/extensions/data-plane/store/cosmos/data-plane-store-cosmos/build.gradle.kts
@@ -16,10 +16,4 @@ dependencies {
 
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/extensions/data-plane/store/sql/data-plane-store-sql/build.gradle.kts
+++ b/extensions/data-plane/store/sql/data-plane-store-sql/build.gradle.kts
@@ -16,10 +16,4 @@ dependencies {
 
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/launchers/data-plane-server/build.gradle.kts
+++ b/launchers/data-plane-server/build.gradle.kts
@@ -40,4 +40,6 @@ tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     archiveFileName.set("data-plane-server.jar")
 }
 
-
+edcBuild {
+    publish.set(false)
+}

--- a/launchers/data-plane-server/build.gradle.kts
+++ b/launchers/data-plane-server/build.gradle.kts
@@ -40,10 +40,4 @@ tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     archiveFileName.set("data-plane-server.jar")
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/launchers/dpf-selector/build.gradle.kts
+++ b/launchers/dpf-selector/build.gradle.kts
@@ -34,3 +34,7 @@ tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     mergeServiceFiles()
     archiveFileName.set("data-plane-selector.jar")
 }
+
+edcBuild {
+    publish.set(false)
+}

--- a/launchers/ids-connector/build.gradle.kts
+++ b/launchers/ids-connector/build.gradle.kts
@@ -45,3 +45,7 @@ tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     mergeServiceFiles()
     archiveFileName.set("dataspace-connector.jar")
 }
+
+edcBuild {
+    publish.set(false)
+}

--- a/spi/common/aggregate-service-spi/build.gradle.kts
+++ b/spi/common/aggregate-service-spi/build.gradle.kts
@@ -21,10 +21,4 @@ dependencies {
     api(project(":spi:common:core-spi"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/spi/common/auth-spi/build.gradle.kts
+++ b/spi/common/auth-spi/build.gradle.kts
@@ -22,10 +22,4 @@ dependencies {
     implementation(libs.jakarta.rsApi)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/spi/common/catalog-spi/build.gradle.kts
+++ b/spi/common/catalog-spi/build.gradle.kts
@@ -22,10 +22,4 @@ dependencies {
     api(project(":spi:control-plane:contract-spi"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/spi/common/core-spi/build.gradle.kts
+++ b/spi/common/core-spi/build.gradle.kts
@@ -33,10 +33,4 @@ dependencies {
     testFixturesImplementation(libs.assertj)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/spi/common/http-spi/build.gradle.kts
+++ b/spi/common/http-spi/build.gradle.kts
@@ -24,10 +24,4 @@ dependencies {
     api(libs.failsafe.okhttp)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/spi/common/identity-did-spi/build.gradle.kts
+++ b/spi/common/identity-did-spi/build.gradle.kts
@@ -8,10 +8,4 @@ dependencies {
     api(libs.nimbus.jwt)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/spi/common/jwt-spi/build.gradle.kts
+++ b/spi/common/jwt-spi/build.gradle.kts
@@ -21,10 +21,4 @@ dependencies {
     api(project(":spi:common:core-spi"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/spi/common/oauth2-spi/build.gradle.kts
+++ b/spi/common/oauth2-spi/build.gradle.kts
@@ -20,10 +20,4 @@ dependencies {
     api(project(":spi:common:jwt-spi"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/spi/common/policy-engine-spi/build.gradle.kts
+++ b/spi/common/policy-engine-spi/build.gradle.kts
@@ -22,10 +22,4 @@ dependencies {
     api(project(":spi:common:policy-model"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/spi/common/policy-model/build.gradle.kts
+++ b/spi/common/policy-model/build.gradle.kts
@@ -17,10 +17,4 @@ plugins {
     `java-library`
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/spi/common/transaction-datasource-spi/build.gradle.kts
+++ b/spi/common/transaction-datasource-spi/build.gradle.kts
@@ -20,10 +20,4 @@ dependencies {
     api(project(":spi:common:core-spi"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/spi/common/transaction-spi/build.gradle.kts
+++ b/spi/common/transaction-spi/build.gradle.kts
@@ -16,10 +16,4 @@ plugins {
     `java-library`
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/spi/common/transform-spi/build.gradle.kts
+++ b/spi/common/transform-spi/build.gradle.kts
@@ -22,10 +22,4 @@ dependencies {
     api(project(":spi:common:core-spi"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/spi/common/web-spi/build.gradle.kts
+++ b/spi/common/web-spi/build.gradle.kts
@@ -22,10 +22,4 @@ dependencies {
     api(project(":spi:common:aggregate-service-spi"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/spi/control-plane/contract-spi/build.gradle.kts
+++ b/spi/control-plane/contract-spi/build.gradle.kts
@@ -30,10 +30,4 @@ dependencies {
     testFixturesRuntimeOnly(libs.junit.jupiter.engine)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/spi/control-plane/control-plane-api-client-spi/build.gradle.kts
+++ b/spi/control-plane/control-plane-api-client-spi/build.gradle.kts
@@ -21,10 +21,4 @@ dependencies {
     api(project(":spi:common:core-spi"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/spi/control-plane/control-plane-spi/build.gradle.kts
+++ b/spi/control-plane/control-plane-spi/build.gradle.kts
@@ -29,10 +29,4 @@ dependencies {
     api(project(":spi:control-plane:transfer-spi"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/spi/control-plane/policy-spi/build.gradle.kts
+++ b/spi/control-plane/policy-spi/build.gradle.kts
@@ -25,10 +25,4 @@ dependencies {
     testFixturesImplementation(libs.assertj)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/spi/control-plane/transfer-data-plane-spi/build.gradle.kts
+++ b/spi/control-plane/transfer-data-plane-spi/build.gradle.kts
@@ -21,10 +21,4 @@ dependencies {
     api(project(":spi:common:core-spi"))
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/spi/control-plane/transfer-spi/build.gradle.kts
+++ b/spi/control-plane/transfer-spi/build.gradle.kts
@@ -29,10 +29,4 @@ dependencies {
     testFixturesImplementation(libs.awaitility)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/spi/data-plane-selector/data-plane-selector-spi/build.gradle.kts
+++ b/spi/data-plane-selector/data-plane-selector-spi/build.gradle.kts
@@ -30,10 +30,4 @@ dependencies {
 }
 
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/spi/data-plane/data-plane-spi/build.gradle.kts
+++ b/spi/data-plane/data-plane-spi/build.gradle.kts
@@ -24,10 +24,4 @@ dependencies {
     testFixturesImplementation(libs.assertj)
 }
 
-publishing {
-    publications {
-        create<MavenPublication>(project.name) {
-            from(components["java"])
-        }
-    }
-}
+

--- a/system-tests/azure-data-factory-tests/build.gradle.kts
+++ b/system-tests/azure-data-factory-tests/build.gradle.kts
@@ -44,3 +44,7 @@ dependencies {
     testRuntimeOnly(project(":system-tests:runtimes:azure-data-factory-transfer-provider"))
     testRuntimeOnly(project(":system-tests:runtimes:azure-data-factory-transfer-consumer"))
 }
+
+edcBuild {
+    publish.set(false)
+}

--- a/system-tests/azure-tests/build.gradle.kts
+++ b/system-tests/azure-tests/build.gradle.kts
@@ -46,3 +46,7 @@ dependencies {
     testCompileOnly(project(":system-tests:runtimes:azure-storage-transfer-provider"))
     testCompileOnly(project(":system-tests:runtimes:azure-storage-transfer-consumer"))
 }
+
+edcBuild {
+    publish.set(false)
+}

--- a/system-tests/e2e-transfer-test/backend-service/build.gradle.kts
+++ b/system-tests/e2e-transfer-test/backend-service/build.gradle.kts
@@ -24,3 +24,7 @@ dependencies {
     implementation(libs.nimbus.jwt)
     implementation(libs.jakarta.rsApi)
 }
+
+edcBuild {
+    publish.set(false)
+}

--- a/system-tests/e2e-transfer-test/control-plane-cosmosdb/build.gradle.kts
+++ b/system-tests/e2e-transfer-test/control-plane-cosmosdb/build.gradle.kts
@@ -21,3 +21,7 @@ dependencies {
     implementation(project(":extensions:control-plane:store:cosmos:control-plane-cosmos"))
     implementation(testFixtures(project(":extensions:common:azure:azure-test")))
 }
+
+edcBuild {
+    publish.set(false)
+}

--- a/system-tests/e2e-transfer-test/control-plane-postgresql/build.gradle.kts
+++ b/system-tests/e2e-transfer-test/control-plane-postgresql/build.gradle.kts
@@ -23,3 +23,7 @@ dependencies {
     implementation(project(":extensions:common:transaction:transaction-local"))
     implementation(libs.postgres)
 }
+
+edcBuild {
+    publish.set(false)
+}

--- a/system-tests/e2e-transfer-test/control-plane/build.gradle.kts
+++ b/system-tests/e2e-transfer-test/control-plane/build.gradle.kts
@@ -35,3 +35,7 @@ dependencies {
     implementation(project(":extensions:control-plane:provision:provision-oauth2:provision-oauth2"))
     implementation(project(":extensions:control-plane:transfer:transfer-pull-http-receiver"))
 }
+
+edcBuild {
+    publish.set(false)
+}

--- a/system-tests/e2e-transfer-test/data-plane/build.gradle.kts
+++ b/system-tests/e2e-transfer-test/data-plane/build.gradle.kts
@@ -22,3 +22,7 @@ dependencies {
     implementation(project(":extensions:data-plane:data-plane-api"))
     implementation(project(":extensions:common:vault:vault-filesystem"))
 }
+
+edcBuild {
+    publish.set(false)
+}

--- a/system-tests/e2e-transfer-test/runner/build.gradle.kts
+++ b/system-tests/e2e-transfer-test/runner/build.gradle.kts
@@ -38,3 +38,7 @@ dependencies {
     testCompileOnly(project(":system-tests:e2e-transfer-test:control-plane-postgresql"))
     testCompileOnly(project(":system-tests:e2e-transfer-test:data-plane"))
 }
+
+edcBuild {
+    publish.set(false)
+}

--- a/system-tests/runtimes/azure-data-factory-transfer-consumer/build.gradle.kts
+++ b/system-tests/runtimes/azure-data-factory-transfer-consumer/build.gradle.kts
@@ -45,3 +45,7 @@ tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     mergeServiceFiles()
     archiveFileName.set("consumer.jar")
 }
+
+edcBuild {
+    publish.set(false)
+}

--- a/system-tests/runtimes/azure-data-factory-transfer-provider/build.gradle.kts
+++ b/system-tests/runtimes/azure-data-factory-transfer-provider/build.gradle.kts
@@ -55,3 +55,7 @@ tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     mergeServiceFiles()
     archiveFileName.set("provider.jar")
 }
+
+edcBuild {
+    publish.set(false)
+}

--- a/system-tests/runtimes/azure-storage-transfer-consumer/build.gradle.kts
+++ b/system-tests/runtimes/azure-storage-transfer-consumer/build.gradle.kts
@@ -46,3 +46,7 @@ tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     mergeServiceFiles()
     archiveFileName.set("consumer.jar")
 }
+
+edcBuild {
+    publish.set(false)
+}

--- a/system-tests/runtimes/azure-storage-transfer-provider/build.gradle.kts
+++ b/system-tests/runtimes/azure-storage-transfer-provider/build.gradle.kts
@@ -52,3 +52,7 @@ tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     mergeServiceFiles()
     archiveFileName.set("provider.jar")
 }
+
+edcBuild {
+    publish.set(false)
+}

--- a/system-tests/runtimes/file-transfer-consumer/build.gradle.kts
+++ b/system-tests/runtimes/file-transfer-consumer/build.gradle.kts
@@ -41,3 +41,7 @@ tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     mergeServiceFiles()
     archiveFileName.set("consumer.jar")
 }
+
+edcBuild {
+    publish.set(false)
+}

--- a/system-tests/runtimes/file-transfer-provider/build.gradle.kts
+++ b/system-tests/runtimes/file-transfer-provider/build.gradle.kts
@@ -50,3 +50,7 @@ tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     mergeServiceFiles()
     archiveFileName.set("provider.jar")
 }
+
+edcBuild {
+    publish.set(false)
+}

--- a/system-tests/tests/build.gradle.kts
+++ b/system-tests/tests/build.gradle.kts
@@ -57,3 +57,7 @@ tasks.getByName<Test>("test") {
         showStandardStreams = true
     }
 }
+
+edcBuild {
+    publish.set(false)
+}


### PR DESCRIPTION
## What this PR changes/adds

Removes the Maven publications from the build files and sets the `publish` flag to false for modules that should not be published (launchers, system tests).

## Why it does that
Once [this PR](https://github.com/eclipse-edc/GradlePlugins/pull/67) is merged, Maven publications will be added automatically by the Plugin.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
