### PR TITLE
refactor(datamanagement-api): remove deprecated GET endpoints

### DIFF
--- a/extensions/common/api/api-core/src/main/java/org/eclipse/edc/api/query/QuerySpecDto.java
+++ b/extensions/common/api/api-core/src/main/java/org/eclipse/edc/api/query/QuerySpecDto.java
@@ -15,10 +15,8 @@
 package org.eclipse.edc.api.query;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.ws.rs.QueryParam;
@@ -39,10 +37,6 @@ public class QuerySpecDto {
     @Positive(message = "limit must be greater than 0")
     private Integer limit = 50;
 
-    @QueryParam("filter")
-    @Deprecated
-    private String filter;
-
     private List<CriterionDto> filterExpression = new ArrayList<>();
 
     @QueryParam("sort")
@@ -59,27 +53,12 @@ public class QuerySpecDto {
         return limit;
     }
 
-    @Deprecated
-    public String getFilter() {
-        return filter;
-    }
-
     public SortOrder getSortOrder() {
         return sortOrder;
     }
 
     public String getSortField() {
         return sortField;
-    }
-
-    @JsonIgnore
-    @AssertTrue
-    public boolean isValid() {
-        if (filter != null && filter.isBlank()) {
-            return false;
-        }
-
-        return sortField == null || !sortField.isBlank();
     }
 
     public List<CriterionDto> getFilterExpression() {
@@ -116,12 +95,6 @@ public class QuerySpecDto {
 
         public Builder sortField(String sortField) {
             querySpec.sortField = sortField;
-            return this;
-        }
-
-        @Deprecated
-        public Builder filter(String filter) {
-            querySpec.filter = filter;
             return this;
         }
 

--- a/extensions/common/api/api-core/src/main/java/org/eclipse/edc/api/transformer/QuerySpecDtoToQuerySpecTransformer.java
+++ b/extensions/common/api/api-core/src/main/java/org/eclipse/edc/api/transformer/QuerySpecDtoToQuerySpecTransformer.java
@@ -47,9 +47,6 @@ public class QuerySpecDtoToQuerySpecTransformer implements DtoTransformer<QueryS
                 .sortField(query.getSortField())
                 .sortOrder(query.getSortOrder());
 
-        // use filter string
-        builder.filter(query.getFilter());
-
         // overwrite with filter expression, if present
         if (!query.getFilterExpression().isEmpty()) {
             var result = transformFilter(query.getFilterExpression(), context);

--- a/extensions/common/api/api-core/src/test/java/org/eclipse/edc/api/query/QuerySpecDtoValidationTest.java
+++ b/extensions/common/api/api-core/src/test/java/org/eclipse/edc/api/query/QuerySpecDtoValidationTest.java
@@ -61,15 +61,6 @@ class QuerySpecDtoValidationTest {
     }
 
     @Test
-    void filterShouldNotBeBlank() {
-        var querySpec = QuerySpecDto.Builder.newInstance().filter("  ").build();
-
-        var result = validator.validate(querySpec);
-
-        assertThat(result).isNotEmpty();
-    }
-
-    @Test
     void sortFieldShouldNotBeBlank() {
         var querySpec = QuerySpecDto.Builder.newInstance().sortField("  ").build();
 

--- a/extensions/common/api/api-core/src/test/java/org/eclipse/edc/api/transformer/QuerySpecDtoToQuerySpecTransformerTest.java
+++ b/extensions/common/api/api-core/src/test/java/org/eclipse/edc/api/transformer/QuerySpecDtoToQuerySpecTransformerTest.java
@@ -46,7 +46,6 @@ class QuerySpecDtoToQuerySpecTransformerTest {
         var querySpecDto = QuerySpecDto.Builder.newInstance()
                 .offset(10)
                 .limit(20)
-                .filter("field=value")
                 .sortOrder(SortOrder.DESC)
                 .sortField("field")
                 .build();
@@ -55,8 +54,6 @@ class QuerySpecDtoToQuerySpecTransformerTest {
 
         assertThat(spec.getOffset()).isEqualTo(10);
         assertThat(spec.getLimit()).isEqualTo(20);
-        assertThat(spec.getFilterExpression()).hasSize(1)
-                .containsExactly(new Criterion("field", "=", "value"));
         assertThat(spec.getSortOrder()).isEqualTo(SortOrder.DESC);
         assertThat(spec.getSortField()).isEqualTo("field");
     }
@@ -83,7 +80,6 @@ class QuerySpecDtoToQuerySpecTransformerTest {
 
         var querySpecDto = QuerySpecDto.Builder.newInstance()
                 .filterExpression(List.of(CriterionDto.from("foo", "=", "bar")))
-                .filter("bar < baz")
                 .build();
 
         var spec = transformer.transform(querySpecDto, context);
@@ -100,7 +96,6 @@ class QuerySpecDtoToQuerySpecTransformerTest {
                 .thenReturn(expected);
 
         var querySpecDto = QuerySpecDto.Builder.newInstance()
-                .filter("bar < baz")
                 .build();
 
         var spec = transformer.transform(querySpecDto, context);

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApi.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApi.java
@@ -47,15 +47,6 @@ public interface AssetApi {
     )
     IdResponseDto createAsset(@Valid AssetEntryDto assetEntryDto);
 
-    @Operation(description = "Gets all assets according to a particular query",
-            responses = {
-                    @ApiResponse(responseCode = "200",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = AssetResponseDto.class)))),
-                    @ApiResponse(responseCode = "400", description = "Request body was malformed",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
-            }, deprecated = true)
-    @Deprecated
-    List<AssetResponseDto> getAllAssets(@Valid QuerySpecDto querySpecDto);
 
     @Operation(description = " all assets according to a particular query",
             responses = {

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApiController.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApiController.java
@@ -17,7 +17,6 @@
 package org.eclipse.edc.connector.api.management.asset;
 
 import jakarta.validation.Valid;
-import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
@@ -93,13 +92,6 @@ public class AssetApiController implements AssetApi {
                 .id(resultContent.getId())
                 .createdAt(resultContent.getCreatedAt())
                 .build();
-    }
-
-    @GET
-    @Override
-    @Deprecated
-    public List<AssetResponseDto> getAllAssets(@Valid @BeanParam QuerySpecDto querySpecDto) {
-        return queryAssets(querySpecDto);
     }
 
     @POST

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/AssetApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/AssetApiControllerIntegrationTest.java
@@ -85,43 +85,6 @@ public class AssetApiControllerIntegrationTest extends RestControllerTestBase {
     }
 
     @Test
-    void getAll_filtersOutFailedTransforms() {
-        when(service.query(any()))
-                .thenReturn(ServiceResult.success(Stream.of(Asset.Builder.newInstance().build())));
-        when(transformerRegistry.transform(isA(QuerySpecDto.class), eq(QuerySpec.class)))
-                .thenReturn(Result.success(QuerySpec.Builder.newInstance().offset(10).build()));
-        when(transformerRegistry.transform(isA(Asset.class), eq(AssetResponseDto.class)))
-                .thenReturn(Result.failure("failed to transform"));
-
-        baseRequest()
-                .get("/assets")
-                .then()
-                .statusCode(200)
-                .contentType(JSON)
-                .body("size()", is(0));
-    }
-
-    @Test
-    void getAll_invalidQuery() {
-        baseRequest()
-                .get("/assets?limit=0&offset=-1&filter=&sortField=")
-                .then()
-                .statusCode(400);
-    }
-
-    @Test
-    void getAll_shouldReturnBadRequest_whenServiceReturnsBadRequest() {
-        when(transformerRegistry.transform(isA(QuerySpecDto.class), eq(QuerySpec.class)))
-                .thenReturn(Result.success(QuerySpec.none()));
-        when(service.query(any())).thenReturn(ServiceResult.badRequest("error"));
-
-        baseRequest()
-                .get("/assets")
-                .then()
-                .statusCode(400);
-    }
-
-    @Test
     void queryAllAssets() {
         when(service.query(any()))
                 .thenReturn(ServiceResult.success(Stream.of(Asset.Builder.newInstance().build())));
@@ -170,29 +133,6 @@ public class AssetApiControllerIntegrationTest extends RestControllerTestBase {
                 .statusCode(400);
     }
 
-    @Test
-    void getAll_shouldReturnBadRequest_whenQueryTransformFails() {
-        when(transformerRegistry.transform(isA(QuerySpecDto.class), eq(QuerySpec.class)))
-                .thenReturn(Result.failure("error"));
-        when(service.query(any())).thenReturn(ServiceResult.success());
-
-        baseRequest()
-                .get("/assets")
-                .then()
-                .statusCode(400);
-    }
-
-    @Test
-    void queryAll_shouldReturnBadRequest_whenServiceReturnsBadRequest() {
-        when(transformerRegistry.transform(isA(QuerySpecDto.class), eq(QuerySpec.class)))
-                .thenReturn(Result.success(QuerySpec.Builder.newInstance().build()));
-        when(service.query(any())).thenReturn(ServiceResult.badRequest());
-
-        baseRequest()
-                .get("/assets")
-                .then()
-                .statusCode(400);
-    }
 
     @Test
     void getSingleAsset() {

--- a/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/api/management/catalog/CatalogApi.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/api/management/catalog/CatalogApi.java
@@ -24,7 +24,6 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.container.AsyncResponse;
 import jakarta.ws.rs.container.Suspended;
-import org.eclipse.edc.api.query.QuerySpecDto;
 import org.eclipse.edc.catalog.spi.Catalog;
 import org.eclipse.edc.connector.api.management.catalog.model.CatalogRequestDto;
 
@@ -33,12 +32,6 @@ import org.eclipse.edc.connector.api.management.catalog.model.CatalogRequestDto;
 public interface CatalogApi {
 
     String PROVIDER_URL_NOT_NULL_MESSAGE = "providerUrl must not be null";
-
-    @Operation(responses = {
-            @ApiResponse(content = @Content(mediaType = "application/json", schema = @Schema(implementation = Catalog.class)), description = "Gets contract offers (=catalog) of a single connector")
-    }, deprecated = true)
-    @Deprecated
-    void getCatalog(@NotNull(message = PROVIDER_URL_NOT_NULL_MESSAGE) String providerUrl, @Valid QuerySpecDto querySpec, AsyncResponse response);
 
     @Operation(responses = {
             @ApiResponse(content = @Content(mediaType = "application/json", schema = @Schema(implementation = Catalog.class)), description = "Gets contract offers (=catalog) of a single connector")

--- a/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/api/management/catalog/CatalogApiController.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/api/management/catalog/CatalogApiController.java
@@ -15,12 +15,9 @@
 package org.eclipse.edc.connector.api.management.catalog;
 
 import jakarta.validation.Valid;
-import jakarta.ws.rs.BeanParam;
-import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.container.AsyncResponse;
 import jakarta.ws.rs.container.Suspended;
 import jakarta.ws.rs.core.MediaType;
@@ -33,7 +30,6 @@ import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.web.spi.exception.BadGatewayException;
 import org.eclipse.edc.web.spi.exception.InvalidRequestException;
-import org.jetbrains.annotations.NotNull;
 
 import static java.util.Optional.ofNullable;
 
@@ -49,26 +45,6 @@ public class CatalogApiController implements CatalogApi {
         this.service = service;
         this.transformerRegistry = transformerRegistry;
         this.monitor = monitor;
-    }
-
-    @Override
-    @GET
-    @Deprecated
-    public void getCatalog(@jakarta.validation.constraints.NotNull(message = PROVIDER_URL_NOT_NULL_MESSAGE) @QueryParam("providerUrl") String providerUrl, @Valid @BeanParam QuerySpecDto querySpecDto, @Suspended AsyncResponse response) {
-
-        @NotNull QuerySpec spec;
-        if (querySpecDto != null) {
-            var result = transformerRegistry.transform(querySpecDto, QuerySpec.class);
-            if (result.failed()) {
-                throw new InvalidRequestException(result.getFailureMessages());
-            }
-            spec = result.getContent();
-        } else {
-            spec = QuerySpec.max();
-            monitor.debug("No paging parameters were supplied, using 0...Integer.MAX_VALUE");
-        }
-
-        performQuery(providerUrl, spec, response);
     }
 
     @Override

--- a/extensions/control-plane/api/management-api/catalog-api/src/test/java/org/eclipse/edc/connector/api/management/catalog/CatalogApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/test/java/org/eclipse/edc/connector/api/management/catalog/CatalogApiControllerIntegrationTest.java
@@ -93,39 +93,6 @@ class CatalogApiControllerIntegrationTest {
     }
 
     @Test
-    void getProviderCatalog() {
-        var contractOffer = createContractOffer();
-        var catalog = Catalog.Builder.newInstance().id("id").contractOffers(List.of(contractOffer)).build();
-        var emptyCatalog = Catalog.Builder.newInstance().id("id2").contractOffers(List.of()).build();
-        when(dispatcher.send(any(), any())).thenReturn(completedFuture(catalog))
-                .thenReturn(completedFuture(emptyCatalog));
-
-        baseRequest()
-                .queryParam("providerUrl", "some.provider.url")
-                .get("/catalog")
-                .then()
-                .statusCode(200)
-                .contentType(JSON)
-                .body("id", notNullValue())
-                .body("contractOffers.size()", is(1));
-    }
-
-    @Test
-    void getProviderCatalog_shouldFailWithoutProviderUrl() {
-        var contractOffer = createContractOffer();
-        var catalog = Catalog.Builder.newInstance().id("id").contractOffers(List.of(contractOffer)).build();
-        var emptyCatalog = Catalog.Builder.newInstance().id("id2").contractOffers(List.of()).build();
-        when(dispatcher.send(any(), any())).thenReturn(completedFuture(catalog))
-                .thenReturn(completedFuture(emptyCatalog));
-
-        baseRequest()
-                .get("/catalog")
-                .then()
-                .statusCode(400)
-                .body("message[0]", is("providerUrl must not be null"));
-    }
-
-    @Test
     void postCatalogRequest() {
         var contractOffer = createContractOffer();
         var catalog = Catalog.Builder.newInstance().id("id").contractOffers(List.of(contractOffer)).build();

--- a/extensions/control-plane/api/management-api/catalog-api/src/test/java/org/eclipse/edc/connector/api/management/catalog/CatalogApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/test/java/org/eclipse/edc/connector/api/management/catalog/CatalogApiControllerTest.java
@@ -22,7 +22,6 @@ import org.eclipse.edc.connector.api.management.catalog.model.CatalogRequestDto;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.spi.catalog.CatalogService;
 import org.eclipse.edc.policy.model.Policy;
-import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.query.SortOrder;
@@ -37,10 +36,8 @@ import java.util.List;
 import java.util.UUID;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static java.util.concurrent.CompletableFuture.failedFuture;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -55,32 +52,6 @@ class CatalogApiControllerTest {
     void setup() {
         transformerRegistry = mock(DtoTransformerRegistry.class);
         when(transformerRegistry.transform(any(), any())).thenReturn(Result.success(new QuerySpec()));
-    }
-
-    @Test
-    void shouldGetTheCatalog() {
-        var controller = new CatalogApiController(service, transformerRegistry, monitor);
-        var response = mock(AsyncResponse.class);
-        var offer = createContractOffer();
-        var catalog = Catalog.Builder.newInstance().id("any").contractOffers(List.of(offer)).build();
-        var url = "test.url";
-        when(service.getByProviderUrl(eq(url), any())).thenReturn(completedFuture(catalog));
-
-        controller.getCatalog(url, new QuerySpecDto(), response);
-
-        verify(response).resume(Mockito.<Catalog>argThat(c -> c.getContractOffers().equals(List.of(offer))));
-    }
-
-    @Test
-    void shouldResumeWithExceptionIfGetCatalogFails() {
-        var controller = new CatalogApiController(service, transformerRegistry, monitor);
-        var response = mock(AsyncResponse.class);
-        var url = "test.url";
-        when(service.getByProviderUrl(eq(url), any())).thenReturn(failedFuture(new EdcException("error")));
-
-        controller.getCatalog(url, new QuerySpecDto(), response);
-
-        verify(response).resume(isA(EdcException.class));
     }
 
     @Test

--- a/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/api/management/contractagreement/ContractAgreementApi.java
+++ b/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/api/management/contractagreement/ContractAgreementApi.java
@@ -38,17 +38,6 @@ public interface ContractAgreementApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ContractAgreementDto.class)))),
                     @ApiResponse(responseCode = "400", description = "Request body was malformed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
-            }, deprecated = true
-    )
-    @Deprecated
-    List<ContractAgreementDto> getAllAgreements(@Valid QuerySpecDto querySpecDto);
-
-    @Operation(description = "Gets all contract agreements according to a particular query",
-            responses = {
-                    @ApiResponse(responseCode = "200",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ContractAgreementDto.class)))),
-                    @ApiResponse(responseCode = "400", description = "Request body was malformed",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
             }
     )
     List<ContractAgreementDto> queryAllAgreements(@Valid QuerySpecDto querySpecDto);

--- a/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/api/management/contractagreement/ContractAgreementApiController.java
+++ b/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/api/management/contractagreement/ContractAgreementApiController.java
@@ -16,7 +16,6 @@
 package org.eclipse.edc.connector.api.management.contractagreement;
 
 import jakarta.validation.Valid;
-import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -55,13 +54,6 @@ public class ContractAgreementApiController implements ContractAgreementApi {
         this.monitor = monitor;
         this.service = service;
         this.transformerRegistry = transformerRegistry;
-    }
-
-    @GET
-    @Override
-    @Deprecated
-    public List<ContractAgreementDto> getAllAgreements(@Valid @BeanParam QuerySpecDto querySpecDto) {
-        return queryContractAgreements(querySpecDto);
     }
 
     @POST

--- a/extensions/control-plane/api/management-api/contract-agreement-api/src/test/java/org/eclipse/edc/connector/api/management/contractagreement/ContractAgreementApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/management-api/contract-agreement-api/src/test/java/org/eclipse/edc/connector/api/management/contractagreement/ContractAgreementApiControllerIntegrationTest.java
@@ -61,38 +61,6 @@ public class ContractAgreementApiControllerIntegrationTest {
     }
 
     @Test
-    void getAllContractAgreements(ContractNegotiationStore store) {
-        store.save(createContractNegotiation(UUID.randomUUID().toString(), createContractAgreement("agreementId")));
-
-        baseRequest()
-                .get("/contractagreements")
-                .then()
-                .statusCode(200)
-                .contentType(JSON)
-                .body("size()", is(1));
-    }
-
-    @Test
-    void getAllContractAgreements_withPaging(ContractNegotiationStore store) {
-        store.save(createContractNegotiation(UUID.randomUUID().toString(), createContractAgreement("agreementId")));
-
-        baseRequest()
-                .get("/contractagreements?offset=0&limit=15&sort=ASC")
-                .then()
-                .statusCode(200)
-                .contentType(JSON)
-                .body("size()", Matchers.is(1));
-    }
-
-    @Test
-    void getAll_invalidQuery() {
-        baseRequest()
-                .get("/contractagreements?limit=1&offset=-1&filter=&sortField=")
-                .then()
-                .statusCode(400);
-    }
-
-    @Test
     void queryAllContractAgreements(ContractNegotiationStore store) {
         store.save(createContractNegotiation(UUID.randomUUID().toString(), createContractAgreement("agreementId")));
 

--- a/extensions/control-plane/api/management-api/contract-agreement-api/src/test/java/org/eclipse/edc/connector/api/management/contractagreement/ContractAgreementApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-agreement-api/src/test/java/org/eclipse/edc/connector/api/management/contractagreement/ContractAgreementApiControllerTest.java
@@ -59,62 +59,6 @@ class ContractAgreementApiControllerTest {
     }
 
     @Test
-    void getAll() {
-        var contractAgreement = createContractAgreement();
-        when(service.query(any())).thenReturn(ServiceResult.success(Stream.of(contractAgreement)));
-        var dto = ContractAgreementDto.Builder.newInstance().id(contractAgreement.getId()).build();
-        when(transformerRegistry.transform(any(), eq(ContractAgreementDto.class))).thenReturn(Result.success(dto));
-        when(transformerRegistry.transform(isA(QuerySpecDto.class), eq(QuerySpec.class)))
-                .thenReturn(Result.success(QuerySpec.Builder.newInstance().offset(10).build()));
-        var querySpec = QuerySpecDto.Builder.newInstance().build();
-
-        var allContractAgreements = controller.getAllAgreements(querySpec);
-
-        assertThat(allContractAgreements).hasSize(1).first().matches(d -> d.getId().equals(contractAgreement.getId()));
-        verify(transformerRegistry).transform(contractAgreement, ContractAgreementDto.class);
-        verify(transformerRegistry).transform(isA(QuerySpecDto.class), eq(QuerySpec.class));
-    }
-
-    @Test
-    void getAll_filtersOutFailedTransforms() {
-        var contractAgreement = createContractAgreement();
-        when(service.query(any())).thenReturn(ServiceResult.success(Stream.of(contractAgreement)));
-        when(transformerRegistry.transform(isA(QuerySpecDto.class), eq(QuerySpec.class)))
-                .thenReturn(Result.success(QuerySpec.Builder.newInstance().offset(10).build()));
-        when(transformerRegistry.transform(isA(ContractAgreement.class), eq(ContractAgreementDto.class)))
-                .thenReturn(Result.failure("failure"));
-
-        var allContractAgreements = controller.getAllAgreements(QuerySpecDto.Builder.newInstance().build());
-
-        assertThat(allContractAgreements).hasSize(0);
-        verify(transformerRegistry).transform(contractAgreement, ContractAgreementDto.class);
-    }
-
-    @Test
-    void getAll_throwsExceptionIfQuerySpecTransformFails() {
-        when(transformerRegistry.transform(isA(QuerySpecDto.class), eq(QuerySpec.class)))
-                .thenReturn(Result.failure("Cannot transform"));
-        var querySpecDto = QuerySpecDto.Builder.newInstance().build();
-
-        assertThatThrownBy(() -> controller.getAllAgreements(querySpecDto)).isInstanceOf(InvalidRequestException.class);
-    }
-
-    @Test
-    void getAll_withInvalidQuery_shouldThrowException() {
-        var contractAgreement = createContractAgreement();
-        when(service.query(any())).thenReturn(ServiceResult.badRequest("test error message"));
-
-        var dto = ContractAgreementDto.Builder.newInstance().id(contractAgreement.getId()).build();
-        when(transformerRegistry.transform(any(), eq(ContractAgreementDto.class))).thenReturn(Result.success(dto));
-        when(transformerRegistry.transform(isA(QuerySpecDto.class), eq(QuerySpec.class)))
-                .thenReturn(Result.success(QuerySpec.Builder.newInstance().offset(10).build()));
-        var querySpec = QuerySpecDto.Builder.newInstance().filter("invalid=foobar").build();
-
-        assertThatThrownBy(() -> controller.getAllAgreements(querySpec)).isInstanceOf(InvalidRequestException.class);
-
-    }
-
-    @Test
     void queryAll() {
         var contractAgreement = createContractAgreement();
         when(service.query(any())).thenReturn(ServiceResult.success(Stream.of(contractAgreement)));

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionApi.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionApi.java
@@ -41,17 +41,6 @@ public interface ContractDefinitionApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ContractDefinitionResponseDto.class)))),
                     @ApiResponse(responseCode = "400", description = "Request was malformed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
-            }, deprecated = true
-    )
-    @Deprecated
-    List<ContractDefinitionResponseDto> getAllContractDefinitions(@Valid QuerySpecDto querySpecDto);
-
-    @Operation(description = "Returns all contract definitions according to a query",
-            responses = {
-                    @ApiResponse(responseCode = "200",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ContractDefinitionResponseDto.class)))),
-                    @ApiResponse(responseCode = "400", description = "Request was malformed",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
             }
     )
     List<ContractDefinitionResponseDto> queryAllContractDefinitions(@Valid QuerySpecDto querySpecDto);

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionApiController.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionApiController.java
@@ -16,7 +16,6 @@
 package org.eclipse.edc.connector.api.management.contractdefinition;
 
 import jakarta.validation.Valid;
-import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
@@ -60,13 +59,6 @@ public class ContractDefinitionApiController implements ContractDefinitionApi {
         this.monitor = monitor;
         this.service = service;
         this.transformerRegistry = transformerRegistry;
-    }
-
-    @GET
-    @Override
-    @Deprecated
-    public List<ContractDefinitionResponseDto> getAllContractDefinitions(@Valid @BeanParam QuerySpecDto querySpecDto) {
-        return queryContractDefinitions(querySpecDto);
     }
 
     @POST

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionApiControllerIntegrationTest.java
@@ -67,38 +67,6 @@ class ContractDefinitionApiControllerIntegrationTest {
     }
 
     @Test
-    void getAllContractDefs(ContractDefinitionStore store) {
-        store.save(createContractDefinition("definitionId"));
-
-        baseRequest()
-                .get("/contractdefinitions")
-                .then()
-                .statusCode(200)
-                .contentType(JSON)
-                .body("size()", is(1));
-    }
-
-    @Test
-    void getAllContractDefs_withPaging(ContractDefinitionStore store) {
-        store.save(createContractDefinition("definitionId"));
-
-        baseRequest()
-                .get("/contractdefinitions?offset=0&limit=15&sort=ASC")
-                .then()
-                .statusCode(200)
-                .contentType(JSON)
-                .body("size()", is(1));
-    }
-
-    @Test
-    void getAll_invalidQuery() {
-        baseRequest()
-                .get("/contractdefinitions?limit=1&offset=-1&filter=&sortField=")
-                .then()
-                .statusCode(400);
-    }
-
-    @Test
     void queryAllContractDefs(ContractDefinitionStore store) {
         store.save(createContractDefinition("definitionId"));
 

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionApiControllerTest.java
@@ -61,47 +61,6 @@ class ContractDefinitionApiControllerTest {
     }
 
     @Test
-    void getAll() {
-        var contractDefinition = createContractDefinition(UUID.randomUUID().toString());
-        when(service.query(any())).thenReturn(ServiceResult.success(Stream.of(contractDefinition)));
-        var dto = ContractDefinitionResponseDto.Builder.newInstance().id(contractDefinition.getId()).build();
-        when(transformerRegistry.transform(any(), eq(ContractDefinitionResponseDto.class))).thenReturn(Result.success(dto));
-        when(transformerRegistry.transform(isA(QuerySpecDto.class), eq(QuerySpec.class)))
-                .thenReturn(Result.success(QuerySpec.Builder.newInstance().offset(10).build()));
-        var querySpec = QuerySpecDto.Builder.newInstance().build();
-
-        var allContractDefinitions = controller.getAllContractDefinitions(querySpec);
-
-        assertThat(allContractDefinitions).hasSize(1).first().matches(d -> d.getId().equals(contractDefinition.getId()));
-        verify(service).query(argThat(s -> s.getOffset() == 10));
-        verify(transformerRegistry).transform(contractDefinition, ContractDefinitionResponseDto.class);
-        verify(transformerRegistry).transform(isA(QuerySpecDto.class), eq(QuerySpec.class));
-    }
-
-    @Test
-    void getAll_filtersOutFailedTransforms() {
-        var contractDefinition = createContractDefinition(UUID.randomUUID().toString());
-        when(service.query(any())).thenReturn(ServiceResult.success(Stream.of(contractDefinition)));
-        when(transformerRegistry.transform(isA(QuerySpecDto.class), eq(QuerySpec.class)))
-                .thenReturn(Result.success(QuerySpec.Builder.newInstance().offset(10).build()));
-        when(transformerRegistry.transform(isA(ContractDefinition.class), eq(ContractDefinitionResponseDto.class)))
-                .thenReturn(Result.failure("failure"));
-
-        var allContractDefinitions = controller.getAllContractDefinitions(QuerySpecDto.Builder.newInstance().build());
-
-        assertThat(allContractDefinitions).isEmpty();
-        verify(transformerRegistry).transform(contractDefinition, ContractDefinitionResponseDto.class);
-    }
-
-    @Test
-    void getAll_throwsExceptionIfQuerySpecTransformFails() {
-        when(transformerRegistry.transform(isA(QuerySpecDto.class), eq(QuerySpec.class)))
-                .thenReturn(Result.failure("Cannot transform"));
-
-        assertThatThrownBy(() -> controller.getAllContractDefinitions(QuerySpecDto.Builder.newInstance().build())).isInstanceOf(InvalidRequestException.class);
-    }
-
-    @Test
     void queryAll() {
         var contractDefinition = createContractDefinition(UUID.randomUUID().toString());
         when(service.query(any())).thenReturn(ServiceResult.success(Stream.of(contractDefinition)));

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApi.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApi.java
@@ -43,17 +43,6 @@ public interface ContractNegotiationApi {
                     @ApiResponse(responseCode = "200",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ContractNegotiationDto.class)))),
                     @ApiResponse(responseCode = "400", description = "Request was malformed",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))) },
-            deprecated = true
-    )
-    @Deprecated
-    List<ContractNegotiationDto> getNegotiations(@Valid QuerySpecDto querySpecDto);
-
-    @Operation(description = "Returns all contract negotiations according to a query",
-            responses = {
-                    @ApiResponse(responseCode = "200",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ContractNegotiationDto.class)))),
-                    @ApiResponse(responseCode = "400", description = "Request was malformed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))) }
     )
     List<ContractNegotiationDto> queryNegotiations(@Valid QuerySpecDto querySpecDto);

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiController.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiController.java
@@ -17,7 +17,6 @@
 package org.eclipse.edc.connector.api.management.contractnegotiation;
 
 import jakarta.validation.Valid;
-import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
@@ -62,13 +61,6 @@ public class ContractNegotiationApiController implements ContractNegotiationApi 
         this.monitor = monitor;
         this.service = service;
         this.transformerRegistry = transformerRegistry;
-    }
-
-    @GET
-    @Override
-    @Deprecated
-    public List<ContractNegotiationDto> getNegotiations(@Valid @BeanParam QuerySpecDto querySpecDto) {
-        return queryContractNegotiations(querySpecDto);
     }
 
     @POST

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerIntegrationTest.java
@@ -80,38 +80,6 @@ class ContractNegotiationApiControllerIntegrationTest {
     }
 
     @Test
-    void getAllContractNegotiations(ContractNegotiationStore store) {
-        store.save(createContractNegotiation("negotiationId"));
-
-        baseRequest()
-                .get("/contractnegotiations")
-                .then()
-                .statusCode(200)
-                .contentType(JSON)
-                .body("size()", is(1));
-    }
-
-    @Test
-    void getAllContractNegotiations_withPaging(ContractNegotiationStore store) {
-        store.save(createContractNegotiation("negotiationId"));
-
-        baseRequest()
-                .get("/contractnegotiations?offset=0&limit=15&sort=ASC")
-                .then()
-                .statusCode(200)
-                .contentType(JSON)
-                .body("size()", is(1));
-    }
-
-    @Test
-    void getAll_invalidQuery() {
-        baseRequest()
-                .get("/contractnegotiations?limit=1&offset=-1&filter=&sortField=")
-                .then()
-                .statusCode(400);
-    }
-
-    @Test
     void queryAllContractNegotiations(ContractNegotiationStore store) {
         store.save(createContractNegotiation("negotiationId"));
 

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApi.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApi.java
@@ -43,16 +43,6 @@ public interface PolicyDefinitionApi {
     )
     List<PolicyDefinitionResponseDto> queryAllPolicies(@Valid QuerySpecDto querySpecDto);
 
-    @Operation(description = "Returns all policy definitions according to a query",
-            responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(array = @ArraySchema(schema = @Schema(implementation = PolicyDefinitionResponseDto.class)))),
-                    @ApiResponse(responseCode = "400", description = "Request was malformed",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))) },
-            deprecated = true
-    )
-    @Deprecated
-    List<PolicyDefinitionResponseDto> getAllPolicies(@Valid QuerySpecDto querySpecDto);
-
     @Operation(description = "Gets a policy definition with the given ID",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The  policy definition",

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiController.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiController.java
@@ -16,7 +16,6 @@
 package org.eclipse.edc.connector.api.management.policy;
 
 import jakarta.validation.Valid;
-import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
@@ -71,13 +70,6 @@ public class PolicyDefinitionApiController implements PolicyDefinitionApi {
     @Override
     public List<PolicyDefinitionResponseDto> queryAllPolicies(@Valid QuerySpecDto querySpecDto) {
         return queryPolicies(ofNullable(querySpecDto).orElse(QuerySpecDto.Builder.newInstance().build()));
-    }
-
-    @GET
-    @Override
-    @Deprecated
-    public List<PolicyDefinitionResponseDto> getAllPolicies(@Valid @BeanParam QuerySpecDto querySpecDto) {
-        return queryPolicies(querySpecDto);
     }
 
     @GET

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiControllerIntegrationTest.java
@@ -64,28 +64,6 @@ public class PolicyDefinitionApiControllerIntegrationTest {
     }
 
     @Test
-    void getAllpolicydefinitions(PolicyDefinitionStore policyStore) {
-        var policy = createPolicy("id");
-
-        policyStore.create(policy);
-
-        baseRequest()
-                .get("/policydefinitions")
-                .then()
-                .statusCode(200)
-                .contentType(ContentType.JSON)
-                .body("size()", is(1));
-    }
-
-    @Test
-    void getAll_invalidQuery() {
-        baseRequest()
-                .get("/policydefinitions?limit=1&offset=-1&filter=&sortField=")
-                .then()
-                .statusCode(400);
-    }
-
-    @Test
     void queryAllPolicyDefinitions(PolicyDefinitionStore policyStore) {
         var policy = createPolicy("id");
 

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiControllerTest.java
@@ -88,48 +88,6 @@ class PolicyDefinitionApiControllerTest {
         assertThatThrownBy(() -> controller.getPolicy("nonExistingId")).isInstanceOf(ObjectNotFoundException.class);
     }
 
-
-    @Test
-    void getAllPolicies() {
-        when(service.query(any())).thenReturn(ServiceResult.success(Stream.of(TestFunctions.createPolicy("id"))));
-        when(transformerRegistry.transform(isA(QuerySpecDto.class), eq(QuerySpec.class)))
-                .thenReturn(Result.success(QuerySpec.Builder.newInstance().offset(10).build()));
-        var responseDto = PolicyDefinitionResponseDto.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build();
-        when(transformerRegistry.transform(isA(PolicyDefinition.class), eq(PolicyDefinitionResponseDto.class)))
-                .thenReturn(Result.success(responseDto));
-        var querySpec = QuerySpecDto.Builder.newInstance().build();
-
-        var allPolicies = controller.getAllPolicies(querySpec);
-
-        assertThat(allPolicies).hasSize(1);
-        verify(service).query(argThat(s -> s.getOffset() == 10));
-        verify(transformerRegistry).transform(isA(QuerySpecDto.class), eq(QuerySpec.class));
-        verify(transformerRegistry).transform(isA(PolicyDefinition.class), eq(PolicyDefinitionResponseDto.class));
-    }
-
-    @Test
-    void getAll_filtersOutFailedTransforms() {
-        var policyDefinition = TestFunctions.createPolicy("id");
-        when(service.query(any())).thenReturn(ServiceResult.success(Stream.of(policyDefinition)));
-        when(transformerRegistry.transform(isA(QuerySpecDto.class), eq(QuerySpec.class)))
-                .thenReturn(Result.success(QuerySpec.Builder.newInstance().offset(10).build()));
-        when(transformerRegistry.transform(isA(PolicyDefinition.class), eq(PolicyDefinitionResponseDto.class)))
-                .thenReturn(Result.failure("failure"));
-
-        var allPolicyDefinitions = controller.getAllPolicies(QuerySpecDto.Builder.newInstance().build());
-
-        assertThat(allPolicyDefinitions).hasSize(0);
-        verify(transformerRegistry).transform(policyDefinition, PolicyDefinitionResponseDto.class);
-    }
-
-    @Test
-    void getAll_throwsExceptionIfQuerySpecTransformFails() {
-        when(transformerRegistry.transform(isA(QuerySpecDto.class), eq(QuerySpec.class)))
-                .thenReturn(Result.failure("Cannot transform"));
-
-        assertThatThrownBy(() -> controller.getAllPolicies(QuerySpecDto.Builder.newInstance().build())).isInstanceOf(InvalidRequestException.class);
-    }
-
     @Test
     void queryAllPolicies() {
         when(service.query(any())).thenReturn(ServiceResult.success(Stream.of(TestFunctions.createPolicy("id"))));

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/TransferProcessApi.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/TransferProcessApi.java
@@ -46,17 +46,6 @@ public interface TransferProcessApi {
     )
     List<TransferProcessDto> queryAllTransferProcesses(@Valid QuerySpecDto querySpecDto);
 
-    @Operation(description = "Returns all transfer process according to a query",
-            responses = {
-                    @ApiResponse(responseCode = "200",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = TransferProcessDto.class)))),
-                    @ApiResponse(responseCode = "400", description = "Request was malformed",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))) },
-            deprecated = true
-    )
-    @Deprecated(since = "milestone8")
-    List<TransferProcessDto> getAllTransferProcesses(@Valid QuerySpecDto querySpecDto);
-
     @Operation(description = "Gets an transfer process with the given ID",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The transfer process",

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/TransferProcessApiController.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/TransferProcessApiController.java
@@ -16,7 +16,6 @@
 package org.eclipse.edc.connector.api.management.transferprocess;
 
 import jakarta.validation.Valid;
-import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
@@ -68,13 +67,6 @@ public class TransferProcessApiController implements TransferProcessApi {
     @Override
     public List<TransferProcessDto> queryAllTransferProcesses(@Valid QuerySpecDto querySpecDto) {
         return queryTransferProcesses(ofNullable(querySpecDto).orElse(QuerySpecDto.Builder.newInstance().build()));
-    }
-
-    @GET
-    @Deprecated
-    @Override
-    public List<TransferProcessDto> getAllTransferProcesses(@Valid @BeanParam QuerySpecDto querySpecDto) {
-        return queryTransferProcesses(querySpecDto);
     }
 
     @GET

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/api/management/transferprocess/TransferProcessApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/api/management/transferprocess/TransferProcessApiControllerIntegrationTest.java
@@ -72,27 +72,6 @@ class TransferProcessApiControllerIntegrationTest {
     }
 
     @Test
-    void getAllTransferProcesses(TransferProcessStore store) {
-        store.save(createTransferProcess(PROCESS_ID));
-
-        baseRequest()
-                .get("/transferprocess")
-                .then()
-                .statusCode(200)
-                .contentType(JSON)
-                .body("size()", is(1));
-    }
-
-    @Test
-    void getAll_invalidQuery() {
-        baseRequest()
-                .get("/transferprocess?limit=1&offset=-1&filter=&sortField=")
-                .then()
-                .statusCode(400);
-    }
-
-
-    @Test
     void queryAllTransferProcesses(TransferProcessStore store) {
         store.save(createTransferProcess(PROCESS_ID));
 

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/api/management/transferprocess/TransferProcessApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/api/management/transferprocess/TransferProcessApiControllerTest.java
@@ -68,44 +68,6 @@ class TransferProcessApiControllerTest {
     }
 
     @Test
-    void getAll() {
-        var transferProcess = transferProcess();
-        var dto = transferProcessDto(transferProcess);
-        when(transformerRegistry.transform(isA(TransferProcess.class), eq(TransferProcessDto.class))).thenReturn(Result.success(dto));
-        when(transformerRegistry.transform(isA(QuerySpecDto.class), eq(QuerySpec.class)))
-                .thenReturn(Result.success(QuerySpec.Builder.newInstance().offset(10).build()));
-        var querySpec = QuerySpecDto.Builder.newInstance().build();
-        when(service.query(any())).thenReturn(ServiceResult.success(Stream.of(transferProcess)));
-
-        var transferProcesses = controller.getAllTransferProcesses(querySpec);
-
-        assertThat(transferProcesses).containsExactly(dto);
-        verify(service).query(argThat(s -> s.getOffset() == 10));
-        verify(transformerRegistry).transform(isA(QuerySpecDto.class), eq(QuerySpec.class));
-    }
-
-    @Test
-    void getAll_filtersOutFailedTransforms() {
-        var transferProcess = transferProcess();
-        when(transformerRegistry.transform(isA(QuerySpecDto.class), eq(QuerySpec.class)))
-                .thenReturn(Result.success(QuerySpec.Builder.newInstance().offset(10).build()));
-        when(transformerRegistry.transform(isA(TransferProcess.class), eq(TransferProcessDto.class))).thenReturn(Result.failure("failure"));
-        when(service.query(any())).thenReturn(ServiceResult.success(Stream.of(transferProcess)));
-
-        var transferProcesses = controller.getAllTransferProcesses(QuerySpecDto.Builder.newInstance().build());
-
-        assertThat(transferProcesses).isEmpty();
-    }
-
-    @Test
-    void getAll_throwsExceptionIfQuerySpecTransformFails() {
-        when(transformerRegistry.transform(isA(QuerySpecDto.class), eq(QuerySpec.class)))
-                .thenReturn(Result.failure("Cannot transform"));
-
-        assertThatThrownBy(() -> controller.getAllTransferProcesses(QuerySpecDto.Builder.newInstance().build())).isInstanceOf(InvalidRequestException.class);
-    }
-
-    @Test
     void queryAll() {
         var transferProcess = transferProcess();
         var dto = transferProcessDto(transferProcess);

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/QuerySpec.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/QuerySpec.java
@@ -18,11 +18,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.eclipse.edc.spi.message.Range;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 /**
  * Specifies various query parameters for collection-like queries. Typical uses include API endpoints, where the query
@@ -110,9 +107,7 @@ public class QuerySpec {
     }
 
     public static final class Builder {
-        private static final String EQUALS_EXPRESSION_PATTERN = "[^\\s\\\\]*(\\s*)=(\\s*)[^\\\\]*";
         private final QuerySpec querySpec;
-        private boolean equalsAsContains = false;
 
         private Builder() {
             querySpec = new QuerySpec();
@@ -152,11 +147,6 @@ public class QuerySpec {
             return this;
         }
 
-        public Builder equalsAsContains(boolean equalsAsContains) {
-            this.equalsAsContains = equalsAsContains;
-            return this;
-        }
-
         public Builder filter(Criterion criterion) {
             querySpec.filterExpression.add(criterion);
             return this;
@@ -166,34 +156,6 @@ public class QuerySpec {
             if (criteria != null) {
                 querySpec.filterExpression.addAll(criteria);
             }
-            return this;
-        }
-
-        @Deprecated
-        public Builder filter(String filterExpression) {
-
-            if (filterExpression != null) {
-                if (Pattern.matches(EQUALS_EXPRESSION_PATTERN, filterExpression)) { // something like X = Y
-                    // we'll interpret the "=" as "contains" if desired
-                    var tokens = filterExpression.split("=", 2);
-                    var left = tokens[0].trim();
-                    var right = tokens[1].trim();
-                    var op = equalsAsContains ? "contains" : "=";
-                    querySpec.filterExpression = List.of(new Criterion(left, op, right));
-                } else {
-                    var s = filterExpression.split(" +", 3);
-
-                    //generic LEFT OPERAND RIGHT expression
-                    if (s.length >= 3) {
-                        var rh = Arrays.stream(s, 2, s.length).collect(Collectors.joining(" "));
-                        querySpec.filterExpression = List.of(new Criterion(s[0], s[1], rh));
-                    } else {
-                        // unsupported filter expression
-                        throw new IllegalArgumentException("Cannot convert " + filterExpression + " into a Criterion");
-                    }
-                }
-            }
-
             return this;
         }
 


### PR DESCRIPTION
## What this PR changes/adds

Removing:

- all the deprecated @GET endpoints
- `QuerySpecDto.getFilter` and `QuerySpecDto.Builder.filter(String)`
- `QuerySpec.Builder.filter(String)`

## Why it does that

clean code

## Further notes

## Linked Issue(s)

Closes #2088

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
