### PR TITLE
refactor: Logs and returns DataFlowRequest ID also in OutputStreamDataSink in cases of failure

### DIFF
--- a/core/data-plane/data-plane-framework/src/test/java/org/eclipse/edc/connector/dataplane/framework/e2e/EndToEndTest.java
+++ b/core/data-plane/data-plane-framework/src/test/java/org/eclipse/edc/connector/dataplane/framework/e2e/EndToEndTest.java
@@ -33,6 +33,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.concurrent.Executors;
 
+import static java.util.UUID.randomUUID;
 import static org.mockito.Mockito.mock;
 
 public class EndToEndTest {
@@ -69,7 +70,7 @@ public class EndToEndTest {
 
         FixedEndpoint(Monitor monitor) {
             stream = new ByteArrayOutputStream();
-            sink = new OutputStreamDataSink(stream, Executors.newFixedThreadPool(1), monitor);
+            sink = new OutputStreamDataSink(randomUUID().toString(), stream, Executors.newFixedThreadPool(1), monitor);
         }
 
         public ByteArrayOutputStream getStream() {

--- a/core/data-plane/data-plane-util/src/main/java/org/eclipse/edc/connector/dataplane/util/sink/OutputStreamDataSink.java
+++ b/core/data-plane/data-plane-util/src/main/java/org/eclipse/edc/connector/dataplane/util/sink/OutputStreamDataSink.java
@@ -25,6 +25,7 @@ import java.io.OutputStream;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 
+import static java.lang.String.format;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static org.eclipse.edc.spi.response.ResponseStatus.ERROR_RETRY;
 import static org.eclipse.edc.util.async.AsyncUtils.asyncAllOf;
@@ -33,11 +34,13 @@ import static org.eclipse.edc.util.async.AsyncUtils.asyncAllOf;
  * Sends data to an output stream. The transfer is done asynchronously using the supplied executor service.
  */
 public class OutputStreamDataSink implements DataSink {
+    private final String requestId;
     private final OutputStream stream;
     private final ExecutorService executorService;
     private final Monitor monitor;
 
-    public OutputStreamDataSink(OutputStream stream, ExecutorService executorService, Monitor monitor) {
+    public OutputStreamDataSink(String requestId, OutputStream stream, ExecutorService executorService, Monitor monitor) {
+        this.requestId = requestId;
         this.stream = stream;
         this.executorService = executorService;
         this.monitor = monitor;
@@ -56,8 +59,9 @@ public class OutputStreamDataSink implements DataSink {
                         return StatusResult.success();
                     });
         } catch (Exception e) {
-            monitor.severe("Error processing data transfer request", e);
-            return CompletableFuture.completedFuture(StatusResult.failure(ERROR_RETRY, "Error processing data transfer request"));
+            var errorMessage = format("Error processing data transfer request - Request ID: %s", requestId);
+            monitor.severe(errorMessage, e);
+            return CompletableFuture.completedFuture(StatusResult.failure(ERROR_RETRY, errorMessage));
         }
     }
 

--- a/core/data-plane/data-plane-util/src/main/java/org/eclipse/edc/connector/dataplane/util/sink/ParallelSink.java
+++ b/core/data-plane/data-plane-util/src/main/java/org/eclipse/edc/connector/dataplane/util/sink/ParallelSink.java
@@ -31,6 +31,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
 
+import static java.lang.String.format;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static java.util.stream.Collectors.toList;
 import static org.eclipse.edc.spi.response.ResponseStatus.ERROR_RETRY;
@@ -63,8 +64,9 @@ public abstract class ParallelSink implements DataSink {
                             .orElseGet(this::complete))
                     .exceptionally(throwable -> StatusResult.failure(ERROR_RETRY, "Unhandled exception raised when transferring data: " + throwable.getMessage()));
         } catch (Exception e) {
-            monitor.severe("Error processing data transfer request: " + requestId, e);
-            return CompletableFuture.completedFuture(StatusResult.failure(ERROR_RETRY, "Error processing data transfer request"));
+            var errorMessage = format("Error processing data transfer request - Request ID: %s", requestId);
+            monitor.severe(errorMessage, e);
+            return CompletableFuture.completedFuture(StatusResult.failure(ERROR_RETRY, errorMessage));
         }
     }
 

--- a/core/data-plane/data-plane-util/src/test/java/org/eclipse/edc/connector/dataplane/util/sink/OutputStreamDataSinkTest.java
+++ b/core/data-plane/data-plane-util/src/test/java/org/eclipse/edc/connector/dataplane/util/sink/OutputStreamDataSinkTest.java
@@ -24,6 +24,7 @@ import java.io.ByteArrayOutputStream;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import static java.util.UUID.randomUUID;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -38,7 +39,7 @@ class OutputStreamDataSinkTest {
         var dataSource = new InputStreamDataSource("foo", new ByteArrayInputStream(data));
 
         var stream = new ByteArrayOutputStream();
-        var dataSink = new OutputStreamDataSink(stream, executor, monitor);
+        var dataSink = new OutputStreamDataSink(randomUUID().toString(), stream, executor, monitor);
 
         dataSink.transfer(dataSource).get(30, SECONDS);
 

--- a/core/data-plane/data-plane-util/src/test/java/org/eclipse/edc/connector/dataplane/util/sink/ParallelSinkTest.java
+++ b/core/data-plane/data-plane-util/src/test/java/org/eclipse/edc/connector/dataplane/util/sink/ParallelSinkTest.java
@@ -26,12 +26,13 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
+import static java.lang.String.format;
+import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -46,6 +47,7 @@ class ParallelSinkTest {
     private final InputStreamDataSource dataSource = new InputStreamDataSource(
             dataSourceName,
             new ByteArrayInputStream(dataSourceContent.getBytes()));
+    private final String dataFlowRequestId = randomUUID().toString();
     FakeParallelSink fakeSink;
 
     @BeforeEach
@@ -54,7 +56,7 @@ class ParallelSinkTest {
         fakeSink.monitor = monitor;
         fakeSink.telemetry = new Telemetry(); // default noop implementation
         fakeSink.executorService = executor;
-        fakeSink.requestId = UUID.randomUUID().toString();
+        fakeSink.requestId = dataFlowRequestId;
     }
 
     @Test
@@ -81,7 +83,7 @@ class ParallelSinkTest {
 
         assertThat(fakeSink.transfer(dataSourceMock)).succeedsWithin(500, TimeUnit.MILLISECONDS)
                 .satisfies(transferResult -> assertThat(transferResult.failed()).isTrue())
-                .satisfies(transferResult -> assertThat(transferResult.getFailureMessages()).containsExactly("Error processing data transfer request"));
+                .satisfies(transferResult -> assertThat(transferResult.getFailureMessages()).containsExactly(format("Error processing data transfer request - Request ID: %s", dataFlowRequestId)));
         assertThat(fakeSink.complete).isEqualTo(0);
     }
 

--- a/extensions/data-plane/data-plane-api/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlanePublicApiController.java
+++ b/extensions/data-plane/data-plane-api/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlanePublicApiController.java
@@ -141,7 +141,7 @@ public class DataPlanePublicApiController implements DataPlanePublicApi {
         }
 
         var stream = new ByteArrayOutputStream();
-        var sink = new OutputStreamDataSink(stream, executorService, monitor);
+        var sink = new OutputStreamDataSink(dataFlowRequest.getId(), stream, executorService, monitor);
 
         dataPlaneManager.transfer(sink, dataFlowRequest)
                 .whenComplete((result, throwable) -> {


### PR DESCRIPTION
## What this PR changes/adds
- Adds `requestId` attribute into `OutputStreamDataSink`.
- Adds `requestId` content into the error messages returned by `DataSink` implementations.
- Adds `requestId` content into the logs.
- Changed the tests accordingly, in order to evaluate the error message content including the new information.

## Why it does that
- Previously there was no way to correlate unsuccessful responses returned to a client and internal diagnostic information. As a new `DataFlowRequest` GUID is generated for every request, it was a good opportunity to use it as a correlation ID, enabling clients to report and operators to accurately analyze error incidents.

## Linked Issue(s)

Closes #2606

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
