### PR TITLE
refactor: persistence implementations in PolicyDefinitionStore harmon…

### DIFF
--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
@@ -139,7 +139,7 @@ class ConsumerContractNegotiationManagerImplTest {
         var result = negotiationManager.confirmed(token, "not a valid id", contractAgreement, policy);
 
         assertThat(result.fatalError()).isTrue();
-        verify(policyStore, never()).save(any());
+        verify(policyStore, never()).create(any());
         verify(store, never()).save(any());
         verifyNoInteractions(listener);
     }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionServiceImpl.java
@@ -96,7 +96,7 @@ public class PolicyDefinitionServiceImpl implements PolicyDefinitionService {
                 }
             }
 
-            var deleted = policyStore.deleteById(policyId);
+            var deleted = policyStore.delete(policyId);
             deleted.onSuccess(pd -> observable.invokeForEach(l -> l.deleted(pd)));
             return ServiceResult.from(deleted);
         });
@@ -105,7 +105,7 @@ public class PolicyDefinitionServiceImpl implements PolicyDefinitionService {
     @Override
     public @NotNull ServiceResult<PolicyDefinition> create(PolicyDefinition policyDefinition) {
         return transactionContext.execute(() -> {
-            var saveResult = policyStore.save(policyDefinition);
+            var saveResult = policyStore.create(policyDefinition);
             saveResult.onSuccess(v -> observable.invokeForEach(l -> l.created(policyDefinition)));
             return ServiceResult.from(saveResult);
         });

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
@@ -92,7 +92,7 @@ class ContractNegotiationEventDispatchTest {
                 .validity(CONTRACT_VALIDITY)
                 .build();
         contractDefinitionStore.save(contractDefinition);
-        policyDefinitionStore.save(PolicyDefinition.Builder.newInstance().id("policyId").policy(policy).build());
+        policyDefinitionStore.create(PolicyDefinition.Builder.newInstance().id("policyId").policy(policy).build());
         assetIndex.accept(Asset.Builder.newInstance().id("assetId").build(), DataAddress.Builder.newInstance().type("any").build());
 
         manager.requested(token, createContractOfferRequest(policy));

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionServiceImplTest.java
@@ -89,25 +89,25 @@ class PolicyDefinitionServiceImplTest {
     @Test
     void createPolicy_shouldCreatePolicyIfItDoesNotAlreadyExist() {
         var policy = createPolicy("policyId");
-        when(policyStore.save(policy)).thenReturn(StoreResult.success(policy));
+        when(policyStore.create(policy)).thenReturn(StoreResult.success(policy));
 
         var inserted = policyServiceImpl.create(policy);
 
         assertThat(inserted.succeeded()).isTrue();
         assertThat(inserted.getContent()).isEqualTo(policy);
-        verify(policyStore).save(policy);
+        verify(policyStore).create(policy);
         verifyNoMoreInteractions(policyStore);
     }
 
     @Test
     void createPolicy_shouldNotCreatePolicyIfItAlreadyExists() {
         var policy = createPolicy("policyId");
-        when(policyStore.save(policy)).thenReturn(StoreResult.alreadyExists("test"));
+        when(policyStore.create(policy)).thenReturn(StoreResult.alreadyExists("test"));
 
         var inserted = policyServiceImpl.create(policy);
 
         assertThat(inserted.succeeded()).isFalse();
-        verify(policyStore).save(policy);
+        verify(policyStore).create(policy);
         verifyNoMoreInteractions(policyStore);
     }
 
@@ -115,7 +115,7 @@ class PolicyDefinitionServiceImplTest {
     void delete_shouldDeletePolicyIfItsNotReferencedByAnyContractDefinition() {
         when(contractDefinitionStore.findAll(any())).thenReturn(Stream.empty(), Stream.empty());
         when(policyStore.findById(any())).thenReturn(createPolicy("policyId"));
-        when(policyStore.deleteById("policyId")).thenReturn(StoreResult.success(createPolicy("policyId")));
+        when(policyStore.delete("policyId")).thenReturn(StoreResult.success(createPolicy("policyId")));
 
         var deleted = policyServiceImpl.deleteById("policyId");
 
@@ -128,7 +128,7 @@ class PolicyDefinitionServiceImplTest {
     @Test
     void delete_shouldNotDelete_whenPolicyPartOfContractDef() {
         var policy = createPolicy("policyId");
-        when(policyStore.deleteById("policyId")).thenReturn(StoreResult.success(policy));
+        when(policyStore.delete("policyId")).thenReturn(StoreResult.success(policy));
 
         var contractDefinition = ContractDefinition.Builder.newInstance()
                 .id("A found Contract Definition")
@@ -149,7 +149,7 @@ class PolicyDefinitionServiceImplTest {
     @Test
     void delete_shouldNotDelete_whenPolicyIsPartOfContractDefinition() {
         var policy = createPolicy("policyId");
-        when(policyStore.deleteById("policyId")).thenReturn(StoreResult.success(policy));
+        when(policyStore.delete("policyId")).thenReturn(StoreResult.success(policy));
 
         ContractDefinition contractDefinition = ContractDefinition.Builder.newInstance()
                 .id("A found Contract Definition")
@@ -169,7 +169,7 @@ class PolicyDefinitionServiceImplTest {
 
     @Test
     void delete_shouldFailIfPolicyDoesNotExist() {
-        when(policyStore.deleteById("policyId")).thenReturn(StoreResult.notFound("test"));
+        when(policyStore.delete("policyId")).thenReturn(StoreResult.notFound("test"));
 
         var deleted = policyServiceImpl.deleteById("policyId");
 
@@ -180,10 +180,10 @@ class PolicyDefinitionServiceImplTest {
     @Test
     void delete_verifyCorrectQueries() {
         var policyId = "test-policy";
-        when(policyStore.deleteById(policyId)).thenReturn(StoreResult.success());
+        when(policyStore.delete(policyId)).thenReturn(StoreResult.success());
         policyServiceImpl.deleteById(policyId);
 
-        verify(policyStore).deleteById(eq(policyId));
+        verify(policyStore).delete(eq(policyId));
         verifyNoMoreInteractions(policyStore);
     }
 

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/policydefinition/InMemoryPolicyDefinitionStore.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/policydefinition/InMemoryPolicyDefinitionStore.java
@@ -62,7 +62,7 @@ public class InMemoryPolicyDefinitionStore implements PolicyDefinitionStore {
     }
 
     @Override
-    public StoreResult<PolicyDefinition> save(PolicyDefinition policy) {
+    public StoreResult<PolicyDefinition> create(PolicyDefinition policy) {
         try {
             return lockManager.writeLock(() -> {
                 var id = policy.getUid();
@@ -99,7 +99,7 @@ public class InMemoryPolicyDefinitionStore implements PolicyDefinitionStore {
     }
 
     @Override
-    public StoreResult<PolicyDefinition> deleteById(String policyId) {
+    public StoreResult<PolicyDefinition> delete(String policyId) {
         try {
             var previous = lockManager.writeLock(() -> policiesById.remove(policyId));
             return previous == null ?

--- a/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/policydefinition/InMemoryPolicyDefinitionStoreTest.java
+++ b/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/policydefinition/InMemoryPolicyDefinitionStoreTest.java
@@ -47,7 +47,7 @@ class InMemoryPolicyDefinitionStoreTest extends PolicyDefinitionStoreTestBase {
 
     @Test
     void deleteById_whenNonexistent() {
-        var result = store.deleteById("nonexistent");
+        var result = store.delete("nonexistent");
         assertThat(result).isNotNull();
         assertThat(result.succeeded()).isFalse();
     }
@@ -70,19 +70,19 @@ class InMemoryPolicyDefinitionStoreTest extends PolicyDefinitionStoreTestBase {
     void save_exceptionThrown() {
         doThrow(new RuntimeException()).when(manager).writeLock(any());
 
-        assertThatExceptionOfType(EdcPersistenceException.class).isThrownBy(() -> store.save(createPolicyDef()));
+        assertThatExceptionOfType(EdcPersistenceException.class).isThrownBy(() -> store.create(createPolicyDef()));
     }
 
     @Test
     void deleteById_exceptionThrown() {
         doThrow(new RuntimeException()).when(manager).writeLock(any());
 
-        assertThatExceptionOfType(EdcPersistenceException.class).isThrownBy(() -> store.deleteById("any-policy-id"));
+        assertThatExceptionOfType(EdcPersistenceException.class).isThrownBy(() -> store.delete("any-policy-id"));
     }
 
     @Test
     void findAll_verifyFiltering_invalidFilterExpression() {
-        IntStream.range(0, 10).mapToObj(i -> createPolicy("test-id")).forEach(d -> getPolicyDefinitionStore().save(d));
+        IntStream.range(0, 10).mapToObj(i -> createPolicy("test-id")).forEach(d -> getPolicyDefinitionStore().create(d));
 
         var query = QuerySpec.Builder.newInstance().filter("something contains other").build();
 
@@ -92,7 +92,7 @@ class InMemoryPolicyDefinitionStoreTest extends PolicyDefinitionStoreTestBase {
     @Test
     void update_throwsException() {
         var policy = createPolicy("test-id");
-        getPolicyDefinitionStore().save(policy);
+        getPolicyDefinitionStore().create(policy);
 
         doThrow(new RuntimeException()).when(manager).writeLock(any());
         assertThatExceptionOfType(EdcPersistenceException.class).isThrownBy(() -> store.update(createPolicyDef()));

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiControllerIntegrationTest.java
@@ -64,7 +64,7 @@ public class PolicyDefinitionApiControllerIntegrationTest {
     void getAllpolicydefinitions(PolicyDefinitionStore policyStore) {
         var policy = createPolicy("id");
 
-        policyStore.save(policy);
+        policyStore.create(policy);
 
         baseRequest()
                 .get("/policydefinitions")
@@ -86,7 +86,7 @@ public class PolicyDefinitionApiControllerIntegrationTest {
     void queryAllPolicyDefinitions(PolicyDefinitionStore policyStore) {
         var policy = createPolicy("id");
 
-        policyStore.save(policy);
+        policyStore.create(policy);
 
         baseRequest()
                 .contentType(JSON)
@@ -99,7 +99,7 @@ public class PolicyDefinitionApiControllerIntegrationTest {
 
     @Test
     void queryAllPolicyDefinitions_withQuery(PolicyDefinitionStore policyStore) {
-        IntStream.range(0, 10).forEach(i -> policyStore.save(createPolicy("id" + i)));
+        IntStream.range(0, 10).forEach(i -> policyStore.create(createPolicy("id" + i)));
 
         baseRequest()
                 .contentType(JSON)
@@ -118,7 +118,7 @@ public class PolicyDefinitionApiControllerIntegrationTest {
 
     @Test
     void queryAllPolicyDefinitions_withPaging(PolicyDefinitionStore policyStore) {
-        IntStream.range(0, 10).forEach(i -> policyStore.save(createPolicy("id" + i)));
+        IntStream.range(0, 10).forEach(i -> policyStore.create(createPolicy("id" + i)));
 
         baseRequest()
                 .contentType(JSON)
@@ -138,7 +138,7 @@ public class PolicyDefinitionApiControllerIntegrationTest {
     @Test
     void getSinglePolicy(PolicyDefinitionStore policyStore) {
         var policy = createPolicy("id");
-        policyStore.save(policy);
+        policyStore.create(policy);
 
         baseRequest()
                 .get("/policydefinitions/id")
@@ -175,7 +175,7 @@ public class PolicyDefinitionApiControllerIntegrationTest {
     @Test
     void put_whenPolicyExists(PolicyDefinitionStore policyStore) {
         var policy = createPolicy("policyDefId");
-        policyStore.save(policy);
+        policyStore.create(policy);
 
         policy.getPolicy().getExtensibleProperties().put("anotherKey", "anotherVal");
 
@@ -207,7 +207,7 @@ public class PolicyDefinitionApiControllerIntegrationTest {
 
     @Test
     void postPolicyId_alreadyExists(PolicyDefinitionStore policyStore) {
-        policyStore.save(createPolicy("id"));
+        policyStore.create(createPolicy("id"));
 
         baseRequest()
                 .body(createPolicy("id"))
@@ -221,7 +221,7 @@ public class PolicyDefinitionApiControllerIntegrationTest {
     void deletePolicy(PolicyDefinitionStore policyStore) {
         var policy = createPolicy("id");
 
-        policyStore.save(policy);
+        policyStore.create(policy);
 
         baseRequest()
                 .contentType(JSON)
@@ -243,7 +243,7 @@ public class PolicyDefinitionApiControllerIntegrationTest {
     @Test
     void deletePolicy_whenReferencedInContractDefinition(ContractDefinitionStore contractDefinitionStore, PolicyDefinitionStore policyStore) {
         var policy = createPolicy("access");
-        policyStore.save(policy);
+        policyStore.create(policy);
         contractDefinitionStore.save(createContractDefinition(policy.getUid()));
 
         baseRequest()

--- a/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
+++ b/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
@@ -96,7 +96,7 @@ public class HttpProvisionerExtensionEndToEndTest {
                                      AssetIndex assetIndex,
                                      TransferProcessStore store, PolicyDefinitionStore policyStore) throws Exception {
         negotiationStore.save(createContractNegotiation());
-        policyStore.save(createPolicyDefinition());
+        policyStore.create(createPolicyDefinition());
         assetIndex.accept(createAssetEntry());
 
         when(delegate.intercept(any()))

--- a/extensions/control-plane/store/cosmos/policy-definition-store-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/policydefinition/CosmosPolicyDefinitionStore.java
+++ b/extensions/control-plane/store/cosmos/policy-definition-store-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/policydefinition/CosmosPolicyDefinitionStore.java
@@ -74,7 +74,7 @@ public class CosmosPolicyDefinitionStore implements PolicyDefinitionStore {
     }
 
     @Override
-    public StoreResult<PolicyDefinition> save(PolicyDefinition policy) {
+    public StoreResult<PolicyDefinition> create(PolicyDefinition policy) {
         try {
             with(retryPolicy).run(() -> cosmosDbApi.createItem(convertToDocument(policy)));
             return StoreResult.success(policy);
@@ -98,7 +98,7 @@ public class CosmosPolicyDefinitionStore implements PolicyDefinitionStore {
     }
 
     @Override
-    public StoreResult<PolicyDefinition> deleteById(String policyId) {
+    public StoreResult<PolicyDefinition> delete(String policyId) {
         try {
             var deletedItem = cosmosDbApi.deleteItem(policyId);
             return StoreResult.success(convert(deletedItem));

--- a/extensions/control-plane/store/cosmos/policy-definition-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/policydefinition/CosmosPolicyDefinitionStoreIntegrationTest.java
+++ b/extensions/control-plane/store/cosmos/policy-definition-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/policydefinition/CosmosPolicyDefinitionStoreIntegrationTest.java
@@ -143,7 +143,7 @@ public class CosmosPolicyDefinitionStoreIntegrationTest extends PolicyDefinition
     @Test
     void save() {
         var policy = generatePolicy();
-        store.save(policy);
+        store.create(policy);
 
         var actual = container.readAllItems(new PartitionKey(TEST_PARTITION_KEY), Object.class);
         assertThat(actual).hasSize(1);
@@ -163,7 +163,7 @@ public class CosmosPolicyDefinitionStoreIntegrationTest extends PolicyDefinition
         policyToUpdate.getPolicy().getObligations().add(Duty.Builder.newInstance().uid("test-obligation-id").build());
 
 
-        var saveResult = store.save(policyToUpdate);
+        var saveResult = store.create(policyToUpdate);
         assertThat(saveResult.succeeded()).isFalse();
         assertThat(saveResult.reason()).isEqualTo(ALREADY_EXISTS);
 
@@ -182,7 +182,7 @@ public class CosmosPolicyDefinitionStoreIntegrationTest extends PolicyDefinition
         container.createItem(document);
 
         var policy = convert(document);
-        var deletedPolicy = store.deleteById(document.getId());
+        var deletedPolicy = store.delete(document.getId());
         assertThat(deletedPolicy.succeeded()).isTrue();
         assertThat(deletedPolicy.getContent()).isEqualTo(policy);
 

--- a/extensions/control-plane/store/cosmos/policy-definition-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/policydefinition/CosmosPolicyDefinitionStoreTest.java
+++ b/extensions/control-plane/store/cosmos/policy-definition-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/policydefinition/CosmosPolicyDefinitionStoreTest.java
@@ -90,7 +90,7 @@ class CosmosPolicyDefinitionStoreTest {
         doNothing().when(cosmosDbApiMock).createItem(captor.capture());
         var definition = generatePolicy();
 
-        store.save(definition);
+        store.create(definition);
 
         assertThat(captor.getValue().getWrappedInstance()).isEqualTo(definition);
         verify(cosmosDbApiMock).createItem(captor.capture());
@@ -104,7 +104,7 @@ class CosmosPolicyDefinitionStoreTest {
 
         when(cosmosDbApiMock.queryItems(any(SqlQuerySpec.class))).thenReturn(IntStream.range(0, 1).mapToObj((i) -> captor.getValue()));
 
-        store.save(definition); //should write through the cache
+        store.create(definition); //should write through the cache
 
         var all = store.findAll(QuerySpec.none());
 
@@ -119,7 +119,7 @@ class CosmosPolicyDefinitionStoreTest {
         doNothing().when(cosmosDbApiMock).createItem(captor.capture());
         var definition = generatePolicy();
 
-        store.save(definition);
+        store.create(definition);
 
         assertThat(captor.getValue().getWrappedInstance()).isEqualTo(definition);
         verify(cosmosDbApiMock).createItem(captor.capture());
@@ -128,7 +128,7 @@ class CosmosPolicyDefinitionStoreTest {
     @Test
     void deleteById_whenMissing_returnsNull() {
         when(cosmosDbApiMock.deleteItem(any())).thenThrow(new NotFoundException());
-        var contractDefinition = store.deleteById("some-id");
+        var contractDefinition = store.delete("some-id");
         assertThat(contractDefinition).isNotNull().extracting(StoreResult::reason).isEqualTo(NOT_FOUND);
         verify(cosmosDbApiMock).deleteItem(notNull());
     }
@@ -139,7 +139,7 @@ class CosmosPolicyDefinitionStoreTest {
         var document = new PolicyDocument(contractDefinition, TEST_PART_KEY);
         when(cosmosDbApiMock.deleteItem(document.getId())).thenReturn(document);
 
-        var deletedDefinition = store.deleteById(document.getId());
+        var deletedDefinition = store.delete(document.getId());
         assertThat(deletedDefinition.succeeded()).isTrue();
         assertThat(deletedDefinition.getContent()).isEqualTo(contractDefinition);
     }
@@ -148,7 +148,7 @@ class CosmosPolicyDefinitionStoreTest {
     void delete_whenCosmoDbApiThrows_throws() {
         var id = "some-id";
         when(cosmosDbApiMock.deleteItem(id)).thenThrow(new EdcPersistenceException("Something went wrong"));
-        assertThatThrownBy(() -> store.deleteById(id)).isInstanceOf(EdcPersistenceException.class);
+        assertThatThrownBy(() -> store.delete(id)).isInstanceOf(EdcPersistenceException.class);
     }
 
     @Test

--- a/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/policydefinition/store/SqlPolicyDefinitionStore.java
+++ b/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/policydefinition/store/SqlPolicyDefinitionStore.java
@@ -92,7 +92,7 @@ public class SqlPolicyDefinitionStore extends AbstractSqlStore implements Policy
     }
 
     @Override
-    public StoreResult<PolicyDefinition> save(PolicyDefinition policy) {
+    public StoreResult<PolicyDefinition> create(PolicyDefinition policy) {
         Objects.requireNonNull(policy);
         var policyId = policy.getUid();
         return transactionContext.execute(() -> {
@@ -118,7 +118,7 @@ public class SqlPolicyDefinitionStore extends AbstractSqlStore implements Policy
     }
 
     @Override
-    public StoreResult<PolicyDefinition> deleteById(String policyId) {
+    public StoreResult<PolicyDefinition> delete(String policyId) {
         Objects.requireNonNull(policyId);
         return transactionContext.execute(() -> {
             try (var connection = getConnection()) {

--- a/extensions/control-plane/store/sql/policy-definition-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/policydefinition/PostgresPolicyDefinitionStoreTest.java
+++ b/extensions/control-plane/store/sql/policy-definition-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/policydefinition/PostgresPolicyDefinitionStoreTest.java
@@ -77,7 +77,7 @@ class PostgresPolicyDefinitionStoreTest extends PolicyDefinitionStoreTestBase {
                 .build();
 
         var policyDef1 = PolicyDefinition.Builder.newInstance().id("test-policy").policy(policy).build();
-        getPolicyDefinitionStore().save(policyDef1);
+        getPolicyDefinitionStore().create(policyDef1);
 
         // query by prohibition assignee
         assertThatThrownBy(() -> getPolicyDefinitionStore().findAll(createQuery("notexist=foobar")))
@@ -88,7 +88,7 @@ class PostgresPolicyDefinitionStoreTest extends PolicyDefinitionStoreTestBase {
     @Test
     void findAll_sorting_nonExistentProperty() {
 
-        IntStream.range(0, 10).mapToObj(i -> createPolicy("test-policy")).forEach((d) -> getPolicyDefinitionStore().save(d));
+        IntStream.range(0, 10).mapToObj(i -> createPolicy("test-policy")).forEach((d) -> getPolicyDefinitionStore().create(d));
 
 
         var query = QuerySpec.Builder.newInstance().sortField("notexist").sortOrder(SortOrder.DESC).build();

--- a/spi/control-plane/policy-spi/src/main/java/org/eclipse/edc/connector/policy/spi/store/PolicyDefinitionStore.java
+++ b/spi/control-plane/policy-spi/src/main/java/org/eclipse/edc/connector/policy/spi/store/PolicyDefinitionStore.java
@@ -57,7 +57,7 @@ public interface PolicyDefinitionStore {
      * @return {@link StoreResult#success()} if it could be stored, {@link StoreResult#alreadyExists(String)} if a policy with the same ID already exists.
      * @throws EdcPersistenceException if something goes wrong.
      */
-    StoreResult<PolicyDefinition> save(PolicyDefinition policy);
+    StoreResult<PolicyDefinition> create(PolicyDefinition policy);
 
     /**
      * Updates the policy.
@@ -75,7 +75,7 @@ public interface PolicyDefinitionStore {
      * @return {@link StoreResult#success()} if was deleted, {@link StoreResult#notFound(String)} if a policy with the same ID was not found.
      * @throws EdcPersistenceException if something goes wrong.
      */
-    StoreResult<PolicyDefinition> deleteById(String policyId);
+    StoreResult<PolicyDefinition> delete(String policyId);
 
     /**
      * If the store implementation supports caching, this method triggers a cache-reload.

--- a/spi/control-plane/policy-spi/src/testFixtures/java/org/eclipse/edc/connector/policy/spi/testfixtures/store/PolicyDefinitionStoreTestBase.java
+++ b/spi/control-plane/policy-spi/src/testFixtures/java/org/eclipse/edc/connector/policy/spi/testfixtures/store/PolicyDefinitionStoreTestBase.java
@@ -71,7 +71,7 @@ public abstract class PolicyDefinitionStoreTestBase {
     void save_notExisting() {
         var policy = createPolicy(getRandomId());
 
-        getPolicyDefinitionStore().save(policy);
+        getPolicyDefinitionStore().create(policy);
 
         var policyFromDb = getPolicyDefinitionStore().findById(policy.getUid());
         assertThat(policy).usingRecursiveComparison().isEqualTo(policyFromDb);
@@ -96,9 +96,9 @@ public abstract class PolicyDefinitionStoreTestBase {
         var spec = QuerySpec.Builder.newInstance().build();
 
         var store = getPolicyDefinitionStore();
-        store.save(policy1);
+        store.create(policy1);
 
-        var result = store.save(policy2);
+        var result = store.create(policy2);
         assertThat(result.succeeded()).isFalse();
         assertThat(result.reason()).isEqualTo(ALREADY_EXISTS);
 
@@ -127,7 +127,7 @@ public abstract class PolicyDefinitionStoreTestBase {
         var policy = getPolicy(id, "target");
 
         var store = getPolicyDefinitionStore();
-        store.save(policy);
+        store.create(policy);
 
         var newPolicy = createPolicy(id, "target2");
         var result = store.update(newPolicy);
@@ -154,7 +154,7 @@ public abstract class PolicyDefinitionStoreTestBase {
     void update_whenPolicyExists_updatingPolicyFields() {
         var policy = createPolicy("test-id");
         var store = getPolicyDefinitionStore();
-        store.save(policy);
+        store.create(policy);
 
         var action = Action.Builder.newInstance().type("UPDATED_USE").build();
         var updatedPermission = Permission.Builder.newInstance().action(action).build();
@@ -180,7 +180,7 @@ public abstract class PolicyDefinitionStoreTestBase {
     @Test
     void update_whenPolicyExists_removingPolicyFields() {
         var policy = createPolicy("test-id");
-        getPolicyDefinitionStore().save(policy);
+        getPolicyDefinitionStore().create(policy);
 
         var updatedPolicy = createPolicyDef("test-id", "updatedTarget");
         var result = getPolicyDefinitionStore().update(updatedPolicy);
@@ -200,7 +200,7 @@ public abstract class PolicyDefinitionStoreTestBase {
         var policyId = "test-id";
         var policy = createPolicy(policyId);
         var store = getPolicyDefinitionStore();
-        store.save(policy);
+        store.create(policy);
 
         var updatedPermission = createPermissionBuilder("updated-id").build();
         var updatedProhibition = createProhibitionBuilder("updated-id").build();
@@ -229,7 +229,7 @@ public abstract class PolicyDefinitionStoreTestBase {
     @DisplayName("Find policy by ID that exists")
     void findById_whenPresent() {
         var policy = createPolicy(getRandomId());
-        getPolicyDefinitionStore().save(policy);
+        getPolicyDefinitionStore().create(policy);
 
         var policyFromDb = getPolicyDefinitionStore().findById(policy.getUid());
 
@@ -248,7 +248,7 @@ public abstract class PolicyDefinitionStoreTestBase {
         var limit = 20;
 
         var definitionsExpected = createPolicies(50);
-        definitionsExpected.forEach(getPolicyDefinitionStore()::save);
+        definitionsExpected.forEach(getPolicyDefinitionStore()::create);
 
         var spec = QuerySpec.Builder.newInstance()
                 .limit(limit)
@@ -266,7 +266,7 @@ public abstract class PolicyDefinitionStoreTestBase {
         var pageSize = 15;
 
         var definitionsExpected = createPolicies(10);
-        definitionsExpected.forEach(getPolicyDefinitionStore()::save);
+        definitionsExpected.forEach(getPolicyDefinitionStore()::create);
 
         var spec = QuerySpec.Builder.newInstance()
                 .offset(pageSize)
@@ -283,7 +283,7 @@ public abstract class PolicyDefinitionStoreTestBase {
         var limit = 5;
 
         var definitionsExpected = createPolicies(10);
-        definitionsExpected.forEach(getPolicyDefinitionStore()::save);
+        definitionsExpected.forEach(getPolicyDefinitionStore()::create);
 
         var spec = QuerySpec.Builder.newInstance()
                 .offset(7)
@@ -300,9 +300,9 @@ public abstract class PolicyDefinitionStoreTestBase {
     void deleteById_whenExists() {
         var policy = createPolicy(getRandomId());
         var store = getPolicyDefinitionStore();
-        store.save(policy);
+        store.create(policy);
 
-        var result = store.deleteById(policy.getUid());
+        var result = store.delete(policy.getUid());
         assertThat(result.succeeded()).isTrue();
         assertThat(result.getContent()).usingRecursiveComparison().isEqualTo(policy);
         assertThat(store.findById(policy.getUid())).isNull();
@@ -311,7 +311,7 @@ public abstract class PolicyDefinitionStoreTestBase {
     @Test
     @DisplayName("Delete a non existing policy")
     void deleteById_whenNonexistent() {
-        assertThat(getPolicyDefinitionStore().deleteById("nonexistent"))
+        assertThat(getPolicyDefinitionStore().delete("nonexistent"))
                 .isNotNull()
                 .extracting(StoreResult::reason)
                 .isEqualTo(NOT_FOUND);
@@ -328,7 +328,7 @@ public abstract class PolicyDefinitionStoreTestBase {
                 .build();
 
         var policyDef = PolicyDefinition.Builder.newInstance().id("test-policy").policy(p).build();
-        getPolicyDefinitionStore().save(policyDef);
+        getPolicyDefinitionStore().create(policyDef);
 
         // query by prohibition assignee
         var query = createQuery("policy.prohibitions.assignee=test-assignee");
@@ -355,7 +355,7 @@ public abstract class PolicyDefinitionStoreTestBase {
                 .build();
 
         var policyDef = PolicyDefinition.Builder.newInstance().id("test-policy").policy(p).build();
-        getPolicyDefinitionStore().save(policyDef);
+        getPolicyDefinitionStore().create(policyDef);
 
         // query by prohibition assignee
         var query = createQuery("policy.prohibitions.fooBarProperty=someval");
@@ -373,7 +373,7 @@ public abstract class PolicyDefinitionStoreTestBase {
                 .build();
 
         var policyDef = PolicyDefinition.Builder.newInstance().id("test-policy").policy(p).build();
-        getPolicyDefinitionStore().save(policyDef);
+        getPolicyDefinitionStore().create(policyDef);
 
         // query by prohibition assignee
         var query = createQuery("policy.prohibitions.action.constraint.leftExpression.value=someval");
@@ -392,7 +392,7 @@ public abstract class PolicyDefinitionStoreTestBase {
                 .build();
 
         var policyDef = PolicyDefinition.Builder.newInstance().id("test-policy").policy(p).build();
-        getPolicyDefinitionStore().save(policyDef);
+        getPolicyDefinitionStore().create(policyDef);
 
         // query by prohibition assignee
         var query = createQuery("policy.permissions.assignee=test-assignee");
@@ -419,7 +419,7 @@ public abstract class PolicyDefinitionStoreTestBase {
                 .build();
 
         var policyDef = PolicyDefinition.Builder.newInstance().id("test-policy").policy(p).build();
-        getPolicyDefinitionStore().save(policyDef);
+        getPolicyDefinitionStore().create(policyDef);
 
         // query by prohibition assignee
         var query = createQuery("policy.permissions.fooBarProperty=someval");
@@ -436,7 +436,7 @@ public abstract class PolicyDefinitionStoreTestBase {
                 .build();
 
         var policyDef = PolicyDefinition.Builder.newInstance().id("test-policy").policy(p).build();
-        getPolicyDefinitionStore().save(policyDef);
+        getPolicyDefinitionStore().create(policyDef);
 
         // query by prohibition assignee
         var query = createQuery("policy.permissions.action.constraint.leftExpression=someval");
@@ -455,8 +455,8 @@ public abstract class PolicyDefinitionStoreTestBase {
                 .build();
 
         var policyDef = PolicyDefinition.Builder.newInstance().id("test-policy").policy(p).build();
-        getPolicyDefinitionStore().save(policyDef);
-        getPolicyDefinitionStore().save(createPolicy("another-policy"));
+        getPolicyDefinitionStore().create(policyDef);
+        getPolicyDefinitionStore().create(createPolicy("another-policy"));
 
         // query by prohibition assignee
         var query = createQuery("policy.obligations.assignee=test-assignee");
@@ -483,7 +483,7 @@ public abstract class PolicyDefinitionStoreTestBase {
                 .build();
 
         var policyDef = PolicyDefinition.Builder.newInstance().id("test-policy").policy(p).build();
-        getPolicyDefinitionStore().save(policyDef);
+        getPolicyDefinitionStore().create(policyDef);
 
         // query by prohibition assignee
         var query = createQuery("policy.obligations.fooBarProperty=someval");
@@ -501,7 +501,7 @@ public abstract class PolicyDefinitionStoreTestBase {
                 .build();
 
         var policyDef = PolicyDefinition.Builder.newInstance().id("test-policy").policy(p).build();
-        getPolicyDefinitionStore().save(policyDef);
+        getPolicyDefinitionStore().create(policyDef);
 
         // query by prohibition assignee
         var query = createQuery("policy.obligations.action.constraint.rightExpression.value=notexist");
@@ -523,8 +523,8 @@ public abstract class PolicyDefinitionStoreTestBase {
                 .build();
 
         var policyDef2 = PolicyDefinition.Builder.newInstance().id("test-policy2").policy(p2).build();
-        getPolicyDefinitionStore().save(policyDef1);
-        getPolicyDefinitionStore().save(policyDef2);
+        getPolicyDefinitionStore().create(policyDef1);
+        getPolicyDefinitionStore().create(policyDef2);
 
         // query by prohibition assignee
         Assertions.assertThat(getPolicyDefinitionStore().findAll(createQuery("policy.assignee=test-assignee")))
@@ -541,7 +541,7 @@ public abstract class PolicyDefinitionStoreTestBase {
                 .build();
 
         var policyDef1 = PolicyDefinition.Builder.newInstance().id("test-policy").policy(policy).build();
-        getPolicyDefinitionStore().save(policyDef1);
+        getPolicyDefinitionStore().create(policyDef1);
 
         // query by prohibition assignee
         Assertions.assertThat(getPolicyDefinitionStore().findAll(createQuery("policy.assigner=notexist")))
@@ -553,9 +553,9 @@ public abstract class PolicyDefinitionStoreTestBase {
         var policy1 = createPolicy(getRandomId());
         var policy2 = createPolicy(getRandomId());
         var policy3 = createPolicy(getRandomId());
-        getPolicyDefinitionStore().save(policy1);
-        getPolicyDefinitionStore().save(policy2);
-        getPolicyDefinitionStore().save(policy3);
+        getPolicyDefinitionStore().create(policy1);
+        getPolicyDefinitionStore().create(policy2);
+        getPolicyDefinitionStore().create(policy3);
 
         var list = getPolicyDefinitionStore().findAll(QuerySpec.Builder.newInstance().limit(3).offset(1).build()).collect(Collectors.toList());
         Assertions.assertThat(list).hasSize(2).usingRecursiveFieldByFieldElementComparator().isSubsetOf(policy1, policy2, policy3);
@@ -566,9 +566,9 @@ public abstract class PolicyDefinitionStoreTestBase {
         var policy1 = createPolicy(getRandomId());
         var policy2 = createPolicy(getRandomId());
         var policy3 = createPolicy(getRandomId());
-        getPolicyDefinitionStore().save(policy1);
-        getPolicyDefinitionStore().save(policy2);
-        getPolicyDefinitionStore().save(policy3);
+        getPolicyDefinitionStore().create(policy1);
+        getPolicyDefinitionStore().create(policy2);
+        getPolicyDefinitionStore().create(policy3);
 
         Assertions.assertThat(getPolicyDefinitionStore().findAll(QuerySpec.Builder.newInstance().filter("id=" + policy1.getUid()).build())).usingRecursiveFieldByFieldElementComparator().containsExactly(policy1);
     }
@@ -580,9 +580,9 @@ public abstract class PolicyDefinitionStoreTestBase {
         var policy2 = createPolicy("A");
         var policy3 = createPolicy("B");
 
-        getPolicyDefinitionStore().save(policy1);
-        getPolicyDefinitionStore().save(policy2);
-        getPolicyDefinitionStore().save(policy3);
+        getPolicyDefinitionStore().create(policy1);
+        getPolicyDefinitionStore().create(policy2);
+        getPolicyDefinitionStore().create(policy3);
 
         Assertions.assertThat(getPolicyDefinitionStore().findAll(QuerySpec.Builder.newInstance().sortField("id").sortOrder(SortOrder.ASC).build())).usingRecursiveFieldByFieldElementComparator().containsExactly(policy2, policy3, policy1);
     }
@@ -595,11 +595,11 @@ public abstract class PolicyDefinitionStoreTestBase {
         var policy3 = createPolicy("1B", "target1");
         var policyX = createPolicy("2X", "target2");
         var policyY = createPolicy("2Y", "target2");
-        getPolicyDefinitionStore().save(policy1);
-        getPolicyDefinitionStore().save(policy2);
-        getPolicyDefinitionStore().save(policy3);
-        getPolicyDefinitionStore().save(policyX);
-        getPolicyDefinitionStore().save(policyY);
+        getPolicyDefinitionStore().create(policy1);
+        getPolicyDefinitionStore().create(policy2);
+        getPolicyDefinitionStore().create(policy3);
+        getPolicyDefinitionStore().create(policyX);
+        getPolicyDefinitionStore().create(policyY);
 
         QuerySpec uid = QuerySpec.Builder.newInstance()
                 .filter("policy.target=target1")
@@ -613,7 +613,7 @@ public abstract class PolicyDefinitionStoreTestBase {
 
     @Test
     void findAll_verifyFiltering_invalidFilterExpression() {
-        IntStream.range(0, 10).mapToObj(i -> createPolicy(getRandomId())).forEach(d -> getPolicyDefinitionStore().save(d));
+        IntStream.range(0, 10).mapToObj(i -> createPolicy(getRandomId())).forEach(d -> getPolicyDefinitionStore().create(d));
 
         var query = QuerySpec.Builder.newInstance().filter("something contains other").build();
 
@@ -624,7 +624,7 @@ public abstract class PolicyDefinitionStoreTestBase {
     @EnabledIfSystemProperty(named = "policydefinitionstore.supports.sortorder", matches = "true", disabledReason = "This test only runs if sorting is supported")
     void findAll_sorting_nonExistentProperty() {
 
-        IntStream.range(0, 10).mapToObj(i -> createPolicy(getRandomId())).forEach((d) -> getPolicyDefinitionStore().save(d));
+        IntStream.range(0, 10).mapToObj(i -> createPolicy(getRandomId())).forEach((d) -> getPolicyDefinitionStore().create(d));
 
 
         var query = QuerySpec.Builder.newInstance().sortField("notexist").sortOrder(SortOrder.DESC).build();
@@ -640,7 +640,7 @@ public abstract class PolicyDefinitionStoreTestBase {
         var policy = createPolicy(getRandomId());
         var store = getPolicyDefinitionStore();
 
-        store.save(policy);
+        store.create(policy);
         Assertions.assertThat(store.findAll(QuerySpec.none())).usingRecursiveFieldByFieldElementComparator().containsExactly(policy);
 
         // modify the object

--- a/system-tests/runtimes/file-transfer-provider/src/main/java/org/eclipse/edc/test/extension/api/FileTransferExtension.java
+++ b/system-tests/runtimes/file-transfer-provider/src/main/java/org/eclipse/edc/test/extension/api/FileTransferExtension.java
@@ -64,7 +64,7 @@ public class FileTransferExtension implements ServiceExtension {
         pipelineService.registerFactory(sinkFactory);
 
         var policy = createPolicy();
-        policyStore.save(policy);
+        policyStore.create(policy);
 
         registerDataEntries(context);
         registerContractDefinition(policy.getUid());


### PR DESCRIPTION
…ize in CRUD operations.

## What this PR changes/adds

The persistence implementations in PolicyDefinitionStore are refactrored in CRUD interactions.


## Why it does that

consistency, recognizability


## Further notes


## Linked Issue(s)

ref #2559 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
