### PR TITLE
fix(SqlContractNegotiationStore): fix next for state when the agreement is not null

### DIFF
--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/SqlContractNegotiationStore.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/SqlContractNegotiationStore.java
@@ -148,7 +148,7 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
         return transactionContext.execute(() -> {
             try {
                 var statement = statements.createNegotiationsQuery(querySpec);
-                return executeQuery(getConnection(), true, this.contractNegotiationMapper(), statement.getQueryAsString(), statement.getParameters());
+                return executeQuery(getConnection(), true, contractNegotiationMapper(), statement.getQueryAsString(), statement.getParameters());
             } catch (SQLException e) {
                 throw new EdcPersistenceException(e);
             }
@@ -173,7 +173,7 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
             var stmt = statements.getNextForStateTemplate();
             try (
                     var connection = getConnection();
-                    var stream = executeQuery(connection, true, this.contractNegotiationWithAgreementMapper(connection), stmt, state, clock.millis(), max)
+                    var stream = executeQuery(connection, true, contractNegotiationWithAgreementMapper(connection), stmt, state, clock.millis(), max)
             ) {
                 var negotiations = stream.collect(Collectors.toList());
                 negotiations.forEach(cn -> leaseContext.withConnection(connection).acquireLease(cn.getId()));
@@ -191,7 +191,7 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
 
     private @Nullable ContractNegotiation findInternal(Connection connection, String id) {
         var sql = statements.getFindTemplate();
-        return executeQuerySingle(connection, false, this.contractNegotiationMapper(), sql, id);
+        return executeQuerySingle(connection, false, contractNegotiationMapper(), sql, id);
     }
 
     private void update(Connection connection, String negotiationId, ContractNegotiation updatedValues) {
@@ -310,7 +310,7 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
     }
 
     private ResultSetMapper<ContractNegotiation> contractNegotiationMapper() {
-        return (resultSet -> mapContractNegotiation(resultSet, this::extractContractAgreement));
+        return resultSet -> mapContractNegotiation(resultSet, this::extractContractAgreement);
     }
 
     private ResultSetMapper<ContractNegotiation> contractNegotiationWithAgreementMapper(Connection connection) {

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/SqlContractNegotiationStore.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/SqlContractNegotiationStore.java
@@ -24,6 +24,7 @@ import org.eclipse.edc.connector.store.sql.contractnegotiation.store.schema.Cont
 import org.eclipse.edc.spi.persistence.EdcPersistenceException;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.sql.ResultSetMapper;
 import org.eclipse.edc.sql.lease.SqlLeaseContextBuilder;
 import org.eclipse.edc.sql.store.AbstractSqlStore;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
@@ -86,9 +87,8 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
     @Override
     public @Nullable ContractAgreement findContractAgreement(String contractId) {
         return transactionContext.execute(() -> {
-            var stmt = statements.getFindContractAgreementTemplate();
-            try {
-                return executeQuerySingle(getConnection(), true, this::mapContractAgreement, stmt, contractId);
+            try (var connection = getConnection()) {
+                return findContractAgreementInternal(connection, contractId);
             } catch (SQLException e) {
                 throw new EdcPersistenceException(e);
             }
@@ -148,7 +148,7 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
         return transactionContext.execute(() -> {
             try {
                 var statement = statements.createNegotiationsQuery(querySpec);
-                return executeQuery(getConnection(), true, this::mapContractNegotiation, statement.getQueryAsString(), statement.getParameters());
+                return executeQuery(getConnection(), true, this.contractNegotiationMapper(), statement.getQueryAsString(), statement.getParameters());
             } catch (SQLException e) {
                 throw new EdcPersistenceException(e);
             }
@@ -173,7 +173,7 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
             var stmt = statements.getNextForStateTemplate();
             try (
                     var connection = getConnection();
-                    var stream = executeQuery(connection, true, this::mapContractNegotiation, stmt, state, clock.millis(), max)
+                    var stream = executeQuery(connection, true, this.contractNegotiationWithAgreementMapper(connection), stmt, state, clock.millis(), max)
             ) {
                 var negotiations = stream.collect(Collectors.toList());
                 negotiations.forEach(cn -> leaseContext.withConnection(connection).acquireLease(cn.getId()));
@@ -184,9 +184,14 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
         });
     }
 
+    private ContractAgreement findContractAgreementInternal(Connection connection, String contractId) {
+        var stmt = statements.getFindContractAgreementTemplate();
+        return executeQuerySingle(connection, false, this::mapContractAgreement, stmt, contractId);
+    }
+
     private @Nullable ContractNegotiation findInternal(Connection connection, String id) {
         var sql = statements.getFindTemplate();
-        return executeQuerySingle(connection, false, this::mapContractNegotiation, sql, id);
+        return executeQuerySingle(connection, false, this.contractNegotiationMapper(), sql, id);
     }
 
     private void update(Connection connection, String negotiationId, ContractNegotiation updatedValues) {
@@ -304,14 +309,29 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
         return format("Expected to find %d items, but found %d", expectedSize, actualSize);
     }
 
-    private ContractNegotiation mapContractNegotiation(ResultSet resultSet) throws SQLException {
+    private ResultSetMapper<ContractNegotiation> contractNegotiationMapper() {
+        return (resultSet -> mapContractNegotiation(resultSet, this::extractContractAgreement));
+    }
+
+    private ResultSetMapper<ContractNegotiation> contractNegotiationWithAgreementMapper(Connection connection) {
+        return (resultSet -> mapContractNegotiation(resultSet, rs -> {
+            var agreementId = rs.getString(statements.getContractAgreementIdFkColumn());
+            if (agreementId == null) {
+                return null;
+            } else {
+                return findContractAgreementInternal(connection, agreementId);
+            }
+        }));
+    }
+
+    private ContractNegotiation mapContractNegotiation(ResultSet resultSet, ResultSetMapper<ContractAgreement> agreementMapper) throws Exception {
         return ContractNegotiation.Builder.newInstance()
                 .id(resultSet.getString(statements.getIdColumn()))
                 .counterPartyId(resultSet.getString(statements.getCounterPartyIdColumn()))
                 .counterPartyAddress(resultSet.getString(statements.getCounterPartyAddressColumn()))
                 .protocol(resultSet.getString(statements.getProtocolColumn()))
                 .correlationId(resultSet.getString(statements.getCorrelationIdColumn()))
-                .contractAgreement(extractContractAgreement(resultSet))
+                .contractAgreement(agreementMapper.mapResultSet(resultSet))
                 .state(resultSet.getInt(statements.getStateColumn()))
                 .stateCount(resultSet.getInt(statements.getStateCountColumn()))
                 .stateTimestamp(resultSet.getLong(statements.getStateTimestampColumn()))

--- a/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/negotiation/store/ContractNegotiationStoreTestBase.java
+++ b/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/negotiation/store/ContractNegotiationStoreTestBase.java
@@ -563,6 +563,23 @@ public abstract class ContractNegotiationStoreTestBase {
     }
 
     @Test
+    @DisplayName("Verify that nextForState returns the agreement")
+    void nextForState_withAgreement() {
+        var contractAgreement = createContract(ContractId.createContractId(UUID.randomUUID().toString()));
+        var negotiation = createNegotiationBuilder(UUID.randomUUID().toString())
+                .contractAgreement(contractAgreement)
+                .state(ContractNegotiationStates.AGREED.code())
+                .build();
+
+        getContractNegotiationStore().save(negotiation);
+
+        var batch = getContractNegotiationStore().nextForState(ContractNegotiationStates.AGREED.code(), 1);
+
+        Assertions.assertThat(batch).hasSize(1).usingRecursiveFieldByFieldElementComparator().containsExactly(negotiation);
+
+    }
+
+    @Test
     void queryAgreements_noQuerySpec() {
         IntStream.range(0, 10).forEach(i -> {
             var contractAgreement = createContract(ContractId.createContractId(UUID.randomUUID().toString()));

--- a/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/negotiation/store/ContractNegotiationStoreTestBase.java
+++ b/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/negotiation/store/ContractNegotiationStoreTestBase.java
@@ -575,7 +575,7 @@ public abstract class ContractNegotiationStoreTestBase {
 
         var batch = getContractNegotiationStore().nextForState(ContractNegotiationStates.AGREED.code(), 1);
 
-        Assertions.assertThat(batch).hasSize(1).usingRecursiveFieldByFieldElementComparator().containsExactly(negotiation);
+        assertThat(batch).hasSize(1).usingRecursiveFieldByFieldElementComparator().containsExactly(negotiation);
 
     }
 


### PR DESCRIPTION
## What this PR changes/adds

This PR fixes the call to `SqlContractNegotiationStore#nextForState` for ContractNegotiation where the ContractAgreement is available.

## Why it does that

Currently the state machine throws an exception for state `AGREED`

## Further notes

The mapper for `SqlContractNegotiationStore#nextForState` has been changed. If the agreement id in contract negotiation is not null it gets lazy loaded.

## Linked Issue(s)

Closes #2692 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
