### PR TITLE
feat: update asset and dataaddress

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/asset/AssetEventListener.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/asset/AssetEventListener.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.connector.service.asset;
 import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.event.asset.AssetCreated;
 import org.eclipse.edc.spi.event.asset.AssetDeleted;
+import org.eclipse.edc.spi.event.asset.AssetUpdated;
 import org.eclipse.edc.spi.observe.asset.AssetListener;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
 
@@ -47,6 +48,16 @@ public class AssetEventListener implements AssetListener {
     @Override
     public void deleted(Asset asset) {
         var event = AssetDeleted.Builder.newInstance()
+                .assetId(asset.getId())
+                .at(clock.millis())
+                .build();
+
+        eventRouter.publish(event);
+    }
+
+    @Override
+    public void updated(Asset asset) {
+        var event = AssetUpdated.Builder.newInstance()
                 .assetId(asset.getId())
                 .at(clock.millis())
                 .build();

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/asset/AssetServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/asset/AssetServiceImpl.java
@@ -109,4 +109,32 @@ public class AssetServiceImpl implements AssetService {
             return ServiceResult.success(deleted);
         });
     }
+
+    @Override
+    public ServiceResult<Void> update(String assetId, Asset asset) {
+        return transactionContext.execute(() -> {
+            if (findById(assetId) == null) {
+                return ServiceResult.notFound(format("Asset %s cannot be updated because it does not exist", assetId));
+            }
+            var updatedAsset = index.updateAsset(assetId, asset);
+            observable.invokeForEach(l -> l.updated(updatedAsset));
+
+            return ServiceResult.success(null);
+        });
+    }
+
+    @Override
+    public ServiceResult<Void> update(String assetId, DataAddress dataAddress) {
+        return transactionContext.execute(() -> {
+            var asset = findById(assetId);
+            if (asset == null) {
+                return ServiceResult.notFound(format("DataAddress for Asset ID= %s cannot be updated because it does not exist", assetId));
+            }
+
+            index.updateDataAddress(assetId, dataAddress);
+            observable.invokeForEach(l -> l.updated(asset));
+
+            return ServiceResult.success(null);
+        });
+    }
 }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/asset/AssetServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/asset/AssetServiceImpl.java
@@ -28,6 +28,7 @@ import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 import static java.lang.String.format;
@@ -112,6 +113,9 @@ public class AssetServiceImpl implements AssetService {
 
     @Override
     public ServiceResult<Void> update(String assetId, Asset asset) {
+        if (!Objects.equals(assetId, asset.getId())) {
+            return ServiceResult.badRequest("Asset.getId() must match assetId");
+        }
         return transactionContext.execute(() -> {
             if (findById(assetId) == null) {
                 return ServiceResult.notFound(format("Asset %s cannot be updated because it does not exist", assetId));

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/asset/AssetServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/asset/AssetServiceImpl.java
@@ -119,7 +119,7 @@ public class AssetServiceImpl implements AssetService {
             var updatedAsset = index.updateAsset(assetId, asset);
             observable.invokeForEach(l -> l.updated(updatedAsset));
 
-            return ServiceResult.success(null);
+            return ServiceResult.success();
         });
     }
 
@@ -134,7 +134,7 @@ public class AssetServiceImpl implements AssetService {
             index.updateDataAddress(assetId, dataAddress);
             observable.invokeForEach(l -> l.updated(asset));
 
-            return ServiceResult.success(null);
+            return ServiceResult.success();
         });
     }
 }

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/asset/AssetServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/asset/AssetServiceImplTest.java
@@ -232,6 +232,20 @@ class AssetServiceImplTest {
     }
 
     @Test
+    void updateAsset_shouldReturnBadRequest_whenAssetIdWrong() {
+        var assetId = "assetId";
+        var asset = createAsset(assetId);
+        when(index.findById(assetId)).thenReturn(asset);
+
+        var updated = service.update("another-id", asset);
+
+        assertThat(updated.failed()).isTrue();
+        assertThat(updated.reason()).isEqualTo(BAD_REQUEST);
+        verifyNoInteractions(index);
+        verifyNoInteractions(observable);
+    }
+
+    @Test
     void updateAsset_shouldReturnNotFound_whenNotExists() {
         var assetId = "assetId";
         var asset = createAsset(assetId);

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/asset/AssetServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/asset/AssetServiceImplTest.java
@@ -45,7 +45,9 @@ import static org.eclipse.edc.service.spi.result.ServiceFailure.Reason.CONFLICT;
 import static org.eclipse.edc.service.spi.result.ServiceFailure.Reason.NOT_FOUND;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -213,6 +215,63 @@ class AssetServiceImplTest {
         var deleted = service.delete("test-asset");
         verify(contractNegotiationStore).queryNegotiations(argThat(argument -> argument.getFilterExpression().size() == 1 &&
                 argument.getFilterExpression().get(0).getOperandLeft().equals("contractAgreement.assetId")));
+    }
+
+
+    @Test
+    void updateAsset_shouldUpdateWhenExists() {
+        var assetId = "assetId";
+        var asset = createAsset(assetId);
+        when(index.findById(assetId)).thenReturn(asset);
+
+        var updated = service.update(assetId, asset);
+
+        assertThat(updated.succeeded()).isTrue();
+        verify(index).updateAsset(eq(assetId), eq(asset));
+        verify(observable).invokeForEach(any());
+    }
+
+    @Test
+    void updateAsset_shouldReturnNotFound_whenNotExists() {
+        var assetId = "assetId";
+        var asset = createAsset(assetId);
+        when(index.findById(assetId)).thenReturn(null);
+
+        var updated = service.update(assetId, asset);
+
+        assertThat(updated.failed()).isTrue();
+        assertThat(updated.reason()).isEqualTo(NOT_FOUND);
+        verify(index, never()).updateAsset(eq(assetId), eq(asset));
+        verify(observable, never()).invokeForEach(any());
+    }
+
+    @Test
+    void updateDataAddress_shouldUpdateWhenExists() {
+        when(dataAddressValidator.validate(any())).thenReturn(Result.success());
+        var assetId = "assetId";
+        var asset = createAsset(assetId);
+        var dataAddress = DataAddress.Builder.newInstance().type("test-type").build();
+        when(index.findById(assetId)).thenReturn(asset);
+
+        var updated = service.update(assetId, dataAddress);
+
+        assertThat(updated.succeeded()).isTrue();
+        verify(index).updateDataAddress(eq(assetId), eq(dataAddress));
+        verify(observable).invokeForEach(any());
+    }
+
+    @Test
+    void updateDataAddress_shouldReturnNotFound_whenNotExists() {
+        var assetId = "assetId";
+        var dataAddress = DataAddress.Builder.newInstance().type("test-type").build();
+        when(index.findById(assetId)).thenReturn(null);
+
+        var updated = service.update(assetId, dataAddress);
+
+        assertThat(updated.failed()).isTrue();
+        assertThat(updated.reason()).isEqualTo(NOT_FOUND);
+        verify(index, never()).updateDataAddress(eq(assetId), eq(dataAddress));
+        verify(observable, never()).invokeForEach(any());
     }
 
     @NotNull

--- a/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/assetindex/InMemoryAssetIndexTest.java
+++ b/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/assetindex/InMemoryAssetIndexTest.java
@@ -285,6 +285,49 @@ class InMemoryAssetIndexTest extends AssetIndexTestBase {
         assertThat(index.deleteById("not-exists")).isNull();
     }
 
+    @Test
+    void updateAsset_whenNotExists_returnsNull() {
+        var id = UUID.randomUUID().toString();
+        var asset = createAsset("test-asset", id);
+        var result = index.updateAsset(id, asset);
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void updateAsset_whenExists_returnsUpdatedAsset() {
+        var id = UUID.randomUUID().toString();
+        var asset = createAsset("test-asset", id);
+        var dataAddress = createDataAddress(asset);
+
+        index.accept(asset, dataAddress);
+
+        var newAsset = createAsset("new-name", id);
+        var result = index.updateAsset(id, newAsset);
+        assertThat(result).isNotNull().usingRecursiveComparison().isEqualTo(newAsset);
+    }
+
+    @Test
+    void updateDataAddress_whenNotExists_returnsNull() {
+        var id = UUID.randomUUID().toString();
+        var address = createDataAddress(createAsset("test-asset", id));
+        var result = index.updateDataAddress(id, address);
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void updateDataAddress_whenExists_returnsUpdatedDataAddress() {
+        var id = UUID.randomUUID().toString();
+        var asset = createAsset("test-asset", id);
+        var dataAddress = createDataAddress(asset);
+
+        index.accept(asset, dataAddress);
+
+        dataAddress.getProperties().put("new", "value");
+        var result = index.updateDataAddress(id, dataAddress);
+        assertThat(result).isNotNull().usingRecursiveComparison().isEqualTo(dataAddress);
+        assertThat(result.getProperties().get("new")).isEqualTo("value");
+    }
+
     @Override
     protected Collection<String> getSupportedOperators() {
         return List.of("=", "in");

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApi.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApi.java
@@ -26,6 +26,7 @@ import org.eclipse.edc.api.model.IdResponseDto;
 import org.eclipse.edc.api.query.QuerySpecDto;
 import org.eclipse.edc.connector.api.management.asset.model.AssetEntryDto;
 import org.eclipse.edc.connector.api.management.asset.model.AssetResponseDto;
+import org.eclipse.edc.connector.api.management.asset.model.AssetUpdateDto;
 import org.eclipse.edc.connector.api.management.asset.model.DataAddressDto;
 import org.eclipse.edc.web.spi.ApiErrorDetail;
 
@@ -89,6 +90,26 @@ public interface AssetApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
             })
     void removeAsset(String id);
+
+    @Operation(description = "Updates an asset with the given ID if it exists, creates a new one otherwise. " +
+            "DANGER ZONE: Note that updating assets can have unexpected results, especially for contract offers that have been sent out or ongoing or contract negotiations.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Asset was updated successfully"),
+                    @ApiResponse(responseCode = "404", description = "Asset could not be updated, because it does not exist. Asset need to be created together with DataAddresses."),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))),
+            })
+    void updateAsset(String assetId, @Valid AssetUpdateDto asset);
+
+    @Operation(description = "Updates a DataAddress for an asset with the given ID. ",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Asset was updated successfully"),
+                    @ApiResponse(responseCode = "404", description = "An asset with the given ID does not exist",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))),
+            })
+    void updateDataAddress(String assetId, @Valid DataAddressDto dataAddress);
 
 
     @Operation(description = "Gets a data address of an asset with the given ID",

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApi.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApi.java
@@ -91,7 +91,7 @@ public interface AssetApi {
             })
     void removeAsset(String id);
 
-    @Operation(description = "Updates an asset with the given ID if it exists, creates a new one otherwise. " +
+    @Operation(description = "Updates an asset with the given ID if it exists. If the asset is not found, no further action is taken. " +
             "DANGER ZONE: Note that updating assets can have unexpected results, especially for contract offers that have been sent out or ongoing or contract negotiations.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "Asset was updated successfully"),
@@ -101,7 +101,7 @@ public interface AssetApi {
             })
     void updateAsset(String assetId, @Valid AssetUpdateDto asset);
 
-    @Operation(description = "Updates a DataAddress for an asset with the given ID. ",
+    @Operation(description = "Updates a DataAddress for an asset with the given ID. If the asset is not found, no further action is taken",
             responses = {
                     @ApiResponse(responseCode = "200", description = "Asset was updated successfully"),
                     @ApiResponse(responseCode = "404", description = "An asset with the given ID does not exist",

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApi.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApi.java
@@ -26,7 +26,7 @@ import org.eclipse.edc.api.model.IdResponseDto;
 import org.eclipse.edc.api.query.QuerySpecDto;
 import org.eclipse.edc.connector.api.management.asset.model.AssetEntryDto;
 import org.eclipse.edc.connector.api.management.asset.model.AssetResponseDto;
-import org.eclipse.edc.connector.api.management.asset.model.AssetUpdateDto;
+import org.eclipse.edc.connector.api.management.asset.model.AssetUpdateRequestDto;
 import org.eclipse.edc.connector.api.management.asset.model.DataAddressDto;
 import org.eclipse.edc.web.spi.ApiErrorDetail;
 
@@ -99,7 +99,7 @@ public interface AssetApi {
                     @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))),
             })
-    void updateAsset(String assetId, @Valid AssetUpdateDto asset);
+    void updateAsset(String assetId, @Valid AssetUpdateRequestDto asset);
 
     @Operation(description = "Updates a DataAddress for an asset with the given ID. If the asset is not found, no further action is taken",
             responses = {

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApiController.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApiController.java
@@ -32,7 +32,7 @@ import org.eclipse.edc.api.query.QuerySpecDto;
 import org.eclipse.edc.api.transformer.DtoTransformerRegistry;
 import org.eclipse.edc.connector.api.management.asset.model.AssetEntryDto;
 import org.eclipse.edc.connector.api.management.asset.model.AssetResponseDto;
-import org.eclipse.edc.connector.api.management.asset.model.AssetUpdateDto;
+import org.eclipse.edc.connector.api.management.asset.model.AssetUpdateRequestDto;
 import org.eclipse.edc.connector.api.management.asset.model.DataAddressDto;
 import org.eclipse.edc.connector.spi.asset.AssetService;
 import org.eclipse.edc.spi.asset.DataAddressResolver;
@@ -134,7 +134,7 @@ public class AssetApiController implements AssetApi {
     @PUT
     @Path("{assetId}")
     @Override
-    public void updateAsset(@PathParam("assetId") String assetId, @Valid AssetUpdateDto asset) {
+    public void updateAsset(@PathParam("assetId") String assetId, @Valid AssetUpdateRequestDto asset) {
         var assetResult = transformerRegistry.transform(asset, Asset.class);
         if (assetResult.failed()) {
             throw new InvalidRequestException(assetResult.getFailureMessages());

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApiController.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApiController.java
@@ -33,6 +33,7 @@ import org.eclipse.edc.api.transformer.DtoTransformerRegistry;
 import org.eclipse.edc.connector.api.management.asset.model.AssetEntryDto;
 import org.eclipse.edc.connector.api.management.asset.model.AssetResponseDto;
 import org.eclipse.edc.connector.api.management.asset.model.AssetUpdateRequestDto;
+import org.eclipse.edc.connector.api.management.asset.model.AssetUpdateRequestWrapperDto;
 import org.eclipse.edc.connector.api.management.asset.model.DataAddressDto;
 import org.eclipse.edc.connector.spi.asset.AssetService;
 import org.eclipse.edc.spi.asset.DataAddressResolver;
@@ -135,7 +136,8 @@ public class AssetApiController implements AssetApi {
     @Path("{assetId}")
     @Override
     public void updateAsset(@PathParam("assetId") String assetId, @Valid AssetUpdateRequestDto asset) {
-        var assetResult = transformerRegistry.transform(asset, Asset.class);
+        var wrapper = AssetUpdateRequestWrapperDto.Builder.newInstance().updateRequest(asset).assetId(assetId).build();
+        var assetResult = transformerRegistry.transform(wrapper, Asset.class);
         if (assetResult.failed()) {
             throw new InvalidRequestException(assetResult.getFailureMessages());
         }

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApiController.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApiController.java
@@ -22,6 +22,7 @@ import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
@@ -31,6 +32,7 @@ import org.eclipse.edc.api.query.QuerySpecDto;
 import org.eclipse.edc.api.transformer.DtoTransformerRegistry;
 import org.eclipse.edc.connector.api.management.asset.model.AssetEntryDto;
 import org.eclipse.edc.connector.api.management.asset.model.AssetResponseDto;
+import org.eclipse.edc.connector.api.management.asset.model.AssetUpdateDto;
 import org.eclipse.edc.connector.api.management.asset.model.DataAddressDto;
 import org.eclipse.edc.connector.spi.asset.AssetService;
 import org.eclipse.edc.spi.asset.DataAddressResolver;
@@ -127,6 +129,30 @@ public class AssetApiController implements AssetApi {
         monitor.debug(format("Attempting to delete Asset with id %s", id));
         service.delete(id).orElseThrow(exceptionMapper(Asset.class, id));
         monitor.debug(format("Asset deleted %s", id));
+    }
+
+    @PUT
+    @Path("{assetId}")
+    @Override
+    public void updateAsset(@PathParam("assetId") String assetId, @Valid AssetUpdateDto asset) {
+        var assetResult = transformerRegistry.transform(asset, Asset.class);
+        if (assetResult.failed()) {
+            throw new InvalidRequestException(assetResult.getFailureMessages());
+        }
+        service.update(assetId, assetResult.getContent())
+                .orElseThrow(exceptionMapper(Asset.class, assetId));
+    }
+
+    @PUT
+    @Path("{assetId}/dataaddress")
+    @Override
+    public void updateDataAddress(@PathParam("assetId") String assetId, DataAddressDto dataAddress) {
+        var dataAddressResult = transformerRegistry.transform(dataAddress, DataAddress.class);
+        if (dataAddressResult.failed()) {
+            throw new InvalidRequestException(dataAddressResult.getFailureMessages());
+        }
+        service.update(assetId, dataAddressResult.getContent())
+                .orElseThrow(exceptionMapper(DataAddress.class, assetId));
     }
 
 

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApiExtension.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApiExtension.java
@@ -19,7 +19,7 @@ package org.eclipse.edc.connector.api.management.asset;
 import org.eclipse.edc.api.transformer.DtoTransformerRegistry;
 import org.eclipse.edc.connector.api.management.asset.transform.AssetRequestDtoToAssetTransformer;
 import org.eclipse.edc.connector.api.management.asset.transform.AssetToAssetResponseDtoTransformer;
-import org.eclipse.edc.connector.api.management.asset.transform.AssetUpdateDtoToAssetTransformer;
+import org.eclipse.edc.connector.api.management.asset.transform.AssetUpdateRequestWrapperDtoToAssetTransformer;
 import org.eclipse.edc.connector.api.management.asset.transform.DataAddressDtoToDataAddressTransformer;
 import org.eclipse.edc.connector.api.management.asset.transform.DataAddressToDataAddressDtoTransformer;
 import org.eclipse.edc.connector.api.management.configuration.ManagementApiConfiguration;
@@ -61,7 +61,7 @@ public class AssetApiExtension implements ServiceExtension {
         var monitor = context.getMonitor();
 
         transformerRegistry.register(new AssetRequestDtoToAssetTransformer());
-        transformerRegistry.register(new AssetUpdateDtoToAssetTransformer());
+        transformerRegistry.register(new AssetUpdateRequestWrapperDtoToAssetTransformer());
         transformerRegistry.register(new AssetToAssetResponseDtoTransformer());
         transformerRegistry.register(new DataAddressDtoToDataAddressTransformer());
         transformerRegistry.register(new DataAddressToDataAddressDtoTransformer());

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApiExtension.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApiExtension.java
@@ -19,6 +19,7 @@ package org.eclipse.edc.connector.api.management.asset;
 import org.eclipse.edc.api.transformer.DtoTransformerRegistry;
 import org.eclipse.edc.connector.api.management.asset.transform.AssetRequestDtoToAssetTransformer;
 import org.eclipse.edc.connector.api.management.asset.transform.AssetToAssetResponseDtoTransformer;
+import org.eclipse.edc.connector.api.management.asset.transform.AssetUpdateDtoToAssetTransformer;
 import org.eclipse.edc.connector.api.management.asset.transform.DataAddressDtoToDataAddressTransformer;
 import org.eclipse.edc.connector.api.management.asset.transform.DataAddressToDataAddressDtoTransformer;
 import org.eclipse.edc.connector.api.management.configuration.ManagementApiConfiguration;
@@ -60,6 +61,7 @@ public class AssetApiExtension implements ServiceExtension {
         var monitor = context.getMonitor();
 
         transformerRegistry.register(new AssetRequestDtoToAssetTransformer());
+        transformerRegistry.register(new AssetUpdateDtoToAssetTransformer());
         transformerRegistry.register(new AssetToAssetResponseDtoTransformer());
         transformerRegistry.register(new DataAddressDtoToDataAddressTransformer());
         transformerRegistry.register(new DataAddressToDataAddressDtoTransformer());

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/model/AssetCreationRequestDto.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/model/AssetCreationRequestDto.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2020 - 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -19,18 +19,16 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import jakarta.validation.constraints.AssertTrue;
-import jakarta.validation.constraints.NotNull;
 
 import java.util.Map;
+import java.util.Optional;
 
-@JsonDeserialize(builder = AssetUpdateDto.Builder.class)
-public class AssetUpdateDto {
+@JsonDeserialize(builder = AssetCreationRequestDto.Builder.class)
+public class AssetCreationRequestDto extends AssetRequestDto {
 
+    private String id;
 
-    @NotNull(message = "properties cannot be null")
-    private Map<String, Object> properties;
-
-    private AssetUpdateDto() {
+    private AssetCreationRequestDto() {
     }
 
     @JsonIgnore
@@ -39,17 +37,28 @@ public class AssetUpdateDto {
         return properties != null && properties.keySet().stream().noneMatch(it -> it == null || it.isBlank());
     }
 
+    @JsonIgnore
+    @AssertTrue(message = "id must be either null or not blank")
+    public boolean isIdValid() {
+        return Optional.of(this)
+                .map(it -> it.id)
+                .map(it -> !id.isBlank())
+                .orElse(true);
+    }
+
     public Map<String, Object> getProperties() {
         return properties;
     }
 
-    @JsonPOJOBuilder(withPrefix = "")
-    public static final class Builder {
+    public String getId() {
+        return id;
+    }
 
-        private final AssetUpdateDto dto;
+    @JsonPOJOBuilder(withPrefix = "")
+    public static final class Builder extends AssetRequestDto.Builder<AssetCreationRequestDto, Builder> {
 
         private Builder() {
-            this.dto = new AssetUpdateDto();
+            super(new AssetCreationRequestDto());
         }
 
         @JsonCreator
@@ -57,12 +66,18 @@ public class AssetUpdateDto {
             return new Builder();
         }
 
-        public Builder properties(Map<String, Object> properties) {
-            dto.properties = properties;
+        public Builder id(String id) {
+            dto.id = id;
             return this;
         }
 
-        public AssetUpdateDto build() {
+        @Override
+        public Builder self() {
+            return this;
+        }
+
+        @Override
+        public AssetCreationRequestDto build() {
             return dto;
         }
     }

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/model/AssetEntryDto.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/model/AssetEntryDto.java
@@ -24,7 +24,7 @@ import jakarta.validation.constraints.NotNull;
 public class AssetEntryDto {
     @NotNull(message = "asset cannot be null")
     @Valid
-    private AssetRequestDto asset;
+    private AssetCreationRequestDto asset;
     @NotNull(message = "dataAddress cannot be null")
     @Valid
     private DataAddressDto dataAddress;
@@ -32,7 +32,7 @@ public class AssetEntryDto {
     private AssetEntryDto() {
     }
 
-    public AssetRequestDto getAsset() {
+    public AssetCreationRequestDto getAsset() {
         return asset;
     }
 
@@ -54,7 +54,7 @@ public class AssetEntryDto {
             return new Builder();
         }
 
-        public Builder asset(AssetRequestDto asset) {
+        public Builder asset(AssetCreationRequestDto asset) {
             assetEntryDto.asset = asset;
             return this;
         }

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/model/AssetRequestDto.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/model/AssetRequestDto.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 - 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -14,75 +14,32 @@
 
 package org.eclipse.edc.connector.api.management.asset.model;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.Map;
-import java.util.Optional;
 
-@JsonDeserialize(builder = AssetRequestDto.Builder.class)
-public class AssetRequestDto {
-
-    private String id;
+public abstract class AssetRequestDto {
 
     @NotNull(message = "properties cannot be null")
-    private Map<String, Object> properties;
+    protected Map<String, Object> properties;
 
-    private AssetRequestDto() {
-    }
+    protected abstract static class Builder<A extends AssetRequestDto, B extends Builder<A, B>> {
 
-    @JsonIgnore
-    @AssertTrue(message = "no empty property keys")
-    public boolean isValid() {
-        return properties != null && properties.keySet().stream().noneMatch(it -> it == null || it.isBlank());
-    }
+        protected final A dto;
 
-    @JsonIgnore
-    @AssertTrue(message = "id must be either null or not blank")
-    public boolean isIdValid() {
-        return Optional.of(this)
-                .map(it -> it.id)
-                .map(it -> !id.isBlank())
-                .orElse(true);
-    }
-
-    public Map<String, Object> getProperties() {
-        return properties;
-    }
-
-    public String getId() {
-        return id;
-    }
-
-    @JsonPOJOBuilder(withPrefix = "")
-    public static final class Builder {
-
-        private final AssetRequestDto dto;
-
-        private Builder() {
-            this.dto = new AssetRequestDto();
+        protected Builder(A dto) {
+            this.dto = dto;
         }
 
-        @JsonCreator
-        public static Builder newInstance() {
-            return new Builder();
-        }
 
-        public Builder id(String id) {
-            dto.id = id;
-            return this;
-        }
-
-        public Builder properties(Map<String, Object> properties) {
+        public B properties(Map<String, Object> properties) {
             dto.properties = properties;
-            return this;
+            return self();
         }
 
-        public AssetRequestDto build() {
+        public abstract B self();
+
+        public A build() {
             return dto;
         }
     }

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/model/AssetUpdateDto.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/model/AssetUpdateDto.java
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.asset.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.Map;
+
+@JsonDeserialize(builder = AssetUpdateDto.Builder.class)
+public class AssetUpdateDto {
+
+
+    @NotNull(message = "properties cannot be null")
+    private Map<String, Object> properties;
+
+    private AssetUpdateDto() {
+    }
+
+    @JsonIgnore
+    @AssertTrue(message = "no empty property keys")
+    public boolean isValid() {
+        return properties != null && properties.keySet().stream().noneMatch(it -> it == null || it.isBlank());
+    }
+
+    public Map<String, Object> getProperties() {
+        return properties;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static final class Builder {
+
+        private final AssetUpdateDto dto;
+
+        private Builder() {
+            this.dto = new AssetUpdateDto();
+        }
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder properties(Map<String, Object> properties) {
+            dto.properties = properties;
+            return this;
+        }
+
+        public AssetUpdateDto build() {
+            return dto;
+        }
+    }
+}

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/model/AssetUpdateRequestDto.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/model/AssetUpdateRequestDto.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.asset.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import jakarta.validation.constraints.AssertTrue;
+
+import java.util.Map;
+
+@JsonDeserialize(builder = AssetUpdateRequestDto.Builder.class)
+public class AssetUpdateRequestDto extends AssetRequestDto {
+
+
+    private AssetUpdateRequestDto() {
+    }
+
+    @JsonIgnore
+    @AssertTrue(message = "no empty property keys")
+    public boolean isValid() {
+        return properties != null && properties.keySet().stream().noneMatch(it -> it == null || it.isBlank());
+    }
+
+    public Map<String, Object> getProperties() {
+        return properties;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static final class Builder extends AssetRequestDto.Builder<AssetUpdateRequestDto, Builder> {
+
+        private Builder() {
+            super(new AssetUpdateRequestDto());
+        }
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        @Override
+        public Builder self() {
+            return this;
+        }
+
+        @Override
+        public AssetUpdateRequestDto build() {
+            return dto;
+        }
+    }
+}

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/model/AssetUpdateRequestWrapperDto.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/model/AssetUpdateRequestWrapperDto.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.asset.model;
+
+public class AssetUpdateRequestWrapperDto extends AssetRequestDto {
+
+    private AssetUpdateRequestDto requestDto;
+    private String assetId;
+
+    private AssetUpdateRequestWrapperDto() {
+    }
+
+    public AssetUpdateRequestDto getRequestDto() {
+        return requestDto;
+    }
+
+    public String getAssetId() {
+        return assetId;
+    }
+
+
+    public static final class Builder {
+
+        private final AssetUpdateRequestWrapperDto dto;
+
+        private Builder() {
+            dto = new AssetUpdateRequestWrapperDto();
+        }
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder updateRequest(AssetUpdateRequestDto dto) {
+            this.dto.requestDto = dto;
+            return this;
+        }
+
+        public Builder assetId(String assetId) {
+            this.dto.assetId = assetId;
+            return this;
+        }
+
+        public AssetUpdateRequestWrapperDto build() {
+            return dto;
+        }
+    }
+}

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/model/AssetUpdateRequestWrapperDto.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/model/AssetUpdateRequestWrapperDto.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.edc.connector.api.management.asset.model;
 
-public class AssetUpdateRequestWrapperDto extends AssetRequestDto {
+public class AssetUpdateRequestWrapperDto {
 
     private AssetUpdateRequestDto requestDto;
     private String assetId;

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/transform/AssetRequestDtoToAssetTransformer.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/transform/AssetRequestDtoToAssetTransformer.java
@@ -15,17 +15,17 @@
 package org.eclipse.edc.connector.api.management.asset.transform;
 
 import org.eclipse.edc.api.transformer.DtoTransformer;
-import org.eclipse.edc.connector.api.management.asset.model.AssetRequestDto;
+import org.eclipse.edc.connector.api.management.asset.model.AssetCreationRequestDto;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class AssetRequestDtoToAssetTransformer implements DtoTransformer<AssetRequestDto, Asset> {
+public class AssetRequestDtoToAssetTransformer implements DtoTransformer<AssetCreationRequestDto, Asset> {
 
     @Override
-    public Class<AssetRequestDto> getInputType() {
-        return AssetRequestDto.class;
+    public Class<AssetCreationRequestDto> getInputType() {
+        return AssetCreationRequestDto.class;
     }
 
     @Override
@@ -34,7 +34,7 @@ public class AssetRequestDtoToAssetTransformer implements DtoTransformer<AssetRe
     }
 
     @Override
-    public @Nullable Asset transform(@NotNull AssetRequestDto object, @NotNull TransformerContext context) {
+    public @Nullable Asset transform(@NotNull AssetCreationRequestDto object, @NotNull TransformerContext context) {
         return Asset.Builder.newInstance()
                 .id(object.getId())
                 .properties(object.getProperties())

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/transform/AssetUpdateDtoToAssetTransformer.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/transform/AssetUpdateDtoToAssetTransformer.java
@@ -15,16 +15,16 @@
 package org.eclipse.edc.connector.api.management.asset.transform;
 
 import org.eclipse.edc.api.transformer.DtoTransformer;
-import org.eclipse.edc.connector.api.management.asset.model.AssetUpdateDto;
+import org.eclipse.edc.connector.api.management.asset.model.AssetUpdateRequestDto;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class AssetUpdateDtoToAssetTransformer implements DtoTransformer<AssetUpdateDto, Asset> {
+public class AssetUpdateDtoToAssetTransformer implements DtoTransformer<AssetUpdateRequestDto, Asset> {
     @Override
-    public Class<AssetUpdateDto> getInputType() {
-        return AssetUpdateDto.class;
+    public Class<AssetUpdateRequestDto> getInputType() {
+        return AssetUpdateRequestDto.class;
     }
 
     @Override
@@ -33,7 +33,7 @@ public class AssetUpdateDtoToAssetTransformer implements DtoTransformer<AssetUpd
     }
 
     @Override
-    public @Nullable Asset transform(@NotNull AssetUpdateDto object, @NotNull TransformerContext context) {
+    public @Nullable Asset transform(@NotNull AssetUpdateRequestDto object, @NotNull TransformerContext context) {
         return Asset.Builder.newInstance()
                 .properties(object.getProperties())
                 .build();

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/transform/AssetUpdateDtoToAssetTransformer.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/transform/AssetUpdateDtoToAssetTransformer.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.asset.transform;
+
+import org.eclipse.edc.api.transformer.DtoTransformer;
+import org.eclipse.edc.connector.api.management.asset.model.AssetUpdateDto;
+import org.eclipse.edc.spi.types.domain.asset.Asset;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class AssetUpdateDtoToAssetTransformer implements DtoTransformer<AssetUpdateDto, Asset> {
+    @Override
+    public Class<AssetUpdateDto> getInputType() {
+        return AssetUpdateDto.class;
+    }
+
+    @Override
+    public Class<Asset> getOutputType() {
+        return Asset.class;
+    }
+
+    @Override
+    public @Nullable Asset transform(@NotNull AssetUpdateDto object, @NotNull TransformerContext context) {
+        return Asset.Builder.newInstance()
+                .properties(object.getProperties())
+                .build();
+    }
+}

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/transform/AssetUpdateRequestWrapperDtoToAssetTransformer.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/transform/AssetUpdateRequestWrapperDtoToAssetTransformer.java
@@ -15,16 +15,16 @@
 package org.eclipse.edc.connector.api.management.asset.transform;
 
 import org.eclipse.edc.api.transformer.DtoTransformer;
-import org.eclipse.edc.connector.api.management.asset.model.AssetUpdateRequestDto;
+import org.eclipse.edc.connector.api.management.asset.model.AssetUpdateRequestWrapperDto;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class AssetUpdateDtoToAssetTransformer implements DtoTransformer<AssetUpdateRequestDto, Asset> {
+public class AssetUpdateRequestWrapperDtoToAssetTransformer implements DtoTransformer<AssetUpdateRequestWrapperDto, Asset> {
     @Override
-    public Class<AssetUpdateRequestDto> getInputType() {
-        return AssetUpdateRequestDto.class;
+    public Class<AssetUpdateRequestWrapperDto> getInputType() {
+        return AssetUpdateRequestWrapperDto.class;
     }
 
     @Override
@@ -33,9 +33,10 @@ public class AssetUpdateDtoToAssetTransformer implements DtoTransformer<AssetUpd
     }
 
     @Override
-    public @Nullable Asset transform(@NotNull AssetUpdateRequestDto object, @NotNull TransformerContext context) {
+    public @Nullable Asset transform(@NotNull AssetUpdateRequestWrapperDto object, @NotNull TransformerContext context) {
         return Asset.Builder.newInstance()
-                .properties(object.getProperties())
+                .properties(object.getRequestDto().getProperties())
+                .id(object.getAssetId())
                 .build();
     }
 }

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/AssetApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/AssetApiControllerIntegrationTest.java
@@ -18,8 +18,8 @@ package org.eclipse.edc.connector.api.management.asset;
 import io.restassured.specification.RequestSpecification;
 import org.eclipse.edc.api.model.CriterionDto;
 import org.eclipse.edc.api.query.QuerySpecDto;
+import org.eclipse.edc.connector.api.management.asset.model.AssetCreationRequestDto;
 import org.eclipse.edc.connector.api.management.asset.model.AssetEntryDto;
-import org.eclipse.edc.connector.api.management.asset.model.AssetRequestDto;
 import org.eclipse.edc.connector.api.management.asset.model.DataAddressDto;
 import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
@@ -190,7 +190,7 @@ public class AssetApiControllerIntegrationTest {
 
     @Test
     void postAsset_supportOldIdAsPropertyApi(AssetIndex assetIndex) {
-        var assetDto = AssetRequestDto.Builder.newInstance().properties(Map.of(Asset.PROPERTY_ID, "assetId", "Asset-1", "An Asset")).build();
+        var assetDto = AssetCreationRequestDto.Builder.newInstance().properties(Map.of(Asset.PROPERTY_ID, "assetId", "Asset-1", "An Asset")).build();
         var dataAddress = DataAddressDto.Builder.newInstance().properties(Map.of("type", "type", "asset-1", "/localhost")).build();
         var assetEntryDto = AssetEntryDto.Builder.newInstance().asset(assetDto).dataAddress(dataAddress).build();
 
@@ -207,7 +207,7 @@ public class AssetApiControllerIntegrationTest {
 
     @Test
     void postAsset_invalidBody_nullDataAddress(AssetIndex assetIndex) {
-        var assetDto = AssetRequestDto.Builder.newInstance().id("assetId").properties(Map.of("Asset-1", "An Asset")).build();
+        var assetDto = AssetCreationRequestDto.Builder.newInstance().id("assetId").properties(Map.of("Asset-1", "An Asset")).build();
         var assetEntryDto = AssetEntryDto.Builder.newInstance().asset(assetDto).dataAddress(null).build();
 
         baseRequest()
@@ -404,13 +404,13 @@ public class AssetApiControllerIntegrationTest {
     }
 
     private AssetEntryDto createAssetEntryDto(String id) {
-        var assetDto = AssetRequestDto.Builder.newInstance().id(id).properties(Map.of("Asset-1", "An Asset")).build();
+        var assetDto = AssetCreationRequestDto.Builder.newInstance().id(id).properties(Map.of("Asset-1", "An Asset")).build();
         var dataAddress = DataAddressDto.Builder.newInstance().properties(Map.of("type", "type", "asset-1", "/localhost")).build();
         return AssetEntryDto.Builder.newInstance().asset(assetDto).dataAddress(dataAddress).build();
     }
 
     private AssetEntryDto createAssetEntryDto_emptyAttributes() {
-        var assetDto = AssetRequestDto.Builder.newInstance().properties(Collections.singletonMap("", "")).build();
+        var assetDto = AssetCreationRequestDto.Builder.newInstance().properties(Collections.singletonMap("", "")).build();
         var dataAddress = DataAddressDto.Builder.newInstance().properties(Collections.singletonMap("", "")).build();
         return AssetEntryDto.Builder.newInstance().asset(assetDto).dataAddress(dataAddress).build();
     }

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/AssetApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/AssetApiControllerTest.java
@@ -20,10 +20,10 @@ package org.eclipse.edc.connector.api.management.asset;
 import org.eclipse.edc.api.model.IdResponseDto;
 import org.eclipse.edc.api.query.QuerySpecDto;
 import org.eclipse.edc.api.transformer.DtoTransformerRegistry;
+import org.eclipse.edc.connector.api.management.asset.model.AssetCreationRequestDto;
 import org.eclipse.edc.connector.api.management.asset.model.AssetEntryDto;
-import org.eclipse.edc.connector.api.management.asset.model.AssetRequestDto;
 import org.eclipse.edc.connector.api.management.asset.model.AssetResponseDto;
-import org.eclipse.edc.connector.api.management.asset.model.AssetUpdateDto;
+import org.eclipse.edc.connector.api.management.asset.model.AssetUpdateRequestDto;
 import org.eclipse.edc.connector.api.management.asset.model.DataAddressDto;
 import org.eclipse.edc.connector.spi.asset.AssetService;
 import org.eclipse.edc.service.spi.result.ServiceResult;
@@ -71,11 +71,11 @@ public class AssetApiControllerTest {
     @Test
     void createAsset() {
         var assetEntry = AssetEntryDto.Builder.newInstance()
-                .asset(AssetRequestDto.Builder.newInstance().build())
+                .asset(AssetCreationRequestDto.Builder.newInstance().build())
                 .dataAddress(DataAddressDto.Builder.newInstance().build())
                 .build();
         var asset = Asset.Builder.newInstance().build();
-        when(transformerRegistry.transform(isA(AssetRequestDto.class), eq(Asset.class))).thenReturn(Result.success(asset));
+        when(transformerRegistry.transform(isA(AssetCreationRequestDto.class), eq(Asset.class))).thenReturn(Result.success(asset));
         when(transformerRegistry.transform(isA(DataAddressDto.class), eq(DataAddress.class))).thenReturn(Result.success(DataAddress.Builder.newInstance().type("any").build()));
         when(service.create(any(), any())).thenReturn(ServiceResult.success(asset));
 
@@ -95,12 +95,12 @@ public class AssetApiControllerTest {
     void createAsset_returnExpectedId() {
         var assetId = UUID.randomUUID().toString();
         var assetEntry = AssetEntryDto.Builder.newInstance()
-                .asset(AssetRequestDto.Builder.newInstance().build())
+                .asset(AssetCreationRequestDto.Builder.newInstance().build())
                 .dataAddress(DataAddressDto.Builder.newInstance().build())
                 .build();
 
         var asset = Asset.Builder.newInstance().id(assetId).build();
-        when(transformerRegistry.transform(isA(AssetRequestDto.class), eq(Asset.class))).thenReturn(Result.success(asset));
+        when(transformerRegistry.transform(isA(AssetCreationRequestDto.class), eq(Asset.class))).thenReturn(Result.success(asset));
         when(transformerRegistry.transform(isA(DataAddressDto.class), eq(DataAddress.class))).thenReturn(Result.success(DataAddress.Builder.newInstance().type("any").build()));
         when(service.create(any(), any())).thenReturn(ServiceResult.success(asset));
 
@@ -112,11 +112,11 @@ public class AssetApiControllerTest {
     @Test
     void createAsset_alreadyExists() {
         var assetEntry = AssetEntryDto.Builder.newInstance()
-                .asset(AssetRequestDto.Builder.newInstance().build())
+                .asset(AssetCreationRequestDto.Builder.newInstance().build())
                 .dataAddress(DataAddressDto.Builder.newInstance().build())
                 .build();
         var asset = Asset.Builder.newInstance().build();
-        when(transformerRegistry.transform(isA(AssetRequestDto.class), eq(Asset.class))).thenReturn(Result.success(asset));
+        when(transformerRegistry.transform(isA(AssetCreationRequestDto.class), eq(Asset.class))).thenReturn(Result.success(asset));
         when(transformerRegistry.transform(isA(DataAddressDto.class), eq(DataAddress.class))).thenReturn(Result.success(DataAddress.Builder.newInstance().type("any").build()));
         when(service.create(any(), any())).thenReturn(ServiceResult.conflict("already exists"));
 
@@ -126,10 +126,10 @@ public class AssetApiControllerTest {
     @Test
     void createAsset_transformFails() {
         var assetEntry = AssetEntryDto.Builder.newInstance()
-                .asset(AssetRequestDto.Builder.newInstance().build())
+                .asset(AssetCreationRequestDto.Builder.newInstance().build())
                 .dataAddress(DataAddressDto.Builder.newInstance().build())
                 .build();
-        when(transformerRegistry.transform(isA(AssetRequestDto.class), eq(Asset.class))).thenReturn(Result.failure("failed"));
+        when(transformerRegistry.transform(isA(AssetCreationRequestDto.class), eq(Asset.class))).thenReturn(Result.failure("failed"));
         when(transformerRegistry.transform(isA(DataAddressDto.class), eq(DataAddress.class))).thenReturn(Result.failure("failed"));
         when(service.create(any(), any())).thenReturn(ServiceResult.conflict("already exists"));
 
@@ -293,11 +293,11 @@ public class AssetApiControllerTest {
 
     @Test
     void update_whenExists() {
-        var assetEntry = AssetUpdateDto.Builder.newInstance()
+        var assetEntry = AssetUpdateRequestDto.Builder.newInstance()
                 .properties(Map.of("key1", "value1"))
                 .build();
         var asset = Asset.Builder.newInstance().property("key1", "value1").build();
-        when(transformerRegistry.transform(isA(AssetUpdateDto.class), eq(Asset.class))).thenReturn(Result.success(asset));
+        when(transformerRegistry.transform(isA(AssetUpdateRequestDto.class), eq(Asset.class))).thenReturn(Result.success(asset));
         when(service.update(any(), any(Asset.class))).thenReturn(ServiceResult.success());
 
         var assetId = "test-asset-1";
@@ -308,11 +308,11 @@ public class AssetApiControllerTest {
 
     @Test
     void update_whenNotExists_shouldThrowException() {
-        var assetEntry = AssetUpdateDto.Builder.newInstance()
+        var assetEntry = AssetUpdateRequestDto.Builder.newInstance()
                 .properties(Map.of("key1", "value1"))
                 .build();
         var asset = Asset.Builder.newInstance().property("key1", "value1").build();
-        when(transformerRegistry.transform(isA(AssetUpdateDto.class), eq(Asset.class))).thenReturn(Result.success(asset));
+        when(transformerRegistry.transform(isA(AssetUpdateRequestDto.class), eq(Asset.class))).thenReturn(Result.success(asset));
         when(service.update(any(), any(Asset.class))).thenReturn(ServiceResult.notFound("not found"));
 
         var assetId = "test-asset-1";
@@ -321,10 +321,10 @@ public class AssetApiControllerTest {
 
     @Test
     void update_whenTransformationFails_shouldThrowException() {
-        var assetEntry = AssetUpdateDto.Builder.newInstance()
+        var assetEntry = AssetUpdateRequestDto.Builder.newInstance()
                 .properties(Map.of("key1", "value1"))
                 .build();
-        when(transformerRegistry.transform(isA(AssetUpdateDto.class), eq(Asset.class))).thenReturn(Result.failure("test"));
+        when(transformerRegistry.transform(isA(AssetUpdateRequestDto.class), eq(Asset.class))).thenReturn(Result.failure("test"));
 
         var assetId = "test-asset-1";
         assertThatThrownBy(() -> controller.updateAsset(assetId, assetEntry))

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/AssetApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/AssetApiControllerTest.java
@@ -298,7 +298,7 @@ public class AssetApiControllerTest {
                 .build();
         var asset = Asset.Builder.newInstance().property("key1", "value1").build();
         when(transformerRegistry.transform(isA(AssetUpdateDto.class), eq(Asset.class))).thenReturn(Result.success(asset));
-        when(service.update(any(), any(Asset.class))).thenReturn(ServiceResult.success(null));
+        when(service.update(any(), any(Asset.class))).thenReturn(ServiceResult.success());
 
         var assetId = "test-asset-1";
         controller.updateAsset(assetId, assetEntry);
@@ -338,7 +338,7 @@ public class AssetApiControllerTest {
                 .build();
         var dataAddress = DataAddress.Builder.newInstance().type("test-type").property("key1", "value1").build();
         when(transformerRegistry.transform(isA(DataAddressDto.class), eq(DataAddress.class))).thenReturn(Result.success(dataAddress));
-        when(service.update(any(), any(DataAddress.class))).thenReturn(ServiceResult.success(null));
+        when(service.update(any(), any(DataAddress.class))).thenReturn(ServiceResult.success());
 
         var assetId = "test-dataAddress-1";
         controller.updateDataAddress(assetId, dataAddressDto);

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/AssetApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/AssetApiControllerTest.java
@@ -24,6 +24,7 @@ import org.eclipse.edc.connector.api.management.asset.model.AssetCreationRequest
 import org.eclipse.edc.connector.api.management.asset.model.AssetEntryDto;
 import org.eclipse.edc.connector.api.management.asset.model.AssetResponseDto;
 import org.eclipse.edc.connector.api.management.asset.model.AssetUpdateRequestDto;
+import org.eclipse.edc.connector.api.management.asset.model.AssetUpdateRequestWrapperDto;
 import org.eclipse.edc.connector.api.management.asset.model.DataAddressDto;
 import org.eclipse.edc.connector.spi.asset.AssetService;
 import org.eclipse.edc.service.spi.result.ServiceResult;
@@ -297,7 +298,7 @@ public class AssetApiControllerTest {
                 .properties(Map.of("key1", "value1"))
                 .build();
         var asset = Asset.Builder.newInstance().property("key1", "value1").build();
-        when(transformerRegistry.transform(isA(AssetUpdateRequestDto.class), eq(Asset.class))).thenReturn(Result.success(asset));
+        when(transformerRegistry.transform(isA(AssetUpdateRequestWrapperDto.class), eq(Asset.class))).thenReturn(Result.success(asset));
         when(service.update(any(), any(Asset.class))).thenReturn(ServiceResult.success());
 
         var assetId = "test-asset-1";
@@ -312,7 +313,7 @@ public class AssetApiControllerTest {
                 .properties(Map.of("key1", "value1"))
                 .build();
         var asset = Asset.Builder.newInstance().property("key1", "value1").build();
-        when(transformerRegistry.transform(isA(AssetUpdateRequestDto.class), eq(Asset.class))).thenReturn(Result.success(asset));
+        when(transformerRegistry.transform(isA(AssetUpdateRequestWrapperDto.class), eq(Asset.class))).thenReturn(Result.success(asset));
         when(service.update(any(), any(Asset.class))).thenReturn(ServiceResult.notFound("not found"));
 
         var assetId = "test-asset-1";
@@ -324,7 +325,7 @@ public class AssetApiControllerTest {
         var assetEntry = AssetUpdateRequestDto.Builder.newInstance()
                 .properties(Map.of("key1", "value1"))
                 .build();
-        when(transformerRegistry.transform(isA(AssetUpdateRequestDto.class), eq(Asset.class))).thenReturn(Result.failure("test"));
+        when(transformerRegistry.transform(isA(AssetUpdateRequestWrapperDto.class), eq(Asset.class))).thenReturn(Result.failure("test"));
 
         var assetId = "test-asset-1";
         assertThatThrownBy(() -> controller.updateAsset(assetId, assetEntry))

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/model/AssetCreationRequestDtoTest.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/model/AssetCreationRequestDtoTest.java
@@ -23,7 +23,7 @@ import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class AssetRequestDtoTest {
+public class AssetCreationRequestDtoTest {
 
     private ObjectMapper objectMapper;
 
@@ -34,13 +34,13 @@ public class AssetRequestDtoTest {
 
     @Test
     void verifySerialization() throws JsonProcessingException {
-        var assetDto = AssetRequestDto.Builder.newInstance().properties(Collections.singletonMap("Asset-1", "")).build();
+        var assetDto = AssetCreationRequestDto.Builder.newInstance().properties(Collections.singletonMap("Asset-1", "")).build();
 
         var str = objectMapper.writeValueAsString(assetDto);
 
         assertThat(str).isNotNull();
 
-        var deserialized = objectMapper.readValue(str, AssetRequestDto.class);
+        var deserialized = objectMapper.readValue(str, AssetCreationRequestDto.class);
         assertThat(deserialized).usingRecursiveComparison().isEqualTo(assetDto);
     }
 }

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/model/AssetCreationRequestDtoValidationTest.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/model/AssetCreationRequestDtoValidationTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class AssetRequestDtoValidationTest {
+class AssetCreationRequestDtoValidationTest {
 
     private Validator validator;
 
@@ -48,7 +48,7 @@ class AssetRequestDtoValidationTest {
     @Test
     void verifyValidation_assetEntryDto_missingDataAddress() {
         var entry = AssetEntryDto.Builder.newInstance()
-                .asset(AssetRequestDto.Builder.newInstance().id("test-asset").build())
+                .asset(AssetCreationRequestDto.Builder.newInstance().id("test-asset").build())
                 .dataAddress(null) // should break validation
                 .build();
 
@@ -59,7 +59,7 @@ class AssetRequestDtoValidationTest {
 
     @Test
     void verifyValidation_assetDto_missingProperties() {
-        var asset = AssetRequestDto.Builder.newInstance()
+        var asset = AssetCreationRequestDto.Builder.newInstance()
                 .properties(null)
                 .build();
 
@@ -70,7 +70,7 @@ class AssetRequestDtoValidationTest {
 
     @Test
     void verifyValidation_assetDto_blankId() {
-        var asset = AssetRequestDto.Builder.newInstance()
+        var asset = AssetCreationRequestDto.Builder.newInstance()
                 .id(" ")
                 .build();
 

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/model/AssetEntryDtoTest.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/model/AssetEntryDtoTest.java
@@ -35,7 +35,7 @@ public class AssetEntryDtoTest {
     @Test
     void verifySerialization() throws JsonProcessingException {
 
-        var assetDto = AssetRequestDto.Builder.newInstance().properties(Collections.singletonMap("Asset-1", "")).build();
+        var assetDto = AssetCreationRequestDto.Builder.newInstance().properties(Collections.singletonMap("Asset-1", "")).build();
         var dataAddress = DataAddressDto.Builder.newInstance().properties(Collections.singletonMap("asset-1", "/localhost")).build();
 
         var assetEntryDto = AssetEntryDto.Builder.newInstance().asset(assetDto).dataAddress(dataAddress).build();

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/model/AssetUpdateRequestDtoTest.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/model/AssetUpdateRequestDtoTest.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.asset.model;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AssetUpdateRequestDtoTest {
+    private ObjectMapper objectMapper;
+
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    void verifySerDes() throws JsonProcessingException {
+        var dto = AssetUpdateRequestDto.Builder.newInstance()
+                .properties(Map.of("key1", "value1", "key2", "value2"))
+                .build();
+
+        var json = objectMapper.writeValueAsString(dto);
+        assertThat(json).isNotNull();
+
+        var deser = objectMapper.readValue(json, AssetUpdateRequestDto.class);
+
+        assertThat(deser).usingRecursiveComparison().isEqualTo(dto);
+    }
+}
+

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/model/AssetUpdateRequestDtoValidationTest.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/model/AssetUpdateRequestDtoValidationTest.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.asset.model;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AssetUpdateRequestDtoValidationTest {
+
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+            validator = factory.getValidator();
+        }
+    }
+
+    @Test
+    void verifyValidation_assetDto_missingProperties() {
+        var asset = AssetUpdateRequestDto.Builder.newInstance()
+                .properties(null)
+                .build();
+
+        var result = validator.validate(asset);
+
+        assertThat(result).anySatisfy(cv -> assertThat(cv.getMessage()).isEqualTo("properties cannot be null"));
+    }
+
+}

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/transform/AssetRequestDtoToAssetTransformerTestCreation.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/transform/AssetRequestDtoToAssetTransformerTestCreation.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.edc.connector.api.management.asset.transform;
 
-import org.eclipse.edc.connector.api.management.asset.model.AssetRequestDto;
+import org.eclipse.edc.connector.api.management.asset.model.AssetCreationRequestDto;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.junit.jupiter.api.Test;
@@ -24,7 +24,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-class AssetRequestDtoToAssetTransformerTest {
+class AssetRequestDtoToAssetTransformerTestCreation {
 
     private final AssetRequestDtoToAssetTransformer transformer = new AssetRequestDtoToAssetTransformer();
 
@@ -37,7 +37,7 @@ class AssetRequestDtoToAssetTransformerTest {
     @Test
     void transform_id() {
         var context = mock(TransformerContext.class);
-        var assetDto = AssetRequestDto.Builder.newInstance().id("assetId").properties(Map.of("key", "value")).build();
+        var assetDto = AssetCreationRequestDto.Builder.newInstance().id("assetId").properties(Map.of("key", "value")).build();
 
         var asset = transformer.transform(assetDto, context);
 
@@ -49,7 +49,7 @@ class AssetRequestDtoToAssetTransformerTest {
     @Test
     void transform_nullId() {
         var context = mock(TransformerContext.class);
-        var assetDto = AssetRequestDto.Builder.newInstance().properties(Map.of("key", "value")).build();
+        var assetDto = AssetCreationRequestDto.Builder.newInstance().properties(Map.of("key", "value")).build();
 
         var asset = transformer.transform(assetDto, context);
 
@@ -61,7 +61,7 @@ class AssetRequestDtoToAssetTransformerTest {
     @Test
     void transform_idFromProperties() {
         var context = mock(TransformerContext.class);
-        var assetDto = AssetRequestDto.Builder.newInstance().properties(Map.of(Asset.PROPERTY_ID, "assetId", "key", "value")).build();
+        var assetDto = AssetCreationRequestDto.Builder.newInstance().properties(Map.of(Asset.PROPERTY_ID, "assetId", "key", "value")).build();
 
         var asset = transformer.transform(assetDto, context);
 

--- a/extensions/control-plane/store/cosmos/asset-index-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/assetindex/AssetIndexCosmosConfig.java
+++ b/extensions/control-plane/store/cosmos/asset-index-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/assetindex/AssetIndexCosmosConfig.java
@@ -26,7 +26,7 @@ public class AssetIndexCosmosConfig extends AbstractCosmosConfig {
     private static final String COSMOS_DBNAME_SETTING = "edc.assetindex.cosmos.database-name";
     @Setting
     private static final String COSMOS_PREFERRED_REGION_SETTING = "edc.assetindex.cosmos.preferred-region";
-    @Setting
+    @Setting(value = "string", type = "something", required = true)
     private static final String COSMOS_CONTAINER_NAME_SETTING = "edc.assetindex.cosmos.container-name";
 
     /**

--- a/extensions/control-plane/store/cosmos/asset-index-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/assetindex/CosmosAssetIndex.java
+++ b/extensions/control-plane/store/cosmos/asset-index-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/assetindex/CosmosAssetIndex.java
@@ -127,6 +127,16 @@ public class CosmosAssetIndex implements AssetIndex {
     }
 
     @Override
+    public Asset updateAsset(String assetId, Asset asset) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DataAddress updateDataAddress(String assetId, DataAddress dataAddress) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public DataAddress resolveForAsset(String assetId) {
         return queryByIdInternal(assetId).map(AssetDocument::getDataAddress).orElse(null);
     }

--- a/extensions/control-plane/store/cosmos/asset-index-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/assetindex/CosmosAssetIndex.java
+++ b/extensions/control-plane/store/cosmos/asset-index-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/assetindex/CosmosAssetIndex.java
@@ -128,12 +128,26 @@ public class CosmosAssetIndex implements AssetIndex {
 
     @Override
     public Asset updateAsset(String assetId, Asset asset) {
-        throw new UnsupportedOperationException();
+        // cannot simply invoke assetDb.saveItem, because for that we'd need the DataAddress, which we don't have here
+        var result = queryByIdInternal(assetId);
+
+        return result.map(assetDocument -> {
+            var updated = new AssetDocument(asset, assetDocument.getPartitionKey(), assetDocument.getDataAddress());
+            assetDb.saveItem(updated);
+            return asset;
+        }).orElse(null);
     }
 
     @Override
     public DataAddress updateDataAddress(String assetId, DataAddress dataAddress) {
-        throw new UnsupportedOperationException();
+        // cannot simply invoke assetDb.saveItem, because for that we'd need the Asset, which we don't have here
+        var result = queryByIdInternal(assetId);
+
+        return result.map(assetDocument -> {
+            var updated = new AssetDocument(assetDocument.getWrappedAsset(), assetDocument.getPartitionKey(), dataAddress);
+            assetDb.saveItem(updated);
+            return dataAddress;
+        }).orElse(null);
     }
 
     @Override

--- a/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/assetindex/SqlAssetIndex.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/assetindex/SqlAssetIndex.java
@@ -191,7 +191,7 @@ public class SqlAssetIndex extends AbstractSqlStore implements AssetIndex {
         return transactionContext.execute(() -> {
             try (var connection = getConnection()) {
                 if (existsById(assetId, connection)) {
-                    executeQuery(connection, "DELETE FROM " + assetStatements.getAssetPropertyTable() + " WHERE " + assetStatements.getPropertyAssetIdFkColumn() + "='" + assetId + "'");
+                    executeQuery(connection, assetStatements.getDeletePropertyByIdTemplate(), assetId);
                     for (var property : asset.getProperties().entrySet()) {
                         executeQuery(connection, assetStatements.getInsertPropertyTemplate(),
                                 assetId,

--- a/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/assetindex/SqlAssetIndex.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/assetindex/SqlAssetIndex.java
@@ -187,6 +187,46 @@ public class SqlAssetIndex extends AbstractSqlStore implements AssetIndex {
     }
 
     @Override
+    public Asset updateAsset(String assetId, Asset asset) {
+        return transactionContext.execute(() -> {
+            try (var connection = getConnection()) {
+                if (existsById(assetId, connection)) {
+                    executeQuery(connection, "DELETE FROM " + assetStatements.getAssetPropertyTable() + " WHERE " + assetStatements.getPropertyAssetIdFkColumn() + "='" + assetId + "'");
+                    for (var property : asset.getProperties().entrySet()) {
+                        executeQuery(connection, assetStatements.getInsertPropertyTemplate(),
+                                assetId,
+                                property.getKey(),
+                                toJson(property.getValue()),
+                                property.getValue().getClass().getName());
+                    }
+                    return asset;
+                }
+                return null;
+
+            } catch (Exception e) {
+                throw new EdcPersistenceException(e);
+            }
+        });
+    }
+
+    @Override
+    public DataAddress updateDataAddress(String assetId, DataAddress dataAddress) {
+        return transactionContext.execute(() -> {
+            try (var connection = getConnection()) {
+                if (existsById(assetId, connection)) {
+                    var updateTemplate = assetStatements.getUpdateDataAddressTemplate();
+                    executeQuery(connection, updateTemplate, toJson(dataAddress.getProperties()), assetId);
+                    return dataAddress;
+                }
+                return null;
+
+            } catch (Exception e) {
+                throw new EdcPersistenceException(e);
+            }
+        });
+    }
+
+    @Override
     public DataAddress resolveForAsset(String assetId) {
         Objects.requireNonNull(assetId);
 
@@ -243,7 +283,7 @@ public class SqlAssetIndex extends AbstractSqlStore implements AssetIndex {
 
     private DataAddress mapDataAddress(ResultSet resultSet) throws SQLException, JsonProcessingException {
         return DataAddress.Builder.newInstance()
-                .properties(fromJson(resultSet.getString(assetStatements.getDataAddressColumnProperties()), new TypeReference<>() {
+                .properties(fromJson(resultSet.getString(assetStatements.getDataAddressPropertiesColumn()), new TypeReference<>() {
                 }))
                 .build();
     }

--- a/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/assetindex/schema/AssetStatements.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/assetindex/schema/AssetStatements.java
@@ -140,6 +140,10 @@ public interface AssetStatements {
      */
     String getUpdateDataAddressTemplate();
 
+    /**
+     * DELETE statement for properties of an Asset. Useful for delete-insert (=update) operations
+     */
+    String getDeletePropertyByIdTemplate();
 
     /**
      * The COUNT variable used in SELECT COUNT queries.
@@ -176,5 +180,6 @@ public interface AssetStatements {
      * Select single asset by ID
      */
     String getSelectAssetByIdTemplate();
+
 
 }

--- a/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/assetindex/schema/AssetStatements.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/assetindex/schema/AssetStatements.java
@@ -51,7 +51,7 @@ public interface AssetStatements {
     /**
      * The data address table properties column.
      */
-    default String getDataAddressColumnProperties() {
+    default String getDataAddressPropertiesColumn() {
         return "properties";
     }
 
@@ -136,6 +136,12 @@ public interface AssetStatements {
     String getDeleteAssetByIdTemplate();
 
     /**
+     * UPDATE statement for data addresses
+     */
+    String getUpdateDataAddressTemplate();
+
+
+    /**
      * The COUNT variable used in SELECT COUNT queries.
      */
     String getCountVariableName();
@@ -170,4 +176,5 @@ public interface AssetStatements {
      * Select single asset by ID
      */
     String getSelectAssetByIdTemplate();
+
 }

--- a/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/assetindex/schema/BaseSqlDialectStatements.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/assetindex/schema/BaseSqlDialectStatements.java
@@ -94,6 +94,11 @@ public class BaseSqlDialectStatements implements AssetStatements {
     }
 
     @Override
+    public String getDeletePropertyByIdTemplate() {
+        return format("DELETE FROM %s WHERE %s = ?", getAssetPropertyTable(), getPropertyAssetIdFkColumn());
+    }
+
+    @Override
     public String getCountVariableName() {
         return "COUNT";
     }

--- a/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/assetindex/schema/BaseSqlDialectStatements.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/assetindex/schema/BaseSqlDialectStatements.java
@@ -39,7 +39,7 @@ public class BaseSqlDialectStatements implements AssetStatements {
         return format("INSERT INTO %s (%s, %s) VALUES (?, ?%s)",
                 getDataAddressTable(),
                 getDataAddressAssetIdFkColumn(),
-                getDataAddressColumnProperties(),
+                getDataAddressPropertiesColumn(),
                 getFormatAsJsonOperator());
     }
 
@@ -83,6 +83,14 @@ public class BaseSqlDialectStatements implements AssetStatements {
     @Override
     public String getDeleteAssetByIdTemplate() {
         return format("DELETE FROM %s WHERE %s = ?", getAssetTable(), getAssetIdColumn());
+    }
+
+    @Override
+    public String getUpdateDataAddressTemplate() {
+        return format("UPDATE %s SET %s = ?%s WHERE %s = ?", getDataAddressTable(),
+                getDataAddressPropertiesColumn(),
+                getFormatAsJsonOperator(),
+                getDataAddressAssetIdFkColumn());
     }
 
     @Override

--- a/extensions/control-plane/store/sql/asset-index-sql/src/test/java/org/eclipse/edc/connector/store/sql/assetindex/PostgresAssetIndexTest.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/test/java/org/eclipse/edc/connector/store/sql/assetindex/PostgresAssetIndexTest.java
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.sql.SQLException;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -52,7 +51,7 @@ class PostgresAssetIndexTest extends AssetIndexTestBase {
 
 
     @BeforeEach
-    void setUp(PostgresqlStoreSetupExtension setupExtension) throws IOException, SQLException {
+    void setUp(PostgresqlStoreSetupExtension setupExtension) throws IOException {
         var typeManager = new TypeManager();
         typeManager.registerTypes(PolicyRegistrationTypes.TYPES.toArray(Class<?>[]::new));
 
@@ -63,7 +62,7 @@ class PostgresAssetIndexTest extends AssetIndexTestBase {
     }
 
     @AfterEach
-    void tearDown(PostgresqlStoreSetupExtension setupExtension) throws SQLException {
+    void tearDown(PostgresqlStoreSetupExtension setupExtension) {
         setupExtension.runQuery("DROP TABLE " + sqlStatements.getAssetTable() + " CASCADE");
         setupExtension.runQuery("DROP TABLE " + sqlStatements.getDataAddressTable() + " CASCADE");
         setupExtension.runQuery("DROP TABLE " + sqlStatements.getAssetPropertyTable() + " CASCADE");

--- a/extensions/control-plane/store/sql/asset-index-sql/src/test/java/org/eclipse/edc/connector/store/sql/assetindex/PostgresAssetIndexTest.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/test/java/org/eclipse/edc/connector/store/sql/assetindex/PostgresAssetIndexTest.java
@@ -17,7 +17,6 @@ package org.eclipse.edc.connector.store.sql.assetindex;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.edc.connector.store.sql.assetindex.schema.BaseSqlDialectStatements;
 import org.eclipse.edc.connector.store.sql.assetindex.schema.postgres.PostgresDialectStatements;
-import org.eclipse.edc.junit.annotations.PostgresqlDbIntegrationTest;
 import org.eclipse.edc.policy.model.PolicyRegistrationTypes;
 import org.eclipse.edc.spi.asset.AssetSelectorExpression;
 import org.eclipse.edc.spi.query.QuerySpec;
@@ -42,7 +41,7 @@ import java.util.stream.IntStream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@PostgresqlDbIntegrationTest
+//@PostgresqlDbIntegrationTest
 @ExtendWith(PostgresqlStoreSetupExtension.class)
 class PostgresAssetIndexTest extends AssetIndexTestBase {
 

--- a/extensions/control-plane/store/sql/asset-index-sql/src/test/java/org/eclipse/edc/connector/store/sql/assetindex/PostgresAssetIndexTest.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/test/java/org/eclipse/edc/connector/store/sql/assetindex/PostgresAssetIndexTest.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.connector.store.sql.assetindex;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.edc.connector.store.sql.assetindex.schema.BaseSqlDialectStatements;
 import org.eclipse.edc.connector.store.sql.assetindex.schema.postgres.PostgresDialectStatements;
+import org.eclipse.edc.junit.annotations.PostgresqlDbIntegrationTest;
 import org.eclipse.edc.policy.model.PolicyRegistrationTypes;
 import org.eclipse.edc.spi.asset.AssetSelectorExpression;
 import org.eclipse.edc.spi.query.QuerySpec;
@@ -41,7 +42,7 @@ import java.util.stream.IntStream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-//@PostgresqlDbIntegrationTest
+@PostgresqlDbIntegrationTest
 @ExtendWith(PostgresqlStoreSetupExtension.class)
 class PostgresAssetIndexTest extends AssetIndexTestBase {
 

--- a/resources/openapi/yaml/management-api/asset-api.yaml
+++ b/resources/openapi/yaml/management-api/asset-api.yaml
@@ -124,10 +124,10 @@ paths:
       - Asset
   /assets/{assetId}:
     put:
-      description: "Updates an asset with the given ID if it exists, creates a new\
-        \ one otherwise. DANGER ZONE: Note that updating assets can have unexpected\
-        \ results, especially for contract offers that have been sent out or ongoing\
-        \ or contract negotiations."
+      description: "Updates an asset with the given ID if it exists. If the asset\
+        \ is not found, no further action is taken. DANGER ZONE: Note that updating\
+        \ assets can have unexpected results, especially for contract offers that\
+        \ have been sent out or ongoing or contract negotiations."
       operationId: updateAsset
       parameters:
       - in: path
@@ -160,7 +160,8 @@ paths:
       - Asset
   /assets/{assetId}/dataaddress:
     put:
-      description: 'Updates a DataAddress for an asset with the given ID. '
+      description: "Updates a DataAddress for an asset with the given ID. If the asset\
+        \ is not found, no further action is taken"
       operationId: updateDataAddress
       parameters:
       - in: path

--- a/resources/openapi/yaml/management-api/asset-api.yaml
+++ b/resources/openapi/yaml/management-api/asset-api.yaml
@@ -122,6 +122,80 @@ paths:
           description: Request body was malformed
       tags:
       - Asset
+  /assets/{assetId}:
+    put:
+      description: "Updates an asset with the given ID if it exists, creates a new\
+        \ one otherwise. DANGER ZONE: Note that updating assets can have unexpected\
+        \ results, especially for contract offers that have been sent out or ongoing\
+        \ or contract negotiations."
+      operationId: updateAsset
+      parameters:
+      - in: path
+        name: assetId
+        required: true
+        schema:
+          type: string
+          example: null
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssetUpdateDto'
+      responses:
+        "200":
+          description: Asset was updated successfully
+        "201":
+          description: "Asset was create anew, because it didn't exist before"
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: "Request was malformed, e.g. id was null"
+      tags:
+      - Asset
+  /assets/{assetId}/dataaddress:
+    put:
+      description: 'Updates a DataAddress for an asset with the given ID. '
+      operationId: updateDataAddress
+      parameters:
+      - in: path
+        name: assetId
+        required: true
+        schema:
+          type: string
+          example: null
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DataAddressDto'
+      responses:
+        "200":
+          description: Asset was updated successfully
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: "Request was malformed, e.g. id was null"
+        "404":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: An asset with the given ID does not exist
+      tags:
+      - Asset
   /assets/{id}:
     delete:
       description: "Removes an asset with the given ID if possible. Deleting an asset\
@@ -306,6 +380,18 @@ components:
             type: object
             example: null
           example: null
+    AssetUpdateDto:
+      type: object
+      example: null
+      properties:
+        properties:
+          type: object
+          additionalProperties:
+            type: object
+            example: null
+          example: null
+      required:
+      - properties
     CriterionDto:
       type: object
       example: null

--- a/resources/openapi/yaml/management-api/asset-api.yaml
+++ b/resources/openapi/yaml/management-api/asset-api.yaml
@@ -140,7 +140,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AssetUpdateDto'
+              $ref: '#/components/schemas/AssetUpdateRequestDto'
       responses:
         "200":
           description: Asset was updated successfully
@@ -339,18 +339,7 @@ components:
         type:
           type: string
           example: null
-    AssetEntryDto:
-      type: object
-      example: null
-      properties:
-        asset:
-          $ref: '#/components/schemas/AssetRequestDto'
-        dataAddress:
-          $ref: '#/components/schemas/DataAddressDto'
-      required:
-      - asset
-      - dataAddress
-    AssetRequestDto:
+    AssetCreationRequestDto:
       type: object
       example: null
       properties:
@@ -365,6 +354,17 @@ components:
           example: null
       required:
       - properties
+    AssetEntryDto:
+      type: object
+      example: null
+      properties:
+        asset:
+          $ref: '#/components/schemas/AssetCreationRequestDto'
+        dataAddress:
+          $ref: '#/components/schemas/DataAddressDto'
+      required:
+      - asset
+      - dataAddress
     AssetResponseDto:
       type: object
       example: null
@@ -382,7 +382,7 @@ components:
             type: object
             example: null
           example: null
-    AssetUpdateDto:
+    AssetUpdateRequestDto:
       type: object
       example: null
       properties:

--- a/resources/openapi/yaml/management-api/asset-api.yaml
+++ b/resources/openapi/yaml/management-api/asset-api.yaml
@@ -144,8 +144,6 @@ paths:
       responses:
         "200":
           description: Asset was updated successfully
-        "201":
-          description: "Asset was create anew, because it didn't exist before"
         "400":
           content:
             application/json:
@@ -155,6 +153,9 @@ paths:
                 items:
                   $ref: '#/components/schemas/ApiErrorDetail'
           description: "Request was malformed, e.g. id was null"
+        "404":
+          description: "Asset could not be updated, because it does not exist. Asset\
+            \ need to be created together with DataAddresses."
       tags:
       - Asset
   /assets/{assetId}/dataaddress:

--- a/spi/common/aggregate-service-spi/src/main/java/org/eclipse/edc/service/spi/result/ServiceResult.java
+++ b/spi/common/aggregate-service-spi/src/main/java/org/eclipse/edc/service/spi/result/ServiceResult.java
@@ -48,6 +48,10 @@ public class ServiceResult<T> extends AbstractResult<T, ServiceFailure> {
         return new ServiceResult<>(null, new ServiceFailure(messages, BAD_REQUEST));
     }
 
+    public static <T> ServiceResult<T> success() {
+        return ServiceResult.success(null);
+    }
+
     public ServiceFailure.Reason reason() {
         return getFailure().getReason();
     }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/asset/AssetIndex.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/asset/AssetIndex.java
@@ -94,4 +94,22 @@ public interface AssetIndex extends DataAddressResolver {
      * @return the number of assets (potentially 0)
      */
     long countAssets(List<Criterion> criteria);
+
+    /**
+     * Updates an asset, that is identified by the assetId parameter
+     *
+     * @param assetId the database of the Asset to update
+     * @param asset   The Asset containing the new values. ID will be ignored.
+     * @return the updated Asset, or null if the asset does not exist
+     */
+    Asset updateAsset(String assetId, Asset asset);
+
+    /**
+     * Updates a DataAddress for a given Asset, that is identified by the assetId parameter
+     *
+     * @param assetId     the database of the Asset to update
+     * @param dataAddress The DataAddress containing the new values.
+     * @return the updated DataAddress
+     */
+    DataAddress updateDataAddress(String assetId, DataAddress dataAddress);
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/asset/AssetIndex.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/asset/AssetIndex.java
@@ -96,7 +96,7 @@ public interface AssetIndex extends DataAddressResolver {
     long countAssets(List<Criterion> criteria);
 
     /**
-     * Updates an asset, that is identified by the assetId parameter
+     * Updates an asset with the content from the given {@link Asset}. If the asset is not found, no further database interaction takes place.
      *
      * @param assetId the database of the Asset to update
      * @param asset   The Asset containing the new values. ID will be ignored.
@@ -105,7 +105,8 @@ public interface AssetIndex extends DataAddressResolver {
     Asset updateAsset(String assetId, Asset asset);
 
     /**
-     * Updates a DataAddress for a given Asset, that is identified by the assetId parameter
+     * Updates a {@link DataAddress} that is associated with the {@link Asset} that is identified by the {@code assetId} argument.
+     * If the asset is not found, no further database interaction takes place.
      *
      * @param assetId     the database of the Asset to update
      * @param dataAddress The DataAddress containing the new values.

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/asset/AssetUpdated.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/asset/AssetUpdated.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - expending Event classes
+ *
+ */
+
+package org.eclipse.edc.spi.event.asset;
+
+/**
+ * Describe a new Asset creation, after this has emitted, an Asset with a certain id will be available.
+ */
+public class AssetUpdated extends AssetEvent<AssetUpdated.Payload> {
+
+    private AssetUpdated() {
+    }
+
+    /**
+     * This class contains all event specific attributes of an Asset Creation Event
+     */
+    public static class Payload extends AssetEvent.Payload {
+
+    }
+
+    public static class Builder extends AssetEvent.Builder<AssetUpdated, Payload, Builder> {
+
+        private Builder() {
+            super(new AssetUpdated(), new Payload());
+        }
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+    }
+
+}

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/observe/asset/AssetListener.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/observe/asset/AssetListener.java
@@ -41,4 +41,13 @@ public interface AssetListener {
 
     }
 
+    /**
+     * Called after a {@link Asset} was updated
+     *
+     * @param asset The new (already updated) asset.
+     */
+    default void updated(Asset asset) {
+
+    }
+
 }

--- a/spi/common/core-spi/src/testFixtures/java/org/eclipse/edc/spi/testfixtures/asset/AssetIndexTestBase.java
+++ b/spi/common/core-spi/src/testFixtures/java/org/eclipse/edc/spi/testfixtures/asset/AssetIndexTestBase.java
@@ -347,6 +347,164 @@ public abstract class AssetIndexTestBase {
         assertThat(dataAddressFound).usingRecursiveComparison().isEqualTo(dataAddress);
     }
 
+    @Test
+    @DisplayName("Update Asset that does not yet exist")
+    void updateAsset_doesNotExist() {
+        var id = "id1";
+        var assetExpected = getAsset(id);
+        var assetIndex = getAssetIndex();
+
+        var updated = assetIndex.updateAsset(id, assetExpected);
+        assertThat(updated).isNull();
+    }
+
+    @Test
+    @DisplayName("Update an Asset that exists, adding a property")
+    void updateAsset_exists_addsProperty() {
+        var id = "id1";
+        var asset = getAsset(id);
+        var assetIndex = getAssetIndex();
+        assetIndex.accept(asset, getDataAddress());
+
+        assertThat(assetIndex.countAssets(List.of())).isEqualTo(1);
+
+        var updatedAsset = asset;
+        updatedAsset.getProperties().put("newKey", "newValue");
+        var updated = assetIndex.updateAsset(id, updatedAsset);
+
+        assertThat(updated).isNotNull();
+
+        var assetFound = getAssetIndex().findById("id1");
+
+        assertThat(assetFound).isNotNull();
+        assertThat(assetFound).usingRecursiveComparison().isEqualTo(updatedAsset);
+    }
+
+    @Test
+    @DisplayName("Update an Asset that exists, removing a property")
+    void updateAsset_exists_removesProperty() {
+        var id = "id1";
+        var asset = getAsset(id);
+        asset.getProperties().put("newKey", "newValue");
+        var assetIndex = getAssetIndex();
+        assetIndex.accept(asset, getDataAddress());
+
+        assertThat(assetIndex.countAssets(List.of())).isEqualTo(1);
+
+        var updatedAsset = asset;
+        updatedAsset.getProperties().remove("newKey");
+        var updated = assetIndex.updateAsset(id, updatedAsset);
+
+        assertThat(updated).isNotNull();
+
+        var assetFound = getAssetIndex().findById("id1");
+
+        assertThat(assetFound).isNotNull();
+        assertThat(assetFound).usingRecursiveComparison().isEqualTo(updatedAsset);
+        assertThat(assetFound.getProperties().keySet()).doesNotContain("newKey");
+    }
+
+    @Test
+    @DisplayName("Update an Asset that exists, replacing a property")
+    void updateAsset_exists_replacingProperty() {
+        var id = "id1";
+        var asset = getAsset(id);
+        asset.getProperties().put("newKey", "originalValue");
+        var assetIndex = getAssetIndex();
+        assetIndex.accept(asset, getDataAddress());
+
+        assertThat(assetIndex.countAssets(List.of())).isEqualTo(1);
+
+        var updatedAsset = asset;
+        updatedAsset.getProperties().put("newKey", "newValue");
+        var updated = assetIndex.updateAsset(id, updatedAsset);
+
+        assertThat(updated).isNotNull();
+
+        var assetFound = getAssetIndex().findById("id1");
+
+        assertThat(assetFound).isNotNull();
+        assertThat(assetFound).usingRecursiveComparison().isEqualTo(updatedAsset);
+        assertThat(assetFound.getProperties()).containsEntry("newKey", "newValue");
+    }
+
+    @Test
+    @DisplayName("Update DataAddress where the Asset does not yet exist")
+    void updateDataAddress_doesNotExist() {
+        var id = "id1";
+        var assetExpected = getDataAddress();
+        var assetIndex = getAssetIndex();
+
+        var updated = assetIndex.updateDataAddress(id, assetExpected);
+        assertThat(updated).isNull();
+    }
+
+    @Test
+    @DisplayName("Update a DataAddress that exists, adding a new property")
+    void updateDataAddress_exists_addsProperty() {
+        var id = "id1";
+        var asset = getAsset(id);
+        var assetIndex = getAssetIndex();
+        var dataAddress = getDataAddress();
+        assetIndex.accept(asset, dataAddress);
+
+        var updatedDataAddress = getDataAddress();
+        updatedDataAddress.getProperties().put("newKey", "newValue");
+        var updated = assetIndex.updateDataAddress(id, updatedDataAddress);
+
+        assertThat(updated).isNotNull();
+
+        var addressFound = getAssetIndex().resolveForAsset("id1");
+
+        assertThat(addressFound).isNotNull();
+        assertThat(addressFound).usingRecursiveComparison().isEqualTo(updatedDataAddress);
+    }
+
+    @Test
+    @DisplayName("Update a DataAddress that exists, removing a property")
+    void updateDataAddress_exists_removesProperty() {
+        var id = "id1";
+        var asset = getAsset(id);
+        var assetIndex = getAssetIndex();
+        var dataAddress = getDataAddress();
+        dataAddress.getProperties().put("newKey", "newValue");
+        assetIndex.accept(asset, dataAddress);
+
+        var updatedDataAddress = dataAddress;
+        updatedDataAddress.getProperties().remove("newKey");
+        var updated = assetIndex.updateDataAddress(id, updatedDataAddress);
+
+        assertThat(updated).isNotNull();
+
+        var addressFound = getAssetIndex().resolveForAsset("id1");
+
+        assertThat(addressFound).isNotNull();
+        assertThat(addressFound).usingRecursiveComparison().isEqualTo(updatedDataAddress);
+        assertThat(addressFound.getProperties()).doesNotContainKeys("newKey");
+    }
+
+    @Test
+    @DisplayName("Update a DataAddress that exists, replacing a property")
+    void updateDataAddress_exists_replacesProperty() {
+        var id = "id1";
+        var asset = getAsset(id);
+        var assetIndex = getAssetIndex();
+        var dataAddress = getDataAddress();
+        dataAddress.getProperties().put("newKey", "originalValue");
+        assetIndex.accept(asset, dataAddress);
+
+        var updatedDataAddress = dataAddress;
+        updatedDataAddress.getProperties().put("newKey", "newValue");
+        var updated = assetIndex.updateDataAddress(id, updatedDataAddress);
+
+        assertThat(updated).isNotNull();
+
+        var addressFound = getAssetIndex().resolveForAsset("id1");
+
+        assertThat(addressFound).isNotNull();
+        assertThat(addressFound).usingRecursiveComparison().isEqualTo(updatedDataAddress);
+        assertThat(addressFound.getProperties()).containsEntry("newKey", "newValue");
+    }
 
     /**
      * Returns an array of all operators supported by a particular AssetIndex. If no limitations or constraints exist

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/asset/AssetService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/asset/AssetService.java
@@ -42,7 +42,7 @@ public interface AssetService {
     /**
      * Create an asset with its related data address
      *
-     * @param asset the asset
+     * @param asset       the asset
      * @param dataAddress the address of the asset
      * @return successful result if the asset is created correctly, failure otherwise
      */
@@ -55,4 +55,22 @@ public interface AssetService {
      * @return successful result if the asset is deleted correctly, failure otherwise
      */
     ServiceResult<Asset> delete(String assetId);
+
+    /**
+     * Updates an asset
+     *
+     * @param assetId The ID of the asset to update.
+     * @param asset   The content of the Asset. Note that {@link Asset#getId()} will be ignored, rather the separately supplied ID is used
+     * @return successful if updated, a failure otherwise.
+     */
+    ServiceResult<Void> update(String assetId, Asset asset);
+
+    /**
+     * Updates an asset
+     *
+     * @param assetId     The ID of the asset to update.
+     * @param dataAddress The content of the DataAddress.
+     * @return successful if updated, a failure otherwise.
+     */
+    ServiceResult<Void> update(String assetId, DataAddress dataAddress);
 }

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/asset/AssetService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/asset/AssetService.java
@@ -57,7 +57,7 @@ public interface AssetService {
     ServiceResult<Asset> delete(String assetId);
 
     /**
-     * Updates an asset
+     * Updates an asset. If the asset does not yet exist, {@link ServiceResult#notFound(String)} will be returned.
      *
      * @param assetId The ID of the asset to update.
      * @param asset   The content of the Asset. Note that {@link Asset#getId()} will be ignored, rather the separately supplied ID is used
@@ -66,7 +66,7 @@ public interface AssetService {
     ServiceResult<Void> update(String assetId, Asset asset);
 
     /**
-     * Updates an asset
+     * Updates a {@link DataAddress}. If the associated asset does not yet exist, {@link ServiceResult#notFound(String)} will be returned;
      *
      * @param assetId     The ID of the asset to update.
      * @param dataAddress The content of the DataAddress.


### PR DESCRIPTION
## What this PR changes/adds

Adds the `UPDATE` endpoint to the `AssetApi`, in particular the following parts are added:
- add two `PUT` endpoints to the `AssetApiController`
- adds new `update()` methods to the `AssetIndex`
- adds implementations for `SqlAssetIndex`, `CosmosAssetIndex` and `InMemoryAssetIndex`
- adds tests for all these impls


## Why it does that

to enable update semantics on assets and dataaddresses

## Further notes

- I created a dedicated `AssetUpdateDto`, that doesn't have an ID, just to explicitly exclude the ID. The `assetId` is passed as path param.
- updating `Assets` will fail if the `Asset` isn't found, because it would be an `Asset` without a `DataAddress`, which is invalid.
- similarly, updating `DataAddresses` for `Assets` that don't exist will fail as well

_As an alternative, we could always update `Asset` and `DataAddress` together, but for that we'd also have to add the `DataAddress` to the `GET` endpoint_.

## Linked Issue(s)

Closes #2508 

## Checklist

- [x] added appropriate tests?
- [ ] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
