### PR TITLE
refactor: persistence implementations harmonize in CRUD operations.

### DIFF
--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -98,7 +98,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
             negotiation.setContractAgreement(null);
         }
         negotiation.transitionDeclined();
-        negotiationStore.save(negotiation);
+        negotiationStore.updateOrCreate(negotiation);
         observable.invokeForEach(l -> l.declined(negotiation));
         monitor.debug(String.format("[Provider] ContractNegotiation %s is now in state %s.",
                 negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
@@ -133,7 +133,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
                 .build();
 
         negotiation.transitionRequested();
-        negotiationStore.save(negotiation);
+        negotiationStore.updateOrCreate(negotiation);
         observable.invokeForEach(l -> l.requested(negotiation));
 
         monitor.debug(String.format("[Provider] ContractNegotiation initiated. %s is now in state %s.",
@@ -148,7 +148,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
             monitor.debug("[Provider] Contract offer received. Will be rejected: " + result.getFailureDetail());
             negotiation.setErrorDetail(result.getFailureMessages().get(0));
             negotiation.transitionDeclining();
-            negotiationStore.save(negotiation);
+            negotiationStore.updateOrCreate(negotiation);
 
             monitor.debug(String.format("[Provider] ContractNegotiation %s is now in state %s.",
                     negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
@@ -157,7 +157,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
 
         monitor.debug("[Provider] Contract offer received. Will be approved.");
         negotiation.transitionConfirming();
-        negotiationStore.save(negotiation);
+        negotiationStore.updateOrCreate(negotiation);
         monitor.debug(String.format("[Provider] ContractNegotiation %s is now in state %s.",
                 negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
 
@@ -170,7 +170,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
     }
 
     private ContractNegotiation findContractNegotiationById(String negotiationId) {
-        var negotiation = negotiationStore.find(negotiationId);
+        var negotiation = negotiationStore.findById(negotiationId);
         if (negotiation == null) {
             negotiation = negotiationStore.findForCorrelationId(negotiationId);
         }
@@ -314,12 +314,12 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
         return new AsyncSendResultHandler(negotiationId, "send counter offer")
                 .onSuccess(negotiation -> {
                     negotiation.transitionOffered();
-                    negotiationStore.save(negotiation);
+                    negotiationStore.updateOrCreate(negotiation);
                     observable.invokeForEach(l -> l.offered(negotiation));
                 })
                 .onFailure(negotiation -> {
                     negotiation.transitionOffering();
-                    negotiationStore.save(negotiation);
+                    negotiationStore.updateOrCreate(negotiation);
                 })
                 .build();
     }
@@ -329,12 +329,12 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
         return new AsyncSendResultHandler(negotiationId, "send rejection")
                 .onSuccess(negotiation -> {
                     negotiation.transitionDeclined();
-                    negotiationStore.save(negotiation);
+                    negotiationStore.updateOrCreate(negotiation);
                     observable.invokeForEach(l -> l.declined(negotiation));
                 })
                 .onFailure(negotiation -> {
                     negotiation.transitionDeclining();
-                    negotiationStore.save(negotiation);
+                    negotiationStore.updateOrCreate(negotiation);
                 })
                 .build();
     }
@@ -345,12 +345,12 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
                 .onSuccess(negotiation -> {
                     negotiation.setContractAgreement(agreement);
                     negotiation.transitionConfirmed();
-                    negotiationStore.save(negotiation);
+                    negotiationStore.updateOrCreate(negotiation);
                     observable.invokeForEach(l -> l.confirmed(negotiation));
                 })
                 .onFailure(negotiation -> {
                     negotiation.transitionConfirming();
-                    negotiationStore.save(negotiation);
+                    negotiationStore.updateOrCreate(negotiation);
                 })
                 .build();
     }

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/command/handlers/SingleContractNegotiationCommandHandler.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/command/handlers/SingleContractNegotiationCommandHandler.java
@@ -46,13 +46,13 @@ public abstract class SingleContractNegotiationCommandHandler<T extends SingleCo
     @Override
     public void handle(SingleContractNegotiationCommand command) {
         var negotiationId = command.getNegotiationId();
-        var negotiation = store.find(negotiationId);
+        var negotiation = store.findById(negotiationId);
         if (negotiation == null) {
             throw new EdcException(format("Could not find ContractNegotiation with ID [%s]", negotiationId));
         } else {
             if (modify(negotiation)) {
                 negotiation.setModified();
-                store.save(negotiation);
+                store.updateOrCreate(negotiation);
             }
         }
     }

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -163,7 +163,7 @@ class ContractNegotiationIntegrationTest {
                 .pollInterval(DEFAULT_POLL_INTERVAL)
                 .untilAsserted(() -> {
                     assertThat(consumerNegotiationId).isNotNull();
-                    var consumerNegotiation = consumerStore.find(consumerNegotiationId);
+                    var consumerNegotiation = consumerStore.findById(consumerNegotiationId);
                     var providerNegotiation = providerStore.findForCorrelationId(consumerNegotiationId);
                     assertThat(consumerNegotiation).isNotNull();
                     assertThat(providerNegotiation).isNotNull();
@@ -209,7 +209,7 @@ class ContractNegotiationIntegrationTest {
                 .untilAsserted(() -> {
 
                     assertThat(consumerNegotiationId).isNotNull();
-                    var consumerNegotiation = consumerStore.find(consumerNegotiationId);
+                    var consumerNegotiation = consumerStore.findById(consumerNegotiationId);
                     var providerNegotiation = providerStore.findForCorrelationId(consumerNegotiationId);
                     assertThat(consumerNegotiation).isNotNull();
                     assertThat(providerNegotiation).isNotNull();
@@ -255,7 +255,7 @@ class ContractNegotiationIntegrationTest {
                 .pollInterval(DEFAULT_POLL_INTERVAL)
                 .untilAsserted(() -> {
                     assertThat(consumerNegotiationId).isNotNull();
-                    var consumerNegotiation = consumerStore.find(consumerNegotiationId);
+                    var consumerNegotiation = consumerStore.findById(consumerNegotiationId);
                     var providerNegotiation = providerStore.findForCorrelationId(consumerNegotiationId);
                     assertThat(consumerNegotiation).isNotNull();
                     assertThat(providerNegotiation).isNotNull();

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/command/ContractNegotiationCommandQueueIntegrationTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/command/ContractNegotiationCommandQueueIntegrationTest.java
@@ -72,7 +72,7 @@ class ContractNegotiationCommandQueueIntegrationTest {
         negotiation = getNegotiation(negotiationId);
         command = new TestCommand(negotiationId);
 
-        when(store.find(negotiationId)).thenReturn(negotiation);
+        when(store.findById(negotiationId)).thenReturn(negotiation);
     }
 
     @Test
@@ -105,7 +105,7 @@ class ContractNegotiationCommandQueueIntegrationTest {
 
     @Test
     void submitTestCommand_consumerManager() throws Exception {
-        when(store.find(negotiationId)).thenReturn(negotiation);
+        when(store.findById(negotiationId)).thenReturn(negotiation);
 
         // Create and start the negotiation manager
         var negotiationManager = ConsumerContractNegotiationManagerImpl.Builder.newInstance()
@@ -175,7 +175,7 @@ class ContractNegotiationCommandQueueIntegrationTest {
         @Override
         protected boolean modify(ContractNegotiation negotiation) {
             negotiation.transitionError(errorDetail);
-            store.save(negotiation);
+            store.updateOrCreate(negotiation);
             return true;
         }
     }

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/command/handlers/CancelNegotiationCommandHandlerTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/command/handlers/CancelNegotiationCommandHandlerTest.java
@@ -53,7 +53,7 @@ class CancelNegotiationCommandHandlerTest {
         var originalTime = negotiation.getUpdatedAt();
         var command = new CancelNegotiationCommand(negotiationId);
 
-        when(store.find(negotiationId)).thenReturn(negotiation);
+        when(store.findById(negotiationId)).thenReturn(negotiation);
 
         commandHandler.handle(command);
 
@@ -67,7 +67,7 @@ class CancelNegotiationCommandHandlerTest {
         var negotiationId = "test";
         var command = new CancelNegotiationCommand(negotiationId);
 
-        when(store.find(negotiationId)).thenReturn(null);
+        when(store.findById(negotiationId)).thenReturn(null);
 
         assertThatThrownBy(() -> commandHandler.handle(command))
                 .isInstanceOf(EdcException.class)

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/command/handlers/DeclineNegotiationCommandHandlerTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/command/handlers/DeclineNegotiationCommandHandlerTest.java
@@ -58,7 +58,7 @@ class DeclineNegotiationCommandHandlerTest {
         var originalTime = negotiation.getUpdatedAt();
         var command = new DeclineNegotiationCommand(negotiationId);
 
-        when(store.find(negotiationId)).thenReturn(negotiation);
+        when(store.findById(negotiationId)).thenReturn(negotiation);
 
         commandHandler.handle(command);
 
@@ -72,7 +72,7 @@ class DeclineNegotiationCommandHandlerTest {
         var negotiationId = "test";
         var command = new DeclineNegotiationCommand(negotiationId);
 
-        when(store.find(negotiationId)).thenReturn(null);
+        when(store.findById(negotiationId)).thenReturn(null);
 
         assertThatThrownBy(() -> commandHandler.handle(command))
                 .isInstanceOf(EdcException.class)

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/asset/AssetServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/asset/AssetServiceImpl.java
@@ -93,7 +93,7 @@ public class AssetServiceImpl implements AssetService {
                     .filter(List.of(new Criterion(ASSET_ID_QUERY, "=", assetId)))
                     .build();
 
-            try (var negotiationsOnAsset = contractNegotiationStore.queryNegotiations(query)) {
+            try (var negotiationsOnAsset = contractNegotiationStore.findAllNegotiations(query)) {
                 if (negotiationsOnAsset.findAny().isPresent()) {
                     return ServiceResult.conflict(format("Asset %s cannot be deleted as it is referenced by at least one contract agreement", assetId));
                 }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractagreement/ContractAgreementServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractagreement/ContractAgreementServiceImpl.java
@@ -50,6 +50,6 @@ public class ContractAgreementServiceImpl implements ContractAgreementService {
             return ServiceResult.badRequest(format("Error validating schema: %s", result.getFailureDetail()));
         }
 
-        return ServiceResult.success(transactionContext.execute(() -> store.queryAgreements(query)));
+        return ServiceResult.success(transactionContext.execute(() -> store.findAllAgreements(query)));
     }
 }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractdefinition/ContractDefinitionServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractdefinition/ContractDefinitionServiceImpl.java
@@ -58,7 +58,7 @@ public class ContractDefinitionServiceImpl implements ContractDefinitionService 
     @Override
     public ServiceResult<ContractDefinition> create(ContractDefinition contractDefinition) {
         return transactionContext.execute(() -> {
-            var saveResult = store.save(contractDefinition);
+            var saveResult = store.create(contractDefinition);
             if (saveResult.succeeded()) {
                 observable.invokeForEach(l -> l.created(contractDefinition));
                 return ServiceResult.success(contractDefinition);

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationServiceImpl.java
@@ -50,7 +50,7 @@ public class ContractNegotiationServiceImpl implements ContractNegotiationServic
 
     @Override
     public ContractNegotiation findbyId(String contractNegotiationId) {
-        return transactionContext.execute(() -> store.find(contractNegotiationId));
+        return transactionContext.execute(() -> store.findById(contractNegotiationId));
     }
 
     @Override
@@ -60,7 +60,7 @@ public class ContractNegotiationServiceImpl implements ContractNegotiationServic
         if (result.failed()) {
             return ServiceResult.badRequest(format("Error validating schema: %s", result.getFailureDetail()));
         }
-        return ServiceResult.success(transactionContext.execute(() -> store.queryNegotiations(query)));
+        return ServiceResult.success(transactionContext.execute(() -> store.findAllNegotiations(query)));
     }
 
     @Override
@@ -75,7 +75,7 @@ public class ContractNegotiationServiceImpl implements ContractNegotiationServic
 
     @Override
     public ContractAgreement getForNegotiation(String negotiationId) {
-        return transactionContext.execute(() -> ofNullable(store.find(negotiationId))
+        return transactionContext.execute(() -> ofNullable(store.findById(negotiationId))
                 .map(ContractNegotiation::getContractAgreement).orElse(null));
     }
 
@@ -87,7 +87,7 @@ public class ContractNegotiationServiceImpl implements ContractNegotiationServic
     @Override
     public ServiceResult<ContractNegotiation> cancel(String negotiationId) {
         return transactionContext.execute(() -> {
-            var negotiation = store.find(negotiationId);
+            var negotiation = store.findById(negotiationId);
             if (negotiation == null) {
                 return ServiceResult.notFound(format("ContractNegotiation %s does not exist", negotiationId));
             } else {
@@ -101,7 +101,7 @@ public class ContractNegotiationServiceImpl implements ContractNegotiationServic
     public ServiceResult<ContractNegotiation> decline(String negotiationId) {
         return transactionContext.execute(() -> {
             try {
-                var negotiation = store.find(negotiationId);
+                var negotiation = store.findById(negotiationId);
                 if (negotiation == null) {
                     return ServiceResult.notFound(format("ContractNegotiation %s does not exist", negotiationId));
                 }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessServiceImpl.java
@@ -77,7 +77,7 @@ public class TransferProcessServiceImpl implements TransferProcessService {
 
     @Override
     public @Nullable TransferProcess findById(String transferProcessId) {
-        return transactionContext.execute(() -> transferProcessStore.find(transferProcessId));
+        return transactionContext.execute(() -> transferProcessStore.findById(transferProcessId));
     }
 
     @Override
@@ -93,7 +93,7 @@ public class TransferProcessServiceImpl implements TransferProcessService {
     @Override
     public @Nullable String getState(String transferProcessId) {
         return transactionContext.execute(() -> {
-            var process = transferProcessStore.find(transferProcessId);
+            var process = transferProcessStore.findById(transferProcessId);
             return Optional.ofNullable(process).map(p -> TransferProcessStates.from(p.getState()).name()).orElse(null);
         });
     }
@@ -175,7 +175,7 @@ public class TransferProcessServiceImpl implements TransferProcessService {
 
     private ServiceResult<TransferProcess> apply(String transferProcessId, Function<TransferProcess, ServiceResult<TransferProcess>> function) {
         return transactionContext.execute(() -> {
-            var transferProcess = transferProcessStore.find(transferProcessId);
+            var transferProcess = transferProcessStore.findById(transferProcessId);
             return Optional.ofNullable(transferProcess)
                     .map(function)
                     .orElse(ServiceResult.notFound(format("TransferProcess %s does not exist", transferProcessId)));

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/asset/AssetServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/asset/AssetServiceImplTest.java
@@ -167,7 +167,7 @@ class AssetServiceImplTest {
 
     @Test
     void delete_shouldDeleteAssetIfItsNotReferencedByAnyNegotiation() {
-        when(contractNegotiationStore.queryNegotiations(any())).thenReturn(Stream.empty());
+        when(contractNegotiationStore.findAllNegotiations(any())).thenReturn(Stream.empty());
         when(index.deleteById("assetId")).thenReturn(StoreResult.success(createAsset("assetId")));
 
         var deleted = service.delete("assetId");
@@ -193,13 +193,13 @@ class AssetServiceImplTest {
                         .policy(Policy.Builder.newInstance().build())
                         .build())
                 .build();
-        when(contractNegotiationStore.queryNegotiations(any())).thenReturn(Stream.of(contractNegotiation));
+        when(contractNegotiationStore.findAllNegotiations(any())).thenReturn(Stream.of(contractNegotiation));
 
         var deleted = service.delete("assetId");
 
         assertThat(deleted.failed()).isTrue();
         assertThat(deleted.getFailure().getReason()).isEqualTo(CONFLICT);
-        verify(contractNegotiationStore).queryNegotiations(any());
+        verify(contractNegotiationStore).findAllNegotiations(any());
         verifyNoMoreInteractions(contractNegotiationStore);
     }
 
@@ -220,7 +220,7 @@ class AssetServiceImplTest {
 
         var deleted = service.delete("test-asset");
         assertThat(deleted.succeeded()).isTrue();
-        verify(contractNegotiationStore).queryNegotiations(argThat(argument -> argument.getFilterExpression().size() == 1 &&
+        verify(contractNegotiationStore).findAllNegotiations(argThat(argument -> argument.getFilterExpression().size() == 1 &&
                 argument.getFilterExpression().get(0).getOperandLeft().equals("contractAgreement.assetId")));
     }
 

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractagreement/ContractAgreementServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractagreement/ContractAgreementServiceImplTest.java
@@ -58,7 +58,7 @@ class ContractAgreementServiceImplTest {
     @Test
     void query_filtersBySpec() {
         var agreement = createContractAgreement("agreementId");
-        when(store.queryAgreements(isA(QuerySpec.class))).thenReturn(Stream.of(agreement));
+        when(store.findAllAgreements(isA(QuerySpec.class))).thenReturn(Stream.of(agreement));
 
         var result = service.query(QuerySpec.none());
 

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractdefinition/ContractDefinitionServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractdefinition/ContractDefinitionServiceImplTest.java
@@ -123,20 +123,20 @@ class ContractDefinitionServiceImplTest {
     void create_shouldCreateDefinitionIfItDoesNotAlreadyExist() {
         var definition = createContractDefinition();
         when(store.findAll(isA(QuerySpec.class))).thenReturn(Stream.empty());
-        when(store.save(definition)).thenReturn(StoreResult.success());
+        when(store.create(definition)).thenReturn(StoreResult.success());
 
         var inserted = service.create(definition);
 
         assertThat(inserted.succeeded()).isTrue();
         assertThat(inserted.getContent()).matches(hasId(definition.getId()));
-        verify(store).save(argThat(it -> definition.getId().equals(it.getId())));
+        verify(store).create(argThat(it -> definition.getId().equals(it.getId())));
         verify(listener).created(any());
     }
 
     @Test
     void create_shouldNotCreateDefinitionIfItAlreadyExists() {
         var definition = createContractDefinition();
-        when(store.save(definition)).thenReturn(StoreResult.alreadyExists(""));
+        when(store.create(definition)).thenReturn(StoreResult.alreadyExists(""));
 
         var inserted = service.create(definition);
 
@@ -149,7 +149,7 @@ class ContractDefinitionServiceImplTest {
     void create_shouldNotCreateDefinitionIfTheStoreFails() {
         var definition = createContractDefinition();
         when(store.findById(definition.getId())).thenReturn(null);
-        when(store.save(definition)).thenReturn(StoreResult.alreadyExists("Exists"));
+        when(store.create(definition)).thenReturn(StoreResult.alreadyExists("Exists"));
 
         var inserted = service.create(definition);
 

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
@@ -91,8 +91,8 @@ class ContractNegotiationEventDispatchTest {
                 .selectorExpression(AssetSelectorExpression.SELECT_ALL)
                 .validity(CONTRACT_VALIDITY)
                 .build();
-        contractDefinitionStore.save(contractDefinition);
-        policyDefinitionStore.save(PolicyDefinition.Builder.newInstance().id("policyId").policy(policy).build());
+        contractDefinitionStore.create(contractDefinition);
+        policyDefinitionStore.create(PolicyDefinition.Builder.newInstance().id("policyId").policy(policy).build());
         assetIndex.accept(Asset.Builder.newInstance().id("assetId").build(), DataAddress.Builder.newInstance().type("any").build());
 
         manager.requested(token, createContractOfferRequest(policy));

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationServiceImplTest.java
@@ -64,7 +64,7 @@ class ContractNegotiationServiceImplTest {
     @Test
     void findById_filtersById() {
         var negotiation = createContractNegotiation("negotiationId");
-        when(store.find("negotiationId")).thenReturn(negotiation);
+        when(store.findById("negotiationId")).thenReturn(negotiation);
 
         var result = service.findbyId("negotiationId");
 
@@ -73,7 +73,7 @@ class ContractNegotiationServiceImplTest {
 
     @Test
     void findById_returnsNullIfNotFound() {
-        when(store.find("negotiationId")).thenReturn(null);
+        when(store.findById("negotiationId")).thenReturn(null);
 
         var result = service.findbyId("negotiationId");
 
@@ -83,7 +83,7 @@ class ContractNegotiationServiceImplTest {
     @Test
     void query_filtersBySpec() {
         var negotiation = createContractNegotiation("negotiationId");
-        when(store.queryNegotiations(isA(QuerySpec.class))).thenReturn(Stream.of(negotiation));
+        when(store.findAllNegotiations(isA(QuerySpec.class))).thenReturn(Stream.of(negotiation));
 
         var result = service.query(QuerySpec.none());
 
@@ -117,7 +117,7 @@ class ContractNegotiationServiceImplTest {
                 .filter(validFilter)
                 .build();
         service.query(query);
-        verify(store).queryNegotiations(query);
+        verify(store).findAllNegotiations(query);
     }
 
     @Test
@@ -125,7 +125,7 @@ class ContractNegotiationServiceImplTest {
         var negotiation = createContractNegotiationBuilder("negotiationId")
                 .state(REQUESTED.code())
                 .build();
-        when(store.find("negotiationId")).thenReturn(negotiation);
+        when(store.findById("negotiationId")).thenReturn(negotiation);
 
         var result = service.getState("negotiationId");
 
@@ -134,7 +134,7 @@ class ContractNegotiationServiceImplTest {
 
     @Test
     void getState_returnsNullIfNegotiationDoesNotExist() {
-        when(store.find("negotiationId")).thenReturn(null);
+        when(store.findById("negotiationId")).thenReturn(null);
 
         var result = service.getState("negotiationId");
 
@@ -147,33 +147,33 @@ class ContractNegotiationServiceImplTest {
         var negotiation = createContractNegotiation("negotiationId");
         negotiation.setContractAgreement(contractAgreement);
 
-        when(store.find("negotiationId")).thenReturn(negotiation);
+        when(store.findById("negotiationId")).thenReturn(negotiation);
 
         var result = service.getForNegotiation("negotiationId");
 
         assertThat(result).matches(it -> it.getId().equals("agreementId"));
-        verify(store).find(any());
+        verify(store).findById(any());
         verifyNoMoreInteractions(store);
     }
 
     @Test
     void getForNegotiation_negotiationNotFound() {
-        when(store.find("negotiationId")).thenReturn(null);
+        when(store.findById("negotiationId")).thenReturn(null);
         var result = service.getForNegotiation("negotiationId");
         assertThat(result).isNull();
-        verify(store).find(any());
+        verify(store).findById(any());
         verifyNoMoreInteractions(store);
     }
 
     @Test
     void getForNegotiation_negotiationNoAgreement() {
         var negotiation = createContractNegotiation("negotiationId");
-        when(store.find("negotiationId")).thenReturn(negotiation);
+        when(store.findById("negotiationId")).thenReturn(negotiation);
 
         var result = service.getForNegotiation("negotiationId");
 
         assertThat(result).isNull();
-        verify(store).find(any());
+        verify(store).findById(any());
         verifyNoMoreInteractions(store);
     }
 
@@ -211,7 +211,7 @@ class ContractNegotiationServiceImplTest {
     @Test
     void cancel_shouldCancelNegotiationIfItCanBeCanceled() {
         var negotiation = createContractNegotiation("negotiationId");
-        when(store.find("negotiationId")).thenReturn(negotiation);
+        when(store.findById("negotiationId")).thenReturn(negotiation);
 
         var result = service.cancel("negotiationId");
 
@@ -222,7 +222,7 @@ class ContractNegotiationServiceImplTest {
 
     @Test
     void cancel_shouldNotCancelNegationIfItDoesNotExist() {
-        when(store.find("negotiationId")).thenReturn(null);
+        when(store.findById("negotiationId")).thenReturn(null);
 
         var result = service.cancel("negotiationId");
 
@@ -234,7 +234,7 @@ class ContractNegotiationServiceImplTest {
     @Test
     void decline_shouldSucceedIfManagerIsBeingAbleToDeclineIt() {
         var negotiation = createContractNegotiationBuilder("negotiationId").state(REQUESTED.code()).build();
-        when(store.find("negotiationId")).thenReturn(negotiation);
+        when(store.findById("negotiationId")).thenReturn(negotiation);
 
         var result = service.decline("negotiationId");
 
@@ -245,7 +245,7 @@ class ContractNegotiationServiceImplTest {
 
     @Test
     void decline_shouldNotCancelNegationIfItDoesNotExist() {
-        when(store.find("negotiationId")).thenReturn(null);
+        when(store.findById("negotiationId")).thenReturn(null);
 
         var result = service.decline("negotiationId");
 
@@ -257,7 +257,7 @@ class ContractNegotiationServiceImplTest {
     @Test
     void decline_shouldFailIfCannotBeDeclined() {
         var negotiation = createContractNegotiationBuilder("negotiationId").state(CONFIRMED.code()).build();
-        when(store.find("negotiationId")).thenReturn(negotiation);
+        when(store.findById("negotiationId")).thenReturn(negotiation);
 
         var result = service.decline("negotiationId");
 

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessServiceImplTest.java
@@ -82,7 +82,7 @@ class TransferProcessServiceImplTest {
 
     @Test
     void findById_whenFound() {
-        when(store.find(id)).thenReturn(process1);
+        when(store.findById(id)).thenReturn(process1);
         assertThat(service.findById(id)).isSameAs(process1);
         verify(transactionContext).execute(any(TransactionContext.ResultTransactionBlock.class));
     }
@@ -126,7 +126,7 @@ class TransferProcessServiceImplTest {
 
     @Test
     void getState_whenFound() {
-        when(store.find(id)).thenReturn(process1);
+        when(store.findById(id)).thenReturn(process1);
         assertThat(service.getState(id)).isEqualTo(TransferProcessStates.from(process1.getState()).name());
         verify(transactionContext).execute(any(TransactionContext.ResultTransactionBlock.class));
     }
@@ -211,7 +211,7 @@ class TransferProcessServiceImplTest {
     @EnumSource(value = TransferProcessStates.class, mode = INCLUDE, names = { "COMPLETED", "DEPROVISIONING", "TERMINATED" })
     void deprovision(TransferProcessStates state) {
         var process = transferProcess(state, id);
-        when(store.find(id)).thenReturn(process);
+        when(store.findById(id)).thenReturn(process);
 
         var result = service.deprovision(id);
 
@@ -227,7 +227,7 @@ class TransferProcessServiceImplTest {
     @EnumSource(value = TransferProcessStates.class, mode = EXCLUDE, names = { "COMPLETED", "DEPROVISIONING", "DEPROVISIONED", "DEPROVISIONING_REQUESTED", "TERMINATED" })
     void deprovision_whenNonDeprovisionable(TransferProcessStates state) {
         var process = transferProcess(state, id);
-        when(store.find(id)).thenReturn(process);
+        when(store.findById(id)).thenReturn(process);
 
         var result = service.deprovision(id);
 
@@ -249,7 +249,7 @@ class TransferProcessServiceImplTest {
     @Test
     void started_shouldEnqueueCommand() {
         when(store.processIdForDataRequestId("dataRequestId")).thenReturn("processId");
-        when(store.find("processId")).thenReturn(transferProcess(REQUESTED, "processId"));
+        when(store.findById("processId")).thenReturn(transferProcess(REQUESTED, "processId"));
 
         var result = service.notifyStarted("dataRequestId");
 
@@ -261,7 +261,7 @@ class TransferProcessServiceImplTest {
     @Test
     void started_shouldNotEnqueueCommandIfProcessIsNotFound() {
         when(store.processIdForDataRequestId("dataRequestId")).thenReturn("processId");
-        when(store.find("processId")).thenReturn(null);
+        when(store.findById("processId")).thenReturn(null);
 
         var result = service.notifyStarted("dataRequestId");
 
@@ -273,7 +273,7 @@ class TransferProcessServiceImplTest {
     @Test
     void started_shouldNotEnqueueCommandIfIsNotConsumerAndStateIsNotValid() {
         when(store.processIdForDataRequestId("dataRequestId")).thenReturn("processId");
-        when(store.find("processId")).thenReturn(TransferProcess.Builder.newInstance().id(UUID.randomUUID().toString()).state(COMPLETED.code()).build());
+        when(store.findById("processId")).thenReturn(TransferProcess.Builder.newInstance().id(UUID.randomUUID().toString()).state(COMPLETED.code()).build());
 
         var result = service.notifyStarted("dataRequestId");
 

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/contractdefinition/InMemoryContractDefinitionStore.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/contractdefinition/InMemoryContractDefinitionStore.java
@@ -51,7 +51,7 @@ public class InMemoryContractDefinitionStore implements ContractDefinitionStore 
 
 
     @Override
-    public StoreResult<Void> save(ContractDefinition definition) {
+    public StoreResult<Void> create(ContractDefinition definition) {
         var prev = cache.putIfAbsent(definition.getId(), definition);
         return Optional.ofNullable(prev)
                 .map(a -> StoreResult.<Void>alreadyExists(format(CONTRACT_DEFINITION_EXISTS, definition.getId())))

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/contractnegotiation/InMemoryContractNegotiationStore.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/contractnegotiation/InMemoryContractNegotiationStore.java
@@ -54,7 +54,7 @@ public class InMemoryContractNegotiationStore implements ContractNegotiationStor
     }
 
     @Override
-    public @Nullable ContractNegotiation find(String negotiationId) {
+    public @Nullable ContractNegotiation findById(String negotiationId) {
         return store.find(negotiationId);
     }
 
@@ -74,7 +74,7 @@ public class InMemoryContractNegotiationStore implements ContractNegotiationStor
     }
 
     @Override
-    public void save(ContractNegotiation negotiation) {
+    public void updateOrCreate(ContractNegotiation negotiation) {
         store.upsert(negotiation);
     }
 
@@ -88,13 +88,13 @@ public class InMemoryContractNegotiationStore implements ContractNegotiationStor
     }
 
     @Override
-    public @NotNull Stream<ContractNegotiation> queryNegotiations(QuerySpec querySpec) {
+    public @NotNull Stream<ContractNegotiation> findAllNegotiations(QuerySpec querySpec) {
         return negotiationQueryResolver.query(store.findAll(), querySpec);
     }
 
 
     @Override
-    public @NotNull Stream<ContractAgreement> queryAgreements(QuerySpec querySpec) {
+    public @NotNull Stream<ContractAgreement> findAllAgreements(QuerySpec querySpec) {
         return agreementQueryResolver.query(getAgreements(), querySpec);
     }
 

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/transferprocess/InMemoryTransferProcessStore.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/transferprocess/InMemoryTransferProcessStore.java
@@ -46,7 +46,7 @@ public class InMemoryTransferProcessStore implements TransferProcessStore {
 
     @Nullable
     @Override
-    public TransferProcess find(String id) {
+    public TransferProcess findById(String id) {
         return store.find(id);
     }
 
@@ -61,7 +61,7 @@ public class InMemoryTransferProcessStore implements TransferProcessStore {
     }
 
     @Override
-    public void save(TransferProcess process) {
+    public void updateOrCreate(TransferProcess process) {
         store.upsert(process);
     }
 

--- a/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/policydefinition/InMemoryPolicyDefinitionStoreTest.java
+++ b/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/policydefinition/InMemoryPolicyDefinitionStoreTest.java
@@ -17,7 +17,11 @@ package org.eclipse.edc.connector.defaults.storage.policydefinition;
 import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
 import org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore;
 import org.eclipse.edc.connector.policy.spi.testfixtures.store.PolicyDefinitionStoreTestBase;
+import org.eclipse.edc.policy.model.Action;
+import org.eclipse.edc.policy.model.Duty;
+import org.eclipse.edc.policy.model.Permission;
 import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.policy.model.Prohibition;
 import org.eclipse.edc.spi.persistence.EdcPersistenceException;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.util.concurrency.LockManager;
@@ -30,7 +34,10 @@ import java.util.stream.IntStream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.eclipse.edc.connector.policy.spi.testfixtures.TestFunctions.createDutyBuilder;
+import static org.eclipse.edc.connector.policy.spi.testfixtures.TestFunctions.createPermissionBuilder;
 import static org.eclipse.edc.connector.policy.spi.testfixtures.TestFunctions.createPolicy;
+import static org.eclipse.edc.connector.policy.spi.testfixtures.TestFunctions.createProhibitionBuilder;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
@@ -45,11 +52,10 @@ class InMemoryPolicyDefinitionStoreTest extends PolicyDefinitionStoreTestBase {
         store = new InMemoryPolicyDefinitionStore(manager);
     }
 
+
     @Test
     void deleteById_whenNonexistent() {
-        var result = store.deleteById("nonexistent");
-        assertThat(result).isNotNull();
-        assertThat(result.succeeded()).isFalse();
+        assertThat(store.deleteById("nonexistent")).isNull();
     }
 
     @Test
@@ -70,7 +76,7 @@ class InMemoryPolicyDefinitionStoreTest extends PolicyDefinitionStoreTestBase {
     void save_exceptionThrown() {
         doThrow(new RuntimeException()).when(manager).writeLock(any());
 
-        assertThatExceptionOfType(EdcPersistenceException.class).isThrownBy(() -> store.save(createPolicyDef()));
+        assertThatExceptionOfType(EdcPersistenceException.class).isThrownBy(() -> store.create(createPolicyDef()));
     }
 
     @Test
@@ -82,7 +88,7 @@ class InMemoryPolicyDefinitionStoreTest extends PolicyDefinitionStoreTestBase {
 
     @Test
     void findAll_verifyFiltering_invalidFilterExpression() {
-        IntStream.range(0, 10).mapToObj(i -> createPolicy("test-id")).forEach(d -> getPolicyDefinitionStore().save(d));
+        IntStream.range(0, 10).mapToObj(i -> createPolicy("test-id")).forEach(d -> getPolicyDefinitionStore().create(d));
 
         var query = QuerySpec.Builder.newInstance().filter("something contains other").build();
 
@@ -90,13 +96,81 @@ class InMemoryPolicyDefinitionStoreTest extends PolicyDefinitionStoreTestBase {
     }
 
     @Test
+    void update_whenPolicyNotExists() {
+        var policy = createPolicy("test-id");
+        var result = getPolicyDefinitionStore().update("test-id", policy);
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void update_whenPolicyExists_updatingPolicyFields() {
+        var policy = createPolicy("test-id");
+        getPolicyDefinitionStore().create(policy);
+
+        Action action = Action.Builder.newInstance().type("UPDATED_USE").build();
+        var updatedPermission = Permission.Builder.newInstance().action(action).build();
+        var updatedDuty = Duty.Builder.newInstance().action(action).build();
+        var updatedProhibition = Prohibition.Builder.newInstance().action(action).build();
+
+        policy.getPolicy().getPermissions().add(updatedPermission);
+        policy.getPolicy().getProhibitions().add(updatedProhibition);
+        policy.getPolicy().getObligations().add(updatedDuty);
+        policy.getPolicy().getExtensibleProperties().put("updatedKey", "updatedValue");
+
+        var result = getPolicyDefinitionStore().update("test-id", policy);
+        assertThat(result.getPolicy().getExtensibleProperties()).containsEntry("updatedKey", "updatedValue");
+        assertThat(result.getPolicy().getPermissions().get(1)).isEqualTo(updatedPermission);
+        assertThat(result.getPolicy().getProhibitions().get(1)).isEqualTo(updatedProhibition);
+        assertThat(result.getPolicy().getObligations().get(1)).isEqualTo(updatedDuty);
+    }
+
+    @Test
+    void update_whenPolicyExists_removingPolicyFields() {
+        var policy = createPolicy("test-id");
+        getPolicyDefinitionStore().create(policy);
+
+        var updatedPolicy = createPolicyDef("test-id", "updatedTarget");
+        var result = getPolicyDefinitionStore().update("test-id", updatedPolicy);
+
+        assertThat(result.getPolicy().getTarget()).isEqualTo("updatedTarget");
+        assertThat(result.getPolicy().getPermissions().size()).isEqualTo(0);
+        assertThat(result.getPolicy().getProhibitions().size()).isEqualTo(0);
+        assertThat(result.getPolicy().getObligations().size()).isEqualTo(0);
+    }
+
+    @Test
+    void update_whenPolicyExists_replacingAllFields() {
+        var policy = createPolicy("test-id");
+        getPolicyDefinitionStore().create(policy);
+
+        var updatedPermission = createPermissionBuilder("updated-id").build();
+        var updatedProhibition = createProhibitionBuilder("updated-id").build();
+        var updatedDuty = createDutyBuilder("updated-id").build();
+        Policy updatedPolicy = Policy.Builder.newInstance()
+                .target("updatedTarget")
+                .permission(updatedPermission)
+                .prohibition(updatedProhibition)
+                .duty(updatedDuty)
+                .extensibleProperty("updatedKey", "updatedValue")
+                .build();
+
+        var result = getPolicyDefinitionStore().update("test-id", PolicyDefinition.Builder.newInstance().policy(updatedPolicy).build());
+
+        assertThat(result.getPolicy().getExtensibleProperties()).containsEntry("updatedKey", "updatedValue");
+        assertThat(result.getPolicy().getPermissions().get(0)).isEqualTo(updatedPermission);
+        assertThat(result.getPolicy().getProhibitions().get(0)).isEqualTo(updatedProhibition);
+        assertThat(result.getPolicy().getObligations().get(0)).isEqualTo(updatedDuty);
+    }
+
+    @Test
     void update_throwsException() {
         var policy = createPolicy("test-id");
-        getPolicyDefinitionStore().save(policy);
+        getPolicyDefinitionStore().create(policy);
 
         doThrow(new RuntimeException()).when(manager).writeLock(any());
-        assertThatExceptionOfType(EdcPersistenceException.class).isThrownBy(() -> store.update(createPolicyDef()));
+        assertThatExceptionOfType(EdcPersistenceException.class).isThrownBy(() -> store.update("test-id", createPolicyDef()));
     }
+
 
     @Override
     protected PolicyDefinitionStore getPolicyDefinitionStore() {
@@ -120,6 +194,17 @@ class InMemoryPolicyDefinitionStoreTest extends PolicyDefinitionStoreTestBase {
 
     private PolicyDefinition createPolicyDef() {
         return PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build();
+    }
+
+    private PolicyDefinition createPolicyDef(String id) {
+        return PolicyDefinition.Builder.newInstance()
+                .id(id)
+                .policy(Policy.Builder.newInstance().build())
+                .build();
+    }
+
+    private PolicyDefinition createPolicyDef(String id, String target) {
+        return PolicyDefinition.Builder.newInstance().id(id).policy(Policy.Builder.newInstance().target(target).build()).build();
     }
 
 

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/command/handlers/SingleTransferProcessCommandHandler.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/command/handlers/SingleTransferProcessCommandHandler.java
@@ -38,13 +38,13 @@ public abstract class SingleTransferProcessCommandHandler<T extends SingleTransf
     @Override
     public void handle(T command) {
         var transferProcessId = command.getTransferProcessId();
-        var transferProcess = store.find(transferProcessId);
+        var transferProcess = store.findById(transferProcessId);
         if (transferProcess == null) {
             throw new EdcException(format("Could not find TransferProcess with ID [%s]", transferProcessId));
         } else {
             if (modify(transferProcess, command)) {
                 transferProcess.setModified();
-                store.save(transferProcess);
+                store.updateOrCreate(transferProcess);
                 postAction(transferProcess);
             }
         }

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/command/handlers/CancelTransferCommandHandlerTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/command/handlers/CancelTransferCommandHandlerTest.java
@@ -59,15 +59,15 @@ class CancelTransferCommandHandlerTest {
                 .type(TransferProcess.Type.CONSUMER).build();
         var originalDate = tp.getUpdatedAt();
 
-        when(store.find(anyString())).thenReturn(tp);
+        when(store.findById(anyString())).thenReturn(tp);
         handler.handle(cmd);
 
         assertThat(tp.getState()).isEqualTo(TERMINATING.code());
         assertThat(tp.getErrorDetail()).isEqualTo("transfer cancelled");
         assertThat(tp.getUpdatedAt()).isNotEqualTo(originalDate);
 
-        verify(store).find(anyString());
-        verify(store).save(tp);
+        verify(store).findById(anyString());
+        verify(store).updateOrCreate(tp);
         verifyNoMoreInteractions(store);
     }
 
@@ -79,12 +79,12 @@ class CancelTransferCommandHandlerTest {
         var originalDate = tp.getUpdatedAt();
         var cmd = new CancelTransferCommand("test-id");
 
-        when(store.find(anyString())).thenReturn(tp);
+        when(store.findById(anyString())).thenReturn(tp);
         handler.handle(cmd);
 
         assertThat(tp.getUpdatedAt()).isEqualTo(originalDate);
 
-        verify(store).find(anyString());
+        verify(store).findById(anyString());
         verifyNoMoreInteractions(store);
         verifyNoInteractions(listener);
     }
@@ -93,7 +93,7 @@ class CancelTransferCommandHandlerTest {
     void handle_notFound() {
         var cmd = new CancelTransferCommand("test-id");
 
-        when(store.find(anyString())).thenReturn(null);
+        when(store.findById(anyString())).thenReturn(null);
         assertThatThrownBy(() -> handler.handle(cmd)).isInstanceOf(EdcException.class).hasMessageStartingWith("Could not find TransferProcess with ID [test-id]");
         verifyNoInteractions(listener);
     }

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/command/handlers/CompleteTransferCommandHandlerTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/command/handlers/CompleteTransferCommandHandlerTest.java
@@ -46,15 +46,15 @@ class CompleteTransferCommandHandlerTest {
                 .updatedAt(124123) //some invalid time
                 .type(TransferProcess.Type.CONSUMER).build();
         var originalDate = tp.getUpdatedAt();
-        when(store.find(anyString())).thenReturn(tp);
+        when(store.findById(anyString())).thenReturn(tp);
 
         handler.handle(command);
 
         assertThat(tp.getState()).isEqualTo(COMPLETING.code());
         assertThat(tp.getErrorDetail()).isNull();
         assertThat(tp.getUpdatedAt()).isNotEqualTo(originalDate);
-        verify(store).find(anyString());
-        verify(store).save(tp);
+        verify(store).findById(anyString());
+        verify(store).updateOrCreate(tp);
         verifyNoMoreInteractions(store);
     }
 
@@ -65,19 +65,19 @@ class CompleteTransferCommandHandlerTest {
                 .type(TransferProcess.Type.CONSUMER).build();
         var originalDate = tp.getUpdatedAt();
         var command = new CompleteTransferCommand("test-id");
-        when(store.find(anyString())).thenReturn(tp);
+        when(store.findById(anyString())).thenReturn(tp);
 
         handler.handle(command);
 
         assertThat(tp.getUpdatedAt()).isEqualTo(originalDate);
-        verify(store).find(anyString());
+        verify(store).findById(anyString());
         verifyNoMoreInteractions(store);
     }
 
     @Test
     void handle_notFound() {
         var command = new CompleteTransferCommand("test-id");
-        when(store.find(anyString())).thenReturn(null);
+        when(store.findById(anyString())).thenReturn(null);
 
         assertThatThrownBy(() -> handler.handle(command)).isInstanceOf(EdcException.class).hasMessageStartingWith("Could not find TransferProcess with ID [test-id]");
     }

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/command/handlers/DeprovisionCommandHandlerTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/command/handlers/DeprovisionCommandHandlerTest.java
@@ -49,7 +49,7 @@ class DeprovisionCommandHandlerTest {
                 .build();
         var originalDate = tp.getUpdatedAt();
 
-        when(storeMock.find(anyString())).thenReturn(tp);
+        when(storeMock.findById(anyString())).thenReturn(tp);
         handler.handle(cmd);
 
         assertThat(tp.getState()).isEqualTo(TransferProcessStates.DEPROVISIONING.code());
@@ -61,7 +61,7 @@ class DeprovisionCommandHandlerTest {
     void handle_notFound() {
         var cmd = new DeprovisionRequest("test-id");
 
-        when(storeMock.find(anyString())).thenReturn(null);
+        when(storeMock.findById(anyString())).thenReturn(null);
         assertThatThrownBy(() -> handler.handle(cmd)).isInstanceOf(EdcException.class).hasMessage("Could not find TransferProcess with ID [test-id]");
     }
 
@@ -72,7 +72,7 @@ class DeprovisionCommandHandlerTest {
                 .type(TransferProcess.Type.CONSUMER).build();
         var originalDate = tp.getUpdatedAt();
 
-        when(storeMock.find(anyString())).thenReturn(tp);
+        when(storeMock.findById(anyString())).thenReturn(tp);
         assertThatThrownBy(() -> handler.handle(cmd)).isInstanceOf(IllegalStateException.class).hasMessage("Cannot transition from state STARTED to DEPROVISIONING");
         assertThat(tp.getUpdatedAt()).isEqualTo(originalDate);
     }

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/command/handlers/NotifyStartedTransferCommandHandlerTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/command/handlers/NotifyStartedTransferCommandHandlerTest.java
@@ -58,22 +58,22 @@ class NotifyStartedTransferCommandHandlerTest {
     @Test
     void shouldTransitStateToStarted() {
         var process = TransferProcess.Builder.newInstance().id("processId").type(CONSUMER).state(REQUESTED.code()).build();
-        when(store.find(process.getId())).thenReturn(process);
+        when(store.findById(process.getId())).thenReturn(process);
 
         handler.handle(new NotifyStartedTransferCommand("processId"));
 
-        verify(store).save(argThat(p -> p.currentStateIsOneOf(STARTED) && p.getId().equals("processId")));
+        verify(store).updateOrCreate(argThat(p -> p.currentStateIsOneOf(STARTED) && p.getId().equals("processId")));
         verify(listener).started(isA(TransferProcess.class));
     }
 
     @Test
     void shouldNotTransitToStarted_whenItInAnInvalidState() {
         var process = TransferProcess.Builder.newInstance().id("processId").type(CONSUMER).state(COMPLETED.code()).build();
-        when(store.find(process.getId())).thenReturn(process);
+        when(store.findById(process.getId())).thenReturn(process);
 
         handler.handle(new NotifyStartedTransferCommand("processId"));
 
-        verify(store, never()).save(any());
+        verify(store, never()).updateOrCreate(any());
         verifyNoInteractions(listener);
     }
 }

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/command/handlers/TerminateTransferCommandHandlerTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/command/handlers/TerminateTransferCommandHandlerTest.java
@@ -64,15 +64,15 @@ class TerminateTransferCommandHandlerTest {
                 .type(TransferProcess.Type.CONSUMER).build();
         var originalDate = tp.getUpdatedAt();
 
-        when(store.find(anyString())).thenReturn(tp);
+        when(store.findById(anyString())).thenReturn(tp);
         handler.handle(cmd);
 
         assertThat(tp.getState()).isEqualTo(TERMINATING.code());
         assertThat(tp.getErrorDetail()).isEqualTo("a reason");
         assertThat(tp.getUpdatedAt()).isNotEqualTo(originalDate);
 
-        verify(store).find(anyString());
-        verify(store).save(tp);
+        verify(store).findById(anyString());
+        verify(store).updateOrCreate(tp);
         verifyNoMoreInteractions(store);
     }
 
@@ -84,12 +84,12 @@ class TerminateTransferCommandHandlerTest {
         var originalDate = tp.getUpdatedAt();
         var cmd = new TerminateTransferCommand("test-id", "a reason");
 
-        when(store.find(anyString())).thenReturn(tp);
+        when(store.findById(anyString())).thenReturn(tp);
         handler.handle(cmd);
 
         assertThat(tp.getUpdatedAt()).isEqualTo(originalDate);
 
-        verify(store).find(anyString());
+        verify(store).findById(anyString());
         verifyNoMoreInteractions(store);
         verifyNoInteractions(listener);
     }
@@ -98,7 +98,7 @@ class TerminateTransferCommandHandlerTest {
     void handle_notFound() {
         var cmd = new TerminateTransferCommand("test-id", "a reason");
 
-        when(store.find(anyString())).thenReturn(null);
+        when(store.findById(anyString())).thenReturn(null);
         assertThatThrownBy(() -> handler.handle(cmd)).isInstanceOf(EdcException.class).hasMessageStartingWith("Could not find TransferProcess with ID [test-id]");
         verifyNoInteractions(listener);
     }

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/transfer/TransferProcessManagerImplIntegrationTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/transfer/TransferProcessManagerImplIntegrationTest.java
@@ -118,7 +118,7 @@ class TransferProcessManagerImplIntegrationTest {
         var processes = IntStream.range(0, numProcesses)
                 .mapToObj(i -> provisionedResourceSet())
                 .map(resourceSet -> createInitialTransferProcess().resourceManifest(manifest).provisionedResourceSet(resourceSet).build())
-                .peek(store::save)
+                .peek(store::updateOrCreate)
                 .collect(Collectors.toList());
 
         transferProcessManager.start();
@@ -127,7 +127,7 @@ class TransferProcessManagerImplIntegrationTest {
             assertThat(processes).describedAs("All transfer processes state should be greater than INITIAL")
                     .allSatisfy(process -> {
                         var id = process.getId();
-                        var storedProcess = store.find(id);
+                        var storedProcess = store.findById(id);
                         assertThat(storedProcess).describedAs("Should exist in the TransferProcessStore")
                                 .isNotNull().extracting(StatefulEntity::getState).asInstanceOf(comparable(Integer.class))
                                 .isGreaterThan(INITIAL.code());

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/transfer/TransferProcessManagerImplTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/transfer/TransferProcessManagerImplTest.java
@@ -162,7 +162,7 @@ class TransferProcessManagerImplTest {
         manager.initiateProviderRequest(dataRequest); // repeat request
         manager.stop();
 
-        verify(transferProcessStore, times(1)).save(isA(TransferProcess.class));
+        verify(transferProcessStore, times(1)).updateOrCreate(isA(TransferProcess.class));
         verify(transferProcessStore, times(2)).processIdForDataRequestId(anyString());
     }
 
@@ -175,7 +175,7 @@ class TransferProcessManagerImplTest {
         manager.initiateProviderRequest(dataRequest);
         manager.stop();
 
-        verify(transferProcessStore, times(1)).save(argThat(p -> p.getCreatedAt() == currentTime));
+        verify(transferProcessStore, times(1)).updateOrCreate(argThat(p -> p.getCreatedAt() == currentTime));
         verify(listener).initiated(any());
     }
 
@@ -194,7 +194,7 @@ class TransferProcessManagerImplTest {
         await().untilAsserted(() -> {
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
             verifyNoInteractions(provisionManager);
-            verify(transferProcessStore).save(argThat(p -> p.getState() == PROVISIONING.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == PROVISIONING.code()));
         });
     }
 
@@ -212,7 +212,7 @@ class TransferProcessManagerImplTest {
         await().untilAsserted(() -> {
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
             verifyNoInteractions(provisionManager);
-            verify(transferProcessStore).save(argThat(p -> p.getState() == TERMINATING.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == TERMINATING.code()));
         });
     }
 
@@ -228,14 +228,14 @@ class TransferProcessManagerImplTest {
         when(policyArchive.findPolicyForContract(anyString())).thenReturn(Policy.Builder.newInstance().build());
         when(provisionManager.provision(any(), isA(Policy.class))).thenReturn(completedFuture(List.of(provisionResult)));
         when(transferProcessStore.nextForState(eq(PROVISIONING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process);
+        when(transferProcessStore.findById(process.getId())).thenReturn(process);
 
         manager.start();
 
         await().untilAsserted(() -> {
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
-            verify(transferProcessStore).find(process.getId());
-            verify(transferProcessStore).save(argThat(p -> p.getState() == PROVISIONED.code()));
+            verify(transferProcessStore).findById(process.getId());
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == PROVISIONED.code()));
             verify(listener).provisioned(process);
         });
     }
@@ -258,13 +258,13 @@ class TransferProcessManagerImplTest {
         when(policyArchive.findPolicyForContract(anyString())).thenReturn(Policy.Builder.newInstance().build());
         when(provisionManager.provision(any(), isA(Policy.class))).thenReturn(completedFuture(List.of(provisionResult)));
         when(transferProcessStore.nextForState(eq(PROVISIONING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process);
+        when(transferProcessStore.findById(process.getId())).thenReturn(process);
 
         manager.start();
 
         await().untilAsserted(() -> {
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
-            verify(transferProcessStore).save(argThat(p -> p.getState() == PROVISIONED.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == PROVISIONED.code()));
             verify(vault).storeSecret(any(), any());
             verify(listener).provisioned(process);
         });
@@ -283,12 +283,12 @@ class TransferProcessManagerImplTest {
         when(policyArchive.findPolicyForContract(anyString())).thenReturn(Policy.Builder.newInstance().build());
         when(provisionManager.provision(any(), isA(Policy.class))).thenReturn(completedFuture(List.of(provisionResult)));
         when(transferProcessStore.nextForState(eq(PROVISIONING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process);
+        when(transferProcessStore.findById(process.getId())).thenReturn(process);
 
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore).save(argThat(p -> p.getState() == PROVISIONING_REQUESTED.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == PROVISIONING_REQUESTED.code()));
             verify(listener).provisioningRequested(any());
         });
     }
@@ -302,13 +302,13 @@ class TransferProcessManagerImplTest {
         when(policyArchive.findPolicyForContract(anyString())).thenReturn(Policy.Builder.newInstance().build());
         when(provisionManager.provision(any(), isA(Policy.class))).thenReturn(failedFuture(new EdcException("provision failed")));
         when(transferProcessStore.nextForState(eq(PROVISIONING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process);
+        when(transferProcessStore.findById(process.getId())).thenReturn(process);
 
         manager.start();
 
         await().untilAsserted(() -> {
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
-            verify(transferProcessStore).save(argThat(p -> p.getState() == TERMINATING.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == TERMINATING.code()));
         });
     }
 
@@ -322,13 +322,13 @@ class TransferProcessManagerImplTest {
         when(policyArchive.findPolicyForContract(anyString())).thenReturn(Policy.Builder.newInstance().build());
         when(provisionManager.provision(any(), isA(Policy.class))).thenReturn(completedFuture(List.of(provisionResult)));
         when(transferProcessStore.nextForState(eq(PROVISIONING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process);
+        when(transferProcessStore.findById(process.getId())).thenReturn(process);
 
         manager.start();
 
         await().untilAsserted(() -> {
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
-            verify(transferProcessStore).save(argThat(p -> p.getState() == TERMINATING.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == TERMINATING.code()));
         });
     }
 
@@ -342,13 +342,13 @@ class TransferProcessManagerImplTest {
         when(policyArchive.findPolicyForContract(anyString())).thenReturn(Policy.Builder.newInstance().build());
         when(provisionManager.provision(any(), isA(Policy.class))).thenReturn(completedFuture(List.of(provisionResult)));
         when(transferProcessStore.nextForState(eq(PROVISIONING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process);
+        when(transferProcessStore.findById(process.getId())).thenReturn(process);
 
         manager.start();
 
         await().untilAsserted(() -> {
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
-            verify(transferProcessStore).save(argThat(p -> p.getState() == PROVISIONING.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == PROVISIONING.code()));
         });
     }
 
@@ -361,7 +361,7 @@ class TransferProcessManagerImplTest {
 
         await().untilAsserted(() -> {
             verify(transferProcessStore, atLeastOnce()).nextForState(eq(PROVISIONED.code()), anyInt());
-            verify(transferProcessStore).save(argThat(p -> p.getState() == REQUESTING.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == REQUESTING.code()));
         });
     }
 
@@ -373,7 +373,7 @@ class TransferProcessManagerImplTest {
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore).save(argThat(p -> p.getState() == STARTING.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == STARTING.code()));
         });
     }
 
@@ -382,12 +382,12 @@ class TransferProcessManagerImplTest {
         var process = createTransferProcess(REQUESTING);
         when(dispatcherRegistry.send(eq(Object.class), any())).thenReturn(completedFuture("any"));
         when(transferProcessStore.nextForState(eq(REQUESTING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process, process.toBuilder().state(REQUESTING.code()).build());
+        when(transferProcessStore.findById(process.getId())).thenReturn(process, process.toBuilder().state(REQUESTING.code()).build());
 
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore, times(1)).save(argThat(p -> p.getState() == REQUESTED.code()));
+            verify(transferProcessStore, times(1)).updateOrCreate(argThat(p -> p.getState() == REQUESTED.code()));
             verify(listener).requested(process);
         });
     }
@@ -397,12 +397,12 @@ class TransferProcessManagerImplTest {
         var process = createTransferProcess(REQUESTING);
         when(dispatcherRegistry.send(eq(Object.class), any())).thenReturn(failedFuture(new EdcException("send failed")));
         when(transferProcessStore.nextForState(eq(REQUESTING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process, process.toBuilder().state(REQUESTING.code()).build());
+        when(transferProcessStore.findById(process.getId())).thenReturn(process, process.toBuilder().state(REQUESTING.code()).build());
 
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore, times(1)).save(argThat(p -> p.getState() == REQUESTING.code()));
+            verify(transferProcessStore, times(1)).updateOrCreate(argThat(p -> p.getState() == REQUESTING.code()));
         });
     }
 
@@ -411,13 +411,13 @@ class TransferProcessManagerImplTest {
         var process = createTransferProcess(REQUESTING);
         when(dispatcherRegistry.send(eq(Object.class), any())).thenReturn(failedFuture(new EdcException("send failed")));
         when(transferProcessStore.nextForState(eq(REQUESTING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process, process.toBuilder().state(REQUESTING.code()).build());
+        when(transferProcessStore.findById(process.getId())).thenReturn(process, process.toBuilder().state(REQUESTING.code()).build());
         when(sendRetryManager.retriesExhausted(process)).thenReturn(true);
 
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore, times(1)).save(argThat(p -> p.getState() == TERMINATING.code()));
+            verify(transferProcessStore, times(1)).updateOrCreate(argThat(p -> p.getState() == TERMINATING.code()));
         });
     }
 
@@ -427,13 +427,13 @@ class TransferProcessManagerImplTest {
         when(sendRetryManager.shouldDelay(process)).thenReturn(true);
         when(dispatcherRegistry.send(eq(Object.class), any())).thenReturn(completedFuture("any"));
         when(transferProcessStore.nextForState(eq(REQUESTING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process, process.toBuilder().state(REQUESTING.code()).build());
+        when(transferProcessStore.findById(process.getId())).thenReturn(process, process.toBuilder().state(REQUESTING.code()).build());
 
         manager.start();
 
         await().untilAsserted(() -> {
             verifyNoInteractions(dispatcherRegistry);
-            verify(transferProcessStore, times(1)).save(argThat(p -> p.getState() == REQUESTING.code()));
+            verify(transferProcessStore, times(1)).updateOrCreate(argThat(p -> p.getState() == REQUESTING.code()));
         });
     }
 
@@ -450,7 +450,7 @@ class TransferProcessManagerImplTest {
 
         manager.start();
 
-        await().pollDelay(1, SECONDS).untilAsserted(() -> verify(transferProcessStore, never()).save(any()));
+        await().pollDelay(1, SECONDS).untilAsserted(() -> verify(transferProcessStore, never()).updateOrCreate(any()));
     }
 
     @Test
@@ -468,7 +468,7 @@ class TransferProcessManagerImplTest {
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore).save(argThat(p -> p.getState() == STARTED.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == STARTED.code()));
         });
     }
 
@@ -481,12 +481,12 @@ class TransferProcessManagerImplTest {
                 .dataRequest(dataRequest).build();
         when(transferProcessStore.nextForState(eq(REQUESTED.code()), anyInt())).thenReturn(List.of(process));
         doThrow(new AssertionError("update() should not be called as process was not updated"))
-                .when(transferProcessStore).save(process);
+                .when(transferProcessStore).updateOrCreate(process);
 
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore, never()).save(any());
+            verify(transferProcessStore, never()).updateOrCreate(any());
         });
     }
 
@@ -502,7 +502,7 @@ class TransferProcessManagerImplTest {
         await().untilAsserted(() -> {
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
             // TODO: verify message sent
-            verify(transferProcessStore).save(argThat(p -> p.getState() == STARTED.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == STARTED.code()));
         });
     }
 
@@ -511,12 +511,12 @@ class TransferProcessManagerImplTest {
         var process = createTransferProcess(STARTING).toBuilder().type(PROVIDER).build();
         when(dataFlowManager.initiate(any(), any(), any())).thenReturn(StatusResult.failure(ResponseStatus.ERROR_RETRY));
         when(transferProcessStore.nextForState(eq(STARTING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process, process.toBuilder().state(STARTING.code()).build());
+        when(transferProcessStore.findById(process.getId())).thenReturn(process, process.toBuilder().state(STARTING.code()).build());
 
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore, times(1)).save(argThat(p -> p.getState() == STARTING.code()));
+            verify(transferProcessStore, times(1)).updateOrCreate(argThat(p -> p.getState() == STARTING.code()));
         });
     }
 
@@ -530,7 +530,7 @@ class TransferProcessManagerImplTest {
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore).save(argThat(p -> p.getState() == TERMINATING.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == TERMINATING.code()));
         });
     }
 
@@ -539,13 +539,13 @@ class TransferProcessManagerImplTest {
         var process = createTransferProcess(STARTING).toBuilder().type(PROVIDER).build();
         when(dataFlowManager.initiate(any(), any(), any())).thenReturn(StatusResult.failure(ResponseStatus.ERROR_RETRY));
         when(transferProcessStore.nextForState(eq(STARTING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process, process.toBuilder().state(STARTING.code()).build());
+        when(transferProcessStore.findById(process.getId())).thenReturn(process, process.toBuilder().state(STARTING.code()).build());
         when(sendRetryManager.retriesExhausted(process)).thenReturn(true);
 
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore, times(1)).save(argThat(p -> p.getState() == TERMINATING.code()));
+            verify(transferProcessStore, times(1)).updateOrCreate(argThat(p -> p.getState() == TERMINATING.code()));
         });
     }
 
@@ -555,13 +555,13 @@ class TransferProcessManagerImplTest {
         when(sendRetryManager.shouldDelay(process)).thenReturn(true);
         when(dataFlowManager.initiate(any(), any(), any())).thenReturn(StatusResult.failure(ResponseStatus.ERROR_RETRY));
         when(transferProcessStore.nextForState(eq(STARTING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process, process.toBuilder().state(STARTING.code()).build());
+        when(transferProcessStore.findById(process.getId())).thenReturn(process, process.toBuilder().state(STARTING.code()).build());
 
         manager.start();
 
         await().untilAsserted(() -> {
             verifyNoInteractions(dataFlowManager);
-            verify(transferProcessStore, times(1)).save(argThat(p -> p.getState() == STARTING.code()));
+            verify(transferProcessStore, times(1)).updateOrCreate(argThat(p -> p.getState() == STARTING.code()));
         });
     }
 
@@ -578,7 +578,7 @@ class TransferProcessManagerImplTest {
 
         await().untilAsserted(() -> {
             verify(statusCheckerRegistry, atLeastOnce()).resolve(any());
-            verify(transferProcessStore).save(argThat(p -> p.getState() == COMPLETING.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == COMPLETING.code()));
         });
     }
 
@@ -595,7 +595,7 @@ class TransferProcessManagerImplTest {
 
         await().untilAsserted(() -> {
             verify(statusCheckerRegistry, atLeastOnce()).resolve(any());
-            verify(transferProcessStore).save(argThat(p -> p.getState() == COMPLETING.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == COMPLETING.code()));
         });
     }
 
@@ -611,7 +611,7 @@ class TransferProcessManagerImplTest {
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore).save(argThat(p -> p.getState() == STARTED.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == STARTED.code()));
         });
     }
 
@@ -622,12 +622,12 @@ class TransferProcessManagerImplTest {
         process.getProvisionedResourceSet().addResource(provisionedDataDestinationResource());
         when(transferProcessStore.nextForState(eq(STARTED.code()), anyInt())).thenReturn(List.of(process));
         doThrow(new AssertionError("update() should not be called as process was not updated"))
-                .when(transferProcessStore).save(process);
+                .when(transferProcessStore).updateOrCreate(process);
 
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore, never()).save(any());
+            verify(transferProcessStore, never()).updateOrCreate(any());
         });
     }
 
@@ -644,7 +644,7 @@ class TransferProcessManagerImplTest {
 
         await().untilAsserted(() -> {
             verify(statusCheckerRegistry, atLeastOnce()).resolve(any());
-            verify(transferProcessStore).save(argThat(p -> p.getState() == COMPLETING.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == COMPLETING.code()));
         });
     }
 
@@ -652,12 +652,12 @@ class TransferProcessManagerImplTest {
     void completing_shouldTransitionToCompleted() {
         var process = createTransferProcess(COMPLETING);
         when(transferProcessStore.nextForState(eq(COMPLETING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process, process.toBuilder().state(COMPLETING.code()).build());
+        when(transferProcessStore.findById(process.getId())).thenReturn(process, process.toBuilder().state(COMPLETING.code()).build());
 
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore, times(1)).save(argThat(p -> p.getState() == COMPLETED.code()));
+            verify(transferProcessStore, times(1)).updateOrCreate(argThat(p -> p.getState() == COMPLETED.code()));
             verify(listener).completed(process);
         });
     }
@@ -666,12 +666,12 @@ class TransferProcessManagerImplTest {
     void terminating_shouldTransitionToTerminated() {
         var process = createTransferProcess(TERMINATING);
         when(transferProcessStore.nextForState(eq(TERMINATING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process, process.toBuilder().state(TERMINATING.code()).build());
+        when(transferProcessStore.findById(process.getId())).thenReturn(process, process.toBuilder().state(TERMINATING.code()).build());
 
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore, times(1)).save(argThat(p -> p.getState() == TERMINATED.code()));
+            verify(transferProcessStore, times(1)).updateOrCreate(argThat(p -> p.getState() == TERMINATED.code()));
             verify(listener).terminated(process);
         });
     }
@@ -699,14 +699,14 @@ class TransferProcessManagerImplTest {
         when(vault.deleteSecret(any())).thenReturn(Result.success());
         when(provisionManager.deprovision(any(), isA(Policy.class))).thenReturn(completedFuture(List.of(deprovisionResult)));
         when(transferProcessStore.nextForState(eq(DEPROVISIONING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process);
+        when(transferProcessStore.findById(process.getId())).thenReturn(process);
 
         manager.start();
 
         await().untilAsserted(() -> {
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
-            verify(transferProcessStore).find(process.getId());
-            verify(transferProcessStore).save(argThat(p -> p.getState() == DEPROVISIONED.code()));
+            verify(transferProcessStore).findById(process.getId());
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == DEPROVISIONED.code()));
             verify(vault).deleteSecret(any());
             verify(listener).deprovisioned(process);
         });
@@ -736,12 +736,12 @@ class TransferProcessManagerImplTest {
         when(vault.deleteSecret(any())).thenReturn(Result.success());
         when(provisionManager.deprovision(any(), isA(Policy.class))).thenReturn(completedFuture(List.of(StatusResult.success(deprovisionedResponse))));
         when(transferProcessStore.nextForState(eq(DEPROVISIONING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process);
+        when(transferProcessStore.findById(process.getId())).thenReturn(process);
 
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore).save(argThat(p -> p.getState() == DEPROVISIONING_REQUESTED.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == DEPROVISIONING_REQUESTED.code()));
             verify(listener).deprovisioningRequested(any());
         });
     }
@@ -766,13 +766,13 @@ class TransferProcessManagerImplTest {
         when(policyArchive.findPolicyForContract(anyString())).thenReturn(Policy.Builder.newInstance().build());
         when(provisionManager.deprovision(any(), isA(Policy.class))).thenReturn(completedFuture(List.of(deprovisionResult)));
         when(transferProcessStore.nextForState(eq(DEPROVISIONING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process);
+        when(transferProcessStore.findById(process.getId())).thenReturn(process);
 
         manager.start();
 
         await().untilAsserted(() -> {
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
-            verify(transferProcessStore).save(argThat(p -> p.getState() == DEPROVISIONED.code() && p.getErrorDetail() != null));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == DEPROVISIONED.code() && p.getErrorDetail() != null));
             verify(listener).deprovisioned(process);
         });
     }
@@ -797,12 +797,12 @@ class TransferProcessManagerImplTest {
         when(policyArchive.findPolicyForContract(anyString())).thenReturn(Policy.Builder.newInstance().build());
         when(provisionManager.deprovision(any(), isA(Policy.class))).thenReturn(completedFuture(List.of(deprovisionResult)));
         when(transferProcessStore.nextForState(eq(DEPROVISIONING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process);
+        when(transferProcessStore.findById(process.getId())).thenReturn(process);
 
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore).save(argThat(p -> p.getState() == DEPROVISIONING.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == DEPROVISIONING.code()));
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
         });
     }
@@ -815,13 +815,13 @@ class TransferProcessManagerImplTest {
         when(policyArchive.findPolicyForContract(anyString())).thenReturn(Policy.Builder.newInstance().build());
         when(provisionManager.deprovision(any(), isA(Policy.class))).thenReturn(failedFuture(new EdcException("provision failed")));
         when(transferProcessStore.nextForState(eq(DEPROVISIONING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process);
+        when(transferProcessStore.findById(process.getId())).thenReturn(process);
 
         manager.start();
 
         await().untilAsserted(() -> {
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
-            verify(transferProcessStore).save(argThat(p -> p.getState() == DEPROVISIONED.code() && p.getErrorDetail() != null));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == DEPROVISIONED.code() && p.getErrorDetail() != null));
             verify(listener).deprovisioned(process);
         });
     }

--- a/core/data-plane-selector/data-plane-selector-core/src/main/java/org/eclipse/edc/connector/dataplane/selector/DataPlaneSelectorServiceImpl.java
+++ b/core/data-plane-selector/data-plane-selector-core/src/main/java/org/eclipse/edc/connector/dataplane/selector/DataPlaneSelectorServiceImpl.java
@@ -19,10 +19,7 @@ import org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService
 import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
 import org.eclipse.edc.connector.dataplane.selector.spi.store.DataPlaneInstanceStore;
 import org.eclipse.edc.connector.dataplane.selector.spi.strategy.SelectionStrategyRegistry;
-import org.eclipse.edc.service.spi.result.ServiceResult;
-import org.eclipse.edc.spi.result.StoreResult;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.eclipse.edc.transaction.spi.TransactionContext;
 
 import java.util.Collection;
 import java.util.List;
@@ -33,13 +30,11 @@ public class DataPlaneSelectorServiceImpl implements DataPlaneSelectorService {
     private final DataPlaneSelector selector;
     private final DataPlaneInstanceStore store;
     private final SelectionStrategyRegistry selectionStrategyRegistry;
-    private final TransactionContext transactionContext;
 
-    public DataPlaneSelectorServiceImpl(DataPlaneSelector selector, DataPlaneInstanceStore store, SelectionStrategyRegistry selectionStrategyRegistry, TransactionContext transactionContext) {
+    public DataPlaneSelectorServiceImpl(DataPlaneSelector selector, DataPlaneInstanceStore store, SelectionStrategyRegistry selectionStrategyRegistry) {
         this.selector = selector;
         this.store = store;
         this.selectionStrategyRegistry = selectionStrategyRegistry;
-        this.transactionContext = transactionContext;
     }
 
     @Override
@@ -67,15 +62,7 @@ public class DataPlaneSelectorServiceImpl implements DataPlaneSelectorService {
     }
 
     @Override
-    public ServiceResult<Void> addInstance(DataPlaneInstance instance) {
-        return transactionContext.execute(() -> {
-            StoreResult<Void> result;
-            if (store.findById(instance.getId()) == null) {
-                result = store.create(instance);
-            } else {
-                result = store.update(instance);
-            }
-            return ServiceResult.from(result);
-        });
+    public void addInstance(DataPlaneInstance instance) {
+        store.updateOrCreate(instance);
     }
 }

--- a/extensions/control-plane/api/control-plane-api-client/src/test/java/org/eclipse/edc/connector/api/client/transferprocess/TransferProcessHttpClientIntegrationTest.java
+++ b/extensions/control-plane/api/control-plane-api-client/src/test/java/org/eclipse/edc/connector/api/client/transferprocess/TransferProcessHttpClientIntegrationTest.java
@@ -74,11 +74,11 @@ public class TransferProcessHttpClientIntegrationTest {
     void shouldCallTransferProcessApiWithComplete(TransferProcessStore store, DataPlaneManager manager, ControlPlaneApiUrl callbackUrl) {
         when(service.transfer(any())).thenReturn(CompletableFuture.completedFuture(StatusResult.success()));
         var id = "tp-id";
-        store.save(createTransferProcess(id));
+        store.updateOrCreate(createTransferProcess(id));
         manager.initiateTransfer(createDataFlowRequest(id, callbackUrl.get()));
 
         await().untilAsserted(() -> {
-            var transferProcess = store.find("tp-id");
+            var transferProcess = store.findById("tp-id");
             assertThat(transferProcess).isNotNull()
                     .extracting(StatefulEntity::getState).isEqualTo(COMPLETED.code());
         });
@@ -88,11 +88,11 @@ public class TransferProcessHttpClientIntegrationTest {
     void shouldCallTransferProcessApiWithFailed(TransferProcessStore store, DataPlaneManager manager, ControlPlaneApiUrl callbackUrl) {
         when(service.transfer(any())).thenReturn(CompletableFuture.completedFuture(StatusResult.failure(ResponseStatus.FATAL_ERROR, "error")));
         var id = "tp-id";
-        store.save(createTransferProcess(id));
+        store.updateOrCreate(createTransferProcess(id));
         manager.initiateTransfer(createDataFlowRequest(id, callbackUrl.get()));
 
         await().untilAsserted(() -> {
-            var transferProcess = store.find("tp-id");
+            var transferProcess = store.findById("tp-id");
             assertThat(transferProcess).isNotNull().satisfies(process -> {
                 assertThat(process.getState()).isEqualTo(TERMINATED.code());
                 assertThat(process.getErrorDetail()).isEqualTo("error");
@@ -104,11 +104,11 @@ public class TransferProcessHttpClientIntegrationTest {
     void shouldCallTransferProcessApiWithException(TransferProcessStore store, DataPlaneManager manager, ControlPlaneApiUrl callbackUrl) {
         when(service.transfer(any())).thenReturn(CompletableFuture.failedFuture(new EdcException("error")));
         var id = "tp-id";
-        store.save(createTransferProcess(id));
+        store.updateOrCreate(createTransferProcess(id));
         manager.initiateTransfer(createDataFlowRequest(id, callbackUrl.get()));
 
         await().untilAsserted(() -> {
-            var transferProcess = store.find("tp-id");
+            var transferProcess = store.findById("tp-id");
             assertThat(transferProcess).isNotNull().satisfies(process -> {
                 assertThat(process.getState()).isEqualTo(TERMINATED.code());
                 assertThat(process.getErrorDetail()).isEqualTo("error");

--- a/extensions/control-plane/api/control-plane-api/src/test/java/org/eclipse/edc/connector/api/TransferProcessControlApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/control-plane-api/src/test/java/org/eclipse/edc/connector/api/TransferProcessControlApiControllerIntegrationTest.java
@@ -56,7 +56,7 @@ class TransferProcessControlApiControllerIntegrationTest {
 
     @Test
     void callTransferProcessHookWithComplete(TransferProcessStore store) {
-        store.save(createTransferProcess());
+        store.updateOrCreate(createTransferProcess());
 
         baseRequest()
                 .contentType("application/json")
@@ -67,7 +67,7 @@ class TransferProcessControlApiControllerIntegrationTest {
 
 
         await().untilAsserted(() -> {
-            var transferProcess = store.find("tp-id");
+            var transferProcess = store.findById("tp-id");
             assertThat(transferProcess).isNotNull()
                     .extracting(StatefulEntity::getState).isEqualTo(COMPLETED.code());
         });
@@ -75,7 +75,7 @@ class TransferProcessControlApiControllerIntegrationTest {
 
     @Test
     void callTransferProcessHookWithError(TransferProcessStore store) {
-        store.save(createTransferProcess());
+        store.updateOrCreate(createTransferProcess());
 
         var rq = TransferProcessFailStateDto.Builder.newInstance()
                 .errorMessage("error")
@@ -91,7 +91,7 @@ class TransferProcessControlApiControllerIntegrationTest {
 
 
         await().untilAsserted(() -> {
-            var transferProcess = store.find("tp-id");
+            var transferProcess = store.findById("tp-id");
             assertThat(transferProcess).isNotNull().satisfies((process) -> {
                 assertThat(process.getState()).isEqualTo(TERMINATED.code());
                 assertThat(process.getErrorDetail()).isEqualTo("error");
@@ -144,7 +144,7 @@ class TransferProcessControlApiControllerIntegrationTest {
 
     @Test
     void callCompleteTransferProcessHook_invalidState(TransferProcessStore store) {
-        store.save(createTransferProcessBuilder().state(INITIAL.code()).build());
+        store.updateOrCreate(createTransferProcessBuilder().state(INITIAL.code()).build());
 
         var rq = TransferProcessFailStateDto.Builder.newInstance()
                 .errorMessage("error")

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/AssetApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/AssetApiControllerIntegrationTest.java
@@ -274,7 +274,7 @@ public class AssetApiControllerIntegrationTest {
         var asset = Asset.Builder.newInstance().id("assetId").build();
         var dataAddress = DataAddress.Builder.newInstance().type("type").build();
         assetIndex.accept(asset, dataAddress);
-        negotiationStore.save(createContractNegotiation(asset));
+        negotiationStore.updateOrCreate(createContractNegotiation(asset));
 
         baseRequest()
                 .contentType(JSON)

--- a/extensions/control-plane/api/management-api/contract-agreement-api/src/test/java/org/eclipse/edc/connector/api/management/contractagreement/ContractAgreementApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/management-api/contract-agreement-api/src/test/java/org/eclipse/edc/connector/api/management/contractagreement/ContractAgreementApiControllerIntegrationTest.java
@@ -59,7 +59,7 @@ public class ContractAgreementApiControllerIntegrationTest {
 
     @Test
     void getAllContractAgreements(ContractNegotiationStore store) {
-        store.save(createContractNegotiation(UUID.randomUUID().toString(), createContractAgreement("agreementId")));
+        store.updateOrCreate(createContractNegotiation(UUID.randomUUID().toString(), createContractAgreement("agreementId")));
 
         baseRequest()
                 .get("/contractagreements")
@@ -71,7 +71,7 @@ public class ContractAgreementApiControllerIntegrationTest {
 
     @Test
     void getAllContractAgreements_withPaging(ContractNegotiationStore store) {
-        store.save(createContractNegotiation(UUID.randomUUID().toString(), createContractAgreement("agreementId")));
+        store.updateOrCreate(createContractNegotiation(UUID.randomUUID().toString(), createContractAgreement("agreementId")));
 
         baseRequest()
                 .get("/contractagreements?offset=0&limit=15&sort=ASC")
@@ -91,7 +91,7 @@ public class ContractAgreementApiControllerIntegrationTest {
 
     @Test
     void queryAllContractAgreements(ContractNegotiationStore store) {
-        store.save(createContractNegotiation(UUID.randomUUID().toString(), createContractAgreement("agreementId")));
+        store.updateOrCreate(createContractNegotiation(UUID.randomUUID().toString(), createContractAgreement("agreementId")));
 
         baseRequest()
                 .contentType(JSON)
@@ -104,7 +104,7 @@ public class ContractAgreementApiControllerIntegrationTest {
 
     @Test
     void queryAllContractAgreements_withPaging(ContractNegotiationStore store) {
-        store.save(createContractNegotiation(UUID.randomUUID().toString(), createContractAgreement("agreementId")));
+        store.updateOrCreate(createContractNegotiation(UUID.randomUUID().toString(), createContractAgreement("agreementId")));
 
         baseRequest()
                 .contentType(JSON)
@@ -118,7 +118,7 @@ public class ContractAgreementApiControllerIntegrationTest {
 
     @Test
     void queryAllContractAgreements_withFilter(ContractNegotiationStore store) {
-        store.save(createContractNegotiation(UUID.randomUUID().toString(), createContractAgreement("agreementId")));
+        store.updateOrCreate(createContractNegotiation(UUID.randomUUID().toString(), createContractAgreement("agreementId")));
 
         baseRequest()
                 .contentType(JSON)
@@ -132,7 +132,7 @@ public class ContractAgreementApiControllerIntegrationTest {
 
     @Test
     void getSingleContractAgreement(ContractNegotiationStore store) {
-        store.save(createContractNegotiation(UUID.randomUUID().toString(), createContractAgreement("agreementId")));
+        store.updateOrCreate(createContractNegotiation(UUID.randomUUID().toString(), createContractAgreement("agreementId")));
 
         baseRequest()
                 .get("/contractagreements/agreementId")

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionApiControllerIntegrationTest.java
@@ -65,7 +65,7 @@ class ContractDefinitionApiControllerIntegrationTest {
 
     @Test
     void getAllContractDefs(ContractDefinitionStore store) {
-        store.save(createContractDefinition("definitionId"));
+        store.create(createContractDefinition("definitionId"));
 
         baseRequest()
                 .get("/contractdefinitions")
@@ -77,7 +77,7 @@ class ContractDefinitionApiControllerIntegrationTest {
 
     @Test
     void getAllContractDefs_withPaging(ContractDefinitionStore store) {
-        store.save(createContractDefinition("definitionId"));
+        store.create(createContractDefinition("definitionId"));
 
         baseRequest()
                 .get("/contractdefinitions?offset=0&limit=15&sort=ASC")
@@ -97,7 +97,7 @@ class ContractDefinitionApiControllerIntegrationTest {
 
     @Test
     void queryAllContractDefs(ContractDefinitionStore store) {
-        store.save(createContractDefinition("definitionId"));
+        store.create(createContractDefinition("definitionId"));
 
         baseRequest()
                 .contentType(JSON)
@@ -110,7 +110,7 @@ class ContractDefinitionApiControllerIntegrationTest {
 
     @Test
     void queryAllContractDefs_withPaging(ContractDefinitionStore store) {
-        store.save(createContractDefinition("definitionId"));
+        store.create(createContractDefinition("definitionId"));
 
         baseRequest()
                 .contentType(JSON)
@@ -136,7 +136,7 @@ class ContractDefinitionApiControllerIntegrationTest {
 
     @Test
     void getSingleContractDef(ContractDefinitionStore store) {
-        store.save(createContractDefinition("definitionId"));
+        store.create(createContractDefinition("definitionId"));
 
         baseRequest()
                 .get("/contractdefinitions/definitionId")
@@ -189,7 +189,7 @@ class ContractDefinitionApiControllerIntegrationTest {
 
     @Test
     void postContractDefinition_alreadyExists(ContractDefinitionStore store) {
-        store.save(createContractDefinition("definitionId"));
+        store.create(createContractDefinition("definitionId"));
         var dto = createDto("definitionId");
 
         baseRequest()
@@ -203,7 +203,7 @@ class ContractDefinitionApiControllerIntegrationTest {
 
     @Test
     void deleteContractDefinition(ContractDefinitionStore store) {
-        store.save(createContractDefinition("definitionId"));
+        store.create(createContractDefinition("definitionId"));
 
         baseRequest()
                 .contentType(JSON)
@@ -226,7 +226,7 @@ class ContractDefinitionApiControllerIntegrationTest {
     void updateContractDefinition_whenExists(ContractDefinitionStore store) {
 
         var cd = createContractDefinition("definitionId");
-        store.save(cd);
+        store.create(cd);
 
         var dto = updateDto();
 

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerIntegrationTest.java
@@ -77,7 +77,7 @@ class ContractNegotiationApiControllerIntegrationTest {
 
     @Test
     void getAllContractNegotiations(ContractNegotiationStore store) {
-        store.save(createContractNegotiation("negotiationId"));
+        store.updateOrCreate(createContractNegotiation("negotiationId"));
 
         baseRequest()
                 .get("/contractnegotiations")
@@ -89,7 +89,7 @@ class ContractNegotiationApiControllerIntegrationTest {
 
     @Test
     void getAllContractNegotiations_withPaging(ContractNegotiationStore store) {
-        store.save(createContractNegotiation("negotiationId"));
+        store.updateOrCreate(createContractNegotiation("negotiationId"));
 
         baseRequest()
                 .get("/contractnegotiations?offset=0&limit=15&sort=ASC")
@@ -109,7 +109,7 @@ class ContractNegotiationApiControllerIntegrationTest {
 
     @Test
     void queryAllContractNegotiations(ContractNegotiationStore store) {
-        store.save(createContractNegotiation("negotiationId"));
+        store.updateOrCreate(createContractNegotiation("negotiationId"));
 
         baseRequest()
                 .contentType(JSON)
@@ -122,7 +122,7 @@ class ContractNegotiationApiControllerIntegrationTest {
 
     @Test
     void queryAllContractNegotiations_withPaging(ContractNegotiationStore store) {
-        store.save(createContractNegotiation("negotiationId"));
+        store.updateOrCreate(createContractNegotiation("negotiationId"));
 
         baseRequest()
                 .contentType(JSON)
@@ -136,7 +136,7 @@ class ContractNegotiationApiControllerIntegrationTest {
 
     @Test
     void queryAll_invalidQuery(ContractNegotiationStore store) {
-        IntStream.range(0, 10).forEach(i -> store.save(createContractNegotiation("negotiationId" + i)));
+        IntStream.range(0, 10).forEach(i -> store.updateOrCreate(createContractNegotiation("negotiationId" + i)));
 
         baseRequest()
                 .contentType(JSON)
@@ -150,7 +150,7 @@ class ContractNegotiationApiControllerIntegrationTest {
 
     @Test
     void getSingleContractNegotation(ContractNegotiationStore store) {
-        store.save(createContractNegotiation("negotiationId"));
+        store.updateOrCreate(createContractNegotiation("negotiationId"));
 
         baseRequest()
                 .get("/contractnegotiations/negotiationId")
@@ -170,7 +170,7 @@ class ContractNegotiationApiControllerIntegrationTest {
 
     @Test
     void getSingleContractNegotationState(ContractNegotiationStore store) {
-        store.save(createContractNegotiationBuilder("negotiationId").state(REQUESTED.code()).build());
+        store.updateOrCreate(createContractNegotiationBuilder("negotiationId").state(REQUESTED.code()).build());
 
         var state = baseRequest()
                 .get("/contractnegotiations/negotiationId/state")
@@ -185,7 +185,7 @@ class ContractNegotiationApiControllerIntegrationTest {
     @Test
     void getSingleContractNegotationAgreement(ContractNegotiationStore store) {
         var contractAgreement = createContractAgreement("negotiationId");
-        store.save(createContractNegotiationBuilder("negotiationId").contractAgreement(contractAgreement).build());
+        store.updateOrCreate(createContractNegotiationBuilder("negotiationId").contractAgreement(contractAgreement).build());
 
         baseRequest()
                 .get("/contractnegotiations/negotiationId/agreement")
@@ -197,7 +197,7 @@ class ContractNegotiationApiControllerIntegrationTest {
 
     @Test
     void getSingleContractNegotationAgreement_notFound(ContractNegotiationStore store) {
-        store.save(createContractNegotiation("negotiationId"));
+        store.updateOrCreate(createContractNegotiation("negotiationId"));
 
         baseRequest()
                 .get("/contractnegotiations/negotiationId/agreement")
@@ -249,7 +249,7 @@ class ContractNegotiationApiControllerIntegrationTest {
 
     @Test
     void cancel(ContractNegotiationStore store) {
-        store.save(createContractNegotiation("negotiationId"));
+        store.updateOrCreate(createContractNegotiation("negotiationId"));
 
         baseRequest()
                 .contentType(JSON)
@@ -266,7 +266,7 @@ class ContractNegotiationApiControllerIntegrationTest {
                 .state(REQUESTED.code())
                 .correlationId(UUID.randomUUID().toString())
                 .build();
-        store.save(negotiation);
+        store.updateOrCreate(negotiation);
 
         baseRequest()
                 .contentType(JSON)
@@ -275,7 +275,7 @@ class ContractNegotiationApiControllerIntegrationTest {
                 .statusCode(204);
 
         await().untilAsserted(() -> {
-            assertThat(store.find("negotiationId").getState()).isEqualTo(DECLINED.code());
+            assertThat(store.findById("negotiationId").getState()).isEqualTo(DECLINED.code());
         });
     }
 

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiControllerIntegrationTest.java
@@ -64,7 +64,7 @@ public class PolicyDefinitionApiControllerIntegrationTest {
     void getAllpolicydefinitions(PolicyDefinitionStore policyStore) {
         var policy = createPolicy("id");
 
-        policyStore.save(policy);
+        policyStore.create(policy);
 
         baseRequest()
                 .get("/policydefinitions")
@@ -86,7 +86,7 @@ public class PolicyDefinitionApiControllerIntegrationTest {
     void queryAllPolicyDefinitions(PolicyDefinitionStore policyStore) {
         var policy = createPolicy("id");
 
-        policyStore.save(policy);
+        policyStore.create(policy);
 
         baseRequest()
                 .contentType(JSON)
@@ -99,7 +99,7 @@ public class PolicyDefinitionApiControllerIntegrationTest {
 
     @Test
     void queryAllPolicyDefinitions_withQuery(PolicyDefinitionStore policyStore) {
-        IntStream.range(0, 10).forEach(i -> policyStore.save(createPolicy("id" + i)));
+        IntStream.range(0, 10).forEach(i -> policyStore.create(createPolicy("id" + i)));
 
         baseRequest()
                 .contentType(JSON)
@@ -118,7 +118,7 @@ public class PolicyDefinitionApiControllerIntegrationTest {
 
     @Test
     void queryAllPolicyDefinitions_withPaging(PolicyDefinitionStore policyStore) {
-        IntStream.range(0, 10).forEach(i -> policyStore.save(createPolicy("id" + i)));
+        IntStream.range(0, 10).forEach(i -> policyStore.create(createPolicy("id" + i)));
 
         baseRequest()
                 .contentType(JSON)
@@ -138,7 +138,7 @@ public class PolicyDefinitionApiControllerIntegrationTest {
     @Test
     void getSinglePolicy(PolicyDefinitionStore policyStore) {
         var policy = createPolicy("id");
-        policyStore.save(policy);
+        policyStore.create(policy);
 
         baseRequest()
                 .get("/policydefinitions/id")
@@ -175,7 +175,7 @@ public class PolicyDefinitionApiControllerIntegrationTest {
     @Test
     void put_whenPolicyExists(PolicyDefinitionStore policyStore) {
         var policy = createPolicy("policyDefId");
-        policyStore.save(policy);
+        policyStore.create(policy);
 
         policy.getPolicy().getExtensibleProperties().put("anotherKey", "anotherVal");
 
@@ -207,7 +207,7 @@ public class PolicyDefinitionApiControllerIntegrationTest {
 
     @Test
     void postPolicyId_alreadyExists(PolicyDefinitionStore policyStore) {
-        policyStore.save(createPolicy("id"));
+        policyStore.create(createPolicy("id"));
 
         baseRequest()
                 .body(createPolicy("id"))
@@ -221,7 +221,7 @@ public class PolicyDefinitionApiControllerIntegrationTest {
     void deletePolicy(PolicyDefinitionStore policyStore) {
         var policy = createPolicy("id");
 
-        policyStore.save(policy);
+        policyStore.create(policy);
 
         baseRequest()
                 .contentType(JSON)
@@ -241,10 +241,21 @@ public class PolicyDefinitionApiControllerIntegrationTest {
     }
 
     @Test
-    void deletePolicy_whenReferencedInContractDefinition(ContractDefinitionStore contractDefinitionStore, PolicyDefinitionStore policyStore) {
+    void deletePolicy_ExistsInContractDefinitionNotExistsInPolicyStore(ContractDefinitionStore contractDefinitionStore) {
         var policy = createPolicy("access");
-        policyStore.save(policy);
-        contractDefinitionStore.save(createContractDefinition(policy.getUid()));
+        contractDefinitionStore.create(createContractDefinition(policy.getUid()));
+        baseRequest()
+                .contentType(JSON)
+                .delete("/policydefinitions/access")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    void deletePolicy_alreadyReferencedInContractDefinition(ContractDefinitionStore contractDefinitionStore, PolicyDefinitionStore policyStore) {
+        var policy = createPolicy("access");
+        policyStore.create(policy);
+        contractDefinitionStore.create(createContractDefinition(policy.getUid()));
 
         baseRequest()
                 .contentType(JSON)

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/api/management/transferprocess/TransferProcessApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/api/management/transferprocess/TransferProcessApiControllerIntegrationTest.java
@@ -69,7 +69,7 @@ class TransferProcessApiControllerIntegrationTest {
 
     @Test
     void getAllTransferProcesses(TransferProcessStore store) {
-        store.save(createTransferProcess(PROCESS_ID));
+        store.updateOrCreate(createTransferProcess(PROCESS_ID));
 
         baseRequest()
                 .get("/transferprocess")
@@ -90,7 +90,7 @@ class TransferProcessApiControllerIntegrationTest {
 
     @Test
     void queryAllTransferProcesses(TransferProcessStore store) {
-        store.save(createTransferProcess(PROCESS_ID));
+        store.updateOrCreate(createTransferProcess(PROCESS_ID));
 
         baseRequest()
                 .contentType(JSON)
@@ -104,7 +104,7 @@ class TransferProcessApiControllerIntegrationTest {
     @Test
     void queryAllTransferProcesses_withPaging(TransferProcessStore store) {
         IntStream.range(0, 10)
-                .forEach(i -> store.save(createTransferProcess(PROCESS_ID + i)));
+                .forEach(i -> store.updateOrCreate(createTransferProcess(PROCESS_ID + i)));
 
         baseRequest()
                 .contentType(JSON)
@@ -119,7 +119,7 @@ class TransferProcessApiControllerIntegrationTest {
     @Test
     void queryAllTransferProcesses_withFilter(TransferProcessStore store) {
         IntStream.range(0, 10)
-                .forEach(i -> store.save(createTransferProcess(PROCESS_ID + i)));
+                .forEach(i -> store.updateOrCreate(createTransferProcess(PROCESS_ID + i)));
 
         baseRequest()
                 .contentType(JSON)
@@ -134,7 +134,7 @@ class TransferProcessApiControllerIntegrationTest {
 
     @Test
     void getSingleTransferProcess(TransferProcessStore store) {
-        store.save(createTransferProcess(PROCESS_ID));
+        store.updateOrCreate(createTransferProcess(PROCESS_ID));
         baseRequest()
                 .get("/transferprocess/" + PROCESS_ID)
                 .then()
@@ -155,7 +155,7 @@ class TransferProcessApiControllerIntegrationTest {
 
     @Test
     void getSingleTransferProcessState(TransferProcessStore store) {
-        store.save(createTransferProcess(PROCESS_ID, PROVISIONING.code()));
+        store.updateOrCreate(createTransferProcess(PROCESS_ID, PROVISIONING.code()));
 
         var state = baseRequest()
                 .get("/transferprocess/" + PROCESS_ID + "/state")
@@ -177,7 +177,7 @@ class TransferProcessApiControllerIntegrationTest {
 
     @Test
     void cancel(TransferProcessStore store) {
-        store.save(createTransferProcess(PROCESS_ID, STARTED.code()));
+        store.updateOrCreate(createTransferProcess(PROCESS_ID, STARTED.code()));
 
         baseRequest()
                 .contentType(JSON)
@@ -197,7 +197,7 @@ class TransferProcessApiControllerIntegrationTest {
 
     @Test
     void cancel_conflict(TransferProcessStore store) {
-        store.save(createTransferProcess(PROCESS_ID, COMPLETED.code()));
+        store.updateOrCreate(createTransferProcess(PROCESS_ID, COMPLETED.code()));
         baseRequest()
                 .contentType(JSON)
                 .post("/transferprocess/" + PROCESS_ID + "/cancel")
@@ -208,7 +208,7 @@ class TransferProcessApiControllerIntegrationTest {
 
     @Test
     void terminate(TransferProcessStore store) {
-        store.save(createTransferProcess(PROCESS_ID, STARTED.code()));
+        store.updateOrCreate(createTransferProcess(PROCESS_ID, STARTED.code()));
 
         baseRequest()
                 .contentType(JSON)
@@ -218,7 +218,7 @@ class TransferProcessApiControllerIntegrationTest {
                 .statusCode(204);
 
         await().untilAsserted(() -> {
-            assertThat(store.find(PROCESS_ID)).isNotNull().extracting(StatefulEntity::getErrorDetail).isEqualTo("any reason");
+            assertThat(store.findById(PROCESS_ID)).isNotNull().extracting(StatefulEntity::getErrorDetail).isEqualTo("any reason");
         });
     }
 
@@ -244,7 +244,7 @@ class TransferProcessApiControllerIntegrationTest {
 
     @Test
     void terminate_conflict(TransferProcessStore store) {
-        store.save(createTransferProcess(PROCESS_ID, COMPLETED.code()));
+        store.updateOrCreate(createTransferProcess(PROCESS_ID, COMPLETED.code()));
         baseRequest()
                 .contentType(JSON)
                 .body(Map.of("reason", "any reason"))
@@ -256,7 +256,7 @@ class TransferProcessApiControllerIntegrationTest {
 
     @Test
     void deprovision(TransferProcessStore store) {
-        store.save(createTransferProcess(PROCESS_ID, COMPLETED.code()));
+        store.updateOrCreate(createTransferProcess(PROCESS_ID, COMPLETED.code()));
 
         baseRequest()
                 .contentType(JSON)
@@ -276,7 +276,7 @@ class TransferProcessApiControllerIntegrationTest {
 
     @Test
     void deprovision_conflict(TransferProcessStore store) {
-        store.save(createTransferProcess(PROCESS_ID, INITIAL.code()));
+        store.updateOrCreate(createTransferProcess(PROCESS_ID, INITIAL.code()));
 
         baseRequest()
                 .contentType(JSON)

--- a/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
+++ b/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
@@ -95,8 +95,8 @@ public class HttpProvisionerExtensionEndToEndTest {
                                      ContractNegotiationStore negotiationStore,
                                      AssetIndex assetIndex,
                                      TransferProcessStore store, PolicyDefinitionStore policyStore) throws Exception {
-        negotiationStore.save(createContractNegotiation());
-        policyStore.save(createPolicyDefinition());
+        negotiationStore.updateOrCreate(createContractNegotiation());
+        policyStore.create(createPolicyDefinition());
         assetIndex.accept(createAssetEntry());
 
         when(delegate.intercept(any()))
@@ -106,7 +106,7 @@ public class HttpProvisionerExtensionEndToEndTest {
         var result = processManager.initiateProviderRequest(createRequest());
 
         await().untilAsserted(() -> {
-            var transferProcess = store.find(result.getContent());
+            var transferProcess = store.findById(result.getContent());
             assertThat(transferProcess).isNotNull()
                     .extracting(StatefulEntity::getState).isEqualTo(PROVISIONING_REQUESTED.code());
         });

--- a/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/webhook/HttpProvisionerWebhookApiControllerIntegrationTest.java
+++ b/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/webhook/HttpProvisionerWebhookApiControllerIntegrationTest.java
@@ -87,7 +87,7 @@ class HttpProvisionerWebhookApiControllerIntegrationTest {
     @Test
     void callProvisionWebhook(TransferProcessStore store) {
 
-        store.save(createTransferProcess());
+        store.updateOrCreate(createTransferProcess());
 
         var rq = ProvisionerWebhookRequest.Builder.newInstance()
                 .assetId("test-asset")
@@ -137,7 +137,7 @@ class HttpProvisionerWebhookApiControllerIntegrationTest {
     @Test
     void callDeprovisionWebhook(TransferProcessStore store) {
 
-        store.save(createTransferProcess());
+        store.updateOrCreate(createTransferProcess());
 
         var rq = DeprovisionedResource.Builder.newInstance()
                 .provisionedResourceId("resource-id")

--- a/extensions/control-plane/store/cosmos/contract-definition-store-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/contractdefinition/CosmosContractDefinitionStore.java
+++ b/extensions/control-plane/store/cosmos/contract-definition-store-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/contractdefinition/CosmosContractDefinitionStore.java
@@ -76,7 +76,7 @@ public class CosmosContractDefinitionStore implements ContractDefinitionStore {
 
 
     @Override
-    public StoreResult<Void> save(ContractDefinition definition) {
+    public StoreResult<Void> create(ContractDefinition definition) {
         try {
             with(retryPolicy).run(() -> cosmosDbApi.createItem(convertToDocument(definition)));
             return StoreResult.success();

--- a/extensions/control-plane/store/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/contractdefinition/CosmosContractDefinitionStoreIntegrationTest.java
+++ b/extensions/control-plane/store/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/contractdefinition/CosmosContractDefinitionStoreIntegrationTest.java
@@ -150,7 +150,7 @@ class CosmosContractDefinitionStoreIntegrationTest extends ContractDefinitionSto
     @Test
     void save() {
         var definition = generateDefinition();
-        store.save(definition);
+        store.create(definition);
 
         var actual = container.readAllItems(new PartitionKey(TEST_PARTITION_KEY), Object.class);
 
@@ -167,7 +167,7 @@ class CosmosContractDefinitionStoreIntegrationTest extends ContractDefinitionSto
         //modify a single field
         defToAdd.getSelectorExpression().getCriteria().add(new Criterion("anotherkey", "isGreaterThan", "anotherValue"));
 
-        var saveResult = store.save(defToAdd);
+        var saveResult = store.create(defToAdd);
 
         assertThat(saveResult.failed()).isTrue();
         assertThat(saveResult.reason()).isEqualTo(ALREADY_EXISTS);
@@ -213,7 +213,7 @@ class CosmosContractDefinitionStoreIntegrationTest extends ContractDefinitionSto
     @Test
     void save_delete_find_shouldNotExist() {
         var def1 = generateDefinition();
-        store.save(def1);
+        store.create(def1);
         assertThat(store.findAll(QuerySpec.max())).containsOnly(def1);
 
         store.deleteById(def1.getId());
@@ -341,7 +341,7 @@ class CosmosContractDefinitionStoreIntegrationTest extends ContractDefinitionSto
     void verify_readWriteFindAll() {
         // add an object
         var def = generateDefinition();
-        store.save(def);
+        store.create(def);
         assertThat(store.findAll(QuerySpec.max())).containsExactly(def);
 
         // modify the object

--- a/extensions/control-plane/store/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/contractdefinition/CosmosContractDefinitionStoreTest.java
+++ b/extensions/control-plane/store/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/contractdefinition/CosmosContractDefinitionStoreTest.java
@@ -114,7 +114,7 @@ class CosmosContractDefinitionStoreTest {
         doNothing().when(cosmosDbApiMock).createItem(captor.capture());
         var definition = generateDefinition();
 
-        store.save(definition);
+        store.create(definition);
 
         assertThat(captor.getValue().getWrappedInstance()).isEqualTo(definition);
         verify(cosmosDbApiMock).createItem(captor.capture());
@@ -128,7 +128,7 @@ class CosmosContractDefinitionStoreTest {
         // cosmosDbApiQueryMock.queryAllItems() should never be called
         var definition = generateDefinition();
 
-        store.save(definition); //should write through the cache
+        store.create(definition); //should write through the cache
 
         var all = store.findAll(QuerySpec.max());
 

--- a/extensions/control-plane/store/cosmos/contract-negotiation-store-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/contractnegotiation/CosmosContractNegotiationStore.java
+++ b/extensions/control-plane/store/cosmos/contract-negotiation-store-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/contractnegotiation/CosmosContractNegotiationStore.java
@@ -75,7 +75,7 @@ public class CosmosContractNegotiationStore implements ContractNegotiationStore 
     }
 
     @Override
-    public @Nullable ContractNegotiation find(String negotiationId) {
+    public @Nullable ContractNegotiation findById(String negotiationId) {
         var object = with(retryPolicy).get(() -> findByIdInternal(negotiationId));
         return object != null ? toNegotiation(object) : null;
     }
@@ -102,7 +102,7 @@ public class CosmosContractNegotiationStore implements ContractNegotiationStore 
     }
 
     @Override
-    public void save(ContractNegotiation negotiation) {
+    public void updateOrCreate(ContractNegotiation negotiation) {
         try {
             leaseContext.acquireLease(negotiation.getId());
             CheckedRunnable action;
@@ -146,7 +146,7 @@ public class CosmosContractNegotiationStore implements ContractNegotiationStore 
     }
 
     @Override
-    public @NotNull Stream<ContractNegotiation> queryNegotiations(QuerySpec querySpec) {
+    public @NotNull Stream<ContractNegotiation> findAllNegotiations(QuerySpec querySpec) {
         var statement = new SqlStatement<>(ContractNegotiationDocument.class);
         var query = statement.where(querySpec.getFilterExpression())
                 .offset(querySpec.getOffset())
@@ -159,7 +159,7 @@ public class CosmosContractNegotiationStore implements ContractNegotiationStore 
     }
 
     @Override
-    public @NotNull Stream<ContractAgreement> queryAgreements(QuerySpec querySpec) {
+    public @NotNull Stream<ContractAgreement> findAllAgreements(QuerySpec querySpec) {
         var criteria = querySpec.getFilterExpression().stream()
                 .map(it -> it.withLeftOperand(op -> "contractAgreement." + op))
                 .collect(Collectors.toList());

--- a/extensions/control-plane/store/cosmos/policy-definition-store-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/policydefinition/CosmosPolicyDefinitionStore.java
+++ b/extensions/control-plane/store/cosmos/policy-definition-store-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/policydefinition/CosmosPolicyDefinitionStore.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.connector.store.azure.cosmos.policydefinition;
 
-import com.azure.cosmos.implementation.ConflictException;
 import com.azure.cosmos.implementation.NotFoundException;
 import dev.failsafe.RetryPolicy;
 import org.eclipse.edc.azure.cosmos.CosmosDbApi;
@@ -25,14 +24,13 @@ import org.eclipse.edc.connector.store.azure.cosmos.policydefinition.model.Polic
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.query.SortOrder;
-import org.eclipse.edc.spi.result.StoreResult;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.stream.Stream;
 
 import static dev.failsafe.Failsafe.with;
-import static java.lang.String.format;
 
 /**
  * Implementation of the {@link PolicyDefinitionStore} based on CosmosDB. This store implements simple write-through
@@ -74,38 +72,30 @@ public class CosmosPolicyDefinitionStore implements PolicyDefinitionStore {
     }
 
     @Override
-    public StoreResult<PolicyDefinition> save(PolicyDefinition policy) {
-        try {
-            with(retryPolicy).run(() -> cosmosDbApi.createItem(convertToDocument(policy)));
-            return StoreResult.success(policy);
-        } catch (ConflictException ex) {
-            var msg = format(POLICY_ALREADY_EXISTS, policy.getUid());
-            monitor.debug(() -> msg);
-            return StoreResult.alreadyExists(msg);
-        }
+    public void create(PolicyDefinition policy) {
+        with(retryPolicy).run(() -> cosmosDbApi.createItem(convertToDocument(policy)));
     }
 
     @Override
-    public StoreResult<PolicyDefinition> update(PolicyDefinition policy) {
-        try {
-            with(retryPolicy).run(() -> cosmosDbApi.updateItem((convertToDocument(policy))));
-            return StoreResult.success(policy);
-        } catch (NotFoundException nfe) {
-            var msg = format(POLICY_NOT_FOUND, policy.getUid());
-            monitor.debug(() -> msg);
-            return StoreResult.notFound(msg);
+    public PolicyDefinition update(String policyId, PolicyDefinition policy) {
+        if (findById(policyId) != null) {
+            with(retryPolicy).run(() -> cosmosDbApi.createItem((convertToDocument(policy))));
+            return policy;
         }
+        return null;
     }
 
     @Override
-    public StoreResult<PolicyDefinition> deleteById(String policyId) {
+    public @Nullable PolicyDefinition deleteById(String policyId) {
         try {
             var deletedItem = cosmosDbApi.deleteItem(policyId);
-            return StoreResult.success(convert(deletedItem));
-        } catch (NotFoundException nfe) {
-            var msg = format(POLICY_NOT_FOUND, policyId);
-            monitor.debug(() -> msg);
-            return StoreResult.notFound(msg);
+            if (deletedItem == null) {
+                return null;
+            }
+            return convert(deletedItem);
+        } catch (NotFoundException e) {
+            monitor.debug(() -> String.format("PolicyDefinition with id %s not found", policyId));
+            return null;
         }
     }
 

--- a/extensions/control-plane/store/cosmos/policy-definition-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/policydefinition/CosmosPolicyDefinitionStoreIntegrationTest.java
+++ b/extensions/control-plane/store/cosmos/policy-definition-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/policydefinition/CosmosPolicyDefinitionStoreIntegrationTest.java
@@ -49,7 +49,6 @@ import java.util.stream.IntStream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.store.azure.cosmos.policydefinition.TestFunctions.generateDocument;
 import static org.eclipse.edc.connector.store.azure.cosmos.policydefinition.TestFunctions.generatePolicy;
-import static org.eclipse.edc.spi.result.StoreFailure.Reason.ALREADY_EXISTS;
 import static org.mockito.Mockito.mock;
 
 @AzureCosmosDbIntegrationTest
@@ -143,7 +142,7 @@ public class CosmosPolicyDefinitionStoreIntegrationTest extends PolicyDefinition
     @Test
     void save() {
         var policy = generatePolicy();
-        store.save(policy);
+        store.create(policy);
 
         var actual = container.readAllItems(new PartitionKey(TEST_PARTITION_KEY), Object.class);
         assertThat(actual).hasSize(1);
@@ -152,7 +151,7 @@ public class CosmosPolicyDefinitionStoreIntegrationTest extends PolicyDefinition
     }
 
     @Test
-    void save_exists_shouldFail() {
+    void save_exists_shouldUpdate() {
         var doc1 = generateDocument(TEST_PARTITION_KEY);
         container.createItem(doc1);
 
@@ -163,17 +162,15 @@ public class CosmosPolicyDefinitionStoreIntegrationTest extends PolicyDefinition
         policyToUpdate.getPolicy().getObligations().add(Duty.Builder.newInstance().uid("test-obligation-id").build());
 
 
-        var saveResult = store.save(policyToUpdate);
-        assertThat(saveResult.succeeded()).isFalse();
-        assertThat(saveResult.reason()).isEqualTo(ALREADY_EXISTS);
-
+        store.create(policyToUpdate);
         var actual = container.readAllItems(new PartitionKey(doc1.getPartitionKey()), Object.class);
         assertThat(actual).hasSize(1);
 
         var first = convert(actual.stream().findFirst().get());
 
-        assertThat(first.getPolicy().getPermissions()).isEmpty();
-        assertThat(first.getPolicy().getObligations()).isEmpty();
+        assertThat(first.getPolicy().getPermissions()).hasSize(1).extracting(Permission::getTarget).containsOnly("test-permission-target");
+        assertThat(first.getPolicy().getObligations()).hasSize(1).extracting(Duty::getUid).containsOnly("test-obligation-id");
+
     }
 
     @Test
@@ -183,8 +180,7 @@ public class CosmosPolicyDefinitionStoreIntegrationTest extends PolicyDefinition
 
         var policy = convert(document);
         var deletedPolicy = store.deleteById(document.getId());
-        assertThat(deletedPolicy.succeeded()).isTrue();
-        assertThat(deletedPolicy.getContent()).isEqualTo(policy);
+        assertThat(deletedPolicy).isEqualTo(policy);
 
         assertThat(container.readAllItems(new PartitionKey(document.getPartitionKey()), Object.class)).isEmpty();
     }

--- a/extensions/control-plane/store/cosmos/policy-definition-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/policydefinition/CosmosPolicyDefinitionStoreTest.java
+++ b/extensions/control-plane/store/cosmos/policy-definition-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/policydefinition/CosmosPolicyDefinitionStoreTest.java
@@ -90,7 +90,7 @@ class CosmosPolicyDefinitionStoreTest {
         doNothing().when(cosmosDbApiMock).createItem(captor.capture());
         var definition = generatePolicy();
 
-        store.save(definition);
+        store.create(definition);
 
         assertThat(captor.getValue().getWrappedInstance()).isEqualTo(definition);
         verify(cosmosDbApiMock).createItem(captor.capture());
@@ -104,7 +104,7 @@ class CosmosPolicyDefinitionStoreTest {
 
         when(cosmosDbApiMock.queryItems(any(SqlQuerySpec.class))).thenReturn(IntStream.range(0, 1).mapToObj((i) -> captor.getValue()));
 
-        store.save(definition); //should write through the cache
+        store.create(definition); //should write through the cache
 
         var all = store.findAll(QuerySpec.none());
 
@@ -119,7 +119,7 @@ class CosmosPolicyDefinitionStoreTest {
         doNothing().when(cosmosDbApiMock).createItem(captor.capture());
         var definition = generatePolicy();
 
-        store.save(definition);
+        store.create(definition);
 
         assertThat(captor.getValue().getWrappedInstance()).isEqualTo(definition);
         verify(cosmosDbApiMock).createItem(captor.capture());

--- a/extensions/control-plane/store/cosmos/transfer-process-store-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/transferprocess/CosmosTransferProcessStore.java
+++ b/extensions/control-plane/store/cosmos/transfer-process-store-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/transferprocess/CosmosTransferProcessStore.java
@@ -98,7 +98,7 @@ public class CosmosTransferProcessStore implements TransferProcessStore {
     }
 
     @Override
-    public TransferProcess find(String id) {
+    public TransferProcess findById(String id) {
         // we need to read the TransferProcessDocument as Object, because no custom JSON deserialization can be registered
         // with the CosmosDB SDK, so it would not know about subtypes, etc.
         Object obj = findByIdInternal(id);
@@ -118,7 +118,7 @@ public class CosmosTransferProcessStore implements TransferProcessStore {
     }
 
     @Override
-    public void save(TransferProcess process) {
+    public void updateOrCreate(TransferProcess process) {
         Objects.requireNonNull(process.getId(), "TransferProcesses must have an ID!");
         try {
             leaseContext.acquireLease(process.getId());

--- a/extensions/control-plane/store/sql/contract-definition-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractdefinition/SqlContractDefinitionStore.java
+++ b/extensions/control-plane/store/sql/contract-definition-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractdefinition/SqlContractDefinitionStore.java
@@ -78,7 +78,7 @@ public class SqlContractDefinitionStore extends AbstractSqlStore implements Cont
 
 
     @Override
-    public StoreResult<Void> save(ContractDefinition definition) {
+    public StoreResult<Void> create(ContractDefinition definition) {
         return transactionContext.execute(() -> {
             try (var connection = getConnection()) {
                 if (existsById(connection, definition.getId())) {

--- a/extensions/control-plane/store/sql/contract-definition-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/contractdefinition/PostgresContractDefinitionStoreTest.java
+++ b/extensions/control-plane/store/sql/contract-definition-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/contractdefinition/PostgresContractDefinitionStoreTest.java
@@ -99,7 +99,7 @@ class PostgresContractDefinitionStoreTest extends ContractDefinitionStoreTestBas
     // Override in PG since it does not have the field mapping
     @Test
     void findAll_verifySorting_invalidProperty() {
-        IntStream.range(0, 10).mapToObj(i -> TestFunctions.createContractDefinition("id" + i)).forEach(getContractDefinitionStore()::save);
+        IntStream.range(0, 10).mapToObj(i -> TestFunctions.createContractDefinition("id" + i)).forEach(getContractDefinitionStore()::create);
         var query = QuerySpec.Builder.newInstance().sortField("notexist").sortOrder(SortOrder.DESC).build();
 
         assertThatThrownBy(() -> getContractDefinitionStore().findAll(query)).isInstanceOf(IllegalArgumentException.class);

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/SqlContractNegotiationStore.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/SqlContractNegotiationStore.java
@@ -62,7 +62,7 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
     }
 
     @Override
-    public @Nullable ContractNegotiation find(String negotiationId) {
+    public @Nullable ContractNegotiation findById(String negotiationId) {
         return transactionContext.execute(() -> {
             try (var connection = getConnection()) {
                 return findInternal(connection, negotiationId);
@@ -77,7 +77,7 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
         return transactionContext.execute(() -> {
             // utilize the generic query api
             var query = QuerySpec.Builder.newInstance().filter(List.of(new Criterion("correlationId", "=", correlationId))).build();
-            try (var stream = queryNegotiations(query)) {
+            try (var stream = findAllNegotiations(query)) {
                 return single(stream.collect(Collectors.toList()));
             }
         });
@@ -96,7 +96,7 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
     }
 
     @Override
-    public void save(ContractNegotiation negotiation) {
+    public void updateOrCreate(ContractNegotiation negotiation) {
         var id = negotiation.getId();
         transactionContext.execute(() -> {
             try (var connection = getConnection()) {
@@ -117,7 +117,7 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
     @Override
     public void delete(String negotiationId) {
         transactionContext.execute(() -> {
-            var existing = find(negotiationId);
+            var existing = findById(negotiationId);
 
             //if exists, attempt delete
             if (existing != null) {
@@ -144,7 +144,7 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
     }
 
     @Override
-    public @NotNull Stream<ContractNegotiation> queryNegotiations(QuerySpec querySpec) {
+    public @NotNull Stream<ContractNegotiation> findAllNegotiations(QuerySpec querySpec) {
         return transactionContext.execute(() -> {
             try {
                 var statement = statements.createNegotiationsQuery(querySpec);
@@ -156,7 +156,7 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
     }
 
     @Override
-    public @NotNull Stream<ContractAgreement> queryAgreements(QuerySpec querySpec) {
+    public @NotNull Stream<ContractAgreement> findAllAgreements(QuerySpec querySpec) {
         return transactionContext.execute(() -> {
             try {
                 var statement = statements.createAgreementsQuery(querySpec);

--- a/extensions/control-plane/store/sql/policy-definition-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/policydefinition/PostgresPolicyDefinitionStoreTest.java
+++ b/extensions/control-plane/store/sql/policy-definition-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/policydefinition/PostgresPolicyDefinitionStoreTest.java
@@ -77,7 +77,7 @@ class PostgresPolicyDefinitionStoreTest extends PolicyDefinitionStoreTestBase {
                 .build();
 
         var policyDef1 = PolicyDefinition.Builder.newInstance().id("test-policy").policy(policy).build();
-        getPolicyDefinitionStore().save(policyDef1);
+        getPolicyDefinitionStore().create(policyDef1);
 
         // query by prohibition assignee
         assertThatThrownBy(() -> getPolicyDefinitionStore().findAll(createQuery("notexist=foobar")))
@@ -88,7 +88,7 @@ class PostgresPolicyDefinitionStoreTest extends PolicyDefinitionStoreTestBase {
     @Test
     void findAll_sorting_nonExistentProperty() {
 
-        IntStream.range(0, 10).mapToObj(i -> createPolicy("test-policy")).forEach((d) -> getPolicyDefinitionStore().save(d));
+        IntStream.range(0, 10).mapToObj(i -> createPolicy("test-policy")).forEach((d) -> getPolicyDefinitionStore().create(d));
 
 
         var query = QuerySpec.Builder.newInstance().sortField("notexist").sortOrder(SortOrder.DESC).build();

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/SqlTransferProcessStore.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/SqlTransferProcessStore.java
@@ -84,7 +84,7 @@ public class SqlTransferProcessStore extends AbstractSqlStore implements Transfe
     }
 
     @Override
-    public @Nullable TransferProcess find(String id) {
+    public @Nullable TransferProcess findById(String id) {
         return transactionContext.execute(() -> {
             var q = QuerySpec.Builder.newInstance().filter("id = " + id).build();
             return single(findAll(q).collect(toList()));
@@ -104,7 +104,7 @@ public class SqlTransferProcessStore extends AbstractSqlStore implements Transfe
     }
 
     @Override
-    public void save(TransferProcess process) {
+    public void updateOrCreate(TransferProcess process) {
         Objects.requireNonNull(process.getId(), "TransferProcesses must have an ID!");
         if (process.getDataRequest() == null) {
             throw new IllegalArgumentException("Cannot store TransferProcess without a DataRequest");
@@ -128,7 +128,7 @@ public class SqlTransferProcessStore extends AbstractSqlStore implements Transfe
     public void delete(String processId) {
 
         transactionContext.execute(() -> {
-            var existing = find(processId);
+            var existing = findById(processId);
             if (existing != null) {
                 try (var conn = getConnection()) {
                     // attempt to acquire lease - should fail if someone else holds the lease

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/transferprocess/PostgresTransferProcessStoreTest.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/transferprocess/PostgresTransferProcessStoreTest.java
@@ -85,8 +85,8 @@ class PostgresTransferProcessStoreTest extends TransferProcessStoreTestBase {
         var tp = createTransferProcessBuilder("testprocess1")
                 .dataRequest(da)
                 .build();
-        store.save(tp);
-        store.save(createTransferProcess("testprocess2"));
+        store.updateOrCreate(tp);
+        store.updateOrCreate(createTransferProcess("testprocess2"));
 
         var query = QuerySpec.Builder.newInstance()
                 .filter(List.of(new Criterion("dataRequest.notexist", "=", "somevalue")))
@@ -104,8 +104,8 @@ class PostgresTransferProcessStoreTest extends TransferProcessStoreTestBase {
         var tp = createTransferProcessBuilder("testprocess1")
                 .resourceManifest(rm)
                 .build();
-        store.save(tp);
-        store.save(createTransferProcess("testprocess2"));
+        store.updateOrCreate(tp);
+        store.updateOrCreate(createTransferProcess("testprocess2"));
 
         // throws exception when an explicit mapping exists
         var query = QuerySpec.Builder.newInstance()
@@ -137,8 +137,8 @@ class PostgresTransferProcessStoreTest extends TransferProcessStoreTestBase {
         var tp = createTransferProcessBuilder("testprocess1")
                 .provisionedResourceSet(prs)
                 .build();
-        store.save(tp);
-        store.save(createTransferProcess("testprocess2"));
+        store.updateOrCreate(tp);
+        store.updateOrCreate(createTransferProcess("testprocess2"));
 
         // throws exception when an explicit mapping exists
         var query = QuerySpec.Builder.newInstance()
@@ -158,7 +158,7 @@ class PostgresTransferProcessStoreTest extends TransferProcessStoreTestBase {
 
     @Test
     void find_queryByLease() {
-        store.save(createTransferProcess("testprocess1"));
+        store.updateOrCreate(createTransferProcess("testprocess1"));
 
         var query = QuerySpec.Builder.newInstance()
                 .filter(List.of(new Criterion("lease.leasedBy", "=", "foobar")))
@@ -174,13 +174,13 @@ class PostgresTransferProcessStoreTest extends TransferProcessStoreTestBase {
         var t1 = TestFunctions.createTransferProcessBuilder("id1")
                 .dataRequest(null)
                 .build();
-        assertThatIllegalArgumentException().isThrownBy(() -> getTransferProcessStore().save(t1));
+        assertThatIllegalArgumentException().isThrownBy(() -> getTransferProcessStore().updateOrCreate(t1));
     }
 
     @Override
     @Test
     protected void findAll_verifySorting_invalidProperty() {
-        IntStream.range(0, 10).forEach(i -> getTransferProcessStore().save(createTransferProcess("test-neg-" + i)));
+        IntStream.range(0, 10).forEach(i -> getTransferProcessStore().updateOrCreate(createTransferProcess("test-neg-" + i)));
 
         var query = QuerySpec.Builder.newInstance().sortField("notexist").sortOrder(SortOrder.DESC).build();
 

--- a/extensions/control-plane/transfer/transfer-pull-http-dynamic-receiver/src/main/java/org/eclipse/edc/connector/receiver/http/dynamic/HttpDynamicEndpointDataReferenceReceiver.java
+++ b/extensions/control-plane/transfer/transfer-pull-http-dynamic-receiver/src/main/java/org/eclipse/edc/connector/receiver/http/dynamic/HttpDynamicEndpointDataReferenceReceiver.java
@@ -67,7 +67,7 @@ public class HttpDynamicEndpointDataReferenceReceiver implements EndpointDataRef
         if (processId == null) {
             return CompletableFuture.completedFuture(Result.failure(format("Failed to found processId for DataRequestId %s", edr.getId())));
         }
-        var transferProcess = transferProcessStore.find(processId);
+        var transferProcess = transferProcessStore.findById(processId);
 
         if (transferProcess == null) {
             return CompletableFuture.completedFuture(Result.failure(format("Failed to found transfer process for id %s", processId)));

--- a/extensions/control-plane/transfer/transfer-pull-http-dynamic-receiver/src/test/java/org/eclipse/edc/connector/receiver/http/dynamic/HttpDynamicEndpointDataReferenceReceiverTest.java
+++ b/extensions/control-plane/transfer/transfer-pull-http-dynamic-receiver/src/test/java/org/eclipse/edc/connector/receiver/http/dynamic/HttpDynamicEndpointDataReferenceReceiverTest.java
@@ -100,7 +100,7 @@ public class HttpDynamicEndpointDataReferenceReceiverTest {
 
 
         when(transferProcessStore.processIdForDataRequestId(any())).thenReturn(TRANSFER_ID);
-        when(transferProcessStore.find(TRANSFER_ID)).thenReturn(createTransferProcess(TRANSFER_ID, transferProperties(receiverUrl())));
+        when(transferProcessStore.findById(TRANSFER_ID)).thenReturn(createTransferProcess(TRANSFER_ID, transferProperties(receiverUrl())));
 
         var edr = createEndpointDataReferenceBuilder()
                 .properties(Map.of(HTTP_RECEIVER_ENDPOINT, receiverUrl()))
@@ -132,7 +132,7 @@ public class HttpDynamicEndpointDataReferenceReceiverTest {
 
 
         when(transferProcessStore.processIdForDataRequestId(any())).thenReturn(TRANSFER_ID);
-        when(transferProcessStore.find(TRANSFER_ID)).thenReturn(createTransferProcess(TRANSFER_ID, transferPropertiesWithAuth(receiverUrl(), authKey, authToken)));
+        when(transferProcessStore.findById(TRANSFER_ID)).thenReturn(createTransferProcess(TRANSFER_ID, transferPropertiesWithAuth(receiverUrl(), authKey, authToken)));
 
 
         var edr = createEndpointDataReferenceBuilder()
@@ -153,7 +153,7 @@ public class HttpDynamicEndpointDataReferenceReceiverTest {
     @Test
     public void send_shouldFailForwardTheEdr_withPathNotFound() throws ExecutionException, InterruptedException {
         when(transferProcessStore.processIdForDataRequestId(any())).thenReturn(TRANSFER_ID);
-        when(transferProcessStore.find(TRANSFER_ID)).thenReturn(createTransferProcess(TRANSFER_ID, transferProperties(receiverUrl() + "/modified")));
+        when(transferProcessStore.findById(TRANSFER_ID)).thenReturn(createTransferProcess(TRANSFER_ID, transferProperties(receiverUrl() + "/modified")));
 
         var edr = createEndpointDataReferenceBuilder()
                 .build();
@@ -189,7 +189,7 @@ public class HttpDynamicEndpointDataReferenceReceiverTest {
     @Test
     public void send_shouldFailForwardTheEdr_transferProcessNotFound() throws ExecutionException, InterruptedException {
         when(transferProcessStore.processIdForDataRequestId(any())).thenReturn(TRANSFER_ID);
-        when(transferProcessStore.find(TRANSFER_ID)).thenReturn(null);
+        when(transferProcessStore.findById(TRANSFER_ID)).thenReturn(null);
 
         var edr = createEndpointDataReferenceBuilder()
                 .build();
@@ -209,7 +209,7 @@ public class HttpDynamicEndpointDataReferenceReceiverTest {
     public void send_shouldNotForwardTheEdr_whenReceiverUrlMissing() throws ExecutionException, InterruptedException {
 
         when(transferProcessStore.processIdForDataRequestId(any())).thenReturn(TRANSFER_ID);
-        when(transferProcessStore.find(TRANSFER_ID)).thenReturn(createTransferProcess(TRANSFER_ID));
+        when(transferProcessStore.findById(TRANSFER_ID)).thenReturn(createTransferProcess(TRANSFER_ID));
 
         var edr = createEndpointDataReferenceBuilder()
                 .build();
@@ -239,7 +239,7 @@ public class HttpDynamicEndpointDataReferenceReceiverTest {
                 .build();
 
         when(transferProcessStore.processIdForDataRequestId(any())).thenReturn(TRANSFER_ID);
-        when(transferProcessStore.find(TRANSFER_ID)).thenReturn(createTransferProcess(TRANSFER_ID));
+        when(transferProcessStore.findById(TRANSFER_ID)).thenReturn(createTransferProcess(TRANSFER_ID));
 
         var edr = createEndpointDataReferenceBuilder()
                 .build();

--- a/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/api/DataplaneSelectorApiControllerIntegrationTest.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/api/DataplaneSelectorApiControllerIntegrationTest.java
@@ -33,7 +33,6 @@ import org.eclipse.edc.spi.http.EdcHttpClient;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.eclipse.edc.transaction.spi.NoopTransactionContext;
 import org.eclipse.edc.web.jersey.JerseyConfiguration;
 import org.eclipse.edc.web.jersey.JerseyRestService;
 import org.eclipse.edc.web.jetty.JettyConfiguration;
@@ -85,7 +84,7 @@ class DataplaneSelectorApiControllerIntegrationTest {
 
         store = new InMemoryDataPlaneInstanceStore();
         var selector = new DataPlaneSelectorImpl(store);
-        var service = new DataPlaneSelectorServiceImpl(selector, store, selectionStrategyRegistry, new NoopTransactionContext());
+        var service = new DataPlaneSelectorServiceImpl(selector, store, selectionStrategyRegistry);
         var controller = new DataplaneSelectorApiController(service);
 
         jetty = new JettyService(config, monitor);
@@ -107,7 +106,7 @@ class DataplaneSelectorApiControllerIntegrationTest {
     @Test
     void getAll() throws IOException {
         var list = List.of(createInstance("test-id1"), createInstance("test-id2"), createInstance("test-id3"));
-        saveInstances(list);
+        store.updateOrCreateAll(list);
 
         var response = get(basePath());
 
@@ -143,7 +142,7 @@ class DataplaneSelectorApiControllerIntegrationTest {
         var dpi1 = createInstance("test-id1");
         var dpi2 = createInstance("test-id2");
         var dpi3 = createInstance("test-id3");
-        saveInstances(List.of(dpi1, dpi2, dpi3));
+        store.updateOrCreateAll(List.of(dpi1, dpi2, dpi3));
 
 
         var newDpi = createInstanceBuilder("test-id2")
@@ -168,7 +167,7 @@ class DataplaneSelectorApiControllerIntegrationTest {
                 .allowedSourceType("test-src2")
                 .allowedDestType("test-dst2")
                 .build();
-        saveInstances(List.of(dpi, dpi2));
+        store.updateOrCreateAll(List.of(dpi, dpi2));
 
         var src = DataAddress.Builder.newInstance().type("test-src1").build();
         var dest = DataAddress.Builder.newInstance().type("test-dst1").build();
@@ -193,7 +192,7 @@ class DataplaneSelectorApiControllerIntegrationTest {
                 .allowedSourceType("test-src2")
                 .allowedDestType("test-dst2")
                 .build();
-        saveInstances(List.of(dpi, dpi2));
+        store.updateOrCreateAll(List.of(dpi, dpi2));
 
         var src = DataAddress.Builder.newInstance().type("notexist-src").build();
         var dest = DataAddress.Builder.newInstance().type("test-dst1").build();
@@ -217,7 +216,7 @@ class DataplaneSelectorApiControllerIntegrationTest {
                 .allowedSourceType("test-src2")
                 .allowedDestType("test-dst2")
                 .build();
-        saveInstances(List.of(dpi, dpi2));
+        store.updateOrCreateAll(List.of(dpi, dpi2));
 
         var src = DataAddress.Builder.newInstance().type("test-src1").build();
         var dest = DataAddress.Builder.newInstance().type("test-dst1").build();
@@ -241,7 +240,7 @@ class DataplaneSelectorApiControllerIntegrationTest {
                 .allowedSourceType("test-src1")
                 .allowedDestType("test-dst1")
                 .build();
-        saveInstances(List.of(dpi, dpi2));
+        store.updateOrCreateAll(List.of(dpi, dpi2));
 
         var myCustomStrategy = new SelectionStrategy() {
             @Override
@@ -287,12 +286,5 @@ class DataplaneSelectorApiControllerIntegrationTest {
     @NotNull
     private Response delete(String url) throws IOException {
         return client.execute(new Request.Builder().delete().url(url).build());
-    }
-
-    private void saveInstances(List<DataPlaneInstance> instances) {
-
-        for (var instance : instances) {
-            store.create(instance);
-        }
     }
 }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/negotiation/store/ContractNegotiationStore.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/negotiation/store/ContractNegotiationStore.java
@@ -36,7 +36,7 @@ public interface ContractNegotiationStore extends StateEntityStore<ContractNegot
      * Finds the contract negotiation for the id or null.
      */
     @Nullable
-    ContractNegotiation find(String negotiationId);
+    ContractNegotiation findById(String negotiationId);
 
     /**
      * Returns the contract negotiation for the correlation id provided by the consumer or null.
@@ -54,7 +54,7 @@ public interface ContractNegotiationStore extends StateEntityStore<ContractNegot
      * Persists a contract negotiation. This follows UPSERT semantics, so if the object didn't exit before, it's
      * created.
      */
-    void save(ContractNegotiation negotiation);
+    void updateOrCreate(ContractNegotiation negotiation);
 
     /**
      * Removes a contract negotiation for the given id.
@@ -75,7 +75,7 @@ public interface ContractNegotiationStore extends StateEntityStore<ContractNegot
      * @return a stream of ContractNegotiation, cannot be null.
      */
     @NotNull
-    Stream<ContractNegotiation> queryNegotiations(QuerySpec querySpec);
+    Stream<ContractNegotiation> findAllNegotiations(QuerySpec querySpec);
 
 
     /**
@@ -86,5 +86,5 @@ public interface ContractNegotiationStore extends StateEntityStore<ContractNegot
      * @return a stream of ContractAgreement, cannot be null.
      */
     @NotNull
-    Stream<ContractAgreement> queryAgreements(QuerySpec querySpec);
+    Stream<ContractAgreement> findAllAgreements(QuerySpec querySpec);
 }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/offer/store/ContractDefinitionStore.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/offer/store/ContractDefinitionStore.java
@@ -58,7 +58,7 @@ public interface ContractDefinitionStore {
      * @return {@link StoreResult#success()} if the contract definition was stored, {@link StoreResult#alreadyExists(String)} if a contract
      *         definition with the same ID already exists.
      */
-    StoreResult<Void> save(ContractDefinition definition);
+    StoreResult<Void> create(ContractDefinition definition);
 
     /**
      * Update the contract definition if a contract definition with the same ID exists.

--- a/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/negotiation/store/ContractNegotiationStoreTestBase.java
+++ b/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/negotiation/store/ContractNegotiationStoreTestBase.java
@@ -48,9 +48,9 @@ public abstract class ContractNegotiationStoreTestBase {
     void find() {
         var id = "test-cn1";
         var negotiation = createNegotiation(id);
-        getContractNegotiationStore().save(negotiation);
+        getContractNegotiationStore().updateOrCreate(negotiation);
 
-        Assertions.assertThat(getContractNegotiationStore().find(id))
+        Assertions.assertThat(getContractNegotiationStore().findById(id))
                 .usingRecursiveComparison()
                 .isEqualTo(negotiation);
 
@@ -61,20 +61,20 @@ public abstract class ContractNegotiationStoreTestBase {
     void find_whenLeased_shouldReturnEntity() {
         var id = "test-cn1";
         var negotiation = createNegotiation(id);
-        getContractNegotiationStore().save(negotiation);
+        getContractNegotiationStore().updateOrCreate(negotiation);
 
         lockEntity(id, CONNECTOR_NAME);
-        Assertions.assertThat(getContractNegotiationStore().find(id))
+        Assertions.assertThat(getContractNegotiationStore().findById(id))
                 .usingRecursiveComparison()
                 .isEqualTo(negotiation);
 
 
         var id2 = "test-cn2";
         var negotiation2 = createNegotiation(id2);
-        getContractNegotiationStore().save(negotiation2);
+        getContractNegotiationStore().updateOrCreate(negotiation2);
 
         lockEntity(id2, "someone-else");
-        Assertions.assertThat(getContractNegotiationStore().find(id2))
+        Assertions.assertThat(getContractNegotiationStore().findById(id2))
                 .usingRecursiveComparison()
                 .isEqualTo(negotiation2);
 
@@ -83,14 +83,14 @@ public abstract class ContractNegotiationStoreTestBase {
     @Test
     @DisplayName("Verify that null is returned when entity not found")
     void find_notExist() {
-        Assertions.assertThat(getContractNegotiationStore().find("not-exist")).isNull();
+        Assertions.assertThat(getContractNegotiationStore().findById("not-exist")).isNull();
     }
 
     @Test
     @DisplayName("Find entity by its correlation ID")
     void findForCorrelationId() {
         var negotiation = createNegotiation("test-cn1");
-        getContractNegotiationStore().save(negotiation);
+        getContractNegotiationStore().updateOrCreate(negotiation);
 
         Assertions.assertThat(getContractNegotiationStore().findForCorrelationId(negotiation.getCorrelationId()))
                 .usingRecursiveComparison()
@@ -102,7 +102,7 @@ public abstract class ContractNegotiationStoreTestBase {
     void findContractAgreement() {
         var agreement = createContract("test-ca1");
         var negotiation = createNegotiation("test-cn1", agreement);
-        getContractNegotiationStore().save(negotiation);
+        getContractNegotiationStore().updateOrCreate(negotiation);
 
         Assertions.assertThat(getContractNegotiationStore().findContractAgreement(agreement.getId()))
                 .usingRecursiveComparison()
@@ -121,9 +121,9 @@ public abstract class ContractNegotiationStoreTestBase {
         var negotiation = createNegotiationBuilder("test-id1")
                 .type(ContractNegotiation.Type.PROVIDER)
                 .build();
-        getContractNegotiationStore().save(negotiation);
+        getContractNegotiationStore().updateOrCreate(negotiation);
 
-        Assertions.assertThat(getContractNegotiationStore().find(negotiation.getId()))
+        Assertions.assertThat(getContractNegotiationStore().findById(negotiation.getId()))
                 .usingRecursiveComparison()
                 .isEqualTo(negotiation);
     }
@@ -133,9 +133,9 @@ public abstract class ContractNegotiationStoreTestBase {
     void save_withContract() {
         var agreement = createContract("test-agreement");
         var negotiation = createNegotiation("test-negotiation", agreement);
-        getContractNegotiationStore().save(negotiation);
+        getContractNegotiationStore().updateOrCreate(negotiation);
 
-        var actual = getContractNegotiationStore().find(negotiation.getId());
+        var actual = getContractNegotiationStore().findById(negotiation.getId());
         Assertions.assertThat(actual)
                 .isNotNull()
                 .usingRecursiveComparison()
@@ -148,7 +148,7 @@ public abstract class ContractNegotiationStoreTestBase {
     void save_exists_shouldUpdate() {
         var id = "test-id1";
         var negotiation = createNegotiation(id);
-        getContractNegotiationStore().save(negotiation);
+        getContractNegotiationStore().updateOrCreate(negotiation);
 
         var newNegotiation = ContractNegotiation.Builder.newInstance()
                 .type(ContractNegotiation.Type.CONSUMER)
@@ -161,9 +161,9 @@ public abstract class ContractNegotiationStoreTestBase {
                 .protocol("ids-multipart")
                 .build();
 
-        getContractNegotiationStore().save(newNegotiation);
+        getContractNegotiationStore().updateOrCreate(newNegotiation);
 
-        var actual = getContractNegotiationStore().find(negotiation.getId());
+        var actual = getContractNegotiationStore().findById(negotiation.getId());
         Assertions.assertThat(actual).isNotNull();
         Assertions.assertThat(actual.getStateCount()).isEqualTo(420);
         Assertions.assertThat(actual.getState()).isEqualTo(800);
@@ -175,7 +175,7 @@ public abstract class ContractNegotiationStoreTestBase {
         var id = "test-id1";
         var builder = createNegotiationBuilder(id);
         var negotiation = builder.build();
-        getContractNegotiationStore().save(negotiation);
+        getContractNegotiationStore().updateOrCreate(negotiation);
 
         lockEntity(id, CONNECTOR_NAME);
 
@@ -186,7 +186,7 @@ public abstract class ContractNegotiationStoreTestBase {
                 .build();
 
         // update should break lease
-        getContractNegotiationStore().save(newNegotiation);
+        getContractNegotiationStore().updateOrCreate(newNegotiation);
 
         assertThat(isLockedBy(id, CONNECTOR_NAME)).isFalse();
 
@@ -200,7 +200,7 @@ public abstract class ContractNegotiationStoreTestBase {
     void update_leasedByOther_shouldThrowException() {
         var id = "test-id1";
         var negotiation = createNegotiation(id);
-        getContractNegotiationStore().save(negotiation);
+        getContractNegotiationStore().updateOrCreate(negotiation);
 
         lockEntity(id, "someone-else");
 
@@ -217,7 +217,7 @@ public abstract class ContractNegotiationStoreTestBase {
 
         // update should break lease
         assertThat(isLockedBy(id, "someone-else")).isTrue();
-        assertThatThrownBy(() -> getContractNegotiationStore().save(newNegotiation)).isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(() -> getContractNegotiationStore().updateOrCreate(newNegotiation)).isInstanceOf(IllegalStateException.class);
     }
 
     @Test
@@ -225,41 +225,41 @@ public abstract class ContractNegotiationStoreTestBase {
     void update_addsAgreement_shouldPersist() {
         var negotiationId = "test-cn1";
         var negotiation = createNegotiation(negotiationId);
-        getContractNegotiationStore().save(negotiation);
+        getContractNegotiationStore().updateOrCreate(negotiation);
 
         // now add the agreement
         var agreement = createContract("test-ca1");
         var updatedNegotiation = createNegotiation(negotiationId, agreement);
 
-        getContractNegotiationStore().save(updatedNegotiation); //should perform an update + insert
+        getContractNegotiationStore().updateOrCreate(updatedNegotiation); //should perform an update + insert
 
-        Assertions.assertThat(getContractNegotiationStore().queryAgreements(QuerySpec.none()))
+        Assertions.assertThat(getContractNegotiationStore().findAllAgreements(QuerySpec.none()))
                 .hasSize(1)
                 .usingRecursiveFieldByFieldElementComparator()
                 .containsExactly(agreement);
 
-        Assertions.assertThat(Objects.requireNonNull(getContractNegotiationStore().find(negotiationId)).getContractAgreement()).usingRecursiveComparison().isEqualTo(agreement);
+        Assertions.assertThat(Objects.requireNonNull(getContractNegotiationStore().findById(negotiationId)).getContractAgreement()).usingRecursiveComparison().isEqualTo(agreement);
     }
 
     @Test
     void create_and_cancel_contractAgreement() {
         var negotiationId = "test-cn1";
         var negotiation = createNegotiation(negotiationId);
-        getContractNegotiationStore().save(negotiation);
+        getContractNegotiationStore().updateOrCreate(negotiation);
 
         // now add the agreement
         var agreement = createContract("test-ca1");
         var updatedNegotiation = createNegotiation(negotiationId, agreement);
 
-        getContractNegotiationStore().save(updatedNegotiation);
-        Assertions.assertThat(getContractNegotiationStore().queryAgreements(QuerySpec.none()))
+        getContractNegotiationStore().updateOrCreate(updatedNegotiation);
+        Assertions.assertThat(getContractNegotiationStore().findAllAgreements(QuerySpec.none()))
                 .hasSize(1)
                 .usingRecursiveFieldByFieldElementComparator()
                 .containsExactly(agreement);
 
         // cancel the agreement
         updatedNegotiation.transitionError("Cancelled");
-        getContractNegotiationStore().save(updatedNegotiation);
+        getContractNegotiationStore().updateOrCreate(updatedNegotiation);
     }
 
     @Test
@@ -268,16 +268,16 @@ public abstract class ContractNegotiationStoreTestBase {
         var negotiationId = "test-cn1";
         var agreement = createContract("test-ca1");
         var negotiation = createNegotiation(negotiationId, null);
-        getContractNegotiationStore().save(negotiation);
-        var dbNegotiation = getContractNegotiationStore().find(negotiationId);
+        getContractNegotiationStore().updateOrCreate(negotiation);
+        var dbNegotiation = getContractNegotiationStore().findById(negotiationId);
         Assertions.assertThat(dbNegotiation).isNotNull().satisfies(n ->
                 Assertions.assertThat(n.getContractAgreement()).isNull()
         );
 
         dbNegotiation.setContractAgreement(agreement);
-        getContractNegotiationStore().save(dbNegotiation);
+        getContractNegotiationStore().updateOrCreate(dbNegotiation);
 
-        var updatedNegotiation = getContractNegotiationStore().find(negotiationId);
+        var updatedNegotiation = getContractNegotiationStore().findById(negotiationId);
         Assertions.assertThat(updatedNegotiation).isNotNull();
         Assertions.assertThat(updatedNegotiation.getContractAgreement()).isNotNull();
     }
@@ -287,14 +287,14 @@ public abstract class ContractNegotiationStoreTestBase {
     void delete() {
         var id = UUID.randomUUID().toString();
         var n = createNegotiation(id);
-        getContractNegotiationStore().save(n);
+        getContractNegotiationStore().updateOrCreate(n);
 
-        Assertions.assertThat(getContractNegotiationStore().find(id)).isNotNull().usingRecursiveComparison().isEqualTo(n);
+        Assertions.assertThat(getContractNegotiationStore().findById(id)).isNotNull().usingRecursiveComparison().isEqualTo(n);
 
         //todo: verify returned object
         getContractNegotiationStore().delete(id);
 
-        Assertions.assertThat(getContractNegotiationStore().find(id)).isNull();
+        Assertions.assertThat(getContractNegotiationStore().findById(id)).isNull();
     }
 
     @Test
@@ -302,7 +302,7 @@ public abstract class ContractNegotiationStoreTestBase {
     void delete_whenLeasedBySelf_shouldThrowException() {
         var id = UUID.randomUUID().toString();
         var n = createNegotiation(id);
-        getContractNegotiationStore().save(n);
+        getContractNegotiationStore().updateOrCreate(n);
 
         lockEntity(id, CONNECTOR_NAME);
 
@@ -315,7 +315,7 @@ public abstract class ContractNegotiationStoreTestBase {
     void delete_whenLeasedByOther_shouldThrowException() {
         var id = UUID.randomUUID().toString();
         var n = createNegotiation(id);
-        getContractNegotiationStore().save(n);
+        getContractNegotiationStore().updateOrCreate(n);
 
         lockEntity(id, "someone-else");
 
@@ -336,9 +336,9 @@ public abstract class ContractNegotiationStoreTestBase {
         var id = UUID.randomUUID().toString();
         var contract = createContract("test-agreement");
         var n = createNegotiation(id, contract);
-        getContractNegotiationStore().save(n);
+        getContractNegotiationStore().updateOrCreate(n);
 
-        Assertions.assertThat(getContractNegotiationStore().find(id)).isNotNull().usingRecursiveComparison().isEqualTo(n);
+        Assertions.assertThat(getContractNegotiationStore().findById(id)).isNotNull().usingRecursiveComparison().isEqualTo(n);
         assertThatThrownBy(() -> getContractNegotiationStore().delete(id)).isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Cannot delete ContractNegotiation")
                 .hasMessageContaining("ContractAgreement already created.");
@@ -353,9 +353,9 @@ public abstract class ContractNegotiationStoreTestBase {
 
         IntStream.range(0, 100)
                 .mapToObj(i -> createNegotiation("" + i))
-                .forEach(cn -> getContractNegotiationStore().save(cn));
+                .forEach(cn -> getContractNegotiationStore().updateOrCreate(cn));
 
-        var result = getContractNegotiationStore().queryNegotiations(querySpec);
+        var result = getContractNegotiationStore().findAllNegotiations(querySpec);
 
         Assertions.assertThat(result).hasSize(10);
     }
@@ -369,9 +369,9 @@ public abstract class ContractNegotiationStoreTestBase {
 
         IntStream.range(0, 100)
                 .mapToObj(i -> createNegotiation("" + i))
-                .forEach(cn -> getContractNegotiationStore().save(cn));
+                .forEach(cn -> getContractNegotiationStore().updateOrCreate(cn));
 
-        var result = getContractNegotiationStore().queryNegotiations(querySpec);
+        var result = getContractNegotiationStore().findAllNegotiations(querySpec);
 
         Assertions.assertThat(result).hasSize(10)
                 .extracting(ContractNegotiation::getId)
@@ -384,12 +384,12 @@ public abstract class ContractNegotiationStoreTestBase {
         var negotiation = createNegotiation("negotiation1", agreement);
         var assetId = agreement.getAssetId();
 
-        getContractNegotiationStore().save(negotiation);
+        getContractNegotiationStore().updateOrCreate(negotiation);
 
         var query = QuerySpec.Builder.newInstance()
                 .filter(List.of(new Criterion("contractAgreement.assetId", "=", assetId)))
                 .build();
-        var result = getContractNegotiationStore().queryNegotiations(query);
+        var result = getContractNegotiationStore().findAllNegotiations(query);
 
         Assertions.assertThat(result).hasSize(1).usingRecursiveFieldByFieldElementComparator().containsOnly(negotiation);
 
@@ -400,15 +400,15 @@ public abstract class ContractNegotiationStoreTestBase {
         var assetId = UUID.randomUUID().toString();
         var negotiation = createNegotiation("negotiation1");
 
-        getContractNegotiationStore().save(negotiation);
+        getContractNegotiationStore().updateOrCreate(negotiation);
 
         var query = QuerySpec.Builder.newInstance()
                 .filter(List.of(new Criterion("contractAgreement.assetId", "=", assetId)))
                 .build();
-        var result = getContractNegotiationStore().queryNegotiations(query);
+        var result = getContractNegotiationStore().findAllNegotiations(query);
 
         Assertions.assertThat(result).isEmpty();
-        Assertions.assertThat(getContractNegotiationStore().queryAgreements(QuerySpec.none())).isEmpty();
+        Assertions.assertThat(getContractNegotiationStore().findAllAgreements(QuerySpec.none())).isEmpty();
 
     }
 
@@ -418,13 +418,13 @@ public abstract class ContractNegotiationStoreTestBase {
         var negotiation1 = createNegotiation("negotiation1", createContractBuilder("contract1").assetId(assetId).build());
         var negotiation2 = createNegotiation("negotiation2", createContractBuilder("contract2").assetId(assetId).build());
 
-        getContractNegotiationStore().save(negotiation1);
-        getContractNegotiationStore().save(negotiation2);
+        getContractNegotiationStore().updateOrCreate(negotiation1);
+        getContractNegotiationStore().updateOrCreate(negotiation2);
 
         var query = QuerySpec.Builder.newInstance()
                 .filter(List.of(new Criterion("contractAgreement.assetId", "=", assetId)))
                 .build();
-        var result = getContractNegotiationStore().queryNegotiations(query);
+        var result = getContractNegotiationStore().findAllNegotiations(query);
 
         Assertions.assertThat(result).hasSize(2)
                 .extracting(ContractNegotiation::getId).containsExactlyInAnyOrder("negotiation1", "negotiation2");
@@ -441,9 +441,9 @@ public abstract class ContractNegotiationStoreTestBase {
                     var agreement = createContract("contract" + i);
                     return createNegotiation("" + i, agreement);
                 })
-                .forEach(cn -> getContractNegotiationStore().save(cn));
+                .forEach(cn -> getContractNegotiationStore().updateOrCreate(cn));
 
-        var result = getContractNegotiationStore().queryNegotiations(querySpec);
+        var result = getContractNegotiationStore().findAllNegotiations(querySpec);
 
         Assertions.assertThat(result).hasSize(10);
     }
@@ -455,9 +455,9 @@ public abstract class ContractNegotiationStoreTestBase {
 
         IntStream.range(0, 10)
                 .mapToObj(i -> createNegotiation("" + i))
-                .forEach(cn -> getContractNegotiationStore().save(cn));
+                .forEach(cn -> getContractNegotiationStore().updateOrCreate(cn));
 
-        var result = getContractNegotiationStore().queryNegotiations(querySpec);
+        var result = getContractNegotiationStore().findAllNegotiations(querySpec);
 
         Assertions.assertThat(result).isEmpty();
     }
@@ -469,7 +469,7 @@ public abstract class ContractNegotiationStoreTestBase {
                 .range(0, 10)
                 .mapToObj(i -> createNegotiation("id" + i))
                 .collect(Collectors.toList());
-        negotiations.forEach(getContractNegotiationStore()::save);
+        negotiations.forEach(getContractNegotiationStore()::updateOrCreate);
 
         var batch = getContractNegotiationStore().nextForState(ContractNegotiationStates.REQUESTED.code(), 5);
 
@@ -484,7 +484,7 @@ public abstract class ContractNegotiationStoreTestBase {
                 .range(0, 10)
                 .mapToObj(i -> createNegotiation(String.valueOf(i)))
                 .collect(Collectors.toList());
-        negotiations.forEach(getContractNegotiationStore()::save);
+        negotiations.forEach(getContractNegotiationStore()::updateOrCreate);
 
         // mark a few as "leased"
         getContractNegotiationStore().nextForState(ContractNegotiationStates.REQUESTED.code(), 5);
@@ -505,7 +505,7 @@ public abstract class ContractNegotiationStoreTestBase {
                 .range(0, 5)
                 .mapToObj(i -> createNegotiation(String.valueOf(i)))
                 .collect(Collectors.toList());
-        negotiations.forEach(getContractNegotiationStore()::save);
+        negotiations.forEach(getContractNegotiationStore()::updateOrCreate);
 
         // mark them as "leased"
         negotiations.forEach(n -> lockEntity(n.getId(), CONNECTOR_NAME, Duration.ofMillis(10)));
@@ -526,10 +526,10 @@ public abstract class ContractNegotiationStoreTestBase {
         IntStream.range(0, 10).forEach(i -> {
             var contractAgreement = createContract(ContractId.createContractId(UUID.randomUUID().toString()));
             var negotiation = createNegotiation(UUID.randomUUID().toString(), contractAgreement);
-            getContractNegotiationStore().save(negotiation);
+            getContractNegotiationStore().updateOrCreate(negotiation);
         });
 
-        var all = getContractNegotiationStore().queryAgreements(QuerySpec.Builder.newInstance().build());
+        var all = getContractNegotiationStore().findAllAgreements(QuerySpec.Builder.newInstance().build());
 
         Assertions.assertThat(all).hasSize(10);
     }
@@ -539,14 +539,14 @@ public abstract class ContractNegotiationStoreTestBase {
         IntStream.range(0, 10).forEach(i -> {
             var contractAgreement = createContract(ContractId.createContractId(UUID.randomUUID().toString()));
             var negotiation = createNegotiation(UUID.randomUUID().toString(), contractAgreement);
-            getContractNegotiationStore().save(negotiation);
+            getContractNegotiationStore().updateOrCreate(negotiation);
         });
 
         // page size fits
-        Assertions.assertThat(getContractNegotiationStore().queryAgreements(QuerySpec.Builder.newInstance().offset(3).limit(4).build())).hasSize(4);
+        Assertions.assertThat(getContractNegotiationStore().findAllAgreements(QuerySpec.Builder.newInstance().offset(3).limit(4).build())).hasSize(4);
 
         // page size too large
-        Assertions.assertThat(getContractNegotiationStore().queryAgreements(QuerySpec.Builder.newInstance().offset(5).limit(100).build())).hasSize(5);
+        Assertions.assertThat(getContractNegotiationStore().findAllAgreements(QuerySpec.Builder.newInstance().offset(5).limit(100).build())).hasSize(5);
     }
 
     protected abstract ContractNegotiationStore getContractNegotiationStore();

--- a/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/offer/store/ContractDefinitionStoreTestBase.java
+++ b/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/offer/store/ContractDefinitionStoreTestBase.java
@@ -59,7 +59,7 @@ public abstract class ContractDefinitionStoreTestBase {
     @DisplayName("Save a single Contract Definition that doesn't already exist")
     void saveOne_doesntExist() {
         var definition = createContractDefinition("id");
-        getContractDefinitionStore().save(definition);
+        getContractDefinitionStore().create(definition);
 
         var definitions = getContractDefinitionStore().findAll(QuerySpec.max())
                 .collect(Collectors.toList());
@@ -72,8 +72,8 @@ public abstract class ContractDefinitionStoreTestBase {
     @Test
     @DisplayName("Shouldn't save a single Contract Definition that already exists")
     void saveOne_alreadyExist_shouldNotUpdate() {
-        getContractDefinitionStore().save(createContractDefinition("id", "policy", "contract"));
-        var saveResult = getContractDefinitionStore().save(createContractDefinition("id", "updatedAccess", "updatedContract"));
+        getContractDefinitionStore().create(createContractDefinition("id", "policy", "contract"));
+        var saveResult = getContractDefinitionStore().create(createContractDefinition("id", "updatedAccess", "updatedContract"));
 
         assertThat(saveResult.failed()).isTrue();
         assertThat(saveResult.reason()).isEqualTo(ALREADY_EXISTS);
@@ -88,8 +88,8 @@ public abstract class ContractDefinitionStoreTestBase {
     void saveOne_sameParametersDifferentId() {
         var definition1 = createContractDefinition("id1", "policy", "contract");
         var definition2 = createContractDefinition("id2", "policy", "contract");
-        getContractDefinitionStore().save(definition1);
-        getContractDefinitionStore().save(definition2);
+        getContractDefinitionStore().create(definition1);
+        getContractDefinitionStore().create(definition2);
 
         var definitions = getContractDefinitionStore().findAll(QuerySpec.max());
 
@@ -151,7 +151,7 @@ public abstract class ContractDefinitionStoreTestBase {
         var definition1 = createContractDefinition("id", "policy1", "contract1");
         var definition2 = createContractDefinition("id", "policy2", "contract2");
 
-        getContractDefinitionStore().save(definition1);
+        getContractDefinitionStore().create(definition1);
         getContractDefinitionStore().update(definition2);
 
         var definitions = getContractDefinitionStore().findAll(QuerySpec.none()).collect(Collectors.toList());
@@ -178,7 +178,7 @@ public abstract class ContractDefinitionStoreTestBase {
     @ValueSource(ints = { 49, 50, 51, 100 })
     void findAll_verifyQueryDefaults(int size) {
         var all = IntStream.range(0, size).mapToObj(i -> createContractDefinition("id" + i, "policyId" + i, "contractId" + i))
-                .peek(cd -> getContractDefinitionStore().save(cd))
+                .peek(cd -> getContractDefinitionStore().create(cd))
                 .collect(Collectors.toList());
 
         assertThat(getContractDefinitionStore().findAll(QuerySpec.max())).hasSize(size)
@@ -272,7 +272,7 @@ public abstract class ContractDefinitionStoreTestBase {
     void findById() {
         var id = "definitionId";
         var definition = createContractDefinition(id, "policyId", "contractId");
-        getContractDefinitionStore().save(definition);
+        getContractDefinitionStore().create(definition);
 
         var result = getContractDefinitionStore().findById(id);
 
@@ -287,7 +287,7 @@ public abstract class ContractDefinitionStoreTestBase {
     @Test
     void delete() {
         var definitionExpected = createContractDefinition("test-id1", "policy1", "contract1");
-        getContractDefinitionStore().save(definitionExpected);
+        getContractDefinitionStore().create(definitionExpected);
         assertThat(getContractDefinitionStore().findAll(QuerySpec.max())).hasSize(1);
 
         var deleted = getContractDefinitionStore().deleteById("test-id1");
@@ -309,10 +309,10 @@ public abstract class ContractDefinitionStoreTestBase {
         var definition1 = createContractDefinition("1");
         var definition2 = createContractDefinition("2");
 
-        getContractDefinitionStore().save(definition1);
+        getContractDefinitionStore().create(definition1);
         assertThat(getContractDefinitionStore().findAll(QuerySpec.max())).contains(definition1);
 
-        getContractDefinitionStore().save(definition2);
+        getContractDefinitionStore().create(definition2);
         assertThat(getContractDefinitionStore().findAll(QuerySpec.max())).contains(definition1);
 
         var deletedDefinition = getContractDefinitionStore().deleteById(definition1.getId());
@@ -323,13 +323,13 @@ public abstract class ContractDefinitionStoreTestBase {
 
     @Test
     void findAll_defaultQuerySpec() {
-        var all = IntStream.range(0, 10).mapToObj(i -> createContractDefinition("id" + i)).peek(getContractDefinitionStore()::save).collect(Collectors.toList());
+        var all = IntStream.range(0, 10).mapToObj(i -> createContractDefinition("id" + i)).peek(getContractDefinitionStore()::create).collect(Collectors.toList());
         assertThat(getContractDefinitionStore().findAll(QuerySpec.none())).containsExactlyInAnyOrder(all.toArray(new ContractDefinition[]{}));
     }
 
     @Test
     void findAll_verifyPaging() {
-        IntStream.range(0, 10).mapToObj(i -> createContractDefinition("id" + i)).forEach(getContractDefinitionStore()::save);
+        IntStream.range(0, 10).mapToObj(i -> createContractDefinition("id" + i)).forEach(getContractDefinitionStore()::create);
 
         // page size fits
         assertThat(getContractDefinitionStore().findAll(QuerySpec.Builder.newInstance().offset(4).limit(2).build())).hasSize(2);
@@ -340,21 +340,21 @@ public abstract class ContractDefinitionStoreTestBase {
 
     @Test
     void findAll_verifyFiltering() {
-        IntStream.range(0, 10).mapToObj(i -> createContractDefinition("id" + i)).forEach(getContractDefinitionStore()::save);
+        IntStream.range(0, 10).mapToObj(i -> createContractDefinition("id" + i)).forEach(getContractDefinitionStore()::create);
         assertThat(getContractDefinitionStore().findAll(QuerySpec.Builder.newInstance().equalsAsContains(false).filter("id=id3").build())).extracting(ContractDefinition::getId)
                 .containsOnly("id3");
     }
 
     @Test
     void findAll_verifyFiltering_invalidFilterExpression() {
-        IntStream.range(0, 10).mapToObj(i -> createContractDefinition("id" + i)).forEach(getContractDefinitionStore()::save);
+        IntStream.range(0, 10).mapToObj(i -> createContractDefinition("id" + i)).forEach(getContractDefinitionStore()::create);
         assertThatThrownBy(() -> getContractDefinitionStore().findAll(QuerySpec.Builder.newInstance().filter("something foobar other").build())).isInstanceOfAny(IllegalArgumentException.class);
     }
 
     @Test
     @EnabledIfSystemProperty(named = "contractdefinitionstore.supports.sortorder", matches = "true", disabledReason = "This test only runs if sorting is supported")
     void findAll_verifySorting() {
-        IntStream.range(0, 10).mapToObj(i -> createContractDefinition("id" + i)).forEach(getContractDefinitionStore()::save);
+        IntStream.range(0, 10).mapToObj(i -> createContractDefinition("id" + i)).forEach(getContractDefinitionStore()::create);
 
         assertThat(getContractDefinitionStore().findAll(QuerySpec.Builder.newInstance().sortField("id").sortOrder(SortOrder.ASC).build())).hasSize(10).isSortedAccordingTo(Comparator.comparing(ContractDefinition::getId));
         assertThat(getContractDefinitionStore().findAll(QuerySpec.Builder.newInstance().sortField("id").sortOrder(SortOrder.DESC).build())).hasSize(10).isSortedAccordingTo((c1, c2) -> c2.getId().compareTo(c1.getId()));
@@ -511,7 +511,7 @@ public abstract class ContractDefinitionStoreTestBase {
     @Test
     @EnabledIfSystemProperty(named = "contractdefinitionstore.supports.sortorder", matches = "true", disabledReason = "This test only runs if sorting is supported")
     void findAll_verifySorting_invalidProperty() {
-        IntStream.range(0, 10).mapToObj(i -> createContractDefinition("id" + i)).forEach(getContractDefinitionStore()::save);
+        IntStream.range(0, 10).mapToObj(i -> createContractDefinition("id" + i)).forEach(getContractDefinitionStore()::create);
         var query = QuerySpec.Builder.newInstance().sortField("notexist").sortOrder(SortOrder.DESC).build();
 
         // must actually collect, otherwise the stream is not materialized
@@ -529,7 +529,7 @@ public abstract class ContractDefinitionStoreTestBase {
 
     protected void saveContractDefinitions(List<ContractDefinition> definitions) {
         for (var cd : definitions) {
-            getContractDefinitionStore().save(cd);
+            getContractDefinitionStore().create(cd);
         }
     }
 }

--- a/spi/control-plane/policy-spi/src/main/java/org/eclipse/edc/connector/policy/spi/store/PolicyDefinitionStore.java
+++ b/spi/control-plane/policy-spi/src/main/java/org/eclipse/edc/connector/policy/spi/store/PolicyDefinitionStore.java
@@ -19,7 +19,7 @@ import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import org.eclipse.edc.spi.persistence.EdcPersistenceException;
 import org.eclipse.edc.spi.query.QuerySpec;
-import org.eclipse.edc.spi.result.StoreResult;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.stream.Stream;
 
@@ -28,9 +28,6 @@ import java.util.stream.Stream;
  */
 @ExtensionPoint
 public interface PolicyDefinitionStore {
-
-    String POLICY_NOT_FOUND = "Policy with ID %s could not be found";
-    String POLICY_ALREADY_EXISTS = "Policy with ID %s already exists";
 
     /**
      * Finds the policy by id.
@@ -51,31 +48,31 @@ public interface PolicyDefinitionStore {
     Stream<PolicyDefinition> findAll(QuerySpec spec);
 
     /**
-     * Persists the policy, if it does not yet exist.
+     * Persists the policy.
      *
      * @param policy to be saved.
-     * @return {@link StoreResult#success()} if it could be stored, {@link StoreResult#alreadyExists(String)} if a policy with the same ID already exists.
      * @throws EdcPersistenceException if something goes wrong.
      */
-    StoreResult<PolicyDefinition> save(PolicyDefinition policy);
+    void create(PolicyDefinition policy);
 
     /**
      * Updates the policy.
      *
+     * @param policyId ID of the Policy to be updated
      * @param policy to be updated.
-     * @return {@link StoreResult#success()} if it could be updated, {@link StoreResult#notFound(String)} if a policy with the same ID was not found.
      * @throws EdcPersistenceException if any exception occurs during Query Execution e.g., SQLException.
      */
-    StoreResult<PolicyDefinition> update(PolicyDefinition policy);
+    PolicyDefinition update(String policyId, PolicyDefinition policy);
 
     /**
      * Deletes a policy for the given id.
      *
      * @param policyId id of the policy to be removed.
-     * @return {@link StoreResult#success()} if was deleted, {@link StoreResult#notFound(String)} if a policy with the same ID was not found.
+     * @return Deleted {@link Policy} or null if policy not found.
      * @throws EdcPersistenceException if something goes wrong.
      */
-    StoreResult<PolicyDefinition> deleteById(String policyId);
+    @Nullable
+    PolicyDefinition deleteById(String policyId);
 
     /**
      * If the store implementation supports caching, this method triggers a cache-reload.

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/store/TransferProcessStore.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/store/TransferProcessStore.java
@@ -32,7 +32,15 @@ public interface TransferProcessStore extends StateEntityStore<TransferProcess> 
      * Returns the transfer process for the id or null if not found.
      */
     @Nullable
-    TransferProcess find(String id);
+    TransferProcess findById(String id);
+
+    /**
+     * Returns all the transfer processes in the store that are covered by a given {@link QuerySpec}.
+     * <p>
+     * Note: supplying a sort field that does not exist on the {@link TransferProcess} may cause some implementations
+     * to return an empty Stream, others will return an unsorted Stream, depending on the backing storage implementation.
+     */
+    Stream<TransferProcess> findAll(QuerySpec querySpec);
 
     /**
      * Returns the transfer process for the data request id or null if not found.
@@ -44,7 +52,7 @@ public interface TransferProcessStore extends StateEntityStore<TransferProcess> 
      * Persists a transfer process. This follows UPSERT semantics, so if the object didn't exit before, it's
      * created.
      */
-    void save(TransferProcess process);
+    void updateOrCreate(TransferProcess process);
 
 
     /**
@@ -52,11 +60,5 @@ public interface TransferProcessStore extends StateEntityStore<TransferProcess> 
      */
     void delete(String processId);
 
-    /**
-     * Returns all the transfer processes in the store that are covered by a given {@link QuerySpec}.
-     * <p>
-     * Note: supplying a sort field that does not exist on the {@link TransferProcess} may cause some implementations
-     * to return an empty Stream, others will return an unsorted Stream, depending on the backing storage implementation.
-     */
-    Stream<TransferProcess> findAll(QuerySpec querySpec);
+
 }

--- a/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/store/DataPlaneInstanceStore.java
+++ b/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/store/DataPlaneInstanceStore.java
@@ -15,8 +15,8 @@
 package org.eclipse.edc.connector.dataplane.selector.spi.store;
 
 import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
-import org.eclipse.edc.spi.result.StoreResult;
 
+import java.util.Collection;
 import java.util.stream.Stream;
 
 /**
@@ -24,29 +24,9 @@ import java.util.stream.Stream;
  * The collection of {@link DataPlaneInstance} objects is mutable at runtime, so implementations must take that into account.
  */
 public interface DataPlaneInstanceStore {
+    void updateOrCreate(DataPlaneInstance instance);
 
-    String DATA_PLANE_INSTANCE_EXISTS = "Data Plane Instance with ID %s already exists";
-    String DATA_PLANE_INSTANCE_NOT_FOUND = "Data Plane Instance with ID %s not found";
-
-    /**
-     * Stores the {@link DataPlaneInstance} if a data plane instance with the same ID doesn't exist.
-     *
-     * @param instance The {@link DataPlaneInstance} to store.
-     *
-     * @return {@link StoreResult#success()} if the data plane instance was stored, {@link StoreResult#alreadyExists(String)} if a data
-     *         plane instance with the same ID already exists
-     */
-    StoreResult<Void> create(DataPlaneInstance instance);
-
-    /**
-     * Updates the {@link DataPlaneInstance} if a data plane instance with the same ID already exists.
-     *
-     * @param instance The {@link DataPlaneInstance} to update.
-     *
-     * @return {@link StoreResult#success()} if the data plane instance was updated, {@link StoreResult#notFound(String)} if a data
-     *         plane instance with the same ID was not found
-     */
-    StoreResult<Void> update(DataPlaneInstance instance);
+    void updateOrCreateAll(Collection<DataPlaneInstance> instances);
 
     DataPlaneInstance findById(String id);
 

--- a/system-tests/runtimes/file-transfer-provider/src/main/java/org/eclipse/edc/test/extension/api/FileTransferExtension.java
+++ b/system-tests/runtimes/file-transfer-provider/src/main/java/org/eclipse/edc/test/extension/api/FileTransferExtension.java
@@ -64,7 +64,7 @@ public class FileTransferExtension implements ServiceExtension {
         pipelineService.registerFactory(sinkFactory);
 
         var policy = createPolicy();
-        policyStore.save(policy);
+        policyStore.create(policy);
 
         registerDataEntries(context);
         registerContractDefinition(policy.getUid());
@@ -112,6 +112,6 @@ public class FileTransferExtension implements ServiceExtension {
                 .validity(TimeUnit.HOURS.toSeconds(1))
                 .build();
 
-        contractStore.save(contractDefinition);
+        contractStore.create(contractDefinition);
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

The persistence implementations are refactrored in CRUD interactions.
## Why it does that

consistency, recognizability


## Further notes


## Linked Issue(s)

Closes #2559 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
