### PR TITLE
fix: catalog pagination

### DIFF
--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/offer/ContractOfferResolverImplIntegrationTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/offer/ContractOfferResolverImplIntegrationTest.java
@@ -36,9 +36,11 @@ import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.eclipse.edc.spi.types.domain.asset.AssetEntry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -112,20 +114,9 @@ class ContractOfferResolverImplIntegrationTest {
         verify(policyStore).findById("contract");
     }
 
-    private static Stream<Arguments> ranges() {
-        return Stream.of(
-                Arguments.of(0, 12),
-                Arguments.of(8, 14),
-                Arguments.of(0, 999),
-                Arguments.of(4, 888),
-                Arguments.of(3, 20),
-                Arguments.of(23, 25)
-        );
-    }
-
     @ParameterizedTest
-    @MethodSource("ranges")
-    void shouldReturnOfferSubsetAcrossMultipleContractDefinitions(int from, int to) {
+    @ArgumentsSource(RangeProvider.class)
+    void should_return_offers_subset_when_across_multiple_contract_definitions(int from, int to) {
 
         var assets1 = range(0, 10).mapToObj(i -> createAsset("asset-" + i).build()).collect(Collectors.toList());
         var assets2 = range(10, 20).mapToObj(i -> createAsset("asset-" + i).build()).collect(Collectors.toList());
@@ -219,4 +210,17 @@ class ContractOfferResolverImplIntegrationTest {
         return Asset.Builder.newInstance().id(id).name("test asset " + id);
     }
 
+    static class RangeProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                    Arguments.of(0, 12),
+                    Arguments.of(8, 14),
+                    Arguments.of(0, 999),
+                    Arguments.of(4, 888),
+                    Arguments.of(3, 20),
+                    Arguments.of(23, 25)
+            );
+        }
+    }
 }

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/offer/ContractOfferResolverImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/offer/ContractOfferResolverImplTest.java
@@ -159,7 +159,7 @@ class ContractOfferResolverImplTest {
 
 
     @Test
-    void shouldNotLimitResult_whenAssetsAreLessThanTheRequested() {
+    void shouldLimitResultToTheRemainingAssetsOfTheContractDefinition() {
         var contractDefinition = getContractDefBuilder("1").build();
 
         when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
@@ -174,7 +174,7 @@ class ContractOfferResolverImplTest {
         var result = contractOfferResolver.queryContractOffers(getQuery(from, to));
 
         assertThat(result).isNotEmpty();
-        verify(assetIndex, times(1)).queryAssets(and(isA(QuerySpec.class), argThat(it -> it.getLimit() == 40)));
+        verify(assetIndex, times(1)).queryAssets(and(isA(QuerySpec.class), argThat(it -> it.getLimit() == 20)));
     }
 
     @Test


### PR DESCRIPTION
## What this PR changes/adds

- Adds test cases to evaluate catalog pagination across multiple contract definitions.
- Changes the logic which dynamically builds the offset and limit for each contract definition.

## Why it does that

  Previously the number of assets that should be skipped in the current iteration was dynamic but the limit was not, which caused the pagination to fail when across multiple contract definitions.
  I decided to use a different approach that for me was easier to understand.
  Based on the given range, the absolute offset and limit are static but could assume a different state on each iteration responding to the number of seen and fetched assets until that point. Therefore, I implemented the logic that sets the values of the dynamic offset and limit variables in the following expressions:

- The dynamic offset must be equal to the absolute offset minus the number of assets seen, but never less than zero.
- The dynamic limit must be equal to the absolute limit minus the number of assets already fetched, but never exceed the number of assets obtained in the current contract definition.

## Linked Issue(s)

Closes #2493

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)