### PR TITLE
feat(dsp): add missing notify methods on `ContractNegotiationService`

### DIFF
--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -88,8 +88,10 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
     @WithSpan
     @Override
     public StatusResult<ContractNegotiation> initiate(ContractOfferRequest contractOffer) {
+        var id = UUID.randomUUID().toString();
         var negotiation = ContractNegotiation.Builder.newInstance()
-                .id(UUID.randomUUID().toString())
+                .id(id)
+                .correlationId(id)
                 .protocol(contractOffer.getProtocol())
                 .counterPartyId(contractOffer.getConnectorId())
                 .counterPartyAddress(contractOffer.getConnectorAddress())
@@ -116,8 +118,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
      */
     @WithSpan
     @Override
-    // TODO: should be renamed to agreed
-    public StatusResult<ContractNegotiation> confirmed(ClaimToken token, String negotiationId, ContractAgreement agreement, Policy policy) {
+    public StatusResult<ContractNegotiation> providerAgreed(ClaimToken token, String negotiationId, ContractAgreement agreement, Policy policy) {
         var negotiation = negotiationStore.findById(negotiationId);
         if (negotiation == null) {
             return StatusResult.failure(FATAL_ERROR, format("ContractNegotiation with id %s not found", negotiationId));

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -123,7 +123,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
      */
     @WithSpan
     @Override
-    public StatusResult<ContractNegotiation> requested(ClaimToken token, ContractOfferRequest request) {
+    public StatusResult<ContractNegotiation> consumerRequested(ClaimToken token, ContractOfferRequest request) {
         var offer = request.getContractOffer();
 
         var result = validationService.validateInitialOffer(token, offer);

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
@@ -136,7 +136,7 @@ class ConsumerContractNegotiationManagerImplTest {
                         negotiation.getCounterPartyId().equals(request.getConnectorId()) &&
                         negotiation.getCounterPartyAddress().equals(request.getConnectorAddress()) &&
                         negotiation.getProtocol().equals(request.getProtocol()) &&
-                        negotiation.getCorrelationId() == null &&
+                        negotiation.getCorrelationId().equals(negotiation.getId()) &&
                         negotiation.getContractOffers().size() == 1 &&
                         negotiation.getLastContractOffer().equals(contractOffer))
         );
@@ -149,7 +149,7 @@ class ConsumerContractNegotiationManagerImplTest {
         var contractAgreement = mock(ContractAgreement.class);
         var policy = Policy.Builder.newInstance().build();
 
-        var result = negotiationManager.confirmed(token, "not a valid id", contractAgreement, policy);
+        var result = negotiationManager.providerAgreed(token, "not a valid id", contractAgreement, policy);
 
         assertThat(result.fatalError()).isTrue();
         verify(policyStore, never()).create(any());
@@ -166,7 +166,7 @@ class ConsumerContractNegotiationManagerImplTest {
         when(store.findById(negotiationConsumerRequested.getId())).thenReturn(negotiationConsumerRequested);
         when(validationService.validateConfirmed(eq(token), eq(contractAgreement), any(ContractOffer.class))).thenReturn(Result.success());
 
-        var result = negotiationManager.confirmed(token, negotiationConsumerRequested.getId(), contractAgreement, def.getPolicy());
+        var result = negotiationManager.providerAgreed(token, negotiationConsumerRequested.getId(), contractAgreement, def.getPolicy());
 
         assertThat(result.succeeded()).isTrue();
         verify(store).save(argThat(negotiation ->
@@ -187,7 +187,7 @@ class ConsumerContractNegotiationManagerImplTest {
         when(store.findById(negotiationConsumerRequested.getId())).thenReturn(negotiationConsumerRequested);
         when(validationService.validateConfirmed(eq(token), eq(contractAgreement), any(ContractOffer.class))).thenReturn(Result.failure("failure"));
 
-        var result = negotiationManager.confirmed(token, negotiationConsumerRequested.getId(), contractAgreement, policy);
+        var result = negotiationManager.providerAgreed(token, negotiationConsumerRequested.getId(), contractAgreement, policy);
 
         assertThat(result.succeeded()).isFalse();
         verify(validationService).validateConfirmed(eq(token), eq(contractAgreement), any(ContractOffer.class));

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -27,6 +27,7 @@ import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.contract.spi.validation.ContractValidationService;
 import org.eclipse.edc.connector.defaults.storage.contractnegotiation.InMemoryContractNegotiationStore;
 import org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore;
+import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.policy.model.Action;
 import org.eclipse.edc.policy.model.Duty;
 import org.eclipse.edc.policy.model.Policy;
@@ -65,7 +66,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-//@ComponentTest
+@ComponentTest
 class ContractNegotiationIntegrationTest {
 
     private static final Duration DEFAULT_TEST_TIMEOUT = Duration.ofSeconds(15);
@@ -246,7 +247,7 @@ class ContractNegotiationIntegrationTest {
         return i -> {
             ContractOfferRequest request = i.getArgument(1);
             consumerNegotiationId = request.getCorrelationId();
-            var result = providerManager.requested(token, request);
+            var result = providerManager.consumerRequested(token, request);
             return toFuture(result);
         };
     }
@@ -273,7 +274,7 @@ class ContractNegotiationIntegrationTest {
     private Answer<Object> onProviderSentAgreementRequest() {
         return i -> {
             ContractAgreementRequest request = i.getArgument(1);
-            var result = consumerManager.confirmed(token, request.getCorrelationId(), request.getContractAgreement(), request.getPolicy());
+            var result = consumerManager.providerAgreed(token, request.getCorrelationId(), request.getContractAgreement(), request.getPolicy());
             return toFuture(result);
         };
     }

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
@@ -135,7 +135,7 @@ class ProviderContractNegotiationManagerImplTest {
                 .correlationId("correlationId")
                 .build();
 
-        var result = negotiationManager.requested(token, request);
+        var result = negotiationManager.consumerRequested(token, request);
 
         assertThat(result.succeeded()).isTrue();
         verify(store, atLeastOnce()).save(argThat(n ->
@@ -164,7 +164,7 @@ class ProviderContractNegotiationManagerImplTest {
                 .correlationId("correlationId")
                 .build();
 
-        var result = negotiationManager.requested(token, request);
+        var result = negotiationManager.consumerRequested(token, request);
 
         assertThat(result.succeeded()).isFalse();
         verify(validationService).validateInitialOffer(token, contractOffer);

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/ControlPlaneServicesExtension.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/ControlPlaneServicesExtension.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.service;
 
 import org.eclipse.edc.connector.contract.spi.definition.observe.ContractDefinitionObservableImpl;
 import org.eclipse.edc.connector.contract.spi.negotiation.ConsumerContractNegotiationManager;
+import org.eclipse.edc.connector.contract.spi.negotiation.ProviderContractNegotiationManager;
 import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.connector.contract.spi.offer.store.ContractDefinitionStore;
 import org.eclipse.edc.connector.contract.spi.validation.ContractValidationService;
@@ -83,6 +84,9 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     private ConsumerContractNegotiationManager consumerContractNegotiationManager;
 
     @Inject
+    private ProviderContractNegotiationManager providerContractNegotiationManager;
+
+    @Inject
     private PolicyDefinitionStore policyDefinitionStore;
 
     @Inject
@@ -128,7 +132,7 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
 
     @Provider
     public ContractNegotiationService contractNegotiationService() {
-        return new ContractNegotiationServiceImpl(contractNegotiationStore, consumerContractNegotiationManager, transactionContext);
+        return new ContractNegotiationServiceImpl(contractNegotiationStore, consumerContractNegotiationManager, providerContractNegotiationManager, transactionContext);
     }
 
     @Provider

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
@@ -104,7 +104,7 @@ class ContractNegotiationEventDispatchTest {
         policyDefinitionStore.create(PolicyDefinition.Builder.newInstance().id("policyId").policy(policy).build());
         assetIndex.accept(Asset.Builder.newInstance().id("assetId").build(), DataAddress.Builder.newInstance().type("any").build());
 
-        var result = manager.requested(token, createContractOfferRequest(policy));
+        manager.consumerRequested(token, createContractOfferRequest(policy));
 
         await().untilAsserted(() -> {
             //noinspection unchecked

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/client/MultipartDispatcherIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/client/MultipartDispatcherIntegrationTest.java
@@ -20,7 +20,6 @@ import de.fraunhofer.iais.eis.BaseConnectorBuilder;
 import de.fraunhofer.iais.eis.ContractAgreementBuilder;
 import de.fraunhofer.iais.eis.ContractOfferBuilder;
 import de.fraunhofer.iais.eis.PermissionBuilder;
-import org.eclipse.edc.connector.contract.spi.negotiation.ConsumerContractNegotiationManager;
 import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementRequest;
@@ -29,6 +28,7 @@ import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferReq
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRejection;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.contract.spi.validation.ContractValidationService;
+import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationService;
 import org.eclipse.edc.connector.transfer.spi.types.protocol.TransferRequestMessage;
 import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.junit.extensions.EdcExtension;
@@ -38,15 +38,13 @@ import org.eclipse.edc.protocol.ids.spi.transform.ContractAgreementTransformerOu
 import org.eclipse.edc.protocol.ids.spi.transform.IdsTransformerRegistry;
 import org.eclipse.edc.protocol.ids.spi.types.MessageProtocol;
 import org.eclipse.edc.protocol.ids.util.CalendarUtil;
-import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.service.spi.result.ServiceResult;
 import org.eclipse.edc.spi.asset.AssetIndex;
 import org.eclipse.edc.spi.iam.ClaimToken;
 import org.eclipse.edc.spi.iam.IdentityService;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
-import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.result.Result;
-import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.eclipse.edc.spi.types.domain.metadata.MetadataRequest;
@@ -83,12 +81,10 @@ class MultipartDispatcherIntegrationTest {
     private final IdsTransformerRegistry transformerRegistry = mock(IdsTransformerRegistry.class);
     private final ContractNegotiationStore negotiationStore = mock(ContractNegotiationStore.class);
     private final ContractValidationService validationService = mock(ContractValidationService.class);
-    private final ConsumerContractNegotiationManager consumerContractNegotiationManager = mock(ConsumerContractNegotiationManager.class);
+    private final ContractNegotiationService negotiationService = mock(ContractNegotiationService.class);
 
     @BeforeEach
     void init(EdcExtension extension) {
-        extension.registerSystemExtension(ServiceExtension.class, new TestExtension());
-
         extension.setConfiguration(Map.of(
                 "web.http.port", String.valueOf(PORT),
                 "web.http.path", "/api",
@@ -98,10 +94,17 @@ class MultipartDispatcherIntegrationTest {
                 "ids.webhook.address", "http://webhook"
         ));
 
+        var identityService = mock(IdentityService.class);
+        var tokenResult = TokenRepresentation.Builder.newInstance().token("token").build();
+        var claimToken = ClaimToken.Builder.newInstance().claim("key", "value").build();
+        when(identityService.obtainClientCredentials(any())).thenReturn(Result.success(tokenResult));
+        when(identityService.verifyJwtToken(any(), any())).thenReturn(Result.success(claimToken));
+        extension.registerServiceMock(IdentityService.class, identityService);
+
         extension.registerServiceMock(IdsTransformerRegistry.class, transformerRegistry);
         extension.registerServiceMock(ContractNegotiationStore.class, negotiationStore);
         extension.registerServiceMock(ContractValidationService.class, validationService);
-        extension.registerServiceMock(ConsumerContractNegotiationManager.class, consumerContractNegotiationManager);
+        extension.registerServiceMock(ContractNegotiationService.class, negotiationService);
     }
 
     @Test
@@ -172,6 +175,7 @@ class MultipartDispatcherIntegrationTest {
     void testSendContractRequestMessage(RemoteMessageDispatcherRegistry dispatcher, AssetIndex assetIndex) {
         var contractOffer = contractOffer("id:someId");
         assetIndex.accept(Asset.Builder.newInstance().id("1").build(), DataAddress.Builder.newInstance().type("any").build());
+        when(negotiationService.notifyConsumerRequested(any(), any())).thenReturn(ServiceResult.success(createContractNegotiation("negotiationId")));
         when(transformerRegistry.transform(any(), eq(de.fraunhofer.iais.eis.ContractOffer.class))).thenReturn(Result.success(getIdsContractOffer()));
         when(transformerRegistry.transform(any(), eq(ContractOffer.class))).thenReturn(Result.success(contractOffer));
         when(validationService.validateInitialOffer(any(), any())).thenReturn(Result.success(contractOffer));
@@ -194,16 +198,17 @@ class MultipartDispatcherIntegrationTest {
 
     @Test
     void testSendContractAgreementMessage(RemoteMessageDispatcherRegistry dispatcher) {
+        var policy = Policy.Builder.newInstance().build();
         var contractAgreement = ContractAgreement.Builder.newInstance()
                 .id("1:23456").consumerAgentId("consumer").providerAgentId("provider")
-                .policy(Policy.Builder.newInstance().build())
+                .policy(policy)
                 .assetId(UUID.randomUUID().toString())
                 .build();
         when(transformerRegistry.transform(any(), eq(de.fraunhofer.iais.eis.ContractAgreement.class)))
                 .thenReturn(Result.success(getIdsContractAgreement()));
         when(transformerRegistry.transform(any(), eq(ContractAgreementTransformerOutput.class)))
-                .thenReturn(Result.success(ContractAgreementTransformerOutput.Builder.newInstance().build()));
-        when(consumerContractNegotiationManager.confirmed(any(), any(), any(), any())).thenReturn(StatusResult.success(createContractNegotiation("negotiationId")));
+                .thenReturn(Result.success(ContractAgreementTransformerOutput.Builder.newInstance().contractAgreement(contractAgreement).policy(policy).build()));
+        when(negotiationService.notifyProviderAgreed(any(), any())).thenReturn(ServiceResult.success(createContractNegotiation("negotiationId")));
 
         var request = ContractAgreementRequest.Builder.newInstance()
                 .connectorId(CONNECTOR_ID)
@@ -211,7 +216,7 @@ class MultipartDispatcherIntegrationTest {
                 .protocol(MessageProtocol.IDS_MULTIPART)
                 .contractAgreement(contractAgreement)
                 .correlationId("1")
-                .policy(Policy.Builder.newInstance().build())
+                .policy(policy)
                 .build();
 
         var future = dispatcher.send(null, request);
@@ -223,7 +228,7 @@ class MultipartDispatcherIntegrationTest {
     @Disabled("Proper test data and setup is needed")
     @Test
     void testSendContractRejectionMessage(RemoteMessageDispatcherRegistry dispatcher) {
-        when(consumerContractNegotiationManager.declined(any(), any())).thenReturn(StatusResult.success(createContractNegotiation("negotiationId")));
+        when(negotiationService.notifyTerminated(any(), any())).thenReturn(ServiceResult.success(createContractNegotiation("negotiationId")));
         var rejection = ContractRejection.Builder.newInstance()
                 .connectorId(CONNECTOR_ID)
                 .connectorAddress(getUrl())
@@ -291,15 +296,4 @@ class MultipartDispatcherIntegrationTest {
                 .build();
     }
 
-    public static class TestExtension implements ServiceExtension {
-        @Provider
-        public IdentityService identityService() {
-            var identityService = mock(IdentityService.class);
-            var tokenResult = TokenRepresentation.Builder.newInstance().token("token").build();
-            var claimToken = ClaimToken.Builder.newInstance().claim("key", "value").claim("client_id", "some-client").build();
-            when(identityService.obtainClientCredentials(any())).thenReturn(Result.success(tokenResult));
-            when(identityService.verifyJwtToken(any(), any())).thenReturn(Result.success(claimToken));
-            return identityService;
-        }
-    }
 }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/IdsMultipartApiServiceExtension.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/IdsMultipartApiServiceExtension.java
@@ -18,10 +18,9 @@
 
 package org.eclipse.edc.protocol.ids.api.multipart;
 
-import org.eclipse.edc.connector.contract.spi.negotiation.ConsumerContractNegotiationManager;
-import org.eclipse.edc.connector.contract.spi.negotiation.ProviderContractNegotiationManager;
 import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.connector.contract.spi.offer.ContractOfferResolver;
+import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationService;
 import org.eclipse.edc.connector.spi.transferprocess.TransferProcessService;
 import org.eclipse.edc.connector.transfer.spi.edr.EndpointDataReferenceReceiverRegistry;
 import org.eclipse.edc.connector.transfer.spi.edr.EndpointDataReferenceTransformerRegistry;
@@ -87,12 +86,6 @@ public final class IdsMultipartApiServiceExtension implements ServiceExtension {
     private ContractNegotiationStore contractNegotiationStore;
 
     @Inject
-    private ConsumerContractNegotiationManager consumerNegotiationManager;
-
-    @Inject
-    private ProviderContractNegotiationManager providerNegotiationManager;
-
-    @Inject
     private EndpointDataReferenceReceiverRegistry endpointDataReferenceReceiverRegistry;
 
     @Inject
@@ -110,6 +103,9 @@ public final class IdsMultipartApiServiceExtension implements ServiceExtension {
     @Inject
     private TypeManager typeManager;
 
+    @Inject
+    private ContractNegotiationService contractNegotiationService;
+
     @Override
     public String name() {
         return NAME;
@@ -125,16 +121,14 @@ public final class IdsMultipartApiServiceExtension implements ServiceExtension {
 
         var objectMapper = typeManager.getMapper("ids");
 
-        // create request handlers
         var handlers = new LinkedList<Handler>();
         handlers.add(new DescriptionRequestHandler(monitor, connectorId, transformerRegistry, assetIndex, dataCatalogService, contractOfferResolver, connectorService, objectMapper));
         handlers.add(new ArtifactRequestHandler(monitor, connectorId, objectMapper, contractNegotiationStore, vault, transferProcessService));
         handlers.add(new EndpointDataReferenceHandler(monitor, connectorId, endpointDataReferenceReceiverRegistry, endpointDataReferenceTransformerRegistry, typeManager));
-        handlers.add(new ContractRequestHandler(monitor, connectorId, objectMapper, providerNegotiationManager, transformerRegistry, assetIndex));
-        handlers.add(new ContractAgreementHandler(monitor, connectorId, objectMapper, consumerNegotiationManager, transformerRegistry));
-        handlers.add(new ContractRejectionHandler(monitor, connectorId, providerNegotiationManager, consumerNegotiationManager));
+        handlers.add(new ContractRequestHandler(monitor, connectorId, objectMapper, transformerRegistry, assetIndex, contractNegotiationService));
+        handlers.add(new ContractAgreementHandler(monitor, connectorId, objectMapper, transformerRegistry, contractNegotiationService));
+        handlers.add(new ContractRejectionHandler(monitor, connectorId, contractNegotiationService));
 
-        // create & register controller
         var multipartController = new MultipartController(monitor, connectorId, objectMapper, dynamicAttributeTokenService, handlers, idsApiConfiguration.getIdsWebhookAddress());
         webService.registerResource(idsApiConfiguration.getContextAlias(), multipartController);
     }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/handler/ContractAgreementHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/handler/ContractAgreementHandler.java
@@ -17,12 +17,14 @@ package org.eclipse.edc.protocol.ids.api.multipart.handler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.fraunhofer.iais.eis.ContractAgreement;
 import de.fraunhofer.iais.eis.ContractAgreementMessage;
-import org.eclipse.edc.connector.contract.spi.negotiation.ConsumerContractNegotiationManager;
+import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementRequest;
+import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationService;
 import org.eclipse.edc.protocol.ids.api.multipart.message.MultipartRequest;
 import org.eclipse.edc.protocol.ids.api.multipart.message.MultipartResponse;
 import org.eclipse.edc.protocol.ids.spi.transform.ContractAgreementTransformerOutput;
 import org.eclipse.edc.protocol.ids.spi.transform.IdsTransformerRegistry;
 import org.eclipse.edc.protocol.ids.spi.types.IdsId;
+import org.eclipse.edc.protocol.ids.spi.types.MessageProtocol;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.jetbrains.annotations.NotNull;
 
@@ -30,7 +32,7 @@ import java.io.IOException;
 
 import static org.eclipse.edc.protocol.ids.api.multipart.util.ResponseUtil.badParameters;
 import static org.eclipse.edc.protocol.ids.api.multipart.util.ResponseUtil.createMultipartResponse;
-import static org.eclipse.edc.protocol.ids.api.multipart.util.ResponseUtil.processedFromStatusResult;
+import static org.eclipse.edc.protocol.ids.api.multipart.util.ResponseUtil.processedFromServiceResult;
 
 /**
  * This class handles and processes incoming IDS {@link ContractAgreementMessage}s.
@@ -40,20 +42,17 @@ public class ContractAgreementHandler implements Handler {
     private final Monitor monitor;
     private final ObjectMapper objectMapper;
     private final IdsId connectorId;
-    private final ConsumerContractNegotiationManager negotiationManager;
     private final IdsTransformerRegistry transformerRegistry;
+    private final ContractNegotiationService contractNegotiationService;
 
     public ContractAgreementHandler(
-            @NotNull Monitor monitor,
-            @NotNull IdsId connectorId,
-            @NotNull ObjectMapper objectMapper,
-            @NotNull ConsumerContractNegotiationManager negotiationManager,
-            @NotNull IdsTransformerRegistry transformerRegistry) {
+            Monitor monitor, IdsId connectorId, ObjectMapper objectMapper,
+            IdsTransformerRegistry transformerRegistry, ContractNegotiationService contractNegotiationService) {
         this.monitor = monitor;
         this.connectorId = connectorId;
         this.objectMapper = objectMapper;
-        this.negotiationManager = negotiationManager;
         this.transformerRegistry = transformerRegistry;
+        this.contractNegotiationService = contractNegotiationService;
     }
 
     @Override
@@ -74,7 +73,6 @@ public class ContractAgreementHandler implements Handler {
             return createMultipartResponse(badParameters(message, connectorId));
         }
 
-        // extract target from contract request
         var permission = contractAgreement.getPermission().get(0);
         if (permission == null) {
             monitor.debug("ContractAgreementHandler: Contract Agreement is invalid");
@@ -87,13 +85,20 @@ public class ContractAgreementHandler implements Handler {
             return createMultipartResponse(badParameters(message, connectorId));
         }
 
-        // TODO get hash from message
         var output = result.getContent();
-        var processId = message.getTransferContract();
-        var negotiationConfirmResult = negotiationManager.confirmed(claimToken,
-                String.valueOf(processId), output.getContractAgreement(), output.getPolicy());
 
-        return createMultipartResponse(processedFromStatusResult(negotiationConfirmResult, message, connectorId));
+        var request = ContractAgreementRequest.Builder.newInstance()
+                .protocol(MessageProtocol.IDS_MULTIPART)
+                .connectorId(String.valueOf(message.getIssuerConnector()))
+                .connectorAddress("") // this will be used by DSP
+                .contractAgreement(output.getContractAgreement())
+                .correlationId(String.valueOf(message.getTransferContract()))
+                .policy(output.getPolicy())
+                .build();
+
+        var negotiationConfirmResult = contractNegotiationService.notifyProviderAgreed(request, claimToken);
+
+        return createMultipartResponse(processedFromServiceResult(negotiationConfirmResult, message, connectorId));
     }
 
 }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/handler/ContractRequestHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/handler/ContractRequestHandler.java
@@ -18,9 +18,9 @@ package org.eclipse.edc.protocol.ids.api.multipart.handler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.fraunhofer.iais.eis.ContractRequest;
 import de.fraunhofer.iais.eis.ContractRequestMessage;
-import org.eclipse.edc.connector.contract.spi.negotiation.ProviderContractNegotiationManager;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferRequest;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
+import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationService;
 import org.eclipse.edc.protocol.ids.api.multipart.message.MultipartRequest;
 import org.eclipse.edc.protocol.ids.api.multipart.message.MultipartResponse;
 import org.eclipse.edc.protocol.ids.spi.transform.ContractTransformerInput;
@@ -29,14 +29,13 @@ import org.eclipse.edc.protocol.ids.spi.types.IdsId;
 import org.eclipse.edc.protocol.ids.spi.types.MessageProtocol;
 import org.eclipse.edc.spi.asset.AssetIndex;
 import org.eclipse.edc.spi.monitor.Monitor;
-import org.eclipse.edc.spi.result.Result;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 
 import static org.eclipse.edc.protocol.ids.api.multipart.util.ResponseUtil.badParameters;
 import static org.eclipse.edc.protocol.ids.api.multipart.util.ResponseUtil.createMultipartResponse;
-import static org.eclipse.edc.protocol.ids.api.multipart.util.ResponseUtil.inProcessFromStatusResult;
+import static org.eclipse.edc.protocol.ids.api.multipart.util.ResponseUtil.inProcessFromServiceResult;
 import static org.eclipse.edc.protocol.ids.spi.domain.IdsConstants.IDS_WEBHOOK_ADDRESS_PROPERTY;
 
 /**
@@ -47,23 +46,20 @@ public class ContractRequestHandler implements Handler {
     private final Monitor monitor;
     private final ObjectMapper objectMapper;
     private final IdsId connectorId;
-    private final ProviderContractNegotiationManager negotiationManager;
     private final IdsTransformerRegistry transformerRegistry;
     private final AssetIndex assetIndex;
+    private final ContractNegotiationService contractNegotiationService;
 
     public ContractRequestHandler(
-            @NotNull Monitor monitor,
-            @NotNull IdsId connectorId,
-            @NotNull ObjectMapper objectMapper,
-            @NotNull ProviderContractNegotiationManager negotiationManager,
-            @NotNull IdsTransformerRegistry transformerRegistry,
-            @NotNull AssetIndex assetIndex) {
+            Monitor monitor, IdsId connectorId, ObjectMapper objectMapper,
+            IdsTransformerRegistry transformerRegistry,
+            AssetIndex assetIndex, ContractNegotiationService contractNegotiationService) {
         this.monitor = monitor;
         this.connectorId = connectorId;
         this.objectMapper = objectMapper;
-        this.negotiationManager = negotiationManager;
         this.transformerRegistry = transformerRegistry;
         this.assetIndex = assetIndex;
+        this.contractNegotiationService = contractNegotiationService;
     }
 
     @Override
@@ -84,7 +80,6 @@ public class ContractRequestHandler implements Handler {
             return createMultipartResponse(badParameters(message, connectorId));
         }
 
-        // Get webhook address of requesting connector from message properties
         var idsWebhookAddress = message.getProperties().get(IDS_WEBHOOK_ADDRESS_PROPERTY);
         if (idsWebhookAddress == null || idsWebhookAddress.toString().isBlank()) {
             var msg = "Ids webhook address is invalid";
@@ -92,7 +87,6 @@ public class ContractRequestHandler implements Handler {
             return createMultipartResponse(badParameters(message, connectorId), msg);
         }
 
-        // extract target from contract request
         var permission = contractRequest.getPermission().stream().findFirst().orElse(null);
         if (permission == null) {
             monitor.debug("ContractRequestHandler: Contract Request is invalid");
@@ -105,7 +99,6 @@ public class ContractRequestHandler implements Handler {
             return createMultipartResponse(badParameters(message, connectorId));
         }
 
-        // search for matching asset
         var assetResult = IdsId.from(String.valueOf(target));
         if (assetResult.failed()) {
             var msg = "Target id is missing";
@@ -121,13 +114,12 @@ public class ContractRequestHandler implements Handler {
             return createMultipartResponse(badParameters(message, connectorId), msg);
         }
 
-        // Create contract offer request
         var input = ContractTransformerInput.Builder.newInstance()
                 .contract(contractRequest)
                 .asset(asset)
                 .build();
 
-        Result<ContractOffer> result = transformerRegistry.transform(input, ContractOffer.class);
+        var result = transformerRegistry.transform(input, ContractOffer.class);
         if (result.failed()) {
             monitor.debug(String.format("Could not transform contract request: [%s]",
                     String.join(", ", result.getFailureMessages())));
@@ -144,10 +136,8 @@ public class ContractRequestHandler implements Handler {
                 .contractOffer(contractOffer)
                 .build();
 
-        //TODO use ContractNegotiationService for initiation after project structure review
+        var negotiationInitiateResult = contractNegotiationService.notifyConsumerRequested(requestObj, claimToken);
 
-        var negotiationInitiateResult = negotiationManager.requested(claimToken, requestObj);
-
-        return createMultipartResponse(inProcessFromStatusResult(negotiationInitiateResult, message, connectorId));
+        return createMultipartResponse(inProcessFromServiceResult(negotiationInitiateResult, message, connectorId));
     }
 }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/util/ResponseUtil.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/util/ResponseUtil.java
@@ -220,6 +220,31 @@ public class ResponseUtil {
     }
 
     /**
+     * Creates a response message depending on the status result of a previously executed action.
+     * Returns a MessageProcessedNotificationMessage, if the result is succeeded and a rejection message otherwise.
+     * The rejection reason is BAD_PARAMETERS if the action can be retried and INTERNAL_RECIPIENT_ERROR
+     * for a fatal error.
+     *
+     * @param statusResult the status result.
+     * @param correlationMessage the request.
+     * @param connectorId the connector ID.
+     * @return the response message depending on the status result.
+     */
+    public static Message processedFromServiceResult(@NotNull ServiceResult<?> statusResult,
+                                                    @NotNull Message correlationMessage,
+                                                    @NotNull IdsId connectorId) {
+        if (statusResult.succeeded()) {
+            return messageProcessedNotification(correlationMessage, connectorId);
+        } else {
+            if (statusResult.reason() == ServiceFailure.Reason.BAD_REQUEST) {
+                return badParameters(correlationMessage, connectorId);
+            } else {
+                return internalRecipientError(correlationMessage, connectorId);
+            }
+        }
+    }
+
+    /**
      * Creates a rejection message with reason NOT_FOUND.
      *
      * @param correlationMessage the request.

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/MultipartControllerIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/MultipartControllerIntegrationTest.java
@@ -42,11 +42,10 @@ import okhttp3.MultipartReader;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
-import org.eclipse.edc.connector.contract.spi.negotiation.ConsumerContractNegotiationManager;
-import org.eclipse.edc.connector.contract.spi.negotiation.ProviderContractNegotiationManager;
 import org.eclipse.edc.connector.contract.spi.offer.ContractOfferResolver;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
+import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationService;
 import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.junit.extensions.EdcExtension;
 import org.eclipse.edc.policy.model.Action;
@@ -59,12 +58,12 @@ import org.eclipse.edc.protocol.ids.spi.types.IdsId;
 import org.eclipse.edc.protocol.ids.spi.types.IdsType;
 import org.eclipse.edc.protocol.ids.util.CalendarUtil;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.service.spi.result.ServiceResult;
 import org.eclipse.edc.spi.asset.AssetIndex;
 import org.eclipse.edc.spi.http.EdcHttpClient;
 import org.eclipse.edc.spi.iam.ClaimToken;
 import org.eclipse.edc.spi.iam.IdentityService;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
-import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.types.TypeManager;
@@ -107,10 +106,7 @@ class MultipartControllerIntegrationTest {
     private final ObjectMapper objectMapper = getCustomizedObjectMapper();
 
     private final ContractOfferResolver contractOfferResolver = mock(ContractOfferResolver.class);
-    private final ConsumerContractNegotiationManager consumerContractNegotiationManager =
-            mock(ConsumerContractNegotiationManager.class);
-    private final ProviderContractNegotiationManager providerContractNegotiationManager =
-            mock(ProviderContractNegotiationManager.class);
+    private final ContractNegotiationService service = mock(ContractNegotiationService.class);
 
     @BeforeEach
     void init(EdcExtension extension) {
@@ -125,8 +121,7 @@ class MultipartControllerIntegrationTest {
 
         extension.registerSystemExtension(ServiceExtension.class, new TestExtension());
         extension.registerServiceMock(ContractOfferResolver.class, contractOfferResolver);
-        extension.registerServiceMock(ProviderContractNegotiationManager.class, providerContractNegotiationManager);
-        extension.registerServiceMock(ConsumerContractNegotiationManager.class, consumerContractNegotiationManager);
+        extension.registerServiceMock(ContractNegotiationService.class, service);
     }
 
     @Test
@@ -601,7 +596,7 @@ class MultipartControllerIntegrationTest {
 
     @Test
     void testHandleContractRequest(EdcHttpClient httpClient, AssetIndex assetIndex) throws Exception {
-        when(providerContractNegotiationManager.requested(any(), any())).thenReturn(StatusResult.success(createContractNegotiation("id")));
+        when(service.notifyConsumerRequested(any(), any())).thenReturn(ServiceResult.success(createContractNegotiation("id")));
         var assetId = "1234";
         var request = createRequestWithPayload(getContractRequestMessage(),
                 new ContractRequestBuilder(URI.create("urn:contractrequest:2345"))
@@ -662,7 +657,7 @@ class MultipartControllerIntegrationTest {
                         .build());
         var asset = Asset.Builder.newInstance().id(assetId).build();
         assetIndex.accept(asset, DataAddress.Builder.newInstance().type("test").build());
-        when(consumerContractNegotiationManager.confirmed(any(), any(), any(), any())).thenReturn(StatusResult.success(createContractNegotiation("id")));
+        when(service.notifyProviderAgreed(any(), any())).thenReturn(ServiceResult.success(createContractNegotiation("id")));
 
         var response = httpClient.execute(request);
 
@@ -694,12 +689,12 @@ class MultipartControllerIntegrationTest {
         });
         jsonHeader.inPath("$.ids:issuerConnector.@id").isString().isEqualTo("urn:connector:" + CONNECTOR_ID);
         jsonHeader.inPath("$.ids:senderAgent.@id").isString().isEqualTo("urn:connector:" + CONNECTOR_ID);
-        verify(consumerContractNegotiationManager).confirmed(any(), any(), argThat(agreement -> assetId.equals(agreement.getAssetId())), any());
+        verify(service).notifyProviderAgreed(argThat(message -> assetId.equals(message.getContractAgreement().getAssetId())), any());
     }
 
     @Test
     void testHandleContractRejection(EdcHttpClient httpClient) throws Exception {
-        when(providerContractNegotiationManager.declined(any(), any())).thenReturn(StatusResult.success(createContractNegotiation("id")));
+        when(service.notifyTerminated(any(), any())).thenReturn(ServiceResult.success(createContractNegotiation("id")));
         var request = createRequest(getContractRejectionMessage());
 
         var response = httpClient.execute(request);

--- a/spi/common/aggregate-service-spi/src/main/java/org/eclipse/edc/service/spi/result/ServiceResult.java
+++ b/spi/common/aggregate-service-spi/src/main/java/org/eclipse/edc/service/spi/result/ServiceResult.java
@@ -23,7 +23,7 @@ import static org.eclipse.edc.service.spi.result.ServiceFailure.Reason.BAD_REQUE
 import static org.eclipse.edc.service.spi.result.ServiceFailure.Reason.CONFLICT;
 import static org.eclipse.edc.service.spi.result.ServiceFailure.Reason.NOT_FOUND;
 
-public class ServiceResult<T> extends AbstractResult<T, ServiceFailure> {
+public class ServiceResult<T> extends AbstractResult<T, ServiceFailure, ServiceResult<T>> {
 
     protected ServiceResult(T content, ServiceFailure failure) {
         super(content, failure);

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/message/RemoteMessageDispatcherRegistry.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/message/RemoteMessageDispatcherRegistry.java
@@ -22,7 +22,7 @@ import java.util.concurrent.CompletableFuture;
 /**
  * Binds and sends remote messages using a {@link RemoteMessageDispatcher}.
  * The registry may support multiple protocols and communication patterns, for example HTTP-based and classic message-oriented variants. Consequently, some protocols may be
- * non-blocking, others my be synchronous request-response.
+ * non-blocking, others may be synchronous request-response.
  */
 @ExtensionPoint
 public interface RemoteMessageDispatcherRegistry {

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/response/StatusResult.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/response/StatusResult.java
@@ -22,7 +22,7 @@ import java.util.List;
 import static org.eclipse.edc.spi.response.ResponseStatus.FATAL_ERROR;
 
 
-public class StatusResult<T> extends AbstractResult<T, ResponseFailure> {
+public class StatusResult<T> extends AbstractResult<T, ResponseFailure, StatusResult<T>> {
 
     public static StatusResult<Void> success() {
         return new StatusResult<>(null, null);

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/AbstractResult.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/AbstractResult.java
@@ -29,7 +29,7 @@ import java.util.function.Function;
  * @param <F> The type of {@link Failure}.
  * @param <T> The type of the content
  */
-public abstract class AbstractResult<T, F extends Failure> {
+public abstract class AbstractResult<T, F extends Failure, R extends AbstractResult<T, F, R>> {
 
     private final T content;
     private final F failure;
@@ -74,7 +74,7 @@ public abstract class AbstractResult<T, F extends Failure> {
     /**
      * Executes a {@link Consumer} if this {@link Result} is successful
      */
-    public AbstractResult<T, F> onSuccess(Consumer<T> successAction) {
+    public AbstractResult<T, F, R> onSuccess(Consumer<T> successAction) {
         if (succeeded()) {
             successAction.accept(getContent());
         }
@@ -84,7 +84,7 @@ public abstract class AbstractResult<T, F extends Failure> {
     /**
      * Executes a {@link Consumer} if this {@link Result} failed. Passes the {@link Failure} to the consumer
      */
-    public AbstractResult<T, F> onFailure(Consumer<F> failureAction) {
+    public AbstractResult<T, F, R> onFailure(Consumer<F> failureAction) {
         if (failed()) {
             failureAction.accept(getFailure());
         }
@@ -94,7 +94,7 @@ public abstract class AbstractResult<T, F extends Failure> {
     /**
      * Alias for {@link AbstractResult#onFailure(Consumer)} to make code a bit more easily readable.
      */
-    public AbstractResult<T, F> orElse(Consumer<F> failureAction) {
+    public AbstractResult<T, F, R> orElse(Consumer<F> failureAction) {
         return onFailure(failureAction);
     }
 
@@ -124,6 +124,20 @@ public abstract class AbstractResult<T, F extends Failure> {
         } else {
             return getContent();
         }
+    }
+
+    /**
+     * Maps one result into another, applying the mapping function.
+     *
+     * @param mappingFunction a function converting this result into another
+     * @return the result of the mapping function
+     */
+    public <T2, F2 extends Failure, R2 extends AbstractResult<T2, F2, R2>> R2 flatMap(Function<R, R2> mappingFunction) {
+        return mappingFunction.apply(self());
+    }
+
+    public R self() {
+        return (R) this;
     }
 
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/Result.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/Result.java
@@ -28,7 +28,7 @@ import static java.util.Optional.of;
 /**
  * A generic result type.
  */
-public class Result<T> extends AbstractResult<T, Failure> {
+public class Result<T> extends AbstractResult<T, Failure, Result<T>> {
 
     private Result(T content, Failure failure) {
         super(content, failure);
@@ -124,16 +124,6 @@ public class Result<T> extends AbstractResult<T, Failure> {
      */
     public <R> Result<R> mapTo(Class<R> clazz) {
         return mapTo();
-    }
-
-    /**
-     * Maps one result into another, applying the mapping function.
-     *
-     * @param mappingFunction a function converting this result into another
-     * @return the result of the mapping function
-     */
-    public <U> Result<U> flatMap(Function<Result<T>, Result<U>> mappingFunction) {
-        return mappingFunction.apply(this);
     }
 
     /**

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/StoreResult.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/StoreResult.java
@@ -24,7 +24,7 @@ import static org.eclipse.edc.spi.result.StoreFailure.Reason.NOT_FOUND;
  *
  * @param <T> The type of content
  */
-public class StoreResult<T> extends AbstractResult<T, StoreFailure> {
+public class StoreResult<T> extends AbstractResult<T, StoreFailure, StoreResult<T>> {
 
     protected StoreResult(T content, StoreFailure failure) {
         super(content, failure);

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/system/health/HealthCheckResult.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/system/health/HealthCheckResult.java
@@ -26,7 +26,7 @@ import java.util.stream.Stream;
 /**
  * Represents the result of one single health check, like a heartbeat to a database or to a messaging service.
  */
-public class HealthCheckResult extends AbstractResult<Boolean, Failure> {
+public class HealthCheckResult extends AbstractResult<Boolean, Failure, HealthCheckResult> {
     private String component;
 
     private HealthCheckResult(boolean successful, Failure failure) {

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/negotiation/ConsumerContractNegotiationManager.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/negotiation/ConsumerContractNegotiationManager.java
@@ -37,9 +37,9 @@ public interface ConsumerContractNegotiationManager extends ContractNegotiationM
     StatusResult<ContractNegotiation> initiate(ContractOfferRequest contractOffer);
 
     /**
-     * The negotiation has been confirmed by the provider and the final contract received.
+     * The negotiation has been agreed by the provider.
      */
-    StatusResult<ContractNegotiation> confirmed(ClaimToken token, String negotiationId, ContractAgreement agreement, Policy policy);
+    StatusResult<ContractNegotiation> providerAgreed(ClaimToken token, String negotiationId, ContractAgreement agreement, Policy policy);
 
     /**
      * The negotiation has been finalized by the provider.

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/negotiation/ProviderContractNegotiationManager.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/negotiation/ProviderContractNegotiationManager.java
@@ -33,7 +33,7 @@ public interface ProviderContractNegotiationManager extends ContractNegotiationM
     /**
      * A contract negotiation has been requested by the consumer represented with the given claims.
      */
-    StatusResult<ContractNegotiation> requested(ClaimToken token, ContractOfferRequest request);
+    StatusResult<ContractNegotiation> consumerRequested(ClaimToken token, ContractOfferRequest request);
 
     /**
      * The negotiation has been verified by the consumer.

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/contractnegotiation/ContractNegotiationService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/contractnegotiation/ContractNegotiationService.java
@@ -15,9 +15,14 @@
 package org.eclipse.edc.connector.spi.contractnegotiation;
 
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
+import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementRequest;
+import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementVerificationMessage;
+import org.eclipse.edc.connector.contract.spi.types.agreement.ContractNegotiationEventMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferRequest;
+import org.eclipse.edc.connector.transfer.spi.types.protocol.TransferTerminationMessage;
 import org.eclipse.edc.service.spi.result.ServiceResult;
+import org.eclipse.edc.spi.iam.ClaimToken;
 import org.eclipse.edc.spi.query.QuerySpec;
 
 import java.util.stream.Stream;
@@ -80,4 +85,73 @@ public interface ContractNegotiationService {
      * @return successful result if the contract negotiation is declined correctly, failure otherwise
      */
     ServiceResult<ContractNegotiation> decline(String negotiationId);
+
+    /**
+     * Notifies the ContractNegotiation that it has been requested by the consumer.
+     * Only callable on provider ContractNegotiation.
+     *
+     * @param message the incoming message
+     * @param claimToken the counter-party claim token
+     * @return a succeeded result if the operation was successful, a failed one otherwise
+     */
+    ServiceResult<ContractNegotiation> notifyConsumerRequested(ContractOfferRequest message, ClaimToken claimToken);
+
+    /**
+     * Notifies the ContractNegotiation that it has been offered by the provider.
+     * Only callable on consumer ContractNegotiation.
+     *
+     * @param message the incoming message
+     * @param claimToken the counter-party claim token
+     * @return a succeeded result if the operation was successful, a failed one otherwise
+     */
+    ServiceResult<ContractNegotiation> notifyProviderOffered(ContractOfferRequest message, ClaimToken claimToken);
+
+    /**
+     * Notifies the ContractNegotiation that it has been agreed by the consumer.
+     * Only callable on provider ContractNegotiation.
+     *
+     * @param message the incoming message
+     * @param claimToken the counter-party claim token
+     * @return a succeeded result if the operation was successful, a failed one otherwise
+     */
+    ServiceResult<ContractNegotiation> notifyConsumerAgreed(ContractNegotiationEventMessage message, ClaimToken claimToken);
+
+    /**
+     * Notifies the ContractNegotiation that it has been agreed by the provider.
+     * Only callable on consumer ContractNegotiation.
+     *
+     * @param message the incoming message
+     * @param claimToken the counter-party claim token
+     * @return a succeeded result if the operation was successful, a failed one otherwise
+     */
+    ServiceResult<ContractNegotiation> notifyProviderAgreed(ContractAgreementRequest message, ClaimToken claimToken);
+
+    /**
+     * Notifies the ContractNegotiation that it has been verified by the consumer.
+     * Only callable on provider ContractNegotiation.
+     *
+     * @param message the incoming message
+     * @param claimToken the counter-party claim token
+     * @return a succeeded result if the operation was successful, a failed one otherwise
+     */
+    ServiceResult<ContractNegotiation> notifyConsumerVerified(ContractAgreementVerificationMessage message, ClaimToken claimToken);
+
+    /**
+     * Notifies the ContractNegotiation that it has been finalized by the provider.
+     * Only callable on consumer ContractNegotiation.
+     *
+     * @param message the incoming message
+     * @param claimToken the counter-party claim token
+     * @return a succeeded result if the operation was successful, a failed one otherwise
+     */
+    ServiceResult<ContractNegotiation> notifyProviderFinalized(ContractNegotiationEventMessage message, ClaimToken claimToken);
+
+    /**
+     * Notifies the ContractNegotiation that it has been terminated by the counter-part.
+     *
+     * @param message the incoming message
+     * @param claimToken the counter-party claim token
+     * @return a succeeded result if the operation was successful, a failed one otherwise
+     */
+    ServiceResult<ContractNegotiation> notifyTerminated(TransferTerminationMessage message, ClaimToken claimToken);
 }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferTerminationMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferTerminationMessage.java
@@ -29,6 +29,7 @@ public class TransferTerminationMessage implements RemoteMessage {
 
     private String connectorAddress;
     private String protocol;
+    private String processId;
 
     @Override
     public String getProtocol() {
@@ -38,6 +39,10 @@ public class TransferTerminationMessage implements RemoteMessage {
     @Override
     public String getConnectorAddress() {
         return connectorAddress;
+    }
+
+    public String getProcessId() {
+        return processId;
     }
 
     @JsonPOJOBuilder(withPrefix = "")
@@ -60,6 +65,11 @@ public class TransferTerminationMessage implements RemoteMessage {
 
         public Builder protocol(String protocol) {
             message.protocol = protocol;
+            return this;
+        }
+
+        public Builder processId(String processId) {
+            message.processId = processId;
             return this;
         }
 

--- a/system-tests/tests/src/test/java/org/eclipse/edc/test/system/local/TracingIntegrationTest.java
+++ b/system-tests/tests/src/test/java/org/eclipse/edc/test/system/local/TracingIntegrationTest.java
@@ -66,8 +66,8 @@ public class TracingIntegrationTest extends FileTransferEdcRuntime {
 
     List<String> contractNegotiationSpanNames = List.of(
             "ConsumerContractNegotiationManagerImpl.initiate", // initial API request
-            "ProviderContractNegotiationManagerImpl.requested", // verify context propagation in ProviderContractNegotiationManagerImpl
-            "ConsumerContractNegotiationManagerImpl.confirmed" // verify context propagation in ConsumerContractNegotiationManagerImpl
+            "ProviderContractNegotiationManagerImpl.consumerRequested", // verify context propagation in ProviderContractNegotiationManagerImpl
+            "ConsumerContractNegotiationManagerImpl.providerAgreed" // verify context propagation in ConsumerContractNegotiationManagerImpl
     );
 
     List<String> transferProcessSpanNames = List.of(


### PR DESCRIPTION
## What this PR changes/adds

Adds missing methods on `ContractNegotiationService` that will permit the DSP controller to ingest an incoming `RemoteMessage` to the service

## Why it does that

refactoring

## Further notes

- at this point is pretty clear the `*ed` public methods on the managers could be inlined, or their logic being put into  command/command handlers (to follow a pattern that we're currently following). I left this refactoring for the future to avoid conflicts with #2630 
- set `correlationId` also on consumer side, this will simplify the "fetch" logic a bit, because the correlationId will become the key used both by consumer and provider to retrieve the negotiation from the store.
- pulled up `Result.flatMap` to `AbstractResult`, so every other `*Result` could use it (really handy to convert from an `AbstractResult` extension to another (e.g. `ServiceResult` to `StatusResult`)

## Linked Issue(s)

Closes #2612 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
