### PR TITLE
fix: thrown excp and logs that would wrongly refer to `ContractDefinition` class

### DIFF
--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiController.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiController.java
@@ -34,7 +34,6 @@ import org.eclipse.edc.connector.api.management.contractnegotiation.model.Negoti
 import org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationState;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferRequest;
-import org.eclipse.edc.connector.contract.spi.types.offer.ContractDefinition;
 import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationService;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.query.QuerySpec;
@@ -101,7 +100,7 @@ public class ContractNegotiationApiController implements ContractNegotiationApi 
         return Optional.of(id)
                 .map(service::getState)
                 .map(NegotiationState::new)
-                .orElseThrow(() -> new ObjectNotFoundException(ContractDefinition.class, id));
+                .orElseThrow(() -> new ObjectNotFoundException(ContractNegotiation.class, id));
     }
 
     @GET
@@ -115,7 +114,7 @@ public class ContractNegotiationApiController implements ContractNegotiationApi 
                 .map(it -> transformerRegistry.transform(it, ContractAgreementDto.class))
                 .filter(Result::succeeded)
                 .map(Result::getContent)
-                .orElseThrow(() -> new ObjectNotFoundException(ContractDefinition.class, negotiationId));
+                .orElseThrow(() -> new ObjectNotFoundException(ContractNegotiation.class, negotiationId));
     }
 
     @POST
@@ -139,7 +138,7 @@ public class ContractNegotiationApiController implements ContractNegotiationApi 
     @Path("/{id}/cancel")
     @Override
     public void cancelNegotiation(@PathParam("id") String id) {
-        monitor.debug(format("Attempting to cancel contract definition with id %s", id));
+        monitor.debug(format("Attempting to cancel contract negotiation with id %s", id));
         var result = service.cancel(id).orElseThrow(exceptionMapper(ContractNegotiation.class, id));
         monitor.debug(format("Contract negotiation canceled %s", result.getId()));
     }
@@ -148,7 +147,7 @@ public class ContractNegotiationApiController implements ContractNegotiationApi 
     @Path("/{id}/decline")
     @Override
     public void declineNegotiation(@PathParam("id") String id) {
-        monitor.debug(format("Attempting to decline contract definition with id %s", id));
+        monitor.debug(format("Attempting to decline contract negotiation with id %s", id));
         var result = service.decline(id).orElseThrow(exceptionMapper(ContractNegotiation.class, id));
         monitor.debug(format("Contract negotiation declined %s", result.getId()));
     }
@@ -161,9 +160,9 @@ public class ContractNegotiationApiController implements ContractNegotiationApi 
 
         var spec = result.getContent();
 
-        monitor.debug(format("Get all contract definitions %s", spec));
+        monitor.debug(format("Get all contract negotiations %s", spec));
 
-        try (var stream = service.query(spec).orElseThrow(exceptionMapper(ContractDefinition.class, null))) {
+        try (var stream = service.query(spec).orElseThrow(exceptionMapper(ContractNegotiation.class, null))) {
             return stream
                     .map(it -> transformerRegistry.transform(it, ContractNegotiationDto.class))
                     .filter(Result::succeeded)

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiController.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiController.java
@@ -89,7 +89,7 @@ public class ContractNegotiationApiController implements ContractNegotiationApi 
                 .map(it -> transformerRegistry.transform(it, ContractNegotiationDto.class))
                 .filter(Result::succeeded)
                 .map(Result::getContent)
-                .orElseThrow(() -> new ObjectNotFoundException(ContractDefinition.class, id));
+                .orElseThrow(() -> new ObjectNotFoundException(ContractNegotiation.class, id));
     }
 
     @GET

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerTest.java
@@ -131,7 +131,9 @@ class ContractNegotiationApiControllerTest {
     void getContractNegotiation_notFound() {
         when(service.findbyId("negotiationId")).thenReturn(null);
 
-        assertThatThrownBy(() -> controller.getNegotiation("nonExistingId")).isInstanceOf(ObjectNotFoundException.class);
+        assertThatThrownBy(() -> controller.getNegotiation("nonExistingId"))
+                .isInstanceOf(ObjectNotFoundException.class)
+                .hasMessage("Object of type ContractNegotiation with ID=nonExistingId was not found");
         verifyNoInteractions(transformerRegistry);
     }
 
@@ -141,7 +143,9 @@ class ContractNegotiationApiControllerTest {
         when(service.findbyId("negotiationId")).thenReturn(contractNegotiation);
         when(transformerRegistry.transform(isA(ContractNegotiation.class), eq(ContractNegotiationDto.class))).thenReturn(Result.failure("failure"));
 
-        assertThatThrownBy(() -> controller.getNegotiation("nonExistingId")).isInstanceOf(ObjectNotFoundException.class);
+        assertThatThrownBy(() -> controller.getNegotiation("nonExistingId"))
+                .isInstanceOf(ObjectNotFoundException.class)
+                .hasMessage("Object of type ContractNegotiation with ID=nonExistingId was not found");
     }
 
     @Test
@@ -157,7 +161,9 @@ class ContractNegotiationApiControllerTest {
     void getContractNegotiationState_notFound() {
         when(service.getState("negotiationId")).thenReturn(null);
 
-        assertThatThrownBy(() -> controller.getNegotiationState("nonExistingId")).isInstanceOf(ObjectNotFoundException.class);
+        assertThatThrownBy(() -> controller.getNegotiationState("nonExistingId"))
+                .isInstanceOf(ObjectNotFoundException.class)
+                .hasMessage("Object of type ContractNegotiation with ID=nonExistingId was not found");
     }
 
     @Test
@@ -177,7 +183,9 @@ class ContractNegotiationApiControllerTest {
     void getAgreementForNegotiation_negotiationNotExist() {
         when(service.getForNegotiation(any())).thenReturn(null);
 
-        assertThatThrownBy(() -> controller.getAgreementForNegotiation("negotiationId")).isInstanceOf(ObjectNotFoundException.class);
+        assertThatThrownBy(() -> controller.getAgreementForNegotiation("negotiationId"))
+                .isInstanceOf(ObjectNotFoundException.class)
+                .hasMessage("Object of type ContractNegotiation with ID=negotiationId was not found");
         verifyNoInteractions(transformerRegistry);
     }
 
@@ -232,7 +240,9 @@ class ContractNegotiationApiControllerTest {
     void cancel_notFound() {
         when(service.cancel("negotiationId")).thenReturn(ServiceResult.notFound("not found"));
 
-        assertThatThrownBy(() -> controller.cancelNegotiation("negotiationId")).isInstanceOf(ObjectNotFoundException.class);
+        assertThatThrownBy(() -> controller.cancelNegotiation("negotiationId"))
+                .isInstanceOf(ObjectNotFoundException.class)
+                .hasMessage("Object of type ContractNegotiation with ID=negotiationId was not found");;
     }
 
     @Test
@@ -256,7 +266,9 @@ class ContractNegotiationApiControllerTest {
     void decline_notFound() {
         when(service.decline("negotiationId")).thenReturn(ServiceResult.notFound("not found"));
 
-        assertThatThrownBy(() -> controller.declineNegotiation("negotiationId")).isInstanceOf(ObjectNotFoundException.class);
+        assertThatThrownBy(() -> controller.declineNegotiation("negotiationId"))
+                .isInstanceOf(ObjectNotFoundException.class)
+                .hasMessage("Object of type ContractNegotiation with ID=negotiationId was not found");
     }
 
     @Test


### PR DESCRIPTION
## What this PR changes/adds

- Fixes API resource class references in logs and exceptions thrown in `ContractNegotiationApiController`.
- Adds assertions for the thrown exception messages' content.

## Why it does that

- Previously it would wrongly refer to `ContractDefinition` instead of `ContracNegotiation`.

## Linked Issue(s)

Closes #2683

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
