### PR TITLE
feat: Adds support for participant identities and checks

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -265,8 +265,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-build
 
-      - name: Download opentelemetry javaagent
-        run: wget -q https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.12.0/opentelemetry-javaagent.jar
       - name: OpenTelemetry Integration Tests
         uses: ./.github/actions/run-tests
         with:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,11 +77,7 @@ allprojects {
             println(sourceSets["main"].runtimeClasspath.asPath)
         }
     }
-
-    dependencies {
-        testRuntimeOnly(platform("org.junit:junit-bom:5.9.2"))
-    }
-
+    
 }
 repositories {
     mavenCentral()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,6 +78,10 @@ allprojects {
         }
     }
 
+    dependencies {
+        testRuntimeOnly(platform("org.junit:junit-bom:5.9.2"))
+    }
+
 }
 repositories {
     mavenCentral()

--- a/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/CoreServicesExtension.java
+++ b/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/CoreServicesExtension.java
@@ -48,6 +48,8 @@ import org.eclipse.edc.spi.types.TypeManager;
 import java.security.PrivateKey;
 import java.time.Duration;
 
+import static org.eclipse.edc.spi.agent.ParticipantAgentService.DEFAULT_IDENTITY_CLAIM_KEY;
+
 @BaseExtension
 @Extension(value = CoreServicesExtension.NAME)
 public class CoreServicesExtension implements ServiceExtension {
@@ -62,6 +64,9 @@ public class CoreServicesExtension implements ServiceExtension {
     public static final String THREADPOOL_SIZE_SETTING = "edc.core.system.health.check.threadpool-size";
     @Setting
     public static final String HOSTNAME_SETTING = "edc.hostname";
+    @Setting
+    public static final String IDENTITY_KEY = "edc.agent.identity.key";
+
     public static final String NAME = "Core Services";
     private static final long DEFAULT_DURATION = 60;
     private static final int DEFAULT_TP_SIZE = 3;
@@ -129,8 +134,9 @@ public class CoreServicesExtension implements ServiceExtension {
     }
 
     @Provider
-    public ParticipantAgentService participantAgentService() {
-        return new ParticipantAgentServiceImpl();
+    public ParticipantAgentService participantAgentService(ServiceExtensionContext context) {
+        var identityKey = context.getSetting(IDENTITY_KEY, DEFAULT_IDENTITY_CLAIM_KEY);
+        return new ParticipantAgentServiceImpl(identityKey);
     }
 
     @Provider

--- a/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/CoreServicesExtension.java
+++ b/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/CoreServicesExtension.java
@@ -64,6 +64,10 @@ public class CoreServicesExtension implements ServiceExtension {
     public static final String THREADPOOL_SIZE_SETTING = "edc.core.system.health.check.threadpool-size";
     @Setting
     public static final String HOSTNAME_SETTING = "edc.hostname";
+
+    /**
+     * The name of the claim key used to determine the participant identity.
+     */
     @Setting
     public static final String IDENTITY_KEY = "edc.agent.identity.key";
 

--- a/core/common/connector-core/src/test/java/org/eclipse/edc/connector/core/base/agent/ParticipantAgentServiceImplTest.java
+++ b/core/common/connector-core/src/test/java/org/eclipse/edc/connector/core/base/agent/ParticipantAgentServiceImplTest.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.connector.core.base.agent.ParticipantAgentServiceImpl.DEFAULT_IDENTITY_CLAIM_KEY;
+import static org.eclipse.edc.spi.agent.ParticipantAgent.PARTICIPANT_IDENTITY;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -44,4 +46,56 @@ class ParticipantAgentServiceImplTest {
         assertThat(participantAgent.getAttributes().containsKey("foo")).isTrue();
         verify(extension).attributesFor(isA(ClaimToken.class));
     }
+
+    @Test
+    void verifyDefaultIdentityClaim() {
+        var participantAgentService = new ParticipantAgentServiceImpl();
+        var agent = participantAgentService.createFor(ClaimToken.Builder.newInstance().claim(DEFAULT_IDENTITY_CLAIM_KEY, "test-participant").build());
+
+        assertThat(agent.getIdentity()).isEqualTo("test-participant");
+    }
+
+    @Test
+    void verifyNoDefaultIdentityClaim() {
+        var participantAgentService = new ParticipantAgentServiceImpl();
+        var agent = participantAgentService.createFor(ClaimToken.Builder.newInstance().build());
+
+        assertThat(agent.getIdentity()).isNull();
+    }
+
+    @Test
+    void verifyCustomIdentityClaim() {
+        var participantAgentService = new ParticipantAgentServiceImpl("custom-key");
+        var agent = participantAgentService.createFor(ClaimToken.Builder.newInstance().claim("custom-key", "test-participant").build());
+
+        assertThat(agent.getIdentity()).isEqualTo("test-participant");
+    }
+
+    @Test
+    void verifyExtensionCreatesIdentity() {
+        var participantAgentService = new ParticipantAgentServiceImpl();
+
+        ParticipantAgentServiceExtension extension = mock(ParticipantAgentServiceExtension.class);
+        when(extension.attributesFor(isA(ClaimToken.class))).thenReturn(Map.of(PARTICIPANT_IDENTITY, "test-participant"));
+        participantAgentService.register(extension);
+
+        var agent = participantAgentService.createFor(ClaimToken.Builder.newInstance().build());
+
+        assertThat(agent.getIdentity()).isEqualTo("test-participant");
+    }
+
+    @Test
+    void verifyExtensionOverridesDefaultIdentityClaim() {
+        var participantAgentService = new ParticipantAgentServiceImpl();
+
+        ParticipantAgentServiceExtension extension = mock(ParticipantAgentServiceExtension.class);
+        when(extension.attributesFor(isA(ClaimToken.class))).thenReturn(Map.of(PARTICIPANT_IDENTITY, "test-participant"));
+        participantAgentService.register(extension);
+
+        var agent = participantAgentService.createFor(ClaimToken.Builder.newInstance().claim(DEFAULT_IDENTITY_CLAIM_KEY, "overriden-identity").build());
+
+        assertThat(agent.getIdentity()).isEqualTo("test-participant");
+    }
+
+
 }

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/ContractCoreExtension.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/ContractCoreExtension.java
@@ -181,7 +181,7 @@ public class ContractCoreExtension implements ServiceExtension {
         context.registerService(ContractOfferResolver.class, contractOfferResolver);
 
         var policyEquality = new PolicyEquality(typeManager);
-        var validationService = new ContractValidationServiceImpl(agentService, definitionService, assetIndex, policyStore, clock, policyEngine, policyEquality);
+        var validationService = new ContractValidationServiceImpl(agentService, definitionService, assetIndex, policyStore, policyEngine, policyEquality, clock);
         context.registerService(ContractValidationService.class, validationService);
 
         var iterationWaitMillis = context.getSetting(NEGOTIATION_STATE_MACHINE_ITERATION_WAIT_MILLIS, DEFAULT_ITERATION_WAIT);

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -58,6 +58,7 @@ import static org.awaitility.Awaitility.await;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.PROVIDER_FINALIZED;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -127,7 +128,7 @@ class ContractNegotiationIntegrationTest {
         consumerNegotiationId = "consumerNegotiationId";
         var offer = getContractOffer();
         when(validationService.validateInitialOffer(token, offer)).thenReturn(Result.success(offer));
-        when(validationService.validateConfirmed(any(ContractAgreement.class), any(ContractOffer.class)))
+        when(validationService.validateConfirmed(eq(token), any(ContractAgreement.class), any(ContractOffer.class)))
                 .thenReturn(Result.success());
 
         // Start provider and consumer negotiation managers
@@ -162,7 +163,7 @@ class ContractNegotiationIntegrationTest {
                     assertThat(consumerNegotiation.getContractAgreement()).isEqualTo(providerNegotiation.getContractAgreement());
 
                     verify(validationService, atLeastOnce()).validateInitialOffer(token, offer);
-                    verify(validationService, atLeastOnce()).validateConfirmed(any(ContractAgreement.class), any(ContractOffer.class));
+                    verify(validationService, atLeastOnce()).validateConfirmed(eq(token), any(ContractAgreement.class), any(ContractOffer.class));
                 });
     }
 
@@ -190,24 +191,7 @@ class ContractNegotiationIntegrationTest {
 
         await().atMost(DEFAULT_TEST_TIMEOUT)
                 .pollInterval(DEFAULT_POLL_INTERVAL)
-                .untilAsserted(() -> {
-
-                    assertThat(consumerNegotiationId).isNotNull();
-                    var consumerNegotiation = consumerStore.findById(consumerNegotiationId);
-                    var providerNegotiation = providerStore.findForCorrelationId(consumerNegotiationId);
-                    assertThat(consumerNegotiation).isNotNull();
-                    assertThat(providerNegotiation).isNotNull();
-
-                    // Assert that provider and consumer have the same offers stored
-                    assertThat(consumerNegotiation.getContractOffers()).hasSize(1);
-                    assertThat(providerNegotiation.getContractOffers()).hasSize(1);
-                    assertThat(consumerNegotiation.getLastContractOffer()).isEqualTo(providerNegotiation.getLastContractOffer());
-
-                    // Assert that no agreement has been stored on either side
-                    assertThat(consumerNegotiation.getContractAgreement()).isNull();
-                    assertThat(providerNegotiation.getContractAgreement()).isNull();
-                    verify(validationService, atLeastOnce()).validateInitialOffer(token, offer);
-                });
+                .untilAsserted(() -> verify(validationService, atLeastOnce()).validateInitialOffer(token, offer));
     }
 
     @Test
@@ -219,7 +203,7 @@ class ContractNegotiationIntegrationTest {
         var offer = getContractOffer();
 
         when(validationService.validateInitialOffer(token, offer)).thenReturn(Result.success(offer));
-        when(validationService.validateConfirmed(any(ContractAgreement.class), any(ContractOffer.class)))
+        when(validationService.validateConfirmed(eq(token), any(ContractAgreement.class), any(ContractOffer.class)))
                 .thenReturn(Result.failure("error"));
 
         // Start provider and consumer negotiation managers
@@ -254,7 +238,7 @@ class ContractNegotiationIntegrationTest {
                     assertThat(providerNegotiation.getContractAgreement()).isNull();
 
                     verify(validationService, atLeastOnce()).validateInitialOffer(token, offer);
-                    verify(validationService, atLeastOnce()).validateConfirmed(any(ContractAgreement.class), any(ContractOffer.class));
+                    verify(validationService, atLeastOnce()).validateConfirmed(eq(token), any(ContractAgreement.class), any(ContractOffer.class));
                 });
     }
 

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
@@ -210,7 +210,7 @@ class ProviderContractNegotiationManagerImplTest {
     @Test
     void declined_invalid() {
         var negotiation = createContractNegotiation();
-        when(store.find(negotiation.getId())).thenReturn(negotiation);
+        when(store.findById(negotiation.getId())).thenReturn(negotiation);
         when(store.findForCorrelationId(negotiation.getCorrelationId())).thenReturn(negotiation);
         var token = ClaimToken.Builder.newInstance().build();
 

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImplTest.java
@@ -20,6 +20,7 @@ package org.eclipse.edc.connector.contract.validation;
 import org.eclipse.edc.connector.contract.policy.PolicyEquality;
 import org.eclipse.edc.connector.contract.spi.offer.ContractDefinitionService;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractDefinition;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
@@ -38,12 +39,16 @@ import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.net.URI;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -53,14 +58,19 @@ import static java.time.ZoneOffset.UTC;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.contract.spi.validation.ContractValidationService.NEGOTIATION_SCOPE;
+import static org.eclipse.edc.spi.agent.ParticipantAgent.PARTICIPANT_IDENTITY;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class ContractValidationServiceImplTest {
+
+    private static final String CONSUMER_ID = "consumer";
+    private static final String PROVIDER_ID = "provider";
 
     private final Instant now = Instant.now();
 
@@ -75,17 +85,18 @@ class ContractValidationServiceImplTest {
 
     @BeforeEach
     void setUp() {
-        validationService = new ContractValidationServiceImpl(agentService, definitionService, assetIndex, policyStore, clock, policyEngine, policyEquality);
+        validationService = new ContractValidationServiceImpl(agentService, definitionService, assetIndex, policyStore, policyEngine, policyEquality, clock);
     }
 
     @Test
     void verifyContractOfferValidation() {
+        var participantAgent = new ParticipantAgent(emptyMap(), Map.of(PARTICIPANT_IDENTITY, CONSUMER_ID));
         var originalPolicy = Policy.Builder.newInstance().target("a").build();
         var newPolicy = Policy.Builder.newInstance().target("b").build();
         var asset = Asset.Builder.newInstance().id("1").build();
         var contractDefinition = createContractDefinition();
 
-        when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
+        when(agentService.createFor(isA(ClaimToken.class))).thenReturn(participantAgent);
         when(definitionService.definitionFor(isA(ParticipantAgent.class), eq("1"))).thenReturn(contractDefinition);
         when(policyStore.findById("access")).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
         when(policyStore.findById("contract")).thenReturn(PolicyDefinition.Builder.newInstance().policy(newPolicy).build());
@@ -104,12 +115,32 @@ class ContractValidationServiceImplTest {
         assertThat(validatedOffer.getAsset()).isEqualTo(asset);
         assertThat(validatedOffer.getContractStart().toInstant()).isEqualTo(clock.instant());
         assertThat(validatedOffer.getContractEnd().toInstant()).isEqualTo(clock.instant().plusSeconds(contractDefinition.getValidity()));
-        assertThat(validatedOffer.getConsumer()).isEqualTo(offer.getConsumer());
+        assertThat(validatedOffer.getConsumer().toString()).isEqualTo(CONSUMER_ID); // verify the returned policy has the consumer id set, essential for later validation checks
         assertThat(validatedOffer.getProvider()).isEqualTo(offer.getProvider());
+
         verify(agentService).createFor(isA(ClaimToken.class));
         verify(definitionService).definitionFor(isA(ParticipantAgent.class), eq("1"));
         verify(assetIndex).findById("1");
         verify(policyEngine).evaluate(eq(NEGOTIATION_SCOPE), eq(newPolicy), isA(ParticipantAgent.class));
+    }
+
+    @Test
+    void verifyContractOfferValidation_failedIfNoConsumerIdentity() {
+        var participantAgent = new ParticipantAgent(emptyMap(), emptyMap());
+        var originalPolicy = Policy.Builder.newInstance().target("a").build();
+        var asset = Asset.Builder.newInstance().id("1").build();
+        var contractDefinition = createContractDefinition();
+
+        when(agentService.createFor(isA(ClaimToken.class))).thenReturn(participantAgent);
+
+        var claimToken = ClaimToken.Builder.newInstance().build();
+        var offer = createContractOffer(asset, originalPolicy, contractDefinition.getValidity());
+
+        var result = validationService.validateInitialOffer(claimToken, offer);
+
+        assertThat(result.succeeded()).isFalse();
+
+        verify(agentService).createFor(isA(ClaimToken.class));
     }
 
     @Test
@@ -180,9 +211,10 @@ class ContractValidationServiceImplTest {
     @Test
     void verifyContractAgreementValidation() {
         var newPolicy = Policy.Builder.newInstance().build();
-        var contractDefinition = createContractDefinition();
+        var participantAgent = new ParticipantAgent(emptyMap(), Map.of(PARTICIPANT_IDENTITY, CONSUMER_ID));
 
-        when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
+        when(agentService.createFor(isA(ClaimToken.class))).thenReturn(participantAgent);
+
         when(policyStore.findById("access")).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
         when(policyStore.findById("contract")).thenReturn(PolicyDefinition.Builder.newInstance().policy(newPolicy).build());
         when(policyEngine.evaluate(eq(NEGOTIATION_SCOPE), eq(newPolicy), isA(ParticipantAgent.class))).thenReturn(Result.success(newPolicy));
@@ -193,20 +225,49 @@ class ContractValidationServiceImplTest {
                 .contractEndDate(now.plus(1, ChronoUnit.DAYS).getEpochSecond())
                 .contractSigningDate(now.getEpochSecond())
                 .id("1:2")
+                .consumerAgentId(CONSUMER_ID)
                 .build();
 
         var isValid = validationService.validateAgreement(claimToken, agreement);
 
         assertThat(isValid.succeeded()).isTrue();
+
         verify(agentService).createFor(isA(ClaimToken.class));
         verify(policyEngine).evaluate(eq(NEGOTIATION_SCOPE), eq(newPolicy), isA(ParticipantAgent.class));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"malicious-actor"})
+    @NullSource
+    void verifyContractAgreementValidation_failedIfInvalidCredentials(String counterPartyId) {
+        var newPolicy = Policy.Builder.newInstance().build();
+        var participantAgent = new ParticipantAgent(emptyMap(), counterPartyId != null ? Map.of(PARTICIPANT_IDENTITY, counterPartyId) : Map.of());
+
+        when(agentService.createFor(isA(ClaimToken.class))).thenReturn(participantAgent);
+
+        when(policyStore.findById("access")).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
+        when(policyStore.findById("contract")).thenReturn(PolicyDefinition.Builder.newInstance().policy(newPolicy).build());
+
+        var claimToken = ClaimToken.Builder.newInstance().build();
+        var agreement = createContractAgreement()
+                .contractStartDate(now.getEpochSecond())
+                .contractEndDate(now.plus(1, ChronoUnit.DAYS).getEpochSecond())
+                .contractSigningDate(now.getEpochSecond())
+                .id("1:2")
+                .consumerAgentId(CONSUMER_ID)
+                .build();
+
+        var isValid = validationService.validateAgreement(claimToken, agreement);
+
+        assertThat(isValid.succeeded()).isFalse();
+
+        verify(agentService).createFor(isA(ClaimToken.class));
     }
 
     @Test
     void verifyContractAgreementExpired() {
         var past = Instant.now().getEpochSecond() - 5000;
-        var isValid =
-                validateAgreementDate(MIN.getEpochSecond(), MIN.getEpochSecond(), past);
+        var isValid = validateAgreementDate(MIN.getEpochSecond(), MIN.getEpochSecond(), past);
 
         assertThat(isValid.failed()).isTrue();
     }
@@ -222,54 +283,119 @@ class ContractValidationServiceImplTest {
     void validateAgreement_failsIfIdIsNotValid() {
         var token = ClaimToken.Builder.newInstance().build();
         var agreement = createContractAgreement().id("not a valid ID").build();
+
         var result = validationService.validateAgreement(token, agreement);
 
         assertThat(result.failed()).isTrue();
 
-    }
-
-    @Test
-    void verifyAgreement_failsIfContractDefinitionIsNull() {
-        var agreement = createContractAgreement().id("1:2").build();
-        var token = ClaimToken.Builder.newInstance().build();
-        when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
-        when(definitionService.definitionFor(any(), any())).thenReturn(null);
-        var result = validationService.validateAgreement(token, agreement);
-
-        assertThat(result.failed()).isTrue();
+        verify(agentService, times(0)).createFor(eq(token));
     }
 
     @Test
     void validateConfirmed_succeed() {
         var agreement = createContractAgreement().id("1:2").build();
         var offer = createContractOffer();
+        var token = ClaimToken.Builder.newInstance().build();
+
+        var participantAgent = new ParticipantAgent(Map.of(), Map.of(PARTICIPANT_IDENTITY, PROVIDER_ID));
+        when(agentService.createFor(eq(token))).thenReturn(participantAgent);
         when(policyEquality.test(any(), any())).thenReturn(true);
 
-        var result = validationService.validateConfirmed(agreement, offer);
+        var result = validationService.validateConfirmed(token, agreement, offer);
 
         assertThat(result.succeeded()).isTrue();
+
+        verify(agentService).createFor(isA(ClaimToken.class));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {CONSUMER_ID})
+    @NullSource
+    void validateConfirmed_failsIfInvalidClaims(String counterPartyId) {
+        var agreement = createContractAgreement().id("1:2").build();
+        var offer = createContractOffer();
+        var token = ClaimToken.Builder.newInstance().build();
+
+        var participantAgent = new ParticipantAgent(Map.of(), counterPartyId != null ? Map.of(PARTICIPANT_IDENTITY, counterPartyId) : Map.of());
+        when(agentService.createFor(eq(token))).thenReturn(participantAgent);
+
+        var result = validationService.validateConfirmed(token, agreement, offer);
+
+        assertThat(result.succeeded()).isFalse();
+
+        verify(agentService).createFor(isA(ClaimToken.class));
     }
 
     @Test
     void validateConfirmed_failsIfIdIsNotValid() {
         var agreement = createContractAgreement().id("not a valid id").build();
         var offer = createContractOffer();
+        var token = ClaimToken.Builder.newInstance().build();
 
-        var result = validationService.validateConfirmed(agreement, offer);
+        var result = validationService.validateConfirmed(token, agreement, offer);
 
         assertThat(result.failed()).isTrue();
+
+        verify(agentService, times(0)).createFor(eq(token));
     }
 
     @Test
     void validateConfirmed_failsIfPoliciesAreNotEqual() {
         var agreement = createContractAgreement().id("1:2").build();
         var offer = createContractOffer();
+        var token = ClaimToken.Builder.newInstance().build();
+
+        var participantAgent = new ParticipantAgent(Map.of(), Map.of(PARTICIPANT_IDENTITY, CONSUMER_ID));
+        when(agentService.createFor(eq(token))).thenReturn(participantAgent);
         when(policyEquality.test(any(), any())).thenReturn(false);
 
-        var result = validationService.validateConfirmed(agreement, offer);
-
+        var result = validationService.validateConfirmed(token, agreement, offer);
 
         assertThat(result.failed()).isTrue();
+
+        verify(agentService).createFor(eq(token));
+    }
+
+    @Test
+    void validateConsumerRequest() {
+        var token = ClaimToken.Builder.newInstance().build();
+        var negotiation = ContractNegotiation.Builder.newInstance()
+                .id("1")
+                .counterPartyId(CONSUMER_ID)
+                .counterPartyAddress("https://consumer.com")
+                .protocol("test")
+                .build();
+
+        var participantAgent = new ParticipantAgent(Map.of(), Map.of(PARTICIPANT_IDENTITY, CONSUMER_ID));
+        when(agentService.createFor(eq(token))).thenReturn(participantAgent);
+
+        var result = validationService.validateRequest(token, negotiation);
+
+        assertThat(result.succeeded()).isTrue();
+
+        verify(agentService).createFor(isA(ClaimToken.class));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {PROVIDER_ID})
+    @NullSource
+    void validateConsumerRequest_failsInvalidCredentials(String counterPartyId) {
+        var token = ClaimToken.Builder.newInstance().build();
+        var negotiation = ContractNegotiation.Builder.newInstance()
+                .id("1")
+                .counterPartyId(CONSUMER_ID)
+                .counterPartyAddress("https://consumer.com")
+                .protocol("test")
+                .build();
+
+        var participantAgent = new ParticipantAgent(Map.of(), counterPartyId != null ? Map.of(PARTICIPANT_IDENTITY, counterPartyId) : Map.of());
+        when(agentService.createFor(eq(token))).thenReturn(participantAgent);
+
+        var result = validationService.validateRequest(token, negotiation);
+
+        assertThat(result.succeeded()).isFalse();
+
+        verify(agentService).createFor(isA(ClaimToken.class));
     }
 
     private Result<ContractAgreement> validateAgreementDate(long signingDate, long startDate, long endDate) {
@@ -294,8 +420,8 @@ class ContractValidationServiceImplTest {
                 .id("1:2")
                 .asset(asset)
                 .policy(policy)
-                .provider(URI.create("provider"))
-                .consumer(URI.create("consumer"))
+                .provider(URI.create(PROVIDER_ID))
+                .consumer(URI.create(CONSUMER_ID))
                 .contractStart(now)
                 .contractEnd(now.plusSeconds(validity))
                 .build();
@@ -308,8 +434,8 @@ class ContractValidationServiceImplTest {
 
     private static ContractAgreement.Builder createContractAgreement() {
         return ContractAgreement.Builder.newInstance().id("1")
-                .providerAgentId("provider")
-                .consumerAgentId("consumer")
+                .providerAgentId(PROVIDER_ID)
+                .consumerAgentId(CONSUMER_ID)
                 .policy(Policy.Builder.newInstance().build())
                 .assetId(UUID.randomUUID().toString());
     }

--- a/extensions/common/iam/iam-mock/src/main/java/org/eclipse/edc/iam/mock/IamMockExtension.java
+++ b/extensions/common/iam/iam-mock/src/main/java/org/eclipse/edc/iam/mock/IamMockExtension.java
@@ -23,7 +23,6 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 
 import java.util.Objects;
-import java.util.UUID;
 
 /**
  * An IAM provider mock used for testing.
@@ -45,7 +44,7 @@ public class IamMockExtension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
         var region = context.getSetting("edc.mock.region", "eu");
-        var idsId = Objects.requireNonNull(context.getSetting("edc.ids.id", UUID.randomUUID().toString()));
+        var idsId = Objects.requireNonNull(context.getSetting("edc.ids.id", null));
         context.registerService(IdentityService.class, new MockIdentityService(typeManager, region, idsId));
     }
 }

--- a/extensions/common/iam/iam-mock/src/main/java/org/eclipse/edc/iam/mock/IamMockExtension.java
+++ b/extensions/common/iam/iam-mock/src/main/java/org/eclipse/edc/iam/mock/IamMockExtension.java
@@ -22,6 +22,9 @@ import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 
+import java.util.Objects;
+import java.util.UUID;
+
 /**
  * An IAM provider mock used for testing.
  */
@@ -42,6 +45,7 @@ public class IamMockExtension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
         var region = context.getSetting("edc.mock.region", "eu");
-        context.registerService(IdentityService.class, new MockIdentityService(typeManager, region));
+        var idsId = Objects.requireNonNull(context.getSetting("edc.ids.id", UUID.randomUUID().toString()));
+        context.registerService(IdentityService.class, new MockIdentityService(typeManager, region, idsId));
     }
 }

--- a/extensions/common/iam/iam-mock/src/main/java/org/eclipse/edc/iam/mock/MockIdentityService.java
+++ b/extensions/common/iam/iam-mock/src/main/java/org/eclipse/edc/iam/mock/MockIdentityService.java
@@ -30,10 +30,12 @@ import static java.lang.String.format;
 public class MockIdentityService implements IdentityService {
     private final String region;
     private final TypeManager typeManager;
+    private final String clientId;
 
-    public MockIdentityService(TypeManager typeManager, String region) {
+    public MockIdentityService(TypeManager typeManager, String region, String clientId) {
         this.typeManager = typeManager;
         this.region = region;
+        this.clientId = clientId;
     }
 
     @Override
@@ -41,6 +43,7 @@ public class MockIdentityService implements IdentityService {
         var token = new MockToken();
         token.setAudience(parameters.getAudience());
         token.setRegion(region);
+        token.setClientId(clientId);
         TokenRepresentation tokenRepresentation = TokenRepresentation.Builder.newInstance()
                 .token(typeManager.writeValueAsString(token))
                 .build();
@@ -53,12 +56,16 @@ public class MockIdentityService implements IdentityService {
         if (!Objects.equals(token.audience, audience)) {
             return Result.failure(format("Mismatched audience: expected %s, got %s", audience, token.audience));
         }
-        return Result.success(ClaimToken.Builder.newInstance().claim("region", token.region).build());
+        return Result.success(ClaimToken.Builder.newInstance()
+                .claim("region", token.region)
+                .claim("client_id", token.clientId)
+                .build());
     }
 
     private static class MockToken {
         private String region;
         private String audience;
+        private String clientId;
 
         public String getAudience() {
             return audience;
@@ -74,6 +81,14 @@ public class MockIdentityService implements IdentityService {
 
         public void setRegion(String region) {
             this.region = region;
+        }
+
+        public String getClientId() {
+            return clientId;
+        }
+
+        public void setClientId(String clientId) {
+            this.clientId = clientId;
         }
     }
 }

--- a/extensions/control-plane/api/management-api/catalog-api/src/test/java/org/eclipse/edc/connector/api/management/catalog/CatalogApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/test/java/org/eclipse/edc/connector/api/management/catalog/CatalogApiControllerIntegrationTest.java
@@ -65,6 +65,16 @@ class CatalogApiControllerIntegrationTest {
     private final String authKey = "123456";
     private final RemoteMessageDispatcher dispatcher = mock(RemoteMessageDispatcher.class);
 
+    private static ContractOffer createContractOffer() {
+        return ContractOffer.Builder.newInstance()
+                .id(UUID.randomUUID().toString())
+                .policy(Policy.Builder.newInstance().build())
+                .asset(Asset.Builder.newInstance().id(UUID.randomUUID().toString()).build())
+                .contractStart(ZonedDateTime.now())
+                .contractEnd(ZonedDateTime.now().plusMonths(1))
+                .build();
+    }
+
     @BeforeEach
     void setUp(EdcExtension extension) {
         when(dispatcher.protocol()).thenReturn("ids-multipart");
@@ -75,7 +85,8 @@ class CatalogApiControllerIntegrationTest {
                 "web.http.path", "/api",
                 "web.http.management.port", String.valueOf(port),
                 "web.http.management.path", "/api/v1/management",
-                "edc.api.auth.key", authKey
+                "edc.api.auth.key", authKey,
+                "edc.ids.id", "test-ids-id"
         ));
     }
 
@@ -234,16 +245,6 @@ class CatalogApiControllerIntegrationTest {
                 .basePath("/api/v1/management")
                 .header("x-api-key", authKey)
                 .when();
-    }
-
-    private static ContractOffer createContractOffer() {
-        return ContractOffer.Builder.newInstance()
-                .id(UUID.randomUUID().toString())
-                .policy(Policy.Builder.newInstance().build())
-                .asset(Asset.Builder.newInstance().id(UUID.randomUUID().toString()).build())
-                .contractStart(ZonedDateTime.now())
-                .contractEnd(ZonedDateTime.now().plusMonths(1))
-                .build();
     }
 
     @Provides(ContractOfferResolver.class)

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiExtension.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiExtension.java
@@ -55,9 +55,10 @@ public class ContractNegotiationApiExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
+        var idsId = context.getSetting("edc.ids.id", null);
         transformerRegistry.register(new ContractNegotiationToContractNegotiationDtoTransformer());
         transformerRegistry.register(new ContractAgreementToContractAgreementDtoTransformer());
-        transformerRegistry.register(new NegotiationInitiateRequestDtoToDataRequestTransformer(clock));
+        transformerRegistry.register(new NegotiationInitiateRequestDtoToDataRequestTransformer(clock, idsId));
 
         var monitor = context.getMonitor();
 

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/model/NegotiationInitiateRequestDto.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/model/NegotiationInitiateRequestDto.java
@@ -26,9 +26,7 @@ public class NegotiationInitiateRequestDto {
     private String connectorId;
     @NotNull(message = "offer cannot be null")
     private ContractOfferDescription offer;
-    @NotNull(message = "provider ID cannot be null")
     private String providerId;
-    @NotNull(message = "consumer ID cannot be null")
     private String consumerId;
 
     private NegotiationInitiateRequestDto() {

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/model/NegotiationInitiateRequestDto.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/model/NegotiationInitiateRequestDto.java
@@ -26,6 +26,10 @@ public class NegotiationInitiateRequestDto {
     private String connectorId;
     @NotNull(message = "offer cannot be null")
     private ContractOfferDescription offer;
+    @NotNull(message = "provider ID cannot be null")
+    private String providerId;
+    @NotNull(message = "consumer ID cannot be null")
+    private String consumerId;
 
     private NegotiationInitiateRequestDto() {
 
@@ -45,6 +49,14 @@ public class NegotiationInitiateRequestDto {
 
     public ContractOfferDescription getOffer() {
         return offer;
+    }
+
+    public String getConsumerId() {
+        return consumerId;
+    }
+
+    public String getProviderId() {
+        return providerId;
     }
 
     public static final class Builder {
@@ -75,6 +87,16 @@ public class NegotiationInitiateRequestDto {
 
         public Builder offer(ContractOfferDescription offer) {
             dto.offer = offer;
+            return this;
+        }
+
+        public Builder consumerId(String consumerId) {
+            dto.consumerId = consumerId;
+            return this;
+        }
+
+        public Builder providerId(String providerId) {
+            dto.providerId = providerId;
             return this;
         }
 

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/NegotiationInitiateRequestDtoToDataRequestTransformer.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/NegotiationInitiateRequestDtoToDataRequestTransformer.java
@@ -52,9 +52,8 @@ public class NegotiationInitiateRequestDtoToDataRequestTransformer implements Dt
         var contractOffer = ContractOffer.Builder.newInstance()
                 .id(object.getOffer().getOfferId())
                 .asset(Asset.Builder.newInstance().id(object.getOffer().getAssetId()).build())
-                // TODO: this is a workaround for the bug described in https://github.com/eclipse-edc/Connector/issues/753
-                .consumer(URI.create("urn:connector:consumer"))
-                .provider(URI.create("urn:connector:provider"))
+                .consumer(URI.create(object.getConsumerId()))
+                .provider(URI.create(object.getProviderId()))
                 .policy(object.getOffer().getPolicy())
                 .contractStart(now)
                 .contractEnd(now.plusSeconds(object.getOffer().getValidity()))

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerIntegrationTest.java
@@ -214,6 +214,8 @@ class ContractNegotiationApiControllerIntegrationTest {
                 .protocol(TestRemoteMessageDispatcher.TEST_PROTOCOL)
                 .connectorAddress("connectorAddress")
                 .offer(TestFunctions.createOffer())
+                .consumerId("test-consumer")
+                .providerId("test-provider")
                 .build();
 
         baseRequest()

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/model/NegotiationInitiateRequestDtoValidationTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/model/NegotiationInitiateRequestDtoValidationTest.java
@@ -19,7 +19,6 @@ import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -49,15 +48,16 @@ class NegotiationInitiateRequestDtoValidationTest {
         }
     }
 
-    @Test
-    void validate_validDto() {
+    @ParameterizedTest
+    @ArgumentsSource(ProviderConsumerProvider.class)
+    void validate_validDto(String consumer, String provider) {
         var offerDescription = validOffer();
         var dto = NegotiationInitiateRequestDto.Builder.newInstance()
                 .connectorAddress("connectorAddress")
                 .connectorId("connectorId")
                 .protocol("protocol")
-                .consumerId("test-consumer")
-                .providerId("test-provider")
+                .consumerId(consumer)
+                .providerId(provider)
                 .offer(offerDescription)
                 .build();
 
@@ -85,6 +85,20 @@ class NegotiationInitiateRequestDtoValidationTest {
                     Arguments.of("https://connector.com", "", "connector-id", validOffer()),
                     Arguments.of("https://connector.com", "ids-multipart", "connector-id", null),
                     Arguments.of("https://connector.com", "ids-multipart", "", validOffer())
+            );
+        }
+    }
+
+    private static class ProviderConsumerProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                    Arguments.of("urn:connector:consumer", "urn:connector:provider"),
+                    Arguments.of("", "provider"),
+                    Arguments.of(null, "provider"),
+                    Arguments.of("consumer", "provider"),
+                    Arguments.of("consumer", ""),
+                    Arguments.of("consumer", null)
             );
         }
     }

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/model/NegotiationInitiateRequestDtoValidationTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/model/NegotiationInitiateRequestDtoValidationTest.java
@@ -56,6 +56,8 @@ class NegotiationInitiateRequestDtoValidationTest {
                 .connectorAddress("connectorAddress")
                 .connectorId("connectorId")
                 .protocol("protocol")
+                .consumerId("test-consumer")
+                .providerId("test-provider")
                 .offer(offerDescription)
                 .build();
 

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/NegotiationInitiateRequestDtoToDataRequestTransformerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/NegotiationInitiateRequestDtoToDataRequestTransformerTest.java
@@ -31,8 +31,8 @@ class NegotiationInitiateRequestDtoToDataRequestTransformerTest {
 
     private final Instant now = Instant.now();
     private final Clock clock = Clock.fixed(now, UTC);
-    private final TransformerContext context = mock(TransformerContext.class);
     private final NegotiationInitiateRequestDtoToDataRequestTransformer transformer = new NegotiationInitiateRequestDtoToDataRequestTransformer(clock);
+    private final TransformerContext context = mock(TransformerContext.class);
 
     @Test
     void inputOutputType() {
@@ -46,6 +46,8 @@ class NegotiationInitiateRequestDtoToDataRequestTransformerTest {
                 .connectorId("connectorId")
                 .connectorAddress("address")
                 .protocol("protocol")
+                .consumerId("test-consumer")
+                .providerId("test-provider")
                 .offer(createOffer("offerId", "assetId"))
                 .build();
 

--- a/resources/openapi/yaml/management-api/contract-negotiation-api.yaml
+++ b/resources/openapi/yaml/management-api/contract-negotiation-api.yaml
@@ -529,10 +529,8 @@ components:
       required:
       - connectorAddress
       - connectorId
-      - consumerId
       - offer
       - protocol
-      - providerId
     NegotiationState:
       type: object
       example: null

--- a/resources/openapi/yaml/management-api/contract-negotiation-api.yaml
+++ b/resources/openapi/yaml/management-api/contract-negotiation-api.yaml
@@ -515,16 +515,24 @@ components:
         connectorId:
           type: string
           example: null
+        consumerId:
+          type: string
+          example: null
         offer:
           $ref: '#/components/schemas/ContractOfferDescription'
         protocol:
           type: string
           example: null
+        providerId:
+          type: string
+          example: null
       required:
       - connectorAddress
       - connectorId
+      - consumerId
       - offer
       - protocol
+      - providerId
     NegotiationState:
       type: object
       example: null

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/agent/ParticipantAgent.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/agent/ParticipantAgent.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.spi.agent;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
 
@@ -26,9 +27,20 @@ import java.util.Map;
  * claim Region=EU.
  * <p>
  * Claims are verifiable claims presented to the current runtime by the ParticipantAgent system, typically as part of a security token or credential store. Attributes are
- * additional values added by the current system based on
+ * additional values added by the current system based on.
+ * <p>
+ * Participant agents must have an {@link #PARTICIPANT_IDENTITY} attribute set. The value of the attribute is determined using a dataspace-specific mechanism, but it must be from
+ * a trusted source since the value is used to authorize operations such as contract negotiations and data transfers. For example, the identity value may be based on a claim token
+ * or a check against a trusted service. The default behavior is to set the identity using the <code>client_id</code> claim, if present. This behavior can be overridden by using a
+ * {@link ParticipantAgentServiceExtension}.
  */
 public class ParticipantAgent {
+
+    /**
+     * The dataspace participant identity attribute key.
+     */
+    public static final String PARTICIPANT_IDENTITY = "edc:identity";
+
     private final Map<String, Object> claims;
     private final Map<String, String> attributes;
 
@@ -51,5 +63,13 @@ public class ParticipantAgent {
     @NotNull
     public Map<String, String> getAttributes() {
         return attributes;
+    }
+
+    /**
+     * Returns the verified identity of the participant or null if one is not available.
+     */
+    @Nullable
+    public String getIdentity() {
+        return attributes.get(PARTICIPANT_IDENTITY);
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/agent/ParticipantAgentService.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/agent/ParticipantAgentService.java
@@ -22,6 +22,11 @@ import org.eclipse.edc.spi.iam.ClaimToken;
 public interface ParticipantAgentService {
 
     /**
+     * The name of the default identity claim.
+     */
+    String DEFAULT_IDENTITY_CLAIM_KEY = "client_id";
+
+    /**
      * Creates a participant agent.
      */
     ParticipantAgent createFor(ClaimToken token);

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/negotiation/ConsumerContractNegotiationManager.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/negotiation/ConsumerContractNegotiationManager.java
@@ -44,5 +44,5 @@ public interface ConsumerContractNegotiationManager extends ContractNegotiationM
     /**
      * The negotiation has been finalized by the provider.
      */
-    StatusResult<ContractNegotiation> finalized(String negotiationId);
+    StatusResult<ContractNegotiation> finalized(ClaimToken token, String negotiationId);
 }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/negotiation/ProviderContractNegotiationManager.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/negotiation/ProviderContractNegotiationManager.java
@@ -38,5 +38,5 @@ public interface ProviderContractNegotiationManager extends ContractNegotiationM
     /**
      * The negotiation has been verified by the consumer.
      */
-    StatusResult<ContractNegotiation> verified(String negotiationId);
+    StatusResult<ContractNegotiation> verified(ClaimToken token, String negotiationId);
 }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/validation/ContractValidationService.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/validation/ContractValidationService.java
@@ -16,6 +16,7 @@
 package org.eclipse.edc.connector.contract.spi.validation;
 
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.policy.engine.spi.PolicyScope;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
@@ -39,30 +40,42 @@ public interface ContractValidationService {
      *
      * @param token The {@link ClaimToken} of the consumer
      * @param offer The initial {@link ContractOffer} to validate
-     * @return the sanitized version {@link ContractOffer}. The input {@link ContractOffer} could contain some fields or values
-     *         on policy or asset that differs from the original policy and asset defined by the provider, which could cause injection attacks.
-     *         The provider validation should return a new {@link ContractOffer} that contains the original policy and asset defined by the provider.
+     * @return The sanitized version {@link ContractOffer}. The input {@link ContractOffer} could contain some fields or value on policy or asset that differs from the original
+     *     policy and asset defined by the provider, which could cause injection attacks. The provider validation should return a new {@link ContractOffer} that contains the
+     *     original policy and asset defined by the provider.
      */
     @NotNull
     Result<ContractOffer> validateInitialOffer(ClaimToken token, ContractOffer offer);
 
     /**
      * Validates the contract agreement that the consumer referenced in its transfer request.
-     * The {@code ClaimToken} must represent the same counter-party, that is referenced in the contract agreement.
+     * The {@code ClaimToken} must represent the counter-party that is referenced in the contract agreement.
      *
      * @param token The {@link ClaimToken} of the consumer
      * @param agreement The {@link ContractAgreement} between consumer and provider to validate
-     * @return the result of the validation
+     * @return The result of the validation
      */
+    @NotNull
     Result<ContractAgreement> validateAgreement(ClaimToken token, ContractAgreement agreement);
 
     /**
-     * When the negotiation has been confirmed by the provider, the consumer must validate it ensuring that is the same
-     * one that was sent in the last offer
+     * Validates the request for a contract negotiation.
      *
+     * @param token The {@link ClaimToken} of the consumer
+     * @param negotiation The negotiation
+     * @return The result of the validation
+     */
+    @NotNull
+    Result<Void> validateRequest(ClaimToken token, ContractNegotiation negotiation);
+
+    /**
+     * When the negotiation has been confirmed by the provider, the consumer must validate it ensuring that it is the same that was sent in the last offer.
+     *
+     * @param token The {@link ClaimToken} the provider token
      * @param agreement The {@link ContractAgreement} between consumer and provider
      * @param latestOffer The last {@link ContractOffer}
      */
-    Result<Void> validateConfirmed(ContractAgreement agreement, ContractOffer latestOffer);
+    @NotNull
+    Result<Void> validateConfirmed(ClaimToken token, ContractAgreement agreement, ContractOffer latestOffer);
 
 }

--- a/system-tests/azure-tests/src/test/java/org/eclipse/edc/test/system/local/BlobTransferIntegrationTest.java
+++ b/system-tests/azure-tests/src/test/java/org/eclipse/edc/test/system/local/BlobTransferIntegrationTest.java
@@ -73,6 +73,7 @@ public class BlobTransferIntegrationTest extends AbstractAzureBlobTest {
                     "web.http.management.path", CONSUMER_MANAGEMENT_PATH,
                     "web.http.ids.port", String.valueOf(CONSUMER_IDS_API_PORT),
                     "web.http.ids.path", IDS_PATH,
+                    "edc.ids.id", "urn:connector:consumer",
                     "ids.webhook.address", CONSUMER_IDS_API));
 
     @RegisterExtension
@@ -88,6 +89,7 @@ public class BlobTransferIntegrationTest extends AbstractAzureBlobTest {
                     "web.http.management.path", PROVIDER_MANAGEMENT_PATH,
                     "web.http.ids.port", String.valueOf(PROVIDER_IDS_API_PORT),
                     "web.http.ids.path", IDS_PATH,
+                    "edc.ids.id", "urn:connector:provider",
                     "ids.webhook.address", PROVIDER_IDS_API));
 
 

--- a/system-tests/azure-tests/src/testFixtures/java/org/eclipse/edc/test/system/local/BlobTransferConfiguration.java
+++ b/system-tests/azure-tests/src/testFixtures/java/org/eclipse/edc/test/system/local/BlobTransferConfiguration.java
@@ -78,6 +78,8 @@ public class BlobTransferConfiguration implements TransferConfiguration {
 
         return NegotiationInitiateRequestDto.Builder.newInstance()
                 .connectorId("consumer")
+                .consumerId("urn:connector:consumer")
+                .providerId("urn:connector:provider")
                 .connectorAddress(providerIdsUrl)
                 .protocol("ids-multipart")
                 .offer(offerDescription)

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/Participant.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/Participant.java
@@ -128,6 +128,8 @@ public class Participant {
     public String negotiateContract(Participant provider, ContractOffer contractOffer) {
         var request = Map.of(
                 "connectorId", "provider",
+                "consumerId", connectorId.toString(),
+                "providerId", provider.connectorId.toString(),
                 "connectorAddress", provider.idsEndpoint() + "/api/v1/ids/data",
                 "protocol", "ids-multipart",
                 "offer", Map.of(

--- a/system-tests/minikube/values-consumer.yaml
+++ b/system-tests/minikube/values-consumer.yaml
@@ -8,5 +8,6 @@ service:
 edc:
   env:
     IDS_WEBHOOK_ADDRESS: http://consumer-dataspace-connector:8282
+    EDC_IDS_ID: "urn:connector:consumer"
   envSecrets:
     EDC_API_CONTROL_AUTH_APIKEY_VALUE: password

--- a/system-tests/minikube/values-provider.yaml
+++ b/system-tests/minikube/values-provider.yaml
@@ -7,3 +7,4 @@ edc:
     IDS_WEBHOOK_ADDRESS: http://provider-dataspace-connector:8282
     # Use /etc/hosts as a copy source as it is a well-known file
     EDC_TEST_ASSET_PATH: /etc/hosts
+    EDC_IDS_ID: "urn:connector:provider"

--- a/system-tests/tests/src/test/java/org/eclipse/edc/test/system/local/FileTransferEdcRuntime.java
+++ b/system-tests/tests/src/test/java/org/eclipse/edc/test/system/local/FileTransferEdcRuntime.java
@@ -57,6 +57,7 @@ public abstract class FileTransferEdcRuntime {
                     "web.http.management.path", PROVIDER_MANAGEMENT_PATH,
                     "web.http.ids.port", String.valueOf(PROVIDER_IDS_API_PORT),
                     "web.http.ids.path", IDS_PATH,
+                    "edc.ids.id", "urn:connector:provider",
                     "ids.webhook.address", PROVIDER_IDS_API));
     @RegisterExtension
     protected static EdcRuntimeExtension consumer = new EdcRuntimeExtension(
@@ -69,6 +70,7 @@ public abstract class FileTransferEdcRuntime {
                     "web.http.management.path", CONSUMER_MANAGEMENT_PATH,
                     "web.http.ids.port", String.valueOf(CONSUMER_IDS_API_PORT),
                     "web.http.ids.path", IDS_PATH,
+                    "edc.ids.id", "urn:connector:consumer",
                     "ids.webhook.address", CONSUMER_IDS_API));
 
 

--- a/system-tests/tests/src/testFixtures/java/org/eclipse/edc/test/system/utils/FileTransferConfiguration.java
+++ b/system-tests/tests/src/testFixtures/java/org/eclipse/edc/test/system/utils/FileTransferConfiguration.java
@@ -69,6 +69,8 @@ public class FileTransferConfiguration implements TransferConfiguration {
 
         return NegotiationInitiateRequestDto.Builder.newInstance()
                 .connectorId("consumer")
+                .consumerId("urn:connector:consumer")
+                .providerId("urn:connector:provider")
                 .connectorAddress(providerIdsUrl)
                 .protocol("ids-multipart")
                 .offer(offerDescription)


### PR DESCRIPTION
## What this PR changes/adds

This PR adds support for configuring participant identities and verifications against those identities when contract negotiation and transfer process operations are performed.

## Why it does that

See the included documentation.

## Further notes

### Requested change

This PR makes an important change in `ProviderContractNegotiationManagerImpl.requested(ClaimToken token, ContractOfferRequest request)`. Previously, contract negotiations were persisted and transitioned to terminated if the request was invalid. To avoid potential issues, the correct behavior should be to reject the request outright and not store the negotiation. This results in a double state transition we should look at cleaning up in a subsequent PR:

```
transitToRequested(negotiation);

negotiation.addContractOffer(offer);

monitor.debug("[Provider] Contract offer received. Will be approved.");
transitToProviderAgreeing(negotiation);
``` 

### Declined change

Similarly,  `ProviderContractNegotiationManagerImpl.declined(ClaimToken token, String correlationId)` and `ConsumerContractNegotiationManagerImpl. declined(ClaimToken token, String negotiationId)` reject invalid requests outright instead of transitioning the negotiation to terminated.


## Linked Issue(s)

Closes #2631 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
