### PR TITLE
refactor: add create update to cosmos api

### DIFF
--- a/extensions/common/azure/azure-cosmos-core/src/main/java/org/eclipse/edc/azure/cosmos/CosmosDbApi.java
+++ b/extensions/common/azure/azure-cosmos-core/src/main/java/org/eclipse/edc/azure/cosmos/CosmosDbApi.java
@@ -24,9 +24,11 @@ import java.util.stream.Stream;
 
 public interface CosmosDbApi extends ReadinessProvider {
 
-    void saveItem(CosmosDocument<?> item);
+    void createItem(CosmosDocument<?> item);
 
-    void saveItems(Collection<CosmosDocument<?>> definitions);
+    void createItems(Collection<CosmosDocument<?>> definitions);
+
+    void updateItem(CosmosDocument<?> item);
 
     Object deleteItem(String id);
 

--- a/extensions/common/azure/azure-cosmos-core/src/main/java/org/eclipse/edc/azure/cosmos/CosmosDbApiImpl.java
+++ b/extensions/common/azure/azure-cosmos-core/src/main/java/org/eclipse/edc/azure/cosmos/CosmosDbApiImpl.java
@@ -73,19 +73,15 @@ public class CosmosDbApiImpl implements CosmosDbApi {
     }
 
     @Override
-    public void saveItem(CosmosDocument<?> item) {
-        try {
-            // we don't need to supply a partition key, it will be extracted from the CosmosDocument
-            CosmosItemResponse<Object> response = container.upsertItem(item, itemRequestOptions);
-            handleResponse(response, "Failed to create item");
-        } catch (CosmosException e) {
-            throw new EdcException(e);
-        }
+    public void createItem(CosmosDocument<?> item) {
+        // we don't need to supply a partition key, it will be extracted from the CosmosDocument
+        var response = container.createItem(item, itemRequestOptions);
+        handleResponse(response, "Failed to create item");
     }
 
     @Override
-    public void saveItems(Collection<CosmosDocument<?>> definitions) {
-        definitions.forEach(this::saveItem);
+    public void createItems(Collection<CosmosDocument<?>> definitions) {
+        definitions.forEach(this::createItem);
     }
 
     @Override
@@ -202,6 +198,12 @@ public class CosmosDbApiImpl implements CosmosDbApi {
         if (scripts.readAllStoredProcedures().stream().noneMatch(sp -> sp.getId().equals(name))) {
             scripts.createStoredProcedure(props);
         }
+    }
+
+    @Override
+    public void updateItem(CosmosDocument<?> item) {
+        var response = container.replaceItem(item, item.getId(), new PartitionKey(item.getPartitionKey()), itemRequestOptions);
+        handleResponse(response, "Failed to update item");
     }
 
     @Override

--- a/extensions/common/azure/azure-cosmos-core/src/test/java/org/eclipse/edc/azure/cosmos/CosmosDbApiImplIntegrationTest.java
+++ b/extensions/common/azure/azure-cosmos-core/src/test/java/org/eclipse/edc/azure/cosmos/CosmosDbApiImplIntegrationTest.java
@@ -82,7 +82,7 @@ class CosmosDbApiImplIntegrationTest {
     @Test
     void createItem() {
         var testItem = new TestCosmosDocument("payload", PARTITION_KEY);
-        cosmosDbApi.saveItem(testItem);
+        cosmosDbApi.createItem(testItem);
         record.add(testItem);
 
         assertThat(container.readAllItems(new PartitionKey(PARTITION_KEY), Object.class)).hasSize(1);
@@ -171,4 +171,24 @@ class CosmosDbApiImplIntegrationTest {
                 .isInstanceOf(NotFoundException.class);
     }
 
+
+    @Test
+    void update_whenNotExists() {
+        var item = new TestCosmosDocument("payload", PARTITION_KEY);
+        assertThatThrownBy(() -> cosmosDbApi.updateItem(item)).isInstanceOf(NotFoundException.class);
+
+        assertThat(container.readAllItems(new PartitionKey(PARTITION_KEY), Object.class)).isEmpty();
+    }
+
+    @Test
+    void update_whenExists() {
+        var item = new TestCosmosDocument("payload", PARTITION_KEY);
+        cosmosDbApi.createItem(item);
+        record.add(item);
+
+        //now update
+        cosmosDbApi.updateItem(item);
+
+        assertThat(container.readAllItems(new PartitionKey(PARTITION_KEY), Object.class)).hasSize(1);
+    }
 }

--- a/extensions/control-plane/store/cosmos/asset-index-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/assetindex/CosmosAssetIndex.java
+++ b/extensions/control-plane/store/cosmos/asset-index-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/assetindex/CosmosAssetIndex.java
@@ -102,7 +102,7 @@ public class CosmosAssetIndex implements AssetIndex {
     @Override
     public void accept(AssetEntry item) {
         var assetDocument = new AssetDocument(item.getAsset(), partitionKey, item.getDataAddress());
-        assetDb.saveItem(assetDocument);
+        assetDb.createItem(assetDocument);
     }
 
     @Override
@@ -133,7 +133,7 @@ public class CosmosAssetIndex implements AssetIndex {
 
         return result.map(assetDocument -> {
             var updated = new AssetDocument(asset, assetDocument.getPartitionKey(), assetDocument.getDataAddress());
-            assetDb.saveItem(updated);
+            assetDb.createItem(updated);
             return asset;
         }).orElse(null);
     }
@@ -145,7 +145,7 @@ public class CosmosAssetIndex implements AssetIndex {
 
         return result.map(assetDocument -> {
             var updated = new AssetDocument(assetDocument.getWrappedAsset(), assetDocument.getPartitionKey(), dataAddress);
-            assetDb.saveItem(updated);
+            assetDb.createItem(updated);
             return dataAddress;
         }).orElse(null);
     }

--- a/extensions/control-plane/store/cosmos/contract-definition-store-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/contractdefinition/CosmosContractDefinitionStore.java
+++ b/extensions/control-plane/store/cosmos/contract-definition-store-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/contractdefinition/CosmosContractDefinitionStore.java
@@ -75,12 +75,12 @@ public class CosmosContractDefinitionStore implements ContractDefinitionStore {
 
     @Override
     public void save(Collection<ContractDefinition> definitions) {
-        with(retryPolicy).run(() -> cosmosDbApi.saveItems(definitions.stream().map(this::convertToDocument).collect(Collectors.toList())));
+        with(retryPolicy).run(() -> cosmosDbApi.createItems(definitions.stream().map(this::convertToDocument).collect(Collectors.toList())));
     }
 
     @Override
     public void save(ContractDefinition definition) {
-        with(retryPolicy).run(() -> cosmosDbApi.saveItem(convertToDocument(definition)));
+        with(retryPolicy).run(() -> cosmosDbApi.createItem(convertToDocument(definition)));
     }
 
     @Override

--- a/extensions/control-plane/store/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/contractdefinition/CosmosContractDefinitionStoreTest.java
+++ b/extensions/control-plane/store/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/contractdefinition/CosmosContractDefinitionStoreTest.java
@@ -108,19 +108,19 @@ class CosmosContractDefinitionStoreTest {
     @Test
     void save() {
         var captor = ArgumentCaptor.forClass(CosmosDocument.class);
-        doNothing().when(cosmosDbApiMock).saveItem(captor.capture());
+        doNothing().when(cosmosDbApiMock).createItem(captor.capture());
         var definition = generateDefinition();
 
         store.save(definition);
 
         assertThat(captor.getValue().getWrappedInstance()).isEqualTo(definition);
-        verify(cosmosDbApiMock).saveItem(captor.capture());
+        verify(cosmosDbApiMock).createItem(captor.capture());
     }
 
     @Test
     void save_verifyWriteThrough() {
         var captor = ArgumentCaptor.forClass(CosmosDocument.class);
-        doNothing().when(cosmosDbApiMock).saveItem(captor.capture());
+        doNothing().when(cosmosDbApiMock).createItem(captor.capture());
         when(cosmosDbApiMock.queryItems(any(SqlQuerySpec.class))).thenReturn(IntStream.range(0, 1).mapToObj((i) -> captor.getValue()));
         // cosmosDbApiQueryMock.queryAllItems() should never be called
         var definition = generateDefinition();
@@ -131,19 +131,19 @@ class CosmosContractDefinitionStoreTest {
 
         assertThat(all).isNotEmpty().containsExactlyInAnyOrder((ContractDefinition) captor.getValue().getWrappedInstance());
         verify(cosmosDbApiMock).queryItems(any(SqlQuerySpec.class));
-        verify(cosmosDbApiMock).saveItem(captor.capture());
+        verify(cosmosDbApiMock).createItem(captor.capture());
     }
 
     @Test
     void update() {
         var captor = ArgumentCaptor.forClass(CosmosDocument.class);
-        doNothing().when(cosmosDbApiMock).saveItem(captor.capture());
+        doNothing().when(cosmosDbApiMock).createItem(captor.capture());
         var definition = generateDefinition();
 
         store.update(definition);
 
         assertThat(captor.getValue().getWrappedInstance()).isEqualTo(definition);
-        verify(cosmosDbApiMock).saveItem(captor.capture());
+        verify(cosmosDbApiMock).createItem(captor.capture());
     }
 
     @Test

--- a/extensions/control-plane/store/cosmos/contract-negotiation-store-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/contractnegotiation/CosmosContractNegotiationStore.java
+++ b/extensions/control-plane/store/cosmos/contract-negotiation-store-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/contractnegotiation/CosmosContractNegotiationStore.java
@@ -104,7 +104,7 @@ public class CosmosContractNegotiationStore implements ContractNegotiationStore 
     public void save(ContractNegotiation negotiation) {
         try {
             leaseContext.acquireLease(negotiation.getId());
-            with(retryPolicy).run(() -> cosmosDbApi.saveItem(new ContractNegotiationDocument(negotiation, partitionKey)));
+            with(retryPolicy).run(() -> cosmosDbApi.createItem(new ContractNegotiationDocument(negotiation, partitionKey)));
             leaseContext.breakLease(negotiation.getId());
         } catch (BadRequestException ex) {
             throw new IllegalStateException(ex);

--- a/extensions/control-plane/store/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/contractnegotiation/CosmosContractNegotiationStoreTest.java
+++ b/extensions/control-plane/store/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/contractnegotiation/CosmosContractNegotiationStoreTest.java
@@ -110,7 +110,7 @@ class CosmosContractNegotiationStoreTest {
 
         store.save(negotiation);
 
-        verify(cosmosDbApi).saveItem(any(ContractNegotiationDocument.class));
+        verify(cosmosDbApi).createItem(any(ContractNegotiationDocument.class));
         verify(cosmosDbApi, times(2)).invokeStoredProcedure(eq("lease"), eq(PARTITION_KEY), any());
         verifyNoMoreInteractions(cosmosDbApi);
     }

--- a/extensions/control-plane/store/cosmos/policy-definition-store-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/policydefinition/CosmosPolicyDefinitionStore.java
+++ b/extensions/control-plane/store/cosmos/policy-definition-store-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/policydefinition/CosmosPolicyDefinitionStore.java
@@ -73,13 +73,13 @@ public class CosmosPolicyDefinitionStore implements PolicyDefinitionStore {
 
     @Override
     public void save(PolicyDefinition policy) {
-        with(retryPolicy).run(() -> cosmosDbApi.saveItem(convertToDocument(policy)));
+        with(retryPolicy).run(() -> cosmosDbApi.createItem(convertToDocument(policy)));
     }
 
     @Override
     public PolicyDefinition update(String policyId, PolicyDefinition policy) {
         if (findById(policyId) != null) {
-            with(retryPolicy).run(() -> cosmosDbApi.saveItem((convertToDocument(policy))));
+            with(retryPolicy).run(() -> cosmosDbApi.createItem((convertToDocument(policy))));
             return policy;
         }
         return null;

--- a/extensions/control-plane/store/cosmos/policy-definition-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/policydefinition/CosmosPolicyDefinitionStoreTest.java
+++ b/extensions/control-plane/store/cosmos/policy-definition-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/policydefinition/CosmosPolicyDefinitionStoreTest.java
@@ -84,19 +84,19 @@ class CosmosPolicyDefinitionStoreTest {
     @Test
     void save() {
         var captor = ArgumentCaptor.forClass(CosmosDocument.class);
-        doNothing().when(cosmosDbApiMock).saveItem(captor.capture());
+        doNothing().when(cosmosDbApiMock).createItem(captor.capture());
         var definition = generatePolicy();
 
         store.save(definition);
 
         assertThat(captor.getValue().getWrappedInstance()).isEqualTo(definition);
-        verify(cosmosDbApiMock).saveItem(captor.capture());
+        verify(cosmosDbApiMock).createItem(captor.capture());
     }
 
     @Test
     void save_verifyWriteThrough() {
         var captor = ArgumentCaptor.forClass(PolicyDocument.class);
-        doNothing().when(cosmosDbApiMock).saveItem(captor.capture());
+        doNothing().when(cosmosDbApiMock).createItem(captor.capture());
         var definition = generatePolicy();
 
         when(cosmosDbApiMock.queryItems(any(SqlQuerySpec.class))).thenReturn(IntStream.range(0, 1).mapToObj((i) -> captor.getValue()));
@@ -107,19 +107,19 @@ class CosmosPolicyDefinitionStoreTest {
 
         assertThat(all).isNotEmpty().containsExactlyInAnyOrder(captor.getValue().getWrappedInstance());
         verify(cosmosDbApiMock).queryItems(any(SqlQuerySpec.class));
-        verify(cosmosDbApiMock).saveItem(captor.capture());
+        verify(cosmosDbApiMock).createItem(captor.capture());
     }
 
     @Test
     void update() {
         var captor = ArgumentCaptor.forClass(CosmosDocument.class);
-        doNothing().when(cosmosDbApiMock).saveItem(captor.capture());
+        doNothing().when(cosmosDbApiMock).createItem(captor.capture());
         var definition = generatePolicy();
 
         store.save(definition);
 
         assertThat(captor.getValue().getWrappedInstance()).isEqualTo(definition);
-        verify(cosmosDbApiMock).saveItem(captor.capture());
+        verify(cosmosDbApiMock).createItem(captor.capture());
     }
 
     @Test

--- a/extensions/control-plane/store/cosmos/transfer-process-store-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/transferprocess/CosmosTransferProcessStore.java
+++ b/extensions/control-plane/store/cosmos/transfer-process-store-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/transferprocess/CosmosTransferProcessStore.java
@@ -121,7 +121,7 @@ public class CosmosTransferProcessStore implements TransferProcessStore {
         Objects.requireNonNull(process.getId(), "TransferProcesses must have an ID!");
         try {
             leaseContext.acquireLease(process.getId());
-            failsafeExecutor.run(() -> cosmosDbApi.saveItem(new TransferProcessDocument(process, partitionKey)));
+            failsafeExecutor.run(() -> cosmosDbApi.createItem(new TransferProcessDocument(process, partitionKey)));
             leaseContext.breakLease(process.getId());
         } catch (BadRequestException ex) {
             throw new EdcException(ex);

--- a/extensions/data-plane-selector/store/cosmos/data-plane-instance-store-cosmos/src/main/java/org/eclipse/edc/connector/dataplane/selector/store/cosmos/CosmosDataPlaneInstanceStore.java
+++ b/extensions/data-plane-selector/store/cosmos/data-plane-instance-store-cosmos/src/main/java/org/eclipse/edc/connector/dataplane/selector/store/cosmos/CosmosDataPlaneInstanceStore.java
@@ -84,7 +84,7 @@ public class CosmosDataPlaneInstanceStore implements DataPlaneInstanceStore {
 
     private void insertOrUpdate(DataPlaneInstance instance) {
         var document = new DataPlaneInstanceDocument(instance, partitionKey);
-        with(retryPolicy).run(() -> cosmosDbApi.saveItem(document));
+        with(retryPolicy).run(() -> cosmosDbApi.createItem(document));
     }
 
     private DataPlaneInstance convert(Object object) {

--- a/extensions/data-plane/store/cosmos/data-plane-store-cosmos/src/main/java/org/eclipse/edc/connector/dataplane/store/cosmos/CosmosDataPlaneStore.java
+++ b/extensions/data-plane/store/cosmos/data-plane-store-cosmos/src/main/java/org/eclipse/edc/connector/dataplane/store/cosmos/CosmosDataPlaneStore.java
@@ -71,7 +71,7 @@ public class CosmosDataPlaneStore implements DataPlaneStore {
     }
 
     private void save(DataFlowRequestDocument doc) {
-        with(retryPolicy).run(() -> cosmosDbApi.saveItem(doc));
+        with(retryPolicy).run(() -> cosmosDbApi.createItem(doc));
     }
 
     private DataFlowRequestDocument findByIdInternal(String processorId) {

--- a/spi/common/aggregate-service-spi/src/main/java/org/eclipse/edc/service/spi/result/ServiceResult.java
+++ b/spi/common/aggregate-service-spi/src/main/java/org/eclipse/edc/service/spi/result/ServiceResult.java
@@ -57,7 +57,20 @@ public class ServiceResult<T> extends AbstractResult<T, ServiceFailure> {
         if (storeResult.succeeded()) {
             return success(storeResult.getContent());
         }
+        switch (storeResult.reason()) {
+            case NOT_FOUND:
+                return notFound(storeResult.getFailureDetail());
+            case ALREADY_EXISTS:
+                return conflict(storeResult.getFailureDetail());
+            default:
+                return badRequest(storeResult.getFailureDetail());
+        }
+    }
 
+    public static <T> ServiceResult<T> fromFailure(StoreResult<?> storeResult) {
+        if (storeResult.succeeded()) {
+            throw new IllegalArgumentException("Can only use fromFailure() when the argument is a failed result. Please use ServiceResult.from() to also convert success results!");
+        }
         switch (storeResult.reason()) {
             case NOT_FOUND:
                 return notFound(storeResult.getFailureDetail());

--- a/spi/common/aggregate-service-spi/src/main/java/org/eclipse/edc/service/spi/result/ServiceResult.java
+++ b/spi/common/aggregate-service-spi/src/main/java/org/eclipse/edc/service/spi/result/ServiceResult.java
@@ -69,7 +69,7 @@ public class ServiceResult<T> extends AbstractResult<T, ServiceFailure> {
 
     public static <T> ServiceResult<T> fromFailure(StoreResult<?> storeResult) {
         if (storeResult.succeeded()) {
-            throw new IllegalArgumentException("Can only use fromFailure() when the argument is a failed result. Please use ServiceResult.from() to also convert success results!");
+            throw new IllegalArgumentException("Can only use this method when the argument is a failed result!");
         }
         switch (storeResult.reason()) {
             case NOT_FOUND:

--- a/spi/common/aggregate-service-spi/src/test/java/org/eclipse/edc/service/spi/result/ServiceResultTest.java
+++ b/spi/common/aggregate-service-spi/src/test/java/org/eclipse/edc/service/spi/result/ServiceResultTest.java
@@ -18,6 +18,7 @@ import org.eclipse.edc.spi.result.StoreResult;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.eclipse.edc.service.spi.result.ServiceFailure.Reason.CONFLICT;
 import static org.eclipse.edc.service.spi.result.ServiceFailure.Reason.NOT_FOUND;
 
@@ -34,5 +35,10 @@ class ServiceResultTest {
         assertThat(f2.succeeded()).isFalse();
 
         assertThat(ServiceResult.from(StoreResult.success("test-message"))).extracting(ServiceResult::succeeded).isEqualTo(true);
+    }
+
+    @Test
+    void fromFailure_withSuccessResult() {
+        assertThatThrownBy(() -> ServiceResult.fromFailure(StoreResult.success())).isInstanceOf(IllegalArgumentException.class);
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Replaces the `saveItem` method of the `CosmosDbApi` with a dedicated `create()` and `update()` method, both of which in turn call the `createItem` and `replaceItem` methods of the Cosmos SDK.


## Why it does that

Preparatory work for #2531 

## Further notes

- Any exceptions coming from the CosmosSDK are not wrapped in an `EdcException` anymore, the calling store implementations must handle a `NotFoundException` and a `ConflictException`
- Subsequent work (#2536 #2537 #2538 #2539) will add code to handle the exceptions and convert them into `StoreResult`s

## Linked Issue(s)

Closes #2531 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
