### PR TITLE
refactor: persistence implementations in TransferProcessStoreStatemen…

### DIFF
--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/SqlTransferProcessStore.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/SqlTransferProcessStore.java
@@ -182,7 +182,7 @@ public class SqlTransferProcessStore extends AbstractSqlStore implements Transfe
     }
 
     private Stream<TransferProcess> executeQuery(Connection connection, QuerySpec querySpec) {
-        var statement = statements.createQuery(querySpec);
+        var statement = statements.create(querySpec);
         return SqlQueryExecutor.executeQuery(connection, true, this::mapTransferProcess, statement.getQueryAsString(), statement.getParameters());
     }
 

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/BaseSqlDialectStatements.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/BaseSqlDialectStatements.java
@@ -120,7 +120,7 @@ public abstract class BaseSqlDialectStatements implements TransferProcessStoreSt
     }
 
     @Override
-    public SqlQueryStatement createQuery(QuerySpec querySpec) {
+    public SqlQueryStatement create(QuerySpec querySpec) {
         return new SqlQueryStatement(getSelectTemplate(), querySpec, new TransferProcessMapping(this));
     }
 }

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/TransferProcessStoreStatements.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/TransferProcessStoreStatements.java
@@ -158,5 +158,5 @@ public interface TransferProcessStoreStatements extends LeaseStatements {
         return BaseSqlDialect.getJsonCastOperator();
     }
 
-    SqlQueryStatement createQuery(QuerySpec querySpec);
+    SqlQueryStatement create(QuerySpec querySpec);
 }

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/postgres/PostgresDialectStatements.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/postgres/PostgresDialectStatements.java
@@ -37,7 +37,7 @@ public class PostgresDialectStatements extends BaseSqlDialectStatements {
     }
 
     @Override
-    public SqlQueryStatement createQuery(QuerySpec querySpec) {
+    public SqlQueryStatement create(QuerySpec querySpec) {
         // if any criterion targets a JSON array field, we need to slightly adapt the FROM clause
         if (querySpec.containsAnyLeftOperand("resourceManifest.definitions")) {
             var select = getSelectFromJsonArrayTemplate(getSelectTemplate(), format("%s -> '%s'", getResourceManifestColumn(), "definitions"), DEFINITIONS_ALIAS);
@@ -49,6 +49,6 @@ public class PostgresDialectStatements extends BaseSqlDialectStatements {
             var select = getSelectFromJsonArrayTemplate(getSelectTemplate(), format("%s", getDeprovisionedResourcesColumn()), DEPROVISIONED_RESOURCES_ALIAS);
             return new SqlQueryStatement(select, querySpec, new TransferProcessMapping(this));
         }
-        return super.createQuery(querySpec);
+        return super.create(querySpec);
     }
 }

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/transferprocess/schema/postgres/PostgresDialectStatementsTest.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/transferprocess/schema/postgres/PostgresDialectStatementsTest.java
@@ -28,14 +28,14 @@ class PostgresDialectStatementsTest {
     void createQuery() {
         var q = query("id=foobar");
 
-        assertThat(statements.createQuery(q).getQueryAsString()).doesNotContain("json_array_elements");
+        assertThat(statements.create(q).getQueryAsString()).doesNotContain("json_array_elements");
     }
 
     @Test
     void createQuery_isJsonArray() {
-        assertThat(statements.createQuery(query("deprovisionedResources.inProcess=true")).getQueryAsString()).contains("->>", "->", "json_array_elements");
-        assertThat(statements.createQuery(query("provisionedResourceSet.resources.id=something")).getQueryAsString()).contains("->>", "->", "json_array_elements");
-        assertThat(statements.createQuery(query("resourceManifest.definitions.id like %foo")).getQueryAsString()).contains("->>", "->", "json_array_elements");
+        assertThat(statements.create(query("deprovisionedResources.inProcess=true")).getQueryAsString()).contains("->>", "->", "json_array_elements");
+        assertThat(statements.create(query("provisionedResourceSet.resources.id=something")).getQueryAsString()).contains("->>", "->", "json_array_elements");
+        assertThat(statements.create(query("resourceManifest.definitions.id like %foo")).getQueryAsString()).contains("->>", "->", "json_array_elements");
     }
 
     @Test


### PR DESCRIPTION
…ts harmonize in CRUD operations.

The persistence implementations in TransferProcessStoreStatemen are refactrored in CRUD interactions.



## Why it does that

consistency, recognizability


## Further notes

## Linked Issue(s)

ref #2559 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
