### PR TITLE
feat(transferProcess): add correlationId to new RemoteMessages and transferProcess

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessEventDispatchTest.java
@@ -123,6 +123,7 @@ public class TransferProcessEventDispatchTest {
         eventRouter.register(TransferProcessEvent.class, eventSubscriber);
 
         var dataRequest = DataRequest.Builder.newInstance()
+                .id("dataRequestId")
                 .assetId("assetId")
                 .destinationType("any")
                 .protocol("test")
@@ -146,6 +147,7 @@ public class TransferProcessEventDispatchTest {
         eventRouter.register(TransferProcessEvent.class, eventSubscriber);
 
         var dataRequest = DataRequest.Builder.newInstance()
+                .id("dataRequestId")
                 .assetId("assetId")
                 .destinationType("any")
                 .protocol("test")

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
@@ -272,6 +272,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
                 .clock(clock)
                 .properties(dataRequest.getProperties())
                 .traceContext(telemetry.getCurrentTraceContext())
+                .correlationId(dataRequest.getId())
                 .build();
 
         observable.invokeForEach(l -> l.preCreated(process));

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
@@ -267,6 +267,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
         var process = TransferProcess.Builder.newInstance()
                 .id(id)
                 .dataRequest(dataRequest)
+                .correlationId(dataRequest.getId())
                 .type(type)
                 .clock(clock)
                 .properties(dataRequest.getProperties())

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
@@ -458,6 +458,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
         var message = TransferStartMessage.Builder.newInstance()
                 .protocol(dataRequest.getProtocol())
                 .connectorAddress(dataRequest.getConnectorAddress()) // TODO: is this correct? it shouldn't be for provider.
+                .correlationId(process.getCorrelationId())
                 .build();
 
         var description = format("Send %s to %s", dataRequest.getClass().getSimpleName(), dataRequest.getConnectorAddress());
@@ -526,6 +527,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
         var message = TransferCompletionMessage.Builder.newInstance()
                 .protocol(dataRequest.getProtocol())
                 .connectorAddress(dataRequest.getConnectorAddress())
+                .correlationId(process.getCorrelationId())
                 .build();
 
         var description =  format("Send %s to %s", dataRequest.getClass().getSimpleName(), dataRequest.getConnectorAddress());
@@ -556,6 +558,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
         var message = TransferTerminationMessage.Builder.newInstance()
                 .connectorAddress(dataRequest.getConnectorAddress())
                 .protocol(dataRequest.getProtocol())
+                .correlationId(process.getCorrelationId())
                 .build();
 
         var description = format("Send %s to %s", dataRequest.getClass().getSimpleName(), dataRequest.getConnectorAddress());

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/transfer/TransferProcessManagerImplTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/transfer/TransferProcessManagerImplTest.java
@@ -918,6 +918,7 @@ class TransferProcessManagerImplTest {
     private TransferProcess.Builder createTransferProcessBuilder(TransferProcessStates inState, boolean managed) {
         var processId = UUID.randomUUID().toString();
         var dataRequest = createDataRequestBuilder()
+                .id("TestId")
                 .processId(processId)
                 .transferType(new TransferType())
                 .protocol("ids-protocol")
@@ -930,6 +931,7 @@ class TransferProcessManagerImplTest {
                 .type(CONSUMER)
                 .id("test-process-" + processId)
                 .state(inState.code())
+                .correlationId(dataRequest.getId())
                 .dataRequest(dataRequest);
     }
 

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/IdsMultipartRemoteMessageDispatcherTest.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/IdsMultipartRemoteMessageDispatcherTest.java
@@ -35,6 +35,7 @@ class IdsMultipartRemoteMessageDispatcherTest {
         var message = TransferStartMessage.Builder.newInstance()
                 .protocol("ids-multipart")
                 .connectorAddress("http://an/address")
+                .correlationId("testId")
                 .build();
 
         var future = dispatcher.send(Object.class, message);
@@ -48,6 +49,7 @@ class IdsMultipartRemoteMessageDispatcherTest {
         var message = TransferCompletionMessage.Builder.newInstance()
                 .protocol("ids-multipart")
                 .connectorAddress("http://an/address")
+                .correlationId("testId")
                 .build();
 
         var future = dispatcher.send(Object.class, message);
@@ -61,6 +63,7 @@ class IdsMultipartRemoteMessageDispatcherTest {
         var message = TransferTerminationMessage.Builder.newInstance()
                 .protocol("ids-multipart")
                 .connectorAddress("http://an/address")
+                .correlationId("testId")
                 .build();
 
         var future = dispatcher.send(Object.class, message);

--- a/extensions/control-plane/api/control-plane-api-client/src/test/java/org/eclipse/edc/connector/api/client/transferprocess/TransferProcessHttpClientIntegrationTest.java
+++ b/extensions/control-plane/api/control-plane-api-client/src/test/java/org/eclipse/edc/connector/api/client/transferprocess/TransferProcessHttpClientIntegrationTest.java
@@ -126,6 +126,7 @@ public class TransferProcessHttpClientIntegrationTest {
                 .id(id)
                 .state(TransferProcessStates.STARTED.code())
                 .type(TransferProcess.Type.PROVIDER)
+                .correlationId("TestId")
                 .dataRequest(DataRequest.Builder.newInstance()
                         .destinationType("file")
                         .protocol("any")

--- a/extensions/control-plane/api/control-plane-api/src/test/java/org/eclipse/edc/connector/api/TransferProcessControlApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/control-plane-api/src/test/java/org/eclipse/edc/connector/api/TransferProcessControlApiControllerIntegrationTest.java
@@ -174,6 +174,7 @@ class TransferProcessControlApiControllerIntegrationTest {
                 .id("tp-id")
                 .state(TransferProcessStates.STARTED.code())
                 .type(TransferProcess.Type.PROVIDER)
+                .correlationId("testCorrelationId")
                 .dataRequest(DataRequest.Builder.newInstance()
                         .destinationType("file")
                         .protocol("protocol")

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/docs/schema.sql
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/docs/schema.sql
@@ -35,7 +35,8 @@ CREATE TABLE IF NOT EXISTS edc_transfer_process
     lease_id                   VARCHAR
         CONSTRAINT transfer_process_lease_lease_id_fk
             REFERENCES edc_lease
-            ON DELETE SET NULL
+            ON DELETE SET NULL,
+    correlation_id             VARCHAR
 );
 
 COMMENT ON COLUMN edc_transfer_process.trace_context IS 'Java Map serialized as JSON';

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/SqlTransferProcessStore.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/SqlTransferProcessStore.java
@@ -254,7 +254,8 @@ public class SqlTransferProcessStore extends AbstractSqlStore implements Transfe
                 toJson(process.getContentDataAddress()),
                 process.getType().toString(),
                 toJson(process.getDeprovisionedResources()),
-                toJson(process.getProperties()));
+                toJson(process.getProperties()),
+                process.getCorrelationId());
 
         //insert DataRequest
         var dr = process.getDataRequest();
@@ -298,6 +299,7 @@ public class SqlTransferProcessStore extends AbstractSqlStore implements Transfe
                 .deprovisionedResources(fromJson(resultSet.getString(statements.getDeprovisionedResourcesColumn()), new TypeReference<>() {
                 }))
                 .properties(fromJson(resultSet.getString(statements.getPropertiesColumn()), getTypeRef()))
+                .correlationId(resultSet.getString(statements.getCorrelationIdColumn()))
                 .build();
     }
 

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/BaseSqlDialectStatements.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/BaseSqlDialectStatements.java
@@ -51,12 +51,13 @@ public abstract class BaseSqlDialectStatements implements TransferProcessStoreSt
 
     @Override
     public String getInsertStatement() {
-        return format("INSERT INTO %s (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) VALUES (?, ?, ?, ?, ?, ?, ?%s, ?, ?%s, ?%s, ?%s, ?, ?%s, ?%s);",
+        return format("INSERT INTO %s (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) VALUES (?, ?, ?, ?, ?, ?, ?%s, ?, ?%s, ?%s, ?%s, ?, ?%s, ?%s, ?);",
                 // keys
                 getTransferProcessTableName(), getIdColumn(), getStateColumn(), getStateCountColumn(), getStateTimestampColumn(),
                 getCreatedAtColumn(), getUpdatedAtColumn(),
                 getTraceContextColumn(), getErrorDetailColumn(), getResourceManifestColumn(),
                 getProvisionedResourcesetColumn(), getContentDataAddressColumn(), getTypeColumn(), getDeprovisionedResourcesColumn(), getPropertiesColumn(),
+                getCorrelationIdColumn(),
                 // values
                 getFormatAsJsonOperator(), getFormatAsJsonOperator(), getFormatAsJsonOperator(), getFormatAsJsonOperator(), getFormatAsJsonOperator(), getFormatAsJsonOperator());
     }

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/TransferProcessStoreStatements.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/TransferProcessStoreStatements.java
@@ -154,6 +154,10 @@ public interface TransferProcessStoreStatements extends LeaseStatements {
         return "deprovisioned_resources";
     }
 
+    default String getCorrelationIdColumn() {
+        return "correlation_id";
+    }
+
     default String getFormatAsJsonOperator() {
         return BaseSqlDialect.getJsonCastOperator();
     }

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/postgres/TransferProcessMapping.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/postgres/TransferProcessMapping.java
@@ -38,6 +38,8 @@ public class TransferProcessMapping extends TranslationMapping {
     private static final String FIELD_PROVISIONED_RESOURCE_SET = "provisionedResourceSet";
     private static final String FIELD_DEPROVISIONED_RESOURCES = "deprovisionedResources";
 
+    private static final String FIELD_CORRELATION_ID = "correlationId";
+
     private static final String FIELD_PROPERTIES = "properties";
 
 
@@ -53,6 +55,7 @@ public class TransferProcessMapping extends TranslationMapping {
         add(FIELD_RESOURCE_MANIFEST, new ResourceManifestMapping());
         add(FIELD_PROPERTIES, new JsonFieldMapping(statements.getPropertiesColumn()));
         add(FIELD_PROVISIONED_RESOURCE_SET, new ProvisionedResourceSetMapping());
+        add(FIELD_CORRELATION_ID, statements.getCorrelationIdColumn());
         // using the alias instead of the actual column name to avoid name clashes.
         add(FIELD_DEPROVISIONED_RESOURCES, new JsonFieldMapping(PostgresDialectStatements.DEPROVISIONED_RESOURCES_ALIAS));
     }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/TransferProcess.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/TransferProcess.java
@@ -143,7 +143,9 @@ public class TransferProcess extends StatefulEntity<TransferProcess> {
         contentDataAddress = dataAddress;
     }
 
-    public String getCorrelationId(){return correlationId;}
+    public String getCorrelationId() {
+        return correlationId;
+    }
 
     public void transitionProvisioning(ResourceManifest manifest) {
         transition(PROVISIONING, INITIAL, PROVISIONING);
@@ -429,7 +431,7 @@ public class TransferProcess extends StatefulEntity<TransferProcess> {
             return this;
         }
 
-        public Builder correlationId(String correlationId){
+        public Builder correlationId(String correlationId) {
             entity.correlationId = correlationId;
             return this;
         }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/TransferProcess.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/TransferProcess.java
@@ -346,6 +346,7 @@ public class TransferProcess extends StatefulEntity<TransferProcess> {
                 .contentDataAddress(contentDataAddress)
                 .deprovisionedResources(deprovisionedResources)
                 .properties(properties)
+                .correlationId(correlationId)
                 .type(type);
         return copy(builder);
     }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/TransferProcess.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/TransferProcess.java
@@ -459,8 +459,6 @@ public class TransferProcess extends StatefulEntity<TransferProcess> {
                 entity.transitionTo(INITIAL.code());
             }
 
-            Objects.requireNonNull(entity.correlationId, "The correlationID must be specified");
-
             return entity;
         }
 

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/TransferProcess.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/TransferProcess.java
@@ -110,6 +110,8 @@ public class TransferProcess extends StatefulEntity<TransferProcess> {
     private List<DeprovisionedResource> deprovisionedResources = new ArrayList<>();
     private Map<String, String> properties = new HashMap<>();
 
+    private String correlationId;
+
     private TransferProcess() {
     }
 
@@ -140,6 +142,8 @@ public class TransferProcess extends StatefulEntity<TransferProcess> {
     public void setContentDataAddress(DataAddress dataAddress) {
         contentDataAddress = dataAddress;
     }
+
+    public String getCorrelationId(){return correlationId;}
 
     public void transitionProvisioning(ResourceManifest manifest) {
         transition(PROVISIONING, INITIAL, PROVISIONING);
@@ -425,6 +429,11 @@ public class TransferProcess extends StatefulEntity<TransferProcess> {
             return this;
         }
 
+        public Builder correlationId(String correlationId){
+            entity.correlationId = correlationId;
+            return this;
+        }
+
         @Override
         public Builder self() {
             return this;
@@ -449,6 +458,8 @@ public class TransferProcess extends StatefulEntity<TransferProcess> {
             if (entity.state == 0) {
                 entity.transitionTo(INITIAL.code());
             }
+
+            Objects.requireNonNull(entity.correlationId, "The correlationID must be specified");
 
             return entity;
         }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferCompletionMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferCompletionMessage.java
@@ -42,7 +42,9 @@ public class TransferCompletionMessage implements RemoteMessage {
         return connectorAddress;
     }
 
-    public String getCorrelationId(){return correlationId;}
+    public String getCorrelationId() {
+        return correlationId;
+    }
 
     @JsonPOJOBuilder(withPrefix = "")
     public static class Builder {
@@ -67,7 +69,7 @@ public class TransferCompletionMessage implements RemoteMessage {
             return this;
         }
 
-        public Builder correlationId(String correlationId){
+        public Builder correlationId(String correlationId) {
             message.correlationId = correlationId;
             return this;
         }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferCompletionMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferCompletionMessage.java
@@ -30,6 +30,8 @@ public class TransferCompletionMessage implements RemoteMessage {
     private String connectorAddress;
     private String protocol;
 
+    private String correlationId;
+
     @Override
     public String getProtocol() {
         return protocol;
@@ -39,6 +41,8 @@ public class TransferCompletionMessage implements RemoteMessage {
     public String getConnectorAddress() {
         return connectorAddress;
     }
+
+    public String getCorrelationId(){return correlationId;}
 
     @JsonPOJOBuilder(withPrefix = "")
     public static class Builder {
@@ -63,9 +67,15 @@ public class TransferCompletionMessage implements RemoteMessage {
             return this;
         }
 
+        public Builder correlationId(String correlationId){
+            message.correlationId = correlationId;
+            return this;
+        }
+
         public TransferCompletionMessage build() {
             Objects.requireNonNull(message.protocol, "The protocol must be specified");
             Objects.requireNonNull(message.connectorAddress, "The connectorAddress must be specified");
+            Objects.requireNonNull(message.correlationId, "The correlationID must be specified");
             return message;
         }
 

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferStartMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferStartMessage.java
@@ -28,6 +28,8 @@ public class TransferStartMessage implements RemoteMessage {
     private String connectorAddress;
     private String protocol;
 
+    private String correlationId;
+
     @Override
     public String getProtocol() {
         return protocol;
@@ -37,6 +39,8 @@ public class TransferStartMessage implements RemoteMessage {
     public String getConnectorAddress() {
         return connectorAddress;
     }
+
+    public String getCorrelationId(){return correlationId;}
 
     @JsonPOJOBuilder(withPrefix = "")
     public static class Builder {
@@ -61,9 +65,15 @@ public class TransferStartMessage implements RemoteMessage {
             return this;
         }
 
+        public Builder correlationId(String correlationId){
+            message.correlationId = correlationId;
+            return this;
+        }
+
         public TransferStartMessage build() {
             Objects.requireNonNull(message.protocol, "The protocol must be specified");
             Objects.requireNonNull(message.connectorAddress, "The connectorAddress must be specified");
+            Objects.requireNonNull(message.correlationId, "The correlationID must be specified");
             return message;
         }
 

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferStartMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferStartMessage.java
@@ -40,7 +40,9 @@ public class TransferStartMessage implements RemoteMessage {
         return connectorAddress;
     }
 
-    public String getCorrelationId(){return correlationId;}
+    public String getCorrelationId() {
+        return correlationId;
+    }
 
     @JsonPOJOBuilder(withPrefix = "")
     public static class Builder {
@@ -65,7 +67,7 @@ public class TransferStartMessage implements RemoteMessage {
             return this;
         }
 
-        public Builder correlationId(String correlationId){
+        public Builder correlationId(String correlationId) {
             message.correlationId = correlationId;
             return this;
         }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferTerminationMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferTerminationMessage.java
@@ -30,6 +30,8 @@ public class TransferTerminationMessage implements RemoteMessage {
     private String connectorAddress;
     private String protocol;
 
+    private String correlationId;
+
     @Override
     public String getProtocol() {
         return protocol;
@@ -39,6 +41,8 @@ public class TransferTerminationMessage implements RemoteMessage {
     public String getConnectorAddress() {
         return connectorAddress;
     }
+
+    public String getCorrelationId(){return correlationId;}
 
     @JsonPOJOBuilder(withPrefix = "")
     public static class Builder {
@@ -63,9 +67,15 @@ public class TransferTerminationMessage implements RemoteMessage {
             return this;
         }
 
+        public Builder correlationId(String correlationId){
+            message.correlationId = correlationId;
+            return this;
+        }
+
         public TransferTerminationMessage build() {
             Objects.requireNonNull(message.protocol, "The protocol must be specified");
             Objects.requireNonNull(message.connectorAddress, "The connectorAddress must be specified");
+            Objects.requireNonNull(message.correlationId, "The correlationID must be specified");
             return message;
         }
 

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferTerminationMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferTerminationMessage.java
@@ -42,7 +42,9 @@ public class TransferTerminationMessage implements RemoteMessage {
         return connectorAddress;
     }
 
-    public String getCorrelationId(){return correlationId;}
+    public String getCorrelationId() {
+        return correlationId;
+    }
 
     @JsonPOJOBuilder(withPrefix = "")
     public static class Builder {
@@ -67,7 +69,7 @@ public class TransferTerminationMessage implements RemoteMessage {
             return this;
         }
 
-        public Builder correlationId(String correlationId){
+        public Builder correlationId(String correlationId) {
             message.correlationId = correlationId;
             return this;
         }


### PR DESCRIPTION
## What this PR changes/adds

Adds correlationId to `TransferCompletionMessage` , `TransferStartMessage` and `TransferTerminationMessage` and adds the value in the `TransferProcessServiceImpl` .

Adds correlationId to `TransferProcess` and adds field in `TransferProcessServiceImpl` . 

The transferProcess-sql-store is expanded with the `correlationId` field. 

## Why it does that

The dataspace protocol delegates needs the `correlationId` for building the URL of the requests. 
 
## Linked Issue(s)

Closes #2636

## Checklist

- [ ] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
