### PR TITLE
refactor: persistence implementations in SqlPolicyStoreStatements har…

### DIFF
--- a/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/policydefinition/store/SqlPolicyDefinitionStore.java
+++ b/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/policydefinition/store/SqlPolicyDefinitionStore.java
@@ -69,7 +69,7 @@ public class SqlPolicyDefinitionStore extends AbstractSqlStore implements Policy
         return transactionContext.execute(() -> {
             var query = QuerySpec.Builder.newInstance().filter(List.of(new Criterion("id", "=", id))).build();
             try {
-                var queryStatement = statements.createQuery(query);
+                var queryStatement = statements.create(query);
                 return executeQuerySingle(getConnection(), true, this::mapResultSet, queryStatement.getQueryAsString(), queryStatement.getParameters());
             } catch (SQLException exception) {
                 throw new EdcPersistenceException(exception);
@@ -83,7 +83,7 @@ public class SqlPolicyDefinitionStore extends AbstractSqlStore implements Policy
 
         return transactionContext.execute(() -> {
             try {
-                var queryStatement = statements.createQuery(querySpec);
+                var queryStatement = statements.create(querySpec);
                 return executeQuery(getConnection(), true, this::mapResultSet, queryStatement.getQueryAsString(), queryStatement.getParameters());
             } catch (SQLException exception) {
                 throw new EdcPersistenceException(exception);

--- a/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/policydefinition/store/schema/BaseSqlDialectStatements.java
+++ b/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/policydefinition/store/schema/BaseSqlDialectStatements.java
@@ -70,7 +70,7 @@ public class BaseSqlDialectStatements implements SqlPolicyStoreStatements {
     }
 
     @Override
-    public SqlQueryStatement createQuery(QuerySpec querySpec) {
+    public SqlQueryStatement create(QuerySpec querySpec) {
         return new SqlQueryStatement(getSelectTemplate(), querySpec, new PolicyDefinitionMapping(this));
     }
 }

--- a/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/policydefinition/store/schema/SqlPolicyStoreStatements.java
+++ b/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/policydefinition/store/schema/SqlPolicyStoreStatements.java
@@ -98,5 +98,5 @@ public interface SqlPolicyStoreStatements {
         return BaseSqlDialect.getJsonCastOperator();
     }
 
-    SqlQueryStatement createQuery(QuerySpec querySpec);
+    SqlQueryStatement create(QuerySpec querySpec);
 }

--- a/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/policydefinition/store/schema/postgres/PostgresDialectStatements.java
+++ b/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/policydefinition/store/schema/postgres/PostgresDialectStatements.java
@@ -37,7 +37,7 @@ public class PostgresDialectStatements extends BaseSqlDialectStatements {
     }
 
     @Override
-    public SqlQueryStatement createQuery(QuerySpec querySpec) {
+    public SqlQueryStatement create(QuerySpec querySpec) {
         if (querySpec.containsAnyLeftOperand("policy.prohibitions")) {
             var select = getSelectFromJsonArrayTemplate(getSelectTemplate(), getProhibitionsColumn(), PROHIBITIONS_ALIAS);
             return new SqlQueryStatement(select, querySpec, new PolicyDefinitionMapping(this));
@@ -51,7 +51,7 @@ public class PostgresDialectStatements extends BaseSqlDialectStatements {
             var select = getSelectFromJsonArrayTemplate(getSelectTemplate(), getExtensiblePropertiesColumn(), EXT_PROPERTIES_ALIAS);
             return new SqlQueryStatement(select, querySpec, new PolicyDefinitionMapping(this));
         } else {
-            return super.createQuery(querySpec);
+            return super.create(querySpec);
         }
     }
 

--- a/extensions/control-plane/store/sql/policy-definition-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/policydefinition/schema/postgres/PostgresDialectStatementsTest.java
+++ b/extensions/control-plane/store/sql/policy-definition-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/policydefinition/schema/postgres/PostgresDialectStatementsTest.java
@@ -31,15 +31,15 @@ class PostgresDialectStatementsTest {
 
     @Test
     void createQuery_jsonArrayProperty() {
-        assertThat(statements.createQuery(createQuery("policy.permissions.duties.target=foo")).getQueryAsString()).contains("->>", "->", "json_array_elements");
-        assertThat(statements.createQuery(createQuery("policy.prohibitions.action.type=foo")).getQueryAsString()).contains("->>", "->", "json_array_elements");
-        assertThat(statements.createQuery(createQuery("policy.obligations.assignee=foo")).getQueryAsString()).contains("->>", "->", "json_array_elements");
-        assertThat(statements.createQuery(createQuery("policy.extensibleProperties.something=foo")).getQueryAsString()).contains("->>", "->", "json_array_elements");
+        assertThat(statements.create(createQuery("policy.permissions.duties.target=foo")).getQueryAsString()).contains("->>", "->", "json_array_elements");
+        assertThat(statements.create(createQuery("policy.prohibitions.action.type=foo")).getQueryAsString()).contains("->>", "->", "json_array_elements");
+        assertThat(statements.create(createQuery("policy.obligations.assignee=foo")).getQueryAsString()).contains("->>", "->", "json_array_elements");
+        assertThat(statements.create(createQuery("policy.extensibleProperties.something=foo")).getQueryAsString()).contains("->>", "->", "json_array_elements");
     }
 
     @Test
     void createQuery_normalProperty() {
         var q = createQuery("policy.assigner=foobar");
-        assertThat(statements.createQuery(q).getQueryAsString()).doesNotContain("->>", "->", "json_array_elements");
+        assertThat(statements.create(q).getQueryAsString()).doesNotContain("->>", "->", "json_array_elements");
     }
 }


### PR DESCRIPTION
…monize in CRUD operations.

## What this PR changes/adds

The persistence implementations in SqlPolicyStoreStatements are refactrored in CRUD interactions.


## Why it does that

consistency, recognizability


## Further notes


## Linked Issue(s)

ref #2559 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
