### PR TITLE
build: stops dependabot opening update PR on `edc-versions`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,5 @@ updates:
     labels:
       - "dependencies"
       - "java"
+    ignore:
+      - dependency-name: "edc-versions"


### PR DESCRIPTION
## What this PR changes/adds

Stops dependabot from opening PR to update `edc-versions`

## Why it does that

the main branch sticks on `0.0.1-SNAPSHOT` version

## Linked Issue(s)

Closes #2343 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
