### PR TITLE
fix: cleanup version to fix release

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,14 +22,8 @@ val edcScmConnection: String by project
 val edcWebsiteUrl: String by project
 val edcScmUrl: String by project
 val groupId: String by project
-val defaultVersion: String by project
 val annotationProcessorVersion: String by project
 val metaModelVersion: String by project
-
-var actualVersion: String = (project.findProperty("version") ?: defaultVersion) as String
-if (actualVersion == "unspecified") {
-    actualVersion = defaultVersion
-}
 
 buildscript {
     repositories {
@@ -53,9 +47,7 @@ allprojects {
     configure<org.eclipse.edc.plugins.edcbuild.extensions.BuildExtension> {
         versions {
             // override default dependency versions here
-            projectVersion.set(actualVersion)
             metaModel.set(metaModelVersion)
-
         }
         pom {
             projectName.set(project.name)

--- a/docs/developer/releases.md
+++ b/docs/developer/releases.md
@@ -149,7 +149,7 @@ time of this writing these are the committers of the project._
 
 To trigger a new release please follow these simple steps:
 
-- update `gradle.properties`: set the `defaultVersion` entry to the new version.
+- update `gradle.properties`: set the `version` entry to the new version.
 - trigger the actual release in GitHub:
     - on the `Actions` tab pick the `Create EDC Release` workflow
     - Select the `main` branch

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 groupId=org.eclipse.edc
 javaVersion=11
-defaultVersion=0.0.1-SNAPSHOT
+version=0.0.1-SNAPSHOT
 # for now, we're using the same version for the autodoc plugin, the processor and the runtime-metamodel lib, but that could
 # change in the future
 annotationProcessorVersion=0.0.1-SNAPSHOT

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,6 +20,7 @@ rootProject.name = "connector"
 // this is needed to have access to snapshot builds of plugins
 pluginManagement {
     repositories {
+        mavenLocal()
         maven {
             url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
         }


### PR DESCRIPTION
## What this PR changes/adds

- avoid `defaultVersion`, that's not needed, 
- remove `projectVersion.set(actualVersion)` that's not used anymore
- add `mavenLocal` as repository for plugin management (used in the Release repo for the release process)

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
