### PR TITLE
docs: provide decision record for CommandHandler Result

### DIFF
--- a/docs/developer/decision-records/2023-02-07-command-handler-result/README.md
+++ b/docs/developer/decision-records/2023-02-07-command-handler-result/README.md
@@ -1,0 +1,46 @@
+# CommandHandler Result
+
+## Decision
+
+Return the `CommandHandler`s' thrown exceptions, that are caught by the `CommandRunner`, should be returned as a failed `Result` instead. 
+
+
+## Rationale
+
+
+At the moment, some `CommandHandler`s throw exceptions to notify validation errors, that are catched by the `CommandRunner`, but these errors are seen as unexpected.
+In order to make these errors detection easier, the `CommandHandler.handle` method is modified to return a `Result` that is evaluated by the `CommandRunner` , then the `Result` would be returned to the `CommandProcessor` and logged accordingly.
+
+## Approach
+
+
+1. Make `CommandHandler.handle` return a `Result`:
+```java
+public interface CommandHandler<T extends Command> {
+
+    Class<T> getType();
+    
+    Result<Void> handle(T command);
+}
+```
+2. Make the `CommandRunner.runCommand` evaluate the `Result` that is returned by the `CommandHandler`:
+```java
+
+
+   public <T extends C> Result<Void> runCommand(T command) {
+
+        @SuppressWarnings("unchecked") var commandClass = (Class<T>) command.getClass();
+
+        var handler = commandHandlerRegistry.get(commandClass);
+        if (handler == null) {
+            command.increaseErrorCount();
+            return Result.failure("No command handler found for command type " + commandClass);
+        }
+        try {
+            var result = handler.handle(command);
+            return result;
+        }
+        .....
+   }
+
+```


### PR DESCRIPTION
## What this PR changes/adds
Add decision record for `CommandHandler` so that the validation errors that are catched by the `CommandRunner` would be easier to detect . 

## Why it does that

documents
## Further notes

## Linked Issue(s)

Ref #2340 
## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
