### PR TITLE
chore: simplify DataSourceFactory and DataSinkFactory APIs

### DIFF
--- a/core/data-plane/data-plane-framework/src/test/java/org/eclipse/edc/connector/dataplane/framework/e2e/EndToEndTest.java
+++ b/core/data-plane/data-plane-framework/src/test/java/org/eclipse/edc/connector/dataplane/framework/e2e/EndToEndTest.java
@@ -87,6 +87,11 @@ public class EndToEndTest {
         }
 
         @Override
+        public @NotNull Result<Void> validateRequest(DataFlowRequest request) {
+            return Result.success();
+        }
+
+        @Override
         public DataSink createSink(DataFlowRequest request) {
             return sink;
         }

--- a/core/data-plane/data-plane-util/src/main/java/org/eclipse/edc/connector/dataplane/util/sink/OutputStreamDataSinkFactory.java
+++ b/core/data-plane/data-plane-util/src/main/java/org/eclipse/edc/connector/dataplane/util/sink/OutputStreamDataSinkFactory.java
@@ -38,9 +38,19 @@ public class OutputStreamDataSinkFactory implements DataSinkFactory {
 
     @Override
     public @NotNull Result<Boolean> validate(DataFlowRequest request) {
-        return canHandle(request) ? Result.success(true) :
-                Result.failure(String.format("%s: Cannot handle destination data address with type: %s",
-                        getClass().getSimpleName(), request.getDestinationDataAddress().getType()));
+        return validateRequest(request).map(it -> true);
+
+    }
+
+    @Override
+    public @NotNull Result<Void> validateRequest(DataFlowRequest request) {
+        if (!canHandle(request)) {
+
+            return Result.failure(String.format("%s: Cannot handle destination data address with type: %s",
+                    getClass().getSimpleName(), request.getDestinationDataAddress().getType()));
+        }
+
+        return Result.success();
     }
 
     @Override

--- a/core/data-plane/data-plane-util/src/test/java/org/eclipse/edc/connector/dataplane/util/sink/OutputStreamDataSinkFactoryTest.java
+++ b/core/data-plane/data-plane-util/src/test/java/org/eclipse/edc/connector/dataplane/util/sink/OutputStreamDataSinkFactoryTest.java
@@ -44,10 +44,10 @@ class OutputStreamDataSinkFactoryTest {
 
     @Test
     void validate() {
-        assertThat(factory.validate(createDataFlowRequest(OutputStreamDataSinkFactory.TYPE)))
+        assertThat(factory.validateRequest(createDataFlowRequest(OutputStreamDataSinkFactory.TYPE)))
                 .satisfies(result -> assertThat(result.succeeded()).isTrue());
 
-        assertThat(factory.validate(createDataFlowRequest("dummy")))
+        assertThat(factory.validateRequest(createDataFlowRequest("dummy")))
                 .satisfies(result -> {
                     assertThat(result.failed()).isTrue();
                     assertThat(result.getFailureMessages())

--- a/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSinkFactory.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSinkFactory.java
@@ -67,14 +67,19 @@ public class S3DataSinkFactory implements DataSinkFactory {
 
     @Override
     public @NotNull Result<Boolean> validate(DataFlowRequest request) {
+        return validateRequest(request).map(it -> true);
+    }
+
+    @Override
+    public @NotNull Result<Void> validateRequest(DataFlowRequest request) {
         var destination = request.getDestinationDataAddress();
 
-        return validation.apply(destination).map(it -> true);
+        return validation.apply(destination).map(it -> null);
     }
 
     @Override
     public DataSink createSink(DataFlowRequest request) {
-        var validationResult = validate(request);
+        var validationResult = validateRequest(request);
         if (validationResult.failed()) {
             throw new EdcException(String.join(", ", validationResult.getFailureMessages()));
         }
@@ -94,14 +99,14 @@ public class S3DataSinkFactory implements DataSinkFactory {
         }
 
         return S3DataSink.Builder.newInstance()
-            .bucketName(destination.getProperty(BUCKET_NAME))
-            .keyName(destination.getKeyName())
-            .requestId(request.getId())
-            .executorService(executorService)
-            .monitor(monitor)
-            .client(client)
-            .chunkSizeBytes(CHUNK_SIZE_IN_BYTES)
-            .build();
+                .bucketName(destination.getProperty(BUCKET_NAME))
+                .keyName(destination.getKeyName())
+                .requestId(request.getId())
+                .executorService(executorService)
+                .monitor(monitor)
+                .client(client)
+                .chunkSizeBytes(CHUNK_SIZE_IN_BYTES)
+                .build();
     }
 
 }

--- a/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSourceFactory.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSourceFactory.java
@@ -58,14 +58,19 @@ public class S3DataSourceFactory implements DataSourceFactory {
 
     @Override
     public @NotNull Result<Boolean> validate(DataFlowRequest request) {
+        return validateRequest(request).map(it -> true);
+    }
+
+    @Override
+    public @NotNull Result<Void> validateRequest(DataFlowRequest request) {
         var source = request.getSourceDataAddress();
 
-        return validation.apply(source).map(it -> true);
+        return validation.apply(source).map(it -> null);
     }
 
     @Override
     public DataSource createSource(DataFlowRequest request) {
-        var validationResult = validate(request);
+        var validationResult = validateRequest(request);
         if (validationResult.failed()) {
             throw new EdcException(String.join(", ", validationResult.getFailureMessages()));
         }

--- a/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSinkFactoryTest.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSinkFactoryTest.java
@@ -75,7 +75,7 @@ class S3DataSinkFactoryTest {
         var destination = TestFunctions.s3DataAddressWithCredentials();
         var request = createRequest(destination);
 
-        var result = factory.validate(request);
+        var result = factory.validateRequest(request);
 
         assertThat(result.succeeded()).isTrue();
     }
@@ -93,7 +93,7 @@ class S3DataSinkFactoryTest {
 
         var request = createRequest(destination);
 
-        var result = factory.validate(request);
+        var result = factory.validateRequest(request);
 
         assertThat(result.failed()).isTrue();
     }

--- a/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSourceFactoryTest.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSourceFactoryTest.java
@@ -77,7 +77,7 @@ class S3DataSourceFactoryTest {
         var source = s3DataAddressWithCredentials();
         var request = createRequest(source);
 
-        var result = factory.validate(request);
+        var result = factory.validateRequest(request);
 
         assertThat(result.succeeded()).isTrue();
     }
@@ -95,7 +95,7 @@ class S3DataSourceFactoryTest {
 
         var request = createRequest(source);
 
-        var result = factory.validate(request);
+        var result = factory.validateRequest(request);
 
         assertThat(result.failed()).isTrue();
     }

--- a/extensions/data-plane/data-plane-azure-storage/src/main/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSinkFactory.java
+++ b/extensions/data-plane/data-plane-azure-storage/src/main/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSinkFactory.java
@@ -63,6 +63,11 @@ public class AzureStorageDataSinkFactory implements DataSinkFactory {
 
     @Override
     public @NotNull Result<Boolean> validate(DataFlowRequest request) {
+        return validateRequest(request).mapTo();
+    }
+
+    @Override
+    public @NotNull Result<Void> validateRequest(DataFlowRequest request) {
         var dataAddress = request.getDestinationDataAddress();
         var properties = new HashMap<>(dataAddress.getProperties());
         try {
@@ -75,12 +80,12 @@ public class AzureStorageDataSinkFactory implements DataSinkFactory {
         } catch (IllegalArgumentException e) {
             return Result.failure(e.getMessage());
         }
-        return VALID;
+        return VALID.mapTo();
     }
 
     @Override
     public DataSink createSink(DataFlowRequest request) {
-        Result<Boolean> validate = validate(request);
+        Result<Void> validate = validateRequest(request);
         if (validate.failed()) {
             throw new EdcException(validate.getFailure().getMessages().toString());
         }

--- a/extensions/data-plane/data-plane-azure-storage/src/main/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSourceFactory.java
+++ b/extensions/data-plane/data-plane-azure-storage/src/main/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSourceFactory.java
@@ -58,6 +58,11 @@ public class AzureStorageDataSourceFactory implements DataSourceFactory {
 
     @Override
     public @NotNull Result<Boolean> validate(DataFlowRequest request) {
+        return validateRequest(request).mapTo();
+    }
+
+    @Override
+    public @NotNull Result<Void> validateRequest(DataFlowRequest request) {
         var dataAddress = request.getSourceDataAddress();
         var properties = new HashMap<>(dataAddress.getProperties());
         try {
@@ -71,12 +76,12 @@ public class AzureStorageDataSourceFactory implements DataSourceFactory {
         } catch (IllegalArgumentException e) {
             return Result.failure(e.getMessage());
         }
-        return VALID;
+        return VALID.mapTo();
     }
 
     @Override
     public DataSource createSource(DataFlowRequest request) {
-        Result<Boolean> validate = validate(request);
+        Result<Void> validate = validateRequest(request);
         if (validate.failed()) {
             throw new EdcException(validate.getFailure().getMessages().toString());
         }

--- a/extensions/data-plane/data-plane-azure-storage/src/test/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSinkFactoryTest.java
+++ b/extensions/data-plane/data-plane-azure-storage/src/test/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSinkFactoryTest.java
@@ -62,7 +62,7 @@ class AzureStorageDataSinkFactoryTest {
 
     @Test
     void validate_whenRequestValid_succeeds() {
-        assertThat(factory.validate(request.destinationDataAddress(dataAddress
+        assertThat(factory.validateRequest(request.destinationDataAddress(dataAddress
                                 .property(AzureBlobStoreSchema.ACCOUNT_NAME, accountName)
                                 .property(AzureBlobStoreSchema.CONTAINER_NAME, containerName)
                                 .keyName(keyName)
@@ -73,7 +73,7 @@ class AzureStorageDataSinkFactoryTest {
 
     @Test
     void validate_whenMissingAccountName_fails() {
-        assertThat(factory.validate(request.destinationDataAddress(dataAddress
+        assertThat(factory.validateRequest(request.destinationDataAddress(dataAddress
                                 .property(AzureBlobStoreSchema.CONTAINER_NAME, containerName)
                                 .keyName(keyName)
                                 .build())
@@ -83,9 +83,19 @@ class AzureStorageDataSinkFactoryTest {
 
     @Test
     void validate_whenMissingContainerName_fails() {
-        assertThat(factory.validate(request.destinationDataAddress(dataAddress
+        assertThat(factory.validateRequest(request.destinationDataAddress(dataAddress
                                 .property(AzureBlobStoreSchema.ACCOUNT_NAME, accountName)
                                 .keyName(keyName)
+                                .build())
+                        .build())
+                .failed()).isTrue();
+    }
+
+    @Test
+    void validate_whenMissingKeyName_fails() {
+        assertThat(factory.validateRequest(request.destinationDataAddress(dataAddress
+                                .property(AzureBlobStoreSchema.ACCOUNT_NAME, accountName)
+                                .property(AzureBlobStoreSchema.CONTAINER_NAME, containerName)
                                 .build())
                         .build())
                 .failed()).isTrue();

--- a/extensions/data-plane/data-plane-azure-storage/src/test/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSourceFactoryTest.java
+++ b/extensions/data-plane/data-plane-azure-storage/src/test/java/org/eclipse/edc/connector/dataplane/azure/storage/pipeline/AzureStorageDataSourceFactoryTest.java
@@ -57,7 +57,7 @@ class AzureStorageDataSourceFactoryTest {
 
     @Test
     void validate_whenRequestValid_succeeds() {
-        assertThat(factory.validate(request.sourceDataAddress(dataAddress
+        assertThat(factory.validateRequest(request.sourceDataAddress(dataAddress
                                 .property(AzureBlobStoreSchema.ACCOUNT_NAME, accountName)
                                 .property(AzureBlobStoreSchema.CONTAINER_NAME, containerName)
                                 .property(AzureBlobStoreSchema.BLOB_NAME, blobName)
@@ -69,7 +69,7 @@ class AzureStorageDataSourceFactoryTest {
 
     @Test
     void validate_whenMissingAccountName_fails() {
-        assertThat(factory.validate(request.sourceDataAddress(dataAddress
+        assertThat(factory.validateRequest(request.sourceDataAddress(dataAddress
                                 .property(AzureBlobStoreSchema.CONTAINER_NAME, containerName)
                                 .property(AzureBlobStoreSchema.BLOB_NAME, blobName)
                                 .build())
@@ -79,7 +79,7 @@ class AzureStorageDataSourceFactoryTest {
 
     @Test
     void validate_whenMissingContainerName_fails() {
-        assertThat(factory.validate(request.sourceDataAddress(dataAddress
+        assertThat(factory.validateRequest(request.sourceDataAddress(dataAddress
                                 .property(AzureBlobStoreSchema.ACCOUNT_NAME, accountName)
                                 .property(AzureBlobStoreSchema.BLOB_NAME, blobName)
                                 .build())
@@ -89,7 +89,7 @@ class AzureStorageDataSourceFactoryTest {
 
     @Test
     void validate_whenMissingBlobName_fails() {
-        assertThat(factory.validate(request.sourceDataAddress(dataAddress
+        assertThat(factory.validateRequest(request.sourceDataAddress(dataAddress
                                 .property(AzureBlobStoreSchema.ACCOUNT_NAME, accountName)
                                 .property(AzureBlobStoreSchema.CONTAINER_NAME, containerName)
                                 .build())

--- a/extensions/data-plane/data-plane-google-storage/src/main/java/org/eclipse/edc/connector/dataplane/gcp/storage/GcsDataSinkFactory.java
+++ b/extensions/data-plane/data-plane-google-storage/src/main/java/org/eclipse/edc/connector/dataplane/gcp/storage/GcsDataSinkFactory.java
@@ -62,13 +62,18 @@ public class GcsDataSinkFactory implements DataSinkFactory {
 
     @Override
     public @NotNull Result<Boolean> validate(DataFlowRequest request) {
+        return validateRequest(request).map(it -> true);
+    }
+
+    @Override
+    public @NotNull Result<Void> validateRequest(DataFlowRequest request) {
         var destination = request.getDestinationDataAddress();
-        return validation.apply(destination).map(it -> true);
+        return validation.apply(destination);
     }
 
     @Override
     public DataSink createSink(DataFlowRequest request) {
-        var validationResult = validate(request);
+        var validationResult = validateRequest(request);
         if (validationResult.failed()) {
             throw new EdcException(String.join(", ", validationResult.getFailureMessages()));
         }

--- a/extensions/data-plane/data-plane-google-storage/src/main/java/org/eclipse/edc/connector/dataplane/gcp/storage/GcsDataSourceFactory.java
+++ b/extensions/data-plane/data-plane-google-storage/src/main/java/org/eclipse/edc/connector/dataplane/gcp/storage/GcsDataSourceFactory.java
@@ -44,13 +44,18 @@ public class GcsDataSourceFactory implements DataSourceFactory {
 
     @Override
     public @NotNull Result<Boolean> validate(DataFlowRequest request) {
+        return validateRequest(request).map(it -> true);
+    }
+
+    @Override
+    public @NotNull Result<Void> validateRequest(DataFlowRequest request) {
         var source = request.getSourceDataAddress();
-        return validation.apply(source).map(it -> true);
+        return validation.apply(source);
     }
 
     @Override
     public DataSource createSource(DataFlowRequest request) {
-        var validationResult = validate(request);
+        var validationResult = validateRequest(request);
         if (validationResult.failed()) {
             throw new EdcException(String.join(", ", validationResult.getFailureMessages()));
         }

--- a/extensions/data-plane/data-plane-google-storage/src/test/java/org/eclipse/edc/connector/dataplane/gcp/storage/GcsDataSinkFactoryTest.java
+++ b/extensions/data-plane/data-plane-google-storage/src/test/java/org/eclipse/edc/connector/dataplane/gcp/storage/GcsDataSinkFactoryTest.java
@@ -76,7 +76,7 @@ class GcsDataSinkFactoryTest {
 
         var request = createRequest(source);
 
-        var result = factory.validate(request);
+        var result = factory.validateRequest(request);
 
         assertThat(result.succeeded()).isTrue();
     }
@@ -92,7 +92,7 @@ class GcsDataSinkFactoryTest {
 
         var request = createRequest(source);
 
-        var result = factory.validate(request);
+        var result = factory.validateRequest(request);
 
         assertThat(result.failed()).isTrue();
     }

--- a/extensions/data-plane/data-plane-google-storage/src/test/java/org/eclipse/edc/connector/dataplane/gcp/storage/GcsDataSourceFactoryTest.java
+++ b/extensions/data-plane/data-plane-google-storage/src/test/java/org/eclipse/edc/connector/dataplane/gcp/storage/GcsDataSourceFactoryTest.java
@@ -61,7 +61,7 @@ class GcsDataSourceFactoryTest {
 
         var request = TestFunctions.createRequest(source);
 
-        var result = factory.validate(request);
+        var result = factory.validateRequest(request);
 
         assertThat(result.succeeded()).isTrue();
     }
@@ -76,7 +76,7 @@ class GcsDataSourceFactoryTest {
 
         var request = TestFunctions.createRequest(source);
 
-        var result = factory.validate(request);
+        var result = factory.validateRequest(request);
 
         assertThat(result.failed()).isTrue();
     }

--- a/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSinkFactory.java
+++ b/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSinkFactory.java
@@ -61,12 +61,17 @@ public class HttpDataSinkFactory implements DataSinkFactory {
 
     @Override
     public @NotNull Result<Boolean> validate(DataFlowRequest request) {
+        return validateRequest(request).map(it -> true);
+    }
+
+    @Override
+    public @NotNull Result<Void> validateRequest(DataFlowRequest request) {
         try {
             createSink(request);
         } catch (Exception e) {
             return Result.failure("Failed to build HttpDataSink: " + e.getMessage());
         }
-        return VALID;
+        return Result.success();
     }
 
     @Override

--- a/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSourceFactory.java
+++ b/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSourceFactory.java
@@ -52,12 +52,17 @@ public class HttpDataSourceFactory implements DataSourceFactory {
 
     @Override
     public @NotNull Result<Boolean> validate(DataFlowRequest request) {
+        return validateRequest(request).map(it -> true);
+    }
+
+    @Override
+    public @NotNull Result<Void> validateRequest(DataFlowRequest request) {
         try {
             createSource(request);
         } catch (Exception e) {
             return Result.failure("Failed to build HttpDataSource: " + e.getMessage());
         }
-        return VALID;
+        return Result.success();
     }
 
     @Override

--- a/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSinkFactoryTest.java
+++ b/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSinkFactoryTest.java
@@ -83,7 +83,7 @@ class HttpDataSinkFactoryTest {
         var request = createRequest(address);
         when(provider.provideSinkParams(request)).thenThrow(new EdcException(errorMsg));
 
-        var result = factory.validate(request);
+        var result = factory.validateRequest(request);
 
         assertThat(result.failed()).isTrue();
         assertThat(result.getFailureMessages()).hasSize(1);
@@ -101,7 +101,7 @@ class HttpDataSinkFactoryTest {
                 .build();
         when(provider.provideSinkParams(request)).thenReturn(params);
 
-        assertThat(factory.validate(request).succeeded()).isTrue();
+        assertThat(factory.validateRequest(request).succeeded()).isTrue();
         var sink = factory.createSink(request);
         assertThat(sink).isNotNull();
 

--- a/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSourceFactoryTest.java
+++ b/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSourceFactoryTest.java
@@ -69,7 +69,7 @@ class HttpDataSourceFactoryTest {
 
         when(provider.provideSourceParams(request)).thenThrow(new EdcException(errorMsg));
 
-        var result = factory.validate(request);
+        var result = factory.validateRequest(request);
         assertThat(result.failed()).isTrue();
         assertThat(result.getFailureMessages()).hasSize(1);
         assertThat(result.getFailureMessages().get(0)).contains(errorMsg);
@@ -85,7 +85,7 @@ class HttpDataSourceFactoryTest {
 
         when(provider.provideSourceParams(request)).thenReturn(params);
 
-        assertThat(factory.validate(request).succeeded()).isTrue();
+        assertThat(factory.validateRequest(request).succeeded()).isTrue();
         var source = factory.createSource(request);
         assertThat(source).isNotNull();
 

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/pipeline/DataSinkFactory.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/pipeline/DataSinkFactory.java
@@ -35,12 +35,22 @@ public interface DataSinkFactory {
 
     /**
      * Returns true if the request is valid.
+     *
+     * @deprecated use {@link #validateRequest(DataFlowRequest)} instead.
      */
+    @Deprecated(since = "milestone9")
     @NotNull Result<Boolean> validate(DataFlowRequest request);
 
     /**
      * Creates a sink to send data to.
      */
     DataSink createSink(DataFlowRequest request);
+
+    /**
+     * Returns a Result object of the validation result.
+     */
+    default @NotNull Result<Void> validateRequest(DataFlowRequest request) {
+        return validate(request).mapTo();
+    }
 
 }

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/pipeline/DataSourceFactory.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/pipeline/DataSourceFactory.java
@@ -35,12 +35,22 @@ public interface DataSourceFactory {
 
     /**
      * Returns true if the request is valid.
+     *
+     * @deprecated use {@link #validateRequest(DataFlowRequest)} instead.
      */
+    @Deprecated(since = "milestone9")
     @NotNull Result<Boolean> validate(DataFlowRequest request);
 
     /**
      * Creates a source to access data to be sent.
      */
     DataSource createSource(DataFlowRequest request);
+
+    /**
+     * Returns a Result object of the validation result.
+     */
+    default @NotNull Result<Void> validateRequest(DataFlowRequest request) {
+        return validate(request).mapTo();
+    }
 
 }

--- a/system-tests/runtimes/file-transfer-provider/src/main/java/org/eclipse/edc/test/extension/api/FileTransferDataSinkFactory.java
+++ b/system-tests/runtimes/file-transfer-provider/src/main/java/org/eclipse/edc/test/extension/api/FileTransferDataSinkFactory.java
@@ -45,8 +45,14 @@ class FileTransferDataSinkFactory implements DataSinkFactory {
 
     @Override
     public @NotNull Result<Boolean> validate(DataFlowRequest request) {
-        return Result.success(true);
+        return validateRequest(request).map(it -> true);
     }
+
+    @Override
+    public @NotNull Result<Void> validateRequest(DataFlowRequest request) {
+        return Result.success();
+    }
+
 
     @Override
     public DataSink createSink(DataFlowRequest request) {

--- a/system-tests/runtimes/file-transfer-provider/src/main/java/org/eclipse/edc/test/extension/api/FileTransferDataSourceFactory.java
+++ b/system-tests/runtimes/file-transfer-provider/src/main/java/org/eclipse/edc/test/extension/api/FileTransferDataSourceFactory.java
@@ -30,13 +30,19 @@ class FileTransferDataSourceFactory implements DataSourceFactory {
 
     @Override
     public @NotNull Result<Boolean> validate(DataFlowRequest request) {
+        return validateRequest(request).map(it -> true);
+    }
+
+    @Override
+    public @NotNull Result<Void> validateRequest(DataFlowRequest request) {
         var source = getFile(request);
         if (!source.exists()) {
             return Result.failure("Source file " + source.getName() + " does not exist!");
         }
 
-        return Result.success(true);
+        return Result.success();
     }
+
 
     @Override
     public DataSource createSource(DataFlowRequest request) {


### PR DESCRIPTION
## What this PR changes/adds

Currently, both 'DataSourceFactory' and 'DataSinkFactory' have validation method from the type Result<Boolean> but we want them to be represented by as simpler which is Result<Void> 
## Why it does that

To make the Validation check result more clear when it is used
## Further notes


## Linked Issue(s)

Closes #2498 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
