### PR TITLE
refactor(DataPlaneInstanceStore): removed upsert semantic and introduced results on CU operations

### DIFF
--- a/core/data-plane-selector/data-plane-selector-core/src/main/java/org/eclipse/edc/connector/dataplane/selector/core/DataPlaneSelectorExtension.java
+++ b/core/data-plane-selector/data-plane-selector-core/src/main/java/org/eclipse/edc/connector/dataplane/selector/core/DataPlaneSelectorExtension.java
@@ -26,6 +26,7 @@ import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provides;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.transaction.spi.TransactionContext;
 
 @Provides({ DataPlaneSelector.class, SelectionStrategyRegistry.class, DataPlaneSelectorService.class })
 @Extension(value = "DataPlane core selector")
@@ -33,6 +34,10 @@ public class DataPlaneSelectorExtension implements ServiceExtension {
 
     @Inject
     private DataPlaneInstanceStore instanceStore;
+
+    @Inject
+    private TransactionContext transactionContext;
+
 
     @Override
     public void initialize(ServiceExtensionContext context) {
@@ -43,7 +48,7 @@ public class DataPlaneSelectorExtension implements ServiceExtension {
 
         context.registerService(DataPlaneSelector.class, selector);
         context.registerService(SelectionStrategyRegistry.class, strategy);
-        context.registerService(DataPlaneSelectorService.class, new DataPlaneSelectorServiceImpl(selector, instanceStore, strategy));
+        context.registerService(DataPlaneSelectorService.class, new DataPlaneSelectorServiceImpl(selector, instanceStore, strategy, transactionContext));
     }
 
 }

--- a/core/data-plane-selector/data-plane-selector-core/src/main/java/org/eclipse/edc/connector/dataplane/selector/store/InMemoryDataPlaneInstanceStore.java
+++ b/core/data-plane-selector/data-plane-selector-core/src/main/java/org/eclipse/edc/connector/dataplane/selector/store/InMemoryDataPlaneInstanceStore.java
@@ -16,48 +16,50 @@ package org.eclipse.edc.connector.dataplane.selector.store;
 
 import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
 import org.eclipse.edc.connector.dataplane.selector.spi.store.DataPlaneInstanceStore;
+import org.eclipse.edc.spi.result.StoreResult;
 import org.eclipse.edc.util.concurrency.LockManager;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Objects;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
+
+import static java.lang.String.format;
 
 /**
  * Default (=in-memory) implementation for the {@link DataPlaneInstanceStore}. All r/w access is secured with a {@link LockManager}.
  */
 public class InMemoryDataPlaneInstanceStore implements DataPlaneInstanceStore {
 
-    private final LockManager lockManager;
-    private final List<DataPlaneInstance> list;
+    private final Map<String, DataPlaneInstance> instances = new ConcurrentHashMap<>();
 
     public InMemoryDataPlaneInstanceStore() {
-        lockManager = new LockManager(new ReentrantReadWriteLock(true));
-        list = new ArrayList<>();
     }
 
     @Override
-    public void save(DataPlaneInstance instance) {
-        lockManager.writeLock(() -> {
-            list.removeIf(i -> Objects.equals(i.getId(), instance.getId()));
-            return list.add(instance);
-        });
+    public StoreResult<Void> create(DataPlaneInstance instance) {
+        var prev = instances.putIfAbsent(instance.getId(), instance);
+        return Optional.ofNullable(prev)
+                .map(a -> StoreResult.<Void>alreadyExists(format(DATA_PLANE_INSTANCE_EXISTS, instance.getId())))
+                .orElse(StoreResult.success());
+
     }
 
     @Override
-    public void saveAll(Collection<DataPlaneInstance> instances) {
-        lockManager.writeLock(() -> list.addAll(instances));
+    public StoreResult<Void> update(DataPlaneInstance instance) {
+        var prev = instances.replace(instance.getId(), instance);
+        return Optional.ofNullable(prev)
+                .map(a -> StoreResult.<Void>success())
+                .orElse(StoreResult.notFound(format(DATA_PLANE_INSTANCE_NOT_FOUND, instance.getId())));
     }
 
     @Override
     public DataPlaneInstance findById(String id) {
-        return lockManager.readLock(() -> list.stream().filter(dpi -> Objects.equals(dpi.getId(), id)).findFirst().orElse(null));
+        return instances.get(id);
     }
 
     @Override
     public Stream<DataPlaneInstance> getAll() {
-        return lockManager.readLock(list::stream);
+        return instances.values().stream();
     }
 }

--- a/extensions/data-plane-selector/data-plane-selector-api/build.gradle.kts
+++ b/extensions/data-plane-selector/data-plane-selector-api/build.gradle.kts
@@ -20,6 +20,7 @@ plugins {
 dependencies {
     api(project(":spi:common:core-spi"))
     api(project(":spi:data-plane-selector:data-plane-selector-spi"))
+    api(project(":spi:common:aggregate-service-spi"))
     implementation(project(":core:common:util"))
     implementation(project(":extensions:common:api:management-api-configuration"))
     implementation(project(":extensions:common:api:api-core")) //for the exception mapper

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/DataplaneSelectorApiController.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/DataplaneSelectorApiController.java
@@ -25,6 +25,8 @@ import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstan
 
 import java.util.List;
 
+import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMapper;
+
 @Consumes({ MediaType.APPLICATION_JSON })
 @Produces({ MediaType.APPLICATION_JSON })
 @Path("/instances")
@@ -48,7 +50,8 @@ public class DataplaneSelectorApiController implements DataplaneSelectorApi {
 
     @POST
     public void addEntry(DataPlaneInstance instance) {
-        selectionService.addInstance(instance);
+        selectionService.addInstance(instance)
+                .orElseThrow(exceptionMapper(DataPlaneInstance.class, instance.getId()));
     }
 
     @GET

--- a/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/DataPlaneSelectorApiExtensionTest.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/DataPlaneSelectorApiExtensionTest.java
@@ -28,6 +28,7 @@ import org.eclipse.edc.spi.system.configuration.Config;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.eclipse.edc.spi.system.injection.ObjectFactory;
 import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.transaction.spi.NoopTransactionContext;
 import org.eclipse.edc.web.spi.WebService;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
@@ -59,7 +60,7 @@ class DataPlaneSelectorApiExtensionTest {
         context.registerService(WebService.class, webService);
         context.registerService(ManagementApiConfiguration.class, managementApiConfiguration);
         context.registerService(DataPlaneSelectorService.class, new DataPlaneSelectorServiceImpl(mock(DataPlaneSelector.class),
-                mock(DataPlaneInstanceStore.class), mock(SelectionStrategyRegistry.class)));
+                mock(DataPlaneInstanceStore.class), mock(SelectionStrategyRegistry.class), new NoopTransactionContext()));
 
         extension = factory.constructInstance(DataPlaneSelectorApiExtension.class);
     }

--- a/extensions/data-plane-selector/store/cosmos/data-plane-instance-store-cosmos/src/main/java/org/eclipse/edc/connector/dataplane/selector/store/cosmos/CosmosDataPlaneInstanceStore.java
+++ b/extensions/data-plane-selector/store/cosmos/data-plane-instance-store-cosmos/src/main/java/org/eclipse/edc/connector/dataplane/selector/store/cosmos/CosmosDataPlaneInstanceStore.java
@@ -14,19 +14,22 @@
 
 package org.eclipse.edc.connector.dataplane.selector.store.cosmos;
 
+import com.azure.cosmos.implementation.ConflictException;
+import com.azure.cosmos.implementation.NotFoundException;
 import dev.failsafe.RetryPolicy;
 import org.eclipse.edc.azure.cosmos.CosmosDbApi;
 import org.eclipse.edc.azure.cosmos.dialect.SqlStatement;
 import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
 import org.eclipse.edc.connector.dataplane.selector.spi.store.DataPlaneInstanceStore;
-import org.eclipse.edc.spi.persistence.EdcPersistenceException;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.result.StoreResult;
 import org.eclipse.edc.spi.types.TypeManager;
 
-import java.util.Collection;
 import java.util.Optional;
 import java.util.stream.Stream;
 
 import static dev.failsafe.Failsafe.with;
+import static java.lang.String.format;
 
 /**
  * Implementation of the {@link DataPlaneInstanceStore} based on CosmosDB. This store implements simple write-through
@@ -41,30 +44,38 @@ public class CosmosDataPlaneInstanceStore implements DataPlaneInstanceStore {
     private final RetryPolicy<Object> retryPolicy;
 
     private final String partitionKey;
+    private final Monitor monitor;
 
     public CosmosDataPlaneInstanceStore(CosmosDbApi cosmosDbApi, TypeManager typeManager,
-                                        RetryPolicy<Object> retryPolicy, String partitionKey) {
+                                        RetryPolicy<Object> retryPolicy, String partitionKey, Monitor monitor) {
         this.cosmosDbApi = cosmosDbApi;
         this.typeManager = typeManager;
         this.retryPolicy = retryPolicy;
         this.partitionKey = partitionKey;
+        this.monitor = monitor;
     }
 
     @Override
-    public void save(DataPlaneInstance instance) {
+    public StoreResult<Void> create(DataPlaneInstance instance) {
         try {
-            insertOrUpdate(instance);
-        } catch (Exception exception) {
-            throw new EdcPersistenceException(exception);
+            insertInternal(instance);
+            return StoreResult.success();
+        } catch (ConflictException exception) {
+            var msg = format(DATA_PLANE_INSTANCE_EXISTS, instance.getId());
+            monitor.debug(msg);
+            return StoreResult.alreadyExists(msg);
         }
     }
 
     @Override
-    public void saveAll(Collection<DataPlaneInstance> instances) {
+    public StoreResult<Void> update(DataPlaneInstance instance) {
         try {
-            instances.forEach(this::insertOrUpdate);
-        } catch (Exception exception) {
-            throw new EdcPersistenceException(exception);
+            updateInternal(instance);
+            return StoreResult.success();
+        } catch (NotFoundException exception) {
+            var msg = format(DATA_PLANE_INSTANCE_NOT_FOUND, instance.getId());
+            monitor.debug(msg);
+            return StoreResult.notFound(msg);
         }
     }
 
@@ -82,9 +93,14 @@ public class CosmosDataPlaneInstanceStore implements DataPlaneInstanceStore {
         return dataSpaceInstances.map(this::convert);
     }
 
-    private void insertOrUpdate(DataPlaneInstance instance) {
+    private void insertInternal(DataPlaneInstance instance) {
         var document = new DataPlaneInstanceDocument(instance, partitionKey);
         with(retryPolicy).run(() -> cosmosDbApi.createItem(document));
+    }
+
+    private void updateInternal(DataPlaneInstance instance) {
+        var document = new DataPlaneInstanceDocument(instance, partitionKey);
+        with(retryPolicy).run(() -> cosmosDbApi.updateItem(document));
     }
 
     private DataPlaneInstance convert(Object object) {

--- a/extensions/data-plane-selector/store/cosmos/data-plane-instance-store-cosmos/src/main/java/org/eclipse/edc/connector/dataplane/selector/store/cosmos/CosmosDataPlaneInstanceStoreExtension.java
+++ b/extensions/data-plane-selector/store/cosmos/data-plane-instance-store-cosmos/src/main/java/org/eclipse/edc/connector/dataplane/selector/store/cosmos/CosmosDataPlaneInstanceStoreExtension.java
@@ -21,6 +21,7 @@ import org.eclipse.edc.connector.dataplane.selector.spi.store.DataPlaneInstanceS
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provides;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
@@ -51,6 +52,10 @@ public class CosmosDataPlaneInstanceStoreExtension implements ServiceExtension {
     @Inject
     private Vault vault;
 
+    @Inject
+    private Monitor monitor;
+
+
     @Override
     public String name() {
         return NAME;
@@ -62,7 +67,7 @@ public class CosmosDataPlaneInstanceStoreExtension implements ServiceExtension {
 
         var cosmosDbApi = new CosmosDbApiImpl(configuration, clientProvider.createClient(vault, configuration));
 
-        var store = new CosmosDataPlaneInstanceStore(cosmosDbApi, typeManager, retryPolicy, configuration.getPartitionKey());
+        var store = new CosmosDataPlaneInstanceStore(cosmosDbApi, typeManager, retryPolicy, configuration.getPartitionKey(), monitor);
         context.registerService(CosmosDataPlaneInstanceStore.class, store);
 
         typeManager.registerTypes(DataPlaneInstanceDocument.class);

--- a/extensions/data-plane-selector/store/cosmos/data-plane-instance-store-cosmos/src/test/java/org/eclipse/edc/connector/dataplane/selector/store/cosmos/CosmosDataPlaneInstanceStoreIntegrationTest.java
+++ b/extensions/data-plane-selector/store/cosmos/data-plane-instance-store-cosmos/src/test/java/org/eclipse/edc/connector/dataplane/selector/store/cosmos/CosmosDataPlaneInstanceStoreIntegrationTest.java
@@ -25,6 +25,7 @@ import org.eclipse.edc.connector.contract.spi.types.offer.ContractDefinition;
 import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
 import org.eclipse.edc.connector.dataplane.selector.spi.store.DataPlaneInstanceStore;
 import org.eclipse.edc.connector.dataplane.selector.spi.testfixtures.store.DataPlaneInstanceStoreTestBase;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -35,6 +36,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 @AzureCosmosDbIntegrationTest
 class CosmosDataPlaneInstanceStoreIntegrationTest extends DataPlaneInstanceStoreTestBase {
@@ -86,7 +88,7 @@ class CosmosDataPlaneInstanceStoreIntegrationTest extends DataPlaneInstanceStore
 
         var cosmosDbApi = new CosmosDbApiImpl(container, true);
         var retryPolicy = RetryPolicy.builder().withMaxRetries(3).withBackoff(1, 5, ChronoUnit.SECONDS).build();
-        store = new CosmosDataPlaneInstanceStore(cosmosDbApi, typeManager, retryPolicy, TEST_PARTITION_KEY);
+        store = new CosmosDataPlaneInstanceStore(cosmosDbApi, typeManager, retryPolicy, TEST_PARTITION_KEY, mock(Monitor.class));
     }
 
     @AfterEach

--- a/spi/data-plane-selector/data-plane-selector-spi/build.gradle.kts
+++ b/spi/data-plane-selector/data-plane-selector-spi/build.gradle.kts
@@ -19,6 +19,7 @@ plugins {
 
 dependencies {
     api(project(":spi:common:core-spi"))
+    api(project(":spi:common:aggregate-service-spi"))
     implementation(project(":core:common:util"))
 
 

--- a/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/DataPlaneSelectorService.java
+++ b/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/DataPlaneSelectorService.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.dataplane.selector.spi;
 
 import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
+import org.eclipse.edc.service.spi.result.ServiceResult;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 
 import java.util.Collection;
@@ -35,5 +36,6 @@ public interface DataPlaneSelectorService {
 
     Collection<String> getAllStrategies();
 
-    void addInstance(DataPlaneInstance instance);
+    ServiceResult<Void> addInstance(DataPlaneInstance instance);
+
 }

--- a/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/store/DataPlaneInstanceStore.java
+++ b/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/store/DataPlaneInstanceStore.java
@@ -15,8 +15,8 @@
 package org.eclipse.edc.connector.dataplane.selector.spi.store;
 
 import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
+import org.eclipse.edc.spi.result.StoreResult;
 
-import java.util.Collection;
 import java.util.stream.Stream;
 
 /**
@@ -24,9 +24,29 @@ import java.util.stream.Stream;
  * The collection of {@link DataPlaneInstance} objects is mutable at runtime, so implementations must take that into account.
  */
 public interface DataPlaneInstanceStore {
-    void save(DataPlaneInstance instance);
 
-    void saveAll(Collection<DataPlaneInstance> instances);
+    String DATA_PLANE_INSTANCE_EXISTS = "Data Plane Instance with ID %s already exists";
+    String DATA_PLANE_INSTANCE_NOT_FOUND = "Data Plane Instance with ID %s not found";
+
+    /**
+     * Stores the {@link DataPlaneInstance} if a data plane instance with the same ID doesn't exist.
+     *
+     * @param instance The {@link DataPlaneInstance} to store.
+     *
+     * @return {@link StoreResult#success()} if the data plane instance was stored, {@link StoreResult#alreadyExists(String)} if a data
+     *         plane instance with the same ID already exists
+     */
+    StoreResult<Void> create(DataPlaneInstance instance);
+
+    /**
+     * Updates the {@link DataPlaneInstance} if a data plane instance with the same ID already exists.
+     *
+     * @param instance The {@link DataPlaneInstance} to update.
+     *
+     * @return {@link StoreResult#success()} if the data plane instance was updated, {@link StoreResult#notFound(String)} if a data
+     *         plane instance with the same ID was not found
+     */
+    StoreResult<Void> update(DataPlaneInstance instance);
 
     DataPlaneInstance findById(String id);
 

--- a/spi/data-plane-selector/data-plane-selector-spi/src/testFixtures/java/org/eclipse/edc/connector/dataplane/selector/spi/testfixtures/store/DataPlaneInstanceStoreTestBase.java
+++ b/spi/data-plane-selector/data-plane-selector-spi/src/testFixtures/java/org/eclipse/edc/connector/dataplane/selector/spi/testfixtures/store/DataPlaneInstanceStoreTestBase.java
@@ -20,10 +20,8 @@ import org.eclipse.edc.connector.dataplane.selector.spi.store.DataPlaneInstanceS
 import org.eclipse.edc.connector.dataplane.selector.spi.testfixtures.TestFunctions;
 import org.junit.jupiter.api.Test;
 
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.spi.result.StoreFailure.Reason.ALREADY_EXISTS;
 
 
 public abstract class DataPlaneInstanceStoreTestBase {
@@ -32,39 +30,53 @@ public abstract class DataPlaneInstanceStoreTestBase {
     @Test
     void save() {
         var inst = TestFunctions.createInstance("test-id");
-        getStore().save(inst);
+        getStore().create(inst);
         Assertions.assertThat(getStore().getAll()).usingRecursiveFieldByFieldElementComparator().containsExactly(inst);
     }
 
     @Test
-    void save_whenExists_shouldUpsert() {
+    void save_whenExists_shouldNotUpsert() {
         var inst = TestFunctions.createInstance("test-id");
-        getStore().save(inst);
+        getStore().create(inst);
+
 
         var inst2 = DataPlaneInstance.Builder.newInstance()
                 .id("test-id")
                 .url("http://somewhere.other:9876/api/v2") //different URL
                 .build();
 
-        getStore().save(inst2);
+        var result = getStore().create(inst2);
+
+        assertThat(result.failed()).isTrue();
+        assertThat(result.getFailure().getReason()).isEqualTo(ALREADY_EXISTS);
+
+        Assertions.assertThat(getStore().getAll()).hasSize(1).usingRecursiveFieldByFieldElementComparator().containsExactly(inst);
+    }
+
+    @Test
+    void save_whenExists_shouldUpdate() {
+        var inst = TestFunctions.createInstance("test-id");
+        getStore().create(inst);
+
+
+        var inst2 = DataPlaneInstance.Builder.newInstance()
+                .id("test-id")
+                .url("http://somewhere.other:9876/api/v2") //different URL
+                .build();
+
+        var result = getStore().update(inst2);
+
+        assertThat(result.succeeded()).isTrue();
 
         Assertions.assertThat(getStore().getAll()).hasSize(1).usingRecursiveFieldByFieldElementComparator().containsExactly(inst2);
     }
 
-    @Test
-    void saveAll() {
-        var allInstances = IntStream.range(0, 10).mapToObj(i -> TestFunctions.createInstance("test-id" + i)).collect(Collectors.toList());
-        getStore().saveAll(allInstances);
-        Assertions.assertThat(getStore().getAll())
-                .usingRecursiveFieldByFieldElementComparator()
-                .containsExactlyInAnyOrder(allInstances.toArray(new DataPlaneInstance[]{}));
-    }
 
     @Test
     void save_shouldReturnCustomInstance() {
         var custom = TestFunctions.createCustomInstance("test-id", "name");
 
-        getStore().save(custom);
+        getStore().create(custom);
 
         var customInstance = getStore().findById(custom.getId());
 
@@ -78,7 +90,7 @@ public abstract class DataPlaneInstanceStoreTestBase {
     @Test
     void findById() {
         var inst = TestFunctions.createInstance("test-id");
-        getStore().save(inst);
+        getStore().create(inst);
 
         Assertions.assertThat(getStore().findById("test-id")).usingRecursiveComparison().isEqualTo(inst);
     }
@@ -95,8 +107,8 @@ public abstract class DataPlaneInstanceStoreTestBase {
 
         var store = getStore();
 
-        store.save(doc1);
-        store.save(doc2);
+        store.create(doc1);
+        store.create(doc2);
 
         var foundItems = store.getAll();
 


### PR DESCRIPTION
## What this PR changes/adds

Refactor the `DataPlaneInstanceStore` as follows:

- Removed upsert semantic
- Added specific update method
- Introduced StoreResult for `create`, `update`  operations
- Removed  `saveAll(Collections)` APIs

## Why it does that

to unify the store implementation, keep code paths clean and separate

## Further notes

The Upsert semantic has been moved to the service layer until we support updating instances
also in the HTTP layer

## Linked Issue(s)

Closes #2556 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
