### PR TITLE
fix: update expected slf4j-api version of MonitorProvider

### DIFF
--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/monitor/MonitorProvider.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/monitor/MonitorProvider.java
@@ -57,7 +57,7 @@ public class MonitorProvider implements SLF4JServiceProvider {
 
     @Override
     public String getRequestedApiVersion() {
-        return "1.8";
+        return "2.0";
     }
 
     @Override


### PR DESCRIPTION
## What this PR changes/adds

Update expected version of slf4j API of SLF4JServiceProvider implementation.

## Why it does that

to fix warnings like:

```
S3StatusCheckerIntegrationTest STANDARD_ERROR
    SLF4J: The requested version 1.8 by your slf4j binding is not compatible with [2.0]
    SLF4J: See https://www.slf4j.org/codes.html#version_mismatch for further details.
```

EDC now [expects slf4j-api 2.0.7](https://github.com/eclipse-edc/GradlePlugins/blob/be9b4417bbe483590e3d348827d88b8699d6480b/gradle/libs.versions.toml#L38).

## Linked Issue(s)

Closes #2654

## Checklist

- [n/a] added appropriate tests?
- [x] performed checkstyle check locally?
- [n/a] added/updated copyright headers?
- [n/a] documented public classes/methods?
- [n/a] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
