### PR TITLE
build: fix dependabot edc-versions ignore entry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,4 +20,4 @@ updates:
       - "dependencies"
       - "java"
     ignore:
-      - dependency-name: "edc-versions"
+      - dependency-name: "org.eclipse.edc:edc-versions"


### PR DESCRIPTION
## What this PR changes/adds

Add the full dependency reference.

## Why it does that

The current definition does not work

## Further notes

## Linked Issue(s)

Closes #2343 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
