### PR TITLE
fix: javadoc compilation

### DIFF
--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/JsonLdKeywords.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/JsonLdKeywords.java
@@ -17,7 +17,7 @@ package org.eclipse.edc.jsonld;
 import java.util.Set;
 
 /**
- * JSON-LD keywords as defined by {@see https://www.w3.org/TR/json-ld/#syntax-tokens-and-keywords}.
+ * JSON-LD keywords as defined by <a href="https://www.w3.org/TR/json-ld/#syntax-tokens-and-keywords">W3C</a>.
  */
 public interface JsonLdKeywords {
     


### PR DESCRIPTION
## What this PR changes/adds

the `@see` tag was misused and caused jenkins to break: https://ci.eclipse.org/edc/job/Publish-Component/

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
