### PR TITLE
refactor(TransferProcessStore): harmonize CRUD operations

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImpl.java
@@ -127,7 +127,7 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
 
         var processId = transferProcessStore.processIdForDataRequestId(dataRequest.getId());
         if (processId != null) {
-            return ServiceResult.success(transferProcessStore.find(processId));
+            return ServiceResult.success(transferProcessStore.findById(processId));
         }
         var process = TransferProcess.Builder.newInstance()
                 .id(randomUUID().toString())
@@ -189,13 +189,13 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
     private ServiceResult<TransferProcess> onMessageDo(TransferRemoteMessage message, Function<TransferProcess, ServiceResult<TransferProcess>> action) {
         return transactionContext.execute(() -> Optional.of(message.getProcessId())
                 .map(transferProcessStore::processIdForDataRequestId)
-                .map(transferProcessStore::find)
+                .map(transferProcessStore::findById)
                 .map(action)
                 .orElse(ServiceResult.notFound(format("TransferProcess with DataRequest id %s not found", message.getProcessId()))));
     }
 
     private void update(TransferProcess transferProcess) {
-        transferProcessStore.save(transferProcess);
+        transferProcessStore.updateOrCreate(transferProcess);
         monitor.debug(format("TransferProcess %s is now in state %s", transferProcess.getId(), TransferProcessStates.from(transferProcess.getState())));
     }
 

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessServiceImpl.java
@@ -70,7 +70,7 @@ public class TransferProcessServiceImpl implements TransferProcessService {
 
     @Override
     public @Nullable TransferProcess findById(String transferProcessId) {
-        return transactionContext.execute(() -> transferProcessStore.find(transferProcessId));
+        return transactionContext.execute(() -> transferProcessStore.findById(transferProcessId));
     }
 
     @Override
@@ -86,7 +86,7 @@ public class TransferProcessServiceImpl implements TransferProcessService {
     @Override
     public @Nullable String getState(String transferProcessId) {
         return transactionContext.execute(() -> {
-            var process = transferProcessStore.find(transferProcessId);
+            var process = transferProcessStore.findById(transferProcessId);
             return Optional.ofNullable(process).map(p -> TransferProcessStates.from(p.getState()).name()).orElse(null);
         });
     }
@@ -135,7 +135,7 @@ public class TransferProcessServiceImpl implements TransferProcessService {
 
     private ServiceResult<TransferProcess> runAsync(SingleTransferProcessCommand command) {
         return Optional.of(command.getTransferProcessId())
-                .map(transferProcessStore::find)
+                .map(transferProcessStore::findById)
                 .map(transferProcess -> {
                     var validator = asyncCommandValidators.get(command.getClass());
                     var validationResult = validator.apply(command, transferProcess);

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessServiceImplTest.java
@@ -70,7 +70,7 @@ class TransferProcessServiceImplTest {
 
     @Test
     void findById_whenFound() {
-        when(store.find(id)).thenReturn(process1);
+        when(store.findById(id)).thenReturn(process1);
         assertThat(service.findById(id)).isSameAs(process1);
         verify(transactionContext).execute(any(TransactionContext.ResultTransactionBlock.class));
     }
@@ -114,7 +114,7 @@ class TransferProcessServiceImplTest {
 
     @Test
     void getState_whenFound() {
-        when(store.find(id)).thenReturn(process1);
+        when(store.findById(id)).thenReturn(process1);
         assertThat(service.getState(id)).isEqualTo(TransferProcessStates.from(process1.getState()).name());
         verify(transactionContext).execute(any(TransactionContext.ResultTransactionBlock.class));
     }
@@ -155,7 +155,7 @@ class TransferProcessServiceImplTest {
     @EnumSource(value = TransferProcessStates.class, mode = INCLUDE, names = { "COMPLETED", "DEPROVISIONING", "TERMINATED" })
     void deprovision(TransferProcessStates state) {
         var process = transferProcess(state, id);
-        when(store.find(id)).thenReturn(process);
+        when(store.findById(id)).thenReturn(process);
 
         var result = service.deprovision(id);
 
@@ -171,7 +171,7 @@ class TransferProcessServiceImplTest {
     @EnumSource(value = TransferProcessStates.class, mode = EXCLUDE, names = { "COMPLETED", "DEPROVISIONING", "DEPROVISIONED", "DEPROVISIONING_REQUESTED", "TERMINATED" })
     void deprovision_whenNonDeprovisionable(TransferProcessStates state) {
         var process = transferProcess(state, id);
-        when(store.find(id)).thenReturn(process);
+        when(store.findById(id)).thenReturn(process);
 
         var result = service.deprovision(id);
 

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/transferprocess/InMemoryTransferProcessStore.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/transferprocess/InMemoryTransferProcessStore.java
@@ -46,7 +46,7 @@ public class InMemoryTransferProcessStore implements TransferProcessStore {
 
     @Nullable
     @Override
-    public TransferProcess find(String id) {
+    public TransferProcess findById(String id) {
         return store.find(id);
     }
 
@@ -61,7 +61,7 @@ public class InMemoryTransferProcessStore implements TransferProcessStore {
     }
 
     @Override
-    public void save(TransferProcess process) {
+    public void updateOrCreate(TransferProcess process) {
         store.upsert(process);
     }
 

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/command/handlers/SingleTransferProcessCommandHandler.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/command/handlers/SingleTransferProcessCommandHandler.java
@@ -38,13 +38,13 @@ public abstract class SingleTransferProcessCommandHandler<T extends SingleTransf
     @Override
     public void handle(T command) {
         var transferProcessId = command.getTransferProcessId();
-        var transferProcess = store.find(transferProcessId);
+        var transferProcess = store.findById(transferProcessId);
         if (transferProcess == null) {
             throw new EdcException(format("Could not find TransferProcess with ID [%s]", transferProcessId));
         } else {
             if (modify(transferProcess, command)) {
                 transferProcess.setModified();
-                store.save(transferProcess);
+                store.updateOrCreate(transferProcess);
                 postAction(transferProcess);
             }
         }

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
@@ -196,7 +196,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
 
     @Override
     public void handleDeprovisionResult(String processId, List<StatusResult<DeprovisionedResource>> responses) {
-        var transferProcess = transferProcessStore.find(processId);
+        var transferProcess = transferProcessStore.findById(processId);
         if (transferProcess == null) {
             monitor.severe("TransferProcessManager: no TransferProcess found for deprovisioned resources");
             return;

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/command/handlers/CancelTransferCommandHandlerTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/command/handlers/CancelTransferCommandHandlerTest.java
@@ -59,15 +59,15 @@ class CancelTransferCommandHandlerTest {
                 .type(TransferProcess.Type.CONSUMER).build();
         var originalDate = tp.getUpdatedAt();
 
-        when(store.find(anyString())).thenReturn(tp);
+        when(store.findById(anyString())).thenReturn(tp);
         handler.handle(cmd);
 
         assertThat(tp.getState()).isEqualTo(TERMINATING.code());
         assertThat(tp.getErrorDetail()).isEqualTo("transfer cancelled");
         assertThat(tp.getUpdatedAt()).isNotEqualTo(originalDate);
 
-        verify(store).find(anyString());
-        verify(store).save(tp);
+        verify(store).findById(anyString());
+        verify(store).updateOrCreate(tp);
         verifyNoMoreInteractions(store);
     }
 
@@ -79,12 +79,12 @@ class CancelTransferCommandHandlerTest {
         var originalDate = tp.getUpdatedAt();
         var cmd = new CancelTransferCommand("test-id");
 
-        when(store.find(anyString())).thenReturn(tp);
+        when(store.findById(anyString())).thenReturn(tp);
         handler.handle(cmd);
 
         assertThat(tp.getUpdatedAt()).isEqualTo(originalDate);
 
-        verify(store).find(anyString());
+        verify(store).findById(anyString());
         verifyNoMoreInteractions(store);
         verifyNoInteractions(listener);
     }
@@ -93,7 +93,7 @@ class CancelTransferCommandHandlerTest {
     void handle_notFound() {
         var cmd = new CancelTransferCommand("test-id");
 
-        when(store.find(anyString())).thenReturn(null);
+        when(store.findById(anyString())).thenReturn(null);
         assertThatThrownBy(() -> handler.handle(cmd)).isInstanceOf(EdcException.class).hasMessageStartingWith("Could not find TransferProcess with ID [test-id]");
         verifyNoInteractions(listener);
     }

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/command/handlers/CompleteTransferCommandHandlerTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/command/handlers/CompleteTransferCommandHandlerTest.java
@@ -46,15 +46,15 @@ class CompleteTransferCommandHandlerTest {
                 .updatedAt(124123) //some invalid time
                 .type(TransferProcess.Type.CONSUMER).build();
         var originalDate = tp.getUpdatedAt();
-        when(store.find(anyString())).thenReturn(tp);
+        when(store.findById(anyString())).thenReturn(tp);
 
         handler.handle(command);
 
         assertThat(tp.getState()).isEqualTo(COMPLETING.code());
         assertThat(tp.getErrorDetail()).isNull();
         assertThat(tp.getUpdatedAt()).isNotEqualTo(originalDate);
-        verify(store).find(anyString());
-        verify(store).save(tp);
+        verify(store).findById(anyString());
+        verify(store).updateOrCreate(tp);
         verifyNoMoreInteractions(store);
     }
 
@@ -65,19 +65,19 @@ class CompleteTransferCommandHandlerTest {
                 .type(TransferProcess.Type.CONSUMER).build();
         var originalDate = tp.getUpdatedAt();
         var command = new CompleteTransferCommand("test-id");
-        when(store.find(anyString())).thenReturn(tp);
+        when(store.findById(anyString())).thenReturn(tp);
 
         handler.handle(command);
 
         assertThat(tp.getUpdatedAt()).isEqualTo(originalDate);
-        verify(store).find(anyString());
+        verify(store).findById(anyString());
         verifyNoMoreInteractions(store);
     }
 
     @Test
     void handle_notFound() {
         var command = new CompleteTransferCommand("test-id");
-        when(store.find(anyString())).thenReturn(null);
+        when(store.findById(anyString())).thenReturn(null);
 
         assertThatThrownBy(() -> handler.handle(command)).isInstanceOf(EdcException.class).hasMessageStartingWith("Could not find TransferProcess with ID [test-id]");
     }

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/command/handlers/DeprovisionCommandHandlerTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/command/handlers/DeprovisionCommandHandlerTest.java
@@ -49,7 +49,7 @@ class DeprovisionCommandHandlerTest {
                 .build();
         var originalDate = tp.getUpdatedAt();
 
-        when(storeMock.find(anyString())).thenReturn(tp);
+        when(storeMock.findById(anyString())).thenReturn(tp);
         handler.handle(cmd);
 
         assertThat(tp.getState()).isEqualTo(TransferProcessStates.DEPROVISIONING.code());
@@ -61,7 +61,7 @@ class DeprovisionCommandHandlerTest {
     void handle_notFound() {
         var cmd = new DeprovisionRequest("test-id");
 
-        when(storeMock.find(anyString())).thenReturn(null);
+        when(storeMock.findById(anyString())).thenReturn(null);
         assertThatThrownBy(() -> handler.handle(cmd)).isInstanceOf(EdcException.class).hasMessage("Could not find TransferProcess with ID [test-id]");
     }
 
@@ -72,7 +72,7 @@ class DeprovisionCommandHandlerTest {
                 .type(TransferProcess.Type.CONSUMER).build();
         var originalDate = tp.getUpdatedAt();
 
-        when(storeMock.find(anyString())).thenReturn(tp);
+        when(storeMock.findById(anyString())).thenReturn(tp);
         assertThatThrownBy(() -> handler.handle(cmd)).isInstanceOf(IllegalStateException.class).hasMessage("Cannot transition from state STARTED to DEPROVISIONING");
         assertThat(tp.getUpdatedAt()).isEqualTo(originalDate);
     }

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/command/handlers/TerminateTransferCommandHandlerTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/command/handlers/TerminateTransferCommandHandlerTest.java
@@ -64,15 +64,15 @@ class TerminateTransferCommandHandlerTest {
                 .type(TransferProcess.Type.CONSUMER).build();
         var originalDate = tp.getUpdatedAt();
 
-        when(store.find(anyString())).thenReturn(tp);
+        when(store.findById(anyString())).thenReturn(tp);
         handler.handle(cmd);
 
         assertThat(tp.getState()).isEqualTo(TERMINATING.code());
         assertThat(tp.getErrorDetail()).isEqualTo("a reason");
         assertThat(tp.getUpdatedAt()).isNotEqualTo(originalDate);
 
-        verify(store).find(anyString());
-        verify(store).save(tp);
+        verify(store).findById(anyString());
+        verify(store).updateOrCreate(tp);
         verifyNoMoreInteractions(store);
     }
 
@@ -84,12 +84,12 @@ class TerminateTransferCommandHandlerTest {
         var originalDate = tp.getUpdatedAt();
         var cmd = new TerminateTransferCommand("test-id", "a reason");
 
-        when(store.find(anyString())).thenReturn(tp);
+        when(store.findById(anyString())).thenReturn(tp);
         handler.handle(cmd);
 
         assertThat(tp.getUpdatedAt()).isEqualTo(originalDate);
 
-        verify(store).find(anyString());
+        verify(store).findById(anyString());
         verifyNoMoreInteractions(store);
         verifyNoInteractions(listener);
     }
@@ -98,7 +98,7 @@ class TerminateTransferCommandHandlerTest {
     void handle_notFound() {
         var cmd = new TerminateTransferCommand("test-id", "a reason");
 
-        when(store.find(anyString())).thenReturn(null);
+        when(store.findById(anyString())).thenReturn(null);
         assertThatThrownBy(() -> handler.handle(cmd)).isInstanceOf(EdcException.class).hasMessageStartingWith("Could not find TransferProcess with ID [test-id]");
         verifyNoInteractions(listener);
     }

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/transfer/TransferProcessManagerImplIntegrationTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/transfer/TransferProcessManagerImplIntegrationTest.java
@@ -123,7 +123,7 @@ class TransferProcessManagerImplIntegrationTest {
         var processes = IntStream.range(0, numProcesses)
                 .mapToObj(i -> provisionedResourceSet())
                 .map(resourceSet -> createInitialTransferProcess().resourceManifest(manifest).callbackAddresses(List.of(callback)).provisionedResourceSet(resourceSet).build())
-                .peek(store::save)
+                .peek(store::updateOrCreate)
                 .collect(Collectors.toList());
 
         transferProcessManager.start();
@@ -132,7 +132,7 @@ class TransferProcessManagerImplIntegrationTest {
             assertThat(processes).describedAs("All transfer processes state should be greater than INITIAL")
                     .allSatisfy(process -> {
                         var id = process.getId();
-                        var storedProcess = store.find(id);
+                        var storedProcess = store.findById(id);
 
                         assertThat(storedProcess).describedAs("Should exist in the TransferProcessStore")
                                 .isNotNull().extracting(StatefulEntity::getState).asInstanceOf(comparable(Integer.class))

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/transfer/TransferProcessManagerImplTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/transfer/TransferProcessManagerImplTest.java
@@ -244,7 +244,7 @@ class TransferProcessManagerImplTest {
         await().untilAsserted(() -> {
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
             verifyNoInteractions(provisionManager);
-            verify(transferProcessStore).save(argThat(p -> p.getState() == TERMINATING.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == TERMINATING.code()));
         });
     }
 

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/transfer/TransferProcessManagerImplTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/transfer/TransferProcessManagerImplTest.java
@@ -189,7 +189,7 @@ class TransferProcessManagerImplTest {
         manager.initiateConsumerRequest(transferRequest);
         manager.stop();
 
-        verify(transferProcessStore, times(RETRY_LIMIT)).save(captor.capture());
+        verify(transferProcessStore, times(RETRY_LIMIT)).updateOrCreate(captor.capture());
         assertThat(captor.getValue().getCallbackAddresses()).usingRecursiveFieldByFieldElementComparator().contains(callback);
         verify(listener).initiated(any());
 
@@ -210,7 +210,7 @@ class TransferProcessManagerImplTest {
         await().untilAsserted(() -> {
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
             verifyNoInteractions(provisionManager);
-            verify(transferProcessStore).save(argThat(p -> p.getState() == PROVISIONING.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == PROVISIONING.code()));
         });
     }
 
@@ -228,7 +228,7 @@ class TransferProcessManagerImplTest {
         await().untilAsserted(() -> {
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
             verifyNoInteractions(provisionManager);
-            verify(transferProcessStore).save(argThat(p -> p.getState() == TERMINATING.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == TERMINATING.code()));
         });
     }
 
@@ -260,13 +260,13 @@ class TransferProcessManagerImplTest {
         when(policyArchive.findPolicyForContract(anyString())).thenReturn(Policy.Builder.newInstance().build());
         when(provisionManager.provision(any(), isA(Policy.class))).thenReturn(completedFuture(List.of(provisionResult)));
         when(transferProcessStore.nextForState(eq(PROVISIONING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process);
+        when(transferProcessStore.findById(process.getId())).thenReturn(process);
 
         manager.start();
 
         await().untilAsserted(() -> {
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
-            verify(transferProcessStore).save(argThat(p -> p.getState() == PROVISIONED.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == PROVISIONED.code()));
             verify(listener).provisioned(process);
         });
     }
@@ -289,13 +289,13 @@ class TransferProcessManagerImplTest {
         when(policyArchive.findPolicyForContract(anyString())).thenReturn(Policy.Builder.newInstance().build());
         when(provisionManager.provision(any(), isA(Policy.class))).thenReturn(completedFuture(List.of(provisionResult)));
         when(transferProcessStore.nextForState(eq(PROVISIONING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process);
+        when(transferProcessStore.findById(process.getId())).thenReturn(process);
 
         manager.start();
 
         await().untilAsserted(() -> {
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
-            verify(transferProcessStore).save(argThat(p -> p.getState() == PROVISIONED.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == PROVISIONED.code()));
             verify(vault).storeSecret(any(), any());
             verify(listener).provisioned(process);
         });
@@ -314,12 +314,12 @@ class TransferProcessManagerImplTest {
         when(policyArchive.findPolicyForContract(anyString())).thenReturn(Policy.Builder.newInstance().build());
         when(provisionManager.provision(any(), isA(Policy.class))).thenReturn(completedFuture(List.of(provisionResult)));
         when(transferProcessStore.nextForState(eq(PROVISIONING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process);
+        when(transferProcessStore.findById(process.getId())).thenReturn(process);
 
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore).save(argThat(p -> p.getState() == PROVISIONING_REQUESTED.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == PROVISIONING_REQUESTED.code()));
             verify(listener).provisioningRequested(any());
         });
     }
@@ -333,13 +333,13 @@ class TransferProcessManagerImplTest {
         when(policyArchive.findPolicyForContract(anyString())).thenReturn(Policy.Builder.newInstance().build());
         when(provisionManager.provision(any(), isA(Policy.class))).thenReturn(failedFuture(new EdcException("provision failed")));
         when(transferProcessStore.nextForState(eq(PROVISIONING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process);
+        when(transferProcessStore.findById(process.getId())).thenReturn(process);
 
         manager.start();
 
         await().untilAsserted(() -> {
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
-            verify(transferProcessStore).save(argThat(p -> p.getState() == TERMINATING.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == TERMINATING.code()));
         });
     }
 
@@ -353,13 +353,13 @@ class TransferProcessManagerImplTest {
         when(policyArchive.findPolicyForContract(anyString())).thenReturn(Policy.Builder.newInstance().build());
         when(provisionManager.provision(any(), isA(Policy.class))).thenReturn(completedFuture(List.of(provisionResult)));
         when(transferProcessStore.nextForState(eq(PROVISIONING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process);
+        when(transferProcessStore.findById(process.getId())).thenReturn(process);
 
         manager.start();
 
         await().untilAsserted(() -> {
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
-            verify(transferProcessStore).save(argThat(p -> p.getState() == TERMINATING.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == TERMINATING.code()));
         });
     }
 
@@ -373,13 +373,13 @@ class TransferProcessManagerImplTest {
         when(policyArchive.findPolicyForContract(anyString())).thenReturn(Policy.Builder.newInstance().build());
         when(provisionManager.provision(any(), isA(Policy.class))).thenReturn(completedFuture(List.of(provisionResult)));
         when(transferProcessStore.nextForState(eq(PROVISIONING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process);
+        when(transferProcessStore.findById(process.getId())).thenReturn(process);
 
         manager.start();
 
         await().untilAsserted(() -> {
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
-            verify(transferProcessStore).save(argThat(p -> p.getState() == PROVISIONING.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == PROVISIONING.code()));
         });
     }
 
@@ -392,7 +392,7 @@ class TransferProcessManagerImplTest {
 
         await().untilAsserted(() -> {
             verify(transferProcessStore, atLeastOnce()).nextForState(eq(PROVISIONED.code()), anyInt());
-            verify(transferProcessStore).save(argThat(p -> p.getState() == REQUESTING.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == REQUESTING.code()));
         });
     }
 
@@ -404,7 +404,7 @@ class TransferProcessManagerImplTest {
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore).save(argThat(p -> p.getState() == STARTING.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == STARTING.code()));
         });
     }
 
@@ -413,13 +413,13 @@ class TransferProcessManagerImplTest {
         var process = createTransferProcess(REQUESTING);
         when(dispatcherRegistry.send(eq(Object.class), any())).thenReturn(completedFuture("any"));
         when(transferProcessStore.nextForState(eq(REQUESTING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process, process.toBuilder().state(REQUESTING.code()).build());
+        when(transferProcessStore.findById(process.getId())).thenReturn(process, process.toBuilder().state(REQUESTING.code()).build());
 
         manager.start();
 
         await().untilAsserted(() -> {
             verify(dispatcherRegistry).send(eq(Object.class), isA(TransferRequestMessage.class));
-            verify(transferProcessStore, times(1)).save(argThat(p -> p.getState() == REQUESTED.code()));
+            verify(transferProcessStore, times(1)).updateOrCreate(argThat(p -> p.getState() == REQUESTED.code()));
             verify(listener).requested(process);
         });
     }
@@ -437,7 +437,7 @@ class TransferProcessManagerImplTest {
 
         manager.start();
 
-        await().pollDelay(RETRY_LIMIT, SECONDS).untilAsserted(() -> verify(transferProcessStore, never()).save(any()));
+        await().pollDelay(RETRY_LIMIT, SECONDS).untilAsserted(() -> verify(transferProcessStore, never()).updateOrCreate(any()));
     }
 
     @Test
@@ -455,7 +455,7 @@ class TransferProcessManagerImplTest {
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore).save(argThat(p -> p.getState() == STARTED.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == STARTED.code()));
         });
     }
 
@@ -468,12 +468,12 @@ class TransferProcessManagerImplTest {
                 .dataRequest(dataRequest).build();
         when(transferProcessStore.nextForState(eq(REQUESTED.code()), anyInt())).thenReturn(List.of(process));
         doThrow(new AssertionError("update() should not be called as process was not updated"))
-                .when(transferProcessStore).save(process);
+                .when(transferProcessStore).updateOrCreate(process);
 
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore, never()).save(any());
+            verify(transferProcessStore, never()).updateOrCreate(any());
         });
     }
 
@@ -483,7 +483,7 @@ class TransferProcessManagerImplTest {
         var dataFlowResponse = createDataFlowResponse();
         when(policyArchive.findPolicyForContract(anyString())).thenReturn(Policy.Builder.newInstance().build());
         when(transferProcessStore.nextForState(eq(STARTING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process);
+        when(transferProcessStore.findById(process.getId())).thenReturn(process);
         when(dataFlowManager.initiate(any(), any(), any())).thenReturn(StatusResult.success(dataFlowResponse));
         when(dispatcherRegistry.send(any(), isA(TransferStartMessage.class))).thenReturn(completedFuture("any"));
 
@@ -494,7 +494,7 @@ class TransferProcessManagerImplTest {
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
             verify(dispatcherRegistry).send(any(), captor.capture());
             assertThat(captor.getValue().getDataAddress()).usingRecursiveComparison().isEqualTo(dataFlowResponse.getDataAddress());
-            verify(transferProcessStore).save(argThat(p -> p.getState() == STARTED.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == STARTED.code()));
             verify(listener).started(eq(process), any());
         });
     }
@@ -504,12 +504,12 @@ class TransferProcessManagerImplTest {
         var process = createTransferProcess(STARTING).toBuilder().type(PROVIDER).build();
         when(dataFlowManager.initiate(any(), any(), any())).thenReturn(StatusResult.failure(ResponseStatus.ERROR_RETRY));
         when(transferProcessStore.nextForState(eq(STARTING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process, process.toBuilder().state(STARTING.code()).build());
+        when(transferProcessStore.findById(process.getId())).thenReturn(process, process.toBuilder().state(STARTING.code()).build());
 
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore, times(RETRY_LIMIT)).save(argThat(p -> p.getState() == STARTING.code()));
+            verify(transferProcessStore, times(RETRY_LIMIT)).updateOrCreate(argThat(p -> p.getState() == STARTING.code()));
         });
     }
 
@@ -523,7 +523,7 @@ class TransferProcessManagerImplTest {
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore).save(argThat(p -> p.getState() == TERMINATING.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == TERMINATING.code()));
         });
     }
 
@@ -532,12 +532,12 @@ class TransferProcessManagerImplTest {
         var process = createTransferProcessBuilder(STARTING).type(PROVIDER).stateCount(RETRY_EXHAUSTED).build();
         when(dataFlowManager.initiate(any(), any(), any())).thenReturn(StatusResult.failure(ResponseStatus.ERROR_RETRY));
         when(transferProcessStore.nextForState(eq(STARTING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process);
+        when(transferProcessStore.findById(process.getId())).thenReturn(process);
 
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore, times(RETRY_LIMIT)).save(argThat(p -> p.getState() == TERMINATING.code()));
+            verify(transferProcessStore, times(RETRY_LIMIT)).updateOrCreate(argThat(p -> p.getState() == TERMINATING.code()));
         });
     }
 
@@ -546,13 +546,13 @@ class TransferProcessManagerImplTest {
         var process = createTransferProcessBuilder(STARTING).type(PROVIDER).stateCount(2).stateTimestamp(clock.millis() + 1000L).build();
         when(dataFlowManager.initiate(any(), any(), any())).thenReturn(StatusResult.failure(ResponseStatus.ERROR_RETRY));
         when(transferProcessStore.nextForState(eq(STARTING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process, process.toBuilder().state(STARTING.code()).build());
+        when(transferProcessStore.findById(process.getId())).thenReturn(process, process.toBuilder().state(STARTING.code()).build());
 
         manager.start();
 
         await().untilAsserted(() -> {
             verifyNoInteractions(dataFlowManager);
-            verify(transferProcessStore).save(argThat(p -> p.getState() == STARTING.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == STARTING.code()));
         });
     }
 
@@ -569,7 +569,7 @@ class TransferProcessManagerImplTest {
 
         await().untilAsserted(() -> {
             verify(statusCheckerRegistry, atLeastOnce()).resolve(any());
-            verify(transferProcessStore).save(argThat(p -> p.getState() == COMPLETING.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == COMPLETING.code()));
         });
     }
 
@@ -588,7 +588,7 @@ class TransferProcessManagerImplTest {
 
         await().untilAsserted(() -> {
             verify(statusCheckerRegistry, atLeastOnce()).resolve(any());
-            verify(transferProcessStore).save(argThat(p -> p.getState() == COMPLETING.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == COMPLETING.code()));
         });
     }
 
@@ -604,7 +604,7 @@ class TransferProcessManagerImplTest {
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore).save(argThat(p -> p.getState() == STARTED.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == STARTED.code()));
         });
     }
 
@@ -615,12 +615,12 @@ class TransferProcessManagerImplTest {
         process.getProvisionedResourceSet().addResource(provisionedDataDestinationResource());
         when(transferProcessStore.nextForState(eq(STARTED.code()), anyInt())).thenReturn(List.of(process));
         doThrow(new AssertionError("update() should not be called as process was not updated"))
-                .when(transferProcessStore).save(process);
+                .when(transferProcessStore).updateOrCreate(process);
 
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore, never()).save(any());
+            verify(transferProcessStore, never()).updateOrCreate(any());
         });
     }
 
@@ -639,7 +639,7 @@ class TransferProcessManagerImplTest {
 
         await().untilAsserted(() -> {
             verify(statusCheckerRegistry, atLeastOnce()).resolve(any());
-            verify(transferProcessStore).save(argThat(p -> p.getState() == COMPLETING.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == COMPLETING.code()));
         });
     }
 
@@ -647,14 +647,14 @@ class TransferProcessManagerImplTest {
     void completing_shouldTransitionToCompleted_whenSendingMessageSucceed() {
         var process = createTransferProcess(COMPLETING);
         when(transferProcessStore.nextForState(eq(COMPLETING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process, process.toBuilder().state(COMPLETING.code()).build());
+        when(transferProcessStore.findById(process.getId())).thenReturn(process, process.toBuilder().state(COMPLETING.code()).build());
         when(dispatcherRegistry.send(any(), isA(TransferCompletionMessage.class))).thenReturn(completedFuture("any"));
 
         manager.start();
 
         await().untilAsserted(() -> {
             verify(dispatcherRegistry).send(any(), isA(TransferCompletionMessage.class));
-            verify(transferProcessStore, times(RETRY_LIMIT)).save(argThat(p -> p.getState() == COMPLETED.code()));
+            verify(transferProcessStore, times(RETRY_LIMIT)).updateOrCreate(argThat(p -> p.getState() == COMPLETED.code()));
             verify(listener).completed(process);
         });
     }
@@ -663,14 +663,14 @@ class TransferProcessManagerImplTest {
     void terminating_shouldTransitionToTerminated_whenMessageSentCorrectly() {
         var process = createTransferProcessBuilder(TERMINATING).type(PROVIDER).build();
         when(transferProcessStore.nextForState(eq(TERMINATING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process, process.toBuilder().state(TERMINATING.code()).build());
+        when(transferProcessStore.findById(process.getId())).thenReturn(process, process.toBuilder().state(TERMINATING.code()).build());
         when(dispatcherRegistry.send(any(), isA(TransferTerminationMessage.class))).thenReturn(completedFuture("any"));
 
         manager.start();
 
         await().untilAsserted(() -> {
             verify(dispatcherRegistry).send(any(), isA(TransferTerminationMessage.class));
-            verify(transferProcessStore, times(RETRY_LIMIT)).save(argThat(p -> p.getState() == TERMINATED.code()));
+            verify(transferProcessStore, times(RETRY_LIMIT)).updateOrCreate(argThat(p -> p.getState() == TERMINATED.code()));
             verify(listener).terminated(process);
         });
     }
@@ -679,13 +679,13 @@ class TransferProcessManagerImplTest {
     void terminating_shouldTransitionToTerminatedWithoutSendingMessage_whenConsumerAndIsNotRequestedYet() {
         var process = createTransferProcessBuilder(TERMINATING).type(CONSUMER).state(REQUESTING.code()).build();
         when(transferProcessStore.nextForState(eq(TERMINATING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process, process.toBuilder().state(TERMINATING.code()).build());
+        when(transferProcessStore.findById(process.getId())).thenReturn(process, process.toBuilder().state(TERMINATING.code()).build());
 
         manager.start();
 
         await().untilAsserted(() -> {
             verifyNoInteractions(dispatcherRegistry);
-            verify(transferProcessStore, times(RETRY_LIMIT)).save(argThat(p -> p.getState() == TERMINATED.code()));
+            verify(transferProcessStore, times(RETRY_LIMIT)).updateOrCreate(argThat(p -> p.getState() == TERMINATED.code()));
             verify(listener).terminated(process);
         });
     }
@@ -713,14 +713,14 @@ class TransferProcessManagerImplTest {
         when(vault.deleteSecret(any())).thenReturn(Result.success());
         when(provisionManager.deprovision(any(), isA(Policy.class))).thenReturn(completedFuture(List.of(deprovisionResult)));
         when(transferProcessStore.nextForState(eq(DEPROVISIONING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process);
+        when(transferProcessStore.findById(process.getId())).thenReturn(process);
 
         manager.start();
 
         await().untilAsserted(() -> {
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
-            verify(transferProcessStore).find(process.getId());
-            verify(transferProcessStore).save(argThat(p -> p.getState() == DEPROVISIONED.code()));
+            verify(transferProcessStore).findById(process.getId());
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == DEPROVISIONED.code()));
             verify(vault).deleteSecret(any());
             verify(listener).deprovisioned(process);
         });
@@ -750,12 +750,12 @@ class TransferProcessManagerImplTest {
         when(vault.deleteSecret(any())).thenReturn(Result.success());
         when(provisionManager.deprovision(any(), isA(Policy.class))).thenReturn(completedFuture(List.of(StatusResult.success(deprovisionedResponse))));
         when(transferProcessStore.nextForState(eq(DEPROVISIONING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process);
+        when(transferProcessStore.findById(process.getId())).thenReturn(process);
 
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore).save(argThat(p -> p.getState() == DEPROVISIONING_REQUESTED.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == DEPROVISIONING_REQUESTED.code()));
             verify(listener).deprovisioningRequested(any());
         });
     }
@@ -780,13 +780,13 @@ class TransferProcessManagerImplTest {
         when(policyArchive.findPolicyForContract(anyString())).thenReturn(Policy.Builder.newInstance().build());
         when(provisionManager.deprovision(any(), isA(Policy.class))).thenReturn(completedFuture(List.of(deprovisionResult)));
         when(transferProcessStore.nextForState(eq(DEPROVISIONING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process);
+        when(transferProcessStore.findById(process.getId())).thenReturn(process);
 
         manager.start();
 
         await().untilAsserted(() -> {
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
-            verify(transferProcessStore).save(argThat(p -> p.getState() == DEPROVISIONED.code() && p.getErrorDetail() != null));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == DEPROVISIONED.code() && p.getErrorDetail() != null));
             verify(listener).deprovisioned(process);
         });
     }
@@ -811,12 +811,12 @@ class TransferProcessManagerImplTest {
         when(policyArchive.findPolicyForContract(anyString())).thenReturn(Policy.Builder.newInstance().build());
         when(provisionManager.deprovision(any(), isA(Policy.class))).thenReturn(completedFuture(List.of(deprovisionResult)));
         when(transferProcessStore.nextForState(eq(DEPROVISIONING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process);
+        when(transferProcessStore.findById(process.getId())).thenReturn(process);
 
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore).save(argThat(p -> p.getState() == DEPROVISIONING.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == DEPROVISIONING.code()));
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
         });
     }
@@ -830,13 +830,13 @@ class TransferProcessManagerImplTest {
         when(policyArchive.findPolicyForContract(anyString())).thenReturn(Policy.Builder.newInstance().build());
         when(provisionManager.deprovision(any(), isA(Policy.class))).thenReturn(failedFuture(new EdcException("provision failed")));
         when(transferProcessStore.nextForState(eq(DEPROVISIONING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(transferProcessStore.find(process.getId())).thenReturn(process);
+        when(transferProcessStore.findById(process.getId())).thenReturn(process);
 
         manager.start();
 
         await().untilAsserted(() -> {
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
-            verify(transferProcessStore).save(argThat(p -> p.getState() == DEPROVISIONED.code() && p.getErrorDetail() != null));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == DEPROVISIONED.code() && p.getErrorDetail() != null));
             verify(listener).deprovisioned(process);
         });
     }
@@ -847,12 +847,12 @@ class TransferProcessManagerImplTest {
         var negotiation = builderEnricher.apply(createTransferProcessBuilder(starting).state(starting.code())).build();
         when(transferProcessStore.nextForState(eq(starting.code()), anyInt())).thenReturn(List.of(negotiation)).thenReturn(emptyList());
         when(dispatcherRegistry.send(any(), any())).thenReturn(failedFuture(new EdcException("error")));
-        when(transferProcessStore.find(negotiation.getId())).thenReturn(negotiation);
+        when(transferProcessStore.findById(negotiation.getId())).thenReturn(negotiation);
 
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore).save(argThat(p -> p.getState() == ending.code()));
+            verify(transferProcessStore).updateOrCreate(argThat(p -> p.getState() == ending.code()));
             verify(dispatcherRegistry, only()).send(any(), any());
         });
     }

--- a/extensions/control-plane/api/control-plane-api-client/src/test/java/org/eclipse/edc/connector/api/client/transferprocess/TransferProcessHttpClientIntegrationTest.java
+++ b/extensions/control-plane/api/control-plane-api-client/src/test/java/org/eclipse/edc/connector/api/client/transferprocess/TransferProcessHttpClientIntegrationTest.java
@@ -82,13 +82,13 @@ public class TransferProcessHttpClientIntegrationTest {
     void shouldCallTransferProcessApiWithComplete(TransferProcessStore store, DataPlaneManager manager, ControlPlaneApiUrl callbackUrl) {
         when(service.transfer(any())).thenReturn(completedFuture(StreamResult.success()));
         var id = "tp-id";
-        store.save(createTransferProcess(id));
+        store.updateOrCreate(createTransferProcess(id));
         var dataFlowRequest = createDataFlowRequest(id, callbackUrl.get());
 
         manager.initiateTransfer(dataFlowRequest);
 
         await().untilAsserted(() -> {
-            var transferProcess = store.find("tp-id");
+            var transferProcess = store.findById("tp-id");
             assertThat(transferProcess).isNotNull()
                     .extracting(StatefulEntity::getState).isEqualTo(COMPLETED.code());
         });
@@ -98,13 +98,13 @@ public class TransferProcessHttpClientIntegrationTest {
     void shouldCallTransferProcessApiWithFailed(TransferProcessStore store, DataPlaneManager manager, ControlPlaneApiUrl callbackUrl) {
         when(service.transfer(any())).thenReturn(completedFuture(StreamResult.error("error")));
         var id = "tp-id";
-        store.save(createTransferProcess(id));
+        store.updateOrCreate(createTransferProcess(id));
         var dataFlowRequest = createDataFlowRequest(id, callbackUrl.get());
 
         manager.initiateTransfer(dataFlowRequest);
 
         await().untilAsserted(() -> {
-            var transferProcess = store.find("tp-id");
+            var transferProcess = store.findById("tp-id");
             assertThat(transferProcess).isNotNull().satisfies(process -> {
                 assertThat(process.getState()).isEqualTo(TERMINATED.code());
                 assertThat(process.getErrorDetail()).isEqualTo("error");
@@ -116,13 +116,13 @@ public class TransferProcessHttpClientIntegrationTest {
     void shouldCallTransferProcessApiWithException(TransferProcessStore store, DataPlaneManager manager, ControlPlaneApiUrl callbackUrl) {
         when(service.transfer(any())).thenReturn(failedFuture(new EdcException("error")));
         var id = "tp-id";
-        store.save(createTransferProcess(id));
+        store.updateOrCreate(createTransferProcess(id));
         var dataFlowRequest = createDataFlowRequest(id, callbackUrl.get());
 
         manager.initiateTransfer(dataFlowRequest);
 
         await().untilAsserted(() -> {
-            var transferProcess = store.find("tp-id");
+            var transferProcess = store.findById("tp-id");
             assertThat(transferProcess).isNotNull().satisfies(process -> {
                 assertThat(process.getState()).isEqualTo(TERMINATED.code());
                 assertThat(process.getErrorDetail()).isEqualTo("error");

--- a/extensions/control-plane/api/control-plane-api/src/test/java/org/eclipse/edc/connector/api/TransferProcessControlApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/control-plane-api/src/test/java/org/eclipse/edc/connector/api/TransferProcessControlApiControllerIntegrationTest.java
@@ -67,7 +67,7 @@ class TransferProcessControlApiControllerIntegrationTest {
 
     @Test
     void callTransferProcessHookWithComplete(TransferProcessStore store) {
-        store.save(createTransferProcess());
+        store.updateOrCreate(createTransferProcess());
 
         baseRequest()
                 .contentType("application/json")
@@ -78,7 +78,7 @@ class TransferProcessControlApiControllerIntegrationTest {
 
 
         await().untilAsserted(() -> {
-            var transferProcess = store.find("tp-id");
+            var transferProcess = store.findById("tp-id");
             assertThat(transferProcess).isNotNull()
                     .extracting(StatefulEntity::getState).isEqualTo(COMPLETED.code());
         });
@@ -86,7 +86,7 @@ class TransferProcessControlApiControllerIntegrationTest {
 
     @Test
     void callTransferProcessHookWithError(TransferProcessStore store) {
-        store.save(createTransferProcess());
+        store.updateOrCreate(createTransferProcess());
 
         var rq = TransferProcessFailStateDto.Builder.newInstance()
                 .errorMessage("error")
@@ -102,7 +102,7 @@ class TransferProcessControlApiControllerIntegrationTest {
 
 
         await().untilAsserted(() -> {
-            var transferProcess = store.find("tp-id");
+            var transferProcess = store.findById("tp-id");
             assertThat(transferProcess).isNotNull().satisfies((process) -> {
                 assertThat(process.getState()).isEqualTo(TERMINATED.code());
                 assertThat(process.getErrorDetail()).isEqualTo("error");
@@ -155,7 +155,7 @@ class TransferProcessControlApiControllerIntegrationTest {
 
     @Test
     void callCompleteTransferProcessHook_invalidState(TransferProcessStore store) {
-        store.save(createTransferProcessBuilder().state(INITIAL.code()).build());
+        store.updateOrCreate(createTransferProcessBuilder().state(INITIAL.code()).build());
 
         var rq = TransferProcessFailStateDto.Builder.newInstance()
                 .errorMessage("error")

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/api/management/transferprocess/TransferProcessApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/api/management/transferprocess/TransferProcessApiControllerIntegrationTest.java
@@ -73,7 +73,7 @@ class TransferProcessApiControllerIntegrationTest {
 
     @Test
     void getAllTransferProcesses(TransferProcessStore store) {
-        store.save(createTransferProcess(PROCESS_ID));
+        store.updateOrCreate(createTransferProcess(PROCESS_ID));
 
         baseRequest()
                 .get("/transferprocess")
@@ -94,7 +94,7 @@ class TransferProcessApiControllerIntegrationTest {
 
     @Test
     void queryAllTransferProcesses(TransferProcessStore store) {
-        store.save(createTransferProcess(PROCESS_ID));
+        store.updateOrCreate(createTransferProcess(PROCESS_ID));
 
         baseRequest()
                 .contentType(JSON)
@@ -108,7 +108,7 @@ class TransferProcessApiControllerIntegrationTest {
     @Test
     void queryAllTransferProcesses_withPaging(TransferProcessStore store) {
         IntStream.range(0, 10)
-                .forEach(i -> store.save(createTransferProcess(PROCESS_ID + i)));
+                .forEach(i -> store.updateOrCreate(createTransferProcess(PROCESS_ID + i)));
 
         baseRequest()
                 .contentType(JSON)
@@ -123,7 +123,7 @@ class TransferProcessApiControllerIntegrationTest {
     @Test
     void queryAllTransferProcesses_withFilter(TransferProcessStore store) {
         IntStream.range(0, 10)
-                .forEach(i -> store.save(createTransferProcess(PROCESS_ID + i)));
+                .forEach(i -> store.updateOrCreate(createTransferProcess(PROCESS_ID + i)));
 
         baseRequest()
                 .contentType(JSON)
@@ -138,7 +138,7 @@ class TransferProcessApiControllerIntegrationTest {
 
     @Test
     void getSingleTransferProcess(TransferProcessStore store) {
-        store.save(createTransferProcess(PROCESS_ID));
+        store.updateOrCreate(createTransferProcess(PROCESS_ID));
         baseRequest()
                 .get("/transferprocess/" + PROCESS_ID)
                 .then()
@@ -159,7 +159,7 @@ class TransferProcessApiControllerIntegrationTest {
 
     @Test
     void getSingleTransferProcessState(TransferProcessStore store) {
-        store.save(createTransferProcess(PROCESS_ID, PROVISIONING.code()));
+        store.updateOrCreate(createTransferProcess(PROCESS_ID, PROVISIONING.code()));
 
         var state = baseRequest()
                 .get("/transferprocess/" + PROCESS_ID + "/state")
@@ -181,7 +181,7 @@ class TransferProcessApiControllerIntegrationTest {
 
     @Test
     void cancel(TransferProcessStore store) {
-        store.save(createTransferProcess(PROCESS_ID, STARTED.code()));
+        store.updateOrCreate(createTransferProcess(PROCESS_ID, STARTED.code()));
 
         baseRequest()
                 .contentType(JSON)
@@ -201,7 +201,7 @@ class TransferProcessApiControllerIntegrationTest {
 
     @Test
     void cancel_conflict(TransferProcessStore store) {
-        store.save(createTransferProcess(PROCESS_ID, COMPLETED.code()));
+        store.updateOrCreate(createTransferProcess(PROCESS_ID, COMPLETED.code()));
         baseRequest()
                 .contentType(JSON)
                 .post("/transferprocess/" + PROCESS_ID + "/cancel")
@@ -212,7 +212,7 @@ class TransferProcessApiControllerIntegrationTest {
 
     @Test
     void terminate(TransferProcessStore store) {
-        store.save(createTransferProcess(PROCESS_ID, STARTED.code()));
+        store.updateOrCreate(createTransferProcess(PROCESS_ID, STARTED.code()));
 
         baseRequest()
                 .contentType(JSON)
@@ -222,7 +222,7 @@ class TransferProcessApiControllerIntegrationTest {
                 .statusCode(204);
 
         await().untilAsserted(() -> {
-            assertThat(store.find(PROCESS_ID)).isNotNull().extracting(StatefulEntity::getErrorDetail).isEqualTo("any reason");
+            assertThat(store.findById(PROCESS_ID)).isNotNull().extracting(StatefulEntity::getErrorDetail).isEqualTo("any reason");
         });
     }
 
@@ -248,7 +248,7 @@ class TransferProcessApiControllerIntegrationTest {
 
     @Test
     void terminate_conflict(TransferProcessStore store) {
-        store.save(createTransferProcess(PROCESS_ID, COMPLETED.code()));
+        store.updateOrCreate(createTransferProcess(PROCESS_ID, COMPLETED.code()));
         baseRequest()
                 .contentType(JSON)
                 .body(Map.of("reason", "any reason"))
@@ -260,7 +260,7 @@ class TransferProcessApiControllerIntegrationTest {
 
     @Test
     void deprovision(TransferProcessStore store) {
-        store.save(createTransferProcess(PROCESS_ID, COMPLETED.code()));
+        store.updateOrCreate(createTransferProcess(PROCESS_ID, COMPLETED.code()));
 
         baseRequest()
                 .contentType(JSON)
@@ -280,7 +280,7 @@ class TransferProcessApiControllerIntegrationTest {
 
     @Test
     void deprovision_conflict(TransferProcessStore store) {
-        store.save(createTransferProcess(PROCESS_ID, INITIAL.code()));
+        store.updateOrCreate(createTransferProcess(PROCESS_ID, INITIAL.code()));
 
         baseRequest()
                 .contentType(JSON)

--- a/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
+++ b/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
@@ -120,7 +120,7 @@ public class HttpProvisionerExtensionEndToEndTest {
 
         assertThat(result).isSucceeded();
         await().untilAsserted(() -> {
-            var transferProcess = store.find(result.getContent().getId());
+            var transferProcess = store.findById(result.getContent().getId());
             assertThat(transferProcess).isNotNull()
                     .extracting(StatefulEntity::getState).isEqualTo(PROVISIONING_REQUESTED.code());
         });

--- a/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/webhook/HttpProvisionerWebhookApiControllerIntegrationTest.java
+++ b/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/webhook/HttpProvisionerWebhookApiControllerIntegrationTest.java
@@ -90,7 +90,7 @@ class HttpProvisionerWebhookApiControllerIntegrationTest {
     @Test
     void callProvisionWebhook(TransferProcessStore store) {
 
-        store.save(createTransferProcess());
+        store.updateOrCreate(createTransferProcess());
 
         var rq = ProvisionerWebhookRequest.Builder.newInstance()
                 .assetId("test-asset")
@@ -140,7 +140,7 @@ class HttpProvisionerWebhookApiControllerIntegrationTest {
     @Test
     void callDeprovisionWebhook(TransferProcessStore store) {
 
-        store.save(createTransferProcess());
+        store.updateOrCreate(createTransferProcess());
 
         var rq = DeprovisionedResource.Builder.newInstance()
                 .provisionedResourceId("resource-id")

--- a/extensions/control-plane/store/cosmos/transfer-process-store-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/transferprocess/CosmosTransferProcessStore.java
+++ b/extensions/control-plane/store/cosmos/transfer-process-store-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/transferprocess/CosmosTransferProcessStore.java
@@ -98,7 +98,7 @@ public class CosmosTransferProcessStore implements TransferProcessStore {
     }
 
     @Override
-    public TransferProcess find(String id) {
+    public TransferProcess findById(String id) {
         // we need to read the TransferProcessDocument as Object, because no custom JSON deserialization can be registered
         // with the CosmosDB SDK, so it would not know about subtypes, etc.
         Object obj = findByIdInternal(id);
@@ -118,7 +118,7 @@ public class CosmosTransferProcessStore implements TransferProcessStore {
     }
 
     @Override
-    public void save(TransferProcess process) {
+    public void updateOrCreate(TransferProcess process) {
         Objects.requireNonNull(process.getId(), "TransferProcesses must have an ID!");
         try {
             leaseContext.acquireLease(process.getId());

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/SqlTransferProcessStore.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/SqlTransferProcessStore.java
@@ -84,7 +84,7 @@ public class SqlTransferProcessStore extends AbstractSqlStore implements Transfe
     }
 
     @Override
-    public @Nullable TransferProcess find(String id) {
+    public @Nullable TransferProcess findById(String id) {
         return transactionContext.execute(() -> {
             var q = QuerySpec.Builder.newInstance().filter("id = " + id).build();
             return single(findAll(q).collect(toList()));
@@ -104,7 +104,7 @@ public class SqlTransferProcessStore extends AbstractSqlStore implements Transfe
     }
 
     @Override
-    public void save(TransferProcess process) {
+    public void updateOrCreate(TransferProcess process) {
         Objects.requireNonNull(process.getId(), "TransferProcesses must have an ID!");
         if (process.getDataRequest() == null) {
             throw new IllegalArgumentException("Cannot store TransferProcess without a DataRequest");
@@ -128,7 +128,7 @@ public class SqlTransferProcessStore extends AbstractSqlStore implements Transfe
     public void delete(String processId) {
 
         transactionContext.execute(() -> {
-            var existing = find(processId);
+            var existing = findById(processId);
             if (existing != null) {
                 try (var conn = getConnection()) {
                     // attempt to acquire lease - should fail if someone else holds the lease

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/transferprocess/PostgresTransferProcessStoreTest.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/transferprocess/PostgresTransferProcessStoreTest.java
@@ -85,8 +85,8 @@ class PostgresTransferProcessStoreTest extends TransferProcessStoreTestBase {
         var tp = createTransferProcessBuilder("testprocess1")
                 .dataRequest(da)
                 .build();
-        store.save(tp);
-        store.save(createTransferProcess("testprocess2"));
+        store.updateOrCreate(tp);
+        store.updateOrCreate(createTransferProcess("testprocess2"));
 
         var query = QuerySpec.Builder.newInstance()
                 .filter(List.of(new Criterion("dataRequest.notexist", "=", "somevalue")))
@@ -104,8 +104,8 @@ class PostgresTransferProcessStoreTest extends TransferProcessStoreTestBase {
         var tp = createTransferProcessBuilder("testprocess1")
                 .resourceManifest(rm)
                 .build();
-        store.save(tp);
-        store.save(createTransferProcess("testprocess2"));
+        store.updateOrCreate(tp);
+        store.updateOrCreate(createTransferProcess("testprocess2"));
 
         // throws exception when an explicit mapping exists
         var query = QuerySpec.Builder.newInstance()
@@ -137,8 +137,8 @@ class PostgresTransferProcessStoreTest extends TransferProcessStoreTestBase {
         var tp = createTransferProcessBuilder("testprocess1")
                 .provisionedResourceSet(prs)
                 .build();
-        store.save(tp);
-        store.save(createTransferProcess("testprocess2"));
+        store.updateOrCreate(tp);
+        store.updateOrCreate(createTransferProcess("testprocess2"));
 
         // throws exception when an explicit mapping exists
         var query = QuerySpec.Builder.newInstance()
@@ -158,7 +158,7 @@ class PostgresTransferProcessStoreTest extends TransferProcessStoreTestBase {
 
     @Test
     void find_queryByLease() {
-        store.save(createTransferProcess("testprocess1"));
+        store.updateOrCreate(createTransferProcess("testprocess1"));
 
         var query = QuerySpec.Builder.newInstance()
                 .filter(List.of(new Criterion("lease.leasedBy", "=", "foobar")))
@@ -174,13 +174,13 @@ class PostgresTransferProcessStoreTest extends TransferProcessStoreTestBase {
         var t1 = TestFunctions.createTransferProcessBuilder("id1")
                 .dataRequest(null)
                 .build();
-        assertThatIllegalArgumentException().isThrownBy(() -> getTransferProcessStore().save(t1));
+        assertThatIllegalArgumentException().isThrownBy(() -> getTransferProcessStore().updateOrCreate(t1));
     }
 
     @Override
     @Test
     protected void findAll_verifySorting_invalidProperty() {
-        IntStream.range(0, 10).forEach(i -> getTransferProcessStore().save(createTransferProcess("test-neg-" + i)));
+        IntStream.range(0, 10).forEach(i -> getTransferProcessStore().updateOrCreate(createTransferProcess("test-neg-" + i)));
 
         var query = QuerySpec.Builder.newInstance().sortField("notexist").sortOrder(SortOrder.DESC).build();
 

--- a/extensions/control-plane/transfer/transfer-pull-http-dynamic-receiver/src/main/java/org/eclipse/edc/connector/receiver/http/dynamic/HttpDynamicEndpointDataReferenceReceiver.java
+++ b/extensions/control-plane/transfer/transfer-pull-http-dynamic-receiver/src/main/java/org/eclipse/edc/connector/receiver/http/dynamic/HttpDynamicEndpointDataReferenceReceiver.java
@@ -67,7 +67,7 @@ public class HttpDynamicEndpointDataReferenceReceiver implements EndpointDataRef
         if (processId == null) {
             return CompletableFuture.completedFuture(Result.failure(format("Failed to found processId for DataRequestId %s", edr.getId())));
         }
-        var transferProcess = transferProcessStore.find(processId);
+        var transferProcess = transferProcessStore.findById(processId);
 
         if (transferProcess == null) {
             return CompletableFuture.completedFuture(Result.failure(format("Failed to found transfer process for id %s", processId)));

--- a/extensions/control-plane/transfer/transfer-pull-http-dynamic-receiver/src/test/java/org/eclipse/edc/connector/receiver/http/dynamic/HttpDynamicEndpointDataReferenceReceiverTest.java
+++ b/extensions/control-plane/transfer/transfer-pull-http-dynamic-receiver/src/test/java/org/eclipse/edc/connector/receiver/http/dynamic/HttpDynamicEndpointDataReferenceReceiverTest.java
@@ -100,7 +100,7 @@ public class HttpDynamicEndpointDataReferenceReceiverTest {
 
 
         when(transferProcessStore.processIdForDataRequestId(any())).thenReturn(TRANSFER_ID);
-        when(transferProcessStore.find(TRANSFER_ID)).thenReturn(createTransferProcess(TRANSFER_ID, transferProperties(receiverUrl())));
+        when(transferProcessStore.findById(TRANSFER_ID)).thenReturn(createTransferProcess(TRANSFER_ID, transferProperties(receiverUrl())));
 
         var edr = createEndpointDataReferenceBuilder()
                 .properties(Map.of(HTTP_RECEIVER_ENDPOINT, receiverUrl()))
@@ -132,7 +132,7 @@ public class HttpDynamicEndpointDataReferenceReceiverTest {
 
 
         when(transferProcessStore.processIdForDataRequestId(any())).thenReturn(TRANSFER_ID);
-        when(transferProcessStore.find(TRANSFER_ID)).thenReturn(createTransferProcess(TRANSFER_ID, transferPropertiesWithAuth(receiverUrl(), authKey, authToken)));
+        when(transferProcessStore.findById(TRANSFER_ID)).thenReturn(createTransferProcess(TRANSFER_ID, transferPropertiesWithAuth(receiverUrl(), authKey, authToken)));
 
 
         var edr = createEndpointDataReferenceBuilder()
@@ -153,7 +153,7 @@ public class HttpDynamicEndpointDataReferenceReceiverTest {
     @Test
     public void send_shouldFailForwardTheEdr_withPathNotFound() throws ExecutionException, InterruptedException {
         when(transferProcessStore.processIdForDataRequestId(any())).thenReturn(TRANSFER_ID);
-        when(transferProcessStore.find(TRANSFER_ID)).thenReturn(createTransferProcess(TRANSFER_ID, transferProperties(receiverUrl() + "/modified")));
+        when(transferProcessStore.findById(TRANSFER_ID)).thenReturn(createTransferProcess(TRANSFER_ID, transferProperties(receiverUrl() + "/modified")));
 
         var edr = createEndpointDataReferenceBuilder()
                 .build();
@@ -189,7 +189,7 @@ public class HttpDynamicEndpointDataReferenceReceiverTest {
     @Test
     public void send_shouldFailForwardTheEdr_transferProcessNotFound() throws ExecutionException, InterruptedException {
         when(transferProcessStore.processIdForDataRequestId(any())).thenReturn(TRANSFER_ID);
-        when(transferProcessStore.find(TRANSFER_ID)).thenReturn(null);
+        when(transferProcessStore.findById(TRANSFER_ID)).thenReturn(null);
 
         var edr = createEndpointDataReferenceBuilder()
                 .build();
@@ -209,7 +209,7 @@ public class HttpDynamicEndpointDataReferenceReceiverTest {
     public void send_shouldNotForwardTheEdr_whenReceiverUrlMissing() throws ExecutionException, InterruptedException {
 
         when(transferProcessStore.processIdForDataRequestId(any())).thenReturn(TRANSFER_ID);
-        when(transferProcessStore.find(TRANSFER_ID)).thenReturn(createTransferProcess(TRANSFER_ID));
+        when(transferProcessStore.findById(TRANSFER_ID)).thenReturn(createTransferProcess(TRANSFER_ID));
 
         var edr = createEndpointDataReferenceBuilder()
                 .build();
@@ -239,7 +239,7 @@ public class HttpDynamicEndpointDataReferenceReceiverTest {
                 .build();
 
         when(transferProcessStore.processIdForDataRequestId(any())).thenReturn(TRANSFER_ID);
-        when(transferProcessStore.find(TRANSFER_ID)).thenReturn(createTransferProcess(TRANSFER_ID));
+        when(transferProcessStore.findById(TRANSFER_ID)).thenReturn(createTransferProcess(TRANSFER_ID));
 
         var edr = createEndpointDataReferenceBuilder()
                 .build();

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/store/TransferProcessStore.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/store/TransferProcessStore.java
@@ -32,7 +32,7 @@ public interface TransferProcessStore extends StateEntityStore<TransferProcess> 
      * Returns the transfer process for the id or null if not found.
      */
     @Nullable
-    TransferProcess find(String id);
+    TransferProcess findById(String id);
 
     /**
      * Returns the transfer process for the data request id or null if not found.
@@ -44,7 +44,7 @@ public interface TransferProcessStore extends StateEntityStore<TransferProcess> 
      * Persists a transfer process. This follows UPSERT semantics, so if the object didn't exit before, it's
      * created.
      */
-    void save(TransferProcess process);
+    void updateOrCreate(TransferProcess process);
 
 
     /**

--- a/spi/control-plane/transfer-spi/src/testFixtures/java/org/eclipse/edc/connector/transfer/spi/testfixtures/store/TransferProcessStoreTestBase.java
+++ b/spi/control-plane/transfer-spi/src/testFixtures/java/org/eclipse/edc/connector/transfer/spi/testfixtures/store/TransferProcessStoreTestBase.java
@@ -70,7 +70,7 @@ public abstract class TransferProcessStoreTestBase {
     @Test
     void create() {
         var t = TestFunctions.createTransferProcessBuilder("test-id").properties(Map.of("key", "value")).build();
-        getTransferProcessStore().save(t);
+        getTransferProcessStore().updateOrCreate(t);
 
         var all = getTransferProcessStore().findAll(QuerySpec.none()).collect(Collectors.toList());
         assertThat(all).containsExactly(t);
@@ -84,7 +84,7 @@ public abstract class TransferProcessStoreTestBase {
         var callbacks = List.of(CallbackAddress.Builder.newInstance().uri("test").events(Set.of("event")).build());
 
         var t = TestFunctions.createTransferProcessBuilder("test-id").properties(Map.of("key", "value")).callbackAddresses(callbacks).build();
-        getTransferProcessStore().save(t);
+        getTransferProcessStore().updateOrCreate(t);
 
         var all = getTransferProcessStore().findAll(QuerySpec.none()).collect(Collectors.toList());
         assertThat(all).containsExactly(t);
@@ -95,10 +95,10 @@ public abstract class TransferProcessStoreTestBase {
     @Test
     void create_withSameIdExists_shouldReplace() {
         var t = TestFunctions.createTransferProcess("id1", INITIAL);
-        getTransferProcessStore().save(t);
+        getTransferProcessStore().updateOrCreate(t);
 
         var t2 = TestFunctions.createTransferProcess("id1", PROVISIONING);
-        getTransferProcessStore().save(t2);
+        getTransferProcessStore().updateOrCreate(t2);
 
         assertThat(getTransferProcessStore().findAll(QuerySpec.none())).hasSize(1).containsExactly(t2);
     }
@@ -108,7 +108,7 @@ public abstract class TransferProcessStoreTestBase {
         var state = STARTED;
         var all = IntStream.range(0, 10)
                 .mapToObj(i -> TestFunctions.createTransferProcess("id" + i, state))
-                .peek(getTransferProcessStore()::save)
+                .peek(getTransferProcessStore()::updateOrCreate)
                 .collect(Collectors.toList());
 
         assertThat(getTransferProcessStore().nextForState(state.code(), 5))
@@ -123,7 +123,7 @@ public abstract class TransferProcessStoreTestBase {
         var state = STARTED;
         var all = IntStream.range(0, 10)
                 .mapToObj(i -> TestFunctions.createTransferProcess("id" + i, state))
-                .peek(getTransferProcessStore()::save)
+                .peek(getTransferProcessStore()::updateOrCreate)
                 .collect(Collectors.toList());
 
         // lease a few
@@ -141,7 +141,7 @@ public abstract class TransferProcessStoreTestBase {
         var state = STARTED;
         IntStream.range(0, 3)
                 .mapToObj(i -> TestFunctions.createTransferProcess("id" + i, state))
-                .forEach(getTransferProcessStore()::save);
+                .forEach(getTransferProcessStore()::updateOrCreate);
 
         // first time works
         assertThat(getTransferProcessStore().nextForState(state.code(), 10)).hasSize(3);
@@ -153,7 +153,7 @@ public abstract class TransferProcessStoreTestBase {
     void nextForState_noneInDesiredState() {
         IntStream.range(0, 3)
                 .mapToObj(i -> TestFunctions.createTransferProcess("id" + i, STARTED))
-                .forEach(getTransferProcessStore()::save);
+                .forEach(getTransferProcessStore()::updateOrCreate);
 
         var nextForState = getTransferProcessStore().nextForState(TERMINATED.code(), 10);
 
@@ -165,7 +165,7 @@ public abstract class TransferProcessStoreTestBase {
         var state = STARTED;
         IntStream.range(0, 10)
                 .mapToObj(i -> TestFunctions.createTransferProcess("id" + i, state))
-                .forEach(getTransferProcessStore()::save);
+                .forEach(getTransferProcessStore()::updateOrCreate);
 
         // first time works
         assertThat(getTransferProcessStore().nextForState(state.code(), 3)).hasSize(3);
@@ -184,7 +184,7 @@ public abstract class TransferProcessStoreTestBase {
                     }
                     t.updateStateTimestamp();
                 })
-                .forEach(getTransferProcessStore()::save);
+                .forEach(getTransferProcessStore()::updateOrCreate);
 
         assertThat(getTransferProcessStore().nextForState(state.code(), 20))
                 .extracting(TransferProcess::getId)
@@ -197,14 +197,14 @@ public abstract class TransferProcessStoreTestBase {
         var state = STARTED;
         var all = IntStream.range(0, 10)
                 .mapToObj(i -> TestFunctions.createTransferProcess("id" + i, state))
-                .peek(getTransferProcessStore()::save)
+                .peek(getTransferProcessStore()::updateOrCreate)
                 .collect(Collectors.toList());
 
         Thread.sleep(100);
 
         var fourth = all.get(3);
         fourth.updateStateTimestamp();
-        getTransferProcessStore().save(fourth);
+        getTransferProcessStore().updateOrCreate(fourth);
 
         var next = getTransferProcessStore().nextForState(STARTED.code(), 20);
         assertThat(next.indexOf(fourth)).isEqualTo(9);
@@ -214,7 +214,7 @@ public abstract class TransferProcessStoreTestBase {
     @DisplayName("Verifies that calling nextForState locks the TP for any subsequent calls")
     void nextForState_locksEntity() {
         var t = TestFunctions.createTransferProcess("id1", INITIAL);
-        getTransferProcessStore().save(t);
+        getTransferProcessStore().updateOrCreate(t);
 
         getTransferProcessStore().nextForState(INITIAL.code(), 100);
 
@@ -224,7 +224,7 @@ public abstract class TransferProcessStoreTestBase {
     @Test
     void nextForState_expiredLease() {
         var t = TestFunctions.createTransferProcess("id1", INITIAL);
-        getTransferProcessStore().save(t);
+        getTransferProcessStore().updateOrCreate(t);
 
         lockEntity(t.getId(), CONNECTOR_NAME, Duration.ofMillis(100));
 
@@ -236,16 +236,16 @@ public abstract class TransferProcessStoreTestBase {
     @Test
     void find() {
         var t = TestFunctions.createTransferProcess("id1");
-        getTransferProcessStore().save(t);
+        getTransferProcessStore().updateOrCreate(t);
 
-        var res = getTransferProcessStore().find("id1");
+        var res = getTransferProcessStore().findById("id1");
 
         assertThat(res).usingRecursiveComparison().isEqualTo(t);
     }
 
     @Test
     void find_notExist() {
-        assertThat(getTransferProcessStore().find("not-exist")).isNull();
+        assertThat(getTransferProcessStore().findById("not-exist")).isNull();
     }
 
     @Test
@@ -256,7 +256,7 @@ public abstract class TransferProcessStoreTestBase {
         var dr = TestFunctions.createDataRequest(pid);
         var t = TestFunctions.createTransferProcess(tid, dr);
 
-        getTransferProcessStore().save(t);
+        getTransferProcessStore().updateOrCreate(t);
 
         assertThat(getTransferProcessStore().processIdForDataRequestId(dr.getId())).isEqualTo("transfer-id1");
     }
@@ -269,10 +269,10 @@ public abstract class TransferProcessStoreTestBase {
     @Test
     void update_shouldPersistDataRequest() {
         var t1 = TestFunctions.createTransferProcess("id1", STARTED);
-        getTransferProcessStore().save(t1);
+        getTransferProcessStore().updateOrCreate(t1);
 
         t1.getDataRequest().getProperties().put("newKey", "newValue");
-        getTransferProcessStore().save(t1);
+        getTransferProcessStore().updateOrCreate(t1);
 
         var all = getTransferProcessStore().findAll(QuerySpec.none()).collect(Collectors.toList());
         assertThat(all)
@@ -286,10 +286,10 @@ public abstract class TransferProcessStoreTestBase {
     @Test
     void update_exists_shouldUpdate() {
         var t1 = TestFunctions.createTransferProcess("id1", STARTED);
-        getTransferProcessStore().save(t1);
+        getTransferProcessStore().updateOrCreate(t1);
 
         t1.transitionCompleted(); //modify
-        getTransferProcessStore().save(t1);
+        getTransferProcessStore().updateOrCreate(t1);
 
         assertThat(getTransferProcessStore().findAll(QuerySpec.none()))
                 .hasSize(1)
@@ -302,7 +302,7 @@ public abstract class TransferProcessStoreTestBase {
         var t1 = TestFunctions.createTransferProcess("id1", STARTED);
 
         t1.transitionCompleted(); //modify
-        getTransferProcessStore().save(t1);
+        getTransferProcessStore().updateOrCreate(t1);
 
         var result = getTransferProcessStore().findAll(QuerySpec.none()).collect(Collectors.toList());
         assertThat(result)
@@ -315,12 +315,12 @@ public abstract class TransferProcessStoreTestBase {
     @DisplayName("Verify that the lease on a TP is cleared by an update")
     void update_shouldBreakLease() {
         var t1 = TestFunctions.createTransferProcess("id1");
-        getTransferProcessStore().save(t1);
+        getTransferProcessStore().updateOrCreate(t1);
         // acquire lease
         lockEntity(t1.getId(), CONNECTOR_NAME);
 
         t1.transitionProvisioning(ResourceManifest.Builder.newInstance().build()); //modify
-        getTransferProcessStore().save(t1);
+        getTransferProcessStore().updateOrCreate(t1);
 
         // lease should be broken
         assertThat(getTransferProcessStore().nextForState(PROVISIONING.code(), 10)).usingRecursiveFieldByFieldElementComparator().containsExactly(t1);
@@ -330,19 +330,19 @@ public abstract class TransferProcessStoreTestBase {
     void update_leasedByOther_shouldThrowException() {
         var tpId = "id1";
         var t1 = TestFunctions.createTransferProcess(tpId);
-        getTransferProcessStore().save(t1);
+        getTransferProcessStore().updateOrCreate(t1);
         lockEntity(tpId, "someone");
 
         t1.transitionProvisioning(ResourceManifest.Builder.newInstance().build()); //modify
 
         // leased by someone else -> throw exception
-        assertThatThrownBy(() -> getTransferProcessStore().save(t1)).isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(() -> getTransferProcessStore().updateOrCreate(t1)).isInstanceOf(IllegalStateException.class);
     }
 
     @Test
     void delete() {
         var t1 = TestFunctions.createTransferProcess("id1");
-        getTransferProcessStore().save(t1);
+        getTransferProcessStore().updateOrCreate(t1);
 
         getTransferProcessStore().delete("id1");
         assertThat(getTransferProcessStore().findAll(QuerySpec.none())).isEmpty();
@@ -351,7 +351,7 @@ public abstract class TransferProcessStoreTestBase {
     @Test
     void delete_isLeasedBySelf_shouldThrowException() {
         var t1 = TestFunctions.createTransferProcess("id1");
-        getTransferProcessStore().save(t1);
+        getTransferProcessStore().updateOrCreate(t1);
         lockEntity(t1.getId(), CONNECTOR_NAME);
 
 
@@ -361,7 +361,7 @@ public abstract class TransferProcessStoreTestBase {
     @Test
     void delete_isLeasedByOther_shouldThrowException() {
         var t1 = TestFunctions.createTransferProcess("id1");
-        getTransferProcessStore().save(t1);
+        getTransferProcessStore().updateOrCreate(t1);
 
         lockEntity(t1.getId(), "someone-else");
 
@@ -378,7 +378,7 @@ public abstract class TransferProcessStoreTestBase {
     void findAll_noQuerySpec() {
         var all = IntStream.range(0, 10)
                 .mapToObj(i -> TestFunctions.createTransferProcess("id" + i))
-                .peek(getTransferProcessStore()::save)
+                .peek(getTransferProcessStore()::updateOrCreate)
                 .collect(Collectors.toList());
 
         assertThat(getTransferProcessStore().findAll(QuerySpec.none())).containsExactlyInAnyOrderElementsOf(all);
@@ -388,7 +388,7 @@ public abstract class TransferProcessStoreTestBase {
     void findAll_verifyPaging() {
         IntStream.range(0, 10)
                 .mapToObj(i -> TestFunctions.createTransferProcess(String.valueOf(i)))
-                .forEach(getTransferProcessStore()::save);
+                .forEach(getTransferProcessStore()::updateOrCreate);
 
         var qs = QuerySpec.Builder.newInstance().limit(5).offset(3).build();
         assertThat(getTransferProcessStore().findAll(qs)).hasSize(5)
@@ -402,7 +402,7 @@ public abstract class TransferProcessStoreTestBase {
 
         IntStream.range(0, 10)
                 .mapToObj(i -> TestFunctions.createTransferProcess(String.valueOf(i)))
-                .forEach(getTransferProcessStore()::save);
+                .forEach(getTransferProcessStore()::updateOrCreate);
 
         var qs = QuerySpec.Builder.newInstance().limit(20).offset(3).build();
         assertThat(getTransferProcessStore().findAll(qs))
@@ -417,7 +417,7 @@ public abstract class TransferProcessStoreTestBase {
 
         IntStream.range(0, 10)
                 .mapToObj(i -> TestFunctions.createTransferProcess(String.valueOf(i)))
-                .forEach(getTransferProcessStore()::save);
+                .forEach(getTransferProcessStore()::updateOrCreate);
 
         var qs = QuerySpec.Builder.newInstance().limit(10).offset(12).build();
         assertThat(getTransferProcessStore().findAll(qs)).isEmpty();
@@ -428,7 +428,7 @@ public abstract class TransferProcessStoreTestBase {
     void update_dataRequestWithNewId_replacesOld() {
         var bldr = TestFunctions.createTransferProcessBuilder("id1").state(STARTED.code());
         var t1 = bldr.build();
-        getTransferProcessStore().save(t1);
+        getTransferProcessStore().updateOrCreate(t1);
 
         var t2 = bldr
                 .dataRequest(TestFunctions.createDataRequestBuilder()
@@ -439,7 +439,7 @@ public abstract class TransferProcessStoreTestBase {
                         .connectorId("new-connector")
                         .build())
                 .build();
-        getTransferProcessStore().save(t2);
+        getTransferProcessStore().updateOrCreate(t2);
 
         var all = getTransferProcessStore().findAll(QuerySpec.none()).collect(Collectors.toList());
         assertThat(all)
@@ -462,8 +462,8 @@ public abstract class TransferProcessStoreTestBase {
         var tp = createTransferProcessBuilder("testprocess1")
                 .contentDataAddress(da)
                 .build();
-        getTransferProcessStore().save(tp);
-        getTransferProcessStore().save(createTransferProcess("testprocess2"));
+        getTransferProcessStore().updateOrCreate(tp);
+        getTransferProcessStore().updateOrCreate(createTransferProcess("testprocess2"));
 
         var query = QuerySpec.Builder.newInstance()
                 .filter(List.of(new Criterion("contentDataAddress.properties.key", "=", "value")))
@@ -483,8 +483,8 @@ public abstract class TransferProcessStoreTestBase {
         var tp = createTransferProcessBuilder("testprocess1")
                 .contentDataAddress(da)
                 .build();
-        getTransferProcessStore().save(tp);
-        getTransferProcessStore().save(createTransferProcess("testprocess2"));
+        getTransferProcessStore().updateOrCreate(tp);
+        getTransferProcessStore().updateOrCreate(createTransferProcess("testprocess2"));
 
         var query = QuerySpec.Builder.newInstance()
                 .filter(List.of(new Criterion("contentDataAddress.properties.notexist", "=", "value")))
@@ -502,8 +502,8 @@ public abstract class TransferProcessStoreTestBase {
         var tp = createTransferProcessBuilder("testprocess1")
                 .contentDataAddress(da)
                 .build();
-        getTransferProcessStore().save(tp);
-        getTransferProcessStore().save(createTransferProcess("testprocess2"));
+        getTransferProcessStore().updateOrCreate(tp);
+        getTransferProcessStore().updateOrCreate(createTransferProcess("testprocess2"));
 
         var query = QuerySpec.Builder.newInstance()
                 .filter(List.of(new Criterion("contentDataAddress.properties.key", "=", "notexist")))
@@ -518,8 +518,8 @@ public abstract class TransferProcessStoreTestBase {
         var tp = createTransferProcessBuilder("testprocess1")
                 .dataRequest(da)
                 .build();
-        getTransferProcessStore().save(tp);
-        getTransferProcessStore().save(createTransferProcess("testprocess2"));
+        getTransferProcessStore().updateOrCreate(tp);
+        getTransferProcessStore().updateOrCreate(createTransferProcess("testprocess2"));
 
         var query = QuerySpec.Builder.newInstance()
                 .filter(List.of(new Criterion("dataRequest.processId", "=", "testprocess1")))
@@ -536,8 +536,8 @@ public abstract class TransferProcessStoreTestBase {
         var tp = createTransferProcessBuilder("testprocess1")
                 .dataRequest(da)
                 .build();
-        getTransferProcessStore().save(tp);
-        getTransferProcessStore().save(createTransferProcess("testprocess2"));
+        getTransferProcessStore().updateOrCreate(tp);
+        getTransferProcessStore().updateOrCreate(createTransferProcess("testprocess2"));
 
         var query = QuerySpec.Builder.newInstance()
                 .filter(List.of(new Criterion("dataRequest.id", "=", da.getId())))
@@ -556,8 +556,8 @@ public abstract class TransferProcessStoreTestBase {
         var tp = createTransferProcessBuilder("testprocess1")
                 .dataRequest(da)
                 .build();
-        getTransferProcessStore().save(tp);
-        getTransferProcessStore().save(createTransferProcess("testprocess2"));
+        getTransferProcessStore().updateOrCreate(tp);
+        getTransferProcessStore().updateOrCreate(createTransferProcess("testprocess2"));
 
         var query = QuerySpec.Builder.newInstance()
                 .filter(List.of(new Criterion("dataRequest.transferType.contentType", "like", "%/contenttype")))
@@ -574,8 +574,8 @@ public abstract class TransferProcessStoreTestBase {
         var tp = createTransferProcessBuilder("testprocess1")
                 .dataRequest(da)
                 .build();
-        getTransferProcessStore().save(tp);
-        getTransferProcessStore().save(createTransferProcess("testprocess2"));
+        getTransferProcessStore().updateOrCreate(tp);
+        getTransferProcessStore().updateOrCreate(createTransferProcess("testprocess2"));
 
         var query = QuerySpec.Builder.newInstance()
                 .filter(List.of(new Criterion("dataRequest.id", "=", "notexist")))
@@ -592,8 +592,8 @@ public abstract class TransferProcessStoreTestBase {
         var tp = createTransferProcessBuilder("testprocess1")
                 .resourceManifest(rm)
                 .build();
-        getTransferProcessStore().save(tp);
-        getTransferProcessStore().save(createTransferProcess("testprocess2"));
+        getTransferProcessStore().updateOrCreate(tp);
+        getTransferProcessStore().updateOrCreate(createTransferProcess("testprocess2"));
 
         var query = QuerySpec.Builder.newInstance()
                 .filter(List.of(new Criterion("resourceManifest.definitions.id", "=", "rd-id")))
@@ -611,8 +611,8 @@ public abstract class TransferProcessStoreTestBase {
         var tp = createTransferProcessBuilder("testprocess1")
                 .resourceManifest(rm)
                 .build();
-        getTransferProcessStore().save(tp);
-        getTransferProcessStore().save(createTransferProcess("testprocess2"));
+        getTransferProcessStore().updateOrCreate(tp);
+        getTransferProcessStore().updateOrCreate(createTransferProcess("testprocess2"));
 
         // throws exception when an explicit mapping exists
         var query = QuerySpec.Builder.newInstance()
@@ -635,8 +635,8 @@ public abstract class TransferProcessStoreTestBase {
         var tp = createTransferProcessBuilder("testprocess1")
                 .provisionedResourceSet(prs)
                 .build();
-        getTransferProcessStore().save(tp);
-        getTransferProcessStore().save(createTransferProcess("testprocess2"));
+        getTransferProcessStore().updateOrCreate(tp);
+        getTransferProcessStore().updateOrCreate(createTransferProcess("testprocess2"));
 
         var query = QuerySpec.Builder.newInstance()
                 .filter(List.of(new Criterion("provisionedResourceSet.resources.transferProcessId", "=", "testprocess1")))
@@ -660,8 +660,8 @@ public abstract class TransferProcessStoreTestBase {
         var tp = createTransferProcessBuilder("testprocess1")
                 .provisionedResourceSet(prs)
                 .build();
-        getTransferProcessStore().save(tp);
-        getTransferProcessStore().save(createTransferProcess("testprocess2"));
+        getTransferProcessStore().updateOrCreate(tp);
+        getTransferProcessStore().updateOrCreate(createTransferProcess("testprocess2"));
 
 
         // returns empty when the invalid value is embedded in JSON
@@ -695,8 +695,8 @@ public abstract class TransferProcessStoreTestBase {
                 .deprovisionedResources(List.of(dp3))
                 .build();
 
-        getTransferProcessStore().save(process1);
-        getTransferProcessStore().save(process2);
+        getTransferProcessStore().updateOrCreate(process1);
+        getTransferProcessStore().updateOrCreate(process2);
 
         var query = QuerySpec.Builder.newInstance()
                 .filter("deprovisionedResources.inProcess=true")
@@ -732,8 +732,8 @@ public abstract class TransferProcessStoreTestBase {
                 .deprovisionedResources(List.of(dp3))
                 .build();
 
-        getTransferProcessStore().save(process1);
-        getTransferProcessStore().save(process2);
+        getTransferProcessStore().updateOrCreate(process1);
+        getTransferProcessStore().updateOrCreate(process2);
 
         var query = QuerySpec.Builder.newInstance()
                 .filter(List.of(
@@ -772,8 +772,8 @@ public abstract class TransferProcessStoreTestBase {
                 .deprovisionedResources(List.of(dp3))
                 .build();
 
-        getTransferProcessStore().save(process1);
-        getTransferProcessStore().save(process2);
+        getTransferProcessStore().updateOrCreate(process1);
+        getTransferProcessStore().updateOrCreate(process2);
 
         var query = QuerySpec.Builder.newInstance()
                 .filter("deprovisionedResources.inProcess=false")
@@ -801,7 +801,7 @@ public abstract class TransferProcessStoreTestBase {
         var process1 = createTransferProcessBuilder("test-pid1")
                 .deprovisionedResources(List.of(dp1, dp2))
                 .build();
-        getTransferProcessStore().save(process1);
+        getTransferProcessStore().updateOrCreate(process1);
 
         var query = QuerySpec.Builder.newInstance()
                 .filter("deprovisionedResources.foobar=barbaz")
@@ -827,7 +827,7 @@ public abstract class TransferProcessStoreTestBase {
         var process1 = createTransferProcessBuilder("test-pid1")
                 .deprovisionedResources(List.of(dp1, dp2))
                 .build();
-        getTransferProcessStore().save(process1);
+        getTransferProcessStore().updateOrCreate(process1);
 
         var query = QuerySpec.Builder.newInstance()
                 .filter("deprovisionedResources.errorMessage=notexist")
@@ -842,9 +842,9 @@ public abstract class TransferProcessStoreTestBase {
     void verifyCreateUpdateDelete() {
         var id = UUID.randomUUID().toString();
         var transferProcess = createTransferProcess(id, createDataRequestBuilder().id("clientid").build());
-        getTransferProcessStore().save(transferProcess);
+        getTransferProcessStore().updateOrCreate(transferProcess);
 
-        TransferProcess found = getTransferProcessStore().find(id);
+        TransferProcess found = getTransferProcessStore().findById(id);
 
         assertNotNull(found);
         assertNotSame(found, transferProcess); // enforce by-value
@@ -855,14 +855,14 @@ public abstract class TransferProcessStoreTestBase {
 
         transferProcess.transitionProvisioning(ResourceManifest.Builder.newInstance().build());
 
-        getTransferProcessStore().save(transferProcess);
+        getTransferProcessStore().updateOrCreate(transferProcess);
 
-        found = getTransferProcessStore().find(id);
+        found = getTransferProcessStore().findById(id);
         assertNotNull(found);
         assertEquals(PROVISIONING.code(), found.getState());
 
         getTransferProcessStore().delete(id);
-        assertNull(getTransferProcessStore().find(id));
+        assertNull(getTransferProcessStore().findById(id));
         assertNull(getTransferProcessStore().processIdForDataRequestId("clientid"));
 
     }
@@ -870,15 +870,15 @@ public abstract class TransferProcessStoreTestBase {
     @Test
     void verifyNext() throws InterruptedException {
         var transferProcess1 = initialTransferProcess(UUID.randomUUID().toString(), "req1");
-        getTransferProcessStore().save(transferProcess1);
+        getTransferProcessStore().updateOrCreate(transferProcess1);
         var transferProcess2 = initialTransferProcess(UUID.randomUUID().toString(), "req2");
-        getTransferProcessStore().save(transferProcess2);
+        getTransferProcessStore().updateOrCreate(transferProcess2);
 
         transferProcess2.transitionProvisioning(ResourceManifest.Builder.newInstance().build());
-        getTransferProcessStore().save(transferProcess2);
+        getTransferProcessStore().updateOrCreate(transferProcess2);
         Thread.sleep(1);
         transferProcess1.transitionProvisioning(ResourceManifest.Builder.newInstance().build());
-        getTransferProcessStore().save(transferProcess1);
+        getTransferProcessStore().updateOrCreate(transferProcess1);
 
         assertThat(getTransferProcessStore().nextForState(INITIAL.code(), 1)).isEmpty();
 
@@ -892,7 +892,7 @@ public abstract class TransferProcessStoreTestBase {
     @Test
     void nextForState_shouldLeaseEntityUntilUpdate() {
         var initialTransferProcess = initialTransferProcess();
-        getTransferProcessStore().save(initialTransferProcess);
+        getTransferProcessStore().updateOrCreate(initialTransferProcess);
 
         var firstQueryResult = getTransferProcessStore().nextForState(INITIAL.code(), 1);
         assertThat(firstQueryResult).hasSize(1);
@@ -901,7 +901,7 @@ public abstract class TransferProcessStoreTestBase {
         assertThat(secondQueryResult).hasSize(0);
 
         var retrieved = firstQueryResult.get(0);
-        getTransferProcessStore().save(retrieved);
+        getTransferProcessStore().updateOrCreate(retrieved);
 
         var thirdQueryResult = getTransferProcessStore().nextForState(INITIAL.code(), 1);
         assertThat(thirdQueryResult).hasSize(1);
@@ -911,17 +911,17 @@ public abstract class TransferProcessStoreTestBase {
     void verifyMutlipleRequets() {
         String id1 = UUID.randomUUID().toString();
         TransferProcess transferProcess1 = createTransferProcess(id1, createDataRequestBuilder().id("clientid1").build());
-        getTransferProcessStore().save(transferProcess1);
+        getTransferProcessStore().updateOrCreate(transferProcess1);
 
         String id2 = UUID.randomUUID().toString();
         TransferProcess transferProcess2 = createTransferProcess(id2, createDataRequestBuilder().id("clientid2").build());
-        getTransferProcessStore().save(transferProcess2);
+        getTransferProcessStore().updateOrCreate(transferProcess2);
 
 
-        TransferProcess found1 = getTransferProcessStore().find(id1);
+        TransferProcess found1 = getTransferProcessStore().findById(id1);
         assertNotNull(found1);
 
-        TransferProcess found2 = getTransferProcessStore().find(id2);
+        TransferProcess found2 = getTransferProcessStore().findById(id2);
         assertNotNull(found2);
 
         var found = getTransferProcessStore().nextForState(INITIAL.code(), 3);
@@ -932,7 +932,7 @@ public abstract class TransferProcessStoreTestBase {
     void verifyOrderingByTimestamp() {
         for (int i = 0; i < 100; i++) {
             var process = createTransferProcess("test-process-" + i);
-            getTransferProcessStore().save(process);
+            getTransferProcessStore().updateOrCreate(process);
         }
 
         var processes = getTransferProcessStore().nextForState(INITIAL.code(), 50);
@@ -944,14 +944,14 @@ public abstract class TransferProcessStoreTestBase {
     void verifyNextForState_avoidsStarvation() throws InterruptedException {
         for (int i = 0; i < 10; i++) {
             var process = createTransferProcess("test-process-" + i);
-            getTransferProcessStore().save(process);
+            getTransferProcessStore().updateOrCreate(process);
         }
 
         var list1 = getTransferProcessStore().nextForState(INITIAL.code(), 5);
         Thread.sleep(50); //simulate a short delay to generate different timestamps
         list1.forEach(tp -> {
             tp.updateStateTimestamp();
-            getTransferProcessStore().save(tp);
+            getTransferProcessStore().updateOrCreate(tp);
         });
         var list2 = getTransferProcessStore().nextForState(INITIAL.code(), 5);
         assertThat(list1).isNotEqualTo(list2).doesNotContainAnyElementsOf(list2);
@@ -959,20 +959,20 @@ public abstract class TransferProcessStoreTestBase {
 
     @Test
     void findAll_verifyFiltering() {
-        IntStream.range(0, 10).forEach(i -> getTransferProcessStore().save(createTransferProcess("test-neg-" + i)));
+        IntStream.range(0, 10).forEach(i -> getTransferProcessStore().updateOrCreate(createTransferProcess("test-neg-" + i)));
         assertThat(getTransferProcessStore().findAll(QuerySpec.Builder.newInstance().equalsAsContains(false).filter("id=test-neg-3").build())).extracting(TransferProcess::getId).containsOnly("test-neg-3");
     }
 
     @Test
     void findAll_verifyFiltering_invalidFilterExpression() {
-        IntStream.range(0, 10).forEach(i -> getTransferProcessStore().save(createTransferProcess("test-neg-" + i)));
+        IntStream.range(0, 10).forEach(i -> getTransferProcessStore().updateOrCreate(createTransferProcess("test-neg-" + i)));
         assertThatThrownBy(() -> getTransferProcessStore().findAll(QuerySpec.Builder.newInstance().filter("something foobar other").build())).isInstanceOfAny(IllegalArgumentException.class);
     }
 
     @Test
     @EnabledIfSystemProperty(named = "transferprocessstore.supports.sortorder", matches = "true", disabledReason = "This test only runs if sorting is supported")
     void findAll_verifySorting() {
-        IntStream.range(0, 10).forEach(i -> getTransferProcessStore().save(createTransferProcess("test-neg-" + i)));
+        IntStream.range(0, 10).forEach(i -> getTransferProcessStore().updateOrCreate(createTransferProcess("test-neg-" + i)));
 
         assertThat(getTransferProcessStore().findAll(QuerySpec.Builder.newInstance().sortField("id").sortOrder(SortOrder.ASC).build())).hasSize(10).isSortedAccordingTo(Comparator.comparing(TransferProcess::getId));
         assertThat(getTransferProcessStore().findAll(QuerySpec.Builder.newInstance().sortField("id").sortOrder(SortOrder.DESC).build())).hasSize(10).isSortedAccordingTo((c1, c2) -> c2.getId().compareTo(c1.getId()));
@@ -981,7 +981,7 @@ public abstract class TransferProcessStoreTestBase {
     @Test
     @EnabledIfSystemProperty(named = "transferprocessstore.supports.sortorder", matches = "true", disabledReason = "This test only runs if sorting is supported")
     protected void findAll_verifySorting_invalidProperty() {
-        IntStream.range(0, 10).forEach(i -> getTransferProcessStore().save(createTransferProcess("test-neg-" + i)));
+        IntStream.range(0, 10).forEach(i -> getTransferProcessStore().updateOrCreate(createTransferProcess("test-neg-" + i)));
 
         var query = QuerySpec.Builder.newInstance().sortField("notexist").sortOrder(SortOrder.DESC).build();
 


### PR DESCRIPTION
## What this PR changes/adds

The persistence implementations in TransferProcessStore are refactrored in CRUD interactions.

## Why it does that

consistency, recognizability


## Further notes


## Linked Issue(s)

ref #2559 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
