### PR TITLE
feat(dsp): new event dispatch on state changes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,11 @@ val metaModelVersion: String by project
 buildscript {
     repositories {
         mavenLocal()
+        maven {
+            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+        }
+        mavenCentral()
+        gradlePluginPortal()
     }
     dependencies {
         val edcGradlePluginsVersion: String by project

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,11 +27,6 @@ val metaModelVersion: String by project
 buildscript {
     repositories {
         mavenLocal()
-        maven {
-            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
-        }
-        mavenCentral()
-        gradlePluginPortal()
     }
     dependencies {
         val edcGradlePluginsVersion: String by project

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/listener/ContractNegotiationEventListener.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/listener/ContractNegotiationEventListener.java
@@ -18,14 +18,16 @@ import org.eclipse.edc.connector.contract.spi.negotiation.observe.ContractNegoti
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.spi.event.EventEnvelope;
 import org.eclipse.edc.spi.event.EventRouter;
-import org.eclipse.edc.spi.event.contractnegotiation.ContractNegotiationApproved;
-import org.eclipse.edc.spi.event.contractnegotiation.ContractNegotiationConfirmed;
+import org.eclipse.edc.spi.event.contractnegotiation.ContractNegotiationConsumerAgreed;
+import org.eclipse.edc.spi.event.contractnegotiation.ContractNegotiationConsumerRequested;
+import org.eclipse.edc.spi.event.contractnegotiation.ContractNegotiationConsumerVerified;
 import org.eclipse.edc.spi.event.contractnegotiation.ContractNegotiationDeclined;
 import org.eclipse.edc.spi.event.contractnegotiation.ContractNegotiationEvent;
 import org.eclipse.edc.spi.event.contractnegotiation.ContractNegotiationFailed;
 import org.eclipse.edc.spi.event.contractnegotiation.ContractNegotiationInitiated;
-import org.eclipse.edc.spi.event.contractnegotiation.ContractNegotiationOffered;
-import org.eclipse.edc.spi.event.contractnegotiation.ContractNegotiationRequested;
+import org.eclipse.edc.spi.event.contractnegotiation.ContractNegotiationProviderAgreed;
+import org.eclipse.edc.spi.event.contractnegotiation.ContractNegotiationProviderFinalized;
+import org.eclipse.edc.spi.event.contractnegotiation.ContractNegotiationProviderOffered;
 import org.eclipse.edc.spi.event.contractnegotiation.ContractNegotiationTerminated;
 
 import java.time.Clock;
@@ -49,8 +51,8 @@ public class ContractNegotiationEventListener implements ContractNegotiationList
     }
 
     @Override
-    public void requested(ContractNegotiation negotiation) {
-        var event = ContractNegotiationRequested.Builder.newInstance()
+    public void consumerRequested(ContractNegotiation negotiation) {
+        var event = ContractNegotiationConsumerRequested.Builder.newInstance()
                 .contractNegotiationId(negotiation.getId())
                 .build();
 
@@ -58,8 +60,8 @@ public class ContractNegotiationEventListener implements ContractNegotiationList
     }
 
     @Override
-    public void offered(ContractNegotiation negotiation) {
-        var event = ContractNegotiationOffered.Builder.newInstance()
+    public void providerOffered(ContractNegotiation negotiation) {
+        var event = ContractNegotiationProviderOffered.Builder.newInstance()
                 .contractNegotiationId(negotiation.getId())
                 .build();
 
@@ -67,8 +69,8 @@ public class ContractNegotiationEventListener implements ContractNegotiationList
     }
 
     @Override
-    public void approved(ContractNegotiation negotiation) {
-        var event = ContractNegotiationApproved.Builder.newInstance()
+    public void consumerAgreed(ContractNegotiation negotiation) {
+        var event = ContractNegotiationConsumerAgreed.Builder.newInstance()
                 .contractNegotiationId(negotiation.getId())
                 .build();
 
@@ -94,8 +96,26 @@ public class ContractNegotiationEventListener implements ContractNegotiationList
     }
 
     @Override
-    public void confirmed(ContractNegotiation negotiation) {
-        var event = ContractNegotiationConfirmed.Builder.newInstance()
+    public void providerAgreed(ContractNegotiation negotiation) {
+        var event = ContractNegotiationProviderAgreed.Builder.newInstance()
+                .contractNegotiationId(negotiation.getId())
+                .build();
+
+        publish(event);
+    }
+
+    @Override
+    public void consumerVerified(ContractNegotiation negotiation) {
+        var event = ContractNegotiationConsumerVerified.Builder.newInstance()
+                .contractNegotiationId(negotiation.getId())
+                .build();
+
+        publish(event);
+    }
+
+    @Override
+    public void providerFinalized(ContractNegotiation negotiation) {
+        var event = ContractNegotiationProviderFinalized.Builder.newInstance()
                 .contractNegotiationId(negotiation.getId())
                 .build();
 

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/AbstractContractNegotiationManager.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/AbstractContractNegotiationManager.java
@@ -69,93 +69,95 @@ public abstract class AbstractContractNegotiationManager {
      */
     protected abstract String getType();
 
-    protected void transitToInitial(ContractNegotiation negotiation) {
+    protected void transitionToInitial(ContractNegotiation negotiation) {
         negotiation.transitionInitial();
         update(negotiation);
         observable.invokeForEach(l -> l.initiated(negotiation));
     }
 
-    protected void transitToRequesting(ContractNegotiation negotiation) {
-        negotiation.transitionRequesting();
+    protected void transitionToConsumerRequesting(ContractNegotiation negotiation) {
+        negotiation.transitionConsumerRequesting();
         update(negotiation);
     }
 
-    protected void transitToRequested(ContractNegotiation negotiation) {
-        negotiation.transitionRequested();
+    protected void transitionToConsumerRequested(ContractNegotiation negotiation) {
+        negotiation.transitionConsumerRequested();
         update(negotiation);
-        observable.invokeForEach(l -> l.requested(negotiation));
+        observable.invokeForEach(l -> l.consumerRequested(negotiation));
     }
 
-    protected void transitToProviderAgreed(ContractNegotiation negotiation, ContractAgreement agreement) {
-        negotiation.setContractAgreement(agreement);
-        negotiation.transitionProviderAgreed();
-        update(negotiation);
-        observable.invokeForEach(l -> l.confirmed(negotiation));
-    }
-
-    protected void transitToApproving(ContractNegotiation negotiation) {
-        negotiation.transitionApproving();
+    protected void transitionToConsumerAgreeing(ContractNegotiation negotiation) {
+        negotiation.transitionConsumerAgreeing();
         update(negotiation);
     }
 
-    protected void transitToApproved(ContractNegotiation negotiation) {
-        negotiation.transitionApproved();
+    protected void transitionToConsumerAgreed(ContractNegotiation negotiation) {
+        negotiation.transitionConsumerAgreed();
         update(negotiation);
-        observable.invokeForEach(l -> l.approved(negotiation));
+        observable.invokeForEach(l -> l.consumerAgreed(negotiation));
     }
 
-    protected void transitToOffering(ContractNegotiation negotiation) {
-        negotiation.transitionOffering();
+    protected void transitionToProviderOffering(ContractNegotiation negotiation) {
+        negotiation.transitionProviderOffering();
         update(negotiation);
     }
 
-    protected void transitToOffered(ContractNegotiation negotiation) {
-        negotiation.transitionOffered();
+    protected void transitionToProviderOffered(ContractNegotiation negotiation) {
+        negotiation.transitionProviderOffered();
         update(negotiation);
-        observable.invokeForEach(l -> l.offered(negotiation));
+        observable.invokeForEach(l -> l.providerOffered(negotiation));
     }
 
-    protected void transitToProviderAgreeing(ContractNegotiation negotiation) {
+    protected void transitionToProviderAgreeing(ContractNegotiation negotiation) {
         negotiation.transitionProviderAgreeing();
         update(negotiation);
     }
 
-    protected void transitToVerifying(ContractNegotiation negotiation) {
-        negotiation.transitionVerifying();
+    protected void transitionToProviderAgreed(ContractNegotiation negotiation, ContractAgreement agreement) {
+        negotiation.setContractAgreement(agreement);
+        negotiation.transitionProviderAgreed();
+        update(negotiation);
+        observable.invokeForEach(l -> l.providerAgreed(negotiation));
+    }
+
+    protected void transitionToConsumerVerifying(ContractNegotiation negotiation) {
+        negotiation.transitionConsumerVerifying();
         update(negotiation);
     }
 
-    protected void transitToVerified(ContractNegotiation negotiation) {
-        negotiation.transitionVerified();
+    protected void transitionToConsumerVerified(ContractNegotiation negotiation) {
+        negotiation.transitionConsumerVerified();
         update(negotiation);
+        observable.invokeForEach(l -> l.consumerVerified(negotiation));
     }
 
-    protected void transitToFinalizing(ContractNegotiation negotiation) {
+    protected void transitionToProviderFinalizing(ContractNegotiation negotiation) {
         negotiation.transitionProviderFinalizing();
         update(negotiation);
     }
 
-    protected void transitToFinalized(ContractNegotiation negotiation) {
+    protected void transitionToProviderFinalized(ContractNegotiation negotiation) {
         negotiation.transitionProviderFinalized();
         update(negotiation);
+        observable.invokeForEach(l -> l.providerFinalized(negotiation));
     }
 
-    protected void transitToTerminating(ContractNegotiation negotiation, String message) {
+    protected void transitionToTerminating(ContractNegotiation negotiation, String message) {
         negotiation.transitionTerminating(message);
         update(negotiation);
     }
 
-    protected void transitToTerminating(ContractNegotiation negotiation) {
+    protected void transitionToTerminating(ContractNegotiation negotiation) {
         negotiation.transitionTerminating();
         update(negotiation);
     }
 
-    protected void transitToTerminated(ContractNegotiation negotiation, String message) {
+    protected void transitionToTerminated(ContractNegotiation negotiation, String message) {
         negotiation.setErrorDetail(message);
-        transitToTerminated(negotiation);
+        transitionToTerminated(negotiation);
     }
 
-    protected void transitToTerminated(ContractNegotiation negotiation) {
+    protected void transitionToTerminated(ContractNegotiation negotiation) {
         negotiation.transitionTerminated();
         update(negotiation);
         observable.invokeForEach(l -> l.terminated(negotiation));

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/DispatchFailure.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/DispatchFailure.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.contract.negotiation;
+
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates;
+import org.junit.jupiter.params.provider.Arguments;
+
+import java.util.function.UnaryOperator;
+
+import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.INITIAL;
+
+public class DispatchFailure implements Arguments {
+
+    private final ContractNegotiationStates starting;
+    private final ContractNegotiationStates ending;
+    private final UnaryOperator<ContractNegotiation.Builder> builderEnricher;
+
+    public DispatchFailure() {
+        this(INITIAL, INITIAL, it -> it);
+    }
+
+    public DispatchFailure(ContractNegotiationStates starting, ContractNegotiationStates ending, UnaryOperator<ContractNegotiation.Builder> builderEnricher) {
+        this.starting = starting;
+        this.ending = ending;
+        this.builderEnricher = builderEnricher;
+    }
+
+    @Override
+    public Object[] get() {
+        return new Object[]{ starting, ending, builderEnricher };
+    }
+}

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
@@ -29,9 +29,9 @@ import org.eclipse.edc.spi.asset.AssetIndex;
 import org.eclipse.edc.spi.asset.AssetSelectorExpression;
 import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.event.EventSubscriber;
-import org.eclipse.edc.spi.event.contractnegotiation.ContractNegotiationConfirmed;
+import org.eclipse.edc.spi.event.contractnegotiation.ContractNegotiationConsumerRequested;
 import org.eclipse.edc.spi.event.contractnegotiation.ContractNegotiationEvent;
-import org.eclipse.edc.spi.event.contractnegotiation.ContractNegotiationRequested;
+import org.eclipse.edc.spi.event.contractnegotiation.ContractNegotiationProviderAgreed;
 import org.eclipse.edc.spi.iam.ClaimToken;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcher;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
@@ -46,9 +46,9 @@ import java.net.URI;
 import java.time.ZonedDateTime;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
+import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.awaitility.Awaitility.await;
 import static org.eclipse.edc.junit.matchers.EventEnvelopeMatcher.isEnvelopeOf;
 import static org.eclipse.edc.junit.testfixtures.TestUtils.getFreePort;
@@ -104,13 +104,13 @@ class ContractNegotiationEventDispatchTest {
         policyDefinitionStore.create(PolicyDefinition.Builder.newInstance().id("policyId").policy(policy).build());
         assetIndex.accept(Asset.Builder.newInstance().id("assetId").build(), DataAddress.Builder.newInstance().type("any").build());
 
-        manager.requested(token, createContractOfferRequest(policy));
+        var result = manager.requested(token, createContractOfferRequest(policy));
 
         await().untilAsserted(() -> {
             //noinspection unchecked
-            verify(eventSubscriber).on(argThat(isEnvelopeOf(ContractNegotiationRequested.class)));
+            verify(eventSubscriber).on(argThat(isEnvelopeOf(ContractNegotiationConsumerRequested.class)));
             //noinspection unchecked
-            verify(eventSubscriber).on(argThat(isEnvelopeOf(ContractNegotiationConfirmed.class)));
+            verify(eventSubscriber).on(argThat(isEnvelopeOf(ContractNegotiationProviderAgreed.class)));
         });
     }
 
@@ -139,7 +139,7 @@ class ContractNegotiationEventDispatchTest {
     private RemoteMessageDispatcher succeedingDispatcher() {
         var testDispatcher = mock(RemoteMessageDispatcher.class);
         when(testDispatcher.protocol()).thenReturn("test");
-        when(testDispatcher.send(any(), any())).thenReturn(CompletableFuture.completedFuture("any"));
+        when(testDispatcher.send(any(), any())).thenReturn(completedFuture("any"));
         return testDispatcher;
     }
 

--- a/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/contractnegotiation/InMemoryContractNegotiationStoreTest.java
+++ b/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/contractnegotiation/InMemoryContractNegotiationStoreTest.java
@@ -91,7 +91,7 @@ class InMemoryContractNegotiationStoreTest extends ContractNegotiationStoreTestB
 
         assertEquals(INITIAL.code(), found.getState());
 
-        negotiation.transitionRequesting();
+        negotiation.transitionConsumerRequesting();
 
         store.save(negotiation);
         found = store.findById(id);
@@ -108,10 +108,10 @@ class InMemoryContractNegotiationStoreTest extends ContractNegotiationStoreTestB
         var negotiation2 = requestingNegotiation();
         store.save(negotiation2);
 
-        negotiation2.transitionRequested();
+        negotiation2.transitionConsumerRequested();
         store.save(negotiation2);
         Thread.sleep(1);
-        negotiation1.transitionRequested();
+        negotiation1.transitionConsumerRequested();
         store.save(negotiation1);
 
         var requestingNegotiations = store.nextForState(CONSUMER_REQUESTING.code(), 1);
@@ -431,7 +431,7 @@ class InMemoryContractNegotiationStoreTest extends ContractNegotiationStoreTestB
     private ContractNegotiation requestingNegotiation() {
         var negotiation = TestFunctions.createNegotiation(UUID.randomUUID().toString());
         negotiation.transitionInitial();
-        negotiation.transitionRequesting();
+        negotiation.transitionConsumerRequesting();
         return negotiation;
     }
 

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
@@ -19,7 +19,6 @@ import io.opentelemetry.extension.annotations.WithSpan;
 import org.eclipse.edc.connector.policy.spi.store.PolicyArchive;
 import org.eclipse.edc.connector.transfer.spi.TransferProcessManager;
 import org.eclipse.edc.connector.transfer.spi.flow.DataFlowManager;
-import org.eclipse.edc.connector.transfer.spi.observe.TransferProcessListener;
 import org.eclipse.edc.connector.transfer.spi.observe.TransferProcessObservable;
 import org.eclipse.edc.connector.transfer.spi.provision.ProvisionManager;
 import org.eclipse.edc.connector.transfer.spi.provision.ResourceManifestGenerator;
@@ -64,7 +63,6 @@ import org.jetbrains.annotations.NotNull;
 import java.time.Clock;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -275,7 +273,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
                 .build();
 
         observable.invokeForEach(l -> l.preCreated(process));
-        updateTransferProcess(process);
+        update(process);
         observable.invokeForEach(l -> l.initiated(process));
         monitor.debug("Process " + process.getId() + " is now " + TransferProcessStates.from(process.getState()));
 
@@ -317,7 +315,8 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
         }
 
         process.transitionProvisioning(manifest);
-        updateTransferProcess(process, l -> l.preProvisioning(process));
+        observable.invokeForEach(l -> l.preProvisioning(process));
+        update(process);
         return true;
     }
 
@@ -343,7 +342,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
         return entityRetryProcessFactory.doAsyncProcess(process, () -> provisionManager.provision(resources, policy))
                 .entityRetrieve(transferProcessStore::find)
                 .onSuccess((t, content) -> handleProvisionResult(t.getId(), content))
-                .onFailure((t, throwable) -> transitToProvisioning(t))
+                .onFailure((t, throwable) -> transitionToProvisioning(t))
                 .onRetryExhausted((t, throwable) -> transitionToTerminating(t, format("Error during provisioning: %s", throwable.getMessage())))
                 .onDelay(this::breakLease)
                 .execute("Provisioning");
@@ -358,9 +357,9 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
     @WithSpan
     private boolean processProvisioned(TransferProcess process) {
         if (CONSUMER == process.getType()) {
-            transitToRequesting(process);
+            transitionToRequesting(process);
         } else {
-            transitToStarting(process);
+            transitionToStarting(process);
         }
         return true;
     }
@@ -393,9 +392,9 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
         var description = format("Send %s to %s", message.getClass().getSimpleName(), message.getConnectorAddress());
         return entityRetryProcessFactory.doAsyncProcess(process, () -> dispatcherRegistry.send(Object.class, message))
                 .entityRetrieve(id -> transferProcessStore.find(id))
-                .onSuccess((t, content) -> transitToRequested(t))
+                .onSuccess((t, content) -> transitionToRequested(t))
                 .onRetryExhausted((t, throwable) -> transitionToTerminating(t, throwable.getMessage(), throwable))
-                .onFailure((t, throwable) -> transitToRequesting(t))
+                .onFailure((t, throwable) -> transitionToRequesting(t))
                 .onDelay(this::breakLease)
                 .execute(description);
     }
@@ -416,7 +415,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
             return false;
         }
         if (!dataRequest.isManagedResources() || (process.getProvisionedResourceSet() != null && !process.getProvisionedResourceSet().empty())) {
-            transitToStarted(process);
+            transitionToStarted(process);
             return true;
         } else {
             monitor.debug("Process " + process.getId() + " does not yet have provisioned resources, will stay in " + TransferProcessStates.REQUESTED);
@@ -447,7 +446,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
         return entityRetryProcessFactory.doSyncProcess(process, () -> dataFlowManager.initiate(dataRequest, contentAddress, policy))
                 .onSuccess((t, content) -> sendTransferStartMessage(t))
                 .onFatalError((p, failure) -> transitionToTerminating(p, failure.getFailureDetail()))
-                .onFailure((t, failure) -> transitToStarting(t))
+                .onFailure((t, failure) -> transitionToStarting(t))
                 .onRetryExhausted((p, failure) -> transitionToTerminating(p, failure.getFailureDetail()))
                 .onDelay(this::breakLease)
                 .execute(description);
@@ -465,8 +464,8 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
 
         entityRetryProcessFactory.doAsyncProcess(process, () -> dispatcherRegistry.send(Object.class, message))
                 .entityRetrieve(id -> transferProcessStore.find(id))
-                .onSuccess((t, content) -> transitToStarted(t))
-                .onFailure((t, throwable) -> transitToStarting(t))
+                .onSuccess((t, content) -> transitionToStarted(t))
+                .onFailure((t, throwable) -> transitionToStarting(t))
                 .onRetryExhausted((t, throwable) -> transitionToTerminating(t, throwable.getMessage(), throwable))
                 .onDelay(this::breakLease)
                 .execute(description);
@@ -532,7 +531,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
         var description = format("Send %s to %s", dataRequest.getClass().getSimpleName(), dataRequest.getConnectorAddress());
         return entityRetryProcessFactory.doAsyncProcess(process, () -> dispatcherRegistry.send(Object.class, message))
                 .entityRetrieve(id -> transferProcessStore.find(id))
-                .onSuccess((t, content) -> transitToCompleted(t))
+                .onSuccess((t, content) -> transitionToCompleted(t))
                 .onFailure((t, throwable) -> transitionToCompleting(t))
                 .onRetryExhausted((t, throwable) -> transitionToTerminating(t, throwable.getMessage(), throwable))
                 .onDelay(this::breakLease)
@@ -549,7 +548,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
     @WithSpan
     private boolean processTerminating(TransferProcess process) {
         if (process.getType() == CONSUMER && process.getState() < REQUESTED.code()) {
-            transitToTerminated(process);
+            transitionToTerminated(process);
             return true;
         }
 
@@ -562,9 +561,9 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
         var description = format("Send %s to %s", dataRequest.getClass().getSimpleName(), dataRequest.getConnectorAddress());
         return entityRetryProcessFactory.doAsyncProcess(process, () -> dispatcherRegistry.send(Object.class, message))
                 .entityRetrieve(id -> transferProcessStore.find(id))
-                .onSuccess((t, content) -> transitToTerminated(t))
+                .onSuccess((t, content) -> transitionToTerminated(t))
                 .onFailure((t, throwable) -> transitionToTerminating(t, throwable.getMessage(), throwable))
-                .onRetryExhausted(this::transitToTerminated)
+                .onRetryExhausted(this::transitionToTerminated)
                 .onDelay(this::breakLease)
                 .execute(description);
     }
@@ -586,16 +585,13 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
 
         var resourcesToDeprovision = process.getResourcesToDeprovision();
 
-        provisionManager.deprovision(resourcesToDeprovision, policy)
-                .whenComplete((responses, throwable) -> {
-                    if (throwable == null) {
-                        handleDeprovisionResult(process.getId(), responses);
-                    } else {
-                        transitionToDeprovisioningError(process.getId(), throwable);
-                    }
-                });
-
-        return true;
+        return entityRetryProcessFactory.doAsyncProcess(process, () -> provisionManager.deprovision(resourcesToDeprovision, policy))
+                        .entityRetrieve(transferProcessStore::find)
+                        .onDelay(this::breakLease)
+                        .onSuccess((t, results) -> handleDeprovisionResult(t.getId(), results))
+                        .onFailure((t, throwable) -> transitionToDeprovisioning(t))
+                        .onRetryExhausted((t, throwable) -> transitionToDeprovisioningError(t.getId(), throwable))
+                        .execute("deprovisioning");
     }
 
     private void handleProvisionResponses(TransferProcess transferProcess, List<ProvisionResponse> responses) {
@@ -629,14 +625,14 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
         if (transferProcess.provisioningComplete()) {
             transferProcess.transitionProvisioned();
             observable.invokeForEach(l -> l.preProvisioned(transferProcess));
-            updateTransferProcess(transferProcess);
+            update(transferProcess);
             observable.invokeForEach(l -> l.provisioned(transferProcess));
         } else if (responses.stream().anyMatch(ProvisionResponse::isInProcess)) {
             transferProcess.transitionProvisioningRequested();
-            updateTransferProcess(transferProcess);
+            update(transferProcess);
             observable.invokeForEach(l -> l.provisioningRequested(transferProcess));
         } else {
-            updateTransferProcess(transferProcess);
+            update(transferProcess);
         }
     }
 
@@ -660,14 +656,14 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
         if (transferProcess.deprovisionComplete()) {
             transferProcess.transitionDeprovisioned();
             observable.invokeForEach(l -> l.preDeprovisioned(transferProcess));
-            updateTransferProcess(transferProcess);
+            update(transferProcess);
             observable.invokeForEach(l -> l.deprovisioned(transferProcess));
         } else if (results.stream().anyMatch(DeprovisionedResource::isInProcess)) {
             transferProcess.transitionDeprovisioningRequested();
-            updateTransferProcess(transferProcess);
+            update(transferProcess);
             observable.invokeForEach(l -> l.deprovisioningRequested(transferProcess));
         } else {
-            updateTransferProcess(transferProcess);
+            update(transferProcess);
         }
     }
 
@@ -713,60 +709,70 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
         return new StateProcessorImpl<>(() -> commandQueue.dequeue(5), process);
     }
 
-    private void transitToProvisioning(TransferProcess process) {
+    private void transitionToProvisioning(TransferProcess process) {
         process.transitionProvisioning(process.getResourceManifest());
-        updateTransferProcess(process, l -> l.preProvisioning(process));
+        observable.invokeForEach(l -> l.preProvisioning(process));
+        update(process);
     }
 
-    private void transitToRequesting(TransferProcess process) {
+    private void transitionToRequesting(TransferProcess process) {
         process.transitionRequesting();
-        updateTransferProcess(process, l -> l.preRequesting(process));
+        observable.invokeForEach(l -> l.preRequesting(process));
+        update(process);
     }
 
-    private void transitToRequested(TransferProcess transferProcess) {
+    private void transitionToRequested(TransferProcess transferProcess) {
         transferProcess.transitionRequested();
-        updateTransferProcess(transferProcess, l -> l.preRequested(transferProcess));
+        observable.invokeForEach(l -> l.preRequested(transferProcess));
+        update(transferProcess);
         observable.invokeForEach(l -> l.requested(transferProcess));
     }
 
-    private void transitToStarting(TransferProcess t) {
-        t.transitionStarting();
-        updateTransferProcess(t);
+    private void transitionToStarting(TransferProcess transferProcess) {
+        transferProcess.transitionStarting();
+        update(transferProcess);
     }
 
-    private void transitToStarted(TransferProcess process) {
+    private void transitionToStarted(TransferProcess process) {
         process.transitionStarted();
-        updateTransferProcess(process, l -> l.preStarted(process));
+        observable.invokeForEach(l -> l.preStarted(process));
+        update(process);
         observable.invokeForEach(l -> l.started(process));
     }
 
     private void transitionToCompleting(TransferProcess process) {
         process.transitionCompleting();
-        updateTransferProcess(process, l -> {
-        });
+        update(process);
     }
 
-    private void transitToCompleted(TransferProcess p) {
-        p.transitionCompleted();
-        updateTransferProcess(p, l -> l.preCompleted(p));
-        observable.invokeForEach(l -> l.completed(p));
+    private void transitionToCompleted(TransferProcess transferProcess) {
+        transferProcess.transitionCompleted();
+        observable.invokeForEach(l -> l.preCompleted(transferProcess));
+        update(transferProcess);
+        observable.invokeForEach(l -> l.completed(transferProcess));
     }
 
     private void transitionToTerminating(TransferProcess process, String message, Throwable... errors) {
         monitor.severe(message, errors);
         process.transitionTerminating(message);
-        updateTransferProcess(process);
+        update(process);
     }
 
-    private void transitToTerminated(TransferProcess process, Throwable throwable) {
+    private void transitionToTerminated(TransferProcess process, Throwable throwable) {
         process.setErrorDetail(throwable.getMessage());
-        transitToTerminated(process);
+        transitionToTerminated(process);
     }
 
-    private void transitToTerminated(TransferProcess process) {
+    private void transitionToTerminated(TransferProcess process) {
         process.transitionTerminated();
-        updateTransferProcess(process, l -> l.preTerminated(process));
+        observable.invokeForEach(l -> l.preTerminated(process));
+        update(process);
         observable.invokeForEach(l -> l.terminated(process));
+    }
+
+    private void transitionToDeprovisioning(TransferProcess process) {
+        process.transitionDeprovisioning();
+        update(process);
     }
 
     private void transitionToDeprovisioningError(String processId, Throwable throwable) {
@@ -782,18 +788,14 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
     private void transitionToDeprovisioningError(TransferProcess transferProcess, String message) {
         monitor.severe(message);
         transferProcess.transitionDeprovisioned(message);
-        updateTransferProcess(transferProcess, l -> l.preDeprovisioned(transferProcess));
+        observable.invokeForEach(l -> l.preDeprovisioned(transferProcess));
+        update(transferProcess);
         observable.invokeForEach(l -> l.deprovisioned(transferProcess));
     }
 
-    private void updateTransferProcess(TransferProcess transferProcess, Consumer<TransferProcessListener> observe) {
-        observable.invokeForEach(observe);
-        updateTransferProcess(transferProcess);
-    }
-
-    private void updateTransferProcess(TransferProcess transferProcess) {
+    private void update(TransferProcess transferProcess) {
         transferProcessStore.save(transferProcess);
-        monitor.debug("Process " + transferProcess.getId() + " is now " + TransferProcessStates.from(transferProcess.getState()));
+        monitor.debug(format("TransferProcess %s is now in state %s", transferProcess.getId(), TransferProcessStates.from(transferProcess.getState())));
     }
 
     private void breakLease(TransferProcess process) {

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/transfer/DispatchFailure.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/transfer/DispatchFailure.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.transfer.transfer;
+
+import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
+import org.eclipse.edc.connector.transfer.spi.types.TransferProcessStates;
+import org.junit.jupiter.params.provider.Arguments;
+
+import java.util.function.UnaryOperator;
+
+import static org.eclipse.edc.connector.transfer.spi.types.TransferProcessStates.INITIAL;
+
+
+public class DispatchFailure implements Arguments {
+
+    private final TransferProcessStates starting;
+    private final TransferProcessStates ending;
+    private final UnaryOperator<TransferProcess.Builder> builderEnricher;
+
+    public DispatchFailure() {
+        this(INITIAL, INITIAL, it -> it);
+    }
+
+    public DispatchFailure(TransferProcessStates starting, TransferProcessStates ending, UnaryOperator<TransferProcess.Builder> builderEnricher) {
+        this.starting = starting;
+        this.ending = ending;
+        this.builderEnricher = builderEnricher;
+    }
+
+    @Override
+    public Object[] get() {
+        return new Object[]{ starting, ending, builderEnricher };
+    }
+}

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/transfer/TransferProcessManagerImplTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/transfer/TransferProcessManagerImplTest.java
@@ -493,6 +493,7 @@ class TransferProcessManagerImplTest {
             verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
             verify(dispatcherRegistry).send(any(), isA(TransferStartMessage.class));
             verify(transferProcessStore).save(argThat(p -> p.getState() == STARTED.code()));
+            verify(listener).started(process);
         });
     }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -31,11 +31,11 @@ pluginManagement {
 
 dependencyResolutionManagement {
     repositories {
+        mavenLocal()
         maven {
             url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
         }
         mavenCentral()
-        mavenLocal()
     }
     versionCatalogs {
         create("libs") {

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/EventEnvelope.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/EventEnvelope.java
@@ -56,7 +56,7 @@ public class EventEnvelope<E extends Event> {
         }
 
         public static Builder newInstance() {
-            return new Builder();
+            return new Builder<>();
         }
 
         public Builder<E> id(String id) {

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/contractnegotiation/ContractNegotiationConsumerAgreed.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/contractnegotiation/ContractNegotiationConsumerAgreed.java
@@ -20,28 +20,23 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 /**
- * This event is raised when the ContractNegotiation has been confirmed.
- *
- * @deprecated please use {@link ContractNegotiationProviderAgreed}
+ * This event is raised when the ContractNegotiation has been approved.
  */
-@Deprecated(since = "milestone9")
-@JsonDeserialize(builder = ContractNegotiationConfirmed.Builder.class)
-public class ContractNegotiationConfirmed extends ContractNegotiationEvent {
+@JsonDeserialize(builder = ContractNegotiationConsumerAgreed.Builder.class)
+public class ContractNegotiationConsumerAgreed extends ContractNegotiationEvent {
 
-    private ContractNegotiationConfirmed() {
+    private ContractNegotiationConsumerAgreed() {
     }
 
-
     @JsonPOJOBuilder(withPrefix = "")
-    public static class Builder extends ContractNegotiationEvent.Builder<ContractNegotiationConfirmed, Builder> {
-
+    public static class Builder extends ContractNegotiationEvent.Builder<ContractNegotiationConsumerAgreed, Builder> {
+        @JsonCreator
         public static Builder newInstance() {
             return new Builder();
         }
 
-        @JsonCreator
         private Builder() {
-            super(new ContractNegotiationConfirmed());
+            super(new ContractNegotiationConsumerAgreed());
         }
 
         @Override
@@ -49,4 +44,5 @@ public class ContractNegotiationConfirmed extends ContractNegotiationEvent {
             return this;
         }
     }
+
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/contractnegotiation/ContractNegotiationConsumerRequested.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/contractnegotiation/ContractNegotiationConsumerRequested.java
@@ -20,28 +20,24 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 /**
- * This event is raised when the ContractNegotiation has been confirmed.
- *
- * @deprecated please use {@link ContractNegotiationProviderAgreed}
+ * This event is raised when the ContractNegotiation has been requested.
  */
-@Deprecated(since = "milestone9")
-@JsonDeserialize(builder = ContractNegotiationConfirmed.Builder.class)
-public class ContractNegotiationConfirmed extends ContractNegotiationEvent {
+@JsonDeserialize(builder = ContractNegotiationConsumerRequested.Builder.class)
+public class ContractNegotiationConsumerRequested extends ContractNegotiationEvent {
 
-    private ContractNegotiationConfirmed() {
+    private ContractNegotiationConsumerRequested() {
     }
 
-
     @JsonPOJOBuilder(withPrefix = "")
-    public static class Builder extends ContractNegotiationEvent.Builder<ContractNegotiationConfirmed, Builder> {
+    public static class Builder extends ContractNegotiationEvent.Builder<ContractNegotiationConsumerRequested, Builder> {
 
+        @JsonCreator
         public static Builder newInstance() {
             return new Builder();
         }
 
-        @JsonCreator
         private Builder() {
-            super(new ContractNegotiationConfirmed());
+            super(new ContractNegotiationConsumerRequested());
         }
 
         @Override
@@ -49,4 +45,5 @@ public class ContractNegotiationConfirmed extends ContractNegotiationEvent {
             return this;
         }
     }
+
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/contractnegotiation/ContractNegotiationConsumerVerified.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/contractnegotiation/ContractNegotiationConsumerVerified.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -9,7 +9,6 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
- *       Fraunhofer Institute for Software and Systems Engineering - expending Event classes
  *
  */
 
@@ -20,24 +19,24 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 /**
- * This event is raised when the ContractNegotiation has been offered.
+ * This event is raised when the ContractNegotiation has been verified by consumer.
  */
-@JsonDeserialize(builder = ContractNegotiationOffered.Builder.class)
-public class ContractNegotiationOffered extends ContractNegotiationEvent {
+@JsonDeserialize(builder = ContractNegotiationConsumerVerified.Builder.class)
+public class ContractNegotiationConsumerVerified extends ContractNegotiationEvent {
 
-    private ContractNegotiationOffered() {
+    private ContractNegotiationConsumerVerified() {
     }
 
     @JsonPOJOBuilder(withPrefix = "")
-    public static class Builder extends ContractNegotiationEvent.Builder<ContractNegotiationOffered, Builder> {
+    public static class Builder extends ContractNegotiationEvent.Builder<ContractNegotiationConsumerVerified, Builder> {
 
-        @JsonCreator
         public static Builder newInstance() {
             return new Builder();
         }
 
+        @JsonCreator
         private Builder() {
-            super(new ContractNegotiationOffered());
+            super(new ContractNegotiationConsumerVerified());
         }
 
         @Override
@@ -45,5 +44,4 @@ public class ContractNegotiationOffered extends ContractNegotiationEvent {
             return this;
         }
     }
-
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/contractnegotiation/ContractNegotiationDeclined.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/contractnegotiation/ContractNegotiationDeclined.java
@@ -21,7 +21,10 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 /**
  * This event is raised when the ContractNegotiation has been declined.
+ *
+ * @deprecated please use {@link ContractNegotiationTerminated}
  */
+@Deprecated(since = "milestone9")
 @JsonDeserialize(builder = ContractNegotiationDeclined.Builder.class)
 public class ContractNegotiationDeclined extends ContractNegotiationEvent {
 

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/contractnegotiation/ContractNegotiationFailed.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/contractnegotiation/ContractNegotiationFailed.java
@@ -21,7 +21,10 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 /**
  * This event is raised when the ContractNegotiation has failed.
+ *
+ * @deprecated please use {@link ContractNegotiationTerminated}
  */
+@Deprecated(since = "milestone9")
 @JsonDeserialize(builder = ContractNegotiationFailed.Builder.class)
 public class ContractNegotiationFailed extends ContractNegotiationEvent {
 

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/contractnegotiation/ContractNegotiationProviderAgreed.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/contractnegotiation/ContractNegotiationProviderAgreed.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -9,7 +9,6 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
- *       Fraunhofer Institute for Software and Systems Engineering - expending Event classes
  *
  */
 
@@ -20,24 +19,24 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 /**
- * This event is raised when the ContractNegotiation has been requested.
+ * This event is raised when the ContractNegotiation has been agreed by provider.
  */
-@JsonDeserialize(builder = ContractNegotiationRequested.Builder.class)
-public class ContractNegotiationRequested extends ContractNegotiationEvent {
+@JsonDeserialize(builder = ContractNegotiationProviderAgreed.Builder.class)
+public class ContractNegotiationProviderAgreed extends ContractNegotiationEvent {
 
-    private ContractNegotiationRequested() {
+    private ContractNegotiationProviderAgreed() {
     }
 
     @JsonPOJOBuilder(withPrefix = "")
-    public static class Builder extends ContractNegotiationEvent.Builder<ContractNegotiationRequested, Builder> {
+    public static class Builder extends ContractNegotiationEvent.Builder<ContractNegotiationProviderAgreed, Builder> {
 
-        @JsonCreator
         public static Builder newInstance() {
             return new Builder();
         }
 
+        @JsonCreator
         private Builder() {
-            super(new ContractNegotiationRequested());
+            super(new ContractNegotiationProviderAgreed());
         }
 
         @Override
@@ -45,5 +44,4 @@ public class ContractNegotiationRequested extends ContractNegotiationEvent {
             return this;
         }
     }
-
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/contractnegotiation/ContractNegotiationProviderFinalized.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/contractnegotiation/ContractNegotiationProviderFinalized.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -9,7 +9,6 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
- *       Fraunhofer Institute for Software and Systems Engineering - expending Event classes
  *
  */
 
@@ -20,23 +19,24 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 /**
- * This event is raised when the ContractNegotiation has been approved.
+ * This event is raised when the ContractNegotiation has been finalized by provider.
  */
-@JsonDeserialize(builder = ContractNegotiationApproved.Builder.class)
-public class ContractNegotiationApproved extends ContractNegotiationEvent {
+@JsonDeserialize(builder = ContractNegotiationProviderFinalized.Builder.class)
+public class ContractNegotiationProviderFinalized extends ContractNegotiationEvent {
 
-    private ContractNegotiationApproved() {
+    private ContractNegotiationProviderFinalized() {
     }
 
     @JsonPOJOBuilder(withPrefix = "")
-    public static class Builder extends ContractNegotiationEvent.Builder<ContractNegotiationApproved, Builder> {
-        @JsonCreator
+    public static class Builder extends ContractNegotiationEvent.Builder<ContractNegotiationProviderFinalized, Builder> {
+
         public static Builder newInstance() {
             return new Builder();
         }
 
+        @JsonCreator
         private Builder() {
-            super(new ContractNegotiationApproved());
+            super(new ContractNegotiationProviderFinalized());
         }
 
         @Override
@@ -44,5 +44,4 @@ public class ContractNegotiationApproved extends ContractNegotiationEvent {
             return this;
         }
     }
-
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/contractnegotiation/ContractNegotiationProviderOffered.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/contractnegotiation/ContractNegotiationProviderOffered.java
@@ -20,28 +20,24 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 /**
- * This event is raised when the ContractNegotiation has been confirmed.
- *
- * @deprecated please use {@link ContractNegotiationProviderAgreed}
+ * This event is raised when the ContractNegotiation has been offered.
  */
-@Deprecated(since = "milestone9")
-@JsonDeserialize(builder = ContractNegotiationConfirmed.Builder.class)
-public class ContractNegotiationConfirmed extends ContractNegotiationEvent {
+@JsonDeserialize(builder = ContractNegotiationProviderOffered.Builder.class)
+public class ContractNegotiationProviderOffered extends ContractNegotiationEvent {
 
-    private ContractNegotiationConfirmed() {
+    private ContractNegotiationProviderOffered() {
     }
 
-
     @JsonPOJOBuilder(withPrefix = "")
-    public static class Builder extends ContractNegotiationEvent.Builder<ContractNegotiationConfirmed, Builder> {
+    public static class Builder extends ContractNegotiationEvent.Builder<ContractNegotiationProviderOffered, Builder> {
 
+        @JsonCreator
         public static Builder newInstance() {
             return new Builder();
         }
 
-        @JsonCreator
         private Builder() {
-            super(new ContractNegotiationConfirmed());
+            super(new ContractNegotiationProviderOffered());
         }
 
         @Override
@@ -49,4 +45,5 @@ public class ContractNegotiationConfirmed extends ContractNegotiationEvent {
             return this;
         }
     }
+
 }

--- a/spi/common/core-spi/src/test/java/org/eclipse/edc/spi/event/EventTest.java
+++ b/spi/common/core-spi/src/test/java/org/eclipse/edc/spi/event/EventTest.java
@@ -19,13 +19,13 @@ import org.eclipse.edc.spi.event.asset.AssetCreated;
 import org.eclipse.edc.spi.event.asset.AssetDeleted;
 import org.eclipse.edc.spi.event.contractdefinition.ContractDefinitionCreated;
 import org.eclipse.edc.spi.event.contractdefinition.ContractDefinitionDeleted;
-import org.eclipse.edc.spi.event.contractnegotiation.ContractNegotiationApproved;
 import org.eclipse.edc.spi.event.contractnegotiation.ContractNegotiationConfirmed;
+import org.eclipse.edc.spi.event.contractnegotiation.ContractNegotiationConsumerAgreed;
+import org.eclipse.edc.spi.event.contractnegotiation.ContractNegotiationConsumerRequested;
 import org.eclipse.edc.spi.event.contractnegotiation.ContractNegotiationDeclined;
 import org.eclipse.edc.spi.event.contractnegotiation.ContractNegotiationFailed;
 import org.eclipse.edc.spi.event.contractnegotiation.ContractNegotiationInitiated;
-import org.eclipse.edc.spi.event.contractnegotiation.ContractNegotiationOffered;
-import org.eclipse.edc.spi.event.contractnegotiation.ContractNegotiationRequested;
+import org.eclipse.edc.spi.event.contractnegotiation.ContractNegotiationProviderOffered;
 import org.eclipse.edc.spi.event.contractnegotiation.ContractNegotiationTerminated;
 import org.eclipse.edc.spi.event.policydefinition.PolicyDefinitionCreated;
 import org.eclipse.edc.spi.event.policydefinition.PolicyDefinitionDeleted;
@@ -79,13 +79,13 @@ class EventTest {
                     AssetDeleted.Builder.newInstance().assetId("id").build(),
                     ContractDefinitionCreated.Builder.newInstance().contractDefinitionId("id").build(),
                     ContractDefinitionDeleted.Builder.newInstance().contractDefinitionId("id").build(),
-                    ContractNegotiationApproved.Builder.newInstance().contractNegotiationId("id").build(),
+                    ContractNegotiationConsumerAgreed.Builder.newInstance().contractNegotiationId("id").build(),
                     ContractNegotiationConfirmed.Builder.newInstance().contractNegotiationId("id").build(),
                     ContractNegotiationDeclined.Builder.newInstance().contractNegotiationId("id").build(),
                     ContractNegotiationFailed.Builder.newInstance().contractNegotiationId("id").build(),
                     ContractNegotiationInitiated.Builder.newInstance().contractNegotiationId("id").build(),
-                    ContractNegotiationOffered.Builder.newInstance().contractNegotiationId("id").build(),
-                    ContractNegotiationRequested.Builder.newInstance().contractNegotiationId("id").build(),
+                    ContractNegotiationProviderOffered.Builder.newInstance().contractNegotiationId("id").build(),
+                    ContractNegotiationConsumerRequested.Builder.newInstance().contractNegotiationId("id").build(),
                     ContractNegotiationTerminated.Builder.newInstance().contractNegotiationId("id").build(),
                     PolicyDefinitionCreated.Builder.newInstance().policyDefinitionId("id").build(),
                     PolicyDefinitionDeleted.Builder.newInstance().policyDefinitionId("id").build(),

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/negotiation/observe/ContractNegotiationListener.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/negotiation/observe/ContractNegotiationListener.java
@@ -41,7 +41,7 @@ public interface ContractNegotiationListener {
      *
      * @param negotiation the contract negotiation that has been requested.
      */
-    default void requested(ContractNegotiation negotiation) {
+    default void consumerRequested(ContractNegotiation negotiation) {
 
     }
 
@@ -50,7 +50,7 @@ public interface ContractNegotiationListener {
      *
      * @param negotiation the contract negotiation that has been offered.
      */
-    default void offered(ContractNegotiation negotiation) {
+    default void providerOffered(ContractNegotiation negotiation) {
 
     }
 
@@ -59,7 +59,7 @@ public interface ContractNegotiationListener {
      *
      * @param negotiation the contract negotiation that has been approved.
      */
-    default void approved(ContractNegotiation negotiation) {
+    default void consumerAgreed(ContractNegotiation negotiation) {
 
     }
 
@@ -95,11 +95,29 @@ public interface ContractNegotiationListener {
     }
 
     /**
-     * Called after a {@link ContractNegotiation} was confirmed.
+     * Called after a {@link ContractNegotiation} was agreed by the provider.
      *
      * @param negotiation the contract negotiation that has been confirmed.
      */
-    default void confirmed(ContractNegotiation negotiation) {
+    default void providerAgreed(ContractNegotiation negotiation) {
+
+    }
+
+    /**
+     * Called after a {@link ContractNegotiation} was verified by the consumer.
+     *
+     * @param negotiation the contract negotiation that has been verified.
+     */
+    default void consumerVerified(ContractNegotiation negotiation) {
+
+    }
+
+    /**
+     * Called after a {@link ContractNegotiation} was finalized by the provider.
+     *
+     * @param negotiation the contract negotiation that has been finalized.
+     */
+    default void providerFinalized(ContractNegotiation negotiation) {
 
     }
 }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractNegotiation.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractNegotiation.java
@@ -156,19 +156,19 @@ public class ContractNegotiation extends StatefulEntity<ContractNegotiation> {
     }
 
     /**
-     * Transition to state REQUESTING (type consumer only).
+     * Transition to state CONSUMER_REQUESTING (type consumer only).
      */
-    public void transitionRequesting() {
+    public void transitionConsumerRequesting() {
         if (Type.PROVIDER == type) {
-            throw new IllegalStateException("Provider processes have no REQUESTING state");
+            throw new IllegalStateException("Provider processes have no CONSUMER_REQUESTING state");
         }
         transition(CONSUMER_REQUESTING, CONSUMER_REQUESTING, INITIAL);
     }
 
     /**
-     * Transition to state REQUESTED.
+     * Transition to state CONSUMER_REQUESTED.
      */
-    public void transitionRequested() {
+    public void transitionConsumerRequested() {
         if (Type.PROVIDER == type) {
             transition(CONSUMER_REQUESTED, INITIAL);
         } else {
@@ -177,21 +177,20 @@ public class ContractNegotiation extends StatefulEntity<ContractNegotiation> {
     }
 
     /**
-     * Transition to state REQUESTED.
+     * Transition to state PROVIDER_OFFERING (type provider only).
      */
-    public void transitionOffering() {
+    public void transitionProviderOffering() {
         if (CONSUMER == type) {
-            transition(CONSUMER_REQUESTING, CONSUMER_REQUESTING, CONSUMER_REQUESTED, PROVIDER_OFFERED);
-        } else {
-            transition(PROVIDER_OFFERING, PROVIDER_OFFERING, PROVIDER_OFFERED, CONSUMER_REQUESTED);
+            throw new IllegalStateException("Provider processes have no PROVIDER_OFFERING state");
         }
+
+        transition(PROVIDER_OFFERING, PROVIDER_OFFERING, PROVIDER_OFFERED, CONSUMER_REQUESTED);
     }
 
     /**
-     * Transition to state CONSUMER_OFFERED for type consumer and PROVIDER_OFFERED for type
-     * provider.
+     * Transition to state PROVIDER_OFFERED.
      */
-    public void transitionOffered() {
+    public void transitionProviderOffered() {
         if (CONSUMER == type) {
             transition(PROVIDER_OFFERED, PROVIDER_OFFERED, CONSUMER_REQUESTED);
         } else {
@@ -202,7 +201,7 @@ public class ContractNegotiation extends StatefulEntity<ContractNegotiation> {
     /**
      * Transition to state CONSUMER_APPROVING (type consumer only).
      */
-    public void transitionApproving() {
+    public void transitionConsumerAgreeing() {
         if (Type.PROVIDER == type) {
             throw new IllegalStateException("Provider processes have no CONSUMER_APPROVING state");
         }
@@ -210,12 +209,9 @@ public class ContractNegotiation extends StatefulEntity<ContractNegotiation> {
     }
 
     /**
-     * Transition to state CONSUMER_APPROVED (type consumer only).
+     * Transition to state CONSUMER_AGREED.
      */
-    public void transitionApproved() {
-        if (Type.PROVIDER == type) {
-            throw new IllegalStateException("Provider processes have no CONSUMER_APPROVED state");
-        }
+    public void transitionConsumerAgreed() {
         transition(CONSUMER_AGREED, CONSUMER_AGREED, CONSUMER_AGREEING, PROVIDER_OFFERED);
     }
 
@@ -243,7 +239,7 @@ public class ContractNegotiation extends StatefulEntity<ContractNegotiation> {
     /**
      * Transition to state CONSUMER_VERIFYING.
      */
-    public void transitionVerifying() {
+    public void transitionConsumerVerifying() {
         if (PROVIDER == type) {
             throw new IllegalStateException("Consumer processes have no CONSUMER_VERIFYING state");
         }
@@ -254,7 +250,7 @@ public class ContractNegotiation extends StatefulEntity<ContractNegotiation> {
     /**
      * Transition to state CONSUMER_VERIFIED.
      */
-    public void transitionVerified() {
+    public void transitionConsumerVerified() {
         if (type == CONSUMER) {
             transition(CONSUMER_VERIFIED, CONSUMER_VERIFIED, CONSUMER_VERIFYING);
         } else {
@@ -272,7 +268,6 @@ public class ContractNegotiation extends StatefulEntity<ContractNegotiation> {
 
         transition(PROVIDER_FINALIZING, PROVIDER_FINALIZING, CONSUMER_VERIFIED);
     }
-
 
     /**
      * Transition to state PROVIDER_FINALIZED.


### PR DESCRIPTION
## What this PR changes/adds

Add missing event dispatch on state changes

## Why it does that

dataspace protocol implementation

## Further notes

- renamed `transition` methods on `ContractNegotiation` and `TransferProcess` to match with the actual DSP states
- introduced parameterized tests for dispatch failure both for CN and TP managers. This cleaned up the test classes a lot.

## Linked Issue(s)

Closes #2603 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
