### PR TITLE
feat: add json-ld module

### DIFF
--- a/extensions/common/json-ld/build.gradle.kts
+++ b/extensions/common/json-ld/build.gradle.kts
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2023 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(libs.jacksonJsonP)
+    api(libs.titaniumJsonLd)
+    api(libs.jakartaJson)
+
+    api(project(":spi:common:core-spi"))
+    api(project(":spi:common:transform-spi"))
+
+    testImplementation(project(":core:common:junit"))
+}

--- a/extensions/common/json-ld/build.gradle.kts
+++ b/extensions/common/json-ld/build.gradle.kts
@@ -22,7 +22,6 @@ dependencies {
     api(libs.jakartaJson)
 
     api(project(":spi:common:core-spi"))
-    api(project(":spi:common:transform-spi"))
 
     testImplementation(project(":core:common:junit"))
 }

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/JsonLdExtension.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/JsonLdExtension.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2023 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.jsonld;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jsonp.JSONPModule;
+import org.eclipse.edc.policy.model.AtomicConstraint;
+import org.eclipse.edc.policy.model.LiteralExpression;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+
+@Extension(value = JsonLdExtension.NAME)
+public class JsonLdExtension implements ServiceExtension {
+    
+    public static final String NAME = "JSON-LD Extension";
+    public static final String TYPE_MANAGER_CONTEXT_JSON_LD = "json-ld";
+    
+    @Inject
+    private TypeManager typeManager;
+    
+    @Override
+    public String name() {
+        return NAME;
+    }
+    
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        var mapper = getObjectMapper();
+        typeManager.registerContext(TYPE_MANAGER_CONTEXT_JSON_LD, mapper);
+    }
+    
+    private ObjectMapper getObjectMapper() {
+        var mapper = new ObjectMapper();
+        mapper.registerModule(new JSONPModule());
+        var module = new SimpleModule() {
+            @Override
+            public void setupModule(SetupContext context) {
+                super.setupModule(context);
+            }
+        };
+        mapper.registerModule(module);
+        mapper.registerSubtypes(AtomicConstraint.class, LiteralExpression.class);
+        return mapper;
+    }
+    
+}

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/JsonLdExtension.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/JsonLdExtension.java
@@ -17,14 +17,17 @@ package org.eclipse.edc.jsonld;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.jsonp.JSONPModule;
-import org.eclipse.edc.policy.model.AtomicConstraint;
-import org.eclipse.edc.policy.model.LiteralExpression;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 
+/**
+ * Adds support for working with JSON-LD. Provides an ObjectMapper that works with Jakarta JSON-P
+ * types through the TypeManager context {@link #TYPE_MANAGER_CONTEXT_JSON_LD} and provides functions
+ * for working with JSON-LD structures.
+ */
 @Extension(value = JsonLdExtension.NAME)
 public class JsonLdExtension implements ServiceExtension {
     
@@ -55,7 +58,6 @@ public class JsonLdExtension implements ServiceExtension {
             }
         };
         mapper.registerModule(module);
-        mapper.registerSubtypes(AtomicConstraint.class, LiteralExpression.class);
         return mapper;
     }
     

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/JsonLdKeywords.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/JsonLdKeywords.java
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.jsonld;
+
+import java.util.Set;
+
+/**
+ * JSON-LD keywords as defined by {@see https://www.w3.org/TR/json-ld/#syntax-tokens-and-keywords}.
+ */
+public interface JsonLdKeywords {
+    
+    String BASE = "@base";
+    String CONTAINER = "@container";
+    String CONTEXT = "@context";
+    String DIRECTION = "@direction";
+    String GRAPH = "@graph";
+    String ID = "@id";
+    String IMPORT = "@import";
+    String INCLUDED = "@included";
+    String INDEX = "@index";
+    String JSON = "@json";
+    String LANGUAGE = "@language";
+    String LIST = "@list";
+    String NEST = "@nest";
+    String NODE = "@node";
+    String PREFIX = "@prefix";
+    String PROPAGATE = "@propagate";
+    String PROTECTED = "@protected";
+    String REVERSE = "@reverse";
+    String SET = "@set";
+    String TYPE = "@type";
+    String VALUE = "@value";
+    String VERSION = "@version";
+    String VOCAB = "@vocab";
+    
+    Set<String> KEYWORDS = Set.of(
+            BASE,
+            CONTAINER,
+            CONTEXT,
+            DIRECTION,
+            GRAPH,
+            ID,
+            IMPORT,
+            INCLUDED,
+            INDEX,
+            JSON,
+            LANGUAGE,
+            LIST,
+            NEST,
+            NODE,
+            PREFIX,
+            PROPAGATE,
+            PROTECTED,
+            REVERSE,
+            SET,
+            TYPE,
+            VALUE,
+            VERSION,
+            VOCAB);
+}

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/util/JsonLdUtil.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/util/JsonLdUtil.java
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (c) 2023 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.jsonld.util;
+
+import com.apicatalog.jsonld.JsonLd;
+import com.apicatalog.jsonld.JsonLdError;
+import com.apicatalog.jsonld.document.JsonDocument;
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.spi.EdcException;
+
+import java.util.Map;
+
+public class JsonLdUtil {
+    
+    private JsonLdUtil() { }
+    
+    /**
+     * Expands a JSON-LD structure. When expanding, the prefixes for attributes are resolved using
+     * the context entries. and replaced by the respective context reference.
+     *
+     * @param object the structure to expand
+     * @return the expanded structure in an array
+     */
+    public static JsonArray expand(JsonObject object) {
+        try {
+            var document = JsonDocument.of(object);
+            return JsonLd.expand(document).get();
+        } catch (JsonLdError e) {
+            throw new EdcException("Failed to expand JSON-LD", e);
+        }
+    }
+    
+    /**
+     * Compacts a JSON-LD structure. When compacting, the context references of attributes are
+     * replaced by the respective context prefixes. A context object for resolving the prefixes
+     * is added to the structure.
+     *
+     * @param object the structure to compact
+     * @param context the context for compacting
+     * @return the compacted structure
+     */
+    public static JsonObject compact(JsonObject object, JsonObject context) {
+        try {
+            var document = JsonDocument.of(object);
+            var jsonFactory = Json.createBuilderFactory(Map.of());
+            var contextDocument = JsonDocument.of(jsonFactory.createObjectBuilder()
+                    .add("@context", context)
+                    .build());
+            return JsonLd.compact(document, contextDocument).get();
+        } catch (JsonLdError e) {
+            throw new EdcException("Failed to compact JSON-LD", e);
+        }
+    }
+    
+}

--- a/extensions/common/json-ld/src/main/resources/META-INF/resources/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/common/json-ld/src/main/resources/META-INF/resources/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2023 Fraunhofer Institute for Software and Systems Engineering
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Fraunhofer Institute for Software and Systems Engineering - Initial API and Implementation
+#
+#
+
+org.eclipse.edc.jsonld.JsonLdExtension

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/util/JsonLdUtilTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/util/JsonLdUtilTest.java
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (c) 2023 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.jsonld.util;
+
+import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.JsonLdKeywords.CONTEXT;
+
+class JsonLdUtilTest {
+    
+    private static final String PREFIX = "prefix";
+    private static final String SCHEMA = "http://schema/";
+    
+    private JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
+    
+    @Test
+    void expand() {
+        var json = jsonFactory.createObjectBuilder()
+                .add(CONTEXT, jsonFactory.createObjectBuilder().add(PREFIX, SCHEMA).build())
+                .add(PREFIX + ":foo", Json.createValue("value"))
+                .build();
+        
+        var resultArray = JsonLdUtil.expand(json);
+        
+        assertThat(resultArray)
+                .isNotNull()
+                .hasSize(1);
+        
+        var result = (JsonObject) resultArray.get(0);
+        assertThat(result.get(CONTEXT)).isNull();
+        assertThat(result.get(PREFIX + ":foo")).isNull();
+        assertThat(result.get(SCHEMA + "foo")).isNotNull();
+    }
+    
+    @Test
+    void compact() {
+        var json = jsonFactory.createObjectBuilder()
+                .add(SCHEMA + "foo", Json.createValue("value"))
+                .build();
+        var context = jsonFactory.createObjectBuilder()
+                .add(PREFIX, SCHEMA)
+                .build();
+        
+        var result = JsonLdUtil.compact(json, context);
+        
+        assertThat(result).isNotNull().hasSize(2);
+        assertThat(result.get(CONTEXT)).isNotNull();
+        assertThat(result.get(PREFIX + ":foo")).isNotNull();
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -42,6 +42,9 @@ dependencyResolutionManagement {
             from("org.eclipse.edc:edc-versions:0.0.1-SNAPSHOT")
             // this is not part of the published EDC Version Catalog, so we'll just "amend" it
             library("dnsOverHttps", "com.squareup.okhttp3", "okhttp-dnsoverhttps").versionRef("okhttp")
+            library("titaniumJsonLd", "com.apicatalog", "titanium-json-ld").version("1.3.1")
+            library("jacksonJsonP", "com.fasterxml.jackson.datatype", "jackson-datatype-jakarta-jsonp").version("jackson")
+            library("jakartaJson", "org.glassfish", "jakarta.json").version("2.0.0")
         }
     }
 }
@@ -108,6 +111,7 @@ include(":extensions:common:iam:oauth2:oauth2-daps")
 include(":extensions:common:iam:oauth2:oauth2-core")
 include(":extensions:common:iam:oauth2:oauth2-client")
 include(":extensions:common:iam:oauth2:oauth2-service")
+include(":extensions:common:json-ld")
 include(":extensions:common:metrics:micrometer-core")
 include(":extensions:common:monitor:monitor-jdk-logger")
 include(":extensions:common:sql:sql-core")


### PR DESCRIPTION
## What this PR changes/adds

Adds an extension that provides an ObjectMapper for working with JSON-LD and utility functions for expanding and compacting JSON-LD structures.

## Why it does that

JSON-LD support is required for the dataspace protocol implementation.

## Further notes

Transformers that handle the mapping between EDC model and JSON-LD will be added in a separate PR.

## Linked Issue(s)

Relates #2474

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
