### PR TITLE
feat: add update endpoint for ContractDefinition

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractdefinition/ContractDefinitionEventListener.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractdefinition/ContractDefinitionEventListener.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.connector.contract.spi.types.offer.ContractDefinition;
 import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.event.contractdefinition.ContractDefinitionCreated;
 import org.eclipse.edc.spi.event.contractdefinition.ContractDefinitionDeleted;
+import org.eclipse.edc.spi.event.contractdefinition.ContractDefinitionUpdated;
 
 import java.time.Clock;
 
@@ -47,6 +48,16 @@ public class ContractDefinitionEventListener implements ContractDefinitionListen
     @Override
     public void deleted(ContractDefinition contractDefinition) {
         var event = ContractDefinitionDeleted.Builder.newInstance()
+                .contractDefinitionId(contractDefinition.getId())
+                .at(clock.millis())
+                .build();
+
+        eventRouter.publish(event);
+    }
+
+    @Override
+    public void updated(ContractDefinition contractDefinition) {
+        var event = ContractDefinitionUpdated.Builder.newInstance()
                 .contractDefinitionId(contractDefinition.getId())
                 .at(clock.millis())
                 .build();

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractdefinition/ContractDefinitionServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractdefinition/ContractDefinitionServiceImpl.java
@@ -69,6 +69,19 @@ public class ContractDefinitionServiceImpl implements ContractDefinitionService 
     }
 
     @Override
+    public ServiceResult<Void> update(ContractDefinition contractDefinition) {
+        return transactionContext.execute(() -> {
+            if (findById(contractDefinition.getId()) != null) {
+                store.update(contractDefinition);
+                observable.invokeForEach(l -> l.updated(contractDefinition));
+                return ServiceResult.success(null);
+            } else {
+                return ServiceResult.notFound(format("ContractDefinition %s does not exist", contractDefinition.getId()));
+            }
+        });
+    }
+
+    @Override
     public ServiceResult<ContractDefinition> delete(String contractDefinitionId) {
         return transactionContext.execute(() -> {
             // TODO: should be checked if a contract agreement based on this definition exists. Currently not implementable because it's not possibile to filter agreements by definition id

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionApi.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionApi.java
@@ -24,8 +24,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.eclipse.edc.api.model.IdResponseDto;
 import org.eclipse.edc.api.query.QuerySpecDto;
-import org.eclipse.edc.connector.api.management.contractdefinition.model.ContractDefinitionRequestDto;
+import org.eclipse.edc.connector.api.management.contractdefinition.model.ContractDefinitionCreateDto;
 import org.eclipse.edc.connector.api.management.contractdefinition.model.ContractDefinitionResponseDto;
+import org.eclipse.edc.connector.api.management.contractdefinition.model.ContractDefinitionUpdateDto;
 import org.eclipse.edc.web.spi.ApiErrorDetail;
 
 import java.util.List;
@@ -76,7 +77,7 @@ public interface ContractDefinitionApi {
                     @ApiResponse(responseCode = "409", description = "Could not create contract definition, because a contract definition with that ID already exists",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))) }
     )
-    IdResponseDto createContractDefinition(@Valid ContractDefinitionRequestDto dto);
+    IdResponseDto createContractDefinition(@Valid ContractDefinitionCreateDto dto);
 
     @Operation(description = "Removes a contract definition with the given ID if possible. " +
             "DANGER ZONE: Note that deleting contract definitions can have unexpected results, especially for contract offers that have been sent out or ongoing or contract negotiations.",
@@ -88,4 +89,14 @@ public interface ContractDefinitionApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
             })
     void deleteContractDefinition(String id);
+
+    @Operation(description = "Updated a contract definition with the given ID",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "Contract definition was updated successfully"),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))),
+                    @ApiResponse(responseCode = "404", description = "A contract definition with the given ID does not exist",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
+            })
+    void updateContractDefinition(String contractDefinitionId, @Valid ContractDefinitionUpdateDto contractDefinition);
 }

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionApiExtension.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionApiExtension.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.api.transformer.DtoTransformerRegistry;
 import org.eclipse.edc.connector.api.management.configuration.ManagementApiConfiguration;
 import org.eclipse.edc.connector.api.management.contractdefinition.transform.ContractDefinitionRequestDtoToContractDefinitionTransformer;
 import org.eclipse.edc.connector.api.management.contractdefinition.transform.ContractDefinitionToContractDefinitionResponseDtoTransformer;
+import org.eclipse.edc.connector.api.management.contractdefinition.transform.ContractDefinitionUpdateDtoWrapperToContractDefinitionTransformer;
 import org.eclipse.edc.connector.spi.contractdefinition.ContractDefinitionService;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
@@ -51,6 +52,8 @@ public class ContractDefinitionApiExtension implements ServiceExtension {
 
         transformerRegistry.register(new ContractDefinitionToContractDefinitionResponseDtoTransformer());
         transformerRegistry.register(new ContractDefinitionRequestDtoToContractDefinitionTransformer());
+        transformerRegistry.register(new ContractDefinitionUpdateDtoWrapperToContractDefinitionTransformer());
+
 
         var monitor = context.getMonitor();
 

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/model/ContractDefinitionCreateDto.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/model/ContractDefinitionCreateDto.java
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.contractdefinition.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import jakarta.validation.constraints.AssertTrue;
+
+import java.util.Optional;
+
+@JsonDeserialize(builder = ContractDefinitionCreateDto.Builder.class)
+public class ContractDefinitionCreateDto extends ContractDefinitionRequestDto {
+
+    private String id;
+
+
+    private ContractDefinitionCreateDto() {
+    }
+
+    @AssertTrue(message = "id must be either be null or not blank, and it cannot contain the ':' character")
+    @JsonIgnore
+    public boolean isIdValid() {
+        return Optional.of(this)
+                .map(it -> it.id)
+                .map(it -> !it.isBlank() && !it.contains(":"))
+                .orElse(true);
+    }
+
+
+    public String getId() {
+        return id;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static final class Builder extends ContractDefinitionRequestDto.Builder<ContractDefinitionCreateDto, Builder> {
+
+        private Builder() {
+            super(new ContractDefinitionCreateDto());
+        }
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        @Override
+        public Builder self() {
+            return this;
+        }
+
+        public Builder id(String id) {
+            dto.id = id;
+            return this;
+        }
+
+        @Override
+        public ContractDefinitionCreateDto build() {
+            return dto;
+        }
+    }
+}

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/model/ContractDefinitionRequestDto.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/model/ContractDefinitionRequestDto.java
@@ -14,51 +14,32 @@
 
 package org.eclipse.edc.connector.api.management.contractdefinition.model;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import org.eclipse.edc.api.model.CriterionDto;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
-@JsonDeserialize(builder = ContractDefinitionRequestDto.Builder.class)
-public class ContractDefinitionRequestDto {
+public abstract class ContractDefinitionRequestDto {
 
     /**
      * Default validity is set to one year.
      */
     private static final long DEFAULT_VALIDITY = TimeUnit.DAYS.toSeconds(365);
 
-    private String id;
     @NotNull(message = "accessPolicyId cannot be null")
-    private String accessPolicyId;
+    protected String accessPolicyId;
     @NotNull(message = "contractPolicyId cannot be null")
-    private String contractPolicyId;
+    protected String contractPolicyId;
     @Valid
     @NotNull(message = "criteria cannot be null")
-    private List<CriterionDto> criteria = new ArrayList<>();
+    protected List<CriterionDto> criteria = new ArrayList<>();
     @Positive(message = "validity must be positive")
-    private long validity = DEFAULT_VALIDITY;
+    protected long validity = DEFAULT_VALIDITY;
 
-    private ContractDefinitionRequestDto() {
-    }
-
-    @AssertTrue(message = "id must be either be null or not blank, and it cannot contain the ':' character")
-    @JsonIgnore
-    public boolean isIdValid() {
-        return Optional.of(this)
-                .map(it -> it.id)
-                .map(it -> !it.isBlank() && !it.contains(":"))
-                .orElse(true);
-    }
 
     public String getAccessPolicyId() {
         return accessPolicyId;
@@ -76,50 +57,39 @@ public class ContractDefinitionRequestDto {
         return validity;
     }
 
-    public String getId() {
-        return id;
-    }
+    protected abstract static class Builder<A extends ContractDefinitionRequestDto, B extends Builder<A, B>> {
+        protected final A dto;
 
-    @JsonPOJOBuilder(withPrefix = "")
-    public static final class Builder {
-        private final ContractDefinitionRequestDto dto;
-
-        private Builder() {
-            this.dto = new ContractDefinitionRequestDto();
+        protected Builder(A dto) {
+            this.dto = dto;
         }
 
-        @JsonCreator
-        public static Builder newInstance() {
-            return new Builder();
-        }
 
-        public Builder accessPolicyId(String accessPolicyId) {
+        public B accessPolicyId(String accessPolicyId) {
             dto.accessPolicyId = accessPolicyId;
-            return this;
+            return self();
         }
 
-        public Builder contractPolicyId(String contractPolicyId) {
+        public B contractPolicyId(String contractPolicyId) {
             dto.contractPolicyId = contractPolicyId;
-            return this;
+            return self();
         }
 
-        public Builder criteria(List<CriterionDto> criteria) {
+        public B criteria(List<CriterionDto> criteria) {
             dto.criteria = criteria;
-            return this;
+            return self();
         }
 
-        public Builder validity(long validity) {
+        public B validity(long validity) {
             dto.validity = validity;
-            return this;
+            return self();
         }
 
-        public Builder id(String id) {
-            dto.id = id;
-            return this;
-        }
+        public abstract B self();
 
-        public ContractDefinitionRequestDto build() {
+        public A build() {
             return dto;
         }
+
     }
 }

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/model/ContractDefinitionUpdateDto.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/model/ContractDefinitionUpdateDto.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.contractdefinition.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+@JsonDeserialize(builder = ContractDefinitionUpdateDto.Builder.class)
+public class ContractDefinitionUpdateDto extends ContractDefinitionRequestDto {
+
+
+    private ContractDefinitionUpdateDto() {
+    }
+
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static final class Builder extends ContractDefinitionRequestDto.Builder<ContractDefinitionUpdateDto, Builder> {
+
+        private Builder() {
+            super(new ContractDefinitionUpdateDto());
+        }
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+
+        @Override
+        public Builder self() {
+            return this;
+        }
+
+        @Override
+        public ContractDefinitionUpdateDto build() {
+            return dto;
+        }
+    }
+}

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/model/ContractDefinitionUpdateDtoWrapper.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/model/ContractDefinitionUpdateDtoWrapper.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.contractdefinition.model;
+
+import java.util.Objects;
+
+public class ContractDefinitionUpdateDtoWrapper {
+
+
+    private ContractDefinitionUpdateDto contractDefinition;
+    private String id;
+
+    private ContractDefinitionUpdateDtoWrapper() {
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public ContractDefinitionUpdateDto getContractDefinition() {
+        return contractDefinition;
+    }
+
+
+    public static final class Builder {
+        private final ContractDefinitionUpdateDtoWrapper wrapper;
+
+        private Builder() {
+            wrapper = new ContractDefinitionUpdateDtoWrapper();
+        }
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder id(String id) {
+            wrapper.id = id;
+            return this;
+        }
+
+        public Builder contractDefinition(ContractDefinitionUpdateDto contractDefinition) {
+            wrapper.contractDefinition = contractDefinition;
+            return this;
+        }
+
+
+        public ContractDefinitionUpdateDtoWrapper build() {
+            Objects.requireNonNull(wrapper.id);
+            Objects.requireNonNull(wrapper.contractDefinition);
+            return wrapper;
+        }
+    }
+}

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/model/ContractDefinitionUpdateDtoWrapper.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/model/ContractDefinitionUpdateDtoWrapper.java
@@ -17,6 +17,12 @@ package org.eclipse.edc.connector.api.management.contractdefinition.model;
 
 import java.util.Objects;
 
+/**
+ * Simple DTO wrapper that contains the updating values from the Request {@link ContractDefinitionUpdateDto} and the id
+ * of the Contract Definition to update.
+ * It will be used in the {@link org.eclipse.edc.connector.api.management.contractdefinition.transform.ContractDefinitionUpdateDtoWrapperToContractDefinitionTransformer} for
+ * building the {@link org.eclipse.edc.connector.contract.spi.types.offer.ContractDefinition} to update.
+ */
 public class ContractDefinitionUpdateDtoWrapper {
 
     private ContractDefinitionUpdateDto contractDefinition;

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/model/ContractDefinitionUpdateDtoWrapper.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/model/ContractDefinitionUpdateDtoWrapper.java
@@ -14,10 +14,10 @@
 
 package org.eclipse.edc.connector.api.management.contractdefinition.model;
 
+
 import java.util.Objects;
 
 public class ContractDefinitionUpdateDtoWrapper {
-
 
     private ContractDefinitionUpdateDto contractDefinition;
     private String id;

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/transform/ContractDefinitionUpdateDtoWrapperToContractDefinitionTransformer.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/transform/ContractDefinitionUpdateDtoWrapperToContractDefinitionTransformer.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,14 +8,14 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
  *
  */
 
 package org.eclipse.edc.connector.api.management.contractdefinition.transform;
 
 import org.eclipse.edc.api.transformer.DtoTransformer;
-import org.eclipse.edc.connector.api.management.contractdefinition.model.ContractDefinitionCreateDto;
+import org.eclipse.edc.connector.api.management.contractdefinition.model.ContractDefinitionUpdateDtoWrapper;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractDefinition;
 import org.eclipse.edc.spi.asset.AssetSelectorExpression;
 import org.eclipse.edc.spi.query.Criterion;
@@ -25,11 +25,11 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.stream.Collectors;
 
-public class ContractDefinitionRequestDtoToContractDefinitionTransformer implements DtoTransformer<ContractDefinitionCreateDto, ContractDefinition> {
+public class ContractDefinitionUpdateDtoWrapperToContractDefinitionTransformer implements DtoTransformer<ContractDefinitionUpdateDtoWrapper, ContractDefinition> {
 
     @Override
-    public Class<ContractDefinitionCreateDto> getInputType() {
-        return ContractDefinitionCreateDto.class;
+    public Class<ContractDefinitionUpdateDtoWrapper> getInputType() {
+        return ContractDefinitionUpdateDtoWrapper.class;
     }
 
     @Override
@@ -38,15 +38,15 @@ public class ContractDefinitionRequestDtoToContractDefinitionTransformer impleme
     }
 
     @Override
-    public @Nullable ContractDefinition transform(@NotNull ContractDefinitionCreateDto object, @NotNull TransformerContext context) {
-        var criteria = object.getCriteria().stream().map(it -> context.transform(it, Criterion.class)).collect(Collectors.toList());
+    public @Nullable ContractDefinition transform(@NotNull ContractDefinitionUpdateDtoWrapper object, @NotNull TransformerContext context) {
+        var criteria = object.getContractDefinition().getCriteria().stream().map(it -> context.transform(it, Criterion.class)).collect(Collectors.toList());
         var selectorExpression = AssetSelectorExpression.Builder.newInstance().criteria(criteria).build();
         return ContractDefinition.Builder.newInstance()
                 .id(object.getId())
-                .accessPolicyId(object.getAccessPolicyId())
-                .contractPolicyId(object.getContractPolicyId())
+                .accessPolicyId(object.getContractDefinition().getAccessPolicyId())
+                .contractPolicyId(object.getContractDefinition().getContractPolicyId())
                 .selectorExpression(selectorExpression)
-                .validity(object.getValidity())
+                .validity(object.getContractDefinition().getValidity())
                 .build();
     }
 }

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionApiControllerTest.java
@@ -17,8 +17,10 @@ package org.eclipse.edc.connector.api.management.contractdefinition;
 import org.eclipse.edc.api.model.IdResponseDto;
 import org.eclipse.edc.api.query.QuerySpecDto;
 import org.eclipse.edc.api.transformer.DtoTransformerRegistry;
-import org.eclipse.edc.connector.api.management.contractdefinition.model.ContractDefinitionRequestDto;
+import org.eclipse.edc.connector.api.management.contractdefinition.model.ContractDefinitionCreateDto;
 import org.eclipse.edc.connector.api.management.contractdefinition.model.ContractDefinitionResponseDto;
+import org.eclipse.edc.connector.api.management.contractdefinition.model.ContractDefinitionUpdateDto;
+import org.eclipse.edc.connector.api.management.contractdefinition.model.ContractDefinitionUpdateDtoWrapper;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractDefinition;
 import org.eclipse.edc.connector.spi.contractdefinition.ContractDefinitionService;
 import org.eclipse.edc.service.spi.result.ServiceResult;
@@ -171,9 +173,9 @@ class ContractDefinitionApiControllerTest {
 
     @Test
     void createContractDefinition_success() {
-        var dto = ContractDefinitionRequestDto.Builder.newInstance().build();
+        var dto = ContractDefinitionCreateDto.Builder.newInstance().build();
         var contractDefinition = createContractDefinition(UUID.randomUUID().toString());
-        when(transformerRegistry.transform(isA(ContractDefinitionRequestDto.class), eq(ContractDefinition.class))).thenReturn(Result.success(contractDefinition));
+        when(transformerRegistry.transform(isA(ContractDefinitionCreateDto.class), eq(ContractDefinition.class))).thenReturn(Result.success(contractDefinition));
         when(service.create(any())).thenReturn(ServiceResult.success(contractDefinition));
 
         var contractDefinitionId = controller.createContractDefinition(dto);
@@ -184,16 +186,16 @@ class ContractDefinitionApiControllerTest {
         assertThat(contractDefinitionId.getCreatedAt()).isNotEqualTo(0L);
 
         verify(service).create(contractDefinition);
-        verify(transformerRegistry).transform(isA(ContractDefinitionRequestDto.class), eq(ContractDefinition.class));
+        verify(transformerRegistry).transform(isA(ContractDefinitionCreateDto.class), eq(ContractDefinition.class));
     }
 
     @Test
     void createContractDefinition_returnExpectedId() {
         var definedContractDefinitionId = UUID.randomUUID().toString();
-        var dto = ContractDefinitionRequestDto.Builder.newInstance().build();
+        var dto = ContractDefinitionCreateDto.Builder.newInstance().build();
         var contractDefinition = createContractDefinition(definedContractDefinitionId);
 
-        when(transformerRegistry.transform(isA(ContractDefinitionRequestDto.class), eq(ContractDefinition.class))).thenReturn(Result.success(contractDefinition));
+        when(transformerRegistry.transform(isA(ContractDefinitionCreateDto.class), eq(ContractDefinition.class))).thenReturn(Result.success(contractDefinition));
         when(service.create(any())).thenReturn(ServiceResult.success(contractDefinition));
 
         var contractDefinitionId = controller.createContractDefinition(dto);
@@ -203,8 +205,8 @@ class ContractDefinitionApiControllerTest {
 
     @Test
     void createContractDefinition_alreadyExists() {
-        var dto = ContractDefinitionRequestDto.Builder.newInstance().build();
-        when(transformerRegistry.transform(isA(ContractDefinitionRequestDto.class), eq(ContractDefinition.class))).thenReturn(Result.success(createContractDefinition(UUID.randomUUID().toString())));
+        var dto = ContractDefinitionCreateDto.Builder.newInstance().build();
+        when(transformerRegistry.transform(isA(ContractDefinitionCreateDto.class), eq(ContractDefinition.class))).thenReturn(Result.success(createContractDefinition(UUID.randomUUID().toString())));
         when(service.create(any())).thenReturn(ServiceResult.conflict("already exists"));
 
         assertThatThrownBy(() -> controller.createContractDefinition(dto)).isInstanceOf(ObjectConflictException.class);
@@ -212,8 +214,8 @@ class ContractDefinitionApiControllerTest {
 
     @Test
     void createContractDefinition_transformationFails() {
-        var dto = ContractDefinitionRequestDto.Builder.newInstance().build();
-        when(transformerRegistry.transform(isA(ContractDefinitionRequestDto.class), eq(ContractDefinition.class))).thenReturn(Result.failure("failure"));
+        var dto = ContractDefinitionCreateDto.Builder.newInstance().build();
+        when(transformerRegistry.transform(isA(ContractDefinitionCreateDto.class), eq(ContractDefinition.class))).thenReturn(Result.failure("failure"));
 
         assertThatThrownBy(() -> controller.createContractDefinition(dto)).isInstanceOf(InvalidRequestException.class);
     }
@@ -240,6 +242,41 @@ class ContractDefinitionApiControllerTest {
         when(service.delete("definitionId")).thenReturn(ServiceResult.conflict("conflict"));
 
         assertThatThrownBy(() -> controller.deleteContractDefinition("definitionId")).isInstanceOf(ObjectConflictException.class);
+    }
+
+    @Test
+    void update_whenExists() {
+        var dto = ContractDefinitionUpdateDto.Builder.newInstance().build();
+        var contractDefinition = createContractDefinition(UUID.randomUUID().toString());
+        when(transformerRegistry.transform(isA(ContractDefinitionUpdateDtoWrapper.class), eq(ContractDefinition.class))).thenReturn(Result.success(contractDefinition));
+        when(service.update(eq(contractDefinition))).thenReturn(ServiceResult.success(null));
+
+        controller.updateContractDefinition(contractDefinition.getId(), dto);
+
+
+        verify(service).update(contractDefinition);
+        verify(transformerRegistry).transform(isA(ContractDefinitionUpdateDtoWrapper.class), eq(ContractDefinition.class));
+    }
+
+
+    @Test
+    void update_whenNotExists_shouldThrowException() {
+        var dto = ContractDefinitionUpdateDto.Builder.newInstance().build();
+        var contractDefinition = createContractDefinition(UUID.randomUUID().toString());
+        when(transformerRegistry.transform(isA(ContractDefinitionUpdateDtoWrapper.class), eq(ContractDefinition.class))).thenReturn(Result.success(contractDefinition));
+        when(service.update(eq(contractDefinition))).thenReturn(ServiceResult.notFound("not found"));
+
+        assertThatThrownBy(() -> controller.updateContractDefinition(contractDefinition.getId(), dto)).isInstanceOf(ObjectNotFoundException.class);
+
+    }
+
+    @Test
+    void update_whenTransformationFails_shouldThrowException() {
+        var dto = ContractDefinitionUpdateDto.Builder.newInstance().build();
+        var contractDefinition = createContractDefinition(UUID.randomUUID().toString());
+        when(transformerRegistry.transform(isA(ContractDefinitionUpdateDtoWrapper.class), eq(ContractDefinition.class))).thenReturn(Result.failure("failure"));
+
+        assertThatThrownBy(() -> controller.updateContractDefinition(contractDefinition.getId(), dto)).isInstanceOf(InvalidRequestException.class);
     }
 
     private ContractDefinition createContractDefinition(String id) {

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/api/management/contractdefinition/model/ContractDefinitionCreateDtoTest.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/api/management/contractdefinition/model/ContractDefinitionCreateDtoTest.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class ContractDefinitionRequestDtoTest {
+class ContractDefinitionCreateDtoTest {
 
     private ObjectMapper objectMapper;
 
@@ -37,7 +37,7 @@ class ContractDefinitionRequestDtoTest {
     @Test
     void verifySerialization() throws JsonProcessingException {
         var criterion = CriterionDto.Builder.newInstance().operandLeft("name").operator("beginsWith").operandRight("test").build();
-        var dto = ContractDefinitionRequestDto.Builder.newInstance()
+        var dto = ContractDefinitionCreateDto.Builder.newInstance()
                 .contractPolicyId("test-contract-policyid")
                 .accessPolicyId("test-access-policyid")
                 .id("test-id")
@@ -48,7 +48,7 @@ class ContractDefinitionRequestDtoTest {
 
         assertThat(str).isNotNull();
 
-        var deserialized = objectMapper.readValue(str, ContractDefinitionRequestDto.class);
+        var deserialized = objectMapper.readValue(str, ContractDefinitionCreateDto.class);
         assertThat(deserialized).usingRecursiveComparison().isEqualTo(dto);
     }
 }

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/api/management/contractdefinition/model/ContractDefinitionCreateDtoValidationTest.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/api/management/contractdefinition/model/ContractDefinitionCreateDtoValidationTest.java
@@ -31,7 +31,7 @@ import java.util.stream.Stream;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-class ContractDefinitionRequestDtoValidationTest {
+class ContractDefinitionCreateDtoValidationTest {
 
     private Validator validator;
 
@@ -45,7 +45,7 @@ class ContractDefinitionRequestDtoValidationTest {
     @ParameterizedTest
     @ArgumentsSource(ValidArgsProvider.class)
     void validate_valid(String id, String accessPolicyId, String contractPolicyId, List<CriterionDto> criteria) {
-        var dto = ContractDefinitionRequestDto.Builder.newInstance()
+        var dto = ContractDefinitionCreateDto.Builder.newInstance()
                 .id(id)
                 .accessPolicyId(accessPolicyId)
                 .contractPolicyId(contractPolicyId)
@@ -60,7 +60,7 @@ class ContractDefinitionRequestDtoValidationTest {
     @ParameterizedTest
     @ArgumentsSource(InvalidArgsProvider.class)
     void validate_invalid(String id, String accessPolicyId, String contractPolicyId, List<CriterionDto> criteria) {
-        var dto = ContractDefinitionRequestDto.Builder.newInstance()
+        var dto = ContractDefinitionCreateDto.Builder.newInstance()
                 .id(id)
                 .accessPolicyId(accessPolicyId)
                 .contractPolicyId(contractPolicyId)

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/api/management/contractdefinition/model/ContractDefinitionUpdateDtoTest.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/api/management/contractdefinition/model/ContractDefinitionUpdateDtoTest.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+
+package org.eclipse.edc.connector.api.management.contractdefinition.model;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.edc.api.model.CriterionDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ContractDefinitionUpdateDtoTest {
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    void verifySerialization() throws JsonProcessingException {
+        var criterion = CriterionDto.Builder.newInstance().operandLeft("name").operator("beginsWith").operandRight("test").build();
+        var dto = ContractDefinitionUpdateDto.Builder.newInstance()
+                .contractPolicyId("test-contract-policyid")
+                .accessPolicyId("test-access-policyid")
+                .criteria(List.of(criterion))
+                .build();
+
+        var str = objectMapper.writeValueAsString(dto);
+
+        assertThat(str).isNotNull();
+
+        var deserialized = objectMapper.readValue(str, ContractDefinitionUpdateDto.class);
+        assertThat(deserialized).usingRecursiveComparison().isEqualTo(dto);
+    }
+}

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/api/management/contractdefinition/model/ContractDefinitionUpdateDtoTest.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/api/management/contractdefinition/model/ContractDefinitionUpdateDtoTest.java
@@ -12,7 +12,6 @@
  *
  */
 
-
 package org.eclipse.edc.connector.api.management.contractdefinition.model;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/api/management/contractdefinition/model/ContractDefinitionUpdateDtoValidationTest.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/api/management/contractdefinition/model/ContractDefinitionUpdateDtoValidationTest.java
@@ -1,0 +1,96 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.contractdefinition.model;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.eclipse.edc.api.model.CriterionDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ContractDefinitionUpdateDtoValidationTest {
+
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+            validator = factory.getValidator();
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ValidArgsProvider.class)
+    void validate_valid(String accessPolicyId, String contractPolicyId, List<CriterionDto> criteria) {
+        var dto = ContractDefinitionUpdateDto.Builder.newInstance()
+                .accessPolicyId(accessPolicyId)
+                .contractPolicyId(contractPolicyId)
+                .criteria(criteria)
+                .build();
+
+        var result = validator.validate(dto);
+
+        assertThat(result).isEmpty();
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(InvalidArgsProvider.class)
+    void validate_invalid(String accessPolicyId, String contractPolicyId, List<CriterionDto> criteria) {
+        var dto = ContractDefinitionUpdateDto.Builder.newInstance()
+                .accessPolicyId(accessPolicyId)
+                .contractPolicyId(contractPolicyId)
+                .criteria(criteria)
+                .build();
+
+        var result = validator.validate(dto);
+
+        assertThat(result).hasSizeGreaterThan(0);
+    }
+
+    private static class ValidArgsProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            var criterion = CriterionDto.Builder.newInstance().operandLeft("foo").operator("=").operandRight("bar").build();
+            return Stream.of(
+                    Arguments.of("accessPolicy", "contractPolicy", List.of(criterion)),
+                    Arguments.of("accessPolicy", "contractPolicy", List.of(criterion)),
+                    Arguments.of("accessPolicy", "contractPolicy", emptyList())
+            );
+        }
+    }
+
+    private static class InvalidArgsProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                    Arguments.of(null, "contractPolicy", emptyList()),
+                    Arguments.of("accessPolicy", null, emptyList()),
+                    Arguments.of("accessPolicy", "contractPolicy", null),
+                    Arguments.of("accessPolicy", "contractPolicy", List.of(CriterionDto.Builder.newInstance().build()))
+            );
+        }
+    }
+}

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/api/management/contractdefinition/transform/ContractDefinitionRequestDtoToContractDefinitionTransformerTest.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/api/management/contractdefinition/transform/ContractDefinitionRequestDtoToContractDefinitionTransformerTest.java
@@ -15,7 +15,7 @@
 package org.eclipse.edc.connector.api.management.contractdefinition.transform;
 
 import org.eclipse.edc.api.model.CriterionDto;
-import org.eclipse.edc.connector.api.management.contractdefinition.model.ContractDefinitionRequestDto;
+import org.eclipse.edc.connector.api.management.contractdefinition.model.ContractDefinitionCreateDto;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.junit.jupiter.api.Test;
@@ -47,7 +47,7 @@ class ContractDefinitionRequestDtoToContractDefinitionTransformerTest {
         var context = mock(TransformerContext.class);
         when(context.transform(isA(CriterionDto.class), eq(Criterion.class))).thenReturn(new Criterion("left", "=", "right"));
 
-        var contractDefinitionDto = ContractDefinitionRequestDto.Builder.newInstance()
+        var contractDefinitionDto = ContractDefinitionCreateDto.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
                 .accessPolicyId(UUID.randomUUID().toString())
                 .contractPolicyId(UUID.randomUUID().toString())

--- a/resources/openapi/yaml/management-api/contract-definition-api.yaml
+++ b/resources/openapi/yaml/management-api/contract-definition-api.yaml
@@ -122,6 +122,45 @@ paths:
           description: Request was malformed
       tags:
       - Contract Definition
+  /contractdefinitions/{contractDefinitionId}:
+    put:
+      description: Updated a contract definition with the given ID
+      operationId: updateContractDefinition
+      parameters:
+      - in: path
+        name: contractDefinitionId
+        required: true
+        schema:
+          type: string
+          example: null
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: '#/components/schemas/ContractDefinitionUpdateDto'
+      responses:
+        "204":
+          description: Contract definition was updated successfully
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: "Request was malformed, e.g. id was null"
+        "404":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: A contract definition with the given ID does not exist
+      tags:
+      - Contract Definition
   /contractdefinitions/{id}:
     delete:
       description: "Removes a contract definition with the given ID if possible. DANGER\
@@ -266,6 +305,29 @@ components:
           type: integer
           format: int64
           example: null
+    ContractDefinitionUpdateDto:
+      type: object
+      example: null
+      properties:
+        accessPolicyId:
+          type: string
+          example: null
+        contractPolicyId:
+          type: string
+          example: null
+        criteria:
+          type: array
+          example: null
+          items:
+            $ref: '#/components/schemas/CriterionDto'
+        validity:
+          type: integer
+          format: int64
+          example: null
+      required:
+      - accessPolicyId
+      - contractPolicyId
+      - criteria
     CriterionDto:
       type: object
       example: null

--- a/resources/openapi/yaml/management-api/contract-definition-api.yaml
+++ b/resources/openapi/yaml/management-api/contract-definition-api.yaml
@@ -63,7 +63,7 @@ paths:
         content:
           '*/*':
             schema:
-              $ref: '#/components/schemas/ContractDefinitionRequestDto'
+              $ref: '#/components/schemas/ContractDefinitionCreateDto'
       responses:
         "200":
           content:
@@ -253,7 +253,7 @@ components:
         type:
           type: string
           example: null
-    ContractDefinitionRequestDto:
+    ContractDefinitionCreateDto:
       type: object
       example: null
       properties:

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/contractdefinition/ContractDefinitionUpdated.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/contractdefinition/ContractDefinitionUpdated.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.spi.event.contractdefinition;
+
+import java.util.Objects;
+
+/**
+ * Describe a ContractDefinition modification.
+ */
+public class ContractDefinitionUpdated extends ContractDefinitionEvent<ContractDefinitionUpdated.Payload> {
+
+    private ContractDefinitionUpdated() {
+    }
+
+    /**
+     * This class contains all event specific attributes of a ContractDefinition Updated Event
+     */
+    public static class Payload extends ContractDefinitionEvent.Payload {
+    }
+
+    public static class Builder extends ContractDefinitionEvent.Builder<ContractDefinitionUpdated, Payload, Builder> {
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        private Builder() {
+            super(new ContractDefinitionUpdated(), new Payload());
+        }
+
+        @Override
+        public Builder contractDefinitionId(String contractDefinitionId) {
+            event.payload.contractDefinitionId = contractDefinitionId;
+            return this;
+        }
+
+        @Override
+        protected void validate() {
+            Objects.requireNonNull(event.payload.contractDefinitionId);
+        }
+    }
+
+}

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/definition/observe/ContractDefinitionListener.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/definition/observe/ContractDefinitionListener.java
@@ -42,4 +42,12 @@ public interface ContractDefinitionListener {
 
     }
 
+    /**
+     * Called after a {@link ContractDefinition} was updated.
+     *
+     * @param contractDefinition the contractDefinition that has been updated.
+     */
+    default void updated(ContractDefinition contractDefinition) {
+
+    }
 }

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/contractdefinition/ContractDefinitionService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/contractdefinition/ContractDefinitionService.java
@@ -51,6 +51,16 @@ public interface ContractDefinitionService {
     ServiceResult<ContractDefinition> create(ContractDefinition contractDefinition);
 
     /**
+     * Update a contract definition. If a definition with the input id doesn't exist, returns
+     * NOT_FOUND failure.
+     *
+     * @param contractDefinition the contract definition
+     * @return successful result if the contract definition is updated correctly, failure otherwise
+     */
+    ServiceResult<Void> update(ContractDefinition contractDefinition);
+
+
+    /**
      * Delete a contract definition. If the definition is already referenced by a contract agreement, returns CONFLICT
      * failure. If the definition does not exist, returns NOT_FOUND failure.
      *


### PR DESCRIPTION
## What this PR changes/adds

Add the `UPDATE` endpoint to the `ContractDefinitionApi`

## Why it does that

to enable update semantics on contract definitions

## Further notes

- I created `ContractDefinitionUpdateDto` for updating the contract definition (same as ContractDefinitionRequestDto without the id)
- I created `ContractDefinitionUpdateDtoWrapper` which is a composition of `ContractDefinitionUpdateDto` + id to update
- The `ContractDefinitionUpdateDtoWrapper` is then transformed through the transformer registry into the final `ContractDefinition` to update

## Linked Issue(s)

Closes #2510 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
