### PR TITLE
feat(ContractValidation): adds ContractAgreement in policy context formation when validating the contract

### DIFF
--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImpl.java
@@ -34,6 +34,7 @@ import org.jetbrains.annotations.NotNull;
 import java.net.URI;
 import java.time.Clock;
 import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
 
 import static java.lang.String.format;
 
@@ -146,7 +147,11 @@ public class ContractValidationServiceImpl implements ContractValidationService 
             return Result.failure("Invalid provider credentials");
         }
 
-        var policyResult = policyEngine.evaluate(NEGOTIATION_SCOPE, agreement.getPolicy(), agent);
+        // Create additional context information for policy engine to make agreement available in context
+        var contextInformation = new HashMap<Class, Object>();
+        contextInformation.put(ContractAgreement.class, agreement);
+
+        var policyResult = policyEngine.evaluate(NEGOTIATION_SCOPE, agreement.getPolicy(), agent, contextInformation);
         if (!policyResult.succeeded()) {
             return Result.failure(format("Policy does not fulfill the agreement %s, policy evaluation %s", agreement.getId(), policyResult.getFailureDetail()));
         }

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImplTest.java
@@ -85,14 +85,6 @@ class ContractValidationServiceImplTest {
     private final PolicyEquality policyEquality = mock(PolicyEquality.class);
     private ContractValidationServiceImpl validationService;
 
-    private static ContractAgreement.Builder createContractAgreement() {
-        return ContractAgreement.Builder.newInstance().id("1")
-                .providerAgentId(PROVIDER_ID)
-                .consumerAgentId(CONSUMER_ID)
-                .policy(Policy.Builder.newInstance().build())
-                .assetId(UUID.randomUUID().toString());
-    }
-
     @BeforeEach
     void setUp() {
         validationService = new ContractValidationServiceImpl(agentService, definitionService, assetIndex, policyStore, policyEngine, policyEquality, clock);
@@ -469,5 +461,13 @@ class ContractValidationServiceImplTest {
                 .selectorExpression(AssetSelectorExpression.SELECT_ALL)
                 .validity(TimeUnit.MINUTES.toSeconds(10))
                 .build();
+    }
+
+    private ContractAgreement.Builder createContractAgreement() {
+        return ContractAgreement.Builder.newInstance().id("1")
+                .providerAgentId(PROVIDER_ID)
+                .consumerAgentId(CONSUMER_ID)
+                .policy(Policy.Builder.newInstance().build())
+                .assetId(UUID.randomUUID().toString());
     }
 }


### PR DESCRIPTION

## What this PR changes/adds

Adds the `ContractAgreement` in context when evaluating the policy 

## Why it does that

To access information about `ContractAgreement` in custom `AtomicConstraintFunction`

## Linked Issue(s)

Closes #2754 

## Checklist

- [x] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
