### PR TITLE
feat: decision record about nightly builds

### DIFF
--- a/docs/developer/decision-records/2023-02-10-nightly-builds/README.md
+++ b/docs/developer/decision-records/2023-02-10-nightly-builds/README.md
@@ -1,0 +1,32 @@
+# Nightly builds become release versions
+
+## Decision
+
+Nightly builds will henceforth be published as release version (as opposed to: snapshots) and will be published to OSSRH
+Releases.
+Only major releases, such as milestones, will get published to MavenCentral.
+
+## Rationale
+
+Downstream projects may want to track the EDC features as closely as possible while still maintaining a consistent and
+repeatable build pipeline. EDC's release train is roughly six to eight weeks, which may be too sparse for downstream
+projects' development schedules.
+
+To that end, the only option currently is to use nightlies, but they are snapshots, and snapshot builds are ill-suited,
+because they are not permanent, and can be overwritten or deleted at any time.
+
+## Approach
+
+- Publish all snapshots to [OSSRH Snapshots](https://oss.sonatype.org/content/repositories/snapshots/)
+- Make nightly versions releases, e.g. `0.0.1-20230210`
+- Publish all release versions to [OSSRH Releases](https://oss.sonatype.org/content/repositories/releases/)
+- Only publish major releases (e.g. milestones) to MavenCentral
+
+The reason for using OSSRH Release instead of MavenCentral for nightly releases is simply that we do not want to spam
+MavenCentral with ~300 artifacts on a daily basis, which would offer little value to the larger community.
+
+The build plugin needs to be adapted to publish to OSSRH Releases by default. Further, we need to implement a separate,
+additional task that allows publishing to MavenCentral, which is invoked from a (new) Jenkins job.
+
+Our GitHub Action [release-edc.yml](../../../../.github/workflows/release-edc.yml) will then also have to invoke that
+new Jenkins job to publish to MavenCentral. 

--- a/docs/developer/decision-records/2023-02-10-nightly-builds/README.md
+++ b/docs/developer/decision-records/2023-02-10-nightly-builds/README.md
@@ -27,6 +27,3 @@ MavenCentral with ~300 artifacts on a daily basis, which would offer little valu
 
 The build plugin needs to be adapted to publish to OSSRH Releases by default. Further, we need to implement a separate,
 additional task that allows publishing to MavenCentral, which is invoked from a (new) Jenkins job.
-
-Our GitHub Action [release-edc.yml](../../../../.github/workflows/release-edc.yml) will then also have to invoke that
-new Jenkins job to publish to MavenCentral. 


### PR DESCRIPTION
## What this PR changes/adds

Adds a decision record about nightly builds becoming release versions instead of snapshots.

## Why it does that

Will enable downstream projects to have repeatable builds other than milestones.

## Further notes

_Another PR to do the actual work will be created in the plugins repo and the pipelines repo_

## Linked Issue(s)

Closes #2481 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
