### PR TITLE
fix: permit `Config` keys with snakeCase format

### DIFF
--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/DefaultServiceExtensionContext.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/DefaultServiceExtensionContext.java
@@ -116,7 +116,7 @@ public class DefaultServiceExtensionContext implements ServiceExtensionContext {
                 .reduce(Config::merge)
                 .orElse(ConfigFactory.empty());
 
-        var environmentConfig = ConfigFactory.fromMap(getEnvironmentVariables());
+        var environmentConfig = ConfigFactory.fromEnvironment(getEnvironmentVariables());
         var systemPropertyConfig = ConfigFactory.fromProperties(System.getProperties());
 
         return config.merge(environmentConfig).merge(systemPropertyConfig);

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/system/configuration/ConfigFactory.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/system/configuration/ConfigFactory.java
@@ -25,19 +25,48 @@ import static org.eclipse.edc.spi.system.configuration.ConfigImpl.TO_MAP;
  */
 public class ConfigFactory {
 
+    /**
+     * Returns an empty {@link Config}.
+     *
+     * @return an empty {@link Config}
+     */
     public static Config empty() {
         return new ConfigImpl(emptyMap());
     }
 
-    public static Config fromMap(Map<String, String> propertyCache) {
-        return new ConfigImpl(propertyCache);
+    /**
+     * Returns a config built from a {@link Map}.
+     *
+     * @return a {@link Config} instance based on the given {@link Map}
+     */
+    public static Config fromMap(Map<String, String> settings) {
+        return new ConfigImpl(settings);
     }
 
+    /**
+     * Returns a config built from {@link Properties}.
+     *
+     * @return a {@link Config} instance based on the given {@link Properties}
+     */
     public static Config fromProperties(Properties properties) {
         var entries = properties.entrySet().stream()
                 .map(it -> Map.entry(it.getKey().toString(), it.getValue().toString()))
                 .collect(TO_MAP);
 
         return new ConfigImpl(entries);
+    }
+
+    /**
+     * Returns a config built from a {@link Map} containing environment variables, converting ENV_KEY_FORMAT to env.key.format
+     * keys.
+     *
+     * @return a {@link Config} instance based on the given {@link Properties}
+     */
+    public static Config fromEnvironment(Map<String, String> environmentVariables) {
+        var settings = environmentVariables.entrySet().stream()
+                .map(it -> Map.entry(it.getKey().toLowerCase().replace("_", "."), it.getValue()))
+                .collect(TO_MAP);
+
+        return new ConfigImpl(settings);
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/system/configuration/ConfigImpl.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/system/configuration/ConfigImpl.java
@@ -27,7 +27,6 @@ import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collector;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.lang.String.format;
@@ -50,11 +49,8 @@ public class ConfigImpl implements Config {
     protected ConfigImpl(String rootPath, Map<String, String> entries) {
         Objects.requireNonNull(rootPath, "rootPath");
 
-        // convert upper snake case to Java Property format: SOME_KEY=value will become some.key=value
-        this.entries = entries.entrySet().stream()
-                .collect(Collectors.toMap(e -> e.getKey().toLowerCase().replace("_", "."),
-                        Map.Entry::getValue, (o, o2) -> o2));
-        this.rootPath = rootPath.toLowerCase().replace("_", ".");
+        this.entries = entries;
+        this.rootPath = rootPath;
     }
 
     @Override

--- a/spi/common/core-spi/src/test/java/org/eclipse/edc/spi/system/configuration/ConfigFactoryTest.java
+++ b/spi/common/core-spi/src/test/java/org/eclipse/edc/spi/system/configuration/ConfigFactoryTest.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - Improvements
+ *
+ */
+
+package org.eclipse.edc.spi.system.configuration;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class ConfigFactoryTest {
+
+    @Test
+    void shouldConvertEnvironmentToPropertiesFormat() {
+        var environment = Map.of("ENV_KEY_FORMAT", "value");
+
+        var config = ConfigFactory.fromEnvironment(environment);
+
+        assertThat(config).isNotNull().extracting(it -> it.getString("env.key.format")).isEqualTo("value");
+    }
+}

--- a/spi/common/core-spi/src/test/java/org/eclipse/edc/spi/system/configuration/ConfigImplTest.java
+++ b/spi/common/core-spi/src/test/java/org/eclipse/edc/spi/system/configuration/ConfigImplTest.java
@@ -319,22 +319,6 @@ class ConfigImplTest {
     }
 
     @Test
-    void verify_snakeCaseGetConverted() {
-        assertThat(new ConfigImpl("GROUP_SUBGROUP", emptyMap()).currentNode()).isEqualTo("subgroup");
-        assertThat(new ConfigImpl(Map.of("SOME_GROUP", "value")).getEntries()).containsEntry("some.group", "value");
-        ConfigImpl config = new ConfigImpl("ROOT_PATH", Map.of("SOME_GROUP", "value"));
-        assertThat(config.getEntries()).containsEntry("some.group", "value");
-        assertThat(config.currentNode()).isEqualTo("path");
-
-    }
-
-    @Test
-    void verify_snakeCaseGetConverted_duplicateKeys() {
-        ConfigImpl config = new ConfigImpl(Map.of("SOME_GROUP", "value", "some.group", "value2"));
-        assertThat(config.getEntries()).hasSize(1);
-    }
-
-    @Test
     void hasPath_returnsTrueIfPathExists() {
         var config = new ConfigImpl(Map.of("example.path.key", "val", "example.path.otherkey", "val"));
 


### PR DESCRIPTION
## What this PR changes/adds

Move the `ENV_KEY_FORMAT` to `env.key.format` conversion to a dedicated method in `ConfigFactory`.

## Why it does that

Permit to use settings with `snakeCase` format.

## Further notes

- add some missing documentation on `ConfigFactory`

## Linked Issue(s)

Closes #2295 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
