### PR TITLE
fix: data plane public api error propagation

### DIFF
--- a/core/data-plane/data-plane-util/src/main/java/org/eclipse/edc/connector/dataplane/util/sink/OutputStreamDataSink.java
+++ b/core/data-plane/data-plane-util/src/main/java/org/eclipse/edc/connector/dataplane/util/sink/OutputStreamDataSink.java
@@ -57,7 +57,7 @@ public class OutputStreamDataSink implements DataSink {
                     });
         } catch (Exception e) {
             monitor.severe("Error processing data transfer request", e);
-            return CompletableFuture.completedFuture(StatusResult.failure(ERROR_RETRY, "Error processing data transfer request"));
+            return CompletableFuture.completedFuture(StatusResult.failure(ERROR_RETRY, String.format("Error processing data transfer request - %s", e.getMessage())));
         }
     }
 

--- a/core/data-plane/data-plane-util/src/main/java/org/eclipse/edc/connector/dataplane/util/sink/ParallelSink.java
+++ b/core/data-plane/data-plane-util/src/main/java/org/eclipse/edc/connector/dataplane/util/sink/ParallelSink.java
@@ -64,7 +64,7 @@ public abstract class ParallelSink implements DataSink {
                     .exceptionally(throwable -> StatusResult.failure(ERROR_RETRY, "Unhandled exception raised when transferring data: " + throwable.getMessage()));
         } catch (Exception e) {
             monitor.severe("Error processing data transfer request: " + requestId, e);
-            return CompletableFuture.completedFuture(StatusResult.failure(ERROR_RETRY, "Error processing data transfer request"));
+            return CompletableFuture.completedFuture(StatusResult.failure(ERROR_RETRY, String.format("Error processing data transfer request - %s", e.getMessage())));
         }
     }
 

--- a/core/data-plane/data-plane-util/src/test/java/org/eclipse/edc/connector/dataplane/util/sink/ParallelSinkTest.java
+++ b/core/data-plane/data-plane-util/src/test/java/org/eclipse/edc/connector/dataplane/util/sink/ParallelSinkTest.java
@@ -81,7 +81,7 @@ class ParallelSinkTest {
 
         assertThat(fakeSink.transfer(dataSourceMock)).succeedsWithin(500, TimeUnit.MILLISECONDS)
                 .satisfies(transferResult -> assertThat(transferResult.failed()).isTrue())
-                .satisfies(transferResult -> assertThat(transferResult.getFailureMessages()).containsExactly("Error processing data transfer request"));
+                .satisfies(transferResult -> assertThat(transferResult.getFailureMessages()).containsExactly("Error processing data transfer request - test-errormessage"));
         assertThat(fakeSink.complete).isEqualTo(0);
     }
 

--- a/extensions/data-plane/data-plane-api/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlanePublicApiController.java
+++ b/extensions/data-plane/data-plane-api/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlanePublicApiController.java
@@ -42,6 +42,7 @@ import java.util.concurrent.ExecutorService;
 
 import static java.lang.String.format;
 import static java.lang.String.join;
+import static org.eclipse.edc.connector.dataplane.api.response.ResponseFunctions.badGatewayErrors;
 import static org.eclipse.edc.connector.dataplane.api.response.ResponseFunctions.internalErrors;
 import static org.eclipse.edc.connector.dataplane.api.response.ResponseFunctions.validationError;
 
@@ -149,7 +150,7 @@ public class DataPlanePublicApiController implements DataPlanePublicApi {
                         if (result.succeeded()) {
                             response.resume(Response.ok(stream.toString()).build());
                         } else {
-                            response.resume(internalErrors(result.getFailureMessages()));
+                            response.resume(badGatewayErrors(result.getFailureMessages()));
                         }
                     } else {
                         response.resume(internalErrors(List.of("Unhandled exception occurred during data transfer: " + throwable.getMessage())));

--- a/extensions/data-plane/data-plane-api/src/main/java/org/eclipse/edc/connector/dataplane/api/response/ResponseFunctions.java
+++ b/extensions/data-plane/data-plane-api/src/main/java/org/eclipse/edc/connector/dataplane/api/response/ResponseFunctions.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.connector.dataplane.spi.response.TransferErrorResponse;
 
 import java.util.List;
 
+import static jakarta.ws.rs.core.Response.Status.BAD_GATEWAY;
 import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 import static jakarta.ws.rs.core.Response.Status.FORBIDDEN;
 import static jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
@@ -47,6 +48,16 @@ public final class ResponseFunctions {
      */
     public static Response validationErrors(List<String> errors) {
         return createErrorResponse(BAD_REQUEST, errors);
+    }
+
+    /**
+     * Returns a response for a collection of bad gateway errors.
+     *
+     * @param errors List of errors.
+     * @return Error response.
+     */
+    public static Response badGatewayErrors(List<String> errors) {
+        return createErrorResponse(BAD_GATEWAY, errors);
     }
 
     /**


### PR DESCRIPTION
## What this PR changes/adds

- Enriches the error message propagated by the DataSink implementations with the message sent by the DataSource/DataSink processes and fixed tests
- Changed the status code sent by the DataPlanePublicApiController from 500 to 502 in cases of failure inside the transfer method, when external dependencies are called

## Why it does that

- Previously the Data Plane would return a status 500 with a generic error message, leading the user to believe it's a failure in the consumer's connector when it is not.

## Linked Issue(s)

Closes #2599

## Checklist

- [x ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [x] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
