### PR TITLE
feat: support virtual-hosted style addressing for overridden endpoint

### DIFF
--- a/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/AwsClientProviderConfiguration.java
+++ b/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/AwsClientProviderConfiguration.java
@@ -22,11 +22,12 @@ import java.util.Objects;
 public class AwsClientProviderConfiguration {
 
     static final int DEFAULT_AWS_ASYNC_CLIENT_THREAD_POOL_SIZE = 50;
+    static final boolean DEFAULT_AWS_PATH_STYLE_ACCESS_ENABLED = false;
 
     private AwsCredentialsProvider credentialsProvider;
     private URI endpointOverride;
     private int threadPoolSize = DEFAULT_AWS_ASYNC_CLIENT_THREAD_POOL_SIZE;
-    private boolean pathStyleAccessEnabled = false;
+    private boolean pathStyleAccessEnabled = DEFAULT_AWS_PATH_STYLE_ACCESS_ENABLED;
 
     private AwsClientProviderConfiguration() {
 

--- a/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/AwsClientProviderConfiguration.java
+++ b/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/AwsClientProviderConfiguration.java
@@ -26,6 +26,7 @@ public class AwsClientProviderConfiguration {
     private AwsCredentialsProvider credentialsProvider;
     private URI endpointOverride;
     private int threadPoolSize = DEFAULT_AWS_ASYNC_CLIENT_THREAD_POOL_SIZE;
+    private boolean pathStyleAccessEnabled = false;
 
     private AwsClientProviderConfiguration() {
 
@@ -41,6 +42,10 @@ public class AwsClientProviderConfiguration {
 
     public int getThreadPoolSize() {
         return threadPoolSize;
+    }
+
+    public boolean getPathStyleAccessEnabled() {
+        return pathStyleAccessEnabled;
     }
 
     public static class Builder {
@@ -67,6 +72,11 @@ public class AwsClientProviderConfiguration {
 
         public Builder threadPoolSize(int threadPoolSize) {
             configuration.threadPoolSize = threadPoolSize;
+            return this;
+        }
+
+        public Builder pathStyleAccessEnabled(boolean pathStyleAccessEnabled) {
+            configuration.pathStyleAccessEnabled = pathStyleAccessEnabled;
             return this;
         }
 

--- a/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/AwsClientProviderImpl.java
+++ b/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/AwsClientProviderImpl.java
@@ -107,6 +107,7 @@ public class AwsClientProviderImpl implements AwsClientProvider {
                 .region(Region.of(region));
 
         handleBaseEndpointOverride(builder);
+        handlePathStyleEnabled(builder);
 
         return builder.build();
     }
@@ -117,6 +118,7 @@ public class AwsClientProviderImpl implements AwsClientProvider {
                 .region(Region.of(region));
 
         handleBaseEndpointOverride(builder);
+        handlePathStyleEnabled(builder);
 
         return builder.build();
     }
@@ -128,6 +130,7 @@ public class AwsClientProviderImpl implements AwsClientProvider {
                 .region(Region.of(region));
 
         handleBaseEndpointOverride(builder);
+        handlePathStyleEnabled(builder);
 
         return builder.build();
     }
@@ -157,8 +160,7 @@ public class AwsClientProviderImpl implements AwsClientProvider {
     private void handleBaseEndpointOverride(S3BaseClientBuilder<?, ?> builder) {
         var endpointOverride = configuration.getEndpointOverride();
         if (endpointOverride != null) {
-            builder.serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(true).build())
-                    .endpointOverride(endpointOverride);
+            builder.endpointOverride(endpointOverride);
         }
     }
 
@@ -167,5 +169,9 @@ public class AwsClientProviderImpl implements AwsClientProvider {
         if (endpointOverride != null) {
             builder.endpointOverride(endpointOverride);
         }
+    }
+
+    private void handlePathStyleEnabled(S3BaseClientBuilder<?, ?> builder) {
+        builder.serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(configuration.getPathStyleAccessEnabled()).build());
     }
 }

--- a/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/AwsClientProviderImpl.java
+++ b/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/AwsClientProviderImpl.java
@@ -104,10 +104,10 @@ public class AwsClientProviderImpl implements AwsClientProvider {
         var credentialsProvider = StaticCredentialsProvider.create(credentials);
         var builder = S3Client.builder()
                 .credentialsProvider(credentialsProvider)
-                .region(Region.of(region));
+                .region(Region.of(region))
+                .serviceConfiguration(createS3Configuration());
 
         handleBaseEndpointOverride(builder);
-        handlePathStyleEnabled(builder);
 
         return builder.build();
     }
@@ -115,10 +115,10 @@ public class AwsClientProviderImpl implements AwsClientProvider {
     private S3Client createS3Client(String region) {
         S3ClientBuilder builder = S3Client.builder()
                 .credentialsProvider(credentialsProvider)
-                .region(Region.of(region));
+                .region(Region.of(region))
+                .serviceConfiguration(createS3Configuration());
 
         handleBaseEndpointOverride(builder);
-        handlePathStyleEnabled(builder);
 
         return builder.build();
     }
@@ -127,10 +127,10 @@ public class AwsClientProviderImpl implements AwsClientProvider {
         var builder = S3AsyncClient.builder()
                 .asyncConfiguration(b -> b.advancedOption(FUTURE_COMPLETION_EXECUTOR, executor))
                 .credentialsProvider(credentialsProvider)
-                .region(Region.of(region));
+                .region(Region.of(region))
+                .serviceConfiguration(createS3Configuration());
 
         handleBaseEndpointOverride(builder);
-        handlePathStyleEnabled(builder);
 
         return builder.build();
     }
@@ -171,7 +171,7 @@ public class AwsClientProviderImpl implements AwsClientProvider {
         }
     }
 
-    private void handlePathStyleEnabled(S3BaseClientBuilder<?, ?> builder) {
-        builder.serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(configuration.getPathStyleAccessEnabled()).build());
+    private S3Configuration createS3Configuration() {
+        return S3Configuration.builder().pathStyleAccessEnabled(configuration.getPathStyleAccessEnabled()).build();
     }
 }

--- a/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/S3CoreExtension.java
+++ b/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/S3CoreExtension.java
@@ -46,7 +46,7 @@ public class S3CoreExtension implements ServiceExtension {
     private static final String AWS_ENDPOINT_OVERRIDE = "edc.aws.endpoint.override";
     @Setting(value = "The size of the thread pool used for the async clients")
     private static final String AWS_ASYNC_CLIENT_THREAD_POOL_SIZE = "edc.aws.client.async.thread-pool-size";
-    @Setting(value = "If true, path style addressing is used instead of virtual-hosted style")
+    @Setting(value = "If true, path style addressing is used instead of virtual-hosted style", type = "boolean", defaultValue = DEFAULT_AWS_PATH_STYLE_ACCESS_ENABLED + "")
     private static final String AWS_PATH_STYLE_ACCESS_ENABLED = "edc.aws.path.style.access.enabled";
     @Inject
     private Vault vault;

--- a/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/S3CoreExtension.java
+++ b/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/S3CoreExtension.java
@@ -45,6 +45,8 @@ public class S3CoreExtension implements ServiceExtension {
     private static final String AWS_ENDPOINT_OVERRIDE = "edc.aws.endpoint.override";
     @Setting(value = "The size of the thread pool used for the async clients")
     private static final String AWS_ASYNC_CLIENT_THREAD_POOL_SIZE = "edc.aws.client.async.thread-pool-size";
+    @Setting(value = "If true, path style addressing is used instead of virtual-hosted style")
+    private static final String AWS_PATH_STYLE_ACCESS_ENABLED = "edc.aws.path.style.access.enabled";
     @Inject
     private Vault vault;
 
@@ -65,10 +67,13 @@ public class S3CoreExtension implements ServiceExtension {
 
         var threadPoolSize = context.getSetting(AWS_ASYNC_CLIENT_THREAD_POOL_SIZE, DEFAULT_AWS_ASYNC_CLIENT_THREAD_POOL_SIZE);
 
+        var pathStyleAccessEnabled = context.getSetting(AWS_PATH_STYLE_ACCESS_ENABLED, true);
+
         var configuration = AwsClientProviderConfiguration.Builder.newInstance()
                 .credentialsProvider(createCredentialsProvider(context))
                 .endpointOverride(endpointOverride)
                 .threadPoolSize(threadPoolSize)
+                .pathStyleAccessEnabled(pathStyleAccessEnabled)
                 .build();
 
         return new AwsClientProviderImpl(configuration);

--- a/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/S3CoreExtension.java
+++ b/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/S3CoreExtension.java
@@ -32,6 +32,7 @@ import java.util.Optional;
 
 import static java.lang.String.format;
 import static org.eclipse.edc.aws.s3.AwsClientProviderConfiguration.DEFAULT_AWS_ASYNC_CLIENT_THREAD_POOL_SIZE;
+import static org.eclipse.edc.aws.s3.AwsClientProviderConfiguration.DEFAULT_AWS_PATH_STYLE_ACCESS_ENABLED;
 
 @Extension(value = S3CoreExtension.NAME)
 public class S3CoreExtension implements ServiceExtension {
@@ -67,7 +68,7 @@ public class S3CoreExtension implements ServiceExtension {
 
         var threadPoolSize = context.getSetting(AWS_ASYNC_CLIENT_THREAD_POOL_SIZE, DEFAULT_AWS_ASYNC_CLIENT_THREAD_POOL_SIZE);
 
-        var pathStyleAccessEnabled = context.getSetting(AWS_PATH_STYLE_ACCESS_ENABLED, true);
+        var pathStyleAccessEnabled = context.getSetting(AWS_PATH_STYLE_ACCESS_ENABLED, DEFAULT_AWS_PATH_STYLE_ACCESS_ENABLED);
 
         var configuration = AwsClientProviderConfiguration.Builder.newInstance()
                 .credentialsProvider(createCredentialsProvider(context))

--- a/extensions/common/aws/aws-s3-test/README.md
+++ b/extensions/common/aws/aws-s3-test/README.md
@@ -32,3 +32,18 @@ $ IT_AWS_ENDPOINT=https://s3.us-east-1.amazonaws.com/ \
 [named profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html)
 referring your own credential.
 You can also use access key and secret access key by `S3_ACCESS_KEY_ID` and `S3_SECRET_ACCESS_KEY`.
+
+
+## Test using virtual-hosted style addressing
+
+Tests uses path style addressing by default since it is assumed to be run against local MinIO.
+You can run tests against AWS S3 or other compatible storages using virtual-host style addressing by
+specifying `IT_AWS_PATH_STYLE_ACCESS_ENABLED=false`
+
+```
+$ IT_AWS_ENDPOINT=https://s3.us-east-1.amazonaws.com/ \
+  IT_AWS_REGION=us-east-1 \
+  IT_AWS_PROFILE=myprofie \
+  IT_AWS_PATH_STYLE_ACCESS_ENABLED=false \
+  ./gradlew clean test -DincludeTags="AwsS3IntegrationTest" --tests '*S3StatusCheckerIntegrationTest'
+```

--- a/extensions/common/aws/aws-s3-test/src/testFixtures/java/org/eclipse/edc/aws/s3/testfixtures/AbstractS3Test.java
+++ b/extensions/common/aws/aws-s3-test/src/testFixtures/java/org/eclipse/edc/aws/s3/testfixtures/AbstractS3Test.java
@@ -68,12 +68,14 @@ public abstract class AbstractS3Test {
     // [see http://stackoverflow.com/questions/13898057/aws-error-message-a-conflicting-conditional-operation-is-currently-in-progress]
     protected static final String MINIO_ENDPOINT = "http://localhost:9000";
     protected static final URI S3_ENDPOINT = URI.create(propOrEnv("it.aws.endpoint", MINIO_ENDPOINT));
+    protected static final Boolean PATH_STYLE_ACCESS_ENABLED = Boolean.valueOf(propOrEnv("it.aws.path.style.access.enabled", "true"));
     protected final UUID processId = UUID.randomUUID();
     protected String bucketName = createBucketName();
     protected S3AsyncClient s3AsyncClient;
     private final AwsClientProviderConfiguration configuration = AwsClientProviderConfiguration.Builder.newInstance()
             .credentialsProvider(this::getCredentials)
             .endpointOverride(S3_ENDPOINT)
+            .pathStyleAccessEnabled(PATH_STYLE_ACCESS_ENABLED)
             .build();
     protected AwsClientProvider clientProvider = new AwsClientProviderImpl(configuration);
 


### PR DESCRIPTION
## What this PR changes/adds

Add configuration knob to switch addressing style of S3 between virtual-hosted style and path style addressing.

## Why it does that

To access S3 compatible data store using virtual-hosted style addressing of S3. The current AwsClientProviderImpl always enable path style addressing for overridden endpoint.

## Testing

I tested the patch against real S3 using endpoint override as following.

```
$ IT_AWS_ENDPOINT=https://s3.ap-northeast-1.amazonaws.com/ \
  IT_AWS_REGION=ap-northeast-1 \
  IT_AWS_PROFILE=iwasakims \
  IT_AWS_PATH_STYLE_ACCESS_ENABLED=false \
    ./gradlew clean test -p extensions/control-plane/provision/provision-aws-s3 -DincludeTags=AwsS3IntegrationTest -PverboseTest

$ IT_AWS_ENDPOINT=https://s3.ap-northeast-1.amazonaws.com/ \
  IT_AWS_REGION=ap-northeast-1 \
  IT_AWS_PROFILE=iwasakims \
  IT_AWS_PATH_STYLE_ACCESS_ENABLED=false \
    ./gradlew clean test -p extensions/data-plane/data-plane-aws-s3 -DincludeTags=AwsS3IntegrationTest -PverboseTest
```

While MinIO supports virtual-hosted style addressing if server is started with configuration like `MINIO_DOMAIN=example.com`, it returns 400 to requests from existing test without enabling path style. I will look into the cause and file another issue later.

## Linked Issue(s)

Closes #2426 

## Checklist

- [n/a] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [n/a] added/updated relevant documentation?
- [] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)