### PR TITLE
refactor: resolve EventSubscriber warnings

### DIFF
--- a/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/event/EventRouterImpl.java
+++ b/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/event/EventRouterImpl.java
@@ -46,12 +46,12 @@ public class EventRouterImpl implements EventRouter {
     }
 
     @Override
-    public <E extends Event> void registerSync(Class<E> eventKind, EventSubscriber<E> subscriber) {
+    public <E extends Event> void registerSync(Class<E> eventKind, EventSubscriber subscriber) {
         syncSubscribers.computeIfAbsent(eventKind, s -> new ArrayList<>()).add(subscriber);
     }
 
     @Override
-    public <E extends Event> void register(Class<E> eventKind, EventSubscriber<E> subscriber) {
+    public <E extends Event> void register(Class<E> eventKind, EventSubscriber subscriber) {
         subscribers.computeIfAbsent(eventKind, s -> new ArrayList<>()).add(subscriber);
     }
     

--- a/core/common/junit/src/main/java/org/eclipse/edc/junit/matchers/EventEnvelopeMatcher.java
+++ b/core/common/junit/src/main/java/org/eclipse/edc/junit/matchers/EventEnvelopeMatcher.java
@@ -27,7 +27,11 @@ public class EventEnvelopeMatcher<T extends Event> implements ArgumentMatcher<Ev
     }
 
     public static <T extends Event> EventEnvelopeMatcher<T> isEnvelopeOf(Class<T> klass) {
-        return new EventEnvelopeMatcher(klass);
+        return new EventEnvelopeMatcher<>(klass);
+    }
+
+    public static <T extends B, B extends Event> EventEnvelopeMatcher<B> isEnvelopeOf(Class<T> klass, Class<B> baseKlass) {
+        return new EventEnvelopeMatcher<>(baseKlass);
     }
 
     @Override

--- a/core/common/junit/src/main/java/org/eclipse/edc/junit/matchers/EventEnvelopeMatcher.java
+++ b/core/common/junit/src/main/java/org/eclipse/edc/junit/matchers/EventEnvelopeMatcher.java
@@ -30,10 +30,6 @@ public class EventEnvelopeMatcher<T extends Event> implements ArgumentMatcher<Ev
         return new EventEnvelopeMatcher<>(klass);
     }
 
-    public static <T extends B, B extends Event> EventEnvelopeMatcher<B> isEnvelopeOf(Class<T> klass, Class<B> baseKlass) {
-        return new EventEnvelopeMatcher<>(baseKlass);
-    }
-
     @Override
     public boolean matches(EventEnvelope<T> argument) {
         return eventKind.isAssignableFrom(argument.getPayload().getClass());

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/asset/AssetEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/asset/AssetEventDispatchTest.java
@@ -35,7 +35,6 @@ import static org.awaitility.Awaitility.await;
 import static org.eclipse.edc.junit.matchers.EventEnvelopeMatcher.isEnvelopeOf;
 import static org.eclipse.edc.junit.testfixtures.TestUtils.getFreePort;
 import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -56,9 +55,6 @@ public class AssetEventDispatchTest {
 
     @Test
     void shouldDispatchEventsOnAssetCreationAndDeletion(AssetService service, EventRouter eventRouter) {
-        doAnswer(i -> null).when(eventSubscriber).on(argThat(isEnvelopeOf(AssetCreated.class)));
-        doAnswer(i -> null).when(eventSubscriber).on(argThat(isEnvelopeOf(AssetDeleted.class)));
-
         eventRouter.register(AssetEvent.class, eventSubscriber);
         var asset = Asset.Builder.newInstance().id("assetId").build();
         var dataAddress = DataAddress.Builder.newInstance().type("any").build();

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
@@ -64,12 +64,9 @@ import static org.mockito.Mockito.when;
 class ContractNegotiationEventDispatchTest {
     private static final String CONSUMER = "consumer";
     private static final String PROVIDER = "provider";
-
     private static final long CONTRACT_VALIDITY = TimeUnit.HOURS.toSeconds(1);
 
-    @SuppressWarnings("rawtypes")
     private final EventSubscriber eventSubscriber = mock(EventSubscriber.class);
-
     private final ClaimToken token = ClaimToken.Builder.newInstance().claim(ParticipantAgentService.DEFAULT_IDENTITY_CLAIM_KEY, CONSUMER).build();
 
     @BeforeEach
@@ -94,7 +91,6 @@ class ContractNegotiationEventDispatchTest {
                                                                        AssetIndex assetIndex) {
         dispatcherRegistry.register(succeedingDispatcher());
 
-        //noinspection unchecked
         eventRouter.register(ContractNegotiationEvent.class, eventSubscriber);
         var policy = Policy.Builder.newInstance().build();
         var contractDefinition = ContractDefinition.Builder.newInstance()
@@ -111,9 +107,7 @@ class ContractNegotiationEventDispatchTest {
         service.notifyRequested(createContractOfferRequest(policy), token);
 
         await().untilAsserted(() -> {
-            //noinspection unchecked
             verify(eventSubscriber).on(argThat(isEnvelopeOf(ContractNegotiationRequested.class)));
-            //noinspection unchecked
             verify(eventSubscriber).on(argThat(isEnvelopeOf(ContractNegotiationAgreed.class)));
         });
     }

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionEventDispatchTest.java
@@ -36,7 +36,6 @@ import static org.awaitility.Awaitility.await;
 import static org.eclipse.edc.junit.matchers.EventEnvelopeMatcher.isEnvelopeOf;
 import static org.eclipse.edc.junit.testfixtures.TestUtils.getFreePort;
 import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -56,14 +55,7 @@ public class PolicyDefinitionEventDispatchTest {
     }
 
     @Test
-    void shouldDispatchEventOnPolicyDefinitionCreationAndDeletionAndUpdate(PolicyDefinitionService service, EventRouter eventRouter) throws InterruptedException {
-
-        doAnswer(i -> null).when(eventSubscriber).on(argThat(isEnvelopeOf(PolicyDefinitionCreated.class)));
-
-        doAnswer(i -> null).when(eventSubscriber).on(argThat(isEnvelopeOf(PolicyDefinitionDeleted.class)));
-
-        doAnswer(i -> null).when(eventSubscriber).on(argThat(isEnvelopeOf(PolicyDefinitionUpdated.class)));
-
+    void shouldDispatchEventOnPolicyDefinitionCreationAndDeletionAndUpdate(PolicyDefinitionService service, EventRouter eventRouter) {
         eventRouter.register(PolicyDefinitionEvent.class, eventSubscriber);
         var policyDefinition = PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build();
 
@@ -83,4 +75,5 @@ public class PolicyDefinitionEventDispatchTest {
 
         });
     }
+
 }

--- a/extensions/common/events/events-cloud-http/src/main/java/org/eclipse/edc/event/cloud/http/CloudEventsPublisher.java
+++ b/extensions/common/events/events-cloud-http/src/main/java/org/eclipse/edc/event/cloud/http/CloudEventsPublisher.java
@@ -38,7 +38,7 @@ import java.time.LocalDateTime;
 import static java.lang.String.format;
 import static java.time.ZoneOffset.UTC;
 
-class CloudEventsPublisher implements EventSubscriber<Event> {
+class CloudEventsPublisher implements EventSubscriber {
     private static final String APPLICATION_JSON = "application/json";
 
     private final String endpoint;
@@ -58,7 +58,7 @@ class CloudEventsPublisher implements EventSubscriber<Event> {
     }
 
     @Override
-    public void on(EventEnvelope<Event> event) {
+    public <E extends Event> void on(EventEnvelope<E> event) {
         var json = typeManager.writeValueAsBytes(event.getPayload());
         var instant = Instant.ofEpochMilli(event.getAt());
         var localDateTime = LocalDateTime.ofInstant(instant, clock.getZone());

--- a/extensions/control-plane/callback/callback-event-dispatcher/src/main/java/org/eclipse/edc/connector/callback/dispatcher/CallbackEventDispatcher.java
+++ b/extensions/control-plane/callback/callback-event-dispatcher/src/main/java/org/eclipse/edc/connector/callback/dispatcher/CallbackEventDispatcher.java
@@ -34,7 +34,7 @@ import static java.lang.String.format;
  * the {@link Event#name()}, the callback is the invoked using a {@link RemoteMessageDispatcherRegistry} with protocol
  * extracted by {@link CallbackAddress#getUri()}
  */
-public class CallbackEventDispatcher<T extends Event> implements EventSubscriber<T> {
+public class CallbackEventDispatcher implements EventSubscriber {
     private final RemoteMessageDispatcherRegistry dispatcher;
     private final boolean transactional;
     private final Monitor monitor;
@@ -49,7 +49,7 @@ public class CallbackEventDispatcher<T extends Event> implements EventSubscriber
     }
 
     @Override
-    public void on(EventEnvelope<T> eventEnvelope) {
+    public <E extends Event> void on(EventEnvelope<E> eventEnvelope) {
         var callbacks = eventEnvelope.getPayload().getCallbackAddresses()
                 .stream().filter(cb -> cb.isTransactional() == transactional)
                 .collect(Collectors.toList());

--- a/extensions/control-plane/callback/callback-event-dispatcher/src/main/java/org/eclipse/edc/connector/callback/dispatcher/CallbackEventDispatcherExtension.java
+++ b/extensions/control-plane/callback/callback-event-dispatcher/src/main/java/org/eclipse/edc/connector/callback/dispatcher/CallbackEventDispatcherExtension.java
@@ -54,8 +54,8 @@ public class CallbackEventDispatcherExtension implements ServiceExtension {
         context.registerService(CallbackProtocolResolverRegistry.class, resolverRegistry);
 
         // Event listener for invoking callbacks in sync (transactional) and async (not transactional)
-        router.registerSync(Event.class, new CallbackEventDispatcher<>(dispatcherRegistry, resolverRegistry, true, monitor));
-        router.register(Event.class, new CallbackEventDispatcher<>(dispatcherRegistry, resolverRegistry, false, monitor));
+        router.registerSync(Event.class, new CallbackEventDispatcher(dispatcherRegistry, resolverRegistry, true, monitor));
+        router.register(Event.class, new CallbackEventDispatcher(dispatcherRegistry, resolverRegistry, false, monitor));
 
     }
 }

--- a/extensions/control-plane/callback/callback-event-dispatcher/src/test/java/org/eclipse/edc/connector/callback/dispatcher/CallbackEventDispatcherExtensionTest.java
+++ b/extensions/control-plane/callback/callback-event-dispatcher/src/test/java/org/eclipse/edc/connector/callback/dispatcher/CallbackEventDispatcherExtensionTest.java
@@ -55,7 +55,7 @@ public class CallbackEventDispatcherExtensionTest {
 
     }
 
-    private ArgumentMatcher<CallbackEventDispatcher<Event>> callbackEventDispatcherMatcher(boolean transactional) {
+    private ArgumentMatcher<CallbackEventDispatcher> callbackEventDispatcherMatcher(boolean transactional) {
         return dispatcher -> dispatcher.isTransactional() == transactional;
     }
 }

--- a/extensions/control-plane/callback/callback-event-dispatcher/src/test/java/org/eclipse/edc/connector/callback/dispatcher/CallbackEventDispatcherTest.java
+++ b/extensions/control-plane/callback/callback-event-dispatcher/src/test/java/org/eclipse/edc/connector/callback/dispatcher/CallbackEventDispatcherTest.java
@@ -42,7 +42,7 @@ import static org.mockito.Mockito.when;
 
 public class CallbackEventDispatcherTest {
 
-    CallbackEventDispatcher<Event> dispatcher;
+    CallbackEventDispatcher dispatcher;
     RemoteMessageDispatcherRegistry registry = mock(RemoteMessageDispatcherRegistry.class);
 
     CallbackProtocolResolverRegistry resolverRegistry = mock(CallbackProtocolResolverRegistry.class);
@@ -50,7 +50,7 @@ public class CallbackEventDispatcherTest {
 
     @Test
     void verifyShouldNotDispatch() {
-        dispatcher = new CallbackEventDispatcher<>(registry, resolverRegistry, true, monitor);
+        dispatcher = new CallbackEventDispatcher(registry, resolverRegistry, true, monitor);
         when(resolverRegistry.resolve("local")).thenReturn("local");
 
 
@@ -63,7 +63,7 @@ public class CallbackEventDispatcherTest {
 
     @Test
     void verifyDispatchShouldThrowException() {
-        dispatcher = new CallbackEventDispatcher<>(registry, resolverRegistry, true, monitor);
+        dispatcher = new CallbackEventDispatcher(registry, resolverRegistry, true, monitor);
         when(resolverRegistry.resolve("local")).thenReturn("local");
 
         when(registry.send(any(), any())).thenReturn(CompletableFuture.failedFuture(new RuntimeException("Test")));
@@ -94,7 +94,7 @@ public class CallbackEventDispatcherTest {
         @SuppressWarnings("unchecked")
         ArgumentCaptor<CallbackEventRemoteMessage<TransferProcessCompleted>> captor = ArgumentCaptor.forClass(CallbackEventRemoteMessage.class);
 
-        dispatcher = new CallbackEventDispatcher<>(registry, resolverRegistry, transactional, monitor);
+        dispatcher = new CallbackEventDispatcher(registry, resolverRegistry, transactional, monitor);
 
         var callback = CallbackAddress.Builder.newInstance()
                 .uri("local://test")
@@ -122,7 +122,7 @@ public class CallbackEventDispatcherTest {
     @ValueSource(booleans = { true, false })
     void verifyShouldNotDispatchWithDifferentTransactionalConfiguration(boolean transactional) {
 
-        dispatcher = new CallbackEventDispatcher<>(registry, resolverRegistry, transactional, monitor);
+        dispatcher = new CallbackEventDispatcher(registry, resolverRegistry, transactional, monitor);
         when(resolverRegistry.resolve("local")).thenReturn("local");
 
 

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/EventRouter.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/EventRouter.java
@@ -30,14 +30,14 @@ public interface EventRouter {
      *
      * @param subscriber that will receive every published event
      */
-    <E extends Event> void registerSync(Class<E> eventKind, EventSubscriber<E> subscriber);
+    <E extends Event> void registerSync(Class<E> eventKind, EventSubscriber subscriber);
 
     /**
      * Register a new asynchronous subscriber to the events
      *
      * @param subscriber that will receive every published event
      */
-    <E extends Event> void register(Class<E> eventKind, EventSubscriber<E> subscriber);
+    <E extends Event> void register(Class<E> eventKind, EventSubscriber subscriber);
 
     /**
      * Publish an event to all the subscribers

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/EventSubscriber.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/EventSubscriber.java
@@ -17,11 +17,11 @@ package org.eclipse.edc.spi.event;
 /**
  * Every implementation of this will have the possibility to react to every event published into the EDC
  */
-public interface EventSubscriber<E extends Event> {
+public interface EventSubscriber {
     /**
      * Add custom logic for every event happened
      *
      * @param event the event happened
      */
-    void on(EventEnvelope<E> event);
+    <E extends Event> void on(EventEnvelope<E> event);
 }


### PR DESCRIPTION
## What this PR changes/adds

Change the `EventSubscriber` interface API 

## Why it does that

Avoid compiler warnings

## Further notes

- also `EventEnvelope` suffers from warnings, caused by the fact that the type of the payload is not known until it has been set with the `payload` builder method. I'd propose to add the payload as a member of the `newInstance` method to avoid this, eventually in another PR.

## Linked Issue(s)

Closes #2740 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
