### PR TITLE
fix: avoid logging sensitive information

### DIFF
--- a/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSource.java
+++ b/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSource.java
@@ -44,7 +44,7 @@ public class HttpDataSource implements DataSource {
 
     private HttpPart getPart() {
         var request = requestFactory.toRequest(params);
-        monitor.debug(() -> "HttpDataSource sends request: " + request.toString());
+        monitor.debug(() -> "Executing HTTP request: " + request.url());
         try {
             // NB: Do not close the response as the body input stream needs to be read after this method returns. The response closes the body stream.
             var response = httpClient.execute(request);


### PR DESCRIPTION
## What this PR changes/adds

Avoids logging the proxied HTTP request, which can expose sensitive information.

## Linked Issue(s)

Closes #2773

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
