### PR TITLE
refactor: adapt RemoteMessage naming to DSP

### DIFF
--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -22,7 +22,7 @@ import io.opentelemetry.extension.annotations.WithSpan;
 import org.eclipse.edc.connector.contract.spi.ContractId;
 import org.eclipse.edc.connector.contract.spi.negotiation.ConsumerContractNegotiationManager;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
-import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementRequest;
+import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementMessage;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementVerificationMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates;
@@ -187,7 +187,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
                 .assetId(lastOffer.getAsset().getId())
                 .build();
 
-        var request = ContractAgreementRequest.Builder.newInstance()
+        var request = ContractAgreementMessage.Builder.newInstance()
                 .protocol(negotiation.getProtocol())
                 .connectorId(negotiation.getCounterPartyId())
                 .connectorAddress(negotiation.getCounterPartyAddress())

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -26,7 +26,7 @@ import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementM
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementVerificationMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferRequest;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRejection;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.command.ContractNegotiationCommand;
 import org.eclipse.edc.spi.response.StatusResult;
@@ -84,7 +84,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
      */
     @WithSpan
     @Override
-    public StatusResult<ContractNegotiation> initiate(ContractOfferRequest contractOffer) {
+    public StatusResult<ContractNegotiation> initiate(ContractRequestMessage contractOffer) {
         var id = UUID.randomUUID().toString();
         var negotiation = ContractNegotiation.Builder.newInstance()
                 .id(id)
@@ -138,13 +138,13 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
     @WithSpan
     private boolean processRequesting(ContractNegotiation negotiation) {
         var offer = negotiation.getLastContractOffer();
-        var request = ContractOfferRequest.Builder.newInstance() // TODO: should be renamed to ContractRequestMessage
+        var request = ContractRequestMessage.Builder.newInstance() // TODO: should be renamed to ContractRequestMessage
                 .contractOffer(offer)
                 .connectorAddress(negotiation.getCounterPartyAddress())
                 .protocol(negotiation.getProtocol())
                 .connectorId(negotiation.getCounterPartyId())
                 .correlationId(negotiation.getId())
-                .type(ContractOfferRequest.Type.INITIAL)
+                .type(ContractRequestMessage.Type.INITIAL)
                 .build();
 
         return entityRetryProcessFactory.doAsyncProcess(negotiation, () -> dispatcherRegistry.send(Object.class, request))

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -143,7 +143,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
                 .connectorAddress(negotiation.getCounterPartyAddress())
                 .protocol(negotiation.getProtocol())
                 .connectorId(negotiation.getCounterPartyId())
-                .correlationId(negotiation.getId())
+                .processId(negotiation.getId())
                 .type(ContractRequestMessage.Type.INITIAL)
                 .build();
 
@@ -192,7 +192,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
                 .connectorId(negotiation.getCounterPartyId())
                 .connectorAddress(negotiation.getCounterPartyAddress())
                 .contractAgreement(agreement)
-                .correlationId(negotiation.getId())
+                .processId(negotiation.getId())
                 .policy(policy)
                 .build();
 
@@ -234,7 +234,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
         var message = ContractAgreementVerificationMessage.Builder.newInstance()
                 .protocol(negotiation.getProtocol())
                 .connectorAddress(negotiation.getCounterPartyAddress())
-                .correlationId(negotiation.getId())
+                .processId(negotiation.getId())
                 .build();
 
         return entityRetryProcessFactory.doAsyncProcess(negotiation, () -> dispatcherRegistry.send(Object.class, message))
@@ -259,7 +259,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
                 .protocol(negotiation.getProtocol())
                 .connectorId(negotiation.getCounterPartyId())
                 .connectorAddress(negotiation.getCounterPartyAddress())
-                .correlationId(negotiation.getId())
+                .processId(negotiation.getId())
                 .rejectionReason(negotiation.getErrorDetail())
                 .build();
 

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -26,8 +26,8 @@ import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementM
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementVerificationMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationTerminationMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRejection;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.command.ContractNegotiationCommand;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.statemachine.StateMachineManager;
@@ -255,7 +255,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
      */
     @WithSpan
     private boolean processTerminating(ContractNegotiation negotiation) {
-        var rejection = ContractRejection.Builder.newInstance()
+        var rejection = ContractNegotiationTerminationMessage.Builder.newInstance()
                 .protocol(negotiation.getProtocol())
                 .connectorId(negotiation.getCounterPartyId())
                 .connectorAddress(negotiation.getCounterPartyAddress())

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -26,8 +26,8 @@ import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementM
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractNegotiationEventMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationTerminationMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRejection;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.command.ContractNegotiationCommand;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.statemachine.StateMachineManager;
@@ -125,7 +125,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
      */
     @WithSpan
     private boolean processTerminating(ContractNegotiation negotiation) {
-        var rejection = ContractRejection.Builder.newInstance()
+        var rejection = ContractNegotiationTerminationMessage.Builder.newInstance()
                 .protocol(negotiation.getProtocol())
                 .connectorId(negotiation.getCounterPartyId())
                 .connectorAddress(negotiation.getCounterPartyAddress())

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -26,7 +26,7 @@ import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementM
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractNegotiationEventMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferRequest;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRejection;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.command.ContractNegotiationCommand;
 import org.eclipse.edc.policy.model.Policy;
@@ -99,7 +99,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
     private boolean processOffering(ContractNegotiation negotiation) {
         var currentOffer = negotiation.getLastContractOffer();
 
-        var contractOfferRequest = ContractOfferRequest.Builder.newInstance()
+        var contractOfferRequest = ContractRequestMessage.Builder.newInstance()
                 .protocol(negotiation.getProtocol())
                 .connectorId(negotiation.getCounterPartyId())
                 .connectorAddress(negotiation.getCounterPartyAddress())

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -22,7 +22,7 @@ import io.opentelemetry.extension.annotations.WithSpan;
 import org.eclipse.edc.connector.contract.spi.ContractId;
 import org.eclipse.edc.connector.contract.spi.negotiation.ProviderContractNegotiationManager;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
-import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementRequest;
+import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementMessage;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractNegotiationEventMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates;
@@ -182,7 +182,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
             policy = agreement.getPolicy();
         }
 
-        var request = ContractAgreementRequest.Builder.newInstance() // TODO: should be renamed to ContractAgreementMessage
+        var request = ContractAgreementMessage.Builder.newInstance() // TODO: should be renamed to ContractAgreementMessage
                 .protocol(negotiation.getProtocol())
                 .connectorId(negotiation.getCounterPartyId())
                 .connectorAddress(negotiation.getCounterPartyAddress())

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -104,7 +104,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
                 .connectorId(negotiation.getCounterPartyId())
                 .connectorAddress(negotiation.getCounterPartyAddress())
                 .contractOffer(currentOffer)
-                .correlationId(negotiation.getCorrelationId())
+                .processId(negotiation.getCorrelationId())
                 .build();
 
         return entityRetryProcessFactory.doAsyncProcess(negotiation, () -> dispatcherRegistry.send(Object.class, contractOfferRequest))
@@ -129,7 +129,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
                 .protocol(negotiation.getProtocol())
                 .connectorId(negotiation.getCounterPartyId())
                 .connectorAddress(negotiation.getCounterPartyAddress())
-                .correlationId(negotiation.getCorrelationId())
+                .processId(negotiation.getCorrelationId())
                 .rejectionReason(negotiation.getErrorDetail())
                 .build();
 
@@ -187,7 +187,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
                 .connectorId(negotiation.getCounterPartyId())
                 .connectorAddress(negotiation.getCounterPartyAddress())
                 .contractAgreement(agreement)
-                .correlationId(negotiation.getCorrelationId())
+                .processId(negotiation.getCorrelationId())
                 .policy(policy)
                 .build();
 
@@ -225,7 +225,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
                 .type(ContractNegotiationEventMessage.Type.FINALIZED)
                 .protocol(negotiation.getProtocol())
                 .connectorAddress(negotiation.getCounterPartyAddress())
-                .correlationId(negotiation.getCorrelationId())
+                .processId(negotiation.getCorrelationId())
                 .build();
 
         return entityRetryProcessFactory.doAsyncProcess(negotiation, () -> dispatcherRegistry.send(Object.class, message))

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
@@ -21,7 +21,7 @@ import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiat
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementVerificationMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferRequest;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.command.ContractNegotiationCommand;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore;
@@ -114,7 +114,7 @@ class ConsumerContractNegotiationManagerImplTest {
     void initiate_shouldSaveNewNegotiationInInitialState() {
         var contractOffer = contractOffer();
 
-        var request = ContractOfferRequest.Builder.newInstance()
+        var request = ContractRequestMessage.Builder.newInstance()
                 .connectorId("connectorId")
                 .connectorAddress("connectorAddress")
                 .protocol("protocol")

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
@@ -266,7 +266,7 @@ class ConsumerContractNegotiationManagerImplTest {
     private ContractNegotiation.Builder contractNegotiationBuilder() {
         return ContractNegotiation.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
-                .correlationId("correlationId")
+                .correlationId("processId")
                 .counterPartyId("connectorId")
                 .counterPartyAddress("connectorAddress")
                 .protocol("protocol")

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -272,7 +272,7 @@ class ContractNegotiationIntegrationTest {
     private Answer<Object> onConsumerSentOfferRequest() {
         return i -> {
             ContractRequestMessage request = i.getArgument(1);
-            consumerNegotiationId = request.getCorrelationId();
+            consumerNegotiationId = request.getProcessId();
             var result = providerService.notifyRequested(request, token);
             return toFuture(result);
         };

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -20,8 +20,8 @@ import org.eclipse.edc.connector.contract.spi.ContractId;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationTerminationMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRejection;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.command.ContractNegotiationCommand;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.contract.spi.validation.ContractValidationService;
@@ -186,7 +186,7 @@ class ContractNegotiationIntegrationTest {
 
     @Test
     void testNegotiation_initialOfferDeclined() {
-        when(providerDispatcherRegistry.send(any(), isA(ContractRejection.class))).then(onProviderSentRejection());
+        when(providerDispatcherRegistry.send(any(), isA(ContractNegotiationTerminationMessage.class))).then(onProviderSentRejection());
         when(consumerDispatcherRegistry.send(any(), isA(ContractRequestMessage.class))).then(onConsumerSentOfferRequest());
         consumerNegotiationId = null;
         ContractOffer offer = getContractOffer();
@@ -218,7 +218,7 @@ class ContractNegotiationIntegrationTest {
     void testNegotiation_agreementDeclined() {
         when(providerDispatcherRegistry.send(any(), isA(ContractAgreementMessage.class))).then(onProviderSentAgreementRequest());
         when(consumerDispatcherRegistry.send(any(), isA(ContractRequestMessage.class))).then(onConsumerSentOfferRequest());
-        when(consumerDispatcherRegistry.send(any(), isA(ContractRejection.class))).then(onConsumerSentRejection());
+        when(consumerDispatcherRegistry.send(any(), isA(ContractNegotiationTerminationMessage.class))).then(onConsumerSentRejection());
         consumerNegotiationId = null;
         var offer = getContractOffer();
 
@@ -281,7 +281,7 @@ class ContractNegotiationIntegrationTest {
     @NotNull
     private Answer<Object> onConsumerSentRejection() {
         return i -> {
-            ContractRejection request = i.getArgument(1);
+            ContractNegotiationTerminationMessage request = i.getArgument(1);
             var result = providerService.notifyTerminated(request, token);
             return toFuture(result);
         };
@@ -299,7 +299,7 @@ class ContractNegotiationIntegrationTest {
     @NotNull
     private Answer<Object> onProviderSentRejection() {
         return i -> {
-            ContractRejection request = i.getArgument(1);
+            ContractNegotiationTerminationMessage request = i.getArgument(1);
             var result = consumerService.notifyTerminated(request, token);
             return toFuture(result);
         };

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -18,7 +18,7 @@ package org.eclipse.edc.connector.contract.negotiation;
 import org.eclipse.edc.connector.contract.observe.ContractNegotiationObservableImpl;
 import org.eclipse.edc.connector.contract.spi.ContractId;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
-import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementRequest;
+import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferRequest;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRejection;
@@ -133,7 +133,7 @@ class ContractNegotiationIntegrationTest {
 
     @Test
     void testNegotiation_initialOfferAccepted() {
-        when(providerDispatcherRegistry.send(any(), isA(ContractAgreementRequest.class))).then(onProviderSentAgreementRequest());
+        when(providerDispatcherRegistry.send(any(), isA(ContractAgreementMessage.class))).then(onProviderSentAgreementRequest());
         when(consumerDispatcherRegistry.send(any(), isA(ContractOfferRequest.class))).then(onConsumerSentOfferRequest());
         consumerNegotiationId = "consumerNegotiationId";
         var offer = getContractOffer();
@@ -216,7 +216,7 @@ class ContractNegotiationIntegrationTest {
 
     @Test
     void testNegotiation_agreementDeclined() {
-        when(providerDispatcherRegistry.send(any(), isA(ContractAgreementRequest.class))).then(onProviderSentAgreementRequest());
+        when(providerDispatcherRegistry.send(any(), isA(ContractAgreementMessage.class))).then(onProviderSentAgreementRequest());
         when(consumerDispatcherRegistry.send(any(), isA(ContractOfferRequest.class))).then(onConsumerSentOfferRequest());
         when(consumerDispatcherRegistry.send(any(), isA(ContractRejection.class))).then(onConsumerSentRejection());
         consumerNegotiationId = null;
@@ -290,7 +290,7 @@ class ContractNegotiationIntegrationTest {
     @NotNull
     private Answer<Object> onProviderSentAgreementRequest() {
         return i -> {
-            ContractAgreementRequest request = i.getArgument(1);
+            ContractAgreementMessage request = i.getArgument(1);
             var result = consumerService.notifyAgreed(request, token);
             return toFuture(result);
         };

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -20,7 +20,7 @@ import org.eclipse.edc.connector.contract.spi.ContractId;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferRequest;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRejection;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.command.ContractNegotiationCommand;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
@@ -134,7 +134,7 @@ class ContractNegotiationIntegrationTest {
     @Test
     void testNegotiation_initialOfferAccepted() {
         when(providerDispatcherRegistry.send(any(), isA(ContractAgreementMessage.class))).then(onProviderSentAgreementRequest());
-        when(consumerDispatcherRegistry.send(any(), isA(ContractOfferRequest.class))).then(onConsumerSentOfferRequest());
+        when(consumerDispatcherRegistry.send(any(), isA(ContractRequestMessage.class))).then(onConsumerSentOfferRequest());
         consumerNegotiationId = "consumerNegotiationId";
         var offer = getContractOffer();
         when(validationService.validateInitialOffer(token, offer)).thenReturn(Result.success(offer));
@@ -146,7 +146,7 @@ class ContractNegotiationIntegrationTest {
         consumerManager.start();
 
         // Create an initial request and trigger consumer manager
-        var request = ContractOfferRequest.Builder.newInstance()
+        var request = ContractRequestMessage.Builder.newInstance()
                 .connectorId("connectorId")
                 .connectorAddress("connectorAddress")
                 .contractOffer(offer)
@@ -187,7 +187,7 @@ class ContractNegotiationIntegrationTest {
     @Test
     void testNegotiation_initialOfferDeclined() {
         when(providerDispatcherRegistry.send(any(), isA(ContractRejection.class))).then(onProviderSentRejection());
-        when(consumerDispatcherRegistry.send(any(), isA(ContractOfferRequest.class))).then(onConsumerSentOfferRequest());
+        when(consumerDispatcherRegistry.send(any(), isA(ContractRequestMessage.class))).then(onConsumerSentOfferRequest());
         consumerNegotiationId = null;
         ContractOffer offer = getContractOffer();
 
@@ -198,7 +198,7 @@ class ContractNegotiationIntegrationTest {
         consumerManager.start();
 
         // Create an initial request and trigger consumer manager
-        var request = ContractOfferRequest.Builder.newInstance()
+        var request = ContractRequestMessage.Builder.newInstance()
                 .connectorId("connectorId")
                 .connectorAddress("connectorAddress")
                 .contractOffer(offer)
@@ -217,7 +217,7 @@ class ContractNegotiationIntegrationTest {
     @Test
     void testNegotiation_agreementDeclined() {
         when(providerDispatcherRegistry.send(any(), isA(ContractAgreementMessage.class))).then(onProviderSentAgreementRequest());
-        when(consumerDispatcherRegistry.send(any(), isA(ContractOfferRequest.class))).then(onConsumerSentOfferRequest());
+        when(consumerDispatcherRegistry.send(any(), isA(ContractRequestMessage.class))).then(onConsumerSentOfferRequest());
         when(consumerDispatcherRegistry.send(any(), isA(ContractRejection.class))).then(onConsumerSentRejection());
         consumerNegotiationId = null;
         var offer = getContractOffer();
@@ -231,7 +231,7 @@ class ContractNegotiationIntegrationTest {
         consumerManager.start();
 
         // Create an initial request and trigger consumer manager
-        var request = ContractOfferRequest.Builder.newInstance()
+        var request = ContractRequestMessage.Builder.newInstance()
                 .connectorId("connectorId")
                 .connectorAddress("connectorAddress")
                 .contractOffer(offer)
@@ -271,7 +271,7 @@ class ContractNegotiationIntegrationTest {
 
     private Answer<Object> onConsumerSentOfferRequest() {
         return i -> {
-            ContractOfferRequest request = i.getArgument(1);
+            ContractRequestMessage request = i.getArgument(1);
             consumerNegotiationId = request.getCorrelationId();
             var result = providerService.notifyRequested(request, token);
             return toFuture(result);

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
@@ -24,7 +24,7 @@ import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementM
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractNegotiationEventMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferRequest;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.command.ContractNegotiationCommand;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
@@ -123,7 +123,7 @@ class ProviderContractNegotiationManagerImplTest {
 
         await().untilAsserted(() -> {
             verify(store).save(argThat(p -> p.getState() == OFFERED.code()));
-            verify(dispatcherRegistry, only()).send(any(), isA(ContractOfferRequest.class));
+            verify(dispatcherRegistry, only()).send(any(), isA(ContractRequestMessage.class));
             verify(listener).offered(any());
         });
     }

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
@@ -20,7 +20,7 @@ import org.eclipse.edc.connector.contract.spi.ContractId;
 import org.eclipse.edc.connector.contract.spi.negotiation.observe.ContractNegotiationListener;
 import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
-import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementRequest;
+import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementMessage;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractNegotiationEventMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates;
@@ -158,7 +158,7 @@ class ProviderContractNegotiationManagerImplTest {
 
         await().untilAsserted(() -> {
             verify(store).save(argThat(p -> p.getState() == AGREED.code()));
-            verify(dispatcherRegistry, only()).send(any(), isA(ContractAgreementRequest.class));
+            verify(dispatcherRegistry, only()).send(any(), isA(ContractAgreementMessage.class));
             verify(listener).agreed(any());
         });
     }

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
@@ -247,7 +247,7 @@ class ProviderContractNegotiationManagerImplTest {
         return ContractNegotiation.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
                 .type(ContractNegotiation.Type.PROVIDER)
-                .correlationId("correlationId")
+                .correlationId("processId")
                 .counterPartyId("connectorId")
                 .counterPartyAddress("connectorAddress")
                 .protocol("protocol")

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/catalog/CatalogServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/catalog/CatalogServiceImpl.java
@@ -16,7 +16,7 @@
 package org.eclipse.edc.connector.service.catalog;
 
 import org.eclipse.edc.catalog.spi.Catalog;
-import org.eclipse.edc.catalog.spi.CatalogRequest;
+import org.eclipse.edc.catalog.spi.CatalogRequestMessage;
 import org.eclipse.edc.connector.spi.catalog.CatalogService;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.query.QuerySpec;
@@ -33,7 +33,7 @@ public class CatalogServiceImpl implements CatalogService {
 
     @Override
     public CompletableFuture<Catalog> getByProviderUrl(String providerUrl, QuerySpec spec) {
-        var request = CatalogRequest.Builder.newInstance()
+        var request = CatalogRequestMessage.Builder.newInstance()
                 .protocol("ids-multipart")
                 .connectorId(providerUrl)
                 .connectorAddress(providerUrl)

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
@@ -147,7 +147,7 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
     private ServiceResult<ContractNegotiation> createNegotiation(ContractRequestMessage message) {
         var negotiation = ContractNegotiation.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
-                .correlationId(message.getCorrelationId())
+                .correlationId(message.getProcessId())
                 .counterPartyId(message.getContractOffer().getConsumer().toString())
                 .counterPartyAddress(message.getConnectorAddress())
                 .protocol(message.getProtocol())

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
@@ -22,8 +22,8 @@ import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementV
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractNegotiationEventMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationTerminationMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRejection;
 import org.eclipse.edc.connector.contract.spi.types.protocol.ContractRemoteMessage;
 import org.eclipse.edc.connector.contract.spi.validation.ContractValidationService;
 import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationProtocolService;
@@ -133,7 +133,7 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
     @Override
     @WithSpan
     @NotNull
-    public ServiceResult<ContractNegotiation> notifyTerminated(ContractRejection message, ClaimToken claimToken) {
+    public ServiceResult<ContractNegotiation> notifyTerminated(ContractNegotiationTerminationMessage message, ClaimToken claimToken) {
         return transactionContext.execute(() -> getNegotiation(message)
                 .compose(negotiation -> validateRequest(claimToken, negotiation))
                 .onSuccess(negotiation -> {

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
@@ -22,7 +22,7 @@ import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementV
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractNegotiationEventMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferRequest;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRejection;
 import org.eclipse.edc.connector.contract.spi.types.protocol.ContractRemoteMessage;
 import org.eclipse.edc.connector.contract.spi.validation.ContractValidationService;
@@ -63,7 +63,7 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
     @Override
     @WithSpan
     @NotNull
-    public ServiceResult<ContractNegotiation> notifyRequested(ContractOfferRequest message, ClaimToken claimToken) {
+    public ServiceResult<ContractNegotiation> notifyRequested(ContractRequestMessage message, ClaimToken claimToken) {
         return transactionContext.execute(() -> createNegotiation(message)
                 .compose(negotiation -> validateOffer(message, claimToken, negotiation))
                 .onSuccess(negotiation -> {
@@ -78,7 +78,7 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
     @Override
     @WithSpan
     @NotNull
-    public ServiceResult<ContractNegotiation> notifyOffered(ContractOfferRequest message, ClaimToken claimToken) {
+    public ServiceResult<ContractNegotiation> notifyOffered(ContractRequestMessage message, ClaimToken claimToken) {
         throw new UnsupportedOperationException("not implemented");
     }
 
@@ -144,7 +144,7 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
     }
 
     @NotNull
-    private ServiceResult<ContractNegotiation> createNegotiation(ContractOfferRequest message) {
+    private ServiceResult<ContractNegotiation> createNegotiation(ContractRequestMessage message) {
         var negotiation = ContractNegotiation.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
                 .correlationId(message.getCorrelationId())
@@ -160,7 +160,7 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
     }
 
     @NotNull
-    private ServiceResult<ContractNegotiation> validateOffer(ContractOfferRequest message, ClaimToken claimToken, ContractNegotiation negotiation) {
+    private ServiceResult<ContractNegotiation> validateOffer(ContractRequestMessage message, ClaimToken claimToken, ContractNegotiation negotiation) {
         var result = validationService.validateInitialOffer(claimToken, message.getContractOffer());
         if (result.failed()) {
             monitor.debug("[Provider] Contract offer rejected as invalid: " + result.getFailureDetail());

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
@@ -17,7 +17,7 @@ package org.eclipse.edc.connector.service.contractnegotiation;
 import io.opentelemetry.extension.annotations.WithSpan;
 import org.eclipse.edc.connector.contract.spi.negotiation.observe.ContractNegotiationObservable;
 import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
-import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementRequest;
+import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementMessage;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementVerificationMessage;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractNegotiationEventMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
@@ -92,7 +92,7 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
     @Override
     @WithSpan
     @NotNull
-    public ServiceResult<ContractNegotiation> notifyAgreed(ContractAgreementRequest message, ClaimToken claimToken) {
+    public ServiceResult<ContractNegotiation> notifyAgreed(ContractAgreementMessage message, ClaimToken claimToken) {
         return transactionContext.execute(() -> getNegotiation(message)
                 .compose(negotiation -> validateAgreed(message, claimToken, negotiation))
                 .onSuccess(negotiation -> {
@@ -171,7 +171,7 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
     }
 
     @NotNull
-    private ServiceResult<ContractNegotiation> validateAgreed(ContractAgreementRequest message, ClaimToken claimToken, ContractNegotiation negotiation) {
+    private ServiceResult<ContractNegotiation> validateAgreed(ContractAgreementMessage message, ClaimToken claimToken, ContractNegotiation negotiation) {
         var agreement = message.getContractAgreement();
         var result = validationService.validateConfirmed(claimToken, agreement, negotiation.getLastContractOffer());
         if (result.failed()) {

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationServiceImpl.java
@@ -21,7 +21,7 @@ import org.eclipse.edc.connector.contract.spi.types.command.CancelNegotiationCom
 import org.eclipse.edc.connector.contract.spi.types.command.DeclineNegotiationCommand;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferRequest;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
 import org.eclipse.edc.connector.service.query.QueryValidator;
 import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationService;
 import org.eclipse.edc.service.spi.result.ServiceResult;
@@ -81,7 +81,7 @@ public class ContractNegotiationServiceImpl implements ContractNegotiationServic
     }
 
     @Override
-    public ContractNegotiation initiateNegotiation(ContractOfferRequest request) {
+    public ContractNegotiation initiateNegotiation(ContractRequestMessage request) {
         return transactionContext.execute(() -> consumerManager.initiate(request).getContent());
     }
 

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/catalog/CatalogServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/catalog/CatalogServiceImplTest.java
@@ -16,7 +16,7 @@ package org.eclipse.edc.connector.service.catalog;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.eclipse.edc.catalog.spi.Catalog;
-import org.eclipse.edc.catalog.spi.CatalogRequest;
+import org.eclipse.edc.catalog.spi.CatalogRequestMessage;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
@@ -60,6 +60,6 @@ class CatalogServiceImplTest {
         var future = service.getByProviderUrl("test.provider.url", new QuerySpec());
 
         assertThat(future).succeedsWithin(1, SECONDS).extracting(Catalog::getContractOffers, InstanceOfAssertFactories.list(ContractOffer.class)).hasSize(1);
-        verify(dispatcher, times(1)).send(eq(Catalog.class), isA(CatalogRequest.class));
+        verify(dispatcher, times(1)).send(eq(Catalog.class), isA(CatalogRequestMessage.class));
     }
 }

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
@@ -131,7 +131,7 @@ class ContractNegotiationEventDispatchTest {
                 .connectorId("connectorId")
                 .connectorAddress("connectorAddress")
                 .contractOffer(contractOffer)
-                .correlationId("correlationId")
+                .processId("processId")
                 .build();
     }
 

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
@@ -16,7 +16,7 @@ package org.eclipse.edc.connector.service.contractnegotiation;
 
 import org.eclipse.edc.connector.contract.spi.negotiation.NegotiationWaitStrategy;
 import org.eclipse.edc.connector.contract.spi.offer.store.ContractDefinitionStore;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferRequest;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractDefinition;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
@@ -114,7 +114,7 @@ class ContractNegotiationEventDispatchTest {
         });
     }
 
-    private ContractOfferRequest createContractOfferRequest(Policy policy) {
+    private ContractRequestMessage createContractOfferRequest(Policy policy) {
         var now = ZonedDateTime.now();
         var contractOffer = ContractOffer.Builder.newInstance()
                 .id("contractDefinitionId:" + UUID.randomUUID())
@@ -126,7 +126,7 @@ class ContractNegotiationEventDispatchTest {
                 .contractEnd(now.plusSeconds(CONTRACT_VALIDITY))
                 .build();
 
-        return ContractOfferRequest.Builder.newInstance()
+        return ContractRequestMessage.Builder.newInstance()
                 .protocol("test")
                 .connectorId("connectorId")
                 .connectorAddress("connectorAddress")

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
@@ -104,7 +104,7 @@ class ContractNegotiationProtocolServiceImplTest {
                 .connectorAddress("connectorAddress")
                 .protocol("protocol")
                 .contractOffer(contractOffer)
-                .correlationId("correlationId")
+                .processId("processId")
                 .build();
 
         var result = service.notifyRequested(message, token);
@@ -117,7 +117,7 @@ class ContractNegotiationProtocolServiceImplTest {
             assertThat(n.getCounterPartyId()).isEqualTo(message.getConnectorId());
             assertThat(n.getCounterPartyAddress()).isEqualTo(message.getConnectorAddress());
             assertThat(n.getProtocol()).isEqualTo(message.getProtocol());
-            assertThat(n.getCorrelationId()).isEqualTo(message.getCorrelationId());
+            assertThat(n.getCorrelationId()).isEqualTo(message.getProcessId());
             assertThat(n.getContractOffers()).hasSize(1);
             assertThat(n.getLastContractOffer()).isEqualTo(contractOffer);
         });
@@ -137,7 +137,7 @@ class ContractNegotiationProtocolServiceImplTest {
                 .connectorAddress("connectorAddress")
                 .protocol("protocol")
                 .contractOffer(contractOffer)
-                .correlationId("correlationId")
+                .processId("processId")
                 .build();
 
         var result = service.notifyRequested(message, token);
@@ -151,13 +151,13 @@ class ContractNegotiationProtocolServiceImplTest {
         var negotiationConsumerRequested = createContractNegotiationRequested();
         var token = ClaimToken.Builder.newInstance().build();
         var contractAgreement = mock(ContractAgreement.class);
-        when(store.findForCorrelationId("correlationId")).thenReturn(negotiationConsumerRequested);
+        when(store.findForCorrelationId("processId")).thenReturn(negotiationConsumerRequested);
         when(validationService.validateConfirmed(eq(token), eq(contractAgreement), any(ContractOffer.class))).thenReturn(Result.success());
         var message = ContractAgreementMessage.Builder.newInstance()
                 .protocol("protocol")
                 .connectorId("connectorId")
                 .connectorAddress("http://any")
-                .correlationId("correlationId")
+                .processId("processId")
                 .contractAgreement(contractAgreement)
                 .policy(createPolicy())
                 .build();
@@ -179,13 +179,13 @@ class ContractNegotiationProtocolServiceImplTest {
         var negotiationConsumerRequested = createContractNegotiationRequested();
         var token = ClaimToken.Builder.newInstance().build();
         var contractAgreement = mock(ContractAgreement.class);
-        when(store.findForCorrelationId("correlationId")).thenReturn(negotiationConsumerRequested);
+        when(store.findForCorrelationId("processId")).thenReturn(negotiationConsumerRequested);
         when(validationService.validateConfirmed(eq(token), eq(contractAgreement), any(ContractOffer.class))).thenReturn(Result.failure("failure"));
         var message = ContractAgreementMessage.Builder.newInstance()
                 .protocol("protocol")
                 .connectorId("connectorId")
                 .connectorAddress("http://any")
-                .correlationId("correlationId")
+                .processId("processId")
                 .contractAgreement(contractAgreement)
                 .policy(createPolicy())
                 .build();
@@ -201,12 +201,12 @@ class ContractNegotiationProtocolServiceImplTest {
     @Test
     void notifyVerified_shouldTransitionToVerified() {
         var negotiation = contractNegotiationBuilder().id("negotiationId").type(PROVIDER).state(AGREED.code()).build();
-        when(store.findForCorrelationId("correlationId")).thenReturn(negotiation);
+        when(store.findForCorrelationId("processId")).thenReturn(negotiation);
         when(validationService.validateRequest(any(), any())).thenReturn(Result.success());
         var message = ContractAgreementVerificationMessage.Builder.newInstance()
                 .protocol("protocol")
                 .connectorAddress("http://any")
-                .correlationId("correlationId")
+                .processId("processId")
                 .build();
 
         var result = service.notifyVerified(message, claimToken());
@@ -221,12 +221,12 @@ class ContractNegotiationProtocolServiceImplTest {
     @Test
     void notifyVerified_shouldReturnBadRequest_whenValidationFails() {
         var negotiation = contractNegotiationBuilder().id("negotiationId").type(PROVIDER).state(AGREED.code()).build();
-        when(store.findForCorrelationId("correlationId")).thenReturn(negotiation);
+        when(store.findForCorrelationId("processId")).thenReturn(negotiation);
         when(validationService.validateRequest(any(), any())).thenReturn(Result.failure("validation error"));
         var message = ContractAgreementVerificationMessage.Builder.newInstance()
                 .protocol("protocol")
                 .connectorAddress("http://any")
-                .correlationId("correlationId")
+                .processId("processId")
                 .build();
 
         var result = service.notifyVerified(message, claimToken());
@@ -239,13 +239,13 @@ class ContractNegotiationProtocolServiceImplTest {
     @Test
     void notifyFinalized_shouldTransitionToFinalized() {
         var negotiation = contractNegotiationBuilder().id("negotiationId").type(PROVIDER).state(VERIFIED.code()).build();
-        when(store.findForCorrelationId("correlationId")).thenReturn(negotiation);
+        when(store.findForCorrelationId("processId")).thenReturn(negotiation);
         when(validationService.validateRequest(any(), any())).thenReturn(Result.success());
         var message = ContractNegotiationEventMessage.Builder.newInstance()
                 .type(ContractNegotiationEventMessage.Type.FINALIZED)
                 .protocol("protocol")
                 .connectorAddress("http://any")
-                .correlationId("correlationId")
+                .processId("processId")
                 .build();
         var token = ClaimToken.Builder.newInstance().build();
 
@@ -261,13 +261,13 @@ class ContractNegotiationProtocolServiceImplTest {
     @Test
     void notifyFinalized_shouldReturnBadRequest_whenValidationFails() {
         var negotiation = contractNegotiationBuilder().id("negotiationId").type(PROVIDER).state(VERIFIED.code()).build();
-        when(store.findForCorrelationId("correlationId")).thenReturn(negotiation);
+        when(store.findForCorrelationId("processId")).thenReturn(negotiation);
         when(validationService.validateRequest(any(), any())).thenReturn(Result.failure("validation error"));
         var message = ContractNegotiationEventMessage.Builder.newInstance()
                 .type(ContractNegotiationEventMessage.Type.FINALIZED)
                 .protocol("protocol")
                 .connectorAddress("http://any")
-                .correlationId("correlationId")
+                .processId("processId")
                 .build();
         var token = ClaimToken.Builder.newInstance().build();
 
@@ -281,11 +281,11 @@ class ContractNegotiationProtocolServiceImplTest {
     @Test
     void notifyTerminated_shouldTransitionToTerminated() {
         var negotiation = contractNegotiationBuilder().id("negotiationId").type(PROVIDER).state(VERIFIED.code()).build();
-        when(store.findForCorrelationId("correlationId")).thenReturn(negotiation);
+        when(store.findForCorrelationId("processId")).thenReturn(negotiation);
         when(validationService.validateRequest(any(), any())).thenReturn(Result.success());
         var message = ContractNegotiationTerminationMessage.Builder.newInstance()
                 .protocol("protocol")
-                .correlationId("correlationId")
+                .processId("processId")
                 .connectorAddress("http://any")
                 .rejectionReason("any")
                 .build();
@@ -303,11 +303,11 @@ class ContractNegotiationProtocolServiceImplTest {
     @Test
     void notifyTerminated_shouldReturnBadRequest_whenValidationFails() {
         var negotiation = contractNegotiationBuilder().id("negotiationId").type(PROVIDER).state(VERIFIED.code()).build();
-        when(store.findForCorrelationId("correlationId")).thenReturn(negotiation);
+        when(store.findForCorrelationId("processId")).thenReturn(negotiation);
         when(validationService.validateRequest(any(), any())).thenReturn(Result.failure("validation error"));
         var message = ContractNegotiationTerminationMessage.Builder.newInstance()
                 .protocol("protocol")
-                .correlationId("correlationId")
+                .processId("processId")
                 .connectorAddress("http://any")
                 .rejectionReason("any")
                 .build();
@@ -344,24 +344,24 @@ class ContractNegotiationProtocolServiceImplTest {
                             .protocol("protocol")
                             .connectorId("connectorId")
                             .connectorAddress("http://any")
-                            .correlationId("correlationId")
+                            .processId("processId")
                             .contractAgreement(mock(ContractAgreement.class))
                             .policy(Policy.Builder.newInstance().build())
                             .build()),
                     Arguments.of(verified, ContractAgreementVerificationMessage.Builder.newInstance()
                             .protocol("protocol")
                             .connectorAddress("http://any")
-                            .correlationId("correlationId")
+                            .processId("processId")
                             .build()),
                     Arguments.of(finalized, ContractNegotiationEventMessage.Builder.newInstance()
                             .type(ContractNegotiationEventMessage.Type.FINALIZED)
                             .protocol("protocol")
                             .connectorAddress("http://any")
-                            .correlationId("correlationId")
+                            .processId("processId")
                             .build()),
                     Arguments.of(terminated, ContractNegotiationTerminationMessage.Builder.newInstance()
                             .protocol("protocol")
-                            .correlationId("correlationId")
+                            .processId("processId")
                             .connectorAddress("http://any")
                             .rejectionReason("any")
                             .build())
@@ -392,7 +392,7 @@ class ContractNegotiationProtocolServiceImplTest {
     private ContractNegotiation.Builder contractNegotiationBuilder() {
         return ContractNegotiation.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
-                .correlationId("correlationId")
+                .correlationId("processId")
                 .counterPartyId("connectorId")
                 .counterPartyAddress("connectorAddress")
                 .protocol("protocol")

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
@@ -23,7 +23,7 @@ import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementM
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementVerificationMessage;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractNegotiationEventMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferRequest;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRejection;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.contract.spi.validation.ContractValidationService;
@@ -99,7 +99,7 @@ class ContractNegotiationProtocolServiceImplTest {
         var token = ClaimToken.Builder.newInstance().build();
         var contractOffer = contractOffer();
         when(validationService.validateInitialOffer(token, contractOffer)).thenReturn(Result.success(contractOffer));
-        var message = ContractOfferRequest.Builder.newInstance()
+        var message = ContractRequestMessage.Builder.newInstance()
                 .connectorId(CONSUMER_ID)
                 .connectorAddress("connectorAddress")
                 .protocol("protocol")
@@ -132,7 +132,7 @@ class ContractNegotiationProtocolServiceImplTest {
         var contractOffer = contractOffer();
         when(validationService.validateInitialOffer(token, contractOffer)).thenReturn(Result.failure("error"));
 
-        var message = ContractOfferRequest.Builder.newInstance()
+        var message = ContractRequestMessage.Builder.newInstance()
                 .connectorId(CONSUMER_ID)
                 .connectorAddress("connectorAddress")
                 .protocol("protocol")

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
@@ -23,8 +23,8 @@ import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementM
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementVerificationMessage;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractNegotiationEventMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationTerminationMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRejection;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.contract.spi.validation.ContractValidationService;
 import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationProtocolService;
@@ -283,7 +283,7 @@ class ContractNegotiationProtocolServiceImplTest {
         var negotiation = contractNegotiationBuilder().id("negotiationId").type(PROVIDER).state(VERIFIED.code()).build();
         when(store.findForCorrelationId("correlationId")).thenReturn(negotiation);
         when(validationService.validateRequest(any(), any())).thenReturn(Result.success());
-        var message = ContractRejection.Builder.newInstance()
+        var message = ContractNegotiationTerminationMessage.Builder.newInstance()
                 .protocol("protocol")
                 .correlationId("correlationId")
                 .connectorAddress("http://any")
@@ -305,7 +305,7 @@ class ContractNegotiationProtocolServiceImplTest {
         var negotiation = contractNegotiationBuilder().id("negotiationId").type(PROVIDER).state(VERIFIED.code()).build();
         when(store.findForCorrelationId("correlationId")).thenReturn(negotiation);
         when(validationService.validateRequest(any(), any())).thenReturn(Result.failure("validation error"));
-        var message = ContractRejection.Builder.newInstance()
+        var message = ContractNegotiationTerminationMessage.Builder.newInstance()
                 .protocol("protocol")
                 .correlationId("correlationId")
                 .connectorAddress("http://any")
@@ -338,7 +338,7 @@ class ContractNegotiationProtocolServiceImplTest {
             MethodCall<ContractAgreementMessage> agreed = ContractNegotiationProtocolService::notifyAgreed;
             MethodCall<ContractAgreementVerificationMessage> verified = ContractNegotiationProtocolService::notifyVerified;
             MethodCall<ContractNegotiationEventMessage> finalized = ContractNegotiationProtocolService::notifyFinalized;
-            MethodCall<ContractRejection> terminated = ContractNegotiationProtocolService::notifyTerminated;
+            MethodCall<ContractNegotiationTerminationMessage> terminated = ContractNegotiationProtocolService::notifyTerminated;
             return Stream.of(
                     Arguments.of(agreed, ContractAgreementMessage.Builder.newInstance()
                             .protocol("protocol")
@@ -359,7 +359,7 @@ class ContractNegotiationProtocolServiceImplTest {
                             .connectorAddress("http://any")
                             .correlationId("correlationId")
                             .build()),
-                    Arguments.of(terminated, ContractRejection.Builder.newInstance()
+                    Arguments.of(terminated, ContractNegotiationTerminationMessage.Builder.newInstance()
                             .protocol("protocol")
                             .correlationId("correlationId")
                             .connectorAddress("http://any")

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
@@ -19,7 +19,7 @@ import org.eclipse.edc.connector.contract.spi.ContractId;
 import org.eclipse.edc.connector.contract.spi.negotiation.observe.ContractNegotiationListener;
 import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
-import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementRequest;
+import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementMessage;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementVerificationMessage;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractNegotiationEventMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
@@ -153,7 +153,7 @@ class ContractNegotiationProtocolServiceImplTest {
         var contractAgreement = mock(ContractAgreement.class);
         when(store.findForCorrelationId("correlationId")).thenReturn(negotiationConsumerRequested);
         when(validationService.validateConfirmed(eq(token), eq(contractAgreement), any(ContractOffer.class))).thenReturn(Result.success());
-        var message = ContractAgreementRequest.Builder.newInstance()
+        var message = ContractAgreementMessage.Builder.newInstance()
                 .protocol("protocol")
                 .connectorId("connectorId")
                 .connectorAddress("http://any")
@@ -181,7 +181,7 @@ class ContractNegotiationProtocolServiceImplTest {
         var contractAgreement = mock(ContractAgreement.class);
         when(store.findForCorrelationId("correlationId")).thenReturn(negotiationConsumerRequested);
         when(validationService.validateConfirmed(eq(token), eq(contractAgreement), any(ContractOffer.class))).thenReturn(Result.failure("failure"));
-        var message = ContractAgreementRequest.Builder.newInstance()
+        var message = ContractAgreementMessage.Builder.newInstance()
                 .protocol("protocol")
                 .connectorId("connectorId")
                 .connectorAddress("http://any")
@@ -335,12 +335,12 @@ class ContractNegotiationProtocolServiceImplTest {
 
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
-            MethodCall<ContractAgreementRequest> agreed = ContractNegotiationProtocolService::notifyAgreed;
+            MethodCall<ContractAgreementMessage> agreed = ContractNegotiationProtocolService::notifyAgreed;
             MethodCall<ContractAgreementVerificationMessage> verified = ContractNegotiationProtocolService::notifyVerified;
             MethodCall<ContractNegotiationEventMessage> finalized = ContractNegotiationProtocolService::notifyFinalized;
             MethodCall<ContractRejection> terminated = ContractNegotiationProtocolService::notifyTerminated;
             return Stream.of(
-                    Arguments.of(agreed, ContractAgreementRequest.Builder.newInstance()
+                    Arguments.of(agreed, ContractAgreementMessage.Builder.newInstance()
                             .protocol("protocol")
                             .connectorId("connectorId")
                             .connectorAddress("http://any")

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationServiceImplTest.java
@@ -21,7 +21,7 @@ import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.contract.spi.types.command.CancelNegotiationCommand;
 import org.eclipse.edc.connector.contract.spi.types.command.DeclineNegotiationCommand;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferRequest;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.command.ContractNegotiationCommand;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.policy.model.Policy;
@@ -189,8 +189,8 @@ class ContractNegotiationServiceImplTest {
     @Test
     void initiateNegotiation_callsManager() {
         var contractNegotiation = createContractNegotiation("negotiationId");
-        when(consumerManager.initiate(isA(ContractOfferRequest.class))).thenReturn(StatusResult.success(contractNegotiation));
-        var request = ContractOfferRequest.Builder.newInstance()
+        when(consumerManager.initiate(isA(ContractRequestMessage.class))).thenReturn(StatusResult.success(contractNegotiation));
+        var request = ContractRequestMessage.Builder.newInstance()
                 .connectorId("connectorId")
                 .connectorAddress("address")
                 .protocol("protocol")

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImplTest.java
@@ -92,7 +92,7 @@ class TransferProcessProtocolServiceImplTest {
     @Test
     void notifyRequested_validAgreement_shouldInitiateTransfer() {
         var message = TransferRequestMessage.Builder.newInstance()
-                .id("correlationId")
+                .id("processId")
                 .protocol("protocol")
                 .connectorAddress("http://any")
                 .dataDestination(DataAddress.Builder.newInstance().type("any").build())
@@ -103,7 +103,7 @@ class TransferProcessProtocolServiceImplTest {
 
         var result = service.notifyRequested(message, claimToken());
 
-        assertThat(result).isSucceeded().extracting(TransferProcess::getCorrelationId).isEqualTo("correlationId");
+        assertThat(result).isSucceeded().extracting(TransferProcess::getCorrelationId).isEqualTo("processId");
         verify(listener).preCreated(any());
         verify(store).save(argThat(t -> t.getState() == INITIAL.code()));
         verify(listener).initiated(any());
@@ -113,7 +113,7 @@ class TransferProcessProtocolServiceImplTest {
     @Test
     void notifyRequested_doNothingIfProcessAlreadyExist() {
         var message = TransferRequestMessage.Builder.newInstance()
-                .id("correlationId")
+                .id("processId")
                 .protocol("protocol")
                 .connectorAddress("http://any")
                 .dataDestination(DataAddress.Builder.newInstance().type("any").build())
@@ -121,7 +121,7 @@ class TransferProcessProtocolServiceImplTest {
         when(negotiationStore.findContractAgreement(any())).thenReturn(contractAgreement());
         when(validationService.validateAgreement(any(), any())).thenReturn(Result.success(null));
         when(dataAddressValidator.validate(any())).thenReturn(Result.success());
-        when(store.processIdForDataRequestId("correlationId")).thenReturn("processId");
+        when(store.processIdForDataRequestId("processId")).thenReturn("processId");
         when(store.find("processId")).thenReturn(transferProcess(REQUESTED, "processId"));
 
         var result = service.notifyRequested(message, claimToken());

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/src/main/java/org/eclipse/edc/protocol/dsp/catalog/dispatcher/delegate/CatalogRequestHttpDelegate.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/src/main/java/org/eclipse/edc/protocol/dsp/catalog/dispatcher/delegate/CatalogRequestHttpDelegate.java
@@ -22,8 +22,7 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import org.eclipse.edc.catalog.spi.Catalog;
-import org.eclipse.edc.catalog.spi.CatalogRequest;
-import org.eclipse.edc.catalog.spi.protocol.CatalogRequestMessage;
+import org.eclipse.edc.catalog.spi.CatalogRequestMessage;
 import org.eclipse.edc.jsonld.transformer.JsonLdTransformerRegistry;
 import org.eclipse.edc.protocol.dsp.spi.dispatcher.DspHttpDispatcherDelegate;
 import org.eclipse.edc.spi.EdcException;
@@ -38,23 +37,23 @@ import static org.eclipse.edc.protocol.dsp.catalog.spi.CatalogApiPaths.CATALOG_R
 /**
  * Delegate for dispatching catalog requests as defined in the dataspace protocol specification.
  */
-public class CatalogRequestHttpDelegate implements DspHttpDispatcherDelegate<CatalogRequest, Catalog> {
-    
+public class CatalogRequestHttpDelegate implements DspHttpDispatcherDelegate<CatalogRequestMessage, Catalog> {
+
     private static final String APPLICATION_JSON = "application/json";
-    
+
     private final ObjectMapper mapper;
     private final JsonLdTransformerRegistry transformerRegistry;
-    
+
     public CatalogRequestHttpDelegate(ObjectMapper mapper, JsonLdTransformerRegistry transformerRegistry) {
         this.mapper = mapper;
         this.transformerRegistry = transformerRegistry;
     }
-    
+
     @Override
-    public Class<CatalogRequest> getMessageType() {
-        return CatalogRequest.class;
+    public Class<CatalogRequestMessage> getMessageType() {
+        return CatalogRequestMessage.class;
     }
-    
+
     /**
      * Sends a catalog request. The request body is constructed as defined in the dataspace protocol
      * implementation. The request is sent to the remote component using the path from the
@@ -64,18 +63,18 @@ public class CatalogRequestHttpDelegate implements DspHttpDispatcherDelegate<Cat
      * @return the built okhttp request
      */
     @Override
-    public Request buildRequest(CatalogRequest message) {
-        var catalogRequestMessage = CatalogRequestMessage.Builder.newInstance()
+    public Request buildRequest(CatalogRequestMessage message) {
+        var catalogRequestMessage = org.eclipse.edc.catalog.spi.protocol.CatalogRequestMessage.Builder.newInstance()
                 .filter(message.getQuerySpec())
                 .build();
         var requestBody = RequestBody.create(toJson(catalogRequestMessage), MediaType.get(APPLICATION_JSON));
-        
+
         return new Request.Builder()
                 .url(message.getConnectorAddress() + BASE_PATH + CATALOG_REQUEST)
                 .post(requestBody)
                 .build();
     }
-    
+
     /**
      * Parses the response to a catalog request. The JSON-LD structure from the response body is
      * expanded and then transformed to an EDC catalog.
@@ -102,8 +101,8 @@ public class CatalogRequestHttpDelegate implements DspHttpDispatcherDelegate<Cat
             }
         };
     }
-    
-    private String toJson(CatalogRequestMessage message) {
+
+    private String toJson(org.eclipse.edc.catalog.spi.protocol.CatalogRequestMessage message) {
         try {
             var transformResult = transformerRegistry.transform(message, JsonObject.class);
             if (transformResult.succeeded()) {

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/src/test/java/org/eclipse/edc/protocol/dsp/catalog/dispatcher/delegate/CatalogRequestMessageHttpDelegateTest.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/src/test/java/org/eclipse/edc/protocol/dsp/catalog/dispatcher/delegate/CatalogRequestMessageHttpDelegateTest.java
@@ -22,8 +22,7 @@ import okhttp3.Response;
 import okhttp3.ResponseBody;
 import okio.Buffer;
 import org.eclipse.edc.catalog.spi.Catalog;
-import org.eclipse.edc.catalog.spi.CatalogRequest;
-import org.eclipse.edc.catalog.spi.protocol.CatalogRequestMessage;
+import org.eclipse.edc.catalog.spi.CatalogRequestMessage;
 import org.eclipse.edc.jsonld.transformer.JsonLdTransformerRegistry;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.query.QuerySpec;
@@ -47,52 +46,52 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-class CatalogRequestHttpDelegateTest {
-    
+class CatalogRequestMessageHttpDelegateTest {
+
     private final ObjectMapper mapper = mock(ObjectMapper.class);
     private final JsonLdTransformerRegistry registry = mock(JsonLdTransformerRegistry.class);
-    
+
     private CatalogRequestHttpDelegate delegate;
-    
+
     @BeforeEach
     void setUp() {
         delegate = new CatalogRequestHttpDelegate(mapper, registry);
     }
-    
+
     @Test
     void getMessageType_returnCatalogRequest() {
-        assertThat(delegate.getMessageType()).isEqualTo(CatalogRequest.class);
+        assertThat(delegate.getMessageType()).isEqualTo(CatalogRequestMessage.class);
     }
-    
+
     @Test
     void buildRequest_returnRequest() throws IOException {
         var jsonObject = getJsonObject();
         var serializedBody = "catalog request";
-        
-        when(registry.transform(isA(CatalogRequestMessage.class), eq(JsonObject.class)))
+
+        when(registry.transform(isA(org.eclipse.edc.catalog.spi.protocol.CatalogRequestMessage.class), eq(JsonObject.class)))
                 .thenReturn(Result.success(jsonObject));
         when(mapper.writeValueAsString(jsonObject)).thenReturn(serializedBody);
-        
+
         var message = getCatalogRequest();
         var httpRequest = delegate.buildRequest(message);
-        
+
         assertThat(httpRequest.url().url()).hasToString(message.getConnectorAddress() + BASE_PATH + CATALOG_REQUEST);
         assertThat(readRequestBody(httpRequest)).isEqualTo(serializedBody);
-        
+
         verify(registry, times(1))
-                .transform(argThat(requestMessage -> ((CatalogRequestMessage) requestMessage).getFilter().equals(message.getQuerySpec())), eq(JsonObject.class));
+                .transform(argThat(requestMessage -> ((org.eclipse.edc.catalog.spi.protocol.CatalogRequestMessage) requestMessage).getFilter().equals(message.getQuerySpec())), eq(JsonObject.class));
         verify(mapper, times(1)).writeValueAsString(jsonObject);
     }
-    
+
     @Test
     void buildRequest_transformationFails_throwException() {
-        when(registry.transform(isA(CatalogRequestMessage.class), eq(JsonObject.class)))
+        when(registry.transform(isA(org.eclipse.edc.catalog.spi.protocol.CatalogRequestMessage.class), eq(JsonObject.class)))
                 .thenReturn(Result.failure("error"));
-        
+
         var message = getCatalogRequest();
         assertThatThrownBy(() -> delegate.buildRequest(message)).isInstanceOf(EdcException.class);
     }
-    
+
     @Test
     void parseResponse_returnCatalog() throws IOException {
         var jsonObject = getJsonObject();
@@ -100,54 +99,54 @@ class CatalogRequestHttpDelegateTest {
         var response = mock(Response.class);
         var responseBody = mock(ResponseBody.class);
         var bytes = "test".getBytes();
-    
+
         when(response.body()).thenReturn(responseBody);
         when(responseBody.bytes()).thenReturn(bytes);
         when(mapper.readValue(bytes, JsonObject.class)).thenReturn(jsonObject);
         when(registry.transform(any(JsonObject.class), eq(Catalog.class))).thenReturn(Result.success(catalog));
-        
+
         var result = delegate.parseResponse().apply(response);
-        
+
         assertThat(result).isEqualTo(catalog);
         verify(mapper, times(1)).readValue(bytes, JsonObject.class);
         verify(registry, times(1)).transform(isA(JsonObject.class), eq(Catalog.class));
     }
-    
+
     @Test
     void parseResponse_transformationFails_throwException() throws IOException {
         var jsonObject = getJsonObject();
         var response = mock(Response.class);
         var responseBody = mock(ResponseBody.class);
-    
+
         when(response.body()).thenReturn(responseBody);
         when(responseBody.bytes()).thenReturn("test".getBytes());
         when(mapper.readValue(any(byte[].class), eq(JsonObject.class))).thenReturn(jsonObject);
         when(registry.transform(any(JsonObject.class), eq(Catalog.class))).thenReturn(Result.failure("error"));
-        
+
         assertThatThrownBy(() -> delegate.parseResponse().apply(response)).isInstanceOf(EdcException.class);
     }
-    
+
     @Test
     void parseResponse_readingResponseBodyFails_throwException() throws IOException {
         var response = mock(Response.class);
         var responseBody = mock(ResponseBody.class);
-        
+
         when(response.body()).thenReturn(responseBody);
         when(responseBody.bytes()).thenReturn("test".getBytes());
         when(mapper.readValue(any(byte[].class), eq(JsonObject.class))).thenThrow(IOException.class);
-        
+
         assertThatThrownBy(() -> delegate.parseResponse().apply(response)).isInstanceOf(EdcException.class);
     }
-    
+
     @Test
     void parseResponse_responseBodyNull_throwException() throws IOException {
         var response = mock(Response.class);
-        
+
         when(response.body()).thenReturn(null);
-        
+
         assertThatThrownBy(() -> delegate.parseResponse().apply(response)).isInstanceOf(EdcException.class);
     }
-    
+
     @Test
     void parseResponse_expandingJsonLdFails_throwException() throws IOException {
         // JSON is missing @context -> expanding returns empty JsonArray
@@ -156,34 +155,34 @@ class CatalogRequestHttpDelegateTest {
                 .build();
         var response = mock(Response.class);
         var responseBody = mock(ResponseBody.class);
-    
+
         when(response.body()).thenReturn(responseBody);
         when(responseBody.bytes()).thenReturn("test".getBytes());
         when(mapper.readValue(any(byte[].class), eq(JsonObject.class))).thenReturn(jsonObject);
-    
+
         assertThatThrownBy(() -> delegate.parseResponse().apply(response)).isInstanceOf(EdcException.class);
     }
-    
+
     private JsonObject getJsonObject() {
         return Json.createObjectBuilder()
                 .add(CONTEXT, Json.createObjectBuilder().add("prefix", "http://schema").build())
                 .add("prefix:key", "value")
                 .build();
     }
-    
-    private CatalogRequest getCatalogRequest() {
-        return CatalogRequest.Builder.newInstance()
+
+    private CatalogRequestMessage getCatalogRequest() {
+        return CatalogRequestMessage.Builder.newInstance()
                 .connectorAddress("http://connector")
                 .connectorId("connector-id")
                 .protocol("protocol")
                 .querySpec(QuerySpec.max())
                 .build();
     }
-    
+
     private String readRequestBody(Request request) throws IOException {
         var buffer = new Buffer();
         request.body().writeTo(buffer);
         return buffer.readUtf8();
     }
-    
+
 }

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/test/java/org/eclipse/edc/protocol/dsp/catalog/transform/from/JsonObjectFromCatalogRequestMessageTransformerTestMessage.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/test/java/org/eclipse/edc/protocol/dsp/catalog/transform/from/JsonObjectFromCatalogRequestMessageTransformerTestMessage.java
@@ -36,48 +36,48 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-class JsonObjectFromCatalogRequestMessageTransformerTest {
-    
+class JsonObjectFromCatalogRequestMessageTransformerTestMessage {
+
     private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
     private final ObjectMapper mapper = mock(ObjectMapper.class);
     private final TransformerContext context = mock(TransformerContext.class);
-    
+
     private JsonObjectFromCatalogRequestMessageTransformer transformer;
-    
+
     @BeforeEach
     void setUp() {
         transformer = new JsonObjectFromCatalogRequestMessageTransformer(jsonFactory, mapper);
     }
-    
+
     @Test
     void transform_noFilter_returnJsonObject() {
         var message = CatalogRequestMessage.Builder.newInstance().build();
-        
+
         var result = transformer.transform(message, context);
-        
+
         assertThat(result).isNotNull();
         assertThat(result.getJsonString(TYPE).getString()).isEqualTo(DSPACE_CATALOG_REQUEST_TYPE);
         assertThat(result.get(DSPACE_FILTER_PROPERTY)).isNull();
-        
+
         verify(context, never()).reportProblem(anyString());
     }
-    
+
     @Test
     void transform_withFilter_returnJsonObject() {
         var querySpec = QuerySpec.Builder.newInstance().build();
         var querySpecJson = jsonFactory.createObjectBuilder().build();
         when(mapper.convertValue(querySpec, JsonObject.class)).thenReturn(querySpecJson);
-    
+
         var message = CatalogRequestMessage.Builder.newInstance()
                 .filter(querySpec)
                 .build();
-    
+
         var result = transformer.transform(message, context);
-    
+
         assertThat(result).isNotNull();
         assertThat(result.getJsonString(TYPE).getString()).isEqualTo(DSPACE_CATALOG_REQUEST_TYPE);
         assertThat(result.get(DSPACE_FILTER_PROPERTY)).isEqualTo(querySpecJson);
-    
+
         verify(context, never()).reportProblem(anyString());
     }
 }

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/test/java/org/eclipse/edc/protocol/dsp/catalog/transform/to/JsonObjectToCatalogRequestMessageTransformerTestMessage.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/test/java/org/eclipse/edc/protocol/dsp/catalog/transform/to/JsonObjectToCatalogRequestMessageTransformerTestMessage.java
@@ -35,60 +35,60 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-class JsonObjectToCatalogRequestMessageTransformerTest {
-    
+class JsonObjectToCatalogRequestMessageTransformerTestMessage {
+
     private JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
     private ObjectMapper mapper = mock(ObjectMapper.class);
     private TransformerContext context = mock(TransformerContext.class);
-    
+
     private JsonObjectToCatalogRequestMessageTransformer transformer;
-    
+
     @BeforeEach
     void setUp() {
         transformer = new JsonObjectToCatalogRequestMessageTransformer(mapper);
     }
-    
+
     @Test
     void transform_noFilter_returnCatalogRequestMessage() {
         var message = jsonFactory.createObjectBuilder()
                 .add(TYPE, DSPACE_CATALOG_REQUEST_TYPE)
                 .build();
-        
+
         var result = transformer.transform(message, context);
-        
+
         assertThat(result).isNotNull();
         assertThat(result.getFilter()).isNull();
-    
+
         verify(context, never()).reportProblem(anyString());
     }
-    
+
     @Test
     void transform_withFilter_returnCatalogRequestMessage() {
         var querySpecJson = jsonFactory.createObjectBuilder().build();
         var querySpec = QuerySpec.Builder.newInstance().build();
         when(mapper.convertValue(querySpecJson, QuerySpec.class)).thenReturn(querySpec);
-    
+
         var message = jsonFactory.createObjectBuilder()
                 .add(TYPE, DSPACE_CATALOG_REQUEST_TYPE)
                 .add(DSPACE_FILTER_PROPERTY, querySpecJson)
                 .build();
-    
+
         var result = transformer.transform(message, context);
-    
+
         assertThat(result).isNotNull();
         assertThat(result.getFilter()).isNotNull().isEqualTo(querySpec);
-    
+
         verify(context, never()).reportProblem(anyString());
     }
-    
+
     @Test
     void transform_invalidType_reportProblem() {
         var message = jsonFactory.createObjectBuilder()
                 .add(TYPE, "not-a-catalog-request-message")
                 .build();
-    
+
         var result = transformer.transform(message, context);
-        
+
         assertThat(result).isNull();
         verify(context, times(1)).reportProblem(anyString());
     }

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/sender/type/MultipartCatalogDescriptionRequestSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/sender/type/MultipartCatalogDescriptionRequestSender.java
@@ -25,7 +25,7 @@ import de.fraunhofer.iais.eis.Resource;
 import de.fraunhofer.iais.eis.ResourceCatalog;
 import de.fraunhofer.iais.eis.ResourceCatalogBuilder;
 import org.eclipse.edc.catalog.spi.Catalog;
-import org.eclipse.edc.catalog.spi.CatalogRequest;
+import org.eclipse.edc.catalog.spi.CatalogRequestMessage;
 import org.eclipse.edc.protocol.ids.api.multipart.dispatcher.sender.MultipartSenderDelegate;
 import org.eclipse.edc.protocol.ids.api.multipart.dispatcher.sender.SenderDelegateContext;
 import org.eclipse.edc.protocol.ids.api.multipart.dispatcher.sender.response.IdsMultipartParts;
@@ -48,7 +48,7 @@ import java.util.Objects;
 /**
  * MultipartSenderDelegate for connector catalog requests.
  */
-public class MultipartCatalogDescriptionRequestSender implements MultipartSenderDelegate<CatalogRequest, Catalog> {
+public class MultipartCatalogDescriptionRequestSender implements MultipartSenderDelegate<CatalogRequestMessage, Catalog> {
 
     private final SenderDelegateContext context;
 
@@ -58,14 +58,14 @@ public class MultipartCatalogDescriptionRequestSender implements MultipartSender
 
     /**
      * Builds a {@link de.fraunhofer.iais.eis.DescriptionRequestMessage} for requesting another
-     * connector's self description. Includes paging information defined in the {@link CatalogRequest}.
+     * connector's self description. Includes paging information defined in the {@link CatalogRequestMessage}.
      *
      * @param request the request.
      * @param token   the dynamic attribute token.
      * @return a DescriptionRequestMessage
      */
     @Override
-    public Message buildMessageHeader(CatalogRequest request, DynamicAttributeToken token) {
+    public Message buildMessageHeader(CatalogRequestMessage request, DynamicAttributeToken token) {
         var message = new DescriptionRequestMessageBuilder()
                 ._modelVersion_(IdsConstants.INFORMATION_MODEL_VERSION)
                 ._issued_(CalendarUtil.gregorianNow())
@@ -80,7 +80,7 @@ public class MultipartCatalogDescriptionRequestSender implements MultipartSender
     }
 
     @Override
-    public String buildMessagePayload(CatalogRequest request) throws Exception {
+    public String buildMessagePayload(CatalogRequestMessage request) throws Exception {
         return null;
     }
 
@@ -126,8 +126,8 @@ public class MultipartCatalogDescriptionRequestSender implements MultipartSender
     }
 
     @Override
-    public Class<CatalogRequest> getMessageType() {
-        return CatalogRequest.class;
+    public Class<CatalogRequestMessage> getMessageType() {
+        return CatalogRequestMessage.class;
     }
 
     private BaseConnector getBaseConnector(IdsMultipartParts parts) {

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/sender/type/MultipartContractAgreementSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/sender/type/MultipartContractAgreementSender.java
@@ -19,7 +19,7 @@ import de.fraunhofer.iais.eis.ContractAgreementMessageBuilder;
 import de.fraunhofer.iais.eis.DynamicAttributeToken;
 import de.fraunhofer.iais.eis.Message;
 import de.fraunhofer.iais.eis.MessageProcessedNotificationMessageImpl;
-import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementRequest;
+import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementMessage;
 import org.eclipse.edc.protocol.ids.api.multipart.dispatcher.sender.MultipartSenderDelegate;
 import org.eclipse.edc.protocol.ids.api.multipart.dispatcher.sender.SenderDelegateContext;
 import org.eclipse.edc.protocol.ids.api.multipart.dispatcher.sender.response.IdsMultipartParts;
@@ -40,7 +40,7 @@ import static org.eclipse.edc.protocol.ids.spi.domain.IdsConstants.IDS_WEBHOOK_A
 /**
  * MultipartSenderDelegate for contract agreements.
  */
-public class MultipartContractAgreementSender implements MultipartSenderDelegate<ContractAgreementRequest, String> {
+public class MultipartContractAgreementSender implements MultipartSenderDelegate<ContractAgreementMessage, String> {
 
     private final SenderDelegateContext context;
 
@@ -49,12 +49,12 @@ public class MultipartContractAgreementSender implements MultipartSenderDelegate
     }
 
     @Override
-    public Class<ContractAgreementRequest> getMessageType() {
-        return ContractAgreementRequest.class;
+    public Class<ContractAgreementMessage> getMessageType() {
+        return ContractAgreementMessage.class;
     }
 
     /**
-     * Builds a {@link de.fraunhofer.iais.eis.ContractAgreementMessage} for the given {@link ContractAgreementRequest}.
+     * Builds a {@link de.fraunhofer.iais.eis.ContractAgreementMessage} for the given {@link ContractAgreementMessage}.
      *
      * @param request the request.
      * @param token   the dynamic attribute token.
@@ -62,7 +62,7 @@ public class MultipartContractAgreementSender implements MultipartSenderDelegate
      * @throws Exception if the agreement ID cannot be parsed.
      */
     @Override
-    public Message buildMessageHeader(ContractAgreementRequest request, DynamicAttributeToken token) throws Exception {
+    public Message buildMessageHeader(ContractAgreementMessage request, DynamicAttributeToken token) throws Exception {
         var idsId = IdsId.Builder.newInstance()
                 .type(IdsType.CONTRACT_AGREEMENT)
                 .value(request.getContractAgreement().getId())
@@ -91,7 +91,7 @@ public class MultipartContractAgreementSender implements MultipartSenderDelegate
      * @throws Exception if parsing the agreement fails.
      */
     @Override
-    public String buildMessagePayload(ContractAgreementRequest request) throws Exception {
+    public String buildMessagePayload(ContractAgreementMessage request) throws Exception {
         var transformationResult = context.getTransformerRegistry().transform(request, ContractAgreement.class);
         if (transformationResult.failed()) {
             throw new EdcException("Failed to create IDS contract agreement");

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/sender/type/MultipartContractAgreementSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/sender/type/MultipartContractAgreementSender.java
@@ -75,7 +75,7 @@ public class MultipartContractAgreementSender implements MultipartSenderDelegate
                 ._issuerConnector_(context.getConnectorId().toUri())
                 ._senderAgent_(context.getConnectorId().toUri())
                 ._recipientConnector_(Collections.singletonList(URI.create(request.getConnectorId())))
-                ._transferContract_(URI.create(request.getCorrelationId()))
+                ._transferContract_(URI.create(request.getProcessId()))
                 .build();
 
         message.setProperty(IDS_WEBHOOK_ADDRESS_PROPERTY, context.getIdsWebhookAddress());

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/sender/type/MultipartContractOfferSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/sender/type/MultipartContractOfferSender.java
@@ -21,7 +21,7 @@ import de.fraunhofer.iais.eis.ContractRequestMessageBuilder;
 import de.fraunhofer.iais.eis.DynamicAttributeToken;
 import de.fraunhofer.iais.eis.Message;
 import de.fraunhofer.iais.eis.RequestInProcessMessageImpl;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferRequest;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.protocol.ids.api.multipart.dispatcher.sender.MultipartSenderDelegate;
 import org.eclipse.edc.protocol.ids.api.multipart.dispatcher.sender.SenderDelegateContext;
@@ -42,7 +42,7 @@ import static org.eclipse.edc.protocol.ids.spi.domain.IdsConstants.IDS_WEBHOOK_A
 /**
  * MultipartSenderDelegate for contract requests.
  */
-public class MultipartContractOfferSender implements MultipartSenderDelegate<ContractOfferRequest, String> {
+public class MultipartContractOfferSender implements MultipartSenderDelegate<ContractRequestMessage, String> {
     private final SenderDelegateContext context;
 
     public MultipartContractOfferSender(SenderDelegateContext context) {
@@ -50,21 +50,21 @@ public class MultipartContractOfferSender implements MultipartSenderDelegate<Con
     }
 
     @Override
-    public Class<ContractOfferRequest> getMessageType() {
-        return ContractOfferRequest.class;
+    public Class<ContractRequestMessage> getMessageType() {
+        return ContractRequestMessage.class;
     }
 
     /**
      * Builds a {@link de.fraunhofer.iais.eis.ContractRequestMessage} or a {@link de.fraunhofer.iais.eis.ContractOfferMessage}
-     * for the given {@link ContractOfferRequest} depending on whether it is an initial request.
+     * for the given {@link ContractRequestMessage} depending on whether it is an initial request.
      *
      * @param request the request.
      * @param token   the dynamic attribute token.
      * @return a ContractRequestMessage or ContractOfferMessage
      */
     @Override
-    public Message buildMessageHeader(ContractOfferRequest request, DynamicAttributeToken token) {
-        if (request.getType() == ContractOfferRequest.Type.INITIAL) {
+    public Message buildMessageHeader(ContractRequestMessage request, DynamicAttributeToken token) {
+        if (request.getType() == ContractRequestMessage.Type.INITIAL) {
             var message = new ContractRequestMessageBuilder()
                     ._modelVersion_(IdsConstants.INFORMATION_MODEL_VERSION)
                     ._issued_(CalendarUtil.gregorianNow())
@@ -102,10 +102,10 @@ public class MultipartContractOfferSender implements MultipartSenderDelegate<Con
      * @throws Exception if parsing the request/offer fails.
      */
     @Override
-    public String buildMessagePayload(ContractOfferRequest request) throws Exception {
+    public String buildMessagePayload(ContractRequestMessage request) throws Exception {
         var contractOffer = request.getContractOffer();
 
-        if (request.getType() == ContractOfferRequest.Type.INITIAL) {
+        if (request.getType() == ContractRequestMessage.Type.INITIAL) {
             return context.getObjectMapper().writeValueAsString(createContractRequest(contractOffer));
         } else {
             return context.getObjectMapper().writeValueAsString(createContractOffer(contractOffer));

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/sender/type/MultipartContractOfferSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/sender/type/MultipartContractOfferSender.java
@@ -72,7 +72,7 @@ public class MultipartContractOfferSender implements MultipartSenderDelegate<Con
                     ._issuerConnector_(context.getConnectorId().toUri())
                     ._senderAgent_(context.getConnectorId().toUri())
                     ._recipientConnector_(Collections.singletonList(URI.create(request.getConnectorId())))
-                    ._transferContract_(URI.create(request.getCorrelationId()))
+                    ._transferContract_(URI.create(request.getProcessId()))
                     .build();
             message.setProperty(IDS_WEBHOOK_ADDRESS_PROPERTY, context.getIdsWebhookAddress());
 
@@ -85,7 +85,7 @@ public class MultipartContractOfferSender implements MultipartSenderDelegate<Con
                     ._issuerConnector_(context.getConnectorId().toUri())
                     ._senderAgent_(context.getConnectorId().toUri())
                     ._recipientConnector_(Collections.singletonList(URI.create(request.getConnectorId())))
-                    ._transferContract_(URI.create(request.getCorrelationId()))
+                    ._transferContract_(URI.create(request.getProcessId()))
                     .build();
             message.setProperty(IDS_WEBHOOK_ADDRESS_PROPERTY, context.getIdsWebhookAddress());
 

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/sender/type/MultipartContractRejectionSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/sender/type/MultipartContractRejectionSender.java
@@ -19,7 +19,7 @@ import de.fraunhofer.iais.eis.DynamicAttributeToken;
 import de.fraunhofer.iais.eis.Message;
 import de.fraunhofer.iais.eis.MessageProcessedNotificationMessageImpl;
 import de.fraunhofer.iais.eis.util.TypedLiteral;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRejection;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationTerminationMessage;
 import org.eclipse.edc.protocol.ids.api.multipart.dispatcher.sender.MultipartSenderDelegate;
 import org.eclipse.edc.protocol.ids.api.multipart.dispatcher.sender.SenderDelegateContext;
 import org.eclipse.edc.protocol.ids.api.multipart.dispatcher.sender.response.IdsMultipartParts;
@@ -35,7 +35,7 @@ import java.util.List;
 /**
  * MultipartSenderDelegate for contract rejections.
  */
-public class MultipartContractRejectionSender implements MultipartSenderDelegate<ContractRejection, String> {
+public class MultipartContractRejectionSender implements MultipartSenderDelegate<ContractNegotiationTerminationMessage, String> {
 
     private final SenderDelegateContext context;
 
@@ -44,19 +44,19 @@ public class MultipartContractRejectionSender implements MultipartSenderDelegate
     }
 
     @Override
-    public Class<ContractRejection> getMessageType() {
-        return ContractRejection.class;
+    public Class<ContractNegotiationTerminationMessage> getMessageType() {
+        return ContractNegotiationTerminationMessage.class;
     }
 
     /**
-     * Builds a {@link de.fraunhofer.iais.eis.ContractRejectionMessage} for the given {@link ContractRejection}.
+     * Builds a {@link de.fraunhofer.iais.eis.ContractRejectionMessage} for the given {@link ContractNegotiationTerminationMessage}.
      *
      * @param rejection the rejection request.
      * @param token   the dynamic attribute token.
      * @return a ContractRejectionMessage
      */
     @Override
-    public Message buildMessageHeader(ContractRejection rejection, DynamicAttributeToken token) throws Exception {
+    public Message buildMessageHeader(ContractNegotiationTerminationMessage rejection, DynamicAttributeToken token) throws Exception {
         return new ContractRejectionMessageBuilder()
                 ._modelVersion_(IdsConstants.INFORMATION_MODEL_VERSION)
                 ._issued_(CalendarUtil.gregorianNow())
@@ -76,7 +76,7 @@ public class MultipartContractRejectionSender implements MultipartSenderDelegate
      * @return the rejection reason.
      */
     @Override
-    public String buildMessagePayload(ContractRejection rejection) throws Exception {
+    public String buildMessagePayload(ContractNegotiationTerminationMessage rejection) throws Exception {
         return rejection.getRejectionReason();
     }
 

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/sender/type/MultipartContractRejectionSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/sender/type/MultipartContractRejectionSender.java
@@ -65,7 +65,7 @@ public class MultipartContractRejectionSender implements MultipartSenderDelegate
                 ._senderAgent_(context.getConnectorId().toUri())
                 ._recipientConnector_(Collections.singletonList(URI.create(rejection.getConnectorId())))
                 ._contractRejectionReason_(new TypedLiteral(rejection.getRejectionReason()))
-                ._transferContract_(URI.create(rejection.getCorrelationId()))
+                ._transferContract_(URI.create(rejection.getProcessId()))
                 .build();
     }
 

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/client/MultipartDispatcherIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/client/MultipartDispatcherIntegrationTest.java
@@ -22,7 +22,7 @@ import de.fraunhofer.iais.eis.ContractOfferBuilder;
 import de.fraunhofer.iais.eis.PermissionBuilder;
 import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
-import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementRequest;
+import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferRequest;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRejection;
@@ -210,7 +210,7 @@ class MultipartDispatcherIntegrationTest {
                 .thenReturn(Result.success(ContractAgreementTransformerOutput.Builder.newInstance().contractAgreement(contractAgreement).policy(policy).build()));
         when(negotiationService.notifyAgreed(any(), any())).thenReturn(ServiceResult.success(createContractNegotiation("negotiationId")));
 
-        var request = ContractAgreementRequest.Builder.newInstance()
+        var request = ContractAgreementMessage.Builder.newInstance()
                 .connectorId(CONNECTOR_ID)
                 .connectorAddress(getUrl())
                 .protocol(MessageProtocol.IDS_MULTIPART)

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/client/MultipartDispatcherIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/client/MultipartDispatcherIntegrationTest.java
@@ -161,7 +161,7 @@ class MultipartDispatcherIntegrationTest {
                 .connectorAddress(getUrl())
                 .protocol(MessageProtocol.IDS_MULTIPART)
                 .contractOffer(contractOffer)
-                .correlationId("1")
+                .processId("1")
                 .build();
 
         var future = dispatcher.send(null, request);
@@ -186,7 +186,7 @@ class MultipartDispatcherIntegrationTest {
                 .connectorAddress(getUrl())
                 .protocol(MessageProtocol.IDS_MULTIPART)
                 .contractOffer(contractOffer)
-                .correlationId("1")
+                .processId("1")
                 .build();
 
         var future = dispatcher.send(null, request);
@@ -215,7 +215,7 @@ class MultipartDispatcherIntegrationTest {
                 .connectorAddress(getUrl())
                 .protocol(MessageProtocol.IDS_MULTIPART)
                 .contractAgreement(contractAgreement)
-                .correlationId("1")
+                .processId("1")
                 .policy(policy)
                 .build();
 
@@ -234,7 +234,7 @@ class MultipartDispatcherIntegrationTest {
                 .connectorAddress(getUrl())
                 .protocol(MessageProtocol.IDS_MULTIPART)
                 .rejectionReason("Modified policy in contract offer.")
-                .correlationId(UUID.randomUUID().toString())
+                .processId(UUID.randomUUID().toString())
                 .build();
 
         var future = dispatcher.send(null, rejection);

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/client/MultipartDispatcherIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/client/MultipartDispatcherIntegrationTest.java
@@ -24,7 +24,7 @@ import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiat
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferRequest;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRejection;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.contract.spi.validation.ContractValidationService;
@@ -155,8 +155,8 @@ class MultipartDispatcherIntegrationTest {
         when(transformerRegistry.transform(any(), any()))
                 .thenReturn(Result.success(getIdsContractOffer()));
 
-        var request = ContractOfferRequest.Builder.newInstance()
-                .type(ContractOfferRequest.Type.COUNTER_OFFER)
+        var request = ContractRequestMessage.Builder.newInstance()
+                .type(ContractRequestMessage.Type.COUNTER_OFFER)
                 .connectorId(CONNECTOR_ID)
                 .connectorAddress(getUrl())
                 .protocol(MessageProtocol.IDS_MULTIPART)
@@ -180,8 +180,8 @@ class MultipartDispatcherIntegrationTest {
         when(transformerRegistry.transform(any(), eq(ContractOffer.class))).thenReturn(Result.success(contractOffer));
         when(validationService.validateInitialOffer(any(), any())).thenReturn(Result.success(contractOffer));
 
-        var request = ContractOfferRequest.Builder.newInstance()
-                .type(ContractOfferRequest.Type.INITIAL)
+        var request = ContractRequestMessage.Builder.newInstance()
+                .type(ContractRequestMessage.Type.INITIAL)
                 .connectorId(CONNECTOR_ID)
                 .connectorAddress(getUrl())
                 .protocol(MessageProtocol.IDS_MULTIPART)

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/client/MultipartDispatcherIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/client/MultipartDispatcherIntegrationTest.java
@@ -24,8 +24,8 @@ import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiat
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationTerminationMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRejection;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.contract.spi.validation.ContractValidationService;
 import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationProtocolService;
@@ -229,7 +229,7 @@ class MultipartDispatcherIntegrationTest {
     @Test
     void testSendContractRejectionMessage(RemoteMessageDispatcherRegistry dispatcher) {
         when(negotiationService.notifyTerminated(any(), any())).thenReturn(ServiceResult.success(createContractNegotiation("negotiationId")));
-        var rejection = ContractRejection.Builder.newInstance()
+        var rejection = ContractNegotiationTerminationMessage.Builder.newInstance()
                 .connectorId(CONNECTOR_ID)
                 .connectorAddress(getUrl())
                 .protocol(MessageProtocol.IDS_MULTIPART)

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/sender/type/MultipartContractOfferSenderTest.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/sender/type/MultipartContractOfferSenderTest.java
@@ -16,7 +16,7 @@ package org.eclipse.edc.protocol.ids.api.multipart.dispatcher.sender.type;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.fraunhofer.iais.eis.ContractRequest;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferRequest;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.policy.model.Action;
 import org.eclipse.edc.policy.model.Permission;
@@ -61,7 +61,7 @@ class MultipartContractOfferSenderTest {
     @Test
     void buildMessagePayload_initialRequest_mapPolicyProperties() throws Exception {
         var policy = getPolicy();
-        var request = getContractOfferRequest(policy, ContractOfferRequest.Type.INITIAL);
+        var request = getContractOfferRequest(policy, ContractRequestMessage.Type.INITIAL);
 
         var result = sender.buildMessagePayload(request);
 
@@ -74,7 +74,7 @@ class MultipartContractOfferSenderTest {
     @Test
     void buildMessagePayload_notInitialRequest_mapPolicyProperties() throws Exception {
         var policy = getPolicy();
-        var request = getContractOfferRequest(policy, ContractOfferRequest.Type.COUNTER_OFFER);
+        var request = getContractOfferRequest(policy, ContractRequestMessage.Type.COUNTER_OFFER);
 
         var result = sender.buildMessagePayload(request);
 
@@ -84,8 +84,8 @@ class MultipartContractOfferSenderTest {
                 .containsAllEntriesOf(policy.getExtensibleProperties());
     }
 
-    private ContractOfferRequest getContractOfferRequest(Policy policy, ContractOfferRequest.Type type) {
-        return ContractOfferRequest.Builder.newInstance()
+    private ContractRequestMessage getContractOfferRequest(Policy policy, ContractRequestMessage.Type type) {
+        return ContractRequestMessage.Builder.newInstance()
                 .contractOffer(ContractOffer.Builder.newInstance()
                         .id("contract-offer")
                         .policy(policy)

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/handler/ContractAgreementHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/handler/ContractAgreementHandler.java
@@ -16,8 +16,7 @@ package org.eclipse.edc.protocol.ids.api.multipart.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.fraunhofer.iais.eis.ContractAgreement;
-import de.fraunhofer.iais.eis.ContractAgreementMessage;
-import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementRequest;
+import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementMessage;
 import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationProtocolService;
 import org.eclipse.edc.protocol.ids.api.multipart.message.MultipartRequest;
 import org.eclipse.edc.protocol.ids.api.multipart.message.MultipartResponse;
@@ -35,7 +34,7 @@ import static org.eclipse.edc.protocol.ids.api.multipart.util.ResponseUtil.creat
 import static org.eclipse.edc.protocol.ids.api.multipart.util.ResponseUtil.processedFromServiceResult;
 
 /**
- * This class handles and processes incoming IDS {@link ContractAgreementMessage}s.
+ * This class handles and processes incoming IDS {@link de.fraunhofer.iais.eis.ContractAgreementMessage}s.
  */
 public class ContractAgreementHandler implements Handler {
 
@@ -57,13 +56,13 @@ public class ContractAgreementHandler implements Handler {
 
     @Override
     public boolean canHandle(@NotNull MultipartRequest multipartRequest) {
-        return multipartRequest.getHeader() instanceof ContractAgreementMessage;
+        return multipartRequest.getHeader() instanceof de.fraunhofer.iais.eis.ContractAgreementMessage;
     }
 
     @Override
     public @NotNull MultipartResponse handleRequest(@NotNull MultipartRequest multipartRequest) {
         var claimToken = multipartRequest.getClaimToken();
-        var message = (ContractAgreementMessage) multipartRequest.getHeader();
+        var message = (de.fraunhofer.iais.eis.ContractAgreementMessage) multipartRequest.getHeader();
 
         ContractAgreement contractAgreement;
         try {
@@ -87,7 +86,7 @@ public class ContractAgreementHandler implements Handler {
 
         var output = result.getContent();
 
-        var request = ContractAgreementRequest.Builder.newInstance()
+        var request = ContractAgreementMessage.Builder.newInstance()
                 .protocol(MessageProtocol.IDS_MULTIPART)
                 .connectorId(String.valueOf(message.getIssuerConnector()))
                 .connectorAddress("") // this will be used by DSP

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/handler/ContractAgreementHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/handler/ContractAgreementHandler.java
@@ -91,7 +91,7 @@ public class ContractAgreementHandler implements Handler {
                 .connectorId(String.valueOf(message.getIssuerConnector()))
                 .connectorAddress("") // this will be used by DSP
                 .contractAgreement(output.getContractAgreement())
-                .correlationId(String.valueOf(message.getTransferContract()))
+                .processId(String.valueOf(message.getTransferContract()))
                 .policy(output.getPolicy())
                 .build();
 

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/handler/ContractRejectionHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/handler/ContractRejectionHandler.java
@@ -63,7 +63,7 @@ public class ContractRejectionHandler implements Handler {
                 correlationId, rejectionReason));
 
         var rejectionMessage = ContractNegotiationTerminationMessage.Builder.newInstance()
-                .correlationId(String.valueOf(correlationId))
+                .processId(String.valueOf(correlationId))
                 .protocol(MessageProtocol.IDS_MULTIPART)
                 .connectorAddress("") // this will be used by DSP implementation
                 .rejectionReason(Optional.ofNullable(rejectionReason).map(TypedLiteral::toString).orElse(""))

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/handler/ContractRejectionHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/handler/ContractRejectionHandler.java
@@ -16,7 +16,7 @@ package org.eclipse.edc.protocol.ids.api.multipart.handler;
 
 import de.fraunhofer.iais.eis.ContractRejectionMessage;
 import de.fraunhofer.iais.eis.util.TypedLiteral;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRejection;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationTerminationMessage;
 import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationProtocolService;
 import org.eclipse.edc.protocol.ids.api.multipart.message.MultipartRequest;
 import org.eclipse.edc.protocol.ids.api.multipart.message.MultipartResponse;
@@ -62,7 +62,7 @@ public class ContractRejectionHandler implements Handler {
                 "message %s. Negotiation process: %s. Rejection Reason: %s", correlationMessageId,
                 correlationId, rejectionReason));
 
-        var rejectionMessage = ContractRejection.Builder.newInstance()
+        var rejectionMessage = ContractNegotiationTerminationMessage.Builder.newInstance()
                 .correlationId(String.valueOf(correlationId))
                 .protocol(MessageProtocol.IDS_MULTIPART)
                 .connectorAddress("") // this will be used by DSP implementation

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/handler/ContractRequestHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/handler/ContractRequestHandler.java
@@ -17,8 +17,7 @@ package org.eclipse.edc.protocol.ids.api.multipart.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.fraunhofer.iais.eis.ContractRequest;
-import de.fraunhofer.iais.eis.ContractRequestMessage;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferRequest;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationProtocolService;
 import org.eclipse.edc.protocol.ids.api.multipart.message.MultipartRequest;
@@ -39,7 +38,7 @@ import static org.eclipse.edc.protocol.ids.api.multipart.util.ResponseUtil.inPro
 import static org.eclipse.edc.protocol.ids.spi.domain.IdsConstants.IDS_WEBHOOK_ADDRESS_PROPERTY;
 
 /**
- * This class handles and processes incoming IDS {@link ContractRequestMessage}s.
+ * This class handles and processes incoming IDS {@link de.fraunhofer.iais.eis.ContractRequestMessage}s.
  */
 public class ContractRequestHandler implements Handler {
 
@@ -64,13 +63,13 @@ public class ContractRequestHandler implements Handler {
 
     @Override
     public boolean canHandle(@NotNull MultipartRequest multipartRequest) {
-        return multipartRequest.getHeader() instanceof ContractRequestMessage;
+        return multipartRequest.getHeader() instanceof de.fraunhofer.iais.eis.ContractRequestMessage;
     }
 
     @Override
     public @NotNull MultipartResponse handleRequest(@NotNull MultipartRequest multipartRequest) {
         var claimToken = multipartRequest.getClaimToken();
-        var message = (ContractRequestMessage) multipartRequest.getHeader();
+        var message = (de.fraunhofer.iais.eis.ContractRequestMessage) multipartRequest.getHeader();
 
         ContractRequest contractRequest;
         try {
@@ -127,10 +126,10 @@ public class ContractRequestHandler implements Handler {
         }
 
         var contractOffer = result.getContent();
-        var requestObj = ContractOfferRequest.Builder.newInstance()
+        var requestObj = ContractRequestMessage.Builder.newInstance()
                 .protocol(MessageProtocol.IDS_MULTIPART)
                 .connectorAddress(idsWebhookAddress.toString())
-                .type(ContractOfferRequest.Type.INITIAL)
+                .type(ContractRequestMessage.Type.INITIAL)
                 .connectorId(String.valueOf(message.getIssuerConnector()))
                 .correlationId(String.valueOf(message.getTransferContract()))
                 .contractOffer(contractOffer)

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/handler/ContractRequestHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/handler/ContractRequestHandler.java
@@ -131,7 +131,7 @@ public class ContractRequestHandler implements Handler {
                 .connectorAddress(idsWebhookAddress.toString())
                 .type(ContractRequestMessage.Type.INITIAL)
                 .connectorId(String.valueOf(message.getIssuerConnector()))
-                .correlationId(String.valueOf(message.getTransferContract()))
+                .processId(String.valueOf(message.getTransferContract()))
                 .contractOffer(contractOffer)
                 .build();
 

--- a/data-protocols/ids/ids-transform-v1/src/main/java/org/eclipse/edc/protocol/ids/transform/type/contract/ContractAgreementToIdsContractAgreementTransformer.java
+++ b/data-protocols/ids/ids-transform-v1/src/main/java/org/eclipse/edc/protocol/ids/transform/type/contract/ContractAgreementToIdsContractAgreementTransformer.java
@@ -20,7 +20,7 @@ import de.fraunhofer.iais.eis.ContractAgreementBuilder;
 import de.fraunhofer.iais.eis.Duty;
 import de.fraunhofer.iais.eis.Permission;
 import de.fraunhofer.iais.eis.Prohibition;
-import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementRequest;
+import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementMessage;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.protocol.ids.spi.transform.IdsTypeTransformer;
 import org.eclipse.edc.protocol.ids.spi.types.IdsId;
@@ -37,11 +37,11 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.xml.datatype.DatatypeConfigurationException;
 
-public class ContractAgreementToIdsContractAgreementTransformer implements IdsTypeTransformer<ContractAgreementRequest, de.fraunhofer.iais.eis.ContractAgreement> {
+public class ContractAgreementToIdsContractAgreementTransformer implements IdsTypeTransformer<ContractAgreementMessage, de.fraunhofer.iais.eis.ContractAgreement> {
 
     @Override
-    public Class<ContractAgreementRequest> getInputType() {
-        return ContractAgreementRequest.class;
+    public Class<ContractAgreementMessage> getInputType() {
+        return ContractAgreementMessage.class;
     }
 
     @Override
@@ -50,7 +50,7 @@ public class ContractAgreementToIdsContractAgreementTransformer implements IdsTy
     }
 
     @Override
-    public @Nullable ContractAgreement transform(@NotNull ContractAgreementRequest request, @NotNull TransformerContext context) {
+    public @Nullable ContractAgreement transform(@NotNull ContractAgreementMessage request, @NotNull TransformerContext context) {
         Objects.requireNonNull(context);
         if (request == null) {
             return null;

--- a/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/edc/protocol/ids/transform/ContractAgreementToIdsContractAgreementTransformerTest.java
+++ b/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/edc/protocol/ids/transform/ContractAgreementToIdsContractAgreementTransformerTest.java
@@ -16,7 +16,7 @@
 package org.eclipse.edc.protocol.ids.transform;
 
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
-import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementRequest;
+import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementMessage;
 import org.eclipse.edc.policy.model.Duty;
 import org.eclipse.edc.policy.model.Permission;
 import org.eclipse.edc.policy.model.Policy;
@@ -87,7 +87,7 @@ class ContractAgreementToIdsContractAgreementTransformerTest {
         verify(context).transform(any(Duty.class), eq(de.fraunhofer.iais.eis.Duty.class));
     }
 
-    private ContractAgreementRequest contractAgreementRequest(Policy policy) {
+    private ContractAgreementMessage contractAgreementRequest(Policy policy) {
         var contractAgreement = ContractAgreement.Builder.newInstance()
                 .id(String.valueOf(AGREEMENT_ID))
                 .providerAgentId(PROVIDER_ID)
@@ -99,7 +99,7 @@ class ContractAgreementToIdsContractAgreementTransformerTest {
                 .policy(policy)
                 .build();
 
-        return ContractAgreementRequest.Builder.newInstance()
+        return ContractAgreementMessage.Builder.newInstance()
                 .contractAgreement(contractAgreement)
                 .policy(policy)
                 .protocol("any")

--- a/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/edc/protocol/ids/transform/ContractAgreementToIdsContractAgreementTransformerTest.java
+++ b/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/edc/protocol/ids/transform/ContractAgreementToIdsContractAgreementTransformerTest.java
@@ -105,7 +105,7 @@ class ContractAgreementToIdsContractAgreementTransformerTest {
                 .protocol("any")
                 .connectorId("any")
                 .connectorAddress("any")
-                .correlationId("any")
+                .processId("any")
                 .build();
     }
 }

--- a/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/edc/protocol/ids/transform/IdsTransformServiceExtensionTest.java
+++ b/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/edc/protocol/ids/transform/IdsTransformServiceExtensionTest.java
@@ -21,7 +21,7 @@ import de.fraunhofer.iais.eis.Resource;
 import de.fraunhofer.iais.eis.ResourceCatalog;
 import de.fraunhofer.iais.eis.util.RdfResource;
 import org.eclipse.edc.catalog.spi.Catalog;
-import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementRequest;
+import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementMessage;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.policy.model.Action;
@@ -89,7 +89,7 @@ class IdsTransformServiceExtensionTest {
                     Arguments.arguments(Connector.class, de.fraunhofer.iais.eis.Connector.class),
                     Arguments.arguments(Constraint.class, de.fraunhofer.iais.eis.Constraint.class),
                     Arguments.arguments(ContractOffer.class, de.fraunhofer.iais.eis.ContractOffer.class),
-                    Arguments.arguments(ContractAgreementRequest.class, de.fraunhofer.iais.eis.ContractAgreement.class),
+                    Arguments.arguments(ContractAgreementMessage.class, de.fraunhofer.iais.eis.ContractAgreement.class),
                     Arguments.arguments(Catalog.class, ResourceCatalog.class),
                     Arguments.arguments(de.fraunhofer.iais.eis.Constraint.class, Constraint.class),
                     Arguments.arguments(de.fraunhofer.iais.eis.Permission.class, Permission.class),

--- a/extensions/control-plane/api/management-api/catalog-api/src/test/java/org/eclipse/edc/connector/api/management/catalog/CatalogApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/test/java/org/eclipse/edc/connector/api/management/catalog/CatalogApiControllerIntegrationTest.java
@@ -17,7 +17,7 @@ package org.eclipse.edc.connector.api.management.catalog;
 import io.restassured.specification.RequestSpecification;
 import org.eclipse.edc.api.query.QuerySpecDto;
 import org.eclipse.edc.catalog.spi.Catalog;
-import org.eclipse.edc.catalog.spi.CatalogRequest;
+import org.eclipse.edc.catalog.spi.CatalogRequestMessage;
 import org.eclipse.edc.connector.api.management.catalog.model.CatalogRequestDto;
 import org.eclipse.edc.connector.contract.spi.offer.ContractOfferResolver;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
@@ -152,7 +152,7 @@ class CatalogApiControllerIntegrationTest {
                 .contentType(JSON)
                 .body("id", notNullValue())
                 .body("contractOffers.size()", is(1));
-        var requestCaptor = ArgumentCaptor.forClass(CatalogRequest.class);
+        var requestCaptor = ArgumentCaptor.forClass(CatalogRequestMessage.class);
         verify(dispatcher).send(eq(Catalog.class), requestCaptor.capture());
         var rq = requestCaptor.getValue().getQuerySpec();
 
@@ -189,7 +189,7 @@ class CatalogApiControllerIntegrationTest {
                 .body("id", notNullValue())
                 .body("contractOffers.size()", is(1));
 
-        var requestCaptor = ArgumentCaptor.forClass(CatalogRequest.class);
+        var requestCaptor = ArgumentCaptor.forClass(CatalogRequestMessage.class);
         verify(dispatcher).send(eq(Catalog.class), requestCaptor.capture());
         var rq = requestCaptor.getValue().getQuerySpec();
         assertThat(rq.getOffset()).isZero();

--- a/extensions/control-plane/api/management-api/catalog-api/src/test/java/org/eclipse/edc/connector/api/management/catalog/model/CatalogRequestMessageDtoTest.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/test/java/org/eclipse/edc/connector/api/management/catalog/model/CatalogRequestMessageDtoTest.java
@@ -25,7 +25,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.api.management.catalog.TestFunctions.createCriterionDto;
 
-class CatalogRequestDtoTest {
+class CatalogRequestMessageDtoTest {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiController.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiController.java
@@ -33,7 +33,7 @@ import org.eclipse.edc.connector.api.management.contractnegotiation.model.Contra
 import org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto;
 import org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationState;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferRequest;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
 import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationService;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.query.QuerySpec;
@@ -120,7 +120,7 @@ public class ContractNegotiationApiController implements ContractNegotiationApi 
     @POST
     @Override
     public IdResponseDto initiateContractNegotiation(@Valid NegotiationInitiateRequestDto initiateDto) {
-        var transformResult = transformerRegistry.transform(initiateDto, ContractOfferRequest.class);
+        var transformResult = transformerRegistry.transform(initiateDto, ContractRequestMessage.class);
         if (transformResult.failed()) {
             throw new InvalidRequestException(transformResult.getFailureMessages());
         }

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/NegotiationInitiateRequestDtoToDataRequestTransformer.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/NegotiationInitiateRequestDtoToDataRequestTransformer.java
@@ -16,7 +16,7 @@ package org.eclipse.edc.connector.api.management.contractnegotiation.transform;
 
 import org.eclipse.edc.api.transformer.DtoTransformer;
 import org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferRequest;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
@@ -29,7 +29,7 @@ import java.time.Clock;
 import java.time.ZonedDateTime;
 import java.util.stream.Collectors;
 
-public class NegotiationInitiateRequestDtoToDataRequestTransformer implements DtoTransformer<NegotiationInitiateRequestDto, ContractOfferRequest> {
+public class NegotiationInitiateRequestDtoToDataRequestTransformer implements DtoTransformer<NegotiationInitiateRequestDto, ContractRequestMessage> {
 
     private final Clock clock;
     private final String defaultConsumerId;
@@ -54,12 +54,12 @@ public class NegotiationInitiateRequestDtoToDataRequestTransformer implements Dt
     }
 
     @Override
-    public Class<ContractOfferRequest> getOutputType() {
-        return ContractOfferRequest.class;
+    public Class<ContractRequestMessage> getOutputType() {
+        return ContractRequestMessage.class;
     }
 
     @Override
-    public @Nullable ContractOfferRequest transform(@NotNull NegotiationInitiateRequestDto object, @NotNull TransformerContext context) {
+    public @Nullable ContractRequestMessage transform(@NotNull NegotiationInitiateRequestDto object, @NotNull TransformerContext context) {
         // TODO: ContractOfferRequest should contain only the contractOfferId and the contract offer should be retrieved from the catalog. Ref #985
         var now = ZonedDateTime.ofInstant(clock.instant(), clock.getZone());
         var contractOffer = ContractOffer.Builder.newInstance()
@@ -74,13 +74,13 @@ public class NegotiationInitiateRequestDtoToDataRequestTransformer implements Dt
 
         var callbacks = object.getCallbackAddresses().stream().map(c -> context.transform(c, CallbackAddress.class)).collect(Collectors.toList());
 
-        return ContractOfferRequest.Builder.newInstance()
+        return ContractRequestMessage.Builder.newInstance()
                 .connectorId(object.getConnectorId())
                 .connectorAddress(object.getConnectorAddress())
                 .protocol(object.getProtocol())
                 .contractOffer(contractOffer)
                 .callbackAddresses(callbacks)
-                .type(ContractOfferRequest.Type.INITIAL)
+                .type(ContractRequestMessage.Type.INITIAL)
                 .build();
     }
 

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerTest.java
@@ -25,7 +25,7 @@ import org.eclipse.edc.connector.api.management.contractnegotiation.model.Contra
 import org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferRequest;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationService;
 import org.eclipse.edc.policy.model.Policy;
@@ -191,9 +191,9 @@ class ContractNegotiationApiControllerTest {
 
     @Test
     void initiateNegotiation() {
-        when(service.initiateNegotiation(isA(ContractOfferRequest.class))).thenReturn(createContractNegotiation("negotiationId"));
+        when(service.initiateNegotiation(isA(ContractRequestMessage.class))).thenReturn(createContractNegotiation("negotiationId"));
         var contractOfferRequest = createContractOfferRequest();
-        when(transformerRegistry.transform(isA(NegotiationInitiateRequestDto.class), eq(ContractOfferRequest.class))).thenReturn(Result.success(contractOfferRequest));
+        when(transformerRegistry.transform(isA(NegotiationInitiateRequestDto.class), eq(ContractRequestMessage.class))).thenReturn(Result.success(contractOfferRequest));
         var request = NegotiationInitiateRequestDto.Builder.newInstance()
                 .connectorId("connectorId")
                 .connectorAddress("connectorAddress")
@@ -214,7 +214,7 @@ class ContractNegotiationApiControllerTest {
 
     @Test
     void initiateNegotiation_illegalArgumentIfTransformationFails() {
-        when(service.initiateNegotiation(isA(ContractOfferRequest.class))).thenReturn(createContractNegotiation("negotiationId"));
+        when(service.initiateNegotiation(isA(ContractRequestMessage.class))).thenReturn(createContractNegotiation("negotiationId"));
         var request = NegotiationInitiateRequestDto.Builder.newInstance()
                 .connectorId("connectorId")
                 .connectorAddress("connectorAddress")
@@ -281,7 +281,7 @@ class ContractNegotiationApiControllerTest {
     @ParameterizedTest
     @ArgumentsSource(InvalidNegotiationParameters.class)
     void initiateNegotiation_invalidRequestBody(String connectorAddress, String connectorId, String protocol, String offerId) {
-        when(transformerRegistry.transform(isA(NegotiationInitiateRequestDto.class), eq(ContractOfferRequest.class))).thenReturn(Result.failure("error"));
+        when(transformerRegistry.transform(isA(NegotiationInitiateRequestDto.class), eq(ContractRequestMessage.class))).thenReturn(Result.failure("error"));
 
         var rq = NegotiationInitiateRequestDto.Builder.newInstance()
                 .connectorAddress(connectorAddress)
@@ -308,8 +308,8 @@ class ContractNegotiationApiControllerTest {
                 .build();
     }
 
-    private ContractOfferRequest createContractOfferRequest() {
-        return ContractOfferRequest.Builder.newInstance()
+    private ContractRequestMessage createContractOfferRequest() {
+        return ContractRequestMessage.Builder.newInstance()
                 .protocol("protocol")
                 .connectorId("connectorId")
                 .connectorAddress("connectorAddress")

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/NegotiationInitiateRequestDtoToDataRequestTransformerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/NegotiationInitiateRequestDtoToDataRequestTransformerTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.api.management.contractnegotiation.TestFunctions.createOffer;
-import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferRequest.Type.INITIAL;
+import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage.Type.INITIAL;
 import static org.mockito.Mockito.mock;
 
 class NegotiationInitiateRequestDtoToDataRequestTransformerTest {

--- a/spi/common/catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/CatalogRequestMessage.java
+++ b/spi/common/catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/CatalogRequestMessage.java
@@ -111,7 +111,6 @@ public class CatalogRequestMessage implements RemoteMessage {
 
         public CatalogRequestMessage build() {
             Objects.requireNonNull(protocol, "protocol");
-            Objects.requireNonNull(connectorId, "connectorId");
             Objects.requireNonNull(connectorAddress, "connectorAddress");
 
             return new CatalogRequestMessage(protocol, connectorId, connectorAddress, querySpec);

--- a/spi/common/catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/CatalogRequestMessage.java
+++ b/spi/common/catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/CatalogRequestMessage.java
@@ -30,7 +30,7 @@ import java.util.Objects;
 public class CatalogRequestMessage implements RemoteMessage {
 
     private final String protocol;
-    private final String connectorId;
+    private final String connectorId; // TODO remove when removing ids module
     private final String connectorAddress;
     private final QuerySpec querySpec;
 
@@ -54,6 +54,7 @@ public class CatalogRequestMessage implements RemoteMessage {
         return connectorAddress;
     }
 
+    @Deprecated
     @NotNull
     public String getConnectorId() {
         return connectorId;
@@ -92,6 +93,7 @@ public class CatalogRequestMessage implements RemoteMessage {
             return this;
         }
 
+        @Deprecated
         public CatalogRequestMessage.Builder connectorId(String connectorId) {
             this.connectorId = connectorId;
             return this;

--- a/spi/common/catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/CatalogRequestMessage.java
+++ b/spi/common/catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/CatalogRequestMessage.java
@@ -30,7 +30,8 @@ import java.util.Objects;
 public class CatalogRequestMessage implements RemoteMessage {
 
     private final String protocol;
-    private final String connectorId; // TODO remove when removing ids module
+    @Deprecated(forRemoval = true)
+    private final String connectorId;
     private final String connectorAddress;
     private final QuerySpec querySpec;
 

--- a/spi/common/catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/CatalogRequestMessage.java
+++ b/spi/common/catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/CatalogRequestMessage.java
@@ -26,16 +26,16 @@ import java.util.Objects;
 /**
  * A request for a participant's {@link Catalog}.
  */
-@JsonDeserialize(builder = CatalogRequest.Builder.class)
-public class CatalogRequest implements RemoteMessage {
+@JsonDeserialize(builder = CatalogRequestMessage.Builder.class)
+public class CatalogRequestMessage implements RemoteMessage {
 
     private final String protocol;
     private final String connectorId;
     private final String connectorAddress;
     private final QuerySpec querySpec;
 
-    private CatalogRequest(@NotNull String protocol, @NotNull String connectorId, @NotNull String connectorAddress,
-            @Nullable QuerySpec querySpec) {
+    private CatalogRequestMessage(@NotNull String protocol, @NotNull String connectorId, @NotNull String connectorAddress,
+                                  @Nullable QuerySpec querySpec) {
         this.protocol = protocol;
         this.connectorId = connectorId;
         this.connectorAddress = connectorAddress;
@@ -83,36 +83,36 @@ public class CatalogRequest implements RemoteMessage {
         }
 
         @JsonCreator
-        public static CatalogRequest.Builder newInstance() {
-            return new CatalogRequest.Builder();
+        public static CatalogRequestMessage.Builder newInstance() {
+            return new CatalogRequestMessage.Builder();
         }
 
-        public CatalogRequest.Builder protocol(String protocol) {
+        public CatalogRequestMessage.Builder protocol(String protocol) {
             this.protocol = protocol;
             return this;
         }
 
-        public CatalogRequest.Builder connectorId(String connectorId) {
+        public CatalogRequestMessage.Builder connectorId(String connectorId) {
             this.connectorId = connectorId;
             return this;
         }
 
-        public CatalogRequest.Builder connectorAddress(String connectorAddress) {
+        public CatalogRequestMessage.Builder connectorAddress(String connectorAddress) {
             this.connectorAddress = connectorAddress;
             return this;
         }
 
-        public CatalogRequest.Builder querySpec(QuerySpec querySpec) {
+        public CatalogRequestMessage.Builder querySpec(QuerySpec querySpec) {
             this.querySpec = querySpec;
             return this;
         }
 
-        public CatalogRequest build() {
+        public CatalogRequestMessage build() {
             Objects.requireNonNull(protocol, "protocol");
             Objects.requireNonNull(connectorId, "connectorId");
             Objects.requireNonNull(connectorAddress, "connectorAddress");
 
-            return new CatalogRequest(protocol, connectorId, connectorAddress, querySpec);
+            return new CatalogRequestMessage(protocol, connectorId, connectorAddress, querySpec);
         }
     }
 }

--- a/spi/common/catalog-spi/src/test/java/org/eclipse/edc/catalog/spi/protocol/CatalogRequestMessageMessageTest.java
+++ b/spi/common/catalog-spi/src/test/java/org/eclipse/edc/catalog/spi/protocol/CatalogRequestMessageMessageTest.java
@@ -21,56 +21,56 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class CatalogRequestMessageTest {
+class CatalogRequestMessageMessageTest {
 
     private final ObjectMapper mapper = new ObjectMapper();
-    
+
     @Test
     void serialize() throws JsonProcessingException {
         var message = CatalogRequestMessage.Builder.newInstance().build();
-        
+
         var json = mapper.writeValueAsString(message);
-        
+
         assertThat(json)
                 .isNotNull()
                 .contains("\"filter\":null");
     }
-    
+
     @Test
     void serialize_withFilter() throws JsonProcessingException {
         var message = CatalogRequestMessage.Builder.newInstance()
                 .filter(QuerySpec.none())
                 .build();
-        
+
         var json = mapper.writeValueAsString(message);
-        
+
         assertThat(json)
                 .isNotNull()
                 .doesNotContain("\"filter\":null")
                 .contains("\"filter\":{");
     }
-    
+
     @Test
     void deserialize() throws JsonProcessingException {
         var json = "{" +
                 "\"filter\": null" +
                 "}";
-        
+
         var message = mapper.readValue(json, CatalogRequestMessage.class);
-        
+
         assertThat(message)
                 .isNotNull()
                 .matches(m -> m.getFilter() == null);
     }
-    
+
     @Test
     void deserialize_withFilter() throws JsonProcessingException {
         var json = "{" +
                 "\"filter\": {}" +
                 "}";
-        
+
         var message = mapper.readValue(json, CatalogRequestMessage.class);
-        
+
         assertThat(message)
                 .isNotNull()
                 .matches(m -> m.getFilter() != null);

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/negotiation/ConsumerContractNegotiationManager.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/negotiation/ConsumerContractNegotiationManager.java
@@ -16,7 +16,7 @@
 package org.eclipse.edc.connector.contract.spi.negotiation;
 
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferRequest;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import org.eclipse.edc.spi.response.StatusResult;
 
@@ -31,6 +31,6 @@ public interface ConsumerContractNegotiationManager extends ContractNegotiationM
     /**
      * Initiates a contract negotiation for the given provider offer. The offer will have been obtained from a previous contract offer request sent to the provider.
      */
-    StatusResult<ContractNegotiation> initiate(ContractOfferRequest contractOffer);
+    StatusResult<ContractNegotiation> initiate(ContractRequestMessage contractOffer);
 
 }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractAgreementMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractAgreementMessage.java
@@ -19,8 +19,7 @@ import org.eclipse.edc.policy.model.Policy;
 
 import java.util.Objects;
 
-public class ContractAgreementRequest implements ContractRemoteMessage {
-
+public class ContractAgreementMessage implements ContractRemoteMessage {
     private String protocol;
     private String connectorId;
     private String connectorAddress;
@@ -60,10 +59,10 @@ public class ContractAgreementRequest implements ContractRemoteMessage {
     }
 
     public static class Builder {
-        private final ContractAgreementRequest contractAgreementRequest;
+        private final ContractAgreementMessage contractAgreementMessage;
 
         private Builder() {
-            this.contractAgreementRequest = new ContractAgreementRequest();
+            this.contractAgreementMessage = new ContractAgreementMessage();
         }
 
         public static Builder newInstance() {
@@ -71,43 +70,43 @@ public class ContractAgreementRequest implements ContractRemoteMessage {
         }
 
         public Builder protocol(String protocol) {
-            this.contractAgreementRequest.protocol = protocol;
+            this.contractAgreementMessage.protocol = protocol;
             return this;
         }
 
         public Builder connectorId(String connectorId) {
-            this.contractAgreementRequest.connectorId = connectorId;
+            this.contractAgreementMessage.connectorId = connectorId;
             return this;
         }
 
         public Builder connectorAddress(String connectorAddress) {
-            this.contractAgreementRequest.connectorAddress = connectorAddress;
+            this.contractAgreementMessage.connectorAddress = connectorAddress;
             return this;
         }
 
         public Builder correlationId(String correlationId) {
-            this.contractAgreementRequest.correlationId = correlationId;
+            this.contractAgreementMessage.correlationId = correlationId;
             return this;
         }
 
         public Builder contractAgreement(ContractAgreement contractAgreement) {
-            this.contractAgreementRequest.contractAgreement = contractAgreement;
+            this.contractAgreementMessage.contractAgreement = contractAgreement;
             return this;
         }
 
         public Builder policy(Policy policy) {
-            this.contractAgreementRequest.policy = policy;
+            this.contractAgreementMessage.policy = policy;
             return this;
         }
 
-        public ContractAgreementRequest build() {
-            Objects.requireNonNull(contractAgreementRequest.protocol, "protocol");
-            Objects.requireNonNull(contractAgreementRequest.connectorId, "connectorId");
-            Objects.requireNonNull(contractAgreementRequest.connectorAddress, "connectorAddress");
-            Objects.requireNonNull(contractAgreementRequest.contractAgreement, "contractAgreement");
-            Objects.requireNonNull(contractAgreementRequest.policy, "policy");
-            Objects.requireNonNull(contractAgreementRequest.correlationId, "correlationId");
-            return contractAgreementRequest;
+        public ContractAgreementMessage build() {
+            Objects.requireNonNull(contractAgreementMessage.protocol, "protocol");
+            Objects.requireNonNull(contractAgreementMessage.connectorId, "connectorId");
+            Objects.requireNonNull(contractAgreementMessage.connectorAddress, "connectorAddress");
+            Objects.requireNonNull(contractAgreementMessage.contractAgreement, "contractAgreement");
+            Objects.requireNonNull(contractAgreementMessage.policy, "policy");
+            Objects.requireNonNull(contractAgreementMessage.correlationId, "correlationId");
+            return contractAgreementMessage;
         }
     }
 }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractAgreementMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractAgreementMessage.java
@@ -101,10 +101,8 @@ public class ContractAgreementMessage implements ContractRemoteMessage {
 
         public ContractAgreementMessage build() {
             Objects.requireNonNull(contractAgreementMessage.protocol, "protocol");
-            Objects.requireNonNull(contractAgreementMessage.connectorId, "connectorId");
             Objects.requireNonNull(contractAgreementMessage.connectorAddress, "connectorAddress");
             Objects.requireNonNull(contractAgreementMessage.contractAgreement, "contractAgreement");
-            Objects.requireNonNull(contractAgreementMessage.policy, "policy");
             Objects.requireNonNull(contractAgreementMessage.processId, "processId");
             return contractAgreementMessage;
         }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractAgreementMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractAgreementMessage.java
@@ -21,11 +21,13 @@ import java.util.Objects;
 
 public class ContractAgreementMessage implements ContractRemoteMessage {
     private String protocol;
-    private String connectorId; // TODO remove when removing ids module
+    @Deprecated(forRemoval = true)
+    private String connectorId;
     private String connectorAddress;
     private String processId;
     private ContractAgreement contractAgreement;
-    private Policy policy; // TODO remove when removing ids module
+    @Deprecated(forRemoval = true)
+    private Policy policy;
 
     @Override
     public String getProtocol() {

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractAgreementMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractAgreementMessage.java
@@ -23,7 +23,7 @@ public class ContractAgreementMessage implements ContractRemoteMessage {
     private String protocol;
     private String connectorId; // TODO remove when removing ids module
     private String connectorAddress;
-    private String correlationId;
+    private String processId;
     private ContractAgreement contractAgreement;
     private Policy policy; // TODO remove when removing ids module
 
@@ -42,8 +42,9 @@ public class ContractAgreementMessage implements ContractRemoteMessage {
         return connectorId;
     }
 
-    public String getCorrelationId() {
-        return correlationId;
+    @Override
+    public String getProcessId() {
+        return processId;
     }
 
     public ContractAgreement getContractAgreement() {
@@ -53,11 +54,6 @@ public class ContractAgreementMessage implements ContractRemoteMessage {
     @Deprecated
     public Policy getPolicy() {
         return policy;
-    }
-
-    @Override
-    public String getProcessId() {
-        return getCorrelationId();
     }
 
     public static class Builder {
@@ -87,8 +83,8 @@ public class ContractAgreementMessage implements ContractRemoteMessage {
             return this;
         }
 
-        public Builder correlationId(String correlationId) {
-            this.contractAgreementMessage.correlationId = correlationId;
+        public Builder processId(String processId) {
+            this.contractAgreementMessage.processId = processId;
             return this;
         }
 
@@ -109,7 +105,7 @@ public class ContractAgreementMessage implements ContractRemoteMessage {
             Objects.requireNonNull(contractAgreementMessage.connectorAddress, "connectorAddress");
             Objects.requireNonNull(contractAgreementMessage.contractAgreement, "contractAgreement");
             Objects.requireNonNull(contractAgreementMessage.policy, "policy");
-            Objects.requireNonNull(contractAgreementMessage.correlationId, "correlationId");
+            Objects.requireNonNull(contractAgreementMessage.processId, "processId");
             return contractAgreementMessage;
         }
     }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractAgreementMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractAgreementMessage.java
@@ -21,11 +21,11 @@ import java.util.Objects;
 
 public class ContractAgreementMessage implements ContractRemoteMessage {
     private String protocol;
-    private String connectorId;
+    private String connectorId; // TODO remove when removing ids module
     private String connectorAddress;
     private String correlationId;
     private ContractAgreement contractAgreement;
-    private Policy policy;
+    private Policy policy; // TODO remove when removing ids module
 
     @Override
     public String getProtocol() {
@@ -37,6 +37,7 @@ public class ContractAgreementMessage implements ContractRemoteMessage {
         return connectorAddress;
     }
 
+    @Deprecated
     public String getConnectorId() {
         return connectorId;
     }
@@ -49,6 +50,7 @@ public class ContractAgreementMessage implements ContractRemoteMessage {
         return contractAgreement;
     }
 
+    @Deprecated
     public Policy getPolicy() {
         return policy;
     }
@@ -74,6 +76,7 @@ public class ContractAgreementMessage implements ContractRemoteMessage {
             return this;
         }
 
+        @Deprecated
         public Builder connectorId(String connectorId) {
             this.contractAgreementMessage.connectorId = connectorId;
             return this;
@@ -94,6 +97,7 @@ public class ContractAgreementMessage implements ContractRemoteMessage {
             return this;
         }
 
+        @Deprecated
         public Builder policy(Policy policy) {
             this.contractAgreementMessage.policy = policy;
             return this;

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractAgreementVerificationMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractAgreementVerificationMessage.java
@@ -22,7 +22,7 @@ public class ContractAgreementVerificationMessage implements ContractRemoteMessa
 
     private String protocol;
     private String connectorAddress;
-    private String correlationId;
+    private String processId;
 
     @Override
     public String getProtocol() {
@@ -34,13 +34,9 @@ public class ContractAgreementVerificationMessage implements ContractRemoteMessa
         return connectorAddress;
     }
 
-    public String getCorrelationId() {
-        return correlationId;
-    }
-
     @Override
     public String getProcessId() {
-        return getCorrelationId();
+        return processId;
     }
 
     public static class Builder {
@@ -64,15 +60,15 @@ public class ContractAgreementVerificationMessage implements ContractRemoteMessa
             return this;
         }
 
-        public Builder correlationId(String correlationId) {
-            this.message.correlationId = correlationId;
+        public Builder processId(String processId) {
+            this.message.processId = processId;
             return this;
         }
 
         public ContractAgreementVerificationMessage build() {
             Objects.requireNonNull(message.protocol, "protocol");
             Objects.requireNonNull(message.connectorAddress, "connectorAddress");
-            Objects.requireNonNull(message.correlationId, "correlationId");
+            Objects.requireNonNull(message.processId, "processId");
             return message;
         }
     }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractNegotiationEventMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractNegotiationEventMessage.java
@@ -22,7 +22,7 @@ public class ContractNegotiationEventMessage implements ContractRemoteMessage {
 
     private String protocol;
     private String connectorAddress;
-    private String correlationId;
+    private String processId;
     private Type type;
 
     @Override
@@ -35,17 +35,13 @@ public class ContractNegotiationEventMessage implements ContractRemoteMessage {
         return connectorAddress;
     }
 
-    public String getCorrelationId() {
-        return correlationId;
+    @Override
+    public String getProcessId() {
+        return processId;
     }
 
     public Type getType() {
         return type;
-    }
-
-    @Override
-    public String getProcessId() {
-        return getCorrelationId();
     }
 
     public static class Builder {
@@ -69,8 +65,8 @@ public class ContractNegotiationEventMessage implements ContractRemoteMessage {
             return this;
         }
 
-        public Builder correlationId(String correlationId) {
-            this.message.correlationId = correlationId;
+        public Builder processId(String processId) {
+            this.message.processId = processId;
             return this;
         }
 
@@ -82,7 +78,7 @@ public class ContractNegotiationEventMessage implements ContractRemoteMessage {
         public ContractNegotiationEventMessage build() {
             Objects.requireNonNull(message.protocol, "protocol");
             Objects.requireNonNull(message.connectorAddress, "connectorAddress");
-            Objects.requireNonNull(message.correlationId, "correlationId");
+            Objects.requireNonNull(message.processId, "processId");
             Objects.requireNonNull(message.type, "type");
             return message;
         }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractNegotiationTerminationMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractNegotiationTerminationMessage.java
@@ -21,10 +21,10 @@ import java.util.Objects;
 public class ContractNegotiationTerminationMessage implements ContractRemoteMessage {
 
     private String protocol;
-    private String connectorId;
+    private String connectorId; // TODO remove when removing ids module
     private String connectorAddress;
-    private String correlationId; // TODO hand over the contract offer/agreement - not an id?
-    private String rejectionReason; // TODO pre-define a set of enums (+ mapping to IDS) ?
+    private String correlationId;
+    private String rejectionReason; // TODO change to list https://github.com/eclipse-edc/Connector/issues/2729
 
     @Override
     public String getProtocol() {
@@ -36,6 +36,7 @@ public class ContractNegotiationTerminationMessage implements ContractRemoteMess
         return connectorAddress;
     }
 
+    @Deprecated
     public String getConnectorId() {
         return connectorId;
     }
@@ -69,6 +70,7 @@ public class ContractNegotiationTerminationMessage implements ContractRemoteMess
             return this;
         }
 
+        @Deprecated
         public Builder connectorId(String connectorId) {
             this.contractNegotiationTerminationMessage.connectorId = connectorId;
             return this;

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractNegotiationTerminationMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractNegotiationTerminationMessage.java
@@ -23,7 +23,7 @@ public class ContractNegotiationTerminationMessage implements ContractRemoteMess
     private String protocol;
     private String connectorId; // TODO remove when removing ids module
     private String connectorAddress;
-    private String correlationId;
+    private String processId;
     private String rejectionReason; // TODO change to list https://github.com/eclipse-edc/Connector/issues/2729
 
     @Override
@@ -41,17 +41,13 @@ public class ContractNegotiationTerminationMessage implements ContractRemoteMess
         return connectorId;
     }
 
-    public String getCorrelationId() {
-        return correlationId;
+    @Override
+    public String getProcessId() {
+        return processId;
     }
 
     public String getRejectionReason() {
         return rejectionReason;
-    }
-
-    @Override
-    public String getProcessId() {
-        return getCorrelationId();
     }
 
     public static class Builder {
@@ -81,8 +77,8 @@ public class ContractNegotiationTerminationMessage implements ContractRemoteMess
             return this;
         }
 
-        public Builder correlationId(String correlationId) {
-            this.contractNegotiationTerminationMessage.correlationId = correlationId;
+        public Builder processId(String processId) {
+            this.contractNegotiationTerminationMessage.processId = processId;
             return this;
         }
 
@@ -94,7 +90,7 @@ public class ContractNegotiationTerminationMessage implements ContractRemoteMess
         public ContractNegotiationTerminationMessage build() {
             Objects.requireNonNull(contractNegotiationTerminationMessage.protocol, "protocol");
             Objects.requireNonNull(contractNegotiationTerminationMessage.connectorAddress, "connectorAddress");
-            Objects.requireNonNull(contractNegotiationTerminationMessage.correlationId, "correlationId");
+            Objects.requireNonNull(contractNegotiationTerminationMessage.processId, "processId");
             Objects.requireNonNull(contractNegotiationTerminationMessage.rejectionReason, "rejectionReason");
             return contractNegotiationTerminationMessage;
         }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractNegotiationTerminationMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractNegotiationTerminationMessage.java
@@ -21,7 +21,8 @@ import java.util.Objects;
 public class ContractNegotiationTerminationMessage implements ContractRemoteMessage {
 
     private String protocol;
-    private String connectorId; // TODO remove when removing ids module
+    @Deprecated(forRemoval = true)
+    private String connectorId;
     private String connectorAddress;
     private String processId;
     private String rejectionReason; // TODO change to list https://github.com/eclipse-edc/Connector/issues/2729

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractNegotiationTerminationMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractNegotiationTerminationMessage.java
@@ -18,7 +18,7 @@ import org.eclipse.edc.connector.contract.spi.types.protocol.ContractRemoteMessa
 
 import java.util.Objects;
 
-public class ContractRejection implements ContractRemoteMessage {
+public class ContractNegotiationTerminationMessage implements ContractRemoteMessage {
 
     private String protocol;
     private String connectorId;
@@ -54,10 +54,10 @@ public class ContractRejection implements ContractRemoteMessage {
     }
 
     public static class Builder {
-        private final ContractRejection contractRejection;
+        private final ContractNegotiationTerminationMessage contractNegotiationTerminationMessage;
 
         private Builder() {
-            this.contractRejection = new ContractRejection();
+            this.contractNegotiationTerminationMessage = new ContractNegotiationTerminationMessage();
         }
 
         public static Builder newInstance() {
@@ -65,36 +65,36 @@ public class ContractRejection implements ContractRemoteMessage {
         }
 
         public Builder protocol(String protocol) {
-            this.contractRejection.protocol = protocol;
+            this.contractNegotiationTerminationMessage.protocol = protocol;
             return this;
         }
 
         public Builder connectorId(String connectorId) {
-            this.contractRejection.connectorId = connectorId;
+            this.contractNegotiationTerminationMessage.connectorId = connectorId;
             return this;
         }
 
         public Builder connectorAddress(String connectorAddress) {
-            this.contractRejection.connectorAddress = connectorAddress;
+            this.contractNegotiationTerminationMessage.connectorAddress = connectorAddress;
             return this;
         }
 
         public Builder correlationId(String correlationId) {
-            this.contractRejection.correlationId = correlationId;
+            this.contractNegotiationTerminationMessage.correlationId = correlationId;
             return this;
         }
 
         public Builder rejectionReason(String rejectionReason) {
-            this.contractRejection.rejectionReason = rejectionReason;
+            this.contractNegotiationTerminationMessage.rejectionReason = rejectionReason;
             return this;
         }
 
-        public ContractRejection build() {
-            Objects.requireNonNull(contractRejection.protocol, "protocol");
-            Objects.requireNonNull(contractRejection.connectorAddress, "connectorAddress");
-            Objects.requireNonNull(contractRejection.correlationId, "correlationId");
-            Objects.requireNonNull(contractRejection.rejectionReason, "rejectionReason");
-            return contractRejection;
+        public ContractNegotiationTerminationMessage build() {
+            Objects.requireNonNull(contractNegotiationTerminationMessage.protocol, "protocol");
+            Objects.requireNonNull(contractNegotiationTerminationMessage.connectorAddress, "connectorAddress");
+            Objects.requireNonNull(contractNegotiationTerminationMessage.correlationId, "correlationId");
+            Objects.requireNonNull(contractNegotiationTerminationMessage.rejectionReason, "rejectionReason");
+            return contractNegotiationTerminationMessage;
         }
     }
 }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessage.java
@@ -30,7 +30,7 @@ public class ContractRequestMessage implements ContractRemoteMessage {
 
     private Type type = Type.COUNTER_OFFER;
     private String protocol;
-    private String connectorId;
+    private String connectorId; // TODO remove when removing ids module
     private String connectorAddress;
     private String correlationId;
     private ContractOffer contractOffer;
@@ -47,6 +47,7 @@ public class ContractRequestMessage implements ContractRemoteMessage {
         return connectorAddress;
     }
 
+    @Deprecated
     public String getConnectorId() {
         return connectorId;
     }
@@ -93,6 +94,7 @@ public class ContractRequestMessage implements ContractRemoteMessage {
             return this;
         }
 
+        @Deprecated
         public Builder connectorId(String connectorId) {
             contractRequestMessage.connectorId = connectorId;
             return this;

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessage.java
@@ -32,7 +32,7 @@ public class ContractRequestMessage implements ContractRemoteMessage {
     private String protocol;
     private String connectorId; // TODO remove when removing ids module
     private String connectorAddress;
-    private String correlationId;
+    private String processId;
     private ContractOffer contractOffer;
 
     private List<CallbackAddress> callbackAddress = new ArrayList<>();
@@ -52,8 +52,9 @@ public class ContractRequestMessage implements ContractRemoteMessage {
         return connectorId;
     }
 
-    public String getCorrelationId() {
-        return correlationId;
+    @Override
+    public String getProcessId() {
+        return processId;
     }
 
     public Type getType() {
@@ -66,11 +67,6 @@ public class ContractRequestMessage implements ContractRemoteMessage {
 
     public List<CallbackAddress> getCallbackAddress() {
         return callbackAddress;
-    }
-
-    @Override
-    public String getProcessId() {
-        return getCorrelationId();
     }
 
     public enum Type {
@@ -105,8 +101,8 @@ public class ContractRequestMessage implements ContractRemoteMessage {
             return this;
         }
 
-        public Builder correlationId(String correlationId) {
-            contractRequestMessage.correlationId = correlationId;
+        public Builder processId(String processId) {
+            contractRequestMessage.processId = processId;
             return this;
         }
 

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessage.java
@@ -123,7 +123,6 @@ public class ContractRequestMessage implements ContractRemoteMessage {
 
         public ContractRequestMessage build() {
             Objects.requireNonNull(contractRequestMessage.protocol, "protocol");
-            Objects.requireNonNull(contractRequestMessage.connectorId, "connectorId");
             Objects.requireNonNull(contractRequestMessage.connectorAddress, "connectorAddress");
             Objects.requireNonNull(contractRequestMessage.contractOffer, "contractOffer");
             return contractRequestMessage;

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessage.java
@@ -26,7 +26,7 @@ import java.util.Objects;
  * Object that wraps the contract offer and provides additional information about e.g. protocol
  * and recipient.
  */
-public class ContractOfferRequest implements ContractRemoteMessage {
+public class ContractRequestMessage implements ContractRemoteMessage {
 
     private Type type = Type.COUNTER_OFFER;
     private String protocol;
@@ -78,10 +78,10 @@ public class ContractOfferRequest implements ContractRemoteMessage {
     }
 
     public static class Builder {
-        private final ContractOfferRequest contractOfferRequest;
+        private final ContractRequestMessage contractRequestMessage;
 
         private Builder() {
-            contractOfferRequest = new ContractOfferRequest();
+            contractRequestMessage = new ContractRequestMessage();
         }
 
         public static Builder newInstance() {
@@ -89,46 +89,46 @@ public class ContractOfferRequest implements ContractRemoteMessage {
         }
 
         public Builder protocol(String protocol) {
-            contractOfferRequest.protocol = protocol;
+            contractRequestMessage.protocol = protocol;
             return this;
         }
 
         public Builder connectorId(String connectorId) {
-            contractOfferRequest.connectorId = connectorId;
+            contractRequestMessage.connectorId = connectorId;
             return this;
         }
 
         public Builder connectorAddress(String connectorAddress) {
-            contractOfferRequest.connectorAddress = connectorAddress;
+            contractRequestMessage.connectorAddress = connectorAddress;
             return this;
         }
 
         public Builder correlationId(String correlationId) {
-            contractOfferRequest.correlationId = correlationId;
+            contractRequestMessage.correlationId = correlationId;
             return this;
         }
 
         public Builder callbackAddresses(List<CallbackAddress> callbackAddresses) {
-            contractOfferRequest.callbackAddress = callbackAddresses;
+            contractRequestMessage.callbackAddress = callbackAddresses;
             return this;
         }
 
         public Builder contractOffer(ContractOffer contractOffer) {
-            contractOfferRequest.contractOffer = contractOffer;
+            contractRequestMessage.contractOffer = contractOffer;
             return this;
         }
 
         public Builder type(Type type) {
-            contractOfferRequest.type = type;
+            contractRequestMessage.type = type;
             return this;
         }
 
-        public ContractOfferRequest build() {
-            Objects.requireNonNull(contractOfferRequest.protocol, "protocol");
-            Objects.requireNonNull(contractOfferRequest.connectorId, "connectorId");
-            Objects.requireNonNull(contractOfferRequest.connectorAddress, "connectorAddress");
-            Objects.requireNonNull(contractOfferRequest.contractOffer, "contractOffer");
-            return contractOfferRequest;
+        public ContractRequestMessage build() {
+            Objects.requireNonNull(contractRequestMessage.protocol, "protocol");
+            Objects.requireNonNull(contractRequestMessage.connectorId, "connectorId");
+            Objects.requireNonNull(contractRequestMessage.connectorAddress, "connectorAddress");
+            Objects.requireNonNull(contractRequestMessage.contractOffer, "contractOffer");
+            return contractRequestMessage;
         }
     }
 }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessage.java
@@ -30,7 +30,8 @@ public class ContractRequestMessage implements ContractRemoteMessage {
 
     private Type type = Type.COUNTER_OFFER;
     private String protocol;
-    private String connectorId; // TODO remove when removing ids module
+    @Deprecated(forRemoval = true)
+    private String connectorId;
     private String connectorAddress;
     private String processId;
     private ContractOffer contractOffer;

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/contractnegotiation/ContractNegotiationProtocolService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/contractnegotiation/ContractNegotiationProtocolService.java
@@ -18,7 +18,7 @@ import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementM
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementVerificationMessage;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractNegotiationEventMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferRequest;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRejection;
 import org.eclipse.edc.service.spi.result.ServiceResult;
 import org.eclipse.edc.spi.iam.ClaimToken;
@@ -38,7 +38,7 @@ public interface ContractNegotiationProtocolService {
      * @return a succeeded result if the operation was successful, a failed one otherwise
      */
     @NotNull
-    ServiceResult<ContractNegotiation> notifyRequested(ContractOfferRequest message, ClaimToken claimToken);
+    ServiceResult<ContractNegotiation> notifyRequested(ContractRequestMessage message, ClaimToken claimToken);
 
     /**
      * Notifies the ContractNegotiation that it has been offered by the provider.
@@ -49,7 +49,7 @@ public interface ContractNegotiationProtocolService {
      * @return a succeeded result if the operation was successful, a failed one otherwise
      */
     @NotNull
-    ServiceResult<ContractNegotiation> notifyOffered(ContractOfferRequest message, ClaimToken claimToken);
+    ServiceResult<ContractNegotiation> notifyOffered(ContractRequestMessage message, ClaimToken claimToken);
 
     /**
      * Notifies the ContractNegotiation that it has been agreed by the accepted.

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/contractnegotiation/ContractNegotiationProtocolService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/contractnegotiation/ContractNegotiationProtocolService.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.edc.connector.spi.contractnegotiation;
 
-import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementRequest;
+import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementMessage;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementVerificationMessage;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractNegotiationEventMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
@@ -71,7 +71,7 @@ public interface ContractNegotiationProtocolService {
      * @return a succeeded result if the operation was successful, a failed one otherwise
      */
     @NotNull
-    ServiceResult<ContractNegotiation> notifyAgreed(ContractAgreementRequest message, ClaimToken claimToken);
+    ServiceResult<ContractNegotiation> notifyAgreed(ContractAgreementMessage message, ClaimToken claimToken);
 
     /**
      * Notifies the ContractNegotiation that it has been verified by the consumer.

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/contractnegotiation/ContractNegotiationProtocolService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/contractnegotiation/ContractNegotiationProtocolService.java
@@ -18,8 +18,8 @@ import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementM
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementVerificationMessage;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractNegotiationEventMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationTerminationMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRejection;
 import org.eclipse.edc.service.spi.result.ServiceResult;
 import org.eclipse.edc.spi.iam.ClaimToken;
 import org.jetbrains.annotations.NotNull;
@@ -103,5 +103,5 @@ public interface ContractNegotiationProtocolService {
      * @return a succeeded result if the operation was successful, a failed one otherwise
      */
     @NotNull
-    ServiceResult<ContractNegotiation> notifyTerminated(ContractRejection message, ClaimToken claimToken);
+    ServiceResult<ContractNegotiation> notifyTerminated(ContractNegotiationTerminationMessage message, ClaimToken claimToken);
 }

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/contractnegotiation/ContractNegotiationService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/contractnegotiation/ContractNegotiationService.java
@@ -16,7 +16,7 @@ package org.eclipse.edc.connector.spi.contractnegotiation;
 
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferRequest;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
 import org.eclipse.edc.service.spi.result.ServiceResult;
 import org.eclipse.edc.spi.query.QuerySpec;
 
@@ -63,7 +63,7 @@ public interface ContractNegotiationService {
      * @param request the contract offer request
      * @return the contract negotiation initiated
      */
-    ContractNegotiation initiateNegotiation(ContractOfferRequest request);
+    ContractNegotiation initiateNegotiation(ContractRequestMessage request);
 
     /**
      * Cancel a contract negotiation

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferRequestMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferRequestMessage.java
@@ -31,9 +31,11 @@ public class TransferRequestMessage implements TransferRemoteMessage {
     private String protocol;
     private String id;
     private String contractId;
-    private String assetId; // TODO remove when removing ids module
+    @Deprecated(forRemoval = true)
+    private String assetId;
     private DataAddress dataDestination;
-    private String connectorId; // TODO remove when removing ids module
+    @Deprecated(forRemoval = true)
+    private String connectorId;
     private Map<String, String> properties = new HashMap<>();
 
     @Override

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferRequestMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferRequestMessage.java
@@ -31,9 +31,9 @@ public class TransferRequestMessage implements TransferRemoteMessage {
     private String protocol;
     private String id;
     private String contractId;
-    private String assetId;
+    private String assetId; // TODO remove when removing ids module
     private DataAddress dataDestination;
-    private String connectorId;
+    private String connectorId; // TODO remove when removing ids module
     private Map<String, String> properties = new HashMap<>();
 
     @Override
@@ -51,6 +51,7 @@ public class TransferRequestMessage implements TransferRemoteMessage {
         return id;
     }
 
+    @Deprecated
     public String getAssetId() {
         return assetId;
     }
@@ -63,6 +64,7 @@ public class TransferRequestMessage implements TransferRemoteMessage {
         return id;
     }
 
+    @Deprecated
     public String getConnectorId() {
         return connectorId;
     }
@@ -108,6 +110,7 @@ public class TransferRequestMessage implements TransferRemoteMessage {
             return this;
         }
 
+        @Deprecated
         public Builder assetId(String assetId) {
             message.assetId = assetId;
             return this;
@@ -118,6 +121,7 @@ public class TransferRequestMessage implements TransferRemoteMessage {
             return this;
         }
 
+        @Deprecated
         public Builder connectorId(String connectorId) {
             message.connectorId = connectorId;
             return this;


### PR DESCRIPTION
## What this PR changes/adds

See commit messages for a list of changes. Values that are only used to set a property that is never used are marked as deprecated & optional and can be removed with the IDS modules.

## Why it does that

Aligns properties and naming of `RemoteMessage` classes to spec documents.

## Further notes

Properties that are still missing will be added later when supporting new protocol functionalities.

## Linked Issue(s)

Closes #2690

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
