### PR TITLE
refactor: persistence implementations in AssetIndex harmonize in CRUD…

### DIFF
--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/offer/ContractOfferResolverImplIntegrationTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/offer/ContractOfferResolverImplIntegrationTest.java
@@ -188,7 +188,7 @@ class ContractOfferResolverImplIntegrationTest {
 
     private void store(Collection<Asset> assets) {
         assets.stream().map(a -> new AssetEntry(a, DataAddress.Builder.newInstance().type("test-type").build()))
-                .forEach(assetIndex::accept);
+                .forEach(assetIndex::create);
     }
 
     private AssetSelectorExpression selectorFrom(Collection<Asset> assets1) {

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/asset/AssetServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/asset/AssetServiceImpl.java
@@ -76,7 +76,7 @@ public class AssetServiceImpl implements AssetService {
         }
 
         return transactionContext.execute(() -> {
-            var createResult = index.accept(asset, dataAddress);
+            var createResult = index.create(asset, dataAddress);
             if (createResult.succeeded()) {
                 observable.invokeForEach(l -> l.created(asset));
                 return ServiceResult.success(asset);

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/asset/AssetServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/asset/AssetServiceImplTest.java
@@ -127,13 +127,13 @@ class AssetServiceImplTest {
         var asset = createAsset(assetId);
         var addressType = "addressType";
         var dataAddress = DataAddress.Builder.newInstance().type(addressType).build();
-        when(index.accept(asset, dataAddress)).thenReturn(StoreResult.success());
+        when(index.create(asset, dataAddress)).thenReturn(StoreResult.success());
 
         var inserted = service.create(asset, dataAddress);
 
         assertThat(inserted.succeeded()).isTrue();
         assertThat(inserted.getContent()).matches(hasId(assetId));
-        verify(index).accept(argThat(it -> assetId.equals(it.getId())), argThat(it -> addressType.equals(it.getType())));
+        verify(index).create(argThat(it -> assetId.equals(it.getId())), argThat(it -> addressType.equals(it.getType())));
         verifyNoMoreInteractions(index);
         verify(observable).invokeForEach(any());
     }
@@ -143,7 +143,7 @@ class AssetServiceImplTest {
         when(dataAddressValidator.validate(any())).thenReturn(Result.success());
         var asset = createAsset("assetId");
         var dataAddress = DataAddress.Builder.newInstance().type("addressType").build();
-        when(index.accept(asset, dataAddress)).thenReturn(StoreResult.alreadyExists("test"));
+        when(index.create(asset, dataAddress)).thenReturn(StoreResult.alreadyExists("test"));
 
         var inserted = service.create(asset, dataAddress);
 

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
@@ -93,7 +93,7 @@ class ContractNegotiationEventDispatchTest {
                 .build();
         contractDefinitionStore.save(contractDefinition);
         policyDefinitionStore.save(PolicyDefinition.Builder.newInstance().id("policyId").policy(policy).build());
-        assetIndex.accept(Asset.Builder.newInstance().id("assetId").build(), DataAddress.Builder.newInstance().type("any").build());
+        assetIndex.create(Asset.Builder.newInstance().id("assetId").build(), DataAddress.Builder.newInstance().type("any").build());
 
         manager.requested(token, createContractOfferRequest(policy));
 

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/assetindex/InMemoryAssetIndex.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/assetindex/InMemoryAssetIndex.java
@@ -105,7 +105,7 @@ public class InMemoryAssetIndex implements AssetIndex {
     }
 
     @Override
-    public StoreResult<Void> accept(AssetEntry item) {
+    public StoreResult<Void> create(AssetEntry item) {
         lock.writeLock().lock();
         try {
             var id = item.getAsset().getId();

--- a/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/assetindex/InMemoryAssetIndexTest.java
+++ b/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/assetindex/InMemoryAssetIndexTest.java
@@ -46,7 +46,7 @@ class InMemoryAssetIndexTest extends AssetIndexTestBase {
     @Test
     void queryAssets() {
         var testAsset = createAsset("foobar");
-        index.accept(testAsset, createDataAddress(testAsset));
+        index.create(testAsset, createDataAddress(testAsset));
         var assets = index.queryAssets(AssetSelectorExpression.Builder.newInstance().whenEquals(Asset.PROPERTY_NAME, "foobar").build());
 
         assertThat(assets).hasSize(1).containsExactly(testAsset);
@@ -55,7 +55,7 @@ class InMemoryAssetIndexTest extends AssetIndexTestBase {
     @Test
     void queryAssets_notFound() {
         var testAsset = createAsset("foobar");
-        index.accept(testAsset, createDataAddress(testAsset));
+        index.create(testAsset, createDataAddress(testAsset));
         var assets = index.queryAssets(AssetSelectorExpression.Builder.newInstance().whenEquals(Asset.PROPERTY_NAME, "barbaz").build());
 
         assertThat(assets).isEmpty();
@@ -64,7 +64,7 @@ class InMemoryAssetIndexTest extends AssetIndexTestBase {
     @Test
     void queryAssets_fieldNull() {
         var testAsset = createAsset("foobar");
-        index.accept(testAsset, createDataAddress(testAsset));
+        index.create(testAsset, createDataAddress(testAsset));
 
         var assets = index.queryAssets(AssetSelectorExpression.Builder.newInstance().whenEquals("description", "barbaz").build());
 
@@ -76,9 +76,9 @@ class InMemoryAssetIndexTest extends AssetIndexTestBase {
         var testAsset1 = createAsset("foobar");
         var testAsset2 = createAsset("barbaz");
         var testAsset3 = createAsset("barbaz");
-        index.accept(testAsset1, createDataAddress(testAsset1));
-        index.accept(testAsset2, createDataAddress(testAsset2));
-        index.accept(testAsset3, createDataAddress(testAsset3));
+        index.create(testAsset1, createDataAddress(testAsset1));
+        index.create(testAsset2, createDataAddress(testAsset2));
+        index.create(testAsset3, createDataAddress(testAsset3));
 
         var assets = index.queryAssets(AssetSelectorExpression.Builder.newInstance()
                 .whenEquals(Asset.PROPERTY_NAME, "barbaz")
@@ -91,10 +91,10 @@ class InMemoryAssetIndexTest extends AssetIndexTestBase {
     @Test
     void queryAssets_selectAll_shouldReturnAll() {
         var testAsset1 = createAsset("barbaz");
-        index.accept(testAsset1, createDataAddress(testAsset1));
+        index.create(testAsset1, createDataAddress(testAsset1));
 
         var testAsset2 = createAsset("foobar");
-        index.accept(testAsset2, createDataAddress(testAsset2));
+        index.create(testAsset2, createDataAddress(testAsset2));
 
         var results = index.queryAssets(SELECT_ALL);
 
@@ -105,7 +105,7 @@ class InMemoryAssetIndexTest extends AssetIndexTestBase {
     void findById() {
         String id = UUID.randomUUID().toString();
         var testAsset = createAsset("barbaz", id);
-        index.accept(testAsset, createDataAddress(testAsset));
+        index.create(testAsset, createDataAddress(testAsset));
 
         var result = index.findById(id);
 
@@ -117,7 +117,7 @@ class InMemoryAssetIndexTest extends AssetIndexTestBase {
     void findById_notfound() {
         String id = UUID.randomUUID().toString();
         var testAsset = createAsset("foobar", id);
-        index.accept(testAsset, createDataAddress(testAsset));
+        index.create(testAsset, createDataAddress(testAsset));
 
         var result = index.findById("not-exist");
 
@@ -129,9 +129,9 @@ class InMemoryAssetIndexTest extends AssetIndexTestBase {
         var testAsset1 = createAsset("foobar");
         var testAsset2 = createAsset("barbaz");
         var testAsset3 = createAsset("barbaz");
-        index.accept(testAsset1, createDataAddress(testAsset1));
-        index.accept(testAsset2, createDataAddress(testAsset2));
-        index.accept(testAsset3, createDataAddress(testAsset3));
+        index.create(testAsset1, createDataAddress(testAsset1));
+        index.create(testAsset2, createDataAddress(testAsset2));
+        index.create(testAsset3, createDataAddress(testAsset3));
 
         var inExpr = List.of(testAsset1.getId(), testAsset2.getId());
         var selector = AssetSelectorExpression.Builder.newInstance()
@@ -148,9 +148,9 @@ class InMemoryAssetIndexTest extends AssetIndexTestBase {
         var testAsset1 = createAsset("foobar");
         var testAsset2 = createAsset("barbaz");
         var testAsset3 = createAsset("barbaz");
-        index.accept(testAsset1, createDataAddress(testAsset1));
-        index.accept(testAsset2, createDataAddress(testAsset2));
-        index.accept(testAsset3, createDataAddress(testAsset3));
+        index.create(testAsset1, createDataAddress(testAsset1));
+        index.create(testAsset2, createDataAddress(testAsset2));
+        index.create(testAsset3, createDataAddress(testAsset3));
 
         var inExpr = List.of("test-id1", "test-id2");
         var selector = AssetSelectorExpression.Builder.newInstance()
@@ -167,9 +167,9 @@ class InMemoryAssetIndexTest extends AssetIndexTestBase {
         var testAsset1 = createAsset("foobar");
         var testAsset2 = createAsset("barbaz");
         var testAsset3 = createAsset("barbaz");
-        index.accept(testAsset1, createDataAddress(testAsset1));
-        index.accept(testAsset2, createDataAddress(testAsset2));
-        index.accept(testAsset3, createDataAddress(testAsset3));
+        index.create(testAsset1, createDataAddress(testAsset1));
+        index.create(testAsset2, createDataAddress(testAsset2));
+        index.create(testAsset3, createDataAddress(testAsset3));
 
         var inExpr = List.of(testAsset1.getId(), testAsset2.getId());
         var selector = AssetSelectorExpression.Builder.newInstance()
@@ -186,9 +186,9 @@ class InMemoryAssetIndexTest extends AssetIndexTestBase {
         var testAsset1 = createAsset("foobar");
         var testAsset2 = createAsset("barbaz");
         var testAsset3 = createAsset("barbaz");
-        index.accept(testAsset1, createDataAddress(testAsset1));
-        index.accept(testAsset2, createDataAddress(testAsset2));
-        index.accept(testAsset3, createDataAddress(testAsset3));
+        index.create(testAsset1, createDataAddress(testAsset1));
+        index.create(testAsset2, createDataAddress(testAsset2));
+        index.create(testAsset3, createDataAddress(testAsset3));
 
         var inExpr = List.of(testAsset1.getId(), testAsset2.getId());
         var selector = AssetSelectorExpression.Builder.newInstance()
@@ -203,7 +203,7 @@ class InMemoryAssetIndexTest extends AssetIndexTestBase {
     @Test
     void findAll_noQuerySpec() {
         var assets = IntStream.range(0, 10).mapToObj(i -> createAsset("test-asset", "id" + i))
-                .peek(a -> index.accept(a, createDataAddress(a))).collect(Collectors.toList());
+                .peek(a -> index.create(a, createDataAddress(a))).collect(Collectors.toList());
 
         assertThat(index.queryAssets(QuerySpec.Builder.newInstance().build())).containsAll(assets);
     }
@@ -212,7 +212,7 @@ class InMemoryAssetIndexTest extends AssetIndexTestBase {
     void findAll_withPaging_noSortOrderDesc() {
         IntStream.range(0, 10)
                 .mapToObj(i -> createAsset("test-asset", "id" + i))
-                .forEach(a -> index.accept(a, createDataAddress(a)));
+                .forEach(a -> index.create(a, createDataAddress(a)));
 
         var spec = QuerySpec.Builder.newInstance().sortOrder(SortOrder.DESC).offset(5).limit(2).build();
 
@@ -224,7 +224,7 @@ class InMemoryAssetIndexTest extends AssetIndexTestBase {
     void findAll_withPaging_noSortOrderAsc() {
         IntStream.range(0, 10)
                 .mapToObj(i -> createAsset("test-asset", "id" + i))
-                .forEach(a -> index.accept(a, createDataAddress(a)));
+                .forEach(a -> index.create(a, createDataAddress(a)));
 
         var spec = QuerySpec.Builder.newInstance().sortOrder(SortOrder.ASC).offset(3).limit(3).build();
 
@@ -236,7 +236,7 @@ class InMemoryAssetIndexTest extends AssetIndexTestBase {
     void findAll_withFiltering() {
         var assets = IntStream.range(0, 10)
                 .mapToObj(i -> createAsset("test-asset", "id" + i))
-                .peek(a -> index.accept(a, createDataAddress(a)))
+                .peek(a -> index.create(a, createDataAddress(a)))
                 .collect(Collectors.toList());
 
         var spec = QuerySpec.Builder.newInstance().equalsAsContains(false).filter(Asset.PROPERTY_ID + " = id1").build();
@@ -247,7 +247,7 @@ class InMemoryAssetIndexTest extends AssetIndexTestBase {
     void findAll_withFiltering_limitExceedsResultSize() {
         IntStream.range(0, 10)
                 .mapToObj(i -> createAsset("test-asset" + i))
-                .forEach(a -> index.accept(a, createDataAddress(a)));
+                .forEach(a -> index.create(a, createDataAddress(a)));
 
         var spec = QuerySpec.Builder.newInstance()
                 .sortOrder(SortOrder.ASC)
@@ -261,7 +261,7 @@ class InMemoryAssetIndexTest extends AssetIndexTestBase {
     void findAll_withSorting() {
         var assets = IntStream.range(0, 10)
                 .mapToObj(i -> createAsset("test-asset", "id" + i))
-                .peek(a -> index.accept(a, createDataAddress(a)))
+                .peek(a -> index.create(a, createDataAddress(a)))
                 .collect(Collectors.toList());
 
         var spec = QuerySpec.Builder.newInstance().sortField(Asset.PROPERTY_ID).sortOrder(SortOrder.ASC).build();
@@ -271,7 +271,7 @@ class InMemoryAssetIndexTest extends AssetIndexTestBase {
     @Test
     void deleteById_whenExists_deletes() {
         var asset = createAsset("foobar");
-        index.accept(asset, createDataAddress(asset));
+        index.create(asset, createDataAddress(asset));
         var deletedAsset = index.deleteById(asset.getId());
 
         assertThat(deletedAsset.succeeded()).isTrue();
@@ -300,7 +300,7 @@ class InMemoryAssetIndexTest extends AssetIndexTestBase {
         var asset = createAsset("test-asset", id);
         var dataAddress = createDataAddress(asset);
 
-        index.accept(asset, dataAddress);
+        index.create(asset, dataAddress);
 
         var newAsset = createAsset("new-name", id);
         var result = index.updateAsset(newAsset);
@@ -321,7 +321,7 @@ class InMemoryAssetIndexTest extends AssetIndexTestBase {
         var asset = createAsset("test-asset", id);
         var dataAddress = createDataAddress(asset);
 
-        index.accept(asset, dataAddress);
+        index.create(asset, dataAddress);
 
         dataAddress.getProperties().put("new", "value");
         var result = index.updateDataAddress(id, dataAddress);

--- a/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/assetindex/InMemoryDataAddressResolverTest.java
+++ b/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/assetindex/InMemoryDataAddressResolverTest.java
@@ -37,7 +37,7 @@ class InMemoryDataAddressResolverTest {
         var id = UUID.randomUUID().toString();
         var testAsset = createAsset("foobar", id);
         var address = createDataAddress(testAsset);
-        resolver.accept(testAsset, address);
+        resolver.create(testAsset, address);
 
         assertThat(resolver.resolveForAsset(testAsset.getId())).isEqualTo(address);
     }
@@ -47,7 +47,7 @@ class InMemoryDataAddressResolverTest {
         var id = UUID.randomUUID().toString();
         var testAsset = createAsset("foobar", id);
         var address = createDataAddress(testAsset);
-        resolver.accept(testAsset, address);
+        resolver.create(testAsset, address);
 
         assertThatThrownBy(() -> resolver.resolveForAsset(null)).isInstanceOf(NullPointerException.class);
     }
@@ -56,7 +56,7 @@ class InMemoryDataAddressResolverTest {
     void resolveForAsset_whenAssetDeleted_raisesException() {
         var testAsset = createAsset("foobar", UUID.randomUUID().toString());
         var address = createDataAddress(testAsset);
-        resolver.accept(testAsset, address);
+        resolver.create(testAsset, address);
         resolver.deleteById(testAsset.getId());
 
         assertThat(resolver.resolveForAsset(testAsset.getId())).isNull();

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/client/MultipartDispatcherIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/client/MultipartDispatcherIntegrationTest.java
@@ -168,7 +168,7 @@ class MultipartDispatcherIntegrationTest {
     @Test
     void testSendContractRequestMessage(RemoteMessageDispatcherRegistry dispatcher, AssetIndex assetIndex) {
         var contractOffer = contractOffer("id");
-        assetIndex.accept(Asset.Builder.newInstance().id("1").build(), DataAddress.Builder.newInstance().type("any").build());
+        assetIndex.create(Asset.Builder.newInstance().id("1").build(), DataAddress.Builder.newInstance().type("any").build());
         when(transformerRegistry.transform(any(), eq(de.fraunhofer.iais.eis.ContractOffer.class))).thenReturn(Result.success(getIdsContractOffer()));
         when(transformerRegistry.transform(any(), eq(ContractOffer.class))).thenReturn(Result.success(contractOffer));
 

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/MultipartControllerIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/MultipartControllerIntegrationTest.java
@@ -262,7 +262,7 @@ class MultipartControllerIntegrationTest {
                 .property("asset:prop:byteSize", BigInteger.valueOf(10))
                 .property("asset:prop:fileExtension", "txt")
                 .build();
-        assetIndex.accept(asset, DataAddress.Builder.newInstance().type("test").build());
+        assetIndex.create(asset, DataAddress.Builder.newInstance().type("test").build());
         var contractOffer = ContractOffer.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
                 .asset(asset)
@@ -398,7 +398,7 @@ class MultipartControllerIntegrationTest {
                 .property("asset:prop:byteSize", BigInteger.valueOf(10))
                 .property("asset:prop:fileExtension", "txt")
                 .build();
-        assetIndex.accept(asset, DataAddress.Builder.newInstance().type("test").build());
+        assetIndex.create(asset, DataAddress.Builder.newInstance().type("test").build());
 
         var request = createRequest(getDescriptionRequestMessage(
                 IdsId.Builder.newInstance().value(assetId).type(IdsType.ARTIFACT).build()
@@ -459,7 +459,7 @@ class MultipartControllerIntegrationTest {
                 .property("asset:prop:byteSize", BigInteger.valueOf(10))
                 .property("asset:prop:fileExtension", "txt")
                 .build();
-        assetIndex.accept(asset, DataAddress.Builder.newInstance().type("test").build());
+        assetIndex.create(asset, DataAddress.Builder.newInstance().type("test").build());
 
         var request = createRequest(getDescriptionRequestMessage(
                 IdsId.Builder.newInstance().value(assetId).type(IdsType.REPRESENTATION).build()
@@ -524,7 +524,7 @@ class MultipartControllerIntegrationTest {
                 .property("asset:prop:byteSize", BigInteger.valueOf(10))
                 .property("asset:prop:fileExtension", "txt")
                 .build();
-        assetIndex.accept(asset, DataAddress.Builder.newInstance().type("test").build());
+        assetIndex.create(asset, DataAddress.Builder.newInstance().type("test").build());
         var contractOffer = ContractOffer.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
                 .asset(asset)
@@ -614,7 +614,7 @@ class MultipartControllerIntegrationTest {
                         ._contractEnd_(CalendarUtil.gregorianNow())
                         .build());
         var asset = Asset.Builder.newInstance().id(assetId).build();
-        assetIndex.accept(asset, DataAddress.Builder.newInstance().type("test").build());
+        assetIndex.create(asset, DataAddress.Builder.newInstance().type("test").build());
 
         var response = httpClient.execute(request);
 
@@ -661,7 +661,7 @@ class MultipartControllerIntegrationTest {
                         ._contractDate_(CalendarUtil.gregorianNow())
                         .build());
         var asset = Asset.Builder.newInstance().id(assetId).build();
-        assetIndex.accept(asset, DataAddress.Builder.newInstance().type("test").build());
+        assetIndex.create(asset, DataAddress.Builder.newInstance().type("test").build());
         when(consumerContractNegotiationManager.confirmed(any(), any(), any(), any())).thenReturn(StatusResult.success(createContractNegotiation("id")));
 
         var response = httpClient.execute(request);

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/AssetApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/AssetApiControllerIntegrationTest.java
@@ -71,7 +71,7 @@ public class AssetApiControllerIntegrationTest {
     void getAllAssets(AssetIndex assetIndex) {
         var asset = Asset.Builder.newInstance().id("id").build();
         var dataAddress = DataAddress.Builder.newInstance().type("type").build();
-        assetIndex.accept(asset, dataAddress);
+        assetIndex.create(asset, dataAddress);
 
         baseRequest()
                 .get("/assets")
@@ -85,7 +85,7 @@ public class AssetApiControllerIntegrationTest {
     void getAllAssetsQuery(AssetIndex assetIndex) {
         var asset = Asset.Builder.newInstance().id("id").build();
         var dataAddress = DataAddress.Builder.newInstance().type("type").build();
-        assetIndex.accept(asset, dataAddress);
+        assetIndex.create(asset, dataAddress);
 
         baseRequest()
                 .get("/assets?limit=1&offset=0&filter=asset:prop:id=id&sort=DESC&sortField=properties.asset:prop:id")
@@ -107,7 +107,7 @@ public class AssetApiControllerIntegrationTest {
     void queryAllAssets(AssetIndex assetIndex) {
         var asset = Asset.Builder.newInstance().id("id").build();
         var dataAddress = DataAddress.Builder.newInstance().type("type").build();
-        assetIndex.accept(asset, dataAddress);
+        assetIndex.create(asset, dataAddress);
 
         baseRequest()
                 .contentType(JSON)
@@ -122,7 +122,7 @@ public class AssetApiControllerIntegrationTest {
     void queryAllAssetsQuery(AssetIndex assetIndex) {
         var asset = Asset.Builder.newInstance().id("id").build();
         var dataAddress = DataAddress.Builder.newInstance().type("type").build();
-        assetIndex.accept(asset, dataAddress);
+        assetIndex.create(asset, dataAddress);
 
         baseRequest()
                 .contentType(JSON)
@@ -138,7 +138,7 @@ public class AssetApiControllerIntegrationTest {
     void queryAll_noResults(AssetIndex assetIndex) {
         var asset = Asset.Builder.newInstance().id("id").build();
         var dataAddress = DataAddress.Builder.newInstance().type("type").build();
-        assetIndex.accept(asset, dataAddress);
+        assetIndex.create(asset, dataAddress);
 
         baseRequest()
                 .contentType(JSON)
@@ -154,7 +154,7 @@ public class AssetApiControllerIntegrationTest {
     void getSingleAsset(AssetIndex assetIndex) {
         var asset = Asset.Builder.newInstance().id("id").build();
         var dataAddress = DataAddress.Builder.newInstance().type("type").build();
-        assetIndex.accept(asset, dataAddress);
+        assetIndex.create(asset, dataAddress);
 
         baseRequest()
                 .get("/assets/id")
@@ -223,7 +223,7 @@ public class AssetApiControllerIntegrationTest {
     void postAssetId_alreadyExists(AssetIndex assetIndex) {
         var asset = Asset.Builder.newInstance().id("assetId").build();
         var dataAddress = DataAddress.Builder.newInstance().type("type").build();
-        assetIndex.accept(asset, dataAddress);
+        assetIndex.create(asset, dataAddress);
         var assetEntryDto = createAssetEntryDto("assetId");
 
         baseRequest()
@@ -250,7 +250,7 @@ public class AssetApiControllerIntegrationTest {
     void deleteAsset(AssetIndex assetIndex) {
         var asset = Asset.Builder.newInstance().id("assetId").build();
         var dataAddress = DataAddress.Builder.newInstance().type("type").build();
-        assetIndex.accept(asset, dataAddress);
+        assetIndex.create(asset, dataAddress);
 
         baseRequest()
                 .contentType(JSON)
@@ -273,7 +273,7 @@ public class AssetApiControllerIntegrationTest {
     void deleteAsset_alreadyReferencedInAgreement(ContractNegotiationStore negotiationStore, AssetIndex assetIndex) {
         var asset = Asset.Builder.newInstance().id("assetId").build();
         var dataAddress = DataAddress.Builder.newInstance().type("type").build();
-        assetIndex.accept(asset, dataAddress);
+        assetIndex.create(asset, dataAddress);
         negotiationStore.save(createContractNegotiation(asset));
 
         baseRequest()
@@ -287,7 +287,7 @@ public class AssetApiControllerIntegrationTest {
     void getAssetAddress(AssetIndex assetIndex) {
         var asset = Asset.Builder.newInstance().id("id").build();
         var dataAddress = DataAddress.Builder.newInstance().type("type").build();
-        assetIndex.accept(asset, dataAddress);
+        assetIndex.create(asset, dataAddress);
 
         baseRequest()
                 .get("/assets/id/address")
@@ -309,7 +309,7 @@ public class AssetApiControllerIntegrationTest {
     void updateAsset_whenExists(AssetIndex assetIndex) {
         var asset = Asset.Builder.newInstance().id("assetId").build();
         var dataAddress = DataAddress.Builder.newInstance().type("type").build();
-        assetIndex.accept(asset, dataAddress);
+        assetIndex.create(asset, dataAddress);
 
         asset.getProperties().put("anotherKey", "anotherVal");
 
@@ -344,7 +344,7 @@ public class AssetApiControllerIntegrationTest {
     void updateDataAddress_whenAssetExists(AssetIndex assetIndex, DataAddressResolver resolver) {
         var asset = Asset.Builder.newInstance().id("assetId").build();
         var dataAddress = DataAddress.Builder.newInstance().type("type").build();
-        assetIndex.accept(asset, dataAddress);
+        assetIndex.create(asset, dataAddress);
 
         dataAddress.getProperties().put("anotherKey", "anotherVal");
 

--- a/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
+++ b/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
@@ -97,7 +97,7 @@ public class HttpProvisionerExtensionEndToEndTest {
                                      TransferProcessStore store, PolicyDefinitionStore policyStore) throws Exception {
         negotiationStore.save(createContractNegotiation());
         policyStore.save(createPolicyDefinition());
-        assetIndex.accept(createAssetEntry());
+        assetIndex.create(createAssetEntry());
 
         when(delegate.intercept(any()))
                 .thenAnswer(invocation -> createResponse(503, invocation))

--- a/extensions/control-plane/store/cosmos/asset-index-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/assetindex/CosmosAssetIndex.java
+++ b/extensions/control-plane/store/cosmos/asset-index-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/assetindex/CosmosAssetIndex.java
@@ -103,7 +103,7 @@ public class CosmosAssetIndex implements AssetIndex {
     }
 
     @Override
-    public StoreResult<Void> accept(AssetEntry item) {
+    public StoreResult<Void> create(AssetEntry item) {
         var assetDocument = new AssetDocument(item.getAsset(), partitionKey, item.getDataAddress());
         try {
             assetDb.createItem(assetDocument);

--- a/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/assetindex/SqlAssetIndex.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/assetindex/SqlAssetIndex.java
@@ -122,7 +122,7 @@ public class SqlAssetIndex extends AbstractSqlStore implements AssetIndex {
     }
 
     @Override
-    public StoreResult<Void> accept(AssetEntry item) {
+    public StoreResult<Void> create(AssetEntry item) {
         Objects.requireNonNull(item);
         var asset = item.getAsset();
         var dataAddress = item.getDataAddress();

--- a/extensions/control-plane/store/sql/asset-index-sql/src/test/java/org/eclipse/edc/connector/store/sql/assetindex/PostgresAssetIndexTest.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/test/java/org/eclipse/edc/connector/store/sql/assetindex/PostgresAssetIndexTest.java
@@ -100,7 +100,7 @@ class PostgresAssetIndexTest extends AssetIndexTestBase {
     void query_assetPropertyAsObject() {
         var asset = TestFunctions.createAsset("id1");
         asset.getProperties().put("testobj", new TestObject("test123", 42, false));
-        sqlAssetIndex.accept(asset, TestFunctions.createDataAddress("test-type"));
+        sqlAssetIndex.create(asset, TestFunctions.createDataAddress("test-type"));
 
         var assetsFound = sqlAssetIndex.queryAssets(AssetSelectorExpression.Builder.newInstance()
                 .constraint("testobj", "like", "%test1%")
@@ -123,7 +123,7 @@ class PostgresAssetIndexTest extends AssetIndexTestBase {
     @DisplayName("Verify an asset query where the operator is invalid (=not supported)")
     void queryAgreements_withQuerySpec_invalidOperator() {
         var asset = TestFunctions.createAssetBuilder("id1").property("testproperty", "testvalue").build();
-        sqlAssetIndex.accept(asset, TestFunctions.createDataAddress("test-type"));
+        sqlAssetIndex.create(asset, TestFunctions.createDataAddress("test-type"));
 
         var query = QuerySpec.Builder.newInstance().filter("testproperty <> foobar").build();
         assertThatThrownBy(() -> sqlAssetIndex.queryAssets(query)).isInstanceOf(IllegalArgumentException.class);
@@ -144,7 +144,7 @@ class PostgresAssetIndexTest extends AssetIndexTestBase {
                     .property("test-key", "test-value" + i)
                     .build();
             var dataAddress = TestFunctions.createDataAddress("test-type");
-            sqlAssetIndex.accept(asset, dataAddress);
+            sqlAssetIndex.create(asset, dataAddress);
             return asset;
         }).collect(Collectors.toList());
     }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/asset/AssetIndex.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/asset/AssetIndex.java
@@ -83,11 +83,11 @@ public interface AssetIndex extends DataAddressResolver {
      * @param dataAddress The {@link DataAddress} to store
      * @return {@link StoreResult#success()} if the objects were stored, {@link StoreResult#alreadyExists(String)} when an object with the same ID already exists.
      */
-    default StoreResult<Void> accept(Asset asset, DataAddress dataAddress) {
-        return accept(new AssetEntry(asset, dataAddress));
+    default StoreResult<Void> create(Asset asset, DataAddress dataAddress) {
+        return create(new AssetEntry(asset, dataAddress));
     }
 
-    StoreResult<Void> accept(AssetEntry item);
+    StoreResult<Void> create(AssetEntry item);
 
     /**
      * Deletes an asset if it exists.

--- a/spi/common/core-spi/src/testFixtures/java/org/eclipse/edc/spi/testfixtures/asset/AssetIndexTestBase.java
+++ b/spi/common/core-spi/src/testFixtures/java/org/eclipse/edc/spi/testfixtures/asset/AssetIndexTestBase.java
@@ -67,7 +67,7 @@ public abstract class AssetIndexTestBase {
     @DisplayName("Accept an asset and a data address that don't exist yet")
     void acceptAssetAndDataAddress_doesNotExist() {
         var assetExpected = getAsset("id1");
-        getAssetIndex().accept(assetExpected, getDataAddress());
+        getAssetIndex().create(assetExpected, getDataAddress());
 
         var assetFound = getAssetIndex().findById("id1");
 
@@ -81,7 +81,7 @@ public abstract class AssetIndexTestBase {
         var asset = createAsset("test-asset", UUID.randomUUID().toString());
         var dataAddress = createDataAddress(asset);
         var assetIndex = getAssetIndex();
-        var result = assetIndex.accept(asset, dataAddress);
+        var result = assetIndex.create(asset, dataAddress);
         assertThat(result.succeeded()).isTrue();
 
         assertThat(assetIndex.queryAssets(QuerySpec.none())).hasSize(1)
@@ -96,10 +96,10 @@ public abstract class AssetIndexTestBase {
         var asset = createAsset("test-asset", UUID.randomUUID().toString());
         var dataAddress = createDataAddress(asset);
         var assetIndex = getAssetIndex();
-        assetIndex.accept(asset, dataAddress);
+        assetIndex.create(asset, dataAddress);
 
         DataAddress dataAddress1 = createDataAddress(asset);
-        var result = assetIndex.accept(asset, dataAddress1);
+        var result = assetIndex.create(asset, dataAddress1);
 
         assertThat(result.succeeded()).isFalse();
         assertThat(result.reason()).isEqualTo(ALREADY_EXISTS);
@@ -120,7 +120,7 @@ public abstract class AssetIndexTestBase {
         var address2 = createDataAddress(asset2);
 
         var assetIndex = getAssetIndex();
-        var results = Stream.of(new AssetEntry(asset1, address1), new AssetEntry(asset2, address2)).map(assetIndex::accept);
+        var results = Stream.of(new AssetEntry(asset1, address1), new AssetEntry(asset2, address2)).map(assetIndex::create);
 
         assertThat(results).allSatisfy(sr -> assertThat(sr.succeeded()).isTrue());
         assertThat(assetIndex.queryAssets(QuerySpec.none())).hasSize(2)
@@ -137,7 +137,7 @@ public abstract class AssetIndexTestBase {
         var address2 = createDataAddress(asset1);
 
         var results = List.of(new AssetEntry(asset1, address1), new AssetEntry(asset1, address2))
-                .stream().map(entry -> getAssetIndex().accept(entry));
+                .stream().map(entry -> getAssetIndex().create(entry));
 
         assertThat(results).extracting(StoreResult::succeeded).contains(true, false);
         // only one address/asset combo should exist
@@ -151,7 +151,7 @@ public abstract class AssetIndexTestBase {
     @DisplayName("Verify that the object was stored with the correct timestamp")
     void accept_verifyTimestamp() {
         var asset = getAsset("test-asset");
-        getAssetIndex().accept(asset, getDataAddress());
+        getAssetIndex().create(asset, getDataAddress());
 
         var allAssets = getAssetIndex().queryAssets(QuerySpec.none());
 
@@ -163,8 +163,8 @@ public abstract class AssetIndexTestBase {
     @DisplayName("Accept an asset and a data address that already exist")
     void acceptAssetAndDataAddress_exists() {
         var asset = getAsset("id1");
-        getAssetIndex().accept(asset, getDataAddress());
-        getAssetIndex().accept(asset, getDataAddress());
+        getAssetIndex().create(asset, getDataAddress());
+        getAssetIndex().create(asset, getDataAddress());
 
         var assets = getAssetIndex().queryAssets(QuerySpec.none());
 
@@ -177,7 +177,7 @@ public abstract class AssetIndexTestBase {
     @DisplayName("Accept an asset entry that doesn't exist yet")
     void acceptAssetEntry_doesNotExist() {
         var assetExpected = getAsset("id1");
-        getAssetIndex().accept(new AssetEntry(assetExpected, getDataAddress()));
+        getAssetIndex().create(new AssetEntry(assetExpected, getDataAddress()));
 
 
         var assetFound = getAssetIndex().findById("id1");
@@ -191,8 +191,8 @@ public abstract class AssetIndexTestBase {
     @DisplayName("Accept an asset entry that already exists")
     void acceptEntry_exists() {
         var asset = getAsset("id1");
-        getAssetIndex().accept(new AssetEntry(asset, getDataAddress()));
-        getAssetIndex().accept(asset, getDataAddress());
+        getAssetIndex().create(new AssetEntry(asset, getDataAddress()));
+        getAssetIndex().create(asset, getDataAddress());
 
         var assets = getAssetIndex().queryAssets(QuerySpec.none());
 
@@ -213,7 +213,7 @@ public abstract class AssetIndexTestBase {
     @DisplayName("Delete an asset that exists")
     void deleteAsset_exists() {
         var asset = getAsset("id1");
-        getAssetIndex().accept(asset, getDataAddress());
+        getAssetIndex().create(asset, getDataAddress());
 
         var assetDeleted = getAssetIndex().deleteById("id1");
 
@@ -226,7 +226,7 @@ public abstract class AssetIndexTestBase {
     @Test
     void count_withResults() {
         var assets = range(0, 5).mapToObj(i -> getAsset("id" + i));
-        assets.forEach(a -> getAssetIndex().accept(a, getDataAddress()));
+        assets.forEach(a -> getAssetIndex().create(a, getDataAddress()));
         var criteria = Collections.<Criterion>emptyList();
 
         var count = getAssetIndex().countAssets(criteria);
@@ -247,9 +247,9 @@ public abstract class AssetIndexTestBase {
     @DisplayName("Query assets with selector expression using the IN operator")
     void queryAsset_selectorExpression_in() {
         var asset1 = getAsset("id1");
-        getAssetIndex().accept(asset1, getDataAddress());
+        getAssetIndex().create(asset1, getDataAddress());
         var asset2 = getAsset("id2");
-        getAssetIndex().accept(asset2, getDataAddress());
+        getAssetIndex().create(asset2, getDataAddress());
 
         var assetsFound = getAssetIndex().queryAssets(AssetSelectorExpression.Builder.newInstance()
                 .constraint(Asset.PROPERTY_ID, "in", List.of("id1", "id2"))
@@ -262,9 +262,9 @@ public abstract class AssetIndexTestBase {
     @DisplayName("Query assets with selector expression using the IN operator, invalid righ-operand")
     void queryAsset_selectorExpression_invalidOperand() {
         var asset1 = getAsset("id1");
-        getAssetIndex().accept(asset1, getDataAddress());
+        getAssetIndex().create(asset1, getDataAddress());
         var asset2 = getAsset("id2");
-        getAssetIndex().accept(asset2, getDataAddress());
+        getAssetIndex().create(asset2, getDataAddress());
 
         var exception = catchException(() -> getAssetIndex().queryAssets(AssetSelectorExpression.Builder.newInstance().constraint(Asset.PROPERTY_ID, "in", "(id1, id2)").build())
                 .collect(Collectors.toList())); // must collect, otherwise the stream may not get materialized
@@ -277,9 +277,9 @@ public abstract class AssetIndexTestBase {
     @EnabledIfSystemProperty(named = "assetindex.supports.operator.like", matches = "true", disabledReason = "This test only runs if the LIKE operator is supported")
     void queryAsset_selectorExpression_like() {
         var asset1 = getAsset("id1");
-        getAssetIndex().accept(asset1, getDataAddress());
+        getAssetIndex().create(asset1, getDataAddress());
         var asset2 = getAsset("id2");
-        getAssetIndex().accept(asset2, getDataAddress());
+        getAssetIndex().create(asset2, getDataAddress());
 
         var assetsFound = getAssetIndex().queryAssets(AssetSelectorExpression.Builder.newInstance()
                 .constraint(Asset.PROPERTY_ID, "LIKE", "id%")
@@ -294,7 +294,7 @@ public abstract class AssetIndexTestBase {
     void queryAsset_selectorExpression_likeJson() throws JsonProcessingException {
         var asset = getAsset("id1");
         asset.getProperties().put("myjson", new ObjectMapper().writeValueAsString(new TestObject("test123", 42, false)));
-        getAssetIndex().accept(asset, getDataAddress());
+        getAssetIndex().create(asset, getDataAddress());
 
         var assetsFound = getAssetIndex().queryAssets(AssetSelectorExpression.Builder.newInstance()
                 .constraint("myjson", "LIKE", "%test123%")
@@ -308,7 +308,7 @@ public abstract class AssetIndexTestBase {
     void queryAsset_querySpec() {
         for (var i = 1; i <= 10; i++) {
             var asset = getAsset("id" + i);
-            getAssetIndex().accept(asset, getDataAddress());
+            getAssetIndex().create(asset, getDataAddress());
         }
 
         var assetsFound = getAssetIndex().queryAssets(getQuerySpec());
@@ -320,7 +320,7 @@ public abstract class AssetIndexTestBase {
     @DisplayName("Query assets with query spec where the property (=leftOperand) does not exist")
     void queryAsset_querySpec_nonExistProperty() {
         var asset = getAsset("id1");
-        getAssetIndex().accept(asset, getDataAddress());
+        getAssetIndex().create(asset, getDataAddress());
 
         var qs = QuerySpec.Builder
                 .newInstance()
@@ -335,7 +335,7 @@ public abstract class AssetIndexTestBase {
     void queryAsset_querySpec_likeJson() throws JsonProcessingException {
         var asset = getAsset("id1");
         asset.getProperties().put("myjson", new ObjectMapper().writeValueAsString(new TestObject("test123", 42, false)));
-        getAssetIndex().accept(asset, getDataAddress());
+        getAssetIndex().create(asset, getDataAddress());
 
         var assetsFound = getAssetIndex().queryAssets(QuerySpec.Builder.newInstance()
                 .filter(List.of(new Criterion("myjson", "LIKE", "%test123%")))
@@ -349,7 +349,7 @@ public abstract class AssetIndexTestBase {
     void queryAsset_querySpec_nonExistValue() {
         var asset = getAsset("id1");
         asset.getProperties().put("someprop", "someval");
-        getAssetIndex().accept(asset, getDataAddress());
+        getAssetIndex().create(asset, getDataAddress());
 
         var qs = QuerySpec.Builder
                 .newInstance()
@@ -363,7 +363,7 @@ public abstract class AssetIndexTestBase {
     void queryAsset_querySpecShortCount() {
         range(1, 5).forEach((item) -> {
             var asset = getAsset("id" + item);
-            getAssetIndex().accept(asset, getDataAddress());
+            getAssetIndex().create(asset, getDataAddress());
         });
 
         var assetsFound = getAssetIndex().queryAssets(getQuerySpec());
@@ -382,7 +382,7 @@ public abstract class AssetIndexTestBase {
         var asset = getAsset("id1");
         asset.getProperties().put("version", "2.0");
         asset.getProperties().put("contenttype", "whatever");
-        getAssetIndex().accept(asset, getDataAddress());
+        getAssetIndex().create(asset, getDataAddress());
 
         var result = getAssetIndex().queryAssets(qs.build());
         assertThat(result).usingRecursiveFieldByFieldElementComparator().containsOnly(asset);
@@ -399,7 +399,7 @@ public abstract class AssetIndexTestBase {
     @DisplayName("Find an asset that exists")
     void findAsset_exists() {
         var asset = getAsset("id1");
-        getAssetIndex().accept(asset, getDataAddress());
+        getAssetIndex().create(asset, getDataAddress());
 
         var assetFound = getAssetIndex().findById("id1");
 
@@ -418,7 +418,7 @@ public abstract class AssetIndexTestBase {
     void resolveDataAddress_exists() {
         var asset = getAsset("id1");
         var dataAddress = getDataAddress();
-        getAssetIndex().accept(asset, dataAddress);
+        getAssetIndex().create(asset, dataAddress);
 
         var dataAddressFound = getAssetIndex().resolveForAsset("id1");
 
@@ -443,7 +443,7 @@ public abstract class AssetIndexTestBase {
         var id = "id1";
         var asset = getAsset(id);
         var assetIndex = getAssetIndex();
-        assetIndex.accept(asset, getDataAddress());
+        assetIndex.create(asset, getDataAddress());
 
         assertThat(assetIndex.countAssets(List.of())).isEqualTo(1);
 
@@ -466,7 +466,7 @@ public abstract class AssetIndexTestBase {
         var asset = getAsset(id);
         asset.getProperties().put("newKey", "newValue");
         var assetIndex = getAssetIndex();
-        assetIndex.accept(asset, getDataAddress());
+        assetIndex.create(asset, getDataAddress());
 
         assertThat(assetIndex.countAssets(List.of())).isEqualTo(1);
 
@@ -490,7 +490,7 @@ public abstract class AssetIndexTestBase {
         var asset = getAsset(id);
         asset.getProperties().put("newKey", "originalValue");
         var assetIndex = getAssetIndex();
-        assetIndex.accept(asset, getDataAddress());
+        assetIndex.create(asset, getDataAddress());
 
         assertThat(assetIndex.countAssets(List.of())).isEqualTo(1);
 
@@ -525,7 +525,7 @@ public abstract class AssetIndexTestBase {
         var asset = getAsset(id);
         var assetIndex = getAssetIndex();
         var dataAddress = getDataAddress();
-        assetIndex.accept(asset, dataAddress);
+        assetIndex.create(asset, dataAddress);
 
         var updatedDataAddress = getDataAddress();
         updatedDataAddress.getProperties().put("newKey", "newValue");
@@ -547,7 +547,7 @@ public abstract class AssetIndexTestBase {
         var assetIndex = getAssetIndex();
         var dataAddress = getDataAddress();
         dataAddress.getProperties().put("newKey", "newValue");
-        assetIndex.accept(asset, dataAddress);
+        assetIndex.create(asset, dataAddress);
 
         var updatedDataAddress = dataAddress;
         updatedDataAddress.getProperties().remove("newKey");
@@ -570,7 +570,7 @@ public abstract class AssetIndexTestBase {
         var assetIndex = getAssetIndex();
         var dataAddress = getDataAddress();
         dataAddress.getProperties().put("newKey", "originalValue");
-        assetIndex.accept(asset, dataAddress);
+        assetIndex.create(asset, dataAddress);
 
         var updatedDataAddress = dataAddress;
         updatedDataAddress.getProperties().put("newKey", "newValue");

--- a/system-tests/runtimes/file-transfer-provider/src/main/java/org/eclipse/edc/test/extension/api/FileTransferExtension.java
+++ b/system-tests/runtimes/file-transfer-provider/src/main/java/org/eclipse/edc/test/extension/api/FileTransferExtension.java
@@ -99,7 +99,7 @@ public class FileTransferExtension implements ServiceExtension {
         var assetId = "test-document";
         var asset = Asset.Builder.newInstance().id(assetId).build();
 
-        assetIndex.accept(asset, dataAddress);
+        assetIndex.create(asset, dataAddress);
     }
 
     private void registerContractDefinition(String policyId) {


### PR DESCRIPTION
… operations.

## What this PR changes/adds

The persistence implementations in AssetIndex are refactrored in CRUD interactions.


## Why it does that

consistency, recognizability


## Further notes


## Linked Issue(s)

ref #2559 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
