### PR TITLE
feat(TransferStartMessage): adds DataAddress field

### DIFF
--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/flow/DataFlowManagerImpl.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/flow/DataFlowManagerImpl.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.connector.transfer.flow;
 import io.opentelemetry.extension.annotations.WithSpan;
 import org.eclipse.edc.connector.transfer.spi.flow.DataFlowController;
 import org.eclipse.edc.connector.transfer.spi.flow.DataFlowManager;
+import org.eclipse.edc.connector.transfer.spi.types.DataFlowResponse;
 import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.response.StatusResult;
@@ -42,7 +43,7 @@ public class DataFlowManagerImpl implements DataFlowManager {
 
     @WithSpan
     @Override
-    public @NotNull StatusResult<Void> initiate(DataRequest dataRequest, DataAddress contentAddress, Policy policy) {
+    public @NotNull StatusResult<DataFlowResponse> initiate(DataRequest dataRequest, DataAddress contentAddress, Policy policy) {
         try {
             return controllers.stream()
                     .filter(controller -> controller.canHandle(dataRequest, contentAddress))

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/flow/DataFlowManagerImplTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/flow/DataFlowManagerImplTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.connector.transfer.flow;
 
 import org.eclipse.edc.connector.transfer.spi.flow.DataFlowController;
+import org.eclipse.edc.connector.transfer.spi.types.DataFlowResponse;
 import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.EdcException;
@@ -40,7 +41,7 @@ class DataFlowManagerImplTest {
         var dataAddress = DataAddress.Builder.newInstance().type("test-type").build();
 
         when(controller.canHandle(any(), any())).thenReturn(true);
-        when(controller.initiateFlow(any(), any(), any())).thenReturn(StatusResult.success());
+        when(controller.initiateFlow(any(), any(), any())).thenReturn(StatusResult.success(DataFlowResponse.Builder.newInstance().build()));
         manager.register(controller);
 
         var response = manager.initiate(dataRequest, dataAddress, policy);

--- a/extensions/control-plane/transfer/transfer-data-plane/src/main/java/org/eclipse/edc/connector/transfer/dataplane/flow/ConsumerPullTransferDataFlowController.java
+++ b/extensions/control-plane/transfer/transfer-data-plane/src/main/java/org/eclipse/edc/connector/transfer/dataplane/flow/ConsumerPullTransferDataFlowController.java
@@ -18,12 +18,14 @@ import org.eclipse.edc.connector.transfer.dataplane.proxy.ConsumerPullTransferPr
 import org.eclipse.edc.connector.transfer.dataplane.spi.proxy.ConsumerPullTransferEndpointDataReferenceCreationRequest;
 import org.eclipse.edc.connector.transfer.dataplane.spi.proxy.ConsumerPullTransferEndpointDataReferenceService;
 import org.eclipse.edc.connector.transfer.spi.flow.DataFlowController;
+import org.eclipse.edc.connector.transfer.spi.types.DataFlowResponse;
 import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.response.ResponseStatus;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.edr.EndpointDataAddressConstants;
 import org.eclipse.edc.spi.types.domain.edr.EndpointDataReference;
 import org.eclipse.edc.spi.types.domain.edr.EndpointDataReferenceMessage;
 import org.jetbrains.annotations.NotNull;
@@ -52,7 +54,7 @@ public class ConsumerPullTransferDataFlowController implements DataFlowControlle
     }
 
     @Override
-    public @NotNull StatusResult<Void> initiateFlow(DataRequest dataRequest, DataAddress contentAddress, Policy policy) {
+    public @NotNull StatusResult<DataFlowResponse> initiateFlow(DataRequest dataRequest, DataAddress contentAddress, Policy policy) {
         var proxyUrl = proxyResolver.resolveProxyUrl(contentAddress);
         if (proxyUrl.failed()) {
             return StatusResult.failure(ResponseStatus.FATAL_ERROR, format("Failed to resolve proxy url for data request %s%n %s", dataRequest.getId(), proxyUrl.getFailureDetail()));
@@ -72,7 +74,7 @@ public class ConsumerPullTransferDataFlowController implements DataFlowControlle
         return dispatch(proxyCreationResult.getContent(), dataRequest);
     }
 
-    private StatusResult<Void> dispatch(@NotNull EndpointDataReference edr, @NotNull DataRequest dataRequest) {
+    private StatusResult<DataFlowResponse> dispatch(@NotNull EndpointDataReference edr, @NotNull DataRequest dataRequest) {
         var request = EndpointDataReferenceMessage.Builder.newInstance()
                 .connectorId(connectorId)
                 .callbackAddress(dataRequest.getConnectorAddress())
@@ -80,9 +82,15 @@ public class ConsumerPullTransferDataFlowController implements DataFlowControlle
                 .endpointDataReference(edr)
                 .build();
 
+
+        // TODO this should be removed once the new dsp lands
         return dispatcherRegistry.send(Object.class, request)
-                .thenApply(o -> StatusResult.success())
+                .thenApply(o -> StatusResult.success(createResponse(edr)))
                 .exceptionally(throwable -> StatusResult.failure(ResponseStatus.ERROR_RETRY, "Transfer failed: " + throwable.getMessage()))
                 .join();
+    }
+
+    private DataFlowResponse createResponse(EndpointDataReference edr) {
+        return DataFlowResponse.Builder.newInstance().dataAddress(EndpointDataAddressConstants.from(edr)).build();
     }
 }

--- a/extensions/control-plane/transfer/transfer-data-plane/src/main/java/org/eclipse/edc/connector/transfer/dataplane/flow/ProviderPushTransferDataFlowController.java
+++ b/extensions/control-plane/transfer/transfer-data-plane/src/main/java/org/eclipse/edc/connector/transfer/dataplane/flow/ProviderPushTransferDataFlowController.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.connector.transfer.dataplane.flow;
 import org.eclipse.edc.connector.dataplane.spi.client.DataPlaneClient;
 import org.eclipse.edc.connector.transfer.spi.callback.ControlPlaneApiUrl;
 import org.eclipse.edc.connector.transfer.spi.flow.DataFlowController;
+import org.eclipse.edc.connector.transfer.spi.types.DataFlowResponse;
 import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.response.ResponseStatus;
@@ -45,13 +46,13 @@ public class ProviderPushTransferDataFlowController implements DataFlowControlle
     }
 
     @Override
-    public @NotNull StatusResult<Void> initiateFlow(DataRequest dataRequest, DataAddress contentAddress, Policy policy) {
+    public @NotNull StatusResult<DataFlowResponse> initiateFlow(DataRequest dataRequest, DataAddress contentAddress, Policy policy) {
         var dataFlowRequest = createRequest(dataRequest, contentAddress);
         var result = dataPlaneClient.transfer(dataFlowRequest);
         if (result.failed()) {
             return StatusResult.failure(ResponseStatus.FATAL_ERROR, "Failed to delegate data transfer to Data Plane: " + result.getFailureDetail());
         }
-        return StatusResult.success();
+        return StatusResult.success(DataFlowResponse.Builder.newInstance().build());
     }
 
     private DataFlowRequest createRequest(DataRequest dataRequest, DataAddress sourceAddress) {

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/edr/EndpointDataAddressConstants.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/edr/EndpointDataAddressConstants.java
@@ -1,0 +1,71 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.spi.types.domain.edr;
+
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+
+/**
+ *  Constants for {@link EndpointDataReference} mapping to {@link DataAddress}
+ */
+public class EndpointDataAddressConstants {
+
+    public static final String TYPE = "EDR";
+    public static final String ID = "id";
+    public static final String AUTH_CODE = "authCode";
+    public static final String AUTH_KEY = "authKey";
+    public static final String ENDPOINT = "endpoint";
+    private static final String TYPE_FIELD = "type";
+
+    private static final Set<String> PROPERTIES = Set.of(ID, TYPE_FIELD, AUTH_CODE, ENDPOINT, AUTH_KEY);
+
+    public static DataAddress from(EndpointDataReference edr) {
+        return DataAddress.Builder.newInstance()
+                .type(TYPE)
+                .property(ID, edr.getId())
+                .property(AUTH_CODE, edr.getAuthCode())
+                .property(AUTH_KEY, edr.getAuthKey())
+                .property(ENDPOINT, edr.getEndpoint())
+                .properties(edr.getProperties())
+                .build();
+    }
+
+    public static Result<EndpointDataReference> to(DataAddress address) {
+        
+        if (!address.getType().equals(TYPE)) {
+            return Result.failure(format("Failed to convert data address with type %s to an EDR", address.getType()));
+        }
+
+        var properties = address.getProperties().entrySet().stream()
+                .filter(entry -> !PROPERTIES.contains(entry.getKey()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        var edr = EndpointDataReference.Builder.newInstance()
+                .id(address.getProperty(ID))
+                .authCode(address.getProperty(AUTH_CODE))
+                .authKey(address.getProperty(AUTH_KEY))
+                .endpoint(address.getProperty(ENDPOINT))
+                .properties(properties)
+                .build();
+
+        return Result.success(edr);
+    }
+}

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/edr/EndpointDataAddressConstants.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/edr/EndpointDataAddressConstants.java
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
 import static java.lang.String.format;
 
 /**
- *  Constants for {@link EndpointDataReference} mapping to {@link DataAddress}
+ * Constants for {@link EndpointDataReference} mapping to {@link DataAddress}
  */
 public class EndpointDataAddressConstants {
 
@@ -33,9 +33,12 @@ public class EndpointDataAddressConstants {
     public static final String AUTH_CODE = "authCode";
     public static final String AUTH_KEY = "authKey";
     public static final String ENDPOINT = "endpoint";
-    private static final String TYPE_FIELD = "type";
+    public static final String TYPE_FIELD = "type";
 
     private static final Set<String> PROPERTIES = Set.of(ID, TYPE_FIELD, AUTH_CODE, ENDPOINT, AUTH_KEY);
+
+    private EndpointDataAddressConstants() {
+    }
 
     public static DataAddress from(EndpointDataReference edr) {
         return DataAddress.Builder.newInstance()
@@ -49,7 +52,7 @@ public class EndpointDataAddressConstants {
     }
 
     public static Result<EndpointDataReference> to(DataAddress address) {
-        
+
         if (!address.getType().equals(TYPE)) {
             return Result.failure(format("Failed to convert data address with type %s to an EDR", address.getType()));
         }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/edr/EndpointDataReference.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/edr/EndpointDataReference.java
@@ -32,7 +32,7 @@ import java.util.UUID;
 @JsonDeserialize(builder = EndpointDataReference.Builder.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class EndpointDataReference {
-
+    
     private final String id;
     private final String endpoint;
     private final String authKey;

--- a/spi/common/core-spi/src/test/java/org/eclipse/edc/spi/types/domain/edr/EndpointDataAddressConstantsTest.java
+++ b/spi/common/core-spi/src/test/java/org/eclipse/edc/spi/types/domain/edr/EndpointDataAddressConstantsTest.java
@@ -1,0 +1,78 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.spi.types.domain.edr;
+
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EndpointDataAddressConstantsTest {
+    
+    @Test
+    void from_shouldConvertEdrToDataAddress() {
+
+        var inputEdr = getEndpointDataReference();
+        var dataAddress = EndpointDataAddressConstants.from(inputEdr);
+
+
+        assertThat(dataAddress.getProperties()).containsAllEntriesOf(inputEdr.getProperties());
+        assertThat(dataAddress.getType()).isEqualTo(EndpointDataAddressConstants.TYPE);
+        assertThat(dataAddress.getProperty(EndpointDataAddressConstants.ID)).isEqualTo(inputEdr.getId());
+        assertThat(dataAddress.getProperty(EndpointDataAddressConstants.AUTH_KEY)).isEqualTo(inputEdr.getAuthKey());
+        assertThat(dataAddress.getProperty(EndpointDataAddressConstants.AUTH_CODE)).isEqualTo(inputEdr.getAuthCode());
+        assertThat(dataAddress.getProperty(EndpointDataAddressConstants.ENDPOINT)).isEqualTo(inputEdr.getEndpoint());
+
+    }
+
+    @Test
+    void to_shouldConvertDataAddressToEdr() {
+
+        var inputEdr = getEndpointDataReference();
+        var dataAddress = EndpointDataAddressConstants.from(inputEdr);
+
+        var outputEdrResult = EndpointDataAddressConstants.to(dataAddress);
+
+        assertThat(outputEdrResult)
+                .extracting(Result::getContent)
+                .usingRecursiveComparison()
+                .isEqualTo(inputEdr);
+    }
+
+    @Test
+    void to_shouldFailToConvertDataAddressToEdr() {
+
+        var dataAddress = DataAddress.Builder.newInstance().type("wrong").build();
+
+        var outputEdrResult = EndpointDataAddressConstants.to(dataAddress);
+
+        assertThat(outputEdrResult.failed()).isTrue();
+    }
+
+    private EndpointDataReference getEndpointDataReference() {
+        return EndpointDataReference.Builder.newInstance()
+                .endpoint("some.test.endpoint")
+                .authKey("test-authkey")
+                .authCode(UUID.randomUUID().toString())
+                .id(UUID.randomUUID().toString())
+                .properties(Map.of("key1", "value1"))
+                .build();
+    }
+
+}

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/flow/DataFlowController.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/flow/DataFlowController.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.connector.transfer.spi.flow;
 
+import org.eclipse.edc.connector.transfer.spi.types.DataFlowResponse;
 import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.response.ResponseStatus;
@@ -45,6 +46,6 @@ public interface DataFlowController {
      * @param policy         the contract agreement usage policy for the asset being transferred
      */
     @NotNull
-    StatusResult<Void> initiateFlow(DataRequest dataRequest, DataAddress contentAddress, Policy policy);
+    StatusResult<DataFlowResponse> initiateFlow(DataRequest dataRequest, DataAddress contentAddress, Policy policy);
 
 }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/flow/DataFlowManager.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/flow/DataFlowManager.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.connector.transfer.spi.flow;
 
+import org.eclipse.edc.connector.transfer.spi.types.DataFlowResponse;
 import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
@@ -40,5 +41,5 @@ public interface DataFlowManager {
      * @param policy         the contract agreement usage policy for the asset being transferred
      */
     @NotNull
-    StatusResult<Void> initiate(DataRequest dataRequest, DataAddress contentAddress, Policy policy);
+    StatusResult<DataFlowResponse> initiate(DataRequest dataRequest, DataAddress contentAddress, Policy policy);
 }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/DataFlowResponse.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/DataFlowResponse.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.transfer.spi.types;
+
+import org.eclipse.edc.connector.transfer.spi.flow.DataFlowManager;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+
+/**
+ * A Response for {@link DataFlowManager#initiate} operation
+ */
+public class DataFlowResponse {
+
+    private DataAddress dataAddress;
+
+    private DataFlowResponse() {
+    }
+
+    public DataAddress getDataAddress() {
+        return dataAddress;
+    }
+
+    public static class Builder {
+
+        DataFlowResponse response;
+
+        private Builder() {
+            response = new DataFlowResponse();
+        }
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder dataAddress(DataAddress dataAddress) {
+            response.dataAddress = dataAddress;
+            return this;
+        }
+
+        public DataFlowResponse build() {
+            return response;
+        }
+    }
+}

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferStartMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferStartMessage.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.transfer.spi.types.protocol;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.spi.types.domain.DataAddress;
 
 import java.util.Objects;
 
@@ -27,6 +28,8 @@ public class TransferStartMessage implements TransferRemoteMessage {
     private String callbackAddress;
     private String protocol;
     private String processId;
+
+    private DataAddress dataAddress;
 
     @Override
     public String getProtocol() {
@@ -41,6 +44,10 @@ public class TransferStartMessage implements TransferRemoteMessage {
     @Override
     public String getProcessId() {
         return processId;
+    }
+
+    public DataAddress getDataAddress() {
+        return dataAddress;
     }
 
     @JsonPOJOBuilder(withPrefix = "")
@@ -68,6 +75,11 @@ public class TransferStartMessage implements TransferRemoteMessage {
 
         public Builder processId(String processId) {
             message.processId = processId;
+            return this;
+        }
+
+        public Builder dataAddress(DataAddress dataAddress) {
+            message.dataAddress = dataAddress;
             return this;
         }
 


### PR DESCRIPTION
## What this PR changes/adds

Adds the DataAddress field in TransferStartMessage

## Why it does that

This is a preliminary work for supporting the EDR via the new protocol

## Further notes

The `DataFlowManager` and `DataFlowController` interface has been changed, now they returns a `DataFlowResponse` which optionally may contain a `DataAddress`.

The `ConsumerPullTransferDataFlowController` now returns the `EDR` encoded in the `DataAddress`, which will be then 
set in the `TransferStartMessage` on the provider side.

Still not sure yet how is the best way to encode an EDR into a `DataAddress`. 
Should we namespace the known properties?

## Linked Issue(s)

Closes #2727 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
