### PR TITLE
fix(dsp catalog dispatcher): compact catalog request

### DIFF
--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/build.gradle.kts
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
 
 dependencies {
     api(project(":data-protocols:dsp:dsp-catalog:dsp-catalog-spi"))
+    api(project(":data-protocols:dsp:dsp-catalog:dsp-catalog-transform"))
     api(project(":data-protocols:dsp:dsp-http-core"))
     api(project(":data-protocols:dsp:dsp-http-spi"))
     api(project(":extensions:common:json-ld"))

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/src/main/java/org/eclipse/edc/protocol/dsp/catalog/dispatcher/delegate/CatalogRequestHttpDelegate.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/src/main/java/org/eclipse/edc/protocol/dsp/catalog/dispatcher/delegate/CatalogRequestHttpDelegate.java
@@ -31,6 +31,8 @@ import org.eclipse.edc.spi.EdcException;
 import java.io.IOException;
 import java.util.function.Function;
 
+import static java.lang.String.format;
+import static java.lang.String.join;
 import static org.eclipse.edc.jsonld.util.JsonLdUtil.compact;
 import static org.eclipse.edc.jsonld.util.JsonLdUtil.expand;
 import static org.eclipse.edc.protocol.dsp.catalog.spi.CatalogApiPaths.BASE_PATH;
@@ -94,7 +96,7 @@ public class CatalogRequestHttpDelegate implements DspHttpDispatcherDelegate<Cat
                 if (result.succeeded()) {
                     return result.getContent();
                 } else {
-                    throw new EdcException("Failed to read response body.");
+                    throw new EdcException(format("Failed to read response body: %s", join(", ", result.getFailureMessages())));
                 }
             } catch (NullPointerException e) {
                 throw new EdcException("Failed to read response body, as body was null.");
@@ -113,7 +115,7 @@ public class CatalogRequestHttpDelegate implements DspHttpDispatcherDelegate<Cat
                 var compacted = compact(transformResult.getContent(), jsonLdContext());
                 return mapper.writeValueAsString(compacted);
             }
-            throw new EdcException("Failed to write request.");
+            throw new EdcException(format("Failed to write request: %s", join(", ", transformResult.getFailureMessages())));
         } catch (JsonProcessingException e) {
             throw new EdcException("Failed to serialize catalog request", e);
         }


### PR DESCRIPTION
## What this PR changes/adds

In the `CatalogRequestHttpDelegate`, compacts the catalog request JSON-LD structure when building a request. This includes setting the JSON-LD context.

## Why it does that

When the catalog request is received, it is expected in the compacted form and compaction was previously missing.

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
