### PR TITLE
refactor: separate `DataRequest` from `RemoteMessage`

### DIFF
--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/transfer/TransferProcessManagerImplTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/transfer/TransferProcessManagerImplTest.java
@@ -42,6 +42,7 @@ import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.connector.transfer.spi.types.TransferProcessStates;
 import org.eclipse.edc.connector.transfer.spi.types.TransferType;
 import org.eclipse.edc.connector.transfer.spi.types.protocol.TransferCompletionMessage;
+import org.eclipse.edc.connector.transfer.spi.types.protocol.TransferRequestMessage;
 import org.eclipse.edc.connector.transfer.spi.types.protocol.TransferStartMessage;
 import org.eclipse.edc.connector.transfer.spi.types.protocol.TransferTerminationMessage;
 import org.eclipse.edc.policy.model.Policy;
@@ -385,7 +386,7 @@ class TransferProcessManagerImplTest {
     }
 
     @Test
-    void requesting_shouldTransitionToRequested() {
+    void requesting_shouldSendMessageAndTransitionToRequested() {
         var process = createTransferProcess(REQUESTING);
         when(dispatcherRegistry.send(eq(Object.class), any())).thenReturn(completedFuture("any"));
         when(transferProcessStore.nextForState(eq(REQUESTING.code()), anyInt())).thenReturn(List.of(process)).thenReturn(emptyList());
@@ -394,6 +395,7 @@ class TransferProcessManagerImplTest {
         manager.start();
 
         await().untilAsserted(() -> {
+            verify(dispatcherRegistry).send(eq(Object.class), isA(TransferRequestMessage.class));
             verify(transferProcessStore, times(1)).save(argThat(p -> p.getState() == REQUESTED.code()));
             verify(listener).requested(process);
         });

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/IdsMultipartDispatcherServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/IdsMultipartDispatcherServiceExtension.java
@@ -18,13 +18,13 @@ package org.eclipse.edc.protocol.ids.api.multipart.dispatcher;
 import org.eclipse.edc.protocol.ids.api.configuration.IdsApiConfiguration;
 import org.eclipse.edc.protocol.ids.api.multipart.dispatcher.sender.IdsMultipartSender;
 import org.eclipse.edc.protocol.ids.api.multipart.dispatcher.sender.SenderDelegateContext;
-import org.eclipse.edc.protocol.ids.api.multipart.dispatcher.sender.type.MultipartArtifactRequestSender;
 import org.eclipse.edc.protocol.ids.api.multipart.dispatcher.sender.type.MultipartCatalogDescriptionRequestSender;
 import org.eclipse.edc.protocol.ids.api.multipart.dispatcher.sender.type.MultipartContractAgreementSender;
 import org.eclipse.edc.protocol.ids.api.multipart.dispatcher.sender.type.MultipartContractOfferSender;
 import org.eclipse.edc.protocol.ids.api.multipart.dispatcher.sender.type.MultipartContractRejectionSender;
 import org.eclipse.edc.protocol.ids.api.multipart.dispatcher.sender.type.MultipartDescriptionRequestSender;
 import org.eclipse.edc.protocol.ids.api.multipart.dispatcher.sender.type.MultipartEndpointDataReferenceRequestSender;
+import org.eclipse.edc.protocol.ids.api.multipart.dispatcher.sender.type.MultipartTransferRequestSender;
 import org.eclipse.edc.protocol.ids.spi.service.DynamicAttributeTokenService;
 import org.eclipse.edc.protocol.ids.spi.transform.IdsTransformerRegistry;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
@@ -83,7 +83,7 @@ public class IdsMultipartDispatcherServiceExtension implements ServiceExtension 
 
         var sender = new IdsMultipartSender(monitor, httpClient, dynamicAttributeTokenService, objectMapper);
         var dispatcher = new IdsMultipartRemoteMessageDispatcher(sender);
-        dispatcher.register(new MultipartArtifactRequestSender(senderContext, vault));
+        dispatcher.register(new MultipartTransferRequestSender(senderContext, vault));
         dispatcher.register(new MultipartDescriptionRequestSender(senderContext));
         dispatcher.register(new MultipartContractOfferSender(senderContext));
         dispatcher.register(new MultipartContractAgreementSender(senderContext));

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/sender/type/MultipartTransferRequestSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/sender/type/MultipartTransferRequestSender.java
@@ -18,7 +18,7 @@ import de.fraunhofer.iais.eis.ArtifactRequestMessageBuilder;
 import de.fraunhofer.iais.eis.DynamicAttributeToken;
 import de.fraunhofer.iais.eis.Message;
 import de.fraunhofer.iais.eis.RequestInProcessMessageImpl;
-import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
+import org.eclipse.edc.connector.transfer.spi.types.protocol.TransferRequestMessage;
 import org.eclipse.edc.protocol.ids.api.multipart.dispatcher.sender.MultipartSenderDelegate;
 import org.eclipse.edc.protocol.ids.api.multipart.dispatcher.sender.SenderDelegateContext;
 import org.eclipse.edc.protocol.ids.api.multipart.dispatcher.sender.response.IdsMultipartParts;
@@ -41,30 +41,30 @@ import static org.eclipse.edc.protocol.ids.spi.domain.IdsConstants.IDS_WEBHOOK_A
 /**
  * MultipartSenderDelegate for data requests.
  */
-public class MultipartArtifactRequestSender implements MultipartSenderDelegate<DataRequest, String> {
+public class MultipartTransferRequestSender implements MultipartSenderDelegate<TransferRequestMessage, String> {
 
     private final SenderDelegateContext context;
     private final Vault vault;
 
-    public MultipartArtifactRequestSender(SenderDelegateContext context, Vault vault) {
+    public MultipartTransferRequestSender(SenderDelegateContext context, Vault vault) {
         this.context = context;
         this.vault = vault;
     }
 
     @Override
-    public Class<DataRequest> getMessageType() {
-        return DataRequest.class;
+    public Class<TransferRequestMessage> getMessageType() {
+        return TransferRequestMessage.class;
     }
 
     /**
-     * Builds an {@link de.fraunhofer.iais.eis.ArtifactRequestMessage} for the given {@link DataRequest}.
+     * Builds an {@link de.fraunhofer.iais.eis.ArtifactRequestMessage} for the given {@link TransferRequestMessage}.
      *
      * @param request the request.
      * @param token   the dynamic attribute token.
      * @return an ArtifactRequestMessage
      */
     @Override
-    public Message buildMessageHeader(DataRequest request, DynamicAttributeToken token) {
+    public Message buildMessageHeader(TransferRequestMessage request, DynamicAttributeToken token) {
         var artifactId = IdsId.Builder.newInstance()
                 .value(request.getAssetId())
                 .type(IdsType.ARTIFACT)
@@ -100,7 +100,7 @@ public class MultipartArtifactRequestSender implements MultipartSenderDelegate<D
      * @throws Exception if parsing the payload fails.
      */
     @Override
-    public String buildMessagePayload(DataRequest request) throws Exception {
+    public String buildMessagePayload(TransferRequestMessage request) throws Exception {
         var requestPayloadBuilder = ArtifactRequestMessagePayload.Builder.newInstance()
                 .dataDestination(request.getDataDestination());
 

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/client/MultipartDispatcherIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/client/MultipartDispatcherIntegrationTest.java
@@ -29,7 +29,7 @@ import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferReq
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRejection;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.contract.spi.validation.ContractValidationService;
-import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
+import org.eclipse.edc.connector.transfer.spi.types.protocol.TransferRequestMessage;
 import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.junit.extensions.EdcExtension;
 import org.eclipse.edc.policy.model.Policy;
@@ -130,7 +130,7 @@ class MultipartDispatcherIntegrationTest {
                 .id("1:2").build());
         when(validationService.validateAgreement(any(), any(ContractAgreement.class))).thenReturn(Result.success(null));
 
-        var request = DataRequest.Builder.newInstance()
+        var request = TransferRequestMessage.Builder.newInstance()
                 .connectorId(CONNECTOR_ID)
                 .connectorAddress(getUrl())
                 .protocol(MessageProtocol.IDS_MULTIPART)
@@ -280,7 +280,7 @@ class MultipartDispatcherIntegrationTest {
                 .id(id)
                 .counterPartyId(UUID.randomUUID().toString())
                 .counterPartyAddress("address")
-                .protocol("protocol")
+                .protocol(MessageProtocol.IDS_MULTIPART)
                 .build();
     }
 

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/sender/type/MultipartTransferRequestSenderTest.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/sender/type/MultipartTransferRequestSenderTest.java
@@ -18,7 +18,7 @@ package org.eclipse.edc.protocol.ids.api.multipart.dispatcher.sender.type;
 
 import de.fraunhofer.iais.eis.ArtifactRequestMessage;
 import de.fraunhofer.iais.eis.DynamicAttributeTokenBuilder;
-import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
+import org.eclipse.edc.connector.transfer.spi.types.protocol.TransferRequestMessage;
 import org.eclipse.edc.protocol.ids.api.multipart.dispatcher.sender.SenderDelegateContext;
 import org.eclipse.edc.protocol.ids.serialization.IdsTypeManagerUtil;
 import org.eclipse.edc.protocol.ids.spi.domain.IdsConstants;
@@ -39,9 +39,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.protocol.ids.spi.domain.IdsConstants.IDS_WEBHOOK_ADDRESS_PROPERTY;
 import static org.mockito.Mockito.mock;
 
-class MultipartArtifactRequestSenderTest {
+class MultipartTransferRequestSenderTest {
 
-    private MultipartArtifactRequestSender sender;
+    private MultipartTransferRequestSender sender;
     private SenderDelegateContext senderContext;
     private String idsWebhookAddress;
 
@@ -55,7 +55,7 @@ class MultipartArtifactRequestSenderTest {
         var objectMapper = IdsTypeManagerUtil.getIdsObjectMapper(new TypeManager());
 
         senderContext = new SenderDelegateContext(connectorId, objectMapper, transformerRegistry, idsWebhookAddress);
-        sender = new MultipartArtifactRequestSender(senderContext, vault);
+        sender = new MultipartTransferRequestSender(senderContext, vault);
     }
 
     @Test
@@ -84,22 +84,23 @@ class MultipartArtifactRequestSenderTest {
 
     @Test
     void buildMessagePayload() throws Exception {
-        var dataAddress = DataAddress.Builder.newInstance().type("type").build();
-        var dataRequest = DataRequest.Builder.newInstance().dataDestination(dataAddress).build();
+        var request = createRequest();
 
-        var result = sender.buildMessagePayload(dataRequest);
+        var result = sender.buildMessagePayload(request);
 
         assertThat(result).isNotNull();
     }
 
-    private static DataRequest createRequest() {
-        return DataRequest.Builder.newInstance()
+    private static TransferRequestMessage createRequest() {
+        return TransferRequestMessage.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
                 .contractId(UUID.randomUUID().toString())
                 .assetId(UUID.randomUUID().toString())
                 .dataDestination(DataAddress.Builder.newInstance().type("test").build())
                 .connectorId("connector-test")
                 .properties(Map.of("foo", "bar", "hello", "world"))
+                .protocol("ids-multipart")
+                .connectorAddress("http://any")
                 .build();
     }
 }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/DataRequest.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/DataRequest.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.Polymorphic;
-import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -30,7 +29,7 @@ import java.util.Map;
  */
 @JsonTypeName("dataspaceconnector:datarequest")
 @JsonDeserialize(builder = DataRequest.Builder.class)
-public class DataRequest implements RemoteMessage, Polymorphic {
+public class DataRequest implements Polymorphic {
     private String id;
     private String processId;
     private String connectorAddress;
@@ -72,7 +71,6 @@ public class DataRequest implements RemoteMessage, Polymorphic {
     /**
      * The protocol over which the data request is sent to the provider connector.
      */
-    @Override
     public String getProtocol() {
         return protocol;
     }
@@ -80,7 +78,6 @@ public class DataRequest implements RemoteMessage, Polymorphic {
     /**
      * The protocol-specific address of the other connector.
      */
-    @Override
     public String getConnectorAddress() {
         return connectorAddress;
     }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferCompletionMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferCompletionMessage.java
@@ -20,6 +20,11 @@ import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
 
 import java.util.Objects;
 
+/**
+ * The {@link TransferCompletionMessage} is sent by the provider or consumer when asset transfer has completed. Note
+ * that some data plane implementations may optimize completion notification by performing it as part of its wire
+ * protocol. In those cases, a {@link TransferCompletionMessage} message does not need to be sent.
+ */
 public class TransferCompletionMessage implements RemoteMessage {
 
     private String connectorAddress;

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferRequestMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferRequestMessage.java
@@ -1,0 +1,133 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.transfer.spi.types.protocol;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * The {@link TransferRequestMessage} is sent by a consumer to initiate a transfer process.
+ */
+public class TransferRequestMessage implements RemoteMessage {
+
+    private String connectorAddress;
+    private String protocol;
+    private String id;
+    private String contractId;
+    private String assetId;
+    private DataAddress dataDestination;
+    private String connectorId;
+    private Map<String, String> properties = new HashMap<>();
+
+    @Override
+    public String getProtocol() {
+        return protocol;
+    }
+
+    @Override
+    public String getConnectorAddress() {
+        return connectorAddress;
+    }
+
+    public String getAssetId() {
+        return assetId;
+    }
+
+    public String getContractId() {
+        return contractId;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getConnectorId() {
+        return connectorId;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    public DataAddress getDataDestination() {
+        return dataDestination;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder {
+        private final TransferRequestMessage message;
+
+        private Builder() {
+            message = new TransferRequestMessage();
+        }
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder id(String id) {
+            message.id = id;
+            return this;
+        }
+
+        public Builder connectorAddress(String address) {
+            message.connectorAddress = address;
+            return this;
+        }
+
+        public Builder protocol(String protocol) {
+            message.protocol = protocol;
+            return this;
+        }
+
+        public Builder contractId(String contractId) {
+            message.contractId = contractId;
+            return this;
+        }
+
+        public Builder assetId(String assetId) {
+            message.assetId = assetId;
+            return this;
+        }
+
+        public Builder dataDestination(DataAddress dataDestination) {
+            message.dataDestination = dataDestination;
+            return this;
+        }
+
+        public Builder connectorId(String connectorId) {
+            message.connectorId = connectorId;
+            return this;
+        }
+
+        public Builder properties(Map<String, String> properties) {
+            message.properties = properties;
+            return this;
+        }
+
+        public TransferRequestMessage build() {
+            Objects.requireNonNull(message.protocol, "The protocol must be specified");
+            Objects.requireNonNull(message.connectorAddress, "The connectorAddress must be specified");
+            return message;
+        }
+    }
+}

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferStartMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferStartMessage.java
@@ -20,6 +20,9 @@ import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
 
 import java.util.Objects;
 
+/**
+ * The {@link TransferStartMessage} is sent by the provider to indicate the asset transfer has been initiated.
+ */
 public class TransferStartMessage implements RemoteMessage {
 
     private String connectorAddress;

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferTerminationMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferTerminationMessage.java
@@ -20,6 +20,11 @@ import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
 
 import java.util.Objects;
 
+/**
+ * The {@link TransferTerminationMessage} is sent by the provider or consumer at any point except a terminal state to
+ * indicate the data transfer process should stop and be placed in a terminal state. If the termination was due to an
+ * error, the sender may include error information.
+ */
 public class TransferTerminationMessage implements RemoteMessage {
 
     private String connectorAddress;


### PR DESCRIPTION
## What this PR changes/adds

Remove `RemoteMessage` interface declaration from `DataRequest` and introduce a dedicate `TransferRequestMessage`. Replaces `MultipartArtifactRequestSender` with `MultipartTransferRequestSender`.

## Why it does that
decoupling

## Further notes

- add some missing documentation on remote messages

## Linked Issue(s)

Closes #2564 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
