### PR TITLE
feat(sql): store `ClaimToken` in `DataRequest`

### DIFF
--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/handler/ArtifactRequestHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/handler/ArtifactRequestHandler.java
@@ -73,7 +73,6 @@ public class ArtifactRequestHandler implements Handler {
 
     @Override
     public @NotNull MultipartResponse handleRequest(@NotNull MultipartRequest multipartRequest) {
-        var claimToken = multipartRequest.getClaimToken();
         var message = (ArtifactRequestMessage) multipartRequest.getHeader();
 
         // Validate request artifact ID
@@ -146,6 +145,8 @@ public class ArtifactRequestHandler implements Handler {
         // NB: DO NOT use the asset id provided by the client as that can open aan attack vector where a client references an artifact that
         //     is different from the one specified by the contract
 
+        var claimToken = multipartRequest.getClaimToken();
+
         var dataRequest = DataRequest.Builder.newInstance()
                 .id(message.getId().toString())
                 .protocol(MessageProtocol.IDS_MULTIPART)
@@ -155,6 +156,7 @@ public class ArtifactRequestHandler implements Handler {
                 .contractId(contractAgreement.getId())
                 .properties(props)
                 .connectorAddress(idsWebhookAddress)
+                .claimToken(claimToken)
                 .build();
 
         // Initiate a transfer process for the request

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/docs/schema.sql
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/docs/schema.sql
@@ -67,6 +67,7 @@ CREATE TABLE IF NOT EXISTS edc_data_request
     managed_resources   BOOLEAN DEFAULT TRUE,
     properties          JSON,
     transfer_type       JSON,
+    claim_token         JSON,
     transfer_process_id VARCHAR NOT NULL
         CONSTRAINT data_request_transfer_process_id_fk
             REFERENCES edc_transfer_process

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/BaseSqlDialectStatements.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/BaseSqlDialectStatements.java
@@ -90,18 +90,19 @@ public abstract class BaseSqlDialectStatements implements TransferProcessStoreSt
                 getTransferProcessTableName(), getStateColumn(), getStateCountColumn(), getStateTimestampColumn(),
                 getTraceContextColumn(), getFormatAsJsonOperator(), getErrorDetailColumn(),
                 getResourceManifestColumn(), getFormatAsJsonOperator(), getProvisionedResourcesetColumn(), getFormatAsJsonOperator(),
-                getContentDataAddressColumn(), getFormatAsJsonOperator(), getDeprovisionedResourcesColumn(), getFormatAsJsonOperator(), getUpdatedAtColumn(), getIdColumn());
+                getContentDataAddressColumn(), getFormatAsJsonOperator(), getDeprovisionedResourcesColumn(), getFormatAsJsonOperator(),
+                getUpdatedAtColumn(), getIdColumn());
     }
 
     @Override
     public String getInsertDataRequestTemplate() {
-        return format("INSERT INTO %s (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)" +
-                        "VALUES (?, ?, ?, ?, ?, ?, ?%s, ?%s, ?%s, ?, ?, ?);",
+        return format("INSERT INTO %s (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)" +
+                        "VALUES (?, ?, ?, ?, ?, ?, ?%s, ?%s, ?%s, ?, ?, ?, ?%s);",
                 getDataRequestTable(), getDataRequestIdColumn(), getProcessIdColumn(), getConnectorAddressColumn(), getConnectorIdColumn(),
-                getAssetIdColumn(), getContractIdColumn(), getDataDestinationColumn(),
-                getDataRequestPropertiesColumn(),
+                getAssetIdColumn(), getContractIdColumn(), getDataDestinationColumn(), getDataRequestPropertiesColumn(),
                 getTransferTypeColumn(), getTransferProcessIdFkColumn(), getProtocolColumn(), getManagedResourcesColumn(),
-                getFormatAsJsonOperator(), getFormatAsJsonOperator(), getFormatAsJsonOperator());
+                getClaimTokenColumn(),
+                getFormatAsJsonOperator(), getFormatAsJsonOperator(), getFormatAsJsonOperator(), getFormatAsJsonOperator());
     }
 
     @Override
@@ -112,10 +113,13 @@ public abstract class BaseSqlDialectStatements implements TransferProcessStoreSt
 
     @Override
     public String getUpdateDataRequestTemplate() {
-        return format("UPDATE %s SET %s=?, %s=?, %s=?, %s=?, %s=?, %s=?, %s=?, %s=?%s, %s=?, %s=?%s, %s=?%s WHERE %s=?",
+        return format("UPDATE %s SET %s=?, %s=?, %s=?, %s=?, %s=?, %s=?, %s=?, %s=?%s, %s=?, %s=?%s, %s=?%s, %s=?%s WHERE %s=?",
                 getDataRequestTable(),
-                getDataRequestIdColumn(), getProcessIdColumn(), getConnectorAddressColumn(), getProtocolColumn(), getConnectorIdColumn(), getAssetIdColumn(), getContractIdColumn(),
-                getDataDestinationColumn(), getFormatAsJsonOperator(), getManagedResourcesColumn(), getDataRequestPropertiesColumn(), getFormatAsJsonOperator(), getTransferTypeColumn(), getFormatAsJsonOperator(),
+                getDataRequestIdColumn(), getProcessIdColumn(), getConnectorAddressColumn(), getProtocolColumn(),
+                getConnectorIdColumn(), getAssetIdColumn(), getContractIdColumn(), getDataDestinationColumn(),
+                getFormatAsJsonOperator(), getManagedResourcesColumn(), getDataRequestPropertiesColumn(),
+                getFormatAsJsonOperator(), getTransferTypeColumn(), getFormatAsJsonOperator(),
+                getClaimTokenColumn(), getFormatAsJsonOperator(),
                 getDataRequestIdColumn());
     }
 

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/TransferProcessStoreStatements.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/TransferProcessStoreStatements.java
@@ -154,6 +154,10 @@ public interface TransferProcessStoreStatements extends LeaseStatements {
         return "deprovisioned_resources";
     }
 
+    default String getClaimTokenColumn() {
+        return "claim_token";
+    }
+
     default String getFormatAsJsonOperator() {
         return BaseSqlDialect.getJsonCastOperator();
     }

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/transferprocess/PostgresTransferProcessStoreTest.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/transferprocess/PostgresTransferProcessStoreTest.java
@@ -36,7 +36,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.sql.SQLException;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.List;
@@ -59,8 +58,7 @@ class PostgresTransferProcessStoreTest extends TransferProcessStoreTestBase {
     private SqlTransferProcessStore store;
 
     @BeforeEach
-    void setUp(PostgresqlStoreSetupExtension extension) throws IOException, SQLException {
-
+    void setUp(PostgresqlStoreSetupExtension extension) throws IOException {
         var typeManager = new TypeManager();
         typeManager.registerTypes(TestFunctions.TestResourceDef.class, TestFunctions.TestProvisionedResource.class);
         typeManager.registerTypes(PolicyRegistrationTypes.TYPES.toArray(Class<?>[]::new));
@@ -73,7 +71,7 @@ class PostgresTransferProcessStoreTest extends TransferProcessStoreTestBase {
     }
 
     @AfterEach
-    void tearDown(PostgresqlStoreSetupExtension extension) throws SQLException {
+    void tearDown(PostgresqlStoreSetupExtension extension) {
         extension.runQuery("DROP TABLE " + statements.getTransferProcessTableName() + " CASCADE");
         extension.runQuery("DROP TABLE " + statements.getDataRequestTable() + " CASCADE");
         extension.runQuery("DROP TABLE " + statements.getLeaseTableName() + " CASCADE");
@@ -95,7 +93,6 @@ class PostgresTransferProcessStoreTest extends TransferProcessStoreTestBase {
         assertThatThrownBy(() -> store.findAll(query)).isInstanceOf(IllegalArgumentException.class)
                 .hasMessageStartingWith("Translation failed");
     }
-
 
     @Test
     void find_queryByResourceManifest_propNotExist() {
@@ -122,7 +119,6 @@ class PostgresTransferProcessStoreTest extends TransferProcessStoreTestBase {
 
         assertThat(store.findAll(query2)).isEmpty();
     }
-
 
     @Test
     void find_queryByProvisionedResourceSet_propNotExist() {
@@ -155,7 +151,6 @@ class PostgresTransferProcessStoreTest extends TransferProcessStoreTestBase {
         assertThat(store.findAll(query2)).isEmpty();
     }
 
-
     @Test
     void find_queryByLease() {
         store.save(createTransferProcess("testprocess1"));
@@ -166,7 +161,6 @@ class PostgresTransferProcessStoreTest extends TransferProcessStoreTestBase {
 
         assertThatThrownBy(() -> store.findAll(query)).isInstanceOf(IllegalArgumentException.class)
                 .hasMessageStartingWith("Translation failed for Model");
-
     }
 
     @Test

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/QuerySpec.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/QuerySpec.java
@@ -174,6 +174,11 @@ public class QuerySpec {
             return this;
         }
 
+        public Builder filter(Criterion criterion) {
+            querySpec.filterExpression.add(criterion);
+            return this;
+        }
+
         @Deprecated
         public Builder filter(String filterExpression) {
 

--- a/spi/common/core-spi/src/test/java/org/eclipse/edc/spi/iam/ClaimTokenTest.java
+++ b/spi/common/core-spi/src/test/java/org/eclipse/edc/spi/iam/ClaimTokenTest.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.spi.iam;
+
+import org.eclipse.edc.spi.types.TypeManager;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ClaimTokenTest {
+
+    @Test
+    void serdes() {
+        var typeManager = new TypeManager();
+        var claimToken = ClaimToken.Builder.newInstance().claim("claimKey", "claimValue").build();
+
+        var json = typeManager.writeValueAsString(claimToken);
+        var deserialized = typeManager.readValue(json, ClaimToken.class);
+
+        assertThat(deserialized).usingRecursiveComparison().isEqualTo(claimToken);
+    }
+}

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/DataRequest.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/DataRequest.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.spi.iam.ClaimToken;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.Polymorphic;
 import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
@@ -39,10 +40,10 @@ public class DataRequest implements RemoteMessage, Polymorphic {
     private String assetId;
     private String contractId;
     private DataAddress dataDestination;
-
     private boolean managedResources = true;
     private Map<String, String> properties = new HashMap<>();
     private TransferType transferType;
+    private ClaimToken claimToken;
 
     private DataRequest() {
         transferType = new TransferType();
@@ -139,6 +140,10 @@ public class DataRequest implements RemoteMessage, Polymorphic {
         return transferType;
     }
 
+    public ClaimToken getClaimToken() {
+        return claimToken;
+    }
+
     @JsonPOJOBuilder(withPrefix = "")
     public static class Builder {
         private final DataRequest request;
@@ -212,21 +217,21 @@ public class DataRequest implements RemoteMessage, Polymorphic {
             return this;
         }
 
-        public DataRequest build() {
-            if (request.dataDestination == null && request.getDestinationType() == null) {
-                throw new IllegalArgumentException("A data destination or type must be specified");
-            }
-            return request;
-        }
-
         public Builder transferType(TransferType transferType) {
             request.transferType = transferType;
             return this;
         }
 
-        private Builder dataAddress(DataAddress dataAddress) {
-            request.dataDestination = dataAddress;
+        public Builder claimToken(ClaimToken claimToken) {
+            request.claimToken = claimToken;
             return this;
+        }
+
+        public DataRequest build() {
+            if (request.dataDestination == null && request.getDestinationType() == null) {
+                throw new IllegalArgumentException("A data destination or type must be specified");
+            }
+            return request;
         }
 
     }

--- a/spi/control-plane/transfer-spi/src/testFixtures/java/org/eclipse/edc/connector/transfer/spi/testfixtures/store/TestFunctions.java
+++ b/spi/control-plane/transfer-spi/src/testFixtures/java/org/eclipse/edc/connector/transfer/spi/testfixtures/store/TestFunctions.java
@@ -24,6 +24,7 @@ import org.eclipse.edc.connector.transfer.spi.types.ResourceDefinition;
 import org.eclipse.edc.connector.transfer.spi.types.ResourceManifest;
 import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.connector.transfer.spi.types.TransferProcessStates;
+import org.eclipse.edc.spi.iam.ClaimToken;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.jetbrains.annotations.NotNull;
@@ -54,6 +55,7 @@ public class TestFunctions {
                 .contractId("some-contract")
                 .managedResources(false)
                 .assetId(Asset.Builder.newInstance().id("asset-id").build().getId())
+                .claimToken(ClaimToken.Builder.newInstance().claim("claim", "value").build())
                 .processId("test-process-id");
     }
 

--- a/spi/control-plane/transfer-spi/src/testFixtures/java/org/eclipse/edc/connector/transfer/spi/testfixtures/store/TransferProcessStoreTestBase.java
+++ b/spi/control-plane/transfer-spi/src/testFixtures/java/org/eclipse/edc/connector/transfer/spi/testfixtures/store/TransferProcessStoreTestBase.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.connector.transfer.spi.testfixtures.store;
 
-import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
 import org.eclipse.edc.connector.transfer.spi.store.TransferProcessStore;
 import org.eclipse.edc.connector.transfer.spi.types.DeprovisionedResource;
@@ -61,7 +60,6 @@ public abstract class TransferProcessStoreTestBase {
         System.setProperty("transferprocessstore.supports.operator.in", String.valueOf(supportsInOperator()));
         System.setProperty("transferprocessstore.supports.collectionQuery", String.valueOf(supportsCollectionQuery()));
         System.setProperty("transferprocessstore.supports.sortorder", String.valueOf(supportsSortOrder()));
-
     }
 
     @Test
@@ -70,9 +68,9 @@ public abstract class TransferProcessStoreTestBase {
         getTransferProcessStore().save(t);
 
         var all = getTransferProcessStore().findAll(QuerySpec.none()).collect(Collectors.toList());
-        Assertions.assertThat(all).containsExactly(t);
-        Assertions.assertThat(all.get(0)).usingRecursiveComparison().isEqualTo(t);
-        Assertions.assertThat(all).allSatisfy(tr -> Assertions.assertThat(tr.getCreatedAt()).isNotEqualTo(0L));
+        assertThat(all).containsExactly(t);
+        assertThat(all.get(0)).usingRecursiveComparison().isEqualTo(t);
+        assertThat(all).allSatisfy(tr -> assertThat(tr.getCreatedAt()).isNotEqualTo(0L));
     }
 
     @Test
@@ -83,7 +81,7 @@ public abstract class TransferProcessStoreTestBase {
         var t2 = TestFunctions.createTransferProcess("id1", TransferProcessStates.PROVISIONING);
         getTransferProcessStore().save(t2);
 
-        Assertions.assertThat(getTransferProcessStore().findAll(QuerySpec.none())).hasSize(1).containsExactly(t2);
+        assertThat(getTransferProcessStore().findAll(QuerySpec.none())).hasSize(1).containsExactly(t2);
     }
 
     @Test
@@ -94,7 +92,7 @@ public abstract class TransferProcessStoreTestBase {
                 .peek(getTransferProcessStore()::save)
                 .collect(Collectors.toList());
 
-        Assertions.assertThat(getTransferProcessStore().nextForState(state.code(), 5))
+        assertThat(getTransferProcessStore().nextForState(state.code(), 5))
                 .hasSize(5)
                 .extracting(TransferProcess::getId)
                 .isSubsetOf(all.stream().map(TransferProcess::getId).collect(Collectors.toList()))
@@ -113,7 +111,7 @@ public abstract class TransferProcessStoreTestBase {
         var leasedTp = all.stream().skip(5).peek(tp -> lockEntity(tp.getId(), CONNECTOR_NAME)).collect(Collectors.toList());
 
         // should not contain leased TPs
-        Assertions.assertThat(getTransferProcessStore().nextForState(state.code(), 10))
+        assertThat(getTransferProcessStore().nextForState(state.code(), 10))
                 .hasSize(5)
                 .isSubsetOf(all)
                 .doesNotContainAnyElementsOf(leasedTp);
@@ -127,9 +125,9 @@ public abstract class TransferProcessStoreTestBase {
                 .forEach(getTransferProcessStore()::save);
 
         // first time works
-        Assertions.assertThat(getTransferProcessStore().nextForState(state.code(), 10)).hasSize(3);
+        assertThat(getTransferProcessStore().nextForState(state.code(), 10)).hasSize(3);
         // second time returns empty list
-        Assertions.assertThat(getTransferProcessStore().nextForState(state.code(), 10)).isEmpty();
+        assertThat(getTransferProcessStore().nextForState(state.code(), 10)).isEmpty();
     }
 
     @Test
@@ -139,7 +137,7 @@ public abstract class TransferProcessStoreTestBase {
                 .mapToObj(i -> TestFunctions.createTransferProcess("id" + i, state))
                 .forEach(getTransferProcessStore()::save);
 
-        Assertions.assertThat(getTransferProcessStore().nextForState(TransferProcessStates.CANCELLED.code(), 10)).isEmpty();
+        assertThat(getTransferProcessStore().nextForState(TransferProcessStates.CANCELLED.code(), 10)).isEmpty();
     }
 
     @Test
@@ -150,7 +148,7 @@ public abstract class TransferProcessStoreTestBase {
                 .forEach(getTransferProcessStore()::save);
 
         // first time works
-        Assertions.assertThat(getTransferProcessStore().nextForState(state.code(), 3)).hasSize(3);
+        assertThat(getTransferProcessStore().nextForState(state.code(), 3)).hasSize(3);
     }
 
     @Test
@@ -168,7 +166,7 @@ public abstract class TransferProcessStoreTestBase {
                 })
                 .forEach(getTransferProcessStore()::save);
 
-        Assertions.assertThat(getTransferProcessStore().nextForState(state.code(), 20))
+        assertThat(getTransferProcessStore().nextForState(state.code(), 20))
                 .extracting(TransferProcess::getId)
                 .map(Integer::parseInt)
                 .isSortedAccordingTo(Integer::compareTo);
@@ -189,7 +187,7 @@ public abstract class TransferProcessStoreTestBase {
         getTransferProcessStore().save(fourth);
 
         var next = getTransferProcessStore().nextForState(TransferProcessStates.IN_PROGRESS.code(), 20);
-        Assertions.assertThat(next.indexOf(fourth)).isEqualTo(9);
+        assertThat(next.indexOf(fourth)).isEqualTo(9);
     }
 
     @Test
@@ -222,12 +220,12 @@ public abstract class TransferProcessStoreTestBase {
 
         var res = getTransferProcessStore().find("id1");
 
-        Assertions.assertThat(res).usingRecursiveComparison().isEqualTo(t);
+        assertThat(res).usingRecursiveComparison().isEqualTo(t);
     }
 
     @Test
     void find_notExist() {
-        Assertions.assertThat(getTransferProcessStore().find("not-exist")).isNull();
+        assertThat(getTransferProcessStore().find("not-exist")).isNull();
     }
 
     @Test
@@ -240,12 +238,12 @@ public abstract class TransferProcessStoreTestBase {
 
         getTransferProcessStore().save(t);
 
-        Assertions.assertThat(getTransferProcessStore().processIdForDataRequestId(dr.getId())).isEqualTo("transfer-id1");
+        assertThat(getTransferProcessStore().processIdForDataRequestId(dr.getId())).isEqualTo("transfer-id1");
     }
 
     @Test
     void processIdForTransferId_notExist() {
-        Assertions.assertThat(getTransferProcessStore().processIdForDataRequestId("not-exist")).isNull();
+        assertThat(getTransferProcessStore().processIdForDataRequestId("not-exist")).isNull();
     }
 
     @Test
@@ -257,12 +255,12 @@ public abstract class TransferProcessStoreTestBase {
         getTransferProcessStore().save(t1);
 
         var all = getTransferProcessStore().findAll(QuerySpec.none()).collect(Collectors.toList());
-        Assertions.assertThat(all)
+        assertThat(all)
                 .hasSize(1)
                 .usingRecursiveFieldByFieldElementComparator()
                 .containsExactly(t1);
 
-        Assertions.assertThat(all.get(0).getDataRequest().getProperties()).containsEntry("newKey", "newValue");
+        assertThat(all.get(0).getDataRequest().getProperties()).containsEntry("newKey", "newValue");
     }
 
     @Test
@@ -273,7 +271,7 @@ public abstract class TransferProcessStoreTestBase {
         t1.transitionCompleted(); //modify
         getTransferProcessStore().save(t1);
 
-        Assertions.assertThat(getTransferProcessStore().findAll(QuerySpec.none()))
+        assertThat(getTransferProcessStore().findAll(QuerySpec.none()))
                 .hasSize(1)
                 .usingRecursiveFieldByFieldElementComparator()
                 .containsExactly(t1);
@@ -287,7 +285,7 @@ public abstract class TransferProcessStoreTestBase {
         getTransferProcessStore().save(t1);
 
         var result = getTransferProcessStore().findAll(QuerySpec.none()).collect(Collectors.toList());
-        Assertions.assertThat(result)
+        assertThat(result)
                 .hasSize(1)
                 .usingRecursiveFieldByFieldElementComparator()
                 .containsExactly(t1);
@@ -305,7 +303,7 @@ public abstract class TransferProcessStoreTestBase {
         getTransferProcessStore().save(t1);
 
         // lease should be broken
-        Assertions.assertThat(getTransferProcessStore().nextForState(TransferProcessStates.INITIAL.code(), 10)).usingRecursiveFieldByFieldElementComparator().containsExactly(t1);
+        assertThat(getTransferProcessStore().nextForState(TransferProcessStates.INITIAL.code(), 10)).usingRecursiveFieldByFieldElementComparator().containsExactly(t1);
     }
 
     @Test
@@ -329,7 +327,7 @@ public abstract class TransferProcessStoreTestBase {
         getTransferProcessStore().save(t1);
 
         getTransferProcessStore().delete("id1");
-        Assertions.assertThat(getTransferProcessStore().findAll(QuerySpec.none())).isEmpty();
+        assertThat(getTransferProcessStore().findAll(QuerySpec.none())).isEmpty();
     }
 
     @Test
@@ -365,7 +363,7 @@ public abstract class TransferProcessStoreTestBase {
                 .peek(getTransferProcessStore()::save)
                 .collect(Collectors.toList());
 
-        Assertions.assertThat(getTransferProcessStore().findAll(QuerySpec.none())).containsExactlyInAnyOrderElementsOf(all);
+        assertThat(getTransferProcessStore().findAll(QuerySpec.none())).containsExactlyInAnyOrderElementsOf(all);
     }
 
     @Test
@@ -375,7 +373,7 @@ public abstract class TransferProcessStoreTestBase {
                 .forEach(getTransferProcessStore()::save);
 
         var qs = QuerySpec.Builder.newInstance().limit(5).offset(3).build();
-        Assertions.assertThat(getTransferProcessStore().findAll(qs)).hasSize(5)
+        assertThat(getTransferProcessStore().findAll(qs)).hasSize(5)
                 .extracting(TransferProcess::getId)
                 .map(Integer::parseInt)
                 .allMatch(id -> id >= 3 && id < 8);
@@ -389,7 +387,7 @@ public abstract class TransferProcessStoreTestBase {
                 .forEach(getTransferProcessStore()::save);
 
         var qs = QuerySpec.Builder.newInstance().limit(20).offset(3).build();
-        Assertions.assertThat(getTransferProcessStore().findAll(qs))
+        assertThat(getTransferProcessStore().findAll(qs))
                 .hasSize(7)
                 .extracting(TransferProcess::getId)
                 .map(Integer::parseInt)
@@ -404,7 +402,7 @@ public abstract class TransferProcessStoreTestBase {
                 .forEach(getTransferProcessStore()::save);
 
         var qs = QuerySpec.Builder.newInstance().limit(10).offset(12).build();
-        Assertions.assertThat(getTransferProcessStore().findAll(qs)).isEmpty();
+        assertThat(getTransferProcessStore().findAll(qs)).isEmpty();
 
     }
 
@@ -426,14 +424,14 @@ public abstract class TransferProcessStoreTestBase {
         getTransferProcessStore().save(t2);
 
         var all = getTransferProcessStore().findAll(QuerySpec.none()).collect(Collectors.toList());
-        Assertions.assertThat(all)
+        assertThat(all)
                 .hasSize(1)
                 .usingRecursiveFieldByFieldElementComparator()
                 .containsExactly(t2);
 
 
         var drs = all.stream().map(TransferProcess::getDataRequest).collect(Collectors.toList());
-        Assertions.assertThat(drs).hasSize(1)
+        assertThat(drs).hasSize(1)
                 .usingRecursiveFieldByFieldElementComparator()
                 .containsOnly(t2.getDataRequest());
     }
@@ -453,7 +451,7 @@ public abstract class TransferProcessStoreTestBase {
                 .filter(List.of(new Criterion("contentDataAddress.properties.key", "=", "value")))
                 .build();
 
-        Assertions.assertThat(getTransferProcessStore().findAll(query))
+        assertThat(getTransferProcessStore().findAll(query))
                 .usingRecursiveFieldByFieldElementComparator()
                 .containsExactly(tp);
 
@@ -474,7 +472,7 @@ public abstract class TransferProcessStoreTestBase {
                 .filter(List.of(new Criterion("contentDataAddress.properties.notexist", "=", "value")))
                 .build();
 
-        Assertions.assertThat(getTransferProcessStore().findAll(query)).isEmpty();
+        assertThat(getTransferProcessStore().findAll(query)).isEmpty();
 
     }
 
@@ -493,7 +491,7 @@ public abstract class TransferProcessStoreTestBase {
                 .filter(List.of(new Criterion("contentDataAddress.properties.key", "=", "notexist")))
                 .build();
 
-        Assertions.assertThat(getTransferProcessStore().findAll(query)).isEmpty();
+        assertThat(getTransferProcessStore().findAll(query)).isEmpty();
     }
 
     @Test
@@ -511,7 +509,7 @@ public abstract class TransferProcessStoreTestBase {
 
         var result = getTransferProcessStore().findAll(query);
 
-        Assertions.assertThat(result).usingRecursiveFieldByFieldElementComparatorIgnoringFields("deprovisionedResources").containsOnly(tp);
+        assertThat(result).usingRecursiveFieldByFieldElementComparatorIgnoringFields("deprovisionedResources").containsOnly(tp);
     }
 
     @Test
@@ -529,7 +527,7 @@ public abstract class TransferProcessStoreTestBase {
 
         var result = getTransferProcessStore().findAll(query);
 
-        Assertions.assertThat(result).usingRecursiveFieldByFieldElementComparatorIgnoringFields("deprovisionedResources").containsOnly(tp);
+        assertThat(result).usingRecursiveFieldByFieldElementComparatorIgnoringFields("deprovisionedResources").containsOnly(tp);
     }
 
     @Test
@@ -549,7 +547,7 @@ public abstract class TransferProcessStoreTestBase {
 
         var result = getTransferProcessStore().findAll(query);
 
-        Assertions.assertThat(result).usingRecursiveFieldByFieldElementComparatorIgnoringFields("deprovisionedResources").containsOnly(tp);
+        assertThat(result).usingRecursiveFieldByFieldElementComparatorIgnoringFields("deprovisionedResources").containsOnly(tp);
     }
 
     @Test
@@ -565,7 +563,7 @@ public abstract class TransferProcessStoreTestBase {
                 .filter(List.of(new Criterion("dataRequest.id", "=", "notexist")))
                 .build();
 
-        Assertions.assertThat(getTransferProcessStore().findAll(query)).isEmpty();
+        assertThat(getTransferProcessStore().findAll(query)).isEmpty();
     }
 
     @Test
@@ -584,7 +582,7 @@ public abstract class TransferProcessStoreTestBase {
                 .build();
 
         var result = getTransferProcessStore().findAll(query);
-        Assertions.assertThat(result).usingRecursiveFieldByFieldElementComparatorIgnoringFields("deprovisionedResources").containsOnly(tp);
+        assertThat(result).usingRecursiveFieldByFieldElementComparatorIgnoringFields("deprovisionedResources").containsOnly(tp);
     }
 
     @Test
@@ -602,7 +600,7 @@ public abstract class TransferProcessStoreTestBase {
         var query = QuerySpec.Builder.newInstance()
                 .filter(List.of(new Criterion("resourceManifest.definitions.id", "=", "someval")))
                 .build();
-        Assertions.assertThat(getTransferProcessStore().findAll(query)).isEmpty();
+        assertThat(getTransferProcessStore().findAll(query)).isEmpty();
     }
 
     @Test
@@ -627,7 +625,7 @@ public abstract class TransferProcessStoreTestBase {
                 .build();
 
         var result = getTransferProcessStore().findAll(query);
-        Assertions.assertThat(result).usingRecursiveFieldByFieldElementComparatorIgnoringFields("deprovisionedResources").containsOnly(tp);
+        assertThat(result).usingRecursiveFieldByFieldElementComparatorIgnoringFields("deprovisionedResources").containsOnly(tp);
     }
 
     @Test
@@ -653,7 +651,7 @@ public abstract class TransferProcessStoreTestBase {
                 .filter(List.of(new Criterion("provisionedResourceSet.resources.id", "=", "someval")))
                 .build();
 
-        Assertions.assertThat(getTransferProcessStore().findAll(query)).isEmpty();
+        assertThat(getTransferProcessStore().findAll(query)).isEmpty();
     }
 
     @Test
@@ -688,7 +686,7 @@ public abstract class TransferProcessStoreTestBase {
 
         var result = getTransferProcessStore().findAll(query).collect(Collectors.toList());
 
-        Assertions.assertThat(result).hasSize(1)
+        assertThat(result).hasSize(1)
                 .usingRecursiveFieldByFieldElementComparator()
                 .containsExactly(process1);
     }
@@ -728,7 +726,7 @@ public abstract class TransferProcessStoreTestBase {
 
         var result = getTransferProcessStore().findAll(query).collect(Collectors.toList());
 
-        Assertions.assertThat(result).hasSize(1)
+        assertThat(result).hasSize(1)
                 .usingRecursiveFieldByFieldElementComparator()
                 .containsExactly(process1);
     }
@@ -765,7 +763,7 @@ public abstract class TransferProcessStoreTestBase {
 
         var result = getTransferProcessStore().findAll(query).collect(Collectors.toList());
 
-        Assertions.assertThat(result).hasSize(2)
+        assertThat(result).hasSize(2)
                 .usingRecursiveFieldByFieldElementComparator()
                 .containsExactlyInAnyOrder(process1, process2);
     }
@@ -791,7 +789,7 @@ public abstract class TransferProcessStoreTestBase {
                 .filter("deprovisionedResources.foobar=barbaz")
                 .build();
 
-        Assertions.assertThat(getTransferProcessStore().findAll(query)).isEmpty();
+        assertThat(getTransferProcessStore().findAll(query)).isEmpty();
     }
 
     @Test
@@ -819,7 +817,7 @@ public abstract class TransferProcessStoreTestBase {
 
         var result = getTransferProcessStore().findAll(query).collect(Collectors.toList());
 
-        Assertions.assertThat(result).isEmpty();
+        assertThat(result).isEmpty();
     }
 
     @Test
@@ -865,13 +863,13 @@ public abstract class TransferProcessStoreTestBase {
         transferProcess1.transitionProvisioning(ResourceManifest.Builder.newInstance().build());
         getTransferProcessStore().save(transferProcess1);
 
-        Assertions.assertThat(getTransferProcessStore().nextForState(INITIAL.code(), 1)).isEmpty();
+        assertThat(getTransferProcessStore().nextForState(INITIAL.code(), 1)).isEmpty();
 
         var found = getTransferProcessStore().nextForState(TransferProcessStates.PROVISIONING.code(), 1);
-        Assertions.assertThat(found).hasSize(1).first().matches(it -> it.equals(transferProcess2));
+        assertThat(found).hasSize(1).first().matches(it -> it.equals(transferProcess2));
 
         found = getTransferProcessStore().nextForState(TransferProcessStates.PROVISIONING.code(), 3);
-        Assertions.assertThat(found).hasSize(1).first().matches(it -> it.equals(transferProcess1));
+        assertThat(found).hasSize(1).first().matches(it -> it.equals(transferProcess1));
     }
 
     @Test
@@ -880,16 +878,16 @@ public abstract class TransferProcessStoreTestBase {
         getTransferProcessStore().save(initialTransferProcess);
 
         var firstQueryResult = getTransferProcessStore().nextForState(INITIAL.code(), 1);
-        Assertions.assertThat(firstQueryResult).hasSize(1);
+        assertThat(firstQueryResult).hasSize(1);
 
         var secondQueryResult = getTransferProcessStore().nextForState(INITIAL.code(), 1);
-        Assertions.assertThat(secondQueryResult).hasSize(0);
+        assertThat(secondQueryResult).hasSize(0);
 
         var retrieved = firstQueryResult.get(0);
         getTransferProcessStore().save(retrieved);
 
         var thirdQueryResult = getTransferProcessStore().nextForState(INITIAL.code(), 1);
-        Assertions.assertThat(thirdQueryResult).hasSize(1);
+        assertThat(thirdQueryResult).hasSize(1);
     }
 
     @Test
@@ -944,13 +942,13 @@ public abstract class TransferProcessStoreTestBase {
             getTransferProcessStore().save(tp);
         });
         var list2 = getTransferProcessStore().nextForState(INITIAL.code(), 5);
-        Assertions.assertThat(list1).isNotEqualTo(list2).doesNotContainAnyElementsOf(list2);
+        assertThat(list1).isNotEqualTo(list2).doesNotContainAnyElementsOf(list2);
     }
 
     @Test
     void findAll_verifyFiltering() {
         IntStream.range(0, 10).forEach(i -> getTransferProcessStore().save(createTransferProcess("test-neg-" + i)));
-        Assertions.assertThat(getTransferProcessStore().findAll(QuerySpec.Builder.newInstance().equalsAsContains(false).filter("id=test-neg-3").build())).extracting(TransferProcess::getId).containsOnly("test-neg-3");
+        assertThat(getTransferProcessStore().findAll(QuerySpec.Builder.newInstance().equalsAsContains(false).filter("id=test-neg-3").build())).extracting(TransferProcess::getId).containsOnly("test-neg-3");
     }
 
     @Test
@@ -964,8 +962,8 @@ public abstract class TransferProcessStoreTestBase {
     void findAll_verifySorting() {
         IntStream.range(0, 10).forEach(i -> getTransferProcessStore().save(createTransferProcess("test-neg-" + i)));
 
-        Assertions.assertThat(getTransferProcessStore().findAll(QuerySpec.Builder.newInstance().sortField("id").sortOrder(SortOrder.ASC).build())).hasSize(10).isSortedAccordingTo(Comparator.comparing(TransferProcess::getId));
-        Assertions.assertThat(getTransferProcessStore().findAll(QuerySpec.Builder.newInstance().sortField("id").sortOrder(SortOrder.DESC).build())).hasSize(10).isSortedAccordingTo((c1, c2) -> c2.getId().compareTo(c1.getId()));
+        assertThat(getTransferProcessStore().findAll(QuerySpec.Builder.newInstance().sortField("id").sortOrder(SortOrder.ASC).build())).hasSize(10).isSortedAccordingTo(Comparator.comparing(TransferProcess::getId));
+        assertThat(getTransferProcessStore().findAll(QuerySpec.Builder.newInstance().sortField("id").sortOrder(SortOrder.DESC).build())).hasSize(10).isSortedAccordingTo((c1, c2) -> c2.getId().compareTo(c1.getId()));
     }
 
     @Test
@@ -975,7 +973,7 @@ public abstract class TransferProcessStoreTestBase {
 
         var query = QuerySpec.Builder.newInstance().sortField("notexist").sortOrder(SortOrder.DESC).build();
 
-        Assertions.assertThat(getTransferProcessStore().findAll(query).collect(Collectors.toList())).isEmpty();
+        assertThat(getTransferProcessStore().findAll(query).collect(Collectors.toList())).isEmpty();
     }
 
     protected abstract boolean supportsCollectionQuery();


### PR DESCRIPTION
## What this PR changes/adds

Stores `ClaimToken` into `DataRequest`

## Why it does that

to make the claims available in other transfer phases as provisioning or data-transfer flow.

## Further notes

- a new `claim_token` json column has been added to the `edc_data_request` table, so this can be considered a breaking change.

## Linked Issue(s)

Closes #2465 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
