### PR TITLE
chore: upgrade to gradle 8, upgrade the shadow plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,7 +46,7 @@ allprojects {
 
     // configure which version of the annotation processor to use. defaults to the same version as the plugin
     configure<org.eclipse.edc.plugins.autodoc.AutodocExtension> {
-        processorVersion.set(annotationProcessorVersion)
+//        processorVersion.set(annotationProcessorVersion)
         outputDirectory.set(project.buildDir)
     }
 

--- a/docs/developer/build-your-own-connector.md
+++ b/docs/developer/build-your-own-connector.md
@@ -7,6 +7,7 @@ This guide will explain how to set up a **connector**, that would be able to com
 negotiate contracts and transfer data.
 
 A connector is logically divided in 3 parts:
+
 - control-plane
 - data-plane
 - data-plane-selector
@@ -18,11 +19,12 @@ to scale data-planes independently of control-planes.
 
 The easiest way to build up a connector is to build all their parts into a single deployment unit.
 To do this, create a new gradle project with a `build.gradle.kts` file in it:
+
 ```kotlin
 plugins {
     `java-library`
     id("application")
-    id("com.github.johnrengelman.shadow") version "7.1.2"
+    id("com.github.johnrengelman.shadow") version "8.0.0"
 }
 
 repositories {
@@ -65,14 +67,17 @@ tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
 
 ```
 
-Note that no `data-plane-selector` modules are needed, this because the `data-plane` is built as embedded in the connector.
+Note that no `data-plane-selector` modules are needed, this because the `data-plane` is built as embedded in the
+connector.
 
 Build:
+
 ```
 ./gradlew build
 ```
 
 Run:
+
 ```
 java -jar build/libs/connector.jar
 ```
@@ -89,10 +94,13 @@ Currently, there are two different database extensions for the control-plane:
 ### Setting data-plane
 
 To make the *control-plane* interact with the *data-plane*, it will need at least one of these extensions:
+
 - `data-plane-transfer-client`: provides a client to delegate data transfer to the *data-plane*.
-- `data-plane-transfer-sync`: provides services to use the *data-plane* as a proxy for querying data from the provider data source.
+- `data-plane-transfer-sync`: provides services to use the *data-plane* as a proxy for querying data from the provider
+  data source.
 
 The *data-plane* will need extensions to being able to read/write data from/to different protocols/services, e.g.:
+
 - `data-plane-api`: will make the *data-plane* expose APIs that are needed to actually transfer data
 - `data-plane-http`: support HTTP protocol
 - `data-plane-azure-storage`: support [Azure Blob Storage](https://azure.microsoft.com/products/storage/blobs/) service

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/launchers/data-plane-server/build.gradle.kts
+++ b/launchers/data-plane-server/build.gradle.kts
@@ -16,7 +16,7 @@
 plugins {
     `java-library`
     id("application")
-    id("com.github.johnrengelman.shadow") version "7.1.2"
+    id("com.github.johnrengelman.shadow") version "8.0.0"
 }
 
 dependencies {

--- a/launchers/dpf-selector/build.gradle.kts
+++ b/launchers/dpf-selector/build.gradle.kts
@@ -15,7 +15,7 @@
 plugins {
     `java-library`
     id("application")
-    id("com.github.johnrengelman.shadow") version "7.1.2"
+    id("com.github.johnrengelman.shadow") version "8.0.0"
 }
 
 dependencies {

--- a/launchers/ids-connector/build.gradle.kts
+++ b/launchers/ids-connector/build.gradle.kts
@@ -16,7 +16,7 @@
 plugins {
     `java-library`
     id("application")
-    id("com.github.johnrengelman.shadow") version "7.1.2"
+    id("com.github.johnrengelman.shadow") version "8.0.0"
 }
 
 dependencies {

--- a/system-tests/runtimes/azure-data-factory-transfer-consumer/build.gradle.kts
+++ b/system-tests/runtimes/azure-data-factory-transfer-consumer/build.gradle.kts
@@ -15,7 +15,7 @@
 plugins {
     `java-library`
     id("application")
-    id("com.github.johnrengelman.shadow") version "7.1.2"
+    id("com.github.johnrengelman.shadow") version "8.0.0"
 }
 
 dependencies {

--- a/system-tests/runtimes/azure-data-factory-transfer-provider/build.gradle.kts
+++ b/system-tests/runtimes/azure-data-factory-transfer-provider/build.gradle.kts
@@ -16,7 +16,7 @@
 plugins {
     `java-library`
     id("application")
-    id("com.github.johnrengelman.shadow") version "7.1.2"
+    id("com.github.johnrengelman.shadow") version "8.0.0"
 }
 
 dependencies {

--- a/system-tests/runtimes/azure-storage-transfer-consumer/build.gradle.kts
+++ b/system-tests/runtimes/azure-storage-transfer-consumer/build.gradle.kts
@@ -16,7 +16,7 @@
 plugins {
     `java-library`
     id("application")
-    id("com.github.johnrengelman.shadow") version "7.1.2"
+    id("com.github.johnrengelman.shadow") version "8.0.0"
 }
 
 dependencies {

--- a/system-tests/runtimes/azure-storage-transfer-provider/build.gradle.kts
+++ b/system-tests/runtimes/azure-storage-transfer-provider/build.gradle.kts
@@ -16,7 +16,7 @@
 plugins {
     `java-library`
     id("application")
-    id("com.github.johnrengelman.shadow") version "7.1.2"
+    id("com.github.johnrengelman.shadow") version "8.0.0"
 }
 
 dependencies {

--- a/system-tests/runtimes/file-transfer-consumer/build.gradle.kts
+++ b/system-tests/runtimes/file-transfer-consumer/build.gradle.kts
@@ -16,7 +16,7 @@
 plugins {
     `java-library`
     id("application")
-    id("com.github.johnrengelman.shadow") version "7.1.2"
+    id("com.github.johnrengelman.shadow") version "8.0.0"
 }
 
 dependencies {

--- a/system-tests/runtimes/file-transfer-provider/build.gradle.kts
+++ b/system-tests/runtimes/file-transfer-provider/build.gradle.kts
@@ -16,7 +16,7 @@
 plugins {
     `java-library`
     id("application")
-    id("com.github.johnrengelman.shadow") version "7.1.2"
+    id("com.github.johnrengelman.shadow") version "8.0.0"
 }
 
 dependencies {


### PR DESCRIPTION
## What this PR changes/adds

Upgrades to Gradle v8.0 and the shadow plugin to v8.0.

## Why it does that

Keep up-to-date with developments, avoid technical debt.

## Further notes
**the CI on this PR will fail unless https://github.com/eclipse-edc/GradlePlugins/pull/89 is merged, as it lays the necessary ground work!**

## Linked Issue(s)

Closes #

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
