### PR TITLE
chore(spi): make ContractOfferRequest implement ContractRemoteMessage

### DIFF
--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractOfferRequest.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractOfferRequest.java
@@ -15,8 +15,8 @@
 package org.eclipse.edc.connector.contract.spi.types.negotiation;
 
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
+import org.eclipse.edc.connector.contract.spi.types.protocol.ContractRemoteMessage;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
-import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,7 +26,7 @@ import java.util.Objects;
  * Object that wraps the contract offer and provides additional information about e.g. protocol
  * and recipient.
  */
-public class ContractOfferRequest implements RemoteMessage {
+public class ContractOfferRequest implements ContractRemoteMessage {
 
     private Type type = Type.COUNTER_OFFER;
     private String protocol;
@@ -65,6 +65,11 @@ public class ContractOfferRequest implements RemoteMessage {
 
     public List<CallbackAddress> getCallbackAddress() {
         return callbackAddress;
+    }
+
+    @Override
+    public String getProcessId() {
+        return getCorrelationId();
     }
 
     public enum Type {


### PR DESCRIPTION
## What this PR changes/adds

Change impl of  `ContractOfferRequest` from `RemoteMessage` to `ContractRemoteMessage`.

## Why it does that

Algin with other contract-related remote messages.

## Further notes

--

## Linked Issue(s)

Closes #2722

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
