### PR TITLE
feat(Callbacks): adds list of callback addresses in CN and TP

### DIFF
--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -94,6 +94,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
                 .protocol(contractOffer.getProtocol())
                 .counterPartyId(contractOffer.getConnectorId())
                 .counterPartyAddress(contractOffer.getConnectorAddress())
+                .callbackAddresses(contractOffer.getCallbackAddress())
                 .traceContext(telemetry.getCurrentTraceContext())
                 .type(CONSUMER)
                 .build();

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -40,6 +40,7 @@ import org.eclipse.edc.spi.monitor.ConsoleMonitor;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,6 +51,7 @@ import java.net.URI;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -141,6 +143,9 @@ class ContractNegotiationIntegrationTest {
                 .connectorId("connectorId")
                 .connectorAddress("connectorAddress")
                 .contractOffer(offer)
+                .callbackAddresses(List.of(CallbackAddress.Builder.newInstance()
+                        .uri("local://test")
+                        .build()))
                 .protocol("ids-multipart")
                 .build();
 
@@ -154,6 +159,10 @@ class ContractNegotiationIntegrationTest {
                     var providerNegotiation = providerStore.findForCorrelationId(consumerNegotiationId);
                     assertThat(consumerNegotiation).isNotNull();
                     assertThat(providerNegotiation).isNotNull();
+
+                    // Assert that the consumer has the callbacks
+                    assertThat(consumerNegotiation.getCallbackAddresses()).hasSize(1);
+                    assertThat(providerNegotiation.getCallbackAddresses()).hasSize(0);
 
                     // Assert that provider and consumer have the same offers and agreement stored
                     assertThat(consumerNegotiation.getContractOffers()).hasSize(1);
@@ -187,6 +196,9 @@ class ContractNegotiationIntegrationTest {
                 .connectorAddress("connectorAddress")
                 .contractOffer(offer)
                 .protocol("ids-multipart")
+                .callbackAddresses(List.of(CallbackAddress.Builder.newInstance()
+                        .uri("local://test")
+                        .build()))
                 .build();
         consumerManager.initiate(request);
 
@@ -217,6 +229,9 @@ class ContractNegotiationIntegrationTest {
                 .connectorAddress("connectorAddress")
                 .contractOffer(offer)
                 .protocol("ids-multipart")
+                .callbackAddresses(List.of(CallbackAddress.Builder.newInstance()
+                        .uri("local://test")
+                        .build()))
                 .build();
         consumerManager.initiate(request);
 
@@ -228,6 +243,10 @@ class ContractNegotiationIntegrationTest {
                     var providerNegotiation = providerStore.findForCorrelationId(consumerNegotiationId);
                     assertThat(consumerNegotiation).isNotNull();
                     assertThat(providerNegotiation).isNotNull();
+
+                    // Assert that the consumer has the callbacks
+                    assertThat(consumerNegotiation.getCallbackAddresses()).hasSize(1);
+                    assertThat(providerNegotiation.getCallbackAddresses()).hasSize(0);
 
                     // Assert that provider and consumer have the same offers stored
                     assertThat(consumerNegotiation.getContractOffers()).hasSize(1);

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
@@ -277,6 +277,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
                 .type(type)
                 .clock(clock)
                 .properties(dataRequest.getProperties())
+                .callbackAddresses(transferRequest.getCallbackAddresses())
                 .traceContext(telemetry.getCurrentTraceContext())
                 .build();
 

--- a/extensions/common/api/api-core/src/main/java/org/eclipse/edc/api/ApiCoreExtension.java
+++ b/extensions/common/api/api-core/src/main/java/org/eclipse/edc/api/ApiCoreExtension.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.api;
 
+import org.eclipse.edc.api.transformer.CallbackAddressDtoToCallbackAddressTransformer;
 import org.eclipse.edc.api.transformer.CriterionDtoToCriterionTransformer;
 import org.eclipse.edc.api.transformer.CriterionToCriterionDtoTransformer;
 import org.eclipse.edc.api.transformer.DtoTransformerRegistry;
@@ -39,6 +40,7 @@ public class ApiCoreExtension implements ServiceExtension {
         transformerRegistry.register(new QuerySpecDtoToQuerySpecTransformer());
         transformerRegistry.register(new CriterionToCriterionDtoTransformer());
         transformerRegistry.register(new CriterionDtoToCriterionTransformer());
+        transformerRegistry.register(new CallbackAddressDtoToCallbackAddressTransformer());
         return transformerRegistry;
     }
 }

--- a/extensions/common/api/api-core/src/main/java/org/eclipse/edc/api/model/CallbackAddressDto.java
+++ b/extensions/common/api/api-core/src/main/java/org/eclipse/edc/api/model/CallbackAddressDto.java
@@ -1,0 +1,93 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.api.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * DTO for {@link CallbackAddress}
+ */
+@JsonDeserialize(builder = CallbackAddressDto.Builder.class)
+public class CallbackAddressDto {
+
+    @NotBlank(message = "uri is mandatory")
+    private String uri;
+
+    @NotNull(message = "events cannot be null")
+    private Set<String> events = new HashSet<>();
+
+    private boolean transactional;
+
+    private CallbackAddressDto() {
+
+    }
+    
+    public boolean isTransactional() {
+        return transactional;
+    }
+
+    public Set<String> getEvents() {
+        return events;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static final class Builder {
+        private final CallbackAddressDto dto;
+
+        private Builder() {
+            this.dto = new CallbackAddressDto();
+        }
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+
+        public Builder uri(String url) {
+            dto.uri = url;
+            return this;
+        }
+
+        public Builder events(Set<String> events) {
+            dto.events = events;
+            return this;
+        }
+
+        public Builder transactional(boolean transactional) {
+            dto.transactional = transactional;
+            return this;
+        }
+
+
+        public CallbackAddressDto build() {
+            return dto;
+        }
+
+    }
+}

--- a/extensions/common/api/api-core/src/main/java/org/eclipse/edc/api/transformer/CallbackAddressDtoToCallbackAddressTransformer.java
+++ b/extensions/common/api/api-core/src/main/java/org/eclipse/edc/api/transformer/CallbackAddressDtoToCallbackAddressTransformer.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
+ *
+ */
+
+package org.eclipse.edc.api.transformer;
+
+import org.eclipse.edc.api.model.CallbackAddressDto;
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class CallbackAddressDtoToCallbackAddressTransformer implements DtoTransformer<CallbackAddressDto, CallbackAddress> {
+
+    @Override
+    public Class<CallbackAddressDto> getInputType() {
+        return CallbackAddressDto.class;
+    }
+
+    @Override
+    public Class<CallbackAddress> getOutputType() {
+        return CallbackAddress.class;
+    }
+
+    @Override
+    public @Nullable CallbackAddress transform(@NotNull CallbackAddressDto object, @NotNull TransformerContext context) {
+        return CallbackAddress.Builder.newInstance()
+                .uri(object.getUri())
+                .events(object.getEvents())
+                .transactional(object.isTransactional())
+                .build();
+    }
+}

--- a/extensions/common/api/api-core/src/test/java/org/eclipse/edc/api/model/CallbackAddressDtoTest.java
+++ b/extensions/common/api/api-core/src/test/java/org/eclipse/edc/api/model/CallbackAddressDtoTest.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.api.model;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CallbackAddressDtoTest {
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    void verifySerialization() throws JsonProcessingException {
+        var dto = CallbackAddressDto.Builder.newInstance().uri("http://test").events(Set.of("event")).transactional(true).build();
+
+        var str = objectMapper.writeValueAsString(dto);
+
+        assertThat(str).isNotNull();
+
+        var deserialized = objectMapper.readValue(str, CallbackAddressDto.class);
+        assertThat(deserialized).usingRecursiveComparison().isEqualTo(dto);
+    }
+}

--- a/extensions/common/api/api-core/src/test/java/org/eclipse/edc/api/model/CallbackAddressDtoValidationTest.java
+++ b/extensions/common/api/api-core/src/test/java/org/eclipse/edc/api/model/CallbackAddressDtoValidationTest.java
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.api.model;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CallbackAddressDtoValidationTest {
+    private Validator validator;
+
+
+    @BeforeEach
+    void setUp() {
+        try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+            validator = factory.getValidator();
+        }
+    }
+
+    @Test
+    void validate_validDto() {
+
+        var dto = CallbackAddressDto.Builder.newInstance()
+                .uri("test")
+                .build();
+
+
+        assertThat(validator.validate(dto)).isEmpty();
+    }
+
+    @Test
+    void validate_invalidDto() {
+
+        var dto = CallbackAddressDto.Builder.newInstance()
+                .events(null)
+                .build();
+
+
+        assertThat(validator.validate(dto)).hasSize(2);
+    }
+
+
+}

--- a/extensions/common/api/api-core/src/test/java/org/eclipse/edc/api/transformer/CallbackAddressDtoToCallbackAddressTransformerTest.java
+++ b/extensions/common/api/api-core/src/test/java/org/eclipse/edc/api/transformer/CallbackAddressDtoToCallbackAddressTransformerTest.java
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
+ *
+ */
+
+package org.eclipse.edc.api.transformer;
+
+import org.eclipse.edc.api.model.CallbackAddressDto;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class CallbackAddressDtoToCallbackAddressTransformerTest {
+
+    private final CallbackAddressDtoToCallbackAddressTransformer transformer = new CallbackAddressDtoToCallbackAddressTransformer();
+
+    @Test
+    void inputOutputType() {
+        assertThat(transformer.getInputType()).isNotNull();
+        assertThat(transformer.getOutputType()).isNotNull();
+    }
+
+    @Test
+    void transform() {
+        var context = mock(TransformerContext.class);
+        var dto = CallbackAddressDto.Builder.newInstance()
+                .uri("http://test")
+                .events(Set.of("event"))
+                .transactional(true)
+                .build();
+
+        var callback = transformer.transform(dto, context);
+
+        assertThat(callback).usingRecursiveComparison().isEqualTo(dto);
+    }
+
+}

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/model/ContractNegotiationDto.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/model/ContractNegotiationDto.java
@@ -19,6 +19,10 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.eclipse.edc.api.model.MutableDto;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation.Type;
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @JsonDeserialize(builder = ContractNegotiationDto.Builder.class)
 public class ContractNegotiationDto extends MutableDto {
@@ -29,6 +33,9 @@ public class ContractNegotiationDto extends MutableDto {
     private String protocol = "ids-multipart";
     private String state;
     private Type type = Type.CONSUMER;
+
+    private List<CallbackAddress> callbackAddresses = new ArrayList<>();
+
 
     private ContractNegotiationDto() {
     }
@@ -59,6 +66,10 @@ public class ContractNegotiationDto extends MutableDto {
 
     public String getContractAgreementId() {
         return contractAgreementId;
+    }
+
+    public List<CallbackAddress> getCallbackAddresses() {
+        return callbackAddresses;
     }
 
     @JsonPOJOBuilder(withPrefix = "")
@@ -102,6 +113,12 @@ public class ContractNegotiationDto extends MutableDto {
             dto.contractAgreementId = contractAgreementId;
             return this;
         }
+
+        public Builder callbackAddresses(List<CallbackAddress> callbackAddresses) {
+            dto.callbackAddresses = callbackAddresses;
+            return this;
+        }
+
 
         public Builder type(Type type) {
             dto.type = type;

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/model/NegotiationInitiateRequestDto.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/model/NegotiationInitiateRequestDto.java
@@ -16,6 +16,10 @@ package org.eclipse.edc.connector.api.management.contractnegotiation.model;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import org.eclipse.edc.api.model.CallbackAddressDto;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class NegotiationInitiateRequestDto {
     @NotBlank(message = "connectorAddress is mandatory")
@@ -28,6 +32,8 @@ public class NegotiationInitiateRequestDto {
     private ContractOfferDescription offer;
     private String providerId;
     private String consumerId;
+
+    private List<CallbackAddressDto> callbackAddresses = new ArrayList<>();
 
     private NegotiationInitiateRequestDto() {
 
@@ -49,12 +55,17 @@ public class NegotiationInitiateRequestDto {
         return offer;
     }
 
+
     public String getConsumerId() {
         return consumerId;
     }
 
     public String getProviderId() {
         return providerId;
+    }
+
+    public List<CallbackAddressDto> getCallbackAddresses() {
+        return callbackAddresses;
     }
 
     public static final class Builder {
@@ -95,6 +106,11 @@ public class NegotiationInitiateRequestDto {
 
         public Builder providerId(String providerId) {
             dto.providerId = providerId;
+            return this;
+        }
+
+        public Builder callbackAddresses(List<CallbackAddressDto> callbackAddresses) {
+            dto.callbackAddresses = callbackAddresses;
             return this;
         }
 

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/ContractNegotiationToContractNegotiationDtoTransformer.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/ContractNegotiationToContractNegotiationDtoTransformer.java
@@ -46,6 +46,7 @@ public class ContractNegotiationToContractNegotiationDtoTransformer implements D
                 .protocol(object.getProtocol())
                 .counterPartyAddress(object.getCounterPartyAddress())
                 .errorDetail(object.getErrorDetail())
+                .callbackAddresses(object.getCallbackAddresses())
                 .createdAt(object.getCreatedAt())
                 .updatedAt(object.getUpdatedAt())
                 .build();

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/NegotiationInitiateRequestDtoToDataRequestTransformer.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/NegotiationInitiateRequestDtoToDataRequestTransformer.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.connector.api.management.contractnegotiation.model.Negoti
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferRequest;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -26,6 +27,7 @@ import org.jetbrains.annotations.Nullable;
 import java.net.URI;
 import java.time.Clock;
 import java.time.ZonedDateTime;
+import java.util.stream.Collectors;
 
 public class NegotiationInitiateRequestDtoToDataRequestTransformer implements DtoTransformer<NegotiationInitiateRequestDto, ContractOfferRequest> {
 
@@ -69,11 +71,15 @@ public class NegotiationInitiateRequestDtoToDataRequestTransformer implements Dt
                 .contractStart(now)
                 .contractEnd(now.plusSeconds(object.getOffer().getValidity()))
                 .build();
+
+        var callbacks = object.getCallbackAddresses().stream().map(c -> context.transform(c, CallbackAddress.class)).collect(Collectors.toList());
+
         return ContractOfferRequest.Builder.newInstance()
                 .connectorId(object.getConnectorId())
                 .connectorAddress(object.getConnectorAddress())
                 .protocol(object.getProtocol())
                 .contractOffer(contractOffer)
+                .callbackAddresses(callbacks)
                 .type(ContractOfferRequest.Type.INITIAL)
                 .build();
     }

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerIntegrationTest.java
@@ -29,6 +29,7 @@ import org.eclipse.edc.spi.entity.StatefulEntity;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcher;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.query.SortOrder;
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -310,6 +311,9 @@ class ContractNegotiationApiControllerIntegrationTest {
                 .id(negotiationId)
                 .counterPartyId(UUID.randomUUID().toString())
                 .counterPartyAddress("address")
+                .callbackAddresses(List.of(CallbackAddress.Builder.newInstance()
+                        .uri("local://test")
+                        .build()))
                 .protocol(protocol);
     }
 

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerTest.java
@@ -16,6 +16,7 @@
 
 package org.eclipse.edc.connector.api.management.contractnegotiation;
 
+import org.eclipse.edc.api.model.CallbackAddressDto;
 import org.eclipse.edc.api.model.IdResponseDto;
 import org.eclipse.edc.api.query.QuerySpecDto;
 import org.eclipse.edc.api.transformer.DtoTransformerRegistry;
@@ -33,6 +34,7 @@ import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 import org.eclipse.edc.web.spi.exception.InvalidRequestException;
 import org.eclipse.edc.web.spi.exception.ObjectConflictException;
 import org.eclipse.edc.web.spi.exception.ObjectNotFoundException;
@@ -45,6 +47,7 @@ import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -188,6 +191,9 @@ class ContractNegotiationApiControllerTest {
                 .connectorAddress("connectorAddress")
                 .protocol("protocol")
                 .offer(TestFunctions.createOffer("offerId"))
+                .callbackAddresses(List.of(CallbackAddressDto.Builder.newInstance()
+                        .uri("local://test")
+                        .build()))
                 .build();
 
         var negotiationId = controller.initiateContractNegotiation(request);
@@ -302,6 +308,9 @@ class ContractNegotiationApiControllerTest {
                         .contractStart(ZonedDateTime.now())
                         .contractEnd(ZonedDateTime.now().plusMonths(1))
                         .build())
+                .callbackAddresses(List.of(CallbackAddress.Builder.newInstance()
+                        .uri("local://test")
+                        .build()))
                 .build();
     }
 

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/ContractNegotiationToContractNegotiationDtoTransformerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/ContractNegotiationToContractNegotiationDtoTransformerTest.java
@@ -18,9 +18,11 @@ import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates;
 import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -40,6 +42,9 @@ class ContractNegotiationToContractNegotiationDtoTransformerTest {
     @Test
     void transform() {
         var context = mock(TransformerContext.class);
+        var callback = CallbackAddress.Builder.newInstance()
+                .uri("local://test")
+                .build();
         var contractNegotiation = ContractNegotiation.Builder.newInstance()
                 .id("negotiationId")
                 .type(PROVIDER)
@@ -50,6 +55,7 @@ class ContractNegotiationToContractNegotiationDtoTransformerTest {
                 .contractAgreement(createContractAgreement("agreementId"))
                 .errorDetail("errorDetail")
                 .correlationId("correlationId")
+                .callbackAddresses(List.of(callback))
                 .build();
 
         var dto = transformer.transform(contractNegotiation, context);
@@ -63,6 +69,7 @@ class ContractNegotiationToContractNegotiationDtoTransformerTest {
         assertThat(dto.getErrorDetail()).isEqualTo("errorDetail");
         assertThat(dto.getUpdatedAt()).isEqualTo(contractNegotiation.getUpdatedAt());
         assertThat(dto.getCreatedAt()).isEqualTo(contractNegotiation.getCreatedAt());
+        assertThat(dto.getCallbackAddresses()).usingRecursiveFieldByFieldElementComparator().contains(callback);
     }
 
     private ContractAgreement createContractAgreement(String id) {

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/NegotiationInitiateRequestDtoToDataRequestTransformerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/NegotiationInitiateRequestDtoToDataRequestTransformerTest.java
@@ -14,12 +14,14 @@
 
 package org.eclipse.edc.connector.api.management.contractnegotiation.transform;
 
+import org.eclipse.edc.api.model.CallbackAddressDto;
 import org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.junit.jupiter.api.Test;
 
 import java.time.Clock;
 import java.time.Instant;
+import java.util.List;
 
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,7 +34,9 @@ class NegotiationInitiateRequestDtoToDataRequestTransformerTest {
     private static final String DEFAULT_CONSUMER_ID = "urn:connector:test-consumer";
     private final Instant now = Instant.now();
     private final Clock clock = Clock.fixed(now, UTC);
+
     private final NegotiationInitiateRequestDtoToDataRequestTransformer transformer = new NegotiationInitiateRequestDtoToDataRequestTransformer(clock, DEFAULT_CONSUMER_ID);
+
     private final TransformerContext context = mock(TransformerContext.class);
 
     @Test
@@ -43,6 +47,9 @@ class NegotiationInitiateRequestDtoToDataRequestTransformerTest {
 
     @Test
     void verify_transform() {
+        var callback = CallbackAddressDto.Builder.newInstance()
+                .uri("local://test")
+                .build();
         var dto = NegotiationInitiateRequestDto.Builder.newInstance()
                 .connectorId("connectorId")
                 .connectorAddress("address")
@@ -50,6 +57,7 @@ class NegotiationInitiateRequestDtoToDataRequestTransformerTest {
                 .consumerId("test-consumer")
                 .providerId("test-provider")
                 .offer(createOffer("offerId", "assetId"))
+                .callbackAddresses(List.of(callback))
                 .build();
 
         var request = transformer.transform(dto, context);
@@ -63,6 +71,7 @@ class NegotiationInitiateRequestDtoToDataRequestTransformerTest {
         assertThat(request.getContractOffer().getContractStart().toInstant()).isEqualTo(clock.instant());
         assertThat(request.getContractOffer().getContractEnd().toInstant()).isEqualTo(clock.instant().plusSeconds(dto.getOffer().getValidity()));
         assertThat(request.getContractOffer().getPolicy()).isNotNull();
+        assertThat(request.getCallbackAddress()).hasSize(1);
     }
 
     @Test

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/model/TransferProcessDto.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/model/TransferProcessDto.java
@@ -18,8 +18,11 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.eclipse.edc.api.model.MutableDto;
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @JsonDeserialize(builder = TransferProcessDto.Builder.class)
@@ -33,6 +36,7 @@ public class TransferProcessDto extends MutableDto {
     private DataAddressInformationDto dataDestination;
 
     private Map<String, String> properties = new HashMap<>();
+    private List<CallbackAddress> callbackAddresses = new ArrayList<>();
 
     private TransferProcessDto() {
     }
@@ -59,6 +63,10 @@ public class TransferProcessDto extends MutableDto {
 
     public DataRequestDto getDataRequest() {
         return dataRequest;
+    }
+
+    public List<CallbackAddress> getCallbackAddresses() {
+        return callbackAddresses;
     }
 
     public DataAddressInformationDto getDataDestination() {
@@ -114,6 +122,11 @@ public class TransferProcessDto extends MutableDto {
 
         public Builder properties(Map<String, String> properties) {
             dto.properties = properties;
+            return this;
+        }
+
+        public Builder callbackAddresses(List<CallbackAddress> callbackAddresses) {
+            dto.callbackAddresses = callbackAddresses;
             return this;
         }
 

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/model/TransferRequestDto.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/model/TransferRequestDto.java
@@ -18,10 +18,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import jakarta.validation.constraints.NotNull;
+import org.eclipse.edc.api.model.CallbackAddressDto;
 import org.eclipse.edc.connector.transfer.spi.types.TransferType;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @JsonDeserialize(builder = TransferRequestDto.Builder.class)
@@ -44,6 +47,9 @@ public class TransferRequestDto {
     private String connectorId;
     @NotNull(message = "assetId cannot be null")
     private String assetId;
+
+    private List<CallbackAddressDto> callbackAddresses = new ArrayList<>();
+
 
     public String getConnectorAddress() {
         return connectorAddress;
@@ -83,6 +89,10 @@ public class TransferRequestDto {
 
     public String getAssetId() {
         return assetId;
+    }
+
+    public List<CallbackAddressDto> getCallbackAddresses() {
+        return callbackAddresses;
     }
 
     @JsonPOJOBuilder(withPrefix = "")
@@ -145,6 +155,11 @@ public class TransferRequestDto {
 
         public Builder assetId(String assetId) {
             request.assetId = assetId;
+            return this;
+        }
+
+        public Builder callbackAddresses(List<CallbackAddressDto> callbackAddresses) {
+            request.callbackAddresses = callbackAddresses;
             return this;
         }
 

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/transform/TransferProcessToTransferProcessDtoTransformer.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/transform/TransferProcessToTransferProcessDtoTransformer.java
@@ -48,6 +48,7 @@ public class TransferProcessToTransferProcessDtoTransformer implements DtoTransf
                 .updatedAt(object.getUpdatedAt())
                 .dataRequest(context.transform(object.getDataRequest(), DataRequestDto.class))
                 .properties(object.getProperties())
+                .callbackAddresses(object.getCallbackAddresses())
                 .dataDestination(
                         DataAddressInformationDto.Builder.newInstance()
                                 .properties(object.getDataRequest().getDataDestination().getProperties())

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/transform/TransferRequestDtoToTransferRequestTransformer.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/transform/TransferRequestDtoToTransferRequestTransformer.java
@@ -18,12 +18,14 @@ import org.eclipse.edc.api.transformer.DtoTransformer;
 import org.eclipse.edc.connector.api.management.transferprocess.model.TransferRequestDto;
 import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
 import org.eclipse.edc.connector.transfer.spi.types.TransferRequest;
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 public class TransferRequestDtoToTransferRequestTransformer implements DtoTransformer<TransferRequestDto, TransferRequest> {
 
@@ -57,8 +59,11 @@ public class TransferRequestDtoToTransferRequestTransformer implements DtoTransf
                 .dataDestination(object.getDataDestination())
                 .build();
 
+        var callbacks = object.getCallbackAddresses().stream().map(c -> context.transform(c, CallbackAddress.class)).collect(Collectors.toList());
+
         return TransferRequest.Builder.newInstance()
                 .dataRequest(dataRequest)
+                .callbackAddresses(callbacks)
                 .build();
     }
 }

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/api/management/transferprocess/transform/TransferProcessToTransferProcessDtoTransformerTest.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/api/management/transferprocess/transform/TransferProcessToTransferProcessDtoTransformerTest.java
@@ -24,6 +24,7 @@ import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -95,6 +96,7 @@ class TransferProcessToTransferProcessDtoTransformerTest {
                 .state(INITIAL.code())
                 .stateTimestamp(data.stateTimestamp)
                 .createdAt(data.createdTimestamp)
+                .callbackAddresses(List.of(data.callbackAddress))
                 .dataRequest(data.dataRequest);
         data.dto
                 .dataDestination(

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/api/management/transferprocess/transform/TransferProcessTransformerTestData.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/api/management/transferprocess/transform/TransferProcessTransformerTestData.java
@@ -21,21 +21,23 @@ import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
 import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.connector.transfer.spi.types.TransferProcessStates;
 import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
 public class TransferProcessTransformerTestData {
 
+    public CallbackAddress callbackAddress = CallbackAddress.Builder.newInstance().uri("local://test").build();
     String id = UUID.randomUUID().toString();
     TransferProcess.Type type = TransferProcess.Type.CONSUMER;
     TransferProcessStates state = TransferProcessStates.values()[ThreadLocalRandom.current().nextInt(TransferProcessStates.values().length)];
     long stateTimestamp = System.currentTimeMillis();
     long createdTimestamp = ThreadLocalRandom.current().nextLong();
     String errorDetail = "test error detail";
-
     Map<String, String> dataDestinationProperties = Map.of("key1", "value1");
     String dataDestinationType = "test-destination-type";
     DataAddress.Builder dataDestination = DataAddress.Builder.newInstance().type(dataDestinationType).properties(dataDestinationProperties);
@@ -49,7 +51,8 @@ public class TransferProcessTransformerTestData {
             .stateTimestamp(stateTimestamp)
             .createdAt(createdTimestamp)
             .errorDetail(errorDetail)
-            .dataRequest(dataRequest);
+            .dataRequest(dataRequest)
+            .callbackAddresses(List.of(callbackAddress));
     DataRequestDto dataRequestDto = DataRequestDto.Builder.newInstance().build();
     TransferProcessDto.Builder dto = TransferProcessDto.Builder.newInstance()
             .id(id)
@@ -60,6 +63,7 @@ public class TransferProcessTransformerTestData {
             .dataRequest(dataRequestDto)
             .createdAt(createdTimestamp)
             .updatedAt(createdTimestamp)
+            .callbackAddresses(List.of(callbackAddress))
             .dataDestination(
                     DataAddressInformationDto.Builder.newInstance()
                             .properties(mapWith(dataDestinationProperties, "type", dataDestinationType))

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/api/management/transferprocess/transform/TransferRequestDtoToTransferRequestTransformerTest.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/api/management/transferprocess/transform/TransferRequestDtoToTransferRequestTransformerTest.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.edc.connector.api.management.transferprocess.transform;
 
+import org.eclipse.edc.api.model.CallbackAddressDto;
 import org.eclipse.edc.api.transformer.DtoTransformer;
 import org.eclipse.edc.connector.api.management.transferprocess.model.TransferRequestDto;
 import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
@@ -24,6 +25,7 @@ import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -71,6 +73,8 @@ class TransferRequestDtoToTransferRequestTransformerTest {
         assertThat(dataRequest.getProperties()).isEqualTo(transferReq.getProperties());
         assertThat(dataRequest.getTransferType()).isEqualTo(transferReq.getTransferType());
         assertThat(dataRequest.isManagedResources()).isEqualTo(transferReq.isManagedResources());
+
+        assertThat(transferRequest.getCallbackAddresses()).hasSize(transferReq.getCallbackAddresses().size());
     }
 
 
@@ -83,6 +87,7 @@ class TransferRequestDtoToTransferRequestTransformerTest {
                 .protocol("test-protocol")
                 .dataDestination(DataAddress.Builder.newInstance().type("test-type").build())
                 .connectorId(UUID.randomUUID().toString())
+                .callbackAddresses(List.of(CallbackAddressDto.Builder.newInstance().uri("local://test").build()))
                 .properties(Map.of("key1", "value1"));
     }
 

--- a/extensions/control-plane/store/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/contractnegotiation/TestFunctions.java
+++ b/extensions/control-plane/store/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/contractnegotiation/TestFunctions.java
@@ -21,9 +21,11 @@ import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiat
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates;
 import org.eclipse.edc.connector.store.azure.cosmos.contractnegotiation.model.ContractNegotiationDocument;
 import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.UUID;
 
 public class TestFunctions {
@@ -40,6 +42,9 @@ public class TestFunctions {
         return createNegotiationBuilder(id)
                 .state(state.code())
                 .contractAgreement(createContractBuilder().build())
+                .callbackAddresses(List.of(CallbackAddress.Builder.newInstance()
+                        .uri("local://test")
+                        .build()))
                 .build();
     }
 

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/docs/schema.sql
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/docs/schema.sql
@@ -55,6 +55,7 @@ CREATE TABLE IF NOT EXISTS edc_contract_negotiation
         CONSTRAINT contract_negotiation_contract_agreement_id_fk
             REFERENCES edc_contract_agreement,
     contract_offers      JSON,
+    callback_addresses   JSON,
     trace_context        JSON,
     lease_id             VARCHAR
         CONSTRAINT contract_negotiation_lease_lease_id_fk

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/SqlContractNegotiationStore.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/SqlContractNegotiationStore.java
@@ -202,6 +202,7 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
                 updatedValues.getStateTimestamp(),
                 updatedValues.getErrorDetail(),
                 toJson(updatedValues.getContractOffers()),
+                toJson(updatedValues.getCallbackAddresses()),
                 toJson(updatedValues.getTraceContext()),
                 ofNullable(updatedValues.getContractAgreement()).map(ContractAgreement::getId).orElse(null),
                 updatedValues.getUpdatedAt(),
@@ -230,6 +231,7 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
                 negotiation.getErrorDetail(),
                 agrId,
                 toJson(negotiation.getContractOffers()),
+                toJson(negotiation.getCallbackAddresses()),
                 toJson(negotiation.getTraceContext()),
                 negotiation.getCreatedAt(),
                 negotiation.getUpdatedAt());
@@ -314,6 +316,8 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
                 .stateCount(resultSet.getInt(statements.getStateCountColumn()))
                 .stateTimestamp(resultSet.getLong(statements.getStateTimestampColumn()))
                 .contractOffers(fromJson(resultSet.getString(statements.getContractOffersColumn()), new TypeReference<>() {
+                }))
+                .callbackAddresses(fromJson(resultSet.getString(statements.getCallbackAddressesColumn()), new TypeReference<>() {
                 }))
                 .errorDetail(resultSet.getString(statements.getErrorDetailColumn()))
                 .traceContext(fromJson(resultSet.getString(statements.getTraceContextColumn()), new TypeReference<>() {

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/schema/BaseSqlDialectStatements.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/schema/BaseSqlDialectStatements.java
@@ -38,17 +38,19 @@ public class BaseSqlDialectStatements implements ContractNegotiationStatements {
 
     @Override
     public String getUpdateNegotiationTemplate() {
-        return format("UPDATE %s SET %s=?, %s=?, %s=?, %s=?, %s=?%s, %s=?%s, %s=?, %s=? WHERE id = ?;",
+        return format("UPDATE %s SET %s=?, %s=?, %s=?, %s=?, %s=?%s, %s=?%s, %s=?%s, %s=?, %s=? WHERE id = ?;",
                 getContractNegotiationTable(), getStateColumn(), getStateCountColumn(), getStateTimestampColumn(),
-                getErrorDetailColumn(), getContractOffersColumn(), getFormatJsonOperator(), getTraceContextColumn(), getFormatJsonOperator(), getContractAgreementIdFkColumn(), getUpdatedAtColumn());
+                getErrorDetailColumn(), getContractOffersColumn(), getFormatJsonOperator(), getCallbackAddressesColumn(), getFormatJsonOperator(), getTraceContextColumn(),
+                getFormatJsonOperator(), getContractAgreementIdFkColumn(), getUpdatedAtColumn());
     }
 
     @Override
     public String getInsertNegotiationTemplate() {
-        return format("INSERT INTO %s (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)\n" +
-                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?%s, ?%s, ?, ?); ",
+        return format("INSERT INTO %s (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)\n" +
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?%s, ?%s, ?%s, ?, ?); ",
                 getContractNegotiationTable(), getIdColumn(), getCorrelationIdColumn(), getCounterPartyIdColumn(), getCounterPartyAddressColumn(), getTypeColumn(), getProtocolColumn(), getStateColumn(), getStateCountColumn(),
-                getStateTimestampColumn(), getErrorDetailColumn(), getContractAgreementIdFkColumn(), getContractOffersColumn(), getTraceContextColumn(), getCreatedAtColumn(), getUpdatedAtColumn(), getFormatJsonOperator(), getFormatJsonOperator()
+                getStateTimestampColumn(), getErrorDetailColumn(), getContractAgreementIdFkColumn(), getContractOffersColumn(), getCallbackAddressesColumn(), getTraceContextColumn(), getCreatedAtColumn(), getUpdatedAtColumn(),
+                getFormatJsonOperator(), getFormatJsonOperator(), getFormatJsonOperator()
         );
     }
 

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/schema/ContractNegotiationStatements.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/schema/ContractNegotiationStatements.java
@@ -144,6 +144,10 @@ public interface ContractNegotiationStatements extends LeaseStatements {
         return "contract_offers";
     }
 
+    default String getCallbackAddressesColumn() {
+        return "callback_addresses";
+    }
+
     default String getErrorDetailColumn() {
         return "error_detail";
     }

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/docs/schema.sql
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/docs/schema.sql
@@ -32,6 +32,7 @@ CREATE TABLE IF NOT EXISTS edc_transfer_process
     content_data_address       JSON,
     deprovisioned_resources    JSON,
     transferprocess_properties JSON,
+    callback_addresses         JSON,
     lease_id                   VARCHAR
         CONSTRAINT transfer_process_lease_lease_id_fk
             REFERENCES edc_lease

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/SqlTransferProcessStore.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/SqlTransferProcessStore.java
@@ -197,6 +197,7 @@ public class SqlTransferProcessStore extends AbstractSqlStore implements Transfe
                 toJson(process.getProvisionedResourceSet()),
                 toJson(process.getContentDataAddress()),
                 toJson(process.getDeprovisionedResources()),
+                toJson(process.getCallbackAddresses()),
                 process.getUpdatedAt(),
                 process.getId());
 
@@ -254,7 +255,8 @@ public class SqlTransferProcessStore extends AbstractSqlStore implements Transfe
                 toJson(process.getContentDataAddress()),
                 process.getType().toString(),
                 toJson(process.getDeprovisionedResources()),
-                toJson(process.getProperties()));
+                toJson(process.getProperties()),
+                toJson(process.getCallbackAddresses()));
 
         //insert DataRequest
         var dr = process.getDataRequest();
@@ -296,6 +298,8 @@ public class SqlTransferProcessStore extends AbstractSqlStore implements Transfe
                 .dataRequest(mapDataRequest(resultSet))
                 .contentDataAddress(fromJson(resultSet.getString(statements.getContentDataAddressColumn()), DataAddress.class))
                 .deprovisionedResources(fromJson(resultSet.getString(statements.getDeprovisionedResourcesColumn()), new TypeReference<>() {
+                }))
+                .callbackAddresses(fromJson(resultSet.getString(statements.getCallbackAddressesColumn()), new TypeReference<>() {
                 }))
                 .properties(fromJson(resultSet.getString(statements.getPropertiesColumn()), getTypeRef()))
                 .build();

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/BaseSqlDialectStatements.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/BaseSqlDialectStatements.java
@@ -51,14 +51,16 @@ public abstract class BaseSqlDialectStatements implements TransferProcessStoreSt
 
     @Override
     public String getInsertStatement() {
-        return format("INSERT INTO %s (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) VALUES (?, ?, ?, ?, ?, ?, ?%s, ?, ?%s, ?%s, ?%s, ?, ?%s, ?%s);",
+        return format("INSERT INTO %s (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) VALUES (?, ?, ?, ?, ?, ?, ?%s, ?, ?%s, ?%s, ?%s, ?, ?%s, ?%s, ?%s);",
                 // keys
                 getTransferProcessTableName(), getIdColumn(), getStateColumn(), getStateCountColumn(), getStateTimestampColumn(),
                 getCreatedAtColumn(), getUpdatedAtColumn(),
                 getTraceContextColumn(), getErrorDetailColumn(), getResourceManifestColumn(),
-                getProvisionedResourcesetColumn(), getContentDataAddressColumn(), getTypeColumn(), getDeprovisionedResourcesColumn(), getPropertiesColumn(),
+                getProvisionedResourcesetColumn(), getContentDataAddressColumn(), getTypeColumn(), getDeprovisionedResourcesColumn(),
+                getPropertiesColumn(), getCallbackAddressesColumn(),
                 // values
-                getFormatAsJsonOperator(), getFormatAsJsonOperator(), getFormatAsJsonOperator(), getFormatAsJsonOperator(), getFormatAsJsonOperator(), getFormatAsJsonOperator());
+                getFormatAsJsonOperator(), getFormatAsJsonOperator(), getFormatAsJsonOperator(), getFormatAsJsonOperator(),
+                getFormatAsJsonOperator(), getFormatAsJsonOperator(), getFormatAsJsonOperator());
     }
 
     @Override
@@ -86,11 +88,12 @@ public abstract class BaseSqlDialectStatements implements TransferProcessStoreSt
 
     @Override
     public String getUpdateTransferProcessTemplate() {
-        return format("UPDATE %s SET %s=?, %s=?, %s=?, %s=?%s, %s=?, %s=?%s, %s=?%s, %s=?%s, %s=?%s, %s=? WHERE %s=?",
+        return format("UPDATE %s SET %s=?, %s=?, %s=?, %s=?%s, %s=?, %s=?%s, %s=?%s, %s=?%s, %s=?%s, %s=?%s, %s=? WHERE %s=?",
                 getTransferProcessTableName(), getStateColumn(), getStateCountColumn(), getStateTimestampColumn(),
                 getTraceContextColumn(), getFormatAsJsonOperator(), getErrorDetailColumn(),
                 getResourceManifestColumn(), getFormatAsJsonOperator(), getProvisionedResourcesetColumn(), getFormatAsJsonOperator(),
-                getContentDataAddressColumn(), getFormatAsJsonOperator(), getDeprovisionedResourcesColumn(), getFormatAsJsonOperator(), getUpdatedAtColumn(), getIdColumn());
+                getContentDataAddressColumn(), getFormatAsJsonOperator(), getDeprovisionedResourcesColumn(), getFormatAsJsonOperator(),
+                getCallbackAddressesColumn(), getFormatAsJsonOperator(), getUpdatedAtColumn(), getIdColumn());
     }
 
     @Override

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/TransferProcessStoreStatements.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/TransferProcessStoreStatements.java
@@ -154,6 +154,10 @@ public interface TransferProcessStoreStatements extends LeaseStatements {
         return "deprovisioned_resources";
     }
 
+    default String getCallbackAddressesColumn() {
+        return "callback_addresses";
+    }
+    
     default String getFormatAsJsonOperator() {
         return BaseSqlDialect.getJsonCastOperator();
     }

--- a/resources/openapi/yaml/management-api/contract-negotiation-api.yaml
+++ b/resources/openapi/yaml/management-api/contract-negotiation-api.yaml
@@ -348,6 +348,43 @@ components:
         type:
           type: string
           example: null
+    CallbackAddress:
+      type: object
+      example: null
+      properties:
+        events:
+          type: array
+          example: null
+          items:
+            type: string
+            example: null
+          uniqueItems: true
+        transactional:
+          type: boolean
+          example: null
+        uri:
+          type: string
+          example: null
+    CallbackAddressDto:
+      type: object
+      example: null
+      properties:
+        events:
+          type: array
+          example: null
+          items:
+            type: string
+            example: null
+          uniqueItems: true
+        transactional:
+          type: boolean
+          example: null
+        uri:
+          type: string
+          example: null
+      required:
+      - events
+      - uri
     Constraint:
       type: object
       discriminator:
@@ -399,6 +436,11 @@ components:
       type: object
       example: null
       properties:
+        callbackAddresses:
+          type: array
+          example: null
+          items:
+            $ref: '#/components/schemas/CallbackAddress'
         contractAgreementId:
           type: string
           example: null
@@ -509,6 +551,11 @@ components:
       type: object
       example: null
       properties:
+        callbackAddresses:
+          type: array
+          example: null
+          items:
+            $ref: '#/components/schemas/CallbackAddressDto'
         connectorAddress:
           type: string
           example: null

--- a/resources/openapi/yaml/management-api/transfer-process-api.yaml
+++ b/resources/openapi/yaml/management-api/transfer-process-api.yaml
@@ -351,6 +351,43 @@ components:
         type:
           type: string
           example: null
+    CallbackAddress:
+      type: object
+      example: null
+      properties:
+        events:
+          type: array
+          example: null
+          items:
+            type: string
+            example: null
+          uniqueItems: true
+        transactional:
+          type: boolean
+          example: null
+        uri:
+          type: string
+          example: null
+    CallbackAddressDto:
+      type: object
+      example: null
+      properties:
+        events:
+          type: array
+          example: null
+          items:
+            type: string
+            example: null
+          uniqueItems: true
+        transactional:
+          type: boolean
+          example: null
+        uri:
+          type: string
+          example: null
+      required:
+      - events
+      - uri
     CriterionDto:
       type: object
       example: null
@@ -456,6 +493,11 @@ components:
       type: object
       example: null
       properties:
+        callbackAddresses:
+          type: array
+          example: null
+          items:
+            $ref: '#/components/schemas/CallbackAddress'
         createdAt:
           type: integer
           format: int64
@@ -491,6 +533,11 @@ components:
         assetId:
           type: string
           example: null
+        callbackAddresses:
+          type: array
+          example: null
+          items:
+            $ref: '#/components/schemas/CallbackAddressDto'
         connectorAddress:
           type: string
           example: null

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/callback/CallbackAddress.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/callback/CallbackAddress.java
@@ -1,0 +1,90 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.spi.types.domain.callback;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * The {@link CallbackAddress} contains information about users configured callbacks
+ * that can be invoked in various state of the requests processing according to the filter provided
+ * in {@link CallbackAddress#events}
+ */
+@JsonDeserialize(builder = CallbackAddress.Builder.class)
+public class CallbackAddress {
+
+    private String uri;
+
+    private Set<String> events = new HashSet<>();
+
+    private boolean transactional;
+
+
+    public Set<String> getEvents() {
+        return events;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public boolean isTransactional() {
+        return transactional;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder {
+
+
+        private final CallbackAddress callbackAddress;
+
+        protected Builder() {
+            callbackAddress = new CallbackAddress();
+        }
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder uri(String url) {
+            callbackAddress.uri = url;
+            return this;
+        }
+
+        public Builder events(Set<String> events) {
+            callbackAddress.events = events;
+            return this;
+        }
+
+        public Builder transactional(boolean transactional) {
+            callbackAddress.transactional = transactional;
+            return this;
+        }
+
+
+        public CallbackAddress build() {
+            Objects.requireNonNull(callbackAddress.uri, "URI should not be null");
+            Objects.requireNonNull(callbackAddress.events, "Events should not be null");
+            return callbackAddress;
+        }
+    }
+
+}

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractNegotiation.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractNegotiation.java
@@ -23,11 +23,13 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.spi.entity.StatefulEntity;
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Predicate;
@@ -60,6 +62,7 @@ import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractN
 @JsonTypeName("dataspaceconnector:contractnegotiation")
 @JsonDeserialize(builder = ContractNegotiation.Builder.class)
 public class ContractNegotiation extends StatefulEntity<ContractNegotiation> {
+    private List<CallbackAddress> callbackAddresses = new ArrayList<>();
     private String correlationId;
     private String counterPartyId;
     private String counterPartyAddress;
@@ -104,6 +107,15 @@ public class ContractNegotiation extends StatefulEntity<ContractNegotiation> {
      */
     public List<ContractOffer> getContractOffers() {
         return contractOffers;
+    }
+
+    /**
+     * Returns all callback addresses configured for the negotiation process.
+     *
+     * @return The callback addresses.
+     */
+    public List<CallbackAddress> getCallbackAddresses() {
+        return Collections.unmodifiableList(callbackAddresses);
     }
 
     /**
@@ -322,7 +334,8 @@ public class ContractNegotiation extends StatefulEntity<ContractNegotiation> {
                 .protocol(protocol)
                 .type(type)
                 .contractAgreement(contractAgreement)
-                .contractOffers(contractOffers);
+                .contractOffers(contractOffers)
+                .callbackAddresses(callbackAddresses);
         return copy(builder);
     }
 
@@ -373,7 +386,7 @@ public class ContractNegotiation extends StatefulEntity<ContractNegotiation> {
     }
 
     public enum Type {
-        CONSUMER, PROVIDER;
+        CONSUMER, PROVIDER
     }
 
     /**
@@ -423,6 +436,11 @@ public class ContractNegotiation extends StatefulEntity<ContractNegotiation> {
             return this;
         }
 
+        public Builder callbackAddresses(List<CallbackAddress> callbackAddresses) {
+            entity.callbackAddresses = callbackAddresses;
+            return this;
+        }
+
         public Builder contractOffer(ContractOffer contractOffer) {
             entity.contractOffers.add(contractOffer);
             return this;
@@ -450,6 +468,9 @@ public class ContractNegotiation extends StatefulEntity<ContractNegotiation> {
             }
             if (entity.state == 0) {
                 entity.transitionTo(INITIAL.code());
+            }
+            if (entity.callbackAddresses == null) {
+                entity.callbackAddresses = new ArrayList<>();
             }
             return entity;
         }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractOfferRequest.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractOfferRequest.java
@@ -15,8 +15,11 @@
 package org.eclipse.edc.connector.contract.spi.types.negotiation;
 
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -31,6 +34,8 @@ public class ContractOfferRequest implements RemoteMessage {
     private String connectorAddress;
     private String correlationId;
     private ContractOffer contractOffer;
+
+    private List<CallbackAddress> callbackAddress = new ArrayList<>();
 
     @Override
     public String getProtocol() {
@@ -58,11 +63,20 @@ public class ContractOfferRequest implements RemoteMessage {
         return contractOffer;
     }
 
+    public List<CallbackAddress> getCallbackAddress() {
+        return callbackAddress;
+    }
+
+    public enum Type {
+        INITIAL,
+        COUNTER_OFFER
+    }
+
     public static class Builder {
         private final ContractOfferRequest contractOfferRequest;
 
         private Builder() {
-            this.contractOfferRequest = new ContractOfferRequest();
+            contractOfferRequest = new ContractOfferRequest();
         }
 
         public static Builder newInstance() {
@@ -70,32 +84,37 @@ public class ContractOfferRequest implements RemoteMessage {
         }
 
         public Builder protocol(String protocol) {
-            this.contractOfferRequest.protocol = protocol;
+            contractOfferRequest.protocol = protocol;
             return this;
         }
 
         public Builder connectorId(String connectorId) {
-            this.contractOfferRequest.connectorId = connectorId;
+            contractOfferRequest.connectorId = connectorId;
             return this;
         }
 
         public Builder connectorAddress(String connectorAddress) {
-            this.contractOfferRequest.connectorAddress = connectorAddress;
+            contractOfferRequest.connectorAddress = connectorAddress;
             return this;
         }
 
         public Builder correlationId(String correlationId) {
-            this.contractOfferRequest.correlationId = correlationId;
+            contractOfferRequest.correlationId = correlationId;
+            return this;
+        }
+
+        public Builder callbackAddresses(List<CallbackAddress> callbackAddresses) {
+            contractOfferRequest.callbackAddress = callbackAddresses;
             return this;
         }
 
         public Builder contractOffer(ContractOffer contractOffer) {
-            this.contractOfferRequest.contractOffer = contractOffer;
+            contractOfferRequest.contractOffer = contractOffer;
             return this;
         }
 
         public Builder type(Type type) {
-            this.contractOfferRequest.type = type;
+            contractOfferRequest.type = type;
             return this;
         }
 
@@ -106,10 +125,5 @@ public class ContractOfferRequest implements RemoteMessage {
             Objects.requireNonNull(contractOfferRequest.contractOffer, "contractOffer");
             return contractOfferRequest;
         }
-    }
-
-    public enum Type {
-        INITIAL,
-        COUNTER_OFFER
     }
 }

--- a/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/negotiation/store/TestFunctions.java
+++ b/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/negotiation/store/TestFunctions.java
@@ -24,9 +24,12 @@ import org.eclipse.edc.policy.model.LiteralExpression;
 import org.eclipse.edc.policy.model.Operator;
 import org.eclipse.edc.policy.model.Permission;
 import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 public class TestFunctions {
@@ -71,6 +74,10 @@ public class TestFunctions {
                 .state(ContractNegotiationStates.REQUESTED.code())
                 .counterPartyAddress("consumer")
                 .counterPartyId("consumerId")
+                .callbackAddresses(List.of(CallbackAddress.Builder.newInstance()
+                        .uri("local://test")
+                        .events(Set.of("contract.negotiation.initiated"))
+                        .build()))
                 .protocol("ids-multipart");
     }
 

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/TransferProcess.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/TransferProcess.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.eclipse.edc.spi.entity.StatefulEntity;
 import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -109,6 +110,7 @@ public class TransferProcess extends StatefulEntity<TransferProcess> {
     private ProvisionedResourceSet provisionedResourceSet;
     private List<DeprovisionedResource> deprovisionedResources = new ArrayList<>();
     private Map<String, String> properties = new HashMap<>();
+    private List<CallbackAddress> callbackAddresses = new ArrayList<>();
 
     private TransferProcess() {
     }
@@ -209,6 +211,10 @@ public class TransferProcess extends StatefulEntity<TransferProcess> {
 
     public Map<String, String> getProperties() {
         return Collections.unmodifiableMap(properties);
+    }
+
+    public List<CallbackAddress> getCallbackAddresses() {
+        return Collections.unmodifiableList(callbackAddresses);
     }
 
     public boolean deprovisionComplete() {
@@ -313,24 +319,6 @@ public class TransferProcess extends StatefulEntity<TransferProcess> {
         return Arrays.stream(states).map(TransferProcessStates::code).anyMatch(code -> code == state);
     }
 
-    private void transition(TransferProcessStates end, TransferProcessStates... starts) {
-        transition(end, (state) -> Arrays.stream(starts).anyMatch(s -> s == state));
-    }
-
-    /**
-     * Transition to a given end state if the passed predicate test correctly. Increases the
-     * state count if transitioned to the same state and updates the state timestamp.
-     *
-     * @param end          The desired state.
-     * @param canTransitTo Tells if the negotiation can transit to that state.
-     */
-    private void transition(TransferProcessStates end, Predicate<TransferProcessStates> canTransitTo) {
-        if (!canTransitTo.test(TransferProcessStates.from(state))) {
-            throw new IllegalStateException(format("Cannot transition from state %s to %s", TransferProcessStates.from(state), TransferProcessStates.from(end.code())));
-        }
-        transitionTo(end.code());
-    }
-
     @Override
     public TransferProcess copy() {
         var builder = Builder.newInstance()
@@ -340,6 +328,7 @@ public class TransferProcess extends StatefulEntity<TransferProcess> {
                 .contentDataAddress(contentDataAddress)
                 .deprovisionedResources(deprovisionedResources)
                 .properties(properties)
+                .callbackAddresses(callbackAddresses)
                 .type(type);
         return copy(builder);
     }
@@ -372,6 +361,24 @@ public class TransferProcess extends StatefulEntity<TransferProcess> {
                 ", state=" + TransferProcessStates.from(state) +
                 ", stateTimestamp=" + Instant.ofEpochMilli(stateTimestamp) +
                 '}';
+    }
+
+    private void transition(TransferProcessStates end, TransferProcessStates... starts) {
+        transition(end, (state) -> Arrays.stream(starts).anyMatch(s -> s == state));
+    }
+
+    /**
+     * Transition to a given end state if the passed predicate test correctly. Increases the
+     * state count if transitioned to the same state and updates the state timestamp.
+     *
+     * @param end          The desired state.
+     * @param canTransitTo Tells if the negotiation can transit to that state.
+     */
+    private void transition(TransferProcessStates end, Predicate<TransferProcessStates> canTransitTo) {
+        if (!canTransitTo.test(TransferProcessStates.from(state))) {
+            throw new IllegalStateException(format("Cannot transition from state %s to %s", TransferProcessStates.from(state), TransferProcessStates.from(end.code())));
+        }
+        transitionTo(end.code());
     }
 
     public enum Type {
@@ -425,6 +432,11 @@ public class TransferProcess extends StatefulEntity<TransferProcess> {
             return this;
         }
 
+        public Builder callbackAddresses(List<CallbackAddress> callbackAddresses) {
+            entity.callbackAddresses = callbackAddresses;
+            return this;
+        }
+
         @Override
         public Builder self() {
             return this;
@@ -448,6 +460,10 @@ public class TransferProcess extends StatefulEntity<TransferProcess> {
 
             if (entity.state == 0) {
                 entity.transitionTo(INITIAL.code());
+            }
+
+            if (entity.callbackAddresses == null) {
+                entity.callbackAddresses = new ArrayList<>();
             }
 
             return entity;

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/TransferRequest.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/TransferRequest.java
@@ -15,7 +15,10 @@
 package org.eclipse.edc.connector.transfer.spi.types;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -24,6 +27,8 @@ import java.util.Objects;
  * go here and not in of the {@link DataRequest}
  */
 public class TransferRequest {
+
+    private List<CallbackAddress> callbackAddresses = new ArrayList<>();
 
     private DataRequest dataRequest;
 
@@ -40,6 +45,15 @@ public class TransferRequest {
         return dataRequest;
     }
 
+    /**
+     * Get the list of associated {@link CallbackAddress}
+     *
+     * @return The callbacks
+     */
+    public List<CallbackAddress> getCallbackAddresses() {
+        return callbackAddresses;
+    }
+
     public static class Builder {
         private final TransferRequest request;
 
@@ -54,6 +68,11 @@ public class TransferRequest {
 
         public Builder dataRequest(DataRequest dataRequest) {
             request.dataRequest = dataRequest;
+            return this;
+        }
+
+        public Builder callbackAddresses(List<CallbackAddress> callbackAddresses) {
+            request.callbackAddresses = callbackAddresses;
             return this;
         }
 

--- a/spi/control-plane/transfer-spi/src/testFixtures/java/org/eclipse/edc/connector/transfer/spi/testfixtures/store/TestFunctions.java
+++ b/spi/control-plane/transfer-spi/src/testFixtures/java/org/eclipse/edc/connector/transfer/spi/testfixtures/store/TestFunctions.java
@@ -26,9 +26,11 @@ import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.connector.transfer.spi.types.TransferProcessStates;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 import org.jetbrains.annotations.NotNull;
 
 import java.time.Clock;
+import java.util.List;
 import java.util.UUID;
 
 public class TestFunctions {
@@ -88,6 +90,7 @@ public class TestFunctions {
                 .type(TransferProcess.Type.CONSUMER)
                 .dataRequest(createDataRequest())
                 .contentDataAddress(createDataAddressBuilder("any").build())
+                .callbackAddresses(List.of(CallbackAddress.Builder.newInstance().uri("local://test").build()))
                 .resourceManifest(createManifest());
     }
 

--- a/spi/control-plane/transfer-spi/src/testFixtures/java/org/eclipse/edc/connector/transfer/spi/testfixtures/store/TransferProcessStoreTestBase.java
+++ b/spi/control-plane/transfer-spi/src/testFixtures/java/org/eclipse/edc/connector/transfer/spi/testfixtures/store/TransferProcessStoreTestBase.java
@@ -24,6 +24,7 @@ import org.eclipse.edc.connector.transfer.spi.types.TransferType;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.query.SortOrder;
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,6 +34,7 @@ import java.time.Duration;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -74,6 +76,20 @@ public abstract class TransferProcessStoreTestBase {
         assertThat(all).containsExactly(t);
         assertThat(all.get(0)).usingRecursiveComparison().isEqualTo(t);
         assertThat(all).allSatisfy(tr -> assertThat(tr.getCreatedAt()).isNotEqualTo(0L));
+    }
+
+    @Test
+    void create_verifyCallbacks() {
+
+        var callbacks = List.of(CallbackAddress.Builder.newInstance().uri("test").events(Set.of("event")).build());
+
+        var t = TestFunctions.createTransferProcessBuilder("test-id").properties(Map.of("key", "value")).callbackAddresses(callbacks).build();
+        getTransferProcessStore().save(t);
+
+        var all = getTransferProcessStore().findAll(QuerySpec.none()).collect(Collectors.toList());
+        assertThat(all).containsExactly(t);
+        assertThat(all.get(0)).usingRecursiveComparison().isEqualTo(t);
+        assertThat(all.get(0).getCallbackAddresses()).hasSize(1).usingRecursiveFieldByFieldElementComparator().containsAll(callbacks);
     }
 
     @Test


### PR DESCRIPTION
## What this PR changes/adds

Add the support for storing list of callbacks in:

- ContractNegotiation
- TransferProcess

## Why it does that

Initial support for callbacks Ref DR #2549 

## Further notes

The initial implementation support storing custom callbacks via DataManagement API in

- ContractNegotiation
- TransferProcess

As the first PR of the story #2626, it doesn't had any behavior yet behind those callbacks.

 
## Linked Issue(s)

Closes #2625 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
