### PR TITLE
feat: support End-to-End Async HTTP Streaming Part I

### DIFF
--- a/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSource.java
+++ b/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSource.java
@@ -45,7 +45,7 @@ public class HttpDataSource implements DataSource {
     private HttpPart getPart() {
         var request = requestFactory.toRequest(params);
         monitor.debug(() -> "HttpDataSource sends request: " + request.toString());
-        try  {
+        try {
             // NB: Do not close the response as the body input stream needs to be read after this method returns. The response closes the body stream.
             var response = httpClient.execute(request);
             if (response.isSuccessful()) {
@@ -55,6 +55,11 @@ public class HttpDataSource implements DataSource {
                 }
                 return new HttpPart(name, body.byteStream());
             } else {
+                try {
+                    response.close();
+                } catch (Exception e) {
+                    monitor.info("Error closing failed response", e);
+                }
                 throw new EdcException(format("Received code transferring HTTP data for request %s: %s - %s.", requestId, response.code(), response.message()));
             }
         } catch (IOException e) {

--- a/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSource.java
+++ b/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSource.java
@@ -45,7 +45,9 @@ public class HttpDataSource implements DataSource {
     private HttpPart getPart() {
         var request = requestFactory.toRequest(params);
         monitor.debug(() -> "HttpDataSource sends request: " + request.toString());
-        try (var response = httpClient.execute(request)) {
+        try  {
+            // NB: Do not close the response as the body input stream needs to be read after this method returns. The response closes the body stream.
+            var response = httpClient.execute(request);
             if (response.isSuccessful()) {
                 var body = response.body();
                 if (body == null) {

--- a/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSource.java
+++ b/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSource.java
@@ -130,7 +130,7 @@ public class HttpDataSource implements DataSource {
 
         @Override
         public long size() {
-            return -1;
+            return SIZE_UNKNOWN;
         }
 
         @Override

--- a/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSourceTest.java
+++ b/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSourceTest.java
@@ -96,7 +96,7 @@ class HttpDataSourceTest {
 
         assertThatExceptionOfType(EdcException.class)
                 .isThrownBy(source::openPartStream)
-                .withMessage("Received code transferring HTTP data for request %s: %d - %s. %s", requestId, 400, message, body);
+                .withMessage("Received code transferring HTTP data for request %s: %d - %s.", requestId, 400, message);
 
         verify(requestFactory).toRequest(any());
     }


### PR DESCRIPTION
## What this PR changes/adds

Streams the HTTP response content instead of materializing it in memory. Note that this PR has the added benefit of removing logging response content which should not be done as it could potentially leak sensitive data.

**NB** Introducing end-to-end HTTP streaming changes the supported retry semantics. First, we cannot easily support sink retries without implementing a multipart wire transfer protocol that the sink endpoint supports. Second, the retry mechanism for source connections only works for initial connection establishment. If an error occurs with the source socket connection, it is not possible to establish a new connection and fast-forward to the failure point in the stream without underlying wire protocol and endpoint support.  

Therefore, this PR removes the `DataPlaneHttpToHttpIntegrationTests.transfer_sinkTemporaryDropsConnection_retry()` integration test.

## Linked Issue(s)

Closes See #2702 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
