### PR TITLE
fix: fix compilation

### DIFF
--- a/core/common/junit/src/main/java/org/eclipse/edc/junit/assertions/AbstractResultAssert.java
+++ b/core/common/junit/src/main/java/org/eclipse/edc/junit/assertions/AbstractResultAssert.java
@@ -28,15 +28,16 @@ import org.eclipse.edc.spi.result.Failure;
  * @param <C> the content type
  * @param <F> the failure type
  */
-public class AbstractResultAssert<SELF extends AbstractAssert<SELF, RESULT>, RESULT extends AbstractResult<C, F>, C, F extends Failure>
+public class AbstractResultAssert<SELF extends AbstractAssert<SELF, RESULT>, RESULT extends AbstractResult<C, F, RESULT>, C, F extends Failure>
         extends AbstractAssert<SELF, RESULT> {
 
     protected AbstractResultAssert(RESULT tfAbstractResult) {
         super(tfAbstractResult, AbstractResultAssert.class);
     }
 
-    public static AbstractResultAssert<?, ?, ?, ?> assertThat(AbstractResult<?, ?> actual) {
-        return new AbstractResultAssert<>(actual);
+    @SuppressWarnings("unchecked")
+    public static <SELF extends AbstractResultAssert<SELF, RESULT, C, F>, RESULT extends AbstractResult<C, F, RESULT>, C, F extends Failure> SELF assertThat(RESULT actual) {
+        return (SELF) new AbstractResultAssert<>(actual);
     }
 
     public ObjectAssert<C> isSucceeded() {


### PR DESCRIPTION
## What this PR changes/adds

Fixes compilation issue

## Why it does that

A breaking change in the `AbstractResult` class caused the merge of the `AbstractResultAssert` PR to break compilation.
Their checks were working because the breaking change happened between the checks and the merge.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
