### PR TITLE
feat: support catalog filtering

### DIFF
--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/assetindex/InMemoryAssetIndex.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/assetindex/InMemoryAssetIndex.java
@@ -15,7 +15,6 @@
 package org.eclipse.edc.connector.defaults.storage.assetindex;
 
 import org.eclipse.edc.spi.asset.AssetIndex;
-import org.eclipse.edc.spi.asset.AssetSelectorExpression;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.query.SortOrder;
@@ -25,7 +24,6 @@ import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.eclipse.edc.spi.types.domain.asset.AssetEntry;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -50,18 +48,6 @@ public class InMemoryAssetIndex implements AssetIndex {
         predicateFactory = new AssetPredicateConverter();
         // fair locks guarantee strong consistency since all waiting threads are processed in order of waiting time
         lock = new ReentrantReadWriteLock(true);
-    }
-
-    @Override
-    public Stream<Asset> queryAssets(AssetSelectorExpression expression) {
-        Objects.requireNonNull(expression, "AssetSelectorExpression can not be null!");
-
-        // select everything ONLY if the special constant is used
-        if (expression == AssetSelectorExpression.SELECT_ALL) {
-            return queryAssets(QuerySpec.none());
-        }
-
-        return queryAssets(QuerySpec.Builder.newInstance().filter(expression.getCriteria()).build());
     }
 
     @Override
@@ -178,14 +164,6 @@ public class InMemoryAssetIndex implements AssetIndex {
         } finally {
             lock.readLock().unlock();
         }
-    }
-
-    public Map<String, Asset> getAssets() {
-        return Collections.unmodifiableMap(cache);
-    }
-
-    public Map<String, DataAddress> getDataAddresses() {
-        return Collections.unmodifiableMap(dataAddresses);
     }
 
     private Stream<Asset> filterBy(List<Criterion> criteria) {

--- a/extensions/common/api/api-core/src/test/java/org/eclipse/edc/api/transformer/QuerySpecDtoToQuerySpecTransformerTest.java
+++ b/extensions/common/api/api-core/src/test/java/org/eclipse/edc/api/transformer/QuerySpecDtoToQuerySpecTransformerTest.java
@@ -76,23 +76,6 @@ class QuerySpecDtoToQuerySpecTransformerTest {
     }
 
     @Test
-    void transform_shouldPrioritizeFilterExpression() {
-        var context = mock(TransformerContext.class);
-        var expected = new Criterion("foo", "=", "bar");
-        when(context.transform(isA(CriterionDto.class), eq(Criterion.class)))
-                .thenReturn(expected);
-
-        var querySpecDto = QuerySpecDto.Builder.newInstance()
-                .filterExpression(List.of(CriterionDto.from("foo", "=", "bar")))
-                .filter("bar < baz")
-                .build();
-
-        var spec = transformer.transform(querySpecDto, context);
-        assertThat(spec).isNotNull();
-        assertThat(spec.getFilterExpression()).hasSize(1).usingRecursiveFieldByFieldElementComparator().containsOnly(expected);
-    }
-
-    @Test
     void transform_shouldReturnNull_whenCriterionNotTransforable() {
         var context = mock(TransformerContext.class);
         when(context.transform(isA(CriterionDto.class), eq(Criterion.class)))

--- a/extensions/control-plane/store/cosmos/asset-index-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/assetindex/CosmosAssetIndex.java
+++ b/extensions/control-plane/store/cosmos/asset-index-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/assetindex/CosmosAssetIndex.java
@@ -16,12 +16,10 @@ package org.eclipse.edc.connector.store.azure.cosmos.assetindex;
 
 import com.azure.cosmos.implementation.ConflictException;
 import com.azure.cosmos.implementation.NotFoundException;
-import com.azure.cosmos.models.SqlQuerySpec;
 import dev.failsafe.RetryPolicy;
 import org.eclipse.edc.azure.cosmos.CosmosDbApi;
 import org.eclipse.edc.connector.store.azure.cosmos.assetindex.model.AssetDocument;
 import org.eclipse.edc.spi.asset.AssetIndex;
-import org.eclipse.edc.spi.asset.AssetSelectorExpression;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
@@ -65,21 +63,6 @@ public class CosmosAssetIndex implements AssetIndex {
         this.retryPolicy = Objects.requireNonNull(retryPolicy);
         this.monitor = monitor;
         queryBuilder = new CosmosAssetQueryBuilder();
-    }
-
-    @Override
-    public Stream<Asset> queryAssets(AssetSelectorExpression expression) {
-        Objects.requireNonNull(expression, "AssetSelectorExpression can not be null!");
-
-        if (expression.equals(AssetSelectorExpression.SELECT_ALL)) {
-            return queryAssets(QuerySpec.none());
-        }
-
-        SqlQuerySpec query = queryBuilder.from(expression.getCriteria());
-
-        var response = with(retryPolicy).get(() -> assetDb.queryItems(query));
-        return response.map(this::convertObject)
-                .map(AssetDocument::getWrappedAsset);
     }
 
     @Override

--- a/extensions/control-plane/store/cosmos/asset-index-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/assetindex/CosmosAssetIndexIntegrationTest.java
+++ b/extensions/control-plane/store/cosmos/asset-index-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/assetindex/CosmosAssetIndexIntegrationTest.java
@@ -24,7 +24,6 @@ import org.eclipse.edc.azure.testfixtures.CosmosTestClient;
 import org.eclipse.edc.azure.testfixtures.annotations.AzureCosmosDbIntegrationTest;
 import org.eclipse.edc.connector.store.azure.cosmos.assetindex.model.AssetDocument;
 import org.eclipse.edc.spi.asset.AssetIndex;
-import org.eclipse.edc.spi.asset.AssetSelectorExpression;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.query.SortOrder;
@@ -39,14 +38,10 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.edc.spi.result.StoreFailure.Reason.NOT_FOUND;
 import static org.mockito.Mockito.mock;
 
@@ -99,60 +94,6 @@ class CosmosAssetIndexIntegrationTest extends AssetIndexTestBase {
     }
 
     @Test
-    void queryAssets_selectAll() {
-        Asset asset1 = createAssetWithProperty("123", "hello", "world");
-
-        Asset asset2 = createAssetWithProperty("456", "foo", "bar");
-
-        container.createItem(new AssetDocument(asset1, TEST_PARTITION_KEY, dataAddress));
-        container.createItem(new AssetDocument(asset2, TEST_PARTITION_KEY, dataAddress));
-
-        List<Asset> assets = assetIndex.queryAssets(AssetSelectorExpression.SELECT_ALL).collect(Collectors.toList());
-
-        assertThat(assets).hasSize(2)
-                .anyMatch(asset -> asset.getProperties().equals(asset1.getProperties()))
-                .anyMatch(asset -> asset.getProperties().equals(asset2.getProperties()));
-    }
-
-    @Test
-    void queryAssets_filterOnProperty() {
-        Asset asset1 = createAssetWithProperty("123", "test", "world");
-
-        Asset asset2 = createAssetWithProperty("456", "test", "bar");
-
-        container.createItem(new AssetDocument(asset1, TEST_PARTITION_KEY, dataAddress));
-        container.createItem(new AssetDocument(asset2, TEST_PARTITION_KEY, dataAddress));
-
-        AssetSelectorExpression expression = AssetSelectorExpression.Builder.newInstance()
-                .whenEquals(Asset.PROPERTY_ID, "456")
-                .build();
-
-        List<Asset> assets = assetIndex.queryAssets(expression).collect(Collectors.toList());
-
-        assertThat(assets).hasSize(1)
-                .allSatisfy(asset -> assertThat(asset.getId()).isEqualTo("456"));
-    }
-
-    @Test
-    void queryAssets_filterOnPropertyContainingIllegalArgs() {
-        Asset asset1 = createAssetWithProperty("123", "test:value", "world");
-
-        Asset asset2 = createAssetWithProperty("456", "test:value", "bar");
-
-        container.createItem(new AssetDocument(asset1, TEST_PARTITION_KEY, dataAddress));
-        container.createItem(new AssetDocument(asset2, TEST_PARTITION_KEY, dataAddress));
-
-        AssetSelectorExpression expression = AssetSelectorExpression.Builder.newInstance()
-                .whenEquals("test:value", "bar")
-                .build();
-
-        List<Asset> assets = assetIndex.queryAssets(expression).collect(Collectors.toList());
-
-        assertThat(assets).hasSize(1)
-                .allSatisfy(asset -> assertThat(asset.getId()).isEqualTo("456"));
-    }
-
-    @Test
     void findById() {
         Asset asset1 = createAssetWithProperty("123", "test", "world");
 
@@ -165,88 +106,6 @@ class CosmosAssetIndexIntegrationTest extends AssetIndexTestBase {
 
         assertThat(asset).isNotNull();
         assertThat(asset.getProperties()).isEqualTo(asset2.getProperties());
-    }
-
-    @Test
-    void queryAssets_operatorIn() {
-        Asset asset1 = createAssetWithProperty("123", "hello", "world");
-
-        Asset asset2 = createAssetWithProperty("456", "foo", "bar");
-
-        container.createItem(new AssetDocument(asset1, TEST_PARTITION_KEY, dataAddress));
-        container.createItem(new AssetDocument(asset2, TEST_PARTITION_KEY, dataAddress));
-
-        var selector = AssetSelectorExpression.Builder.newInstance()
-                .constraint(Asset.PROPERTY_ID, "IN", List.of(asset1.getId(), asset2.getId()))
-                .build();
-
-        List<Asset> assets = assetIndex.queryAssets(selector).collect(Collectors.toList());
-
-        assertThat(assets).hasSize(2)
-                .anyMatch(asset -> asset.getProperties().equals(asset1.getProperties()))
-                .anyMatch(asset -> asset.getProperties().equals(asset2.getProperties()));
-    }
-
-    @Test
-    void queryAssets_operatorIn_notList_throwsException() {
-        Asset asset1 = createAssetWithProperty("123", "hello", "world");
-
-        Asset asset2 = createAssetWithProperty("456", "foo", "bar");
-
-        container.createItem(new AssetDocument(asset1, TEST_PARTITION_KEY, dataAddress));
-        container.createItem(new AssetDocument(asset2, TEST_PARTITION_KEY, dataAddress));
-
-        var inExpr = format("'%s', '%s'", asset1.getId(), asset2.getId());
-        var selector = AssetSelectorExpression.Builder.newInstance()
-                .constraint(Asset.PROPERTY_ID, "IN", inExpr)
-                .build();
-
-        // collecting is necessary, otherwise the cosmos query is not executed
-        assertThatThrownBy(() -> assetIndex.queryAssets(selector).collect(Collectors.toList())).isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Cannot build WHERE clause, reason: The \"in\" operator requires the right-hand operand to be of type interface java.lang.Iterable but was actually class java.lang.String");
-
-    }
-
-    @Test
-    void queryAssets_operatorIn_syntaxError_throwsException() {
-        Asset asset1 = createAssetWithProperty("123", "hello", "world");
-
-        Asset asset2 = createAssetWithProperty("456", "foo", "bar");
-
-        container.createItem(new AssetDocument(asset1, TEST_PARTITION_KEY, dataAddress));
-        container.createItem(new AssetDocument(asset2, TEST_PARTITION_KEY, dataAddress));
-
-        var inExpr = format("('%s' ; '%s')", asset1.getId(), asset2.getId());
-        var selector = AssetSelectorExpression.Builder.newInstance()
-                .constraint(Asset.PROPERTY_ID, "IN foobar", List.of(asset1.getId(), asset2.getId()))
-                .build();
-
-        // collecting is necessary, otherwise the cosmos query is not executed
-        assertThatThrownBy(() -> assetIndex.queryAssets(selector).collect(Collectors.toList())).isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Cannot build WHERE clause, reason: unsupported operator IN foobar");
-    }
-
-    @Test
-    void queryAssets_operatorIn_notFound() {
-
-        var inExpr = List.of("not-exist1", "not-exist2");
-        var selector = AssetSelectorExpression.Builder.newInstance()
-                .constraint(Asset.PROPERTY_ID, "IN", inExpr)
-                .build();
-
-        List<Asset> assets = assetIndex.queryAssets(selector).collect(Collectors.toList());
-
-        assertThat(assets).isEmpty();
-    }
-
-    @Test
-    void findAll_noQuerySpec() {
-        Asset asset1 = createAssetWithProperty("123", "test", "world");
-        container.createItem(new AssetDocument(asset1, TEST_PARTITION_KEY, dataAddress));
-
-        var all = assetIndex.queryAssets(QuerySpec.none());
-        assertThat(all).hasSize(1).extracting(Asset::getId).containsExactly(asset1.getId());
-
     }
 
     @Test
@@ -288,48 +147,6 @@ class CosmosAssetIndexIntegrationTest extends AssetIndexTestBase {
 
         var all = assetIndex.queryAssets(limitQuery);
         assertThat(all).hasSize(3).extracting(Asset::getId).containsExactly("id2", "id3", "id4");
-    }
-
-    @Test
-    void findAll_withFiltering() {
-        IntStream.range(0, 5).mapToObj(i -> createAssetWithProperty("id" + i, "foo", "bar" + i))
-                .forEach(a -> container.createItem(new AssetDocument(a, TEST_PARTITION_KEY, dataAddress)));
-
-        var filterQuery = QuerySpec.Builder.newInstance()
-                .equalsAsContains(false)
-                .filter("foo=bar4")
-                .build();
-
-        var all = assetIndex.queryAssets(filterQuery);
-        assertThat(all).hasSize(1).extracting(a -> a.getProperty("foo")).containsOnly("bar4");
-    }
-
-    @Test
-    void findAll_withInvalidFilter_throwsException() {
-        IntStream.range(0, 5).mapToObj(i -> createAssetWithProperty("id" + i, "foo", "bar" + i))
-                .forEach(a -> container.createItem(new AssetDocument(a, TEST_PARTITION_KEY, dataAddress)));
-
-        var filterQuery = QuerySpec.Builder.newInstance()
-                .equalsAsContains(false)
-                .filter("foo STARTSWITH bar4")
-                .build();
-
-        assertThatThrownBy(() -> assetIndex.queryAssets(filterQuery)).isInstanceOf(IllegalArgumentException.class).hasMessage("Cannot build WHERE clause, reason: unsupported operator STARTSWITH");
-    }
-
-    @Test
-    void findAll_withFilteringOperatorIn_limitExceedsResultSize() {
-        IntStream.range(0, 5).mapToObj(i -> createAssetWithProperty("id" + i, "foo", "bar" + i))
-                .forEach(a -> container.createItem(new AssetDocument(a, TEST_PARTITION_KEY, dataAddress)));
-
-        var filterQuery = QuerySpec.Builder.newInstance()
-                .equalsAsContains(false)
-                .filter("foo IN [\"bar4\", \"bar3\", \"bar2\", \"bar1\"]")
-                .limit(10)
-                .build();
-
-        var all = assetIndex.queryAssets(filterQuery);
-        assertThat(all).hasSize(4).extracting(Asset::getId).containsExactlyInAnyOrder("id4", "id3", "id2", "id1");
     }
 
     @Test

--- a/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/assetindex/SqlAssetIndex.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/assetindex/SqlAssetIndex.java
@@ -15,12 +15,10 @@
 
 package org.eclipse.edc.connector.store.sql.assetindex;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.edc.connector.store.sql.assetindex.schema.AssetStatements;
 import org.eclipse.edc.spi.asset.AssetIndex;
-import org.eclipse.edc.spi.asset.AssetSelectorExpression;
 import org.eclipse.edc.spi.persistence.EdcPersistenceException;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
@@ -53,18 +51,6 @@ public class SqlAssetIndex extends AbstractSqlStore implements AssetIndex {
     public SqlAssetIndex(DataSourceRegistry dataSourceRegistry, String dataSourceName, TransactionContext transactionContext, ObjectMapper objectMapper, AssetStatements assetStatements) {
         super(dataSourceRegistry, dataSourceName, transactionContext, objectMapper);
         this.assetStatements = Objects.requireNonNull(assetStatements);
-    }
-
-    @Override
-    public Stream<Asset> queryAssets(AssetSelectorExpression expression) {
-        Objects.requireNonNull(expression);
-
-        var criteria = expression.getCriteria();
-        var querySpec = QuerySpec.Builder.newInstance().filter(criteria)
-                .offset(0)
-                .limit(Integer.MAX_VALUE) // means effectively no limit
-                .build();
-        return queryAssets(querySpec);
     }
 
     @Override
@@ -256,7 +242,7 @@ public class SqlAssetIndex extends AbstractSqlStore implements AssetIndex {
         return resultSet.getInt(assetStatements.getCountVariableName());
     }
 
-    private AbstractMap.SimpleImmutableEntry<String, Object> mapPropertyResultSet(ResultSet resultSet) throws SQLException, ClassNotFoundException, JsonProcessingException {
+    private AbstractMap.SimpleImmutableEntry<String, Object> mapPropertyResultSet(ResultSet resultSet) throws SQLException, ClassNotFoundException {
         var name = resultSet.getString(assetStatements.getAssetPropertyColumnName());
         var value = resultSet.getString(assetStatements.getAssetPropertyColumnValue());
         var type = resultSet.getString(assetStatements.getAssetPropertyColumnType());
@@ -285,7 +271,7 @@ public class SqlAssetIndex extends AbstractSqlStore implements AssetIndex {
     }
 
 
-    private DataAddress mapDataAddress(ResultSet resultSet) throws SQLException, JsonProcessingException {
+    private DataAddress mapDataAddress(ResultSet resultSet) throws SQLException {
         return DataAddress.Builder.newInstance()
                 .properties(fromJson(resultSet.getString(assetStatements.getDataAddressPropertiesColumn()), new TypeReference<>() {
                 }))

--- a/extensions/control-plane/store/sql/asset-index-sql/src/test/java/org/eclipse/edc/connector/store/sql/assetindex/PostgresAssetIndexTest.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/test/java/org/eclipse/edc/connector/store/sql/assetindex/PostgresAssetIndexTest.java
@@ -19,7 +19,7 @@ import org.eclipse.edc.connector.store.sql.assetindex.schema.BaseSqlDialectState
 import org.eclipse.edc.connector.store.sql.assetindex.schema.postgres.PostgresDialectStatements;
 import org.eclipse.edc.junit.annotations.PostgresqlDbIntegrationTest;
 import org.eclipse.edc.policy.model.PolicyRegistrationTypes;
-import org.eclipse.edc.spi.asset.AssetSelectorExpression;
+import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.testfixtures.asset.AssetIndexTestBase;
 import org.eclipse.edc.spi.testfixtures.asset.TestObject;
@@ -102,8 +102,8 @@ class PostgresAssetIndexTest extends AssetIndexTestBase {
         asset.getProperties().put("testobj", new TestObject("test123", 42, false));
         sqlAssetIndex.accept(asset, TestFunctions.createDataAddress("test-type"));
 
-        var assetsFound = sqlAssetIndex.queryAssets(AssetSelectorExpression.Builder.newInstance()
-                .constraint("testobj", "like", "%test1%")
+        var assetsFound = sqlAssetIndex.queryAssets(QuerySpec.Builder.newInstance()
+                .filter(new Criterion("testobj", "like", "%test1%"))
                 .build());
 
         assertThat(assetsFound).usingRecursiveFieldByFieldElementComparator().containsExactly(asset);

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/asset/AssetIndex.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/asset/AssetIndex.java
@@ -41,17 +41,6 @@ public interface AssetIndex extends DataAddressResolver {
     String DATAADDRESS_NOT_FOUND_TEMPLATE = "DataAddress with ID %s not found";
 
     /**
-     * Returns all {@link Asset} objects that are selected by a certain expression
-     *
-     * @param expression An object containing a structured query to asset objects. If the expression contains no criteria,
-     *                   {@code Stream.empty()} is returned. If {@link AssetSelectorExpression#SELECT_ALL} is passed in, all
-     *                   Assets in the index are returned.
-     * @return A {@code Stream} that contains all assets that are selected by the expression. Might be empty, never null.
-     * @throws NullPointerException if the {@code AssetSelectorExpression} is null
-     */
-    Stream<Asset> queryAssets(AssetSelectorExpression expression);
-
-    /**
      * Finds all assets that are covered by a specific {@link QuerySpec}. Results are always sorted. If no {@link QuerySpec#getSortField()}
      * is specified, results are not explicitly sorted.
      * <p>

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/QuerySpec.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/QuerySpec.java
@@ -157,19 +157,14 @@ public class QuerySpec {
             return this;
         }
 
-        public QuerySpec build() {
-            if (querySpec.offset < 0) {
-                throw new IllegalArgumentException("offset");
-            }
-            if (querySpec.limit <= 0) {
-                throw new IllegalArgumentException("limit");
-            }
-            return querySpec;
+        public Builder filter(Criterion criterion) {
+            querySpec.filterExpression.add(criterion);
+            return this;
         }
 
         public Builder filter(List<Criterion> criteria) {
             if (criteria != null) {
-                querySpec.filterExpression = criteria;
+                querySpec.filterExpression.addAll(criteria);
             }
             return this;
         }
@@ -200,6 +195,16 @@ public class QuerySpec {
             }
 
             return this;
+        }
+
+        public QuerySpec build() {
+            if (querySpec.offset < 0) {
+                throw new IllegalArgumentException("offset");
+            }
+            if (querySpec.limit <= 0) {
+                throw new IllegalArgumentException("limit");
+            }
+            return querySpec;
         }
 
 


### PR DESCRIPTION
## What this PR changes/adds

Supports catalog filtering

## Why it does that

dataspace-protocol implementation

## Further notes

- I noticed that there's a method in the `AssetIndex` used only by tests: `queryAssets(AssetSelectorExpression expression)`, I took some time to replace its test occurrencies with the actually used `queryAssets(QuerySpec querySpec)` and remove it. There still are some duplicate tests in the `Postgres`/`Cosmos`/`InMemory` integration test classes to be moved to the `AssetIndexTestBase`, but I will open an issue to do that later on.

## Linked Issue(s)

Closes #2697 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
