### PR TITLE
refactor: rename and move ServiceResult

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,7 +46,7 @@ allprojects {
 
     // configure which version of the annotation processor to use. defaults to the same version as the plugin
     configure<org.eclipse.edc.plugins.autodoc.AutodocExtension> {
-//        processorVersion.set(annotationProcessorVersion)
+        processorVersion.set(annotationProcessorVersion)
         outputDirectory.set(project.buildDir)
     }
 

--- a/spi/common/aggregate-service-spi/src/main/java/org/eclipse/edc/service/spi/result/ServiceResult.java
+++ b/spi/common/aggregate-service-spi/src/main/java/org/eclipse/edc/service/spi/result/ServiceResult.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.service.spi.result;
 
 import org.eclipse.edc.spi.result.AbstractResult;
+import org.eclipse.edc.spi.result.StoreResult;
 
 import java.util.List;
 
@@ -50,6 +51,21 @@ public class ServiceResult<T> extends AbstractResult<T, ServiceFailure> {
 
     public static <T> ServiceResult<T> success() {
         return ServiceResult.success(null);
+    }
+
+    public static <T> ServiceResult<T> from(StoreResult<T> storeResult) {
+        if (storeResult.succeeded()) {
+            return success(storeResult.getContent());
+        }
+
+        switch (storeResult.reason()) {
+            case NOT_FOUND:
+                return notFound(storeResult.getFailureDetail());
+            case ALREADY_EXISTS:
+                return conflict(storeResult.getFailureDetail());
+            default:
+                return badRequest(storeResult.getFailureDetail());
+        }
     }
 
     public ServiceFailure.Reason reason() {

--- a/spi/common/aggregate-service-spi/src/test/java/org/eclipse/edc/service/spi/result/ServiceResultTest.java
+++ b/spi/common/aggregate-service-spi/src/test/java/org/eclipse/edc/service/spi/result/ServiceResultTest.java
@@ -1,0 +1,24 @@
+package org.eclipse.edc.service.spi.result;
+
+import org.eclipse.edc.spi.result.StoreResult;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.eclipse.edc.service.spi.result.ServiceFailure.Reason.CONFLICT;
+import static org.eclipse.edc.service.spi.result.ServiceFailure.Reason.NOT_FOUND;
+
+class ServiceResultTest {
+
+    @Test
+    void verifyFromStorageResult() {
+        var f = ServiceResult.from(StoreResult.notFound("test-message"));
+        assertThat(f.reason()).isEqualTo(NOT_FOUND);
+        assertThat(f.succeeded()).isFalse();
+
+        var f2 = ServiceResult.from(StoreResult.alreadyExists("test-message"));
+        assertThat(f2.reason()).isEqualTo(CONFLICT);
+        assertThat(f2.succeeded()).isFalse();
+
+        assertThat(ServiceResult.from(StoreResult.success("test-message"))).extracting(ServiceResult::succeeded).isEqualTo(true);
+    }
+}

--- a/spi/common/aggregate-service-spi/src/test/java/org/eclipse/edc/service/spi/result/ServiceResultTest.java
+++ b/spi/common/aggregate-service-spi/src/test/java/org/eclipse/edc/service/spi/result/ServiceResultTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
 package org.eclipse.edc.service.spi.result;
 
 import org.eclipse.edc.spi.result.StoreResult;

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/StoreFailure.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/StoreFailure.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.spi.result;
+
+import java.util.List;
+
+public class StoreFailure extends Failure {
+    private final Reason reason;
+
+    public StoreFailure(List<String> messages, Reason reason) {
+        super(messages);
+        this.reason = reason;
+    }
+
+    public Reason getReason() {
+        return reason;
+    }
+
+    public enum Reason {
+        NOT_FOUND, ALREADY_EXISTS
+    }
+}

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/StoreResult.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/StoreResult.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.spi.result;
+
+import java.util.List;
+
+import static org.eclipse.edc.spi.result.StoreFailure.Reason.ALREADY_EXISTS;
+import static org.eclipse.edc.spi.result.StoreFailure.Reason.NOT_FOUND;
+
+/**
+ * Specialized {@link Result} class to indicate the success or failure of an interaction with the persistence layer.
+ *
+ * @param <T> The type of content
+ */
+public class StoreResult<T> extends AbstractResult<T, StoreFailure> {
+
+    protected StoreResult(T content, StoreFailure failure) {
+        super(content, failure);
+    }
+
+    public static <T> StoreResult<T> success(T content) {
+        return new StoreResult<>(content, null);
+    }
+
+    public static <T> StoreResult<T> alreadyExists(String message) {
+        return new StoreResult<>(null, new StoreFailure(List.of(message), ALREADY_EXISTS));
+    }
+
+    public static <T> StoreResult<T> notFound(String message) {
+        return new StoreResult<>(null, new StoreFailure(List.of(message), NOT_FOUND));
+    }
+
+
+    public static <T> StoreResult<T> success() {
+        return StoreResult.success(null);
+    }
+
+    public StoreFailure.Reason reason() {
+        return getFailure().getReason();
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

- Renames `ServiceResult` -> `RequestResult` and `ServiceFailure` -> `RequestFailure`
- Moves the `RequestResult` and `RequestFailure` to the `core-spi` module
- deleted the now-empty `aggregate-service-spi` module and references to it

_this is just renaming and moving, no functional change was performed_

## Why it does that

Make these two classes accessible to more core features like entity stores

## Further notes

- I also uncommented a line in the root `build.gradle.kts`, which I assume slipped in by mistake


## Linked Issue(s)

Closes #2545 

## Checklist

- [ ] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
