### PR TITLE
refactor: persistence implementations in ContractNegotiationStore har…

### DIFF
--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/AbstractContractNegotiationManager.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/AbstractContractNegotiationManager.java
@@ -272,8 +272,10 @@ public abstract class AbstractContractNegotiationManager {
         negotiationStore.save(negotiation);
     }
 
+
     @NotNull
     private EntityRetryProcessConfiguration defaultEntityRetryProcessConfiguration() {
         return new EntityRetryProcessConfiguration(DEFAULT_SEND_RETRY_LIMIT, () -> new ExponentialWaitStrategy(DEFAULT_SEND_RETRY_BASE_DELAY));
+
     }
 }

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -118,7 +118,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
     @Override
     // TODO: should be renamed to agreed
     public StatusResult<ContractNegotiation> confirmed(ClaimToken token, String negotiationId, ContractAgreement agreement, Policy policy) {
-        var negotiation = negotiationStore.find(negotiationId);
+        var negotiation = negotiationStore.findById(negotiationId);
         if (negotiation == null) {
             return StatusResult.failure(FATAL_ERROR, format("ContractNegotiation with id %s not found", negotiationId));
         }
@@ -145,7 +145,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
 
     @Override
     public StatusResult<ContractNegotiation> finalized(String negotiationId) {
-        var negotiation = negotiationStore.find(negotiationId);
+        var negotiation = negotiationStore.findById(negotiationId);
         if (negotiation == null) {
             return StatusResult.failure(FATAL_ERROR, format("ContractNegotiation with id %s not found", negotiationId));
         }
@@ -186,7 +186,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
     }
 
     private ContractNegotiation findContractNegotiationById(String negotiationId) {
-        var negotiation = negotiationStore.find(negotiationId);
+        var negotiation = negotiationStore.findById(negotiationId);
         if (negotiation == null) {
             negotiation = negotiationStore.findForCorrelationId(negotiationId);
         }
@@ -225,7 +225,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
                 .build();
 
         return entityRetryProcessFactory.doAsyncProcess(negotiation, () -> dispatcherRegistry.send(Object.class, request))
-                .entityRetrieve(negotiationStore::find)
+                .entityRetrieve(negotiationStore::findById)
                 .onDelay(this::breakLease)
                 .onSuccess((n, result) -> transitToRequested(n))
                 .onFailure((n, throwable) -> transitToRequesting(n))
@@ -274,7 +274,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
                 .build();
 
         return entityRetryProcessFactory.doAsyncProcess(negotiation, () -> dispatcherRegistry.send(Object.class, request))
-                .entityRetrieve(negotiationStore::find)
+                .entityRetrieve(negotiationStore::findById)
                 .onDelay(this::breakLease)
                 .onSuccess((n, result) -> transitToApproved(n))
                 .onFailure((n, throwable) -> transitToApproving(n))
@@ -315,7 +315,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
                 .build();
 
         return entityRetryProcessFactory.doAsyncProcess(negotiation, () -> dispatcherRegistry.send(Object.class, message))
-                .entityRetrieve(negotiationStore::find)
+                .entityRetrieve(negotiationStore::findById)
                 .onDelay(this::breakLease)
                 .onSuccess((n, result) -> transitToVerified(n))
                 .onFailure((n, throwable) -> transitToVerifying(n))
@@ -341,7 +341,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
                 .build();
 
         return entityRetryProcessFactory.doAsyncProcess(negotiation, () -> dispatcherRegistry.send(Object.class, rejection))
-                .entityRetrieve(negotiationStore::find)
+                .entityRetrieve(negotiationStore::findById)
                 .onDelay(this::breakLease)
                 .onSuccess((n, result) -> transitToTerminated(n))
                 .onFailure((n, throwable) -> transitToTerminating(n))

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -151,7 +151,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
 
     @Override
     public StatusResult<ContractNegotiation> verified(String negotiationId) {
-        var negotiation = negotiationStore.find(negotiationId);
+        var negotiation = negotiationStore.findById(negotiationId);
         if (negotiation == null) {
             return StatusResult.failure(FATAL_ERROR, format("ContractNegotiation with id %s not found", negotiationId));
         }
@@ -166,7 +166,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
     }
 
     private ContractNegotiation findContractNegotiationById(String negotiationId) {
-        var negotiation = negotiationStore.find(negotiationId);
+        var negotiation = negotiationStore.findById(negotiationId);
         if (negotiation == null) {
             negotiation = negotiationStore.findForCorrelationId(negotiationId);
         }
@@ -206,7 +206,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
                 .build();
 
         return entityRetryProcessFactory.doAsyncProcess(negotiation, () -> dispatcherRegistry.send(Object.class, contractOfferRequest))
-                .entityRetrieve(negotiationStore::find)
+                .entityRetrieve(negotiationStore::findById)
                 .onDelay(this::breakLease)
                 .onSuccess((n, result) -> transitToOffered(n))
                 .onFailure((n, throwable) -> transitToOffering(n))
@@ -232,7 +232,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
                 .build();
 
         return entityRetryProcessFactory.doAsyncProcess(negotiation, () -> dispatcherRegistry.send(Object.class, rejection))
-                .entityRetrieve(negotiationStore::find)
+                .entityRetrieve(negotiationStore::findById)
                 .onDelay(this::breakLease)
                 .onSuccess((n, result) -> transitToTerminated(n))
                 .onFailure((n, throwable) -> transitToTerminating(n))
@@ -290,7 +290,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
                 .build();
 
         return entityRetryProcessFactory.doAsyncProcess(negotiation, () -> dispatcherRegistry.send(Object.class, request))
-                .entityRetrieve(negotiationStore::find)
+                .entityRetrieve(negotiationStore::findById)
                 .onDelay(this::breakLease)
                 .onSuccess((n, result) -> transitToProviderAgreed(n, agreement))
                 .onFailure((n, throwable) -> transitToProviderAgreeing(n))
@@ -327,7 +327,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
                 .build();
 
         return entityRetryProcessFactory.doAsyncProcess(negotiation, () -> dispatcherRegistry.send(Object.class, message))
-                .entityRetrieve(negotiationStore::find)
+                .entityRetrieve(negotiationStore::findById)
                 .onDelay(this::breakLease)
                 .onSuccess((n, result) -> transitToFinalized(n))
                 .onFailure((n, throwable) -> transitToFinalizing(n))

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/command/handlers/SingleContractNegotiationCommandHandler.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/command/handlers/SingleContractNegotiationCommandHandler.java
@@ -46,7 +46,7 @@ public abstract class SingleContractNegotiationCommandHandler<T extends SingleCo
     @Override
     public void handle(SingleContractNegotiationCommand command) {
         var negotiationId = command.getNegotiationId();
-        var negotiation = store.find(negotiationId);
+        var negotiation = store.findById(negotiationId);
         if (negotiation == null) {
             throw new EdcException(format("Could not find ContractNegotiation with ID [%s]", negotiationId));
         } else {

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -148,7 +148,7 @@ class ContractNegotiationIntegrationTest {
                 .pollInterval(DEFAULT_POLL_INTERVAL)
                 .untilAsserted(() -> {
                     assertThat(consumerNegotiationId).isNotNull();
-                    var consumerNegotiation = consumerStore.find(consumerNegotiationId);
+                    var consumerNegotiation = consumerStore.findById(consumerNegotiationId);
                     var providerNegotiation = providerStore.findForCorrelationId(consumerNegotiationId);
                     assertThat(consumerNegotiation).isNotNull();
                     assertThat(providerNegotiation).isNotNull();
@@ -193,7 +193,7 @@ class ContractNegotiationIntegrationTest {
                 .untilAsserted(() -> {
 
                     assertThat(consumerNegotiationId).isNotNull();
-                    var consumerNegotiation = consumerStore.find(consumerNegotiationId);
+                    var consumerNegotiation = consumerStore.findById(consumerNegotiationId);
                     var providerNegotiation = providerStore.findForCorrelationId(consumerNegotiationId);
                     assertThat(consumerNegotiation).isNotNull();
                     assertThat(providerNegotiation).isNotNull();
@@ -239,7 +239,7 @@ class ContractNegotiationIntegrationTest {
                 .pollInterval(DEFAULT_POLL_INTERVAL)
                 .untilAsserted(() -> {
                     assertThat(consumerNegotiationId).isNotNull();
-                    var consumerNegotiation = consumerStore.find(consumerNegotiationId);
+                    var consumerNegotiation = consumerStore.findById(consumerNegotiationId);
                     var providerNegotiation = providerStore.findForCorrelationId(consumerNegotiationId);
                     assertThat(consumerNegotiation).isNotNull();
                     assertThat(providerNegotiation).isNotNull();

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
@@ -174,7 +174,7 @@ class ProviderContractNegotiationManagerImplTest {
     @Test
     void verified_shouldTransitToVerifiedState() {
         var negotiation = contractNegotiationBuilder().id("negotiationId").state(PROVIDER_AGREED.code()).build();
-        when(store.find("negotiationId")).thenReturn(negotiation);
+        when(store.findById("negotiationId")).thenReturn(negotiation);
 
         var result = negotiationManager.verified("negotiationId");
 
@@ -185,7 +185,7 @@ class ProviderContractNegotiationManagerImplTest {
 
     @Test
     void verified_shouldFail_whenNegotiationDoesNotExist() {
-        when(store.find("negotiationId")).thenReturn(null);
+        when(store.findById("negotiationId")).thenReturn(null);
 
         var result = negotiationManager.verified("negotiationId");
 
@@ -195,7 +195,7 @@ class ProviderContractNegotiationManagerImplTest {
     @Test
     void declined() {
         var negotiation = createContractNegotiation();
-        when(store.find(negotiation.getId())).thenReturn(negotiation);
+        when(store.findById(negotiation.getId())).thenReturn(negotiation);
         when(store.findForCorrelationId(negotiation.getCorrelationId())).thenReturn(negotiation);
         var token = ClaimToken.Builder.newInstance().build();
 
@@ -211,7 +211,7 @@ class ProviderContractNegotiationManagerImplTest {
         var negotiation = contractNegotiationBuilder().state(PROVIDER_OFFERING.code()).contractOffer(contractOffer()).build();
         when(store.nextForState(eq(PROVIDER_OFFERING.code()), anyInt())).thenReturn(List.of(negotiation)).thenReturn(emptyList());
         when(dispatcherRegistry.send(any(), any())).thenReturn(completedFuture(null));
-        when(store.find(negotiation.getId())).thenReturn(negotiation);
+        when(store.findById(negotiation.getId())).thenReturn(negotiation);
 
         negotiationManager.start();
 
@@ -227,7 +227,8 @@ class ProviderContractNegotiationManagerImplTest {
         var negotiation = contractNegotiationBuilder().state(PROVIDER_OFFERING.code()).stateCount(RETRIES_NOT_EXHAUSTED).contractOffer(contractOffer()).build();
         when(store.nextForState(eq(PROVIDER_OFFERING.code()), anyInt())).thenReturn(List.of(negotiation)).thenReturn(emptyList());
         when(dispatcherRegistry.send(any(), any())).thenReturn(failedFuture(new EdcException("error")));
-        when(store.find(negotiation.getId())).thenReturn(negotiation);
+        when(store.findById(negotiation.getId())).thenReturn(negotiation);
+
 
         negotiationManager.start();
 
@@ -242,7 +243,8 @@ class ProviderContractNegotiationManagerImplTest {
         var negotiation = contractNegotiationBuilder().state(PROVIDER_OFFERING.code()).stateCount(RETRIES_EXHAUSTED).contractOffer(contractOffer()).build();
         when(store.nextForState(eq(PROVIDER_OFFERING.code()), anyInt())).thenReturn(List.of(negotiation)).thenReturn(emptyList());
         when(dispatcherRegistry.send(any(), any())).thenReturn(failedFuture(new EdcException("error")));
-        when(store.find(negotiation.getId())).thenReturn(negotiation);
+        when(store.findById(negotiation.getId())).thenReturn(negotiation);
+
 
         negotiationManager.start();
 
@@ -256,7 +258,7 @@ class ProviderContractNegotiationManagerImplTest {
     void consumerVerified_shouldTransitToFinalizing() {
         var negotiation = contractNegotiationBuilder().state(CONSUMER_VERIFIED.code()).build();
         when(store.nextForState(eq(CONSUMER_VERIFIED.code()), anyInt())).thenReturn(List.of(negotiation)).thenReturn(emptyList());
-        when(store.find(negotiation.getId())).thenReturn(negotiation);
+        when(store.findById(negotiation.getId())).thenReturn(negotiation);
 
         negotiationManager.start();
 
@@ -270,7 +272,7 @@ class ProviderContractNegotiationManagerImplTest {
     void providerFinalizing_shouldSendMessageAndTransitToFinalized() {
         var negotiation = contractNegotiationBuilder().state(PROVIDER_FINALIZING.code()).build();
         when(store.nextForState(eq(PROVIDER_FINALIZING.code()), anyInt())).thenReturn(List.of(negotiation)).thenReturn(emptyList());
-        when(store.find(negotiation.getId())).thenReturn(negotiation);
+        when(store.findById(negotiation.getId())).thenReturn(negotiation);
         when(dispatcherRegistry.send(any(), any())).thenReturn(completedFuture("any"));
 
         negotiationManager.start();
@@ -285,7 +287,7 @@ class ProviderContractNegotiationManagerImplTest {
     void providerFinalizing_shouldKeepState_whenDispatchFails() {
         var negotiation = contractNegotiationBuilder().state(PROVIDER_FINALIZING.code()).stateCount(RETRIES_NOT_EXHAUSTED).build();
         when(store.nextForState(eq(PROVIDER_FINALIZING.code()), anyInt())).thenReturn(List.of(negotiation)).thenReturn(emptyList());
-        when(store.find(negotiation.getId())).thenReturn(negotiation);
+        when(store.findById(negotiation.getId())).thenReturn(negotiation);
         when(dispatcherRegistry.send(any(), any())).thenReturn(failedFuture(new EdcException("error")));
 
         negotiationManager.start();
@@ -300,7 +302,7 @@ class ProviderContractNegotiationManagerImplTest {
     void providerFinalizing_shouldTransitToTerminating_whenDispatchFailsAndRetriesExhausted() {
         var negotiation = contractNegotiationBuilder().state(PROVIDER_FINALIZING.code()).stateCount(RETRIES_EXHAUSTED).build();
         when(store.nextForState(eq(PROVIDER_FINALIZING.code()), anyInt())).thenReturn(List.of(negotiation)).thenReturn(emptyList());
-        when(store.find(negotiation.getId())).thenReturn(negotiation);
+        when(store.findById(negotiation.getId())).thenReturn(negotiation);
         when(dispatcherRegistry.send(any(), any())).thenReturn(failedFuture(new EdcException("error")));
 
         negotiationManager.start();
@@ -317,7 +319,7 @@ class ProviderContractNegotiationManagerImplTest {
         negotiation.setErrorDetail("an error");
         when(store.nextForState(eq(TERMINATING.code()), anyInt())).thenReturn(List.of(negotiation)).thenReturn(emptyList());
         when(dispatcherRegistry.send(any(), any())).thenReturn(completedFuture(null));
-        when(store.find(negotiation.getId())).thenReturn(negotiation);
+        when(store.findById(negotiation.getId())).thenReturn(negotiation);
 
         negotiationManager.start();
 
@@ -334,7 +336,8 @@ class ProviderContractNegotiationManagerImplTest {
         negotiation.setErrorDetail("an error");
         when(store.nextForState(eq(TERMINATING.code()), anyInt())).thenReturn(List.of(negotiation)).thenReturn(emptyList());
         when(dispatcherRegistry.send(any(), any())).thenReturn(failedFuture(new EdcException("error")));
-        when(store.find(negotiation.getId())).thenReturn(negotiation);
+        when(store.findById(negotiation.getId())).thenReturn(negotiation);
+
 
         negotiationManager.start();
 
@@ -349,8 +352,9 @@ class ProviderContractNegotiationManagerImplTest {
         var negotiation = contractNegotiationBuilder().state(TERMINATING.code()).stateCount(RETRIES_EXHAUSTED).contractOffer(contractOffer()).build();
         negotiation.setErrorDetail("an error");
         when(store.nextForState(eq(TERMINATING.code()), anyInt())).thenReturn(List.of(negotiation)).thenReturn(emptyList());
-        when(store.find(negotiation.getId())).thenReturn(negotiation);
+        when(store.findById(negotiation.getId())).thenReturn(negotiation);
         when(dispatcherRegistry.send(any(), any())).thenReturn(failedFuture(new EdcException("error")));
+
 
         negotiationManager.start();
 
@@ -369,7 +373,7 @@ class ProviderContractNegotiationManagerImplTest {
                 .build();
         when(store.nextForState(eq(PROVIDER_AGREEING.code()), anyInt())).thenReturn(List.of(negotiation)).thenReturn(emptyList());
         when(dispatcherRegistry.send(any(), any())).thenReturn(completedFuture(null));
-        when(store.find(negotiation.getId())).thenReturn(negotiation);
+        when(store.findById(negotiation.getId())).thenReturn(negotiation);
         when(policyStore.findById(any())).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).id("policyId").build());
 
         negotiationManager.start();
@@ -389,7 +393,7 @@ class ProviderContractNegotiationManagerImplTest {
                 .build();
         when(store.nextForState(eq(PROVIDER_AGREEING.code()), anyInt())).thenReturn(List.of(negotiation)).thenReturn(emptyList());
         when(dispatcherRegistry.send(any(), any())).thenReturn(completedFuture(null));
-        when(store.find(negotiation.getId())).thenReturn(negotiation);
+        when(store.findById(negotiation.getId())).thenReturn(negotiation);
 
         negotiationManager.start();
 
@@ -405,7 +409,8 @@ class ProviderContractNegotiationManagerImplTest {
         var negotiation = contractNegotiationBuilder().state(PROVIDER_AGREEING.code()).stateCount(RETRIES_NOT_EXHAUSTED).contractOffer(contractOffer()).build();
         when(store.nextForState(eq(PROVIDER_AGREEING.code()), anyInt())).thenReturn(List.of(negotiation)).thenReturn(emptyList());
         when(dispatcherRegistry.send(any(), any())).thenReturn(failedFuture(new EdcException("error")));
-        when(store.find(negotiation.getId())).thenReturn(negotiation);
+        when(store.findById(negotiation.getId())).thenReturn(negotiation);
+
 
         negotiationManager.start();
 
@@ -420,7 +425,8 @@ class ProviderContractNegotiationManagerImplTest {
         var negotiation = contractNegotiationBuilder().state(PROVIDER_AGREEING.code()).stateCount(RETRIES_EXHAUSTED).contractOffer(contractOffer()).build();
         when(store.nextForState(eq(PROVIDER_AGREEING.code()), anyInt())).thenReturn(List.of(negotiation)).thenReturn(emptyList());
         when(dispatcherRegistry.send(any(), any())).thenReturn(failedFuture(new EdcException("error")));
-        when(store.find(negotiation.getId())).thenReturn(negotiation);
+        when(store.findById(negotiation.getId())).thenReturn(negotiation);
+
 
         negotiationManager.start();
 

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/command/ContractNegotiationCommandQueueIntegrationTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/command/ContractNegotiationCommandQueueIntegrationTest.java
@@ -70,7 +70,7 @@ class ContractNegotiationCommandQueueIntegrationTest {
         negotiation = getNegotiation(negotiationId);
         command = new TestCommand(negotiationId);
 
-        when(store.find(negotiationId)).thenReturn(negotiation);
+        when(store.findById(negotiationId)).thenReturn(negotiation);
     }
 
     @Test
@@ -102,7 +102,7 @@ class ContractNegotiationCommandQueueIntegrationTest {
 
     @Test
     void submitTestCommand_consumerManager() {
-        when(store.find(negotiationId)).thenReturn(negotiation);
+        when(store.findById(negotiationId)).thenReturn(negotiation);
 
         // Create and start the negotiation manager
         var negotiationManager = ConsumerContractNegotiationManagerImpl.Builder.newInstance()

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/command/handlers/CancelNegotiationCommandHandlerTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/command/handlers/CancelNegotiationCommandHandlerTest.java
@@ -56,7 +56,7 @@ class CancelNegotiationCommandHandlerTest {
         var originalTime = negotiation.getUpdatedAt();
         var command = new CancelNegotiationCommand(negotiationId);
 
-        when(store.find(negotiationId)).thenReturn(negotiation);
+        when(store.findById(negotiationId)).thenReturn(negotiation);
 
         commandHandler.handle(command);
 
@@ -70,7 +70,7 @@ class CancelNegotiationCommandHandlerTest {
         var negotiationId = "test";
         var command = new CancelNegotiationCommand(negotiationId);
 
-        when(store.find(negotiationId)).thenReturn(null);
+        when(store.findById(negotiationId)).thenReturn(null);
 
         assertThatThrownBy(() -> commandHandler.handle(command))
                 .isInstanceOf(EdcException.class)

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/command/handlers/DeclineNegotiationCommandHandlerTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/command/handlers/DeclineNegotiationCommandHandlerTest.java
@@ -59,7 +59,7 @@ class DeclineNegotiationCommandHandlerTest {
         var originalTime = negotiation.getUpdatedAt();
         var command = new DeclineNegotiationCommand(negotiationId);
 
-        when(store.find(negotiationId)).thenReturn(negotiation);
+        when(store.findById(negotiationId)).thenReturn(negotiation);
 
         commandHandler.handle(command);
 
@@ -73,7 +73,7 @@ class DeclineNegotiationCommandHandlerTest {
         var negotiationId = "test";
         var command = new DeclineNegotiationCommand(negotiationId);
 
-        when(store.find(negotiationId)).thenReturn(null);
+        when(store.findById(negotiationId)).thenReturn(null);
 
         assertThatThrownBy(() -> commandHandler.handle(command))
                 .isInstanceOf(EdcException.class)

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationServiceImpl.java
@@ -50,7 +50,7 @@ public class ContractNegotiationServiceImpl implements ContractNegotiationServic
 
     @Override
     public ContractNegotiation findbyId(String contractNegotiationId) {
-        return transactionContext.execute(() -> store.find(contractNegotiationId));
+        return transactionContext.execute(() -> store.findById(contractNegotiationId));
     }
 
     @Override
@@ -75,7 +75,7 @@ public class ContractNegotiationServiceImpl implements ContractNegotiationServic
 
     @Override
     public ContractAgreement getForNegotiation(String negotiationId) {
-        return transactionContext.execute(() -> ofNullable(store.find(negotiationId))
+        return transactionContext.execute(() -> ofNullable(store.findById(negotiationId))
                 .map(ContractNegotiation::getContractAgreement).orElse(null));
     }
 
@@ -87,7 +87,7 @@ public class ContractNegotiationServiceImpl implements ContractNegotiationServic
     @Override
     public ServiceResult<ContractNegotiation> cancel(String negotiationId) {
         return transactionContext.execute(() -> {
-            var negotiation = store.find(negotiationId);
+            var negotiation = store.findById(negotiationId);
             if (negotiation == null) {
                 return ServiceResult.notFound(format("ContractNegotiation %s does not exist", negotiationId));
             } else {
@@ -101,7 +101,7 @@ public class ContractNegotiationServiceImpl implements ContractNegotiationServic
     public ServiceResult<ContractNegotiation> decline(String negotiationId) {
         return transactionContext.execute(() -> {
             try {
-                var negotiation = store.find(negotiationId);
+                var negotiation = store.findById(negotiationId);
                 if (negotiation == null) {
                     return ServiceResult.notFound(format("ContractNegotiation %s does not exist", negotiationId));
                 }

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationServiceImplTest.java
@@ -62,7 +62,7 @@ class ContractNegotiationServiceImplTest {
     @Test
     void findById_filtersById() {
         var negotiation = createContractNegotiation("negotiationId");
-        when(store.find("negotiationId")).thenReturn(negotiation);
+        when(store.findById("negotiationId")).thenReturn(negotiation);
 
         var result = service.findbyId("negotiationId");
 
@@ -71,7 +71,7 @@ class ContractNegotiationServiceImplTest {
 
     @Test
     void findById_returnsNullIfNotFound() {
-        when(store.find("negotiationId")).thenReturn(null);
+        when(store.findById("negotiationId")).thenReturn(null);
 
         var result = service.findbyId("negotiationId");
 
@@ -123,7 +123,7 @@ class ContractNegotiationServiceImplTest {
         var negotiation = createContractNegotiationBuilder("negotiationId")
                 .state(CONSUMER_REQUESTED.code())
                 .build();
-        when(store.find("negotiationId")).thenReturn(negotiation);
+        when(store.findById("negotiationId")).thenReturn(negotiation);
 
         var result = service.getState("negotiationId");
 
@@ -132,7 +132,7 @@ class ContractNegotiationServiceImplTest {
 
     @Test
     void getState_returnsNullIfNegotiationDoesNotExist() {
-        when(store.find("negotiationId")).thenReturn(null);
+        when(store.findById("negotiationId")).thenReturn(null);
 
         var result = service.getState("negotiationId");
 
@@ -145,33 +145,33 @@ class ContractNegotiationServiceImplTest {
         var negotiation = createContractNegotiation("negotiationId");
         negotiation.setContractAgreement(contractAgreement);
 
-        when(store.find("negotiationId")).thenReturn(negotiation);
+        when(store.findById("negotiationId")).thenReturn(negotiation);
 
         var result = service.getForNegotiation("negotiationId");
 
         assertThat(result).matches(it -> it.getId().equals("agreementId"));
-        verify(store).find(any());
+        verify(store).findById(any());
         verifyNoMoreInteractions(store);
     }
 
     @Test
     void getForNegotiation_negotiationNotFound() {
-        when(store.find("negotiationId")).thenReturn(null);
+        when(store.findById("negotiationId")).thenReturn(null);
         var result = service.getForNegotiation("negotiationId");
         assertThat(result).isNull();
-        verify(store).find(any());
+        verify(store).findById(any());
         verifyNoMoreInteractions(store);
     }
 
     @Test
     void getForNegotiation_negotiationNoAgreement() {
         var negotiation = createContractNegotiation("negotiationId");
-        when(store.find("negotiationId")).thenReturn(negotiation);
+        when(store.findById("negotiationId")).thenReturn(negotiation);
 
         var result = service.getForNegotiation("negotiationId");
 
         assertThat(result).isNull();
-        verify(store).find(any());
+        verify(store).findById(any());
         verifyNoMoreInteractions(store);
     }
 
@@ -209,7 +209,7 @@ class ContractNegotiationServiceImplTest {
     @Test
     void cancel_shouldCancelNegotiationIfItCanBeCanceled() {
         var negotiation = createContractNegotiation("negotiationId");
-        when(store.find("negotiationId")).thenReturn(negotiation);
+        when(store.findById("negotiationId")).thenReturn(negotiation);
 
         var result = service.cancel("negotiationId");
 
@@ -220,7 +220,7 @@ class ContractNegotiationServiceImplTest {
 
     @Test
     void cancel_shouldNotCancelNegationIfItDoesNotExist() {
-        when(store.find("negotiationId")).thenReturn(null);
+        when(store.findById("negotiationId")).thenReturn(null);
 
         var result = service.cancel("negotiationId");
 
@@ -232,7 +232,7 @@ class ContractNegotiationServiceImplTest {
     @Test
     void decline_shouldSucceedIfManagerIsBeingAbleToDeclineIt() {
         var negotiation = createContractNegotiationBuilder("negotiationId").state(CONSUMER_REQUESTED.code()).build();
-        when(store.find("negotiationId")).thenReturn(negotiation);
+        when(store.findById("negotiationId")).thenReturn(negotiation);
 
         var result = service.decline("negotiationId");
 
@@ -243,7 +243,7 @@ class ContractNegotiationServiceImplTest {
 
     @Test
     void decline_shouldNotCancelNegationIfItDoesNotExist() {
-        when(store.find("negotiationId")).thenReturn(null);
+        when(store.findById("negotiationId")).thenReturn(null);
 
         var result = service.decline("negotiationId");
 

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/contractnegotiation/InMemoryContractNegotiationStore.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/contractnegotiation/InMemoryContractNegotiationStore.java
@@ -54,7 +54,7 @@ public class InMemoryContractNegotiationStore implements ContractNegotiationStor
     }
 
     @Override
-    public @Nullable ContractNegotiation find(String negotiationId) {
+    public @Nullable ContractNegotiation findById(String negotiationId) {
         return store.find(negotiationId);
     }
 

--- a/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/contractnegotiation/InMemoryContractNegotiationStoreTest.java
+++ b/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/contractnegotiation/InMemoryContractNegotiationStoreTest.java
@@ -68,13 +68,13 @@ class InMemoryContractNegotiationStoreTest extends ContractNegotiationStoreTestB
 
         store.save(negotiation);
 
-        ContractNegotiation found = store.find(id);
+        ContractNegotiation found = store.findById(id);
 
         assertNotNull(found);
         assertNotSame(found, negotiation); // enforce by-value
 
         store.delete(id);
-        assertNull(store.find(id));
+        assertNull(store.findById(id));
         assertNull(store.findContractAgreement("agreementId"));
     }
 
@@ -86,7 +86,7 @@ class InMemoryContractNegotiationStoreTest extends ContractNegotiationStoreTestB
 
         store.save(negotiation);
 
-        var found = store.find(id);
+        var found = store.findById(id);
         assertNotNull(store.findContractAgreement("agreementId"));
 
         assertEquals(INITIAL.code(), found.getState());
@@ -94,7 +94,7 @@ class InMemoryContractNegotiationStoreTest extends ContractNegotiationStoreTestB
         negotiation.transitionRequesting();
 
         store.save(negotiation);
-        found = store.find(id);
+        found = store.findById(id);
         assertNotNull(found);
         assertEquals(CONSUMER_REQUESTING.code(), found.getState());
 
@@ -158,10 +158,10 @@ class InMemoryContractNegotiationStoreTest extends ContractNegotiationStoreTestB
         store.save(negotiation2);
 
 
-        ContractNegotiation found1 = store.find(id1);
+        ContractNegotiation found1 = store.findById(id1);
         assertNotNull(found1);
 
-        ContractNegotiation found2 = store.find(id2);
+        ContractNegotiation found2 = store.findById(id2);
         assertNotNull(found2);
 
         var found = store.nextForState(INITIAL.code(), 3);

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerIntegrationTest.java
@@ -276,7 +276,7 @@ class ContractNegotiationApiControllerIntegrationTest {
                 .statusCode(204);
 
         await().untilAsserted(() -> {
-            assertThat(store.find("negotiationId")).isNotNull().extracting(StatefulEntity::getState).isEqualTo(TERMINATED.code());
+            assertThat(store.findById("negotiationId")).isNotNull().extracting(StatefulEntity::getState).isEqualTo(TERMINATED.code());
         });
     }
 

--- a/extensions/control-plane/store/cosmos/contract-negotiation-store-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/contractnegotiation/CosmosContractNegotiationStore.java
+++ b/extensions/control-plane/store/cosmos/contract-negotiation-store-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/contractnegotiation/CosmosContractNegotiationStore.java
@@ -75,7 +75,7 @@ public class CosmosContractNegotiationStore implements ContractNegotiationStore 
     }
 
     @Override
-    public @Nullable ContractNegotiation find(String negotiationId) {
+    public @Nullable ContractNegotiation findById(String negotiationId) {
         var object = with(retryPolicy).get(() -> findByIdInternal(negotiationId));
         return object != null ? toNegotiation(object) : null;
     }

--- a/extensions/control-plane/store/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/contractnegotiation/CosmosContractNegotiationStoreIntegrationTest.java
+++ b/extensions/control-plane/store/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/contractnegotiation/CosmosContractNegotiationStoreIntegrationTest.java
@@ -127,14 +127,14 @@ class CosmosContractNegotiationStoreIntegrationTest extends ContractNegotiationS
         container.createItem(doc1);
         container.createItem(doc2);
 
-        var foundItem = store.find(doc1.getId());
+        var foundItem = store.findById(doc1.getId());
 
         assertThat(foundItem).isNotNull().usingRecursiveComparison().isEqualTo(doc1.getWrappedInstance());
     }
 
     @Test
     void findById_notExist() {
-        var foundItem = store.find("not-exit");
+        var foundItem = store.findById("not-exit");
         assertThat(foundItem).isNull();
     }
 

--- a/extensions/control-plane/store/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/contractnegotiation/CosmosContractNegotiationStoreTest.java
+++ b/extensions/control-plane/store/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/contractnegotiation/CosmosContractNegotiationStoreTest.java
@@ -69,7 +69,7 @@ class CosmosContractNegotiationStoreTest {
         var doc = generateDocument();
         when(cosmosDbApi.queryItemById("test-id-1")).thenReturn(doc);
 
-        var result = store.find("test-id-1");
+        var result = store.findById("test-id-1");
 
         assertThat(result).usingRecursiveComparison().isEqualTo(doc.getWrappedInstance());
         verify(cosmosDbApi).queryItemById("test-id-1");
@@ -80,7 +80,7 @@ class CosmosContractNegotiationStoreTest {
     void find_notFound() {
         when(cosmosDbApi.queryItemById(anyString())).thenReturn(null);
 
-        assertThat(store.find("test-id-1")).isNull();
+        assertThat(store.findById("test-id-1")).isNull();
         verify(cosmosDbApi).queryItemById(anyString());
         verifyNoMoreInteractions(cosmosDbApi);
     }

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/SqlContractNegotiationStore.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/SqlContractNegotiationStore.java
@@ -62,7 +62,7 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
     }
 
     @Override
-    public @Nullable ContractNegotiation find(String negotiationId) {
+    public @Nullable ContractNegotiation findById(String negotiationId) {
         return transactionContext.execute(() -> {
             try (var connection = getConnection()) {
                 return findInternal(connection, negotiationId);
@@ -117,7 +117,7 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
     @Override
     public void delete(String negotiationId) {
         transactionContext.execute(() -> {
-            var existing = find(negotiationId);
+            var existing = findById(negotiationId);
 
             //if exists, attempt delete
             if (existing != null) {

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/negotiation/store/ContractNegotiationStore.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/negotiation/store/ContractNegotiationStore.java
@@ -36,7 +36,7 @@ public interface ContractNegotiationStore extends StateEntityStore<ContractNegot
      * Finds the contract negotiation for the id or null.
      */
     @Nullable
-    ContractNegotiation find(String negotiationId);
+    ContractNegotiation findById(String negotiationId);
 
     /**
      * Returns the contract negotiation for the correlation id provided by the consumer or null.

--- a/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/negotiation/store/ContractNegotiationStoreTestBase.java
+++ b/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/negotiation/store/ContractNegotiationStoreTestBase.java
@@ -50,7 +50,7 @@ public abstract class ContractNegotiationStoreTestBase {
         var negotiation = createNegotiation(id);
         getContractNegotiationStore().save(negotiation);
 
-        Assertions.assertThat(getContractNegotiationStore().find(id))
+        Assertions.assertThat(getContractNegotiationStore().findById(id))
                 .usingRecursiveComparison()
                 .isEqualTo(negotiation);
 
@@ -64,7 +64,7 @@ public abstract class ContractNegotiationStoreTestBase {
         getContractNegotiationStore().save(negotiation);
 
         lockEntity(id, CONNECTOR_NAME);
-        Assertions.assertThat(getContractNegotiationStore().find(id))
+        Assertions.assertThat(getContractNegotiationStore().findById(id))
                 .usingRecursiveComparison()
                 .isEqualTo(negotiation);
 
@@ -74,7 +74,7 @@ public abstract class ContractNegotiationStoreTestBase {
         getContractNegotiationStore().save(negotiation2);
 
         lockEntity(id2, "someone-else");
-        Assertions.assertThat(getContractNegotiationStore().find(id2))
+        Assertions.assertThat(getContractNegotiationStore().findById(id2))
                 .usingRecursiveComparison()
                 .isEqualTo(negotiation2);
 
@@ -83,7 +83,7 @@ public abstract class ContractNegotiationStoreTestBase {
     @Test
     @DisplayName("Verify that null is returned when entity not found")
     void find_notExist() {
-        Assertions.assertThat(getContractNegotiationStore().find("not-exist")).isNull();
+        Assertions.assertThat(getContractNegotiationStore().findById("not-exist")).isNull();
     }
 
     @Test
@@ -123,7 +123,7 @@ public abstract class ContractNegotiationStoreTestBase {
                 .build();
         getContractNegotiationStore().save(negotiation);
 
-        Assertions.assertThat(getContractNegotiationStore().find(negotiation.getId()))
+        Assertions.assertThat(getContractNegotiationStore().findById(negotiation.getId()))
                 .usingRecursiveComparison()
                 .isEqualTo(negotiation);
     }
@@ -135,7 +135,7 @@ public abstract class ContractNegotiationStoreTestBase {
         var negotiation = createNegotiation("test-negotiation", agreement);
         getContractNegotiationStore().save(negotiation);
 
-        var actual = getContractNegotiationStore().find(negotiation.getId());
+        var actual = getContractNegotiationStore().findById(negotiation.getId());
         Assertions.assertThat(actual)
                 .isNotNull()
                 .usingRecursiveComparison()
@@ -163,7 +163,7 @@ public abstract class ContractNegotiationStoreTestBase {
 
         getContractNegotiationStore().save(newNegotiation);
 
-        var actual = getContractNegotiationStore().find(negotiation.getId());
+        var actual = getContractNegotiationStore().findById(negotiation.getId());
         Assertions.assertThat(actual).isNotNull();
         Assertions.assertThat(actual.getStateCount()).isEqualTo(420);
         Assertions.assertThat(actual.getState()).isEqualTo(800);
@@ -238,7 +238,7 @@ public abstract class ContractNegotiationStoreTestBase {
                 .usingRecursiveFieldByFieldElementComparator()
                 .containsExactly(agreement);
 
-        Assertions.assertThat(Objects.requireNonNull(getContractNegotiationStore().find(negotiationId)).getContractAgreement()).usingRecursiveComparison().isEqualTo(agreement);
+        Assertions.assertThat(Objects.requireNonNull(getContractNegotiationStore().findById(negotiationId)).getContractAgreement()).usingRecursiveComparison().isEqualTo(agreement);
     }
 
     @Test
@@ -269,7 +269,7 @@ public abstract class ContractNegotiationStoreTestBase {
         var agreement = createContract("test-ca1");
         var negotiation = createNegotiation(negotiationId, null);
         getContractNegotiationStore().save(negotiation);
-        var dbNegotiation = getContractNegotiationStore().find(negotiationId);
+        var dbNegotiation = getContractNegotiationStore().findById(negotiationId);
         Assertions.assertThat(dbNegotiation).isNotNull().satisfies(n ->
                 Assertions.assertThat(n.getContractAgreement()).isNull()
         );
@@ -277,7 +277,7 @@ public abstract class ContractNegotiationStoreTestBase {
         dbNegotiation.setContractAgreement(agreement);
         getContractNegotiationStore().save(dbNegotiation);
 
-        var updatedNegotiation = getContractNegotiationStore().find(negotiationId);
+        var updatedNegotiation = getContractNegotiationStore().findById(negotiationId);
         Assertions.assertThat(updatedNegotiation).isNotNull();
         Assertions.assertThat(updatedNegotiation.getContractAgreement()).isNotNull();
     }
@@ -289,12 +289,12 @@ public abstract class ContractNegotiationStoreTestBase {
         var n = createNegotiation(id);
         getContractNegotiationStore().save(n);
 
-        Assertions.assertThat(getContractNegotiationStore().find(id)).isNotNull().usingRecursiveComparison().isEqualTo(n);
+        Assertions.assertThat(getContractNegotiationStore().findById(id)).isNotNull().usingRecursiveComparison().isEqualTo(n);
 
         //todo: verify returned object
         getContractNegotiationStore().delete(id);
 
-        Assertions.assertThat(getContractNegotiationStore().find(id)).isNull();
+        Assertions.assertThat(getContractNegotiationStore().findById(id)).isNull();
     }
 
     @Test
@@ -338,7 +338,7 @@ public abstract class ContractNegotiationStoreTestBase {
         var n = createNegotiation(id, contract);
         getContractNegotiationStore().save(n);
 
-        Assertions.assertThat(getContractNegotiationStore().find(id)).isNotNull().usingRecursiveComparison().isEqualTo(n);
+        Assertions.assertThat(getContractNegotiationStore().findById(id)).isNotNull().usingRecursiveComparison().isEqualTo(n);
         assertThatThrownBy(() -> getContractNegotiationStore().delete(id)).isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Cannot delete ContractNegotiation")
                 .hasMessageContaining("ContractAgreement already created.");


### PR DESCRIPTION
…monize in CRUD operations.

## What this PR changes/adds

The persistence implementations in ContractNegotiationStore are refactrored in CRUD interactions.


## Why it does that

consistency, recognizability


## Further notes


## Linked Issue(s)

ref #2559 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
