### PR TITLE
feat: dataspace protocol catalog HTTP dispatcher

### DIFF
--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/build.gradle.kts
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/build.gradle.kts
@@ -17,6 +17,7 @@ plugins {
 }
 
 dependencies {
+    api(project(":data-protocols:dsp:dsp-catalog:dsp-catalog-spi"))
     api(project(":data-protocols:dsp:dsp-http-core"))
     api(project(":data-protocols:dsp:dsp-http-spi"))
     api(project(":extensions:common:json-ld"))

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/build.gradle.kts
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/build.gradle.kts
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2023 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(project(":data-protocols:dsp:dsp-http-core"))
+    api(project(":data-protocols:dsp:dsp-http-spi"))
+    api(project(":extensions:common:json-ld"))
+    api(project(":spi:common:catalog-spi"))
+
+    api(libs.jakartaJson)
+}

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/src/main/java/org/eclipse/edc/protocol/dsp/catalog/dispatcher/DspCatalogHttpDispatcherExtension.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/src/main/java/org/eclipse/edc/protocol/dsp/catalog/dispatcher/DspCatalogHttpDispatcherExtension.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2023 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.catalog.dispatcher;
+
+import org.eclipse.edc.jsonld.transformer.JsonLdTransformerRegistry;
+import org.eclipse.edc.protocol.dsp.catalog.dispatcher.delegate.CatalogRequestHttpDelegate;
+import org.eclipse.edc.protocol.dsp.spi.dispatcher.DspHttpRemoteMessageDispatcher;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+
+import static org.eclipse.edc.jsonld.JsonLdExtension.TYPE_MANAGER_CONTEXT_JSON_LD;
+
+/**
+ * Creates and registers the HTTP dispatcher delegate for sending a catalog request as defined in
+ * the dataspace protocol specification.
+ */
+@Extension(value = DspCatalogHttpDispatcherExtension.NAME)
+public class DspCatalogHttpDispatcherExtension implements ServiceExtension {
+    
+    public static final String NAME = "Dataspace Protocol Catalog HTTP Dispatcher Extension";
+    
+    @Inject
+    private DspHttpRemoteMessageDispatcher messageDispatcher;
+    @Inject
+    private TypeManager typeManager;
+    @Inject
+    private JsonLdTransformerRegistry transformerRegistry;
+    
+    @Override
+    public String name() {
+        return NAME;
+    }
+    
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        messageDispatcher.registerDelegate(new CatalogRequestHttpDelegate(typeManager.getMapper(TYPE_MANAGER_CONTEXT_JSON_LD), transformerRegistry));
+    }
+    
+}

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/src/main/java/org/eclipse/edc/protocol/dsp/catalog/dispatcher/delegate/CatalogRequestHttpDelegate.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/src/main/java/org/eclipse/edc/protocol/dsp/catalog/dispatcher/delegate/CatalogRequestHttpDelegate.java
@@ -72,21 +72,8 @@ public class CatalogRequestHttpDelegate implements DspHttpDispatcherDelegate<Cat
         
         return new Request.Builder()
                 .url(message.getConnectorAddress() + BASE_PATH + CATALOG_REQUEST)
-                .header("Content-Type", APPLICATION_JSON)
                 .post(requestBody)
                 .build();
-    }
-    
-    private String toJson(CatalogRequestMessage message) {
-        try {
-            var transformResult = transformerRegistry.transform(message, JsonObject.class);
-            if (transformResult.succeeded()) {
-                return mapper.writeValueAsString(transformResult.getContent());
-            }
-            throw new EdcException("Failed to write request.");
-        } catch (JsonProcessingException e) {
-            throw new EdcException("Failed to serialize catalog request", e);
-        }
     }
     
     /**
@@ -114,5 +101,17 @@ public class CatalogRequestHttpDelegate implements DspHttpDispatcherDelegate<Cat
                 throw new EdcException("Failed to read response body.", e);
             }
         };
+    }
+    
+    private String toJson(CatalogRequestMessage message) {
+        try {
+            var transformResult = transformerRegistry.transform(message, JsonObject.class);
+            if (transformResult.succeeded()) {
+                return mapper.writeValueAsString(transformResult.getContent());
+            }
+            throw new EdcException("Failed to write request.");
+        } catch (JsonProcessingException e) {
+            throw new EdcException("Failed to serialize catalog request", e);
+        }
     }
 }

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/src/main/java/org/eclipse/edc/protocol/dsp/catalog/dispatcher/delegate/CatalogRequestHttpDelegate.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/src/main/java/org/eclipse/edc/protocol/dsp/catalog/dispatcher/delegate/CatalogRequestHttpDelegate.java
@@ -14,10 +14,8 @@
 
 package org.eclipse.edc.protocol.dsp.catalog.dispatcher.delegate;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import jakarta.json.JsonObject;
 import okhttp3.MediaType;
 import okhttp3.Request;
@@ -26,14 +24,16 @@ import okhttp3.Response;
 import org.eclipse.edc.catalog.spi.Catalog;
 import org.eclipse.edc.catalog.spi.CatalogRequest;
 import org.eclipse.edc.jsonld.transformer.JsonLdTransformerRegistry;
+import org.eclipse.edc.protocol.dsp.catalog.spi.types.CatalogRequestMessage;
 import org.eclipse.edc.protocol.dsp.spi.dispatcher.DspHttpDispatcherDelegate;
 import org.eclipse.edc.spi.EdcException;
-import org.eclipse.edc.spi.query.QuerySpec;
 
 import java.io.IOException;
 import java.util.function.Function;
 
 import static org.eclipse.edc.jsonld.util.JsonLdUtil.expand;
+import static org.eclipse.edc.protocol.dsp.catalog.spi.CatalogApiPaths.BASE_PATH;
+import static org.eclipse.edc.protocol.dsp.catalog.spi.CatalogApiPaths.CATALOG_REQUEST;
 
 /**
  * Delegate for dispatching catalog requests as defined in the dataspace protocol specification.
@@ -41,10 +41,6 @@ import static org.eclipse.edc.jsonld.util.JsonLdUtil.expand;
 public class CatalogRequestHttpDelegate implements DspHttpDispatcherDelegate<CatalogRequest, Catalog> {
     
     private static final String APPLICATION_JSON = "application/json";
-    
-    //TODO to be removed once #2685 is merged
-    static final String BASE_PATH = "/catalog";
-    static final String CATALOG_REQUEST = "/request";
     
     private ObjectMapper mapper;
     private JsonLdTransformerRegistry transformerRegistry;
@@ -118,37 +114,5 @@ public class CatalogRequestHttpDelegate implements DspHttpDispatcherDelegate<Cat
                 throw new EdcException("Failed to read response body.", e);
             }
         };
-    }
-    
-    //TODO to be removed once #2685 is merged
-    static class CatalogRequestMessage {
-        private QuerySpec filter;
-    
-        public QuerySpec getFilter() {
-            return filter;
-        }
-    
-        @JsonPOJOBuilder(withPrefix = "")
-        public static class Builder {
-            private final CatalogRequestMessage request;
-        
-            private Builder() {
-                request = new CatalogRequestMessage();
-            }
-        
-            @JsonCreator
-            public static Builder newInstance() {
-                return new Builder();
-            }
-        
-            public Builder filter(QuerySpec filter) {
-                request.filter = filter;
-                return this;
-            }
-        
-            public CatalogRequestMessage build() {
-                return request;
-            }
-        }
     }
 }

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/src/main/java/org/eclipse/edc/protocol/dsp/catalog/dispatcher/delegate/CatalogRequestHttpDelegate.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/src/main/java/org/eclipse/edc/protocol/dsp/catalog/dispatcher/delegate/CatalogRequestHttpDelegate.java
@@ -1,0 +1,154 @@
+/*
+ *  Copyright (c) 2023 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.catalog.dispatcher.delegate;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import jakarta.json.JsonObject;
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.eclipse.edc.catalog.spi.Catalog;
+import org.eclipse.edc.catalog.spi.CatalogRequest;
+import org.eclipse.edc.jsonld.transformer.JsonLdTransformerRegistry;
+import org.eclipse.edc.protocol.dsp.spi.dispatcher.DspHttpDispatcherDelegate;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.query.QuerySpec;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+import static org.eclipse.edc.jsonld.util.JsonLdUtil.expand;
+
+/**
+ * Delegate for dispatching catalog requests as defined in the dataspace protocol implementation.
+ */
+public class CatalogRequestHttpDelegate implements DspHttpDispatcherDelegate<CatalogRequest, Catalog> {
+    
+    private static final String APPLICATION_JSON = "application/json";
+    
+    //TODO to be removed once #2685 is merged
+    static final String BASE_PATH = "/catalog";
+    static final String CATALOG_REQUEST = "/request";
+    
+    private ObjectMapper mapper;
+    private JsonLdTransformerRegistry transformerRegistry;
+    
+    public CatalogRequestHttpDelegate(ObjectMapper mapper, JsonLdTransformerRegistry transformerRegistry) {
+        this.mapper = mapper;
+        this.transformerRegistry = transformerRegistry;
+    }
+    
+    @Override
+    public Class<CatalogRequest> getMessageType() {
+        return CatalogRequest.class;
+    }
+    
+    /**
+     * Sends a catalog request. The request body is constructed as defined in the dataspace protocol
+     * implementation. The request is sent to the remote component using the path from the
+     * specification.
+     *
+     * @param message the message
+     * @return the built okhttp request
+     */
+    @Override
+    public Request buildRequest(CatalogRequest message) {
+        var catalogRequestMessage = CatalogRequestMessage.Builder.newInstance()
+                .filter(message.getQuerySpec())
+                .build();
+        var requestBody = RequestBody.create(toJson(catalogRequestMessage), MediaType.get(APPLICATION_JSON));
+        
+        return new Request.Builder()
+                .url(message.getConnectorAddress() + BASE_PATH + CATALOG_REQUEST)
+                .header("Content-Type", APPLICATION_JSON)
+                .post(requestBody)
+                .build();
+    }
+    
+    private String toJson(CatalogRequestMessage message) {
+        try {
+            var transformResult = transformerRegistry.transform(message, JsonObject.class);
+            if (transformResult.succeeded()) {
+                return mapper.writeValueAsString(transformResult.getContent());
+            }
+            throw new EdcException("Failed to write request.");
+        } catch (JsonProcessingException e) {
+            throw new EdcException("Failed to serialize catalog request", e);
+        }
+    }
+    
+    /**
+     * Parses the response to a catalog request. The JSON-LD structure from the response body is
+     * expanded and then transformed to an EDC catalog.
+     *
+     * @return a function that transforms the response body to a catalog.
+     */
+    @Override
+    public Function<Response, Catalog> parseResponse() {
+        return response -> {
+            try {
+                var jsonObject = mapper.readValue(response.body().bytes(), JsonObject.class);
+                var result = transformerRegistry.transform(expand(jsonObject).get(0), Catalog.class);
+                if (result.succeeded()) {
+                    return result.getContent();
+                } else {
+                    throw new EdcException("Failed to read response body.");
+                }
+            } catch (NullPointerException e) {
+                throw new EdcException("Failed to read response body, as body was null.");
+            } catch (IndexOutOfBoundsException e) {
+                throw new EdcException("Failed to expand JSON-LD in response body.", e);
+            } catch (IOException e) {
+                throw new EdcException("Failed to read response body.", e);
+            }
+        };
+    }
+    
+    //TODO to be removed once #2685 is merged
+    static class CatalogRequestMessage {
+        private QuerySpec filter;
+    
+        public QuerySpec getFilter() {
+            return filter;
+        }
+    
+        @JsonPOJOBuilder(withPrefix = "")
+        public static class Builder {
+            private final CatalogRequestMessage request;
+        
+            private Builder() {
+                request = new CatalogRequestMessage();
+            }
+        
+            @JsonCreator
+            public static Builder newInstance() {
+                return new Builder();
+            }
+        
+            public Builder filter(QuerySpec filter) {
+                request.filter = filter;
+                return this;
+            }
+        
+            public CatalogRequestMessage build() {
+                return request;
+            }
+        }
+    }
+}

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/src/main/java/org/eclipse/edc/protocol/dsp/catalog/dispatcher/delegate/CatalogRequestHttpDelegate.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/src/main/java/org/eclipse/edc/protocol/dsp/catalog/dispatcher/delegate/CatalogRequestHttpDelegate.java
@@ -36,7 +36,7 @@ import java.util.function.Function;
 import static org.eclipse.edc.jsonld.util.JsonLdUtil.expand;
 
 /**
- * Delegate for dispatching catalog requests as defined in the dataspace protocol implementation.
+ * Delegate for dispatching catalog requests as defined in the dataspace protocol specification.
  */
 public class CatalogRequestHttpDelegate implements DspHttpDispatcherDelegate<CatalogRequest, Catalog> {
     

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2023 Fraunhofer Institute for Software and Systems Engineering
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Fraunhofer Institute for Software and Systems Engineering - Initial API and Implementation
+#
+#
+
+org.eclipse.edc.protocol.dsp.catalog.dispatcher.DspCatalogHttpDispatcherExtension

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/src/test/java/org/eclipse/edc/protocol/dsp/catalog/dispatcher/delegate/CatalogRequestHttpDelegateTest.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/src/test/java/org/eclipse/edc/protocol/dsp/catalog/dispatcher/delegate/CatalogRequestHttpDelegateTest.java
@@ -1,0 +1,190 @@
+/*
+ *  Copyright (c) 2023 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.catalog.dispatcher.delegate;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import okio.Buffer;
+import org.eclipse.edc.catalog.spi.Catalog;
+import org.eclipse.edc.catalog.spi.CatalogRequest;
+import org.eclipse.edc.jsonld.transformer.JsonLdTransformerRegistry;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.Result;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.eclipse.edc.jsonld.JsonLdKeywords.CONTEXT;
+import static org.eclipse.edc.protocol.dsp.catalog.dispatcher.delegate.CatalogRequestHttpDelegate.BASE_PATH;
+import static org.eclipse.edc.protocol.dsp.catalog.dispatcher.delegate.CatalogRequestHttpDelegate.CATALOG_REQUEST;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CatalogRequestHttpDelegateTest {
+    
+    //TODO replace BASE_PATH, CATALOG_REQUEST & CatalogRequestMessage after #2685 is merged
+    
+    private ObjectMapper mapper = mock(ObjectMapper.class);
+    private JsonLdTransformerRegistry registry = mock(JsonLdTransformerRegistry.class);
+    
+    private CatalogRequestHttpDelegate delegate;
+    
+    @BeforeEach
+    void setUp() {
+        delegate = new CatalogRequestHttpDelegate(mapper, registry);
+    }
+    
+    @Test
+    void getMessageType_returnCatalogRequest() {
+        assertThat(delegate.getMessageType()).isEqualTo(CatalogRequest.class);
+    }
+    
+    @Test
+    void buildRequest_returnRequest() throws IOException {
+        var jsonObject = getJsonObject();
+        var serializedBody = "catalog request";
+        
+        when(registry.transform(isA(CatalogRequestHttpDelegate.CatalogRequestMessage.class), eq(JsonObject.class)))
+                .thenReturn(Result.success(jsonObject));
+        when(mapper.writeValueAsString(jsonObject)).thenReturn(serializedBody);
+        
+        var message = getCatalogRequest();
+        var httpRequest = delegate.buildRequest(message);
+        
+        assertThat(httpRequest.url().url()).hasToString(message.getConnectorAddress() + BASE_PATH + CATALOG_REQUEST);
+        assertThat(readRequestBody(httpRequest)).isEqualTo(serializedBody);
+        
+        verify(registry, times(1))
+                .transform(argThat(requestMessage -> ((CatalogRequestHttpDelegate.CatalogRequestMessage) requestMessage).getFilter().equals(message.getQuerySpec())), eq(JsonObject.class));
+        verify(mapper, times(1)).writeValueAsString(jsonObject);
+    }
+    
+    @Test
+    void buildRequest_transformationFails_throwException() {
+        when(registry.transform(isA(CatalogRequestHttpDelegate.CatalogRequestMessage.class), eq(JsonObject.class)))
+                .thenReturn(Result.failure("error"));
+        
+        var message = getCatalogRequest();
+        assertThatThrownBy(() -> delegate.buildRequest(message)).isInstanceOf(EdcException.class);
+    }
+    
+    @Test
+    void parseResponse_returnCatalog() throws IOException {
+        var jsonObject = getJsonObject();
+        var catalog = Catalog.Builder.newInstance().build();
+        var response = mock(Response.class);
+        var responseBody = mock(ResponseBody.class);
+        var bytes = "test".getBytes();
+    
+        when(response.body()).thenReturn(responseBody);
+        when(responseBody.bytes()).thenReturn(bytes);
+        when(mapper.readValue(bytes, JsonObject.class)).thenReturn(jsonObject);
+        when(registry.transform(any(JsonObject.class), eq(Catalog.class))).thenReturn(Result.success(catalog));
+        
+        var result = delegate.parseResponse().apply(response);
+        
+        assertThat(result).isEqualTo(catalog);
+        verify(mapper, times(1)).readValue(bytes, JsonObject.class);
+        verify(registry, times(1)).transform(isA(JsonObject.class), eq(Catalog.class));
+    }
+    
+    @Test
+    void parseResponse_transformationFails_throwException() throws IOException {
+        var jsonObject = getJsonObject();
+        var response = mock(Response.class);
+        var responseBody = mock(ResponseBody.class);
+    
+        when(response.body()).thenReturn(responseBody);
+        when(responseBody.bytes()).thenReturn("test".getBytes());
+        when(mapper.readValue(any(byte[].class), eq(JsonObject.class))).thenReturn(jsonObject);
+        when(registry.transform(any(JsonObject.class), eq(Catalog.class))).thenReturn(Result.failure("error"));
+        
+        assertThatThrownBy(() -> delegate.parseResponse().apply(response)).isInstanceOf(EdcException.class);
+    }
+    
+    @Test
+    void parseResponse_readingResponseBodyFails_throwException() throws IOException {
+        var response = mock(Response.class);
+        var responseBody = mock(ResponseBody.class);
+        
+        when(response.body()).thenReturn(responseBody);
+        when(responseBody.bytes()).thenReturn("test".getBytes());
+        when(mapper.readValue(any(byte[].class), eq(JsonObject.class))).thenThrow(IOException.class);
+        
+        assertThatThrownBy(() -> delegate.parseResponse().apply(response)).isInstanceOf(EdcException.class);
+    }
+    
+    @Test
+    void parseResponse_responseBodyNull_throwException() throws IOException {
+        var response = mock(Response.class);
+        
+        when(response.body()).thenReturn(null);
+        
+        assertThatThrownBy(() -> delegate.parseResponse().apply(response)).isInstanceOf(EdcException.class);
+    }
+    
+    @Test
+    void parseResponse_expandingJsonLdFails_throwException() throws IOException {
+        // JSON is missing @context -> expanding returns empty JsonArray
+        var jsonObject = Json.createObjectBuilder()
+                .add("key", "value")
+                .build();
+        var response = mock(Response.class);
+        var responseBody = mock(ResponseBody.class);
+    
+        when(response.body()).thenReturn(responseBody);
+        when(responseBody.bytes()).thenReturn("test".getBytes());
+        when(mapper.readValue(any(byte[].class), eq(JsonObject.class))).thenReturn(jsonObject);
+    
+        assertThatThrownBy(() -> delegate.parseResponse().apply(response)).isInstanceOf(EdcException.class);
+    }
+    
+    private JsonObject getJsonObject() {
+        return Json.createObjectBuilder()
+                .add(CONTEXT, Json.createObjectBuilder().add("prefix", "http://schema").build())
+                .add("prefix:key", "value")
+                .build();
+    }
+    
+    private CatalogRequest getCatalogRequest() {
+        return CatalogRequest.Builder.newInstance()
+                .connectorAddress("http://connector")
+                .connectorId("connector-id")
+                .protocol("protocol")
+                .querySpec(QuerySpec.max())
+                .build();
+    }
+    
+    private String readRequestBody(Request request) throws IOException {
+        var buffer = new Buffer();
+        request.body().writeTo(buffer);
+        return buffer.readUtf8();
+    }
+    
+}

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/src/test/java/org/eclipse/edc/protocol/dsp/catalog/dispatcher/delegate/CatalogRequestHttpDelegateTest.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/src/test/java/org/eclipse/edc/protocol/dsp/catalog/dispatcher/delegate/CatalogRequestHttpDelegateTest.java
@@ -24,6 +24,7 @@ import okio.Buffer;
 import org.eclipse.edc.catalog.spi.Catalog;
 import org.eclipse.edc.catalog.spi.CatalogRequest;
 import org.eclipse.edc.jsonld.transformer.JsonLdTransformerRegistry;
+import org.eclipse.edc.protocol.dsp.catalog.spi.types.CatalogRequestMessage;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.Result;
@@ -35,8 +36,8 @@ import java.io.IOException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.edc.jsonld.JsonLdKeywords.CONTEXT;
-import static org.eclipse.edc.protocol.dsp.catalog.dispatcher.delegate.CatalogRequestHttpDelegate.BASE_PATH;
-import static org.eclipse.edc.protocol.dsp.catalog.dispatcher.delegate.CatalogRequestHttpDelegate.CATALOG_REQUEST;
+import static org.eclipse.edc.protocol.dsp.catalog.spi.CatalogApiPaths.BASE_PATH;
+import static org.eclipse.edc.protocol.dsp.catalog.spi.CatalogApiPaths.CATALOG_REQUEST;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -47,8 +48,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class CatalogRequestHttpDelegateTest {
-    
-    //TODO replace BASE_PATH, CATALOG_REQUEST & CatalogRequestMessage after #2685 is merged
     
     private ObjectMapper mapper = mock(ObjectMapper.class);
     private JsonLdTransformerRegistry registry = mock(JsonLdTransformerRegistry.class);
@@ -70,7 +69,7 @@ class CatalogRequestHttpDelegateTest {
         var jsonObject = getJsonObject();
         var serializedBody = "catalog request";
         
-        when(registry.transform(isA(CatalogRequestHttpDelegate.CatalogRequestMessage.class), eq(JsonObject.class)))
+        when(registry.transform(isA(CatalogRequestMessage.class), eq(JsonObject.class)))
                 .thenReturn(Result.success(jsonObject));
         when(mapper.writeValueAsString(jsonObject)).thenReturn(serializedBody);
         
@@ -81,13 +80,13 @@ class CatalogRequestHttpDelegateTest {
         assertThat(readRequestBody(httpRequest)).isEqualTo(serializedBody);
         
         verify(registry, times(1))
-                .transform(argThat(requestMessage -> ((CatalogRequestHttpDelegate.CatalogRequestMessage) requestMessage).getFilter().equals(message.getQuerySpec())), eq(JsonObject.class));
+                .transform(argThat(requestMessage -> ((CatalogRequestMessage) requestMessage).getFilter().equals(message.getQuerySpec())), eq(JsonObject.class));
         verify(mapper, times(1)).writeValueAsString(jsonObject);
     }
     
     @Test
     void buildRequest_transformationFails_throwException() {
-        when(registry.transform(isA(CatalogRequestHttpDelegate.CatalogRequestMessage.class), eq(JsonObject.class)))
+        when(registry.transform(isA(CatalogRequestMessage.class), eq(JsonObject.class)))
                 .thenReturn(Result.failure("error"));
         
         var message = getCatalogRequest();

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -68,6 +68,7 @@ include(":core:data-plane-selector:data-plane-selector-core")
 // modules that provide implementations for data ingress/egress ------------------------------------
 include(":data-protocols:dsp:dsp-api-configuration")
 include(":data-protocols:dsp:dsp-catalog:dsp-catalog-api")
+include(":data-protocols:dsp:dsp-catalog:dsp-catalog-http-dispatcher")
 include(":data-protocols:dsp:dsp-catalog:dsp-catalog-spi")
 include(":data-protocols:dsp:dsp-catalog:dsp-catalog-transform")
 include(":data-protocols:dsp:dsp-http-core")


### PR DESCRIPTION
## What this PR changes/adds

Creates the `dsp-catalog-http-dispatcher` module, which provides the delegate for sending catalog requests.

## Why it does that

To support the dataspace protocol catalog specification.

## Linked Issue(s)

Relates #2474 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
