### PR TITLE
feat: dataspace-protocol add missing fields to TransferTerminationMessage

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImplTest.java
@@ -245,6 +245,8 @@ class TransferProcessProtocolServiceImplTest {
                 .protocol("protocol")
                 .callbackAddress("http://any")
                 .processId("dataRequestId")
+                .code("TestCode")
+                .reason("TestReason")
                 .build();
 
         var result = service.notifyTerminated(message, claimToken());
@@ -264,6 +266,8 @@ class TransferProcessProtocolServiceImplTest {
                 .protocol("protocol")
                 .callbackAddress("http://any")
                 .processId("dataRequestId")
+                .code("TestCode")
+                .reason("TestReason")
                 .build();
 
         var result = service.notifyTerminated(message, claimToken());
@@ -299,7 +303,8 @@ class TransferProcessProtocolServiceImplTest {
                     Arguments.of(completed, TransferCompletionMessage.Builder.newInstance().protocol("protocol")
                                     .callbackAddress("http://any").processId("dataRequestId").build()),
                     Arguments.of(terminated, TransferTerminationMessage.Builder.newInstance().protocol("protocol")
-                                    .callbackAddress("http://any").processId("dataRequestId").build())
+                                    .callbackAddress("http://any").processId("dataRequestId").code("TestCode")
+                                    .reason("TestReason").build())
             );
         }
     }

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/IdsMultipartRemoteMessageDispatcherTest.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/IdsMultipartRemoteMessageDispatcherTest.java
@@ -63,6 +63,8 @@ class IdsMultipartRemoteMessageDispatcherTest {
         var message = TransferTerminationMessage.Builder.newInstance()
                 .protocol("ids-multipart")
                 .processId("processId")
+                .code("TestCode")
+                .reason("TestReason")
                 .build();
 
         var future = dispatcher.send(Object.class, message);

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferTerminationMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferTerminationMessage.java
@@ -30,6 +30,10 @@ public class TransferTerminationMessage implements TransferRemoteMessage {
     private String protocol;
     private String processId;
 
+    private String code;
+
+    private String reason; //TODO change to List  https://github.com/eclipse-edc/Connector/issues/2729
+
     @Override
     public String getProtocol() {
         return protocol;
@@ -43,6 +47,14 @@ public class TransferTerminationMessage implements TransferRemoteMessage {
     @Override
     public String getProcessId() {
         return processId;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getReason() {
+        return reason;
     }
 
     @JsonPOJOBuilder(withPrefix = "")
@@ -70,6 +82,16 @@ public class TransferTerminationMessage implements TransferRemoteMessage {
 
         public Builder processId(String processId) {
             message.processId = processId;
+            return this;
+        }
+
+        public Builder code(String code) {
+            message.code = code;
+            return this;
+        }
+
+        public Builder reason(String reason) {
+            message.reason = reason;
             return this;
         }
 


### PR DESCRIPTION
## What this PR changes/adds

Adds the attribute fields `code` and `reason` to `TransferTerminationMessage` like the [spec](https://docs.internationaldataspaces.org/dataspace-protocol/transfer-process/transfer.process.protocol#5.-transferterminationmessage) describes. Also adds the new fields to exisiting Tests.

## Why it does that

To align the TransferTerminationMessage with the dataspace-protocol

## Further notes

The issue #2764 also defines to add the `code` attribute to the ContractNegotiationTerminationMessage. This is done in
the PR #2771.
  
## Linked Issue(s)

Relates #2764 

## Checklist

- [ ] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
