### PR TITLE
fix: contract offer timing issue

### DIFF
--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/offer/ContractOfferResolverImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/offer/ContractOfferResolverImpl.java
@@ -136,7 +136,7 @@ public class ContractOfferResolverImpl implements ContractOfferResolver {
             contractEndTime = now.plusSeconds(definition.getValidity());
         } catch (DateTimeException exception) {
             monitor.warning("The added ContractEnd value is bigger than the maximum number allowed by a long value. " +
-                    "Changing contractEndTime to Maximum value possible in the ContractOffer");
+                    "Changing contractEndTime to Maximum value possible in the ContractOffer", exception);
         }
         return contractEndTime;
     }


### PR DESCRIPTION
## What this PR changes/adds

Fixes the contract offer timing issue.

## Why it does that

Using the same timestamp as basis to calculate the contract end

## Further notes
Using `clock` to get the current time zone

## Linked Issue(s)

Closes #2650 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
