### PR TITLE
feat(negotiation): add correlationId to new RemoteMessages

### DIFF
--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -311,6 +311,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
         var message = ContractAgreementVerificationMessage.Builder.newInstance()
                 .protocol(negotiation.getProtocol())
                 .connectorAddress(negotiation.getCounterPartyAddress())
+                .correlationId(negotiation.getId())
                 .build();
 
         return entityRetryProcessFactory.doAsyncProcess(negotiation, () -> dispatcherRegistry.send(Object.class, message))

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -323,6 +323,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
                 .type(ContractNegotiationEventMessage.Type.FINALIZED)
                 .protocol(negotiation.getProtocol())
                 .connectorAddress(negotiation.getCounterPartyAddress())
+                .correlationId(negotiation.getCorrelationId())
                 .build();
 
         return entityRetryProcessFactory.doAsyncProcess(negotiation, () -> dispatcherRegistry.send(Object.class, message))

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractAgreementVerificationMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractAgreementVerificationMessage.java
@@ -22,6 +22,7 @@ public class ContractAgreementVerificationMessage implements RemoteMessage {
 
     private String protocol;
     private String connectorAddress;
+    private String correlationId;
 
     @Override
     public String getProtocol() {
@@ -31,6 +32,10 @@ public class ContractAgreementVerificationMessage implements RemoteMessage {
     @Override
     public String getConnectorAddress() {
         return connectorAddress;
+    }
+
+    public String getCorrelationId() {
+        return correlationId;
     }
 
     public static class Builder {
@@ -54,9 +59,15 @@ public class ContractAgreementVerificationMessage implements RemoteMessage {
             return this;
         }
 
+        public Builder correlationId(String correlationId) {
+            this.message.correlationId = correlationId;
+            return this;
+        }
+
         public ContractAgreementVerificationMessage build() {
             Objects.requireNonNull(message.protocol, "protocol");
             Objects.requireNonNull(message.connectorAddress, "connectorAddress");
+            Objects.requireNonNull(message.correlationId, "correlationId");
             return message;
         }
     }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractNegotiationEventMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractNegotiationEventMessage.java
@@ -22,6 +22,7 @@ public class ContractNegotiationEventMessage implements RemoteMessage {
 
     private String protocol;
     private String connectorAddress;
+    private String correlationId;
     private Type type;
 
     @Override
@@ -32,6 +33,10 @@ public class ContractNegotiationEventMessage implements RemoteMessage {
     @Override
     public String getConnectorAddress() {
         return connectorAddress;
+    }
+
+    public String getCorrelationId() {
+        return correlationId;
     }
 
     public Type getType() {
@@ -59,6 +64,11 @@ public class ContractNegotiationEventMessage implements RemoteMessage {
             return this;
         }
 
+        public Builder correlationId(String correlationId) {
+            this.message.correlationId = correlationId;
+            return this;
+        }
+
         public Builder type(Type type) {
             this.message.type = type;
             return this;
@@ -67,6 +77,7 @@ public class ContractNegotiationEventMessage implements RemoteMessage {
         public ContractNegotiationEventMessage build() {
             Objects.requireNonNull(message.protocol, "protocol");
             Objects.requireNonNull(message.connectorAddress, "connectorAddress");
+            Objects.requireNonNull(message.correlationId, "correlationId");
             Objects.requireNonNull(message.type, "type");
             return message;
         }


### PR DESCRIPTION
## What this PR changes/adds

Adds `correlationId` to `ContractAgreementVerificationMessage` and `ContractNegotiationEventMessage`.

## Why it does that

The dataspace protocol delegates need the `negotiationId` to build the URL for the request.

## Further notes

Sry, missed that in #2595

## Linked Issue(s)

Closes #2617 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
