### PR TITLE
fix: javadoc tags

### DIFF
--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/AbstractJsonLdTransformer.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/AbstractJsonLdTransformer.java
@@ -151,7 +151,7 @@ public abstract class AbstractJsonLdTransformer<INPUT, OUTPUT> implements JsonLd
     }
     
     /**
-     * Returns the {@code @type} of the JSON object. If more than one type is specified, this method will return the first. For multiple types, {@see #nodeTypes}.
+     * Returns the {@code @type} of the JSON object. If more than one type is specified, this method will return the first.
      */
     protected String nodeType(JsonObject object, TransformerContext context) {
         var typeNode = object.get(TYPE);

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/JsonLdTransformer.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/JsonLdTransformer.java
@@ -19,7 +19,7 @@ import org.eclipse.edc.transform.spi.TypeTransformer;
 /**
  * Base type for transformers that operate on JSON-LD types. JSON-LD types (input and output) must be expanded per the JSON-LD Processing Algorithms API.
  * <p>
- * {@see https://www.w3.org/TR/json-ld11-api/}
+ * <a href="https://www.w3.org/TR/json-ld11-api/">W3C</a>
  */
 public interface JsonLdTransformer<INPUT, OUTPUT> extends TypeTransformer<INPUT, OUTPUT> {
 }


### PR DESCRIPTION
## What this PR changes/adds

Removes remaining @see tags from `json-ld` module.

## Why it does that
The usage of @see causes the javadoc task to fail.

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
