### PR TITLE
feat: improve `DatasetResolverImpl` performances

### DIFF
--- a/core/control-plane/catalog-core/src/test/java/org/eclipse/edc/connector/catalog/DatasetResolverImplPerformanceTest.java
+++ b/core/control-plane/catalog-core/src/test/java/org/eclipse/edc/connector/catalog/DatasetResolverImplPerformanceTest.java
@@ -1,0 +1,130 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.catalog;
+
+import org.eclipse.edc.catalog.spi.DataService;
+import org.eclipse.edc.catalog.spi.Dataset;
+import org.eclipse.edc.catalog.spi.DatasetResolver;
+import org.eclipse.edc.connector.contract.spi.offer.store.ContractDefinitionStore;
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractDefinition;
+import org.eclipse.edc.connector.dataplane.selector.spi.store.DataPlaneInstanceStore;
+import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
+import org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore;
+import org.eclipse.edc.junit.extensions.EdcExtension;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.agent.ParticipantAgent;
+import org.eclipse.edc.spi.asset.AssetIndex;
+import org.eclipse.edc.spi.asset.AssetSelectorExpression;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.asset.Asset;
+import org.eclipse.edc.spi.types.domain.asset.AssetEntry;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.util.stream.Stream;
+
+import static java.time.Duration.ofSeconds;
+import static java.util.Collections.emptyMap;
+import static java.util.stream.IntStream.range;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.spi.asset.AssetSelectorExpression.SELECT_ALL;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(EdcExtension.class)
+class DatasetResolverImplPerformanceTest {
+
+    private final Clock clock = Clock.systemUTC();
+
+    @BeforeEach
+    void setUp(EdcExtension extension) {
+        extension.registerServiceMock(DataService.class, DataService.Builder.newInstance().build());
+        extension.registerServiceMock(DataPlaneInstanceStore.class, mock(DataPlaneInstanceStore.class));
+    }
+
+    @Test
+    void oneAssetPerDefinition(DatasetResolver datasetResolver, ContractDefinitionStore contractDefinitionStore, AssetIndex assetIndex, PolicyDefinitionStore policyDefinitionStore) {
+        policyDefinitionStore.create(createPolicyDefinition("policy").build());
+        range(0, 10000).mapToObj(i -> createContractDefinition(String.valueOf(i)).accessPolicyId("policy").contractPolicyId("policy").selectorExpression(selectAsset(String.valueOf(i))).build()).forEach(contractDefinitionStore::save);
+        range(0, 10000).mapToObj(i -> createAsset(String.valueOf(i)).build()).map(this::createAssetEntry).forEach(assetIndex::accept);
+
+        var firstPageQuery = QuerySpec.Builder.newInstance().offset(0).limit(100).build();
+        var firstPageDatasets = queryDatasetsIn(datasetResolver, firstPageQuery, ofSeconds(1));
+
+        assertThat(firstPageDatasets).hasSize(100);
+
+        var lastPageQuery = QuerySpec.Builder.newInstance().offset(9900).limit(100).build();
+        var lastPageDatasets = queryDatasetsIn(datasetResolver, lastPageQuery, ofSeconds(1));
+
+        assertThat(lastPageDatasets).hasSize(100);
+    }
+
+    @Test
+    void fewDefinitionsSelectAllAssets(DatasetResolver datasetResolver, ContractDefinitionStore contractDefinitionStore, AssetIndex assetIndex, PolicyDefinitionStore policyDefinitionStore) {
+        policyDefinitionStore.create(createPolicyDefinition("policy").build());
+        range(0, 10).mapToObj(i -> createContractDefinition(String.valueOf(i)).accessPolicyId("policy").contractPolicyId("policy").selectorExpression(SELECT_ALL).build()).forEach(contractDefinitionStore::save);
+        range(0, 10000).mapToObj(i -> createAsset(String.valueOf(i)).build()).map(this::createAssetEntry).forEach(assetIndex::accept);
+
+        var firstPageQuery = QuerySpec.Builder.newInstance().offset(0).limit(100).build();
+        var firstPageDatasets = queryDatasetsIn(datasetResolver, firstPageQuery, ofSeconds(1));
+
+        assertThat(firstPageDatasets).hasSize(100);
+
+        var lastPageQuery = QuerySpec.Builder.newInstance().offset(9900).limit(100).build();
+        var lastPageDatasets = queryDatasetsIn(datasetResolver, lastPageQuery, ofSeconds(1));
+
+        assertThat(lastPageDatasets).hasSize(100);
+    }
+
+    private Stream<Dataset> queryDatasetsIn(DatasetResolver datasetResolver, QuerySpec querySpec, Duration duration) {
+        var start = clock.instant();
+        var datasets = datasetResolver.query(new ParticipantAgent(emptyMap(), emptyMap()), querySpec);
+        var end = clock.instant();
+
+        assertThat(Duration.between(start, end)).isLessThan(duration);
+        return datasets;
+    }
+
+    private AssetSelectorExpression selectAsset(String assetId) {
+        return AssetSelectorExpression.Builder.newInstance().whenEquals(Asset.PROPERTY_ID, assetId).build();
+    }
+
+    private ContractDefinition.Builder createContractDefinition(String id) {
+        return ContractDefinition.Builder.newInstance()
+                .id(id)
+                .accessPolicyId("access")
+                .contractPolicyId("contract")
+                .selectorExpression(SELECT_ALL)
+                .validity(100);
+    }
+
+    @NotNull
+    private AssetEntry createAssetEntry(Asset it) {
+        return new AssetEntry(it, DataAddress.Builder.newInstance().type("type").build());
+    }
+
+    private Asset.Builder createAsset(String id) {
+        return Asset.Builder.newInstance().id(id).name("test asset " + id);
+    }
+
+    @NotNull
+    private static PolicyDefinition.Builder createPolicyDefinition(String id) {
+        return PolicyDefinition.Builder.newInstance().id(id).policy(Policy.Builder.newInstance().build());
+    }
+}

--- a/core/control-plane/catalog-core/src/test/java/org/eclipse/edc/connector/catalog/DatasetResolverImplTest.java
+++ b/core/control-plane/catalog-core/src/test/java/org/eclipse/edc/connector/catalog/DatasetResolverImplTest.java
@@ -153,7 +153,7 @@ class DatasetResolverImplTest {
 
         verify(assetIndex).queryAssets(and(
                 isA(QuerySpec.class),
-                argThat(q -> q.getFilterExpression().containsAll(List.of(definitionCriterion, additionalCriterion)))
+                argThat(q -> q.getFilterExpression().contains(additionalCriterion))
         ));
     }
 
@@ -191,10 +191,9 @@ class DatasetResolverImplTest {
     void query_shouldLimitDataset_whenMultipleDefinitionAndMultipleAssets_across() {
         var contractDefinitions = range(0, 2).mapToObj(it -> contractDefinitionBuilder(String.valueOf(it)).build()).collect(toList());
         var contractPolicy = Policy.Builder.newInstance().build();
-        var assets1 = range(0, 10).mapToObj(it -> createAsset(String.valueOf(it)).build()).collect(toList());
-        var assets2 = range(10, 20).mapToObj(it -> createAsset(String.valueOf(it)).build()).collect(toList());
+        var assets = range(0, 20).mapToObj(it -> createAsset(String.valueOf(it)).build()).collect(toList());
         when(contractDefinitionResolver.definitionsFor(any())).thenAnswer(it -> contractDefinitions.stream());
-        when(assetIndex.queryAssets(isA(QuerySpec.class))).thenAnswer(i -> assets1.stream()).thenAnswer(i -> assets2.stream());
+        when(assetIndex.queryAssets(isA(QuerySpec.class))).thenAnswer(i -> assets.stream());
         when(policyStore.findById(any())).thenReturn(PolicyDefinition.Builder.newInstance().policy(contractPolicy).build());
         var querySpec = QuerySpec.Builder.newInstance().range(new Range(6, 14)).build();
 

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/ReflectionBasedQueryResolver.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/ReflectionBasedQueryResolver.java
@@ -79,9 +79,9 @@ public class ReflectionBasedQueryResolver<T> implements QueryResolver<T> {
     }
 
     private Predicate<T> toPredicate(Criterion criterion) {
-        BaseCriterionToPredicateConverter<T> predicateConverter = new BaseCriterionToPredicateConverter<>() {
+        var predicateConverter = new BaseCriterionToPredicateConverter<T>() {
             @Override
-            protected <R> R property(String key, Object object) {
+            protected Object property(String key, Object object) {
                 return ReflectionUtil.getFieldValueSilent(key, object);
             }
         };

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/assetindex/InMemoryAssetIndex.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/assetindex/InMemoryAssetIndex.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.connector.defaults.storage.assetindex;
 
 import org.eclipse.edc.spi.asset.AssetIndex;
+import org.eclipse.edc.spi.asset.AssetPredicateConverter;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.query.SortOrder;
@@ -41,11 +42,10 @@ import static java.lang.String.format;
 public class InMemoryAssetIndex implements AssetIndex {
     private final Map<String, Asset> cache = new ConcurrentHashMap<>();
     private final Map<String, DataAddress> dataAddresses = new ConcurrentHashMap<>();
-    private final AssetPredicateConverter predicateFactory;
+    private final AssetPredicateConverter predicateConverter = new AssetPredicateConverter();
     private final ReentrantReadWriteLock lock;
 
     public InMemoryAssetIndex() {
-        predicateFactory = new AssetPredicateConverter();
         // fair locks guarantee strong consistency since all waiting threads are processed in order of waiting time
         lock = new ReentrantReadWriteLock(true);
     }
@@ -168,7 +168,7 @@ public class InMemoryAssetIndex implements AssetIndex {
 
     private Stream<Asset> filterBy(List<Criterion> criteria) {
         var predicate = criteria.stream()
-                .map(predicateFactory::convert)
+                .map(predicateConverter::convert)
                 .reduce(x -> true, Predicate::and);
 
         return cache.values().stream()

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/asset/AssetPredicateConverter.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/asset/AssetPredicateConverter.java
@@ -12,9 +12,8 @@
  *
  */
 
-package org.eclipse.edc.connector.defaults.storage.assetindex;
+package org.eclipse.edc.spi.asset;
 
-import org.eclipse.edc.spi.asset.AssetIndex;
 import org.eclipse.edc.spi.query.BaseCriterionToPredicateConverter;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
@@ -27,15 +26,16 @@ import org.eclipse.edc.spi.types.domain.asset.Asset;
  * <p>
  * _Note: other {@link AssetIndex} implementations might have different converters!
  */
-class AssetPredicateConverter extends BaseCriterionToPredicateConverter<Asset> {
+public class AssetPredicateConverter extends BaseCriterionToPredicateConverter<Asset> {
+
     @Override
-    public <T> T property(String key, Object object) {
+    public Object property(String key, Object object) {
         if (object instanceof Asset) {
             var asset = (Asset) object;
             if (asset.getProperties() == null || asset.getProperties().isEmpty()) {
                 return null;
             }
-            return (T) asset.getProperty(key);
+            return asset.getProperty(key);
         }
         throw new IllegalArgumentException("Can only handle objects of type " + Asset.class.getSimpleName() + " but received an " + object.getClass().getSimpleName());
     }

--- a/spi/common/core-spi/src/test/java/org/eclipse/edc/spi/asset/AssetPredicateConverterTest.java
+++ b/spi/common/core-spi/src/test/java/org/eclipse/edc/spi/asset/AssetPredicateConverterTest.java
@@ -12,11 +12,10 @@
  *
  */
 
-package org.eclipse.edc.connector.defaults.storage.assetindex;
+package org.eclipse.edc.spi.asset;
 
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -26,12 +25,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class AssetPredicateConverterTest {
 
-    private AssetPredicateConverter converter;
-
-    @BeforeEach
-    void setUp() {
-        converter = new AssetPredicateConverter();
-    }
+    private final AssetPredicateConverter converter = new AssetPredicateConverter();
 
     @Test
     void convert_nameEquals() {
@@ -39,6 +33,7 @@ class AssetPredicateConverterTest {
         var asset = Asset.Builder.newInstance()
                 .name("test-asset")
                 .build();
+
         var predicate = converter.convert(criterion);
 
         assertThat(predicate).isNotNull();
@@ -52,6 +47,7 @@ class AssetPredicateConverterTest {
                 .name("test-asset")
                 .version("6.9")
                 .build();
+
         var predicate = converter.convert(criterion);
 
         assertThat(predicate).isNotNull();
@@ -66,6 +62,7 @@ class AssetPredicateConverterTest {
                 .version("6.9")
                 .property("test-property", "somevalue")
                 .build();
+
         var predicate = converter.convert(criterion);
 
         assertThat(predicate).isNotNull();
@@ -80,17 +77,30 @@ class AssetPredicateConverterTest {
                 .property("test-property", "somevalue")
                 .build();
         var criterion = new Criterion(Asset.PROPERTY_NAME, "in", List.of("bob", "alice"));
-        var pred = converter.convert(criterion);
-        assertThat(pred).isNotNull().accepts(asset);
 
+        var predicate = converter.convert(criterion);
+
+        assertThat(predicate).isNotNull().accepts(asset);
+    }
+
+    @Test
+    void convert_operatorIn_numbers() {
+        var criterion = new Criterion("number", "in", List.of(3));
+        var asset = Asset.Builder.newInstance()
+                .property("number", 3)
+                .build();
+
+        var predicate = converter.convert(criterion);
+
+        assertThat(predicate).isNotNull();
+        assertThat(predicate.test(asset)).isTrue();
     }
 
     @Test
     void convert_invalidOperator() {
         var criterion = new Criterion("name", "GREATER_THAN", "(bob, alice)");
+
         assertThatThrownBy(() -> converter.convert(criterion)).isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Operator [GREATER_THAN] is not supported by this converter!");
-
     }
-
 }

--- a/spi/common/core-spi/src/test/java/org/eclipse/edc/spi/query/BaseCriterionToPredicateConverterTest.java
+++ b/spi/common/core-spi/src/test/java/org/eclipse/edc/spi/query/BaseCriterionToPredicateConverterTest.java
@@ -41,7 +41,6 @@ class BaseCriterionToPredicateConverterTest {
         assertThatThrownBy(() -> predicate.test(new TestObject("first")))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Operator IN requires the right-hand operand to be an");
-
     }
 
     @Test
@@ -56,7 +55,7 @@ class BaseCriterionToPredicateConverterTest {
     private static class TestCriterionToPredicateConverter extends BaseCriterionToPredicateConverter<TestObject> {
 
         @Override
-        protected <R> R property(String key, Object object) {
+        protected Object property(String key, Object object) {
             return ReflectionUtil.getFieldValueSilent(key, object);
         }
     }


### PR DESCRIPTION
## What this PR changes/adds

Refactor `DatasetResolverImpl` to achieve better performances.

## Why it does that

This is one of the most crucial components, because building a `Catalog` could become an heavy operation, as it is done on demand and it involves different stores.
I added two simple performance tests, one of them was failing with the old implementation.
With the new implementation the `Dataset` is built starting from the `Asset`s, and the advantage is that the pagination is applied before the `Stream` collection, this way there won't be any overkill operation.
Note that the `ContractDefinition`s are loaded in memory, this is because the `definitionsFor` method is expensive, because for every `ContractDefinition` the `accessPolicy` must be verified. Having all the definitions in memory shouldn't be an issue tho, as they are really lightweight objects.

## Further notes

- moved the `AssetPredicateConverter` to the `spi` module, as it is needed in the `DatasetResolver` to evaluate the Asset Selector Expression
- I left the performance tests to be run with the unit tests because they don't take more than 10-15 seconds, nevertheless they could be separated to a different suite using tags, but it seemed too much for the moment.
- did little modifications to `BaseCriterionToPredicateConverter` to avoid compiler warnings, the behavior is the same 

## Linked Issue(s)

Closes #2726 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
