### PR TITLE
fix: binary data transfer for `HttpDataSource`

### DIFF
--- a/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSource.java
+++ b/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSource.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       sovity GmbH - fix for binary data transfer
  *
  */
 
@@ -48,19 +49,19 @@ public class HttpDataSource implements DataSource {
         monitor.debug(() -> "HttpDataSource sends request: " + request.toString());
         try (var response = httpClient.execute(request)) {
             var body = response.body();
-            var stringBody = body != null ? body.string() : null;
-            if (stringBody == null) {
+            var bodyBytes = body != null ? body.bytes() : null;
+            if (bodyBytes == null) {
                 throw new EdcException(format("Received empty response body transferring HTTP data for request %s: %s", requestId, response.code()));
             }
             if (response.isSuccessful()) {
-                return new HttpPart(name, stringBody.getBytes());
+                return new HttpPart(name, bodyBytes);
             } else {
-                throw new EdcException(format("Received code transferring HTTP data for request %s: %s - %s. %s", requestId, response.code(), response.message(), stringBody));
+                throw new EdcException(format("Received code transferring HTTP data for request %s: %s - %s. %s", requestId, response.code(), response.message(), new String(bodyBytes)));
             }
         } catch (IOException e) {
             throw new EdcException(e);
         }
-        
+
     }
 
     private HttpDataSource() {


### PR DESCRIPTION
## What this PR changes/adds

Provides a test for transferring binary data using the `HttpDataSource` which currently fails. Furthermore changes the `HttpDataSource` to correctly transmit binary data.

## Why it does that

Currently binary data transfers lead to modified data. Checksums of provided and received data differ.

## Linked Issue(s)

Closes #2646 

## Checklist

- [x] added appropriate tests?
- [ ] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
