### PR TITLE
feat(api): create new Asset API

### DIFF
--- a/core/control-plane/catalog-core/src/test/java/org/eclipse/edc/connector/catalog/DatasetResolverImplTest.java
+++ b/core/control-plane/catalog-core/src/test/java/org/eclipse/edc/connector/catalog/DatasetResolverImplTest.java
@@ -27,6 +27,7 @@ import org.eclipse.edc.connector.contract.spi.types.offer.ContractDefinition;
 import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
 import org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore;
 import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.CoreConstants;
 import org.eclipse.edc.spi.agent.ParticipantAgent;
 import org.eclipse.edc.spi.asset.AssetIndex;
 import org.eclipse.edc.spi.asset.AssetSelectorExpression;
@@ -138,7 +139,7 @@ class DatasetResolverImplTest {
 
     @Test
     void query_shouldFilterAssetsByPassedCriteria() {
-        var definitionCriterion = new Criterion("asset:props:id", "=", "id");
+        var definitionCriterion = new Criterion(CoreConstants.EDC_NAMESPACE + "id", "=", "id");
         var contractDefinition = contractDefinitionBuilder("definitionId")
                 .selectorExpression(AssetSelectorExpression.Builder.newInstance().criteria(List.of(definitionCriterion)).build())
                 .contractPolicyId("contractPolicyId")
@@ -146,7 +147,7 @@ class DatasetResolverImplTest {
         when(contractDefinitionResolver.definitionsFor(any())).thenReturn(Stream.of(contractDefinition));
         when(assetIndex.queryAssets(isA(QuerySpec.class))).thenReturn(Stream.of(createAsset("id").property("key", "value").build()));
         when(policyStore.findById("contractPolicyId")).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
-        var additionalCriterion = new Criterion("asset:props:key", "=", "value");
+        var additionalCriterion = new Criterion(CoreConstants.EDC_NAMESPACE + "key", "=", "value");
         var querySpec = QuerySpec.Builder.newInstance().filter(additionalCriterion).build();
 
         datasetResolver.query(createParticipantAgent(), querySpec);

--- a/core/control-plane/catalog-core/src/test/java/org/eclipse/edc/connector/catalog/DatasetResolverImplTest.java
+++ b/core/control-plane/catalog-core/src/test/java/org/eclipse/edc/connector/catalog/DatasetResolverImplTest.java
@@ -27,7 +27,6 @@ import org.eclipse.edc.connector.contract.spi.types.offer.ContractDefinition;
 import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
 import org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore;
 import org.eclipse.edc.policy.model.Policy;
-import org.eclipse.edc.spi.CoreConstants;
 import org.eclipse.edc.spi.agent.ParticipantAgent;
 import org.eclipse.edc.spi.asset.AssetIndex;
 import org.eclipse.edc.spi.asset.AssetSelectorExpression;
@@ -50,6 +49,7 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 import static org.mockito.AdditionalMatchers.and;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -139,7 +139,7 @@ class DatasetResolverImplTest {
 
     @Test
     void query_shouldFilterAssetsByPassedCriteria() {
-        var definitionCriterion = new Criterion(CoreConstants.EDC_NAMESPACE + "id", "=", "id");
+        var definitionCriterion = new Criterion(EDC_NAMESPACE + "id", "=", "id");
         var contractDefinition = contractDefinitionBuilder("definitionId")
                 .selectorExpression(AssetSelectorExpression.Builder.newInstance().criteria(List.of(definitionCriterion)).build())
                 .contractPolicyId("contractPolicyId")
@@ -147,7 +147,7 @@ class DatasetResolverImplTest {
         when(contractDefinitionResolver.definitionsFor(any())).thenReturn(Stream.of(contractDefinition));
         when(assetIndex.queryAssets(isA(QuerySpec.class))).thenReturn(Stream.of(createAsset("id").property("key", "value").build()));
         when(policyStore.findById("contractPolicyId")).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
-        var additionalCriterion = new Criterion(CoreConstants.EDC_NAMESPACE + "key", "=", "value");
+        var additionalCriterion = new Criterion(EDC_NAMESPACE + "key", "=", "value");
         var querySpec = QuerySpec.Builder.newInstance().filter(additionalCriterion).build();
 
         datasetResolver.query(createParticipantAgent(), querySpec);

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/asset/AssetQueryValidatorTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/asset/AssetQueryValidatorTest.java
@@ -14,13 +14,13 @@
 
 package org.eclipse.edc.connector.service.asset;
 
-import org.eclipse.edc.spi.CoreConstants;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 
 class AssetQueryValidatorTest {
 
@@ -44,8 +44,8 @@ class AssetQueryValidatorTest {
     @ValueSource(strings = {
             "asset_prop_id in (foo, bar)", // invalid key
             "customProp=whatever", // no custom properties supported
-            CoreConstants.EDC_NAMESPACE + "id.=something", // trailing dot
-            "." + CoreConstants.EDC_NAMESPACE + ":id=something" // leading dot
+            EDC_NAMESPACE + "id.=something", // trailing dot
+            "." + EDC_NAMESPACE + ":id=something" // leading dot
     })
     void validate_invalidProperty(String filter) {
         var query = QuerySpec.Builder.newInstance()

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/asset/AssetQueryValidatorTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/asset/AssetQueryValidatorTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.connector.service.asset;
 
+import org.eclipse.edc.spi.CoreConstants;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -43,8 +44,8 @@ class AssetQueryValidatorTest {
     @ValueSource(strings = {
             "asset_prop_id in (foo, bar)", // invalid key
             "customProp=whatever", // no custom properties supported
-            "asset:prop:id.=something", // trailing dot
-            ".asset:prop:id=something" // leading dot
+            CoreConstants.EDC_NAMESPACE + "id.=something", // trailing dot
+            "." + CoreConstants.EDC_NAMESPACE + ":id=something" // leading dot
     })
     void validate_invalidProperty(String filter) {
         var query = QuerySpec.Builder.newInstance()

--- a/data-protocols/dsp/build.gradle.kts
+++ b/data-protocols/dsp/build.gradle.kts
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+
+plugins {
+    `java-library`
+}
+
+
+dependencies {
+    api(project(":data-protocols:dsp:dsp-api-configuration"))
+    api(project(":data-protocols:dsp:dsp-catalog"))
+    api(project(":data-protocols:dsp:dsp-http-core"))
+    api(project(":data-protocols:dsp:dsp-http-spi"))
+    api(project(":data-protocols:dsp:dsp-negotiation"))
+    api(project(":data-protocols:dsp:dsp-transfer-process"))
+    api(project(":data-protocols:dsp:dsp-transform"))
+}
+
+

--- a/data-protocols/dsp/dsp-transform/src/main/java/org/eclipse/edc/protocol/dsp/transform/DspTransformExtension.java
+++ b/data-protocols/dsp/dsp-transform/src/main/java/org/eclipse/edc/protocol/dsp/transform/DspTransformExtension.java
@@ -15,12 +15,14 @@
 package org.eclipse.edc.protocol.dsp.transform;
 
 import jakarta.json.Json;
+import org.eclipse.edc.jsonld.transformer.from.JsonObjectFromAssetTransformer;
 import org.eclipse.edc.jsonld.transformer.from.JsonObjectFromCatalogTransformer;
 import org.eclipse.edc.jsonld.transformer.from.JsonObjectFromDataServiceTransformer;
 import org.eclipse.edc.jsonld.transformer.from.JsonObjectFromDatasetTransformer;
 import org.eclipse.edc.jsonld.transformer.from.JsonObjectFromDistributionTransformer;
 import org.eclipse.edc.jsonld.transformer.from.JsonObjectFromPolicyTransformer;
 import org.eclipse.edc.jsonld.transformer.to.JsonObjectToActionTransformer;
+import org.eclipse.edc.jsonld.transformer.to.JsonObjectToAssetTransformer;
 import org.eclipse.edc.jsonld.transformer.to.JsonObjectToCatalogTransformer;
 import org.eclipse.edc.jsonld.transformer.to.JsonObjectToConstraintTransformer;
 import org.eclipse.edc.jsonld.transformer.to.JsonObjectToDataServiceTransformer;
@@ -77,6 +79,7 @@ public class DspTransformExtension implements ServiceExtension {
         registry.register(new JsonObjectFromPolicyTransformer(jsonBuilderFactory));
         registry.register(new JsonObjectFromDistributionTransformer(jsonBuilderFactory));
         registry.register(new JsonObjectFromDataServiceTransformer(jsonBuilderFactory));
+        registry.register(new JsonObjectFromAssetTransformer(jsonBuilderFactory, mapper));
 
         // JSON-LD to EDC model transformers
         registry.register(new JsonObjectToCatalogTransformer());
@@ -90,5 +93,6 @@ public class DspTransformExtension implements ServiceExtension {
         registry.register(new JsonObjectToActionTransformer());
         registry.register(new JsonObjectToConstraintTransformer());
         registry.register(new JsonValueToGenericTypeTransformer(mapper));
+        registry.register(new JsonObjectToAssetTransformer());
     }
 }

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/MultipartControllerIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/MultipartControllerIntegrationTest.java
@@ -60,6 +60,7 @@ import org.eclipse.edc.protocol.ids.spi.types.IdsType;
 import org.eclipse.edc.protocol.ids.util.CalendarUtil;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.service.spi.result.ServiceResult;
+import org.eclipse.edc.spi.CoreConstants;
 import org.eclipse.edc.spi.asset.AssetIndex;
 import org.eclipse.edc.spi.http.EdcHttpClient;
 import org.eclipse.edc.spi.iam.ClaimToken;
@@ -255,9 +256,9 @@ class MultipartControllerIntegrationTest {
         var assetId = UUID.randomUUID().toString();
         var asset = Asset.Builder.newInstance()
                 .id(assetId)
-                .property("asset:prop:fileName", "test.txt")
-                .property("asset:prop:byteSize", BigInteger.valueOf(10))
-                .property("asset:prop:fileExtension", "txt")
+                .property(CoreConstants.EDC_NAMESPACE + "fileName", "test.txt")
+                .property(CoreConstants.EDC_NAMESPACE + "byteSize", BigInteger.valueOf(10))
+                .property(CoreConstants.EDC_NAMESPACE + "fileExtension", "txt")
                 .build();
         assetIndex.accept(asset, DataAddress.Builder.newInstance().type("test").build());
         var contractOffer = ContractOffer.Builder.newInstance()
@@ -391,9 +392,9 @@ class MultipartControllerIntegrationTest {
         String assetId = UUID.randomUUID().toString();
         Asset asset = Asset.Builder.newInstance()
                 .id(assetId)
-                .property("asset:prop:fileName", "test.txt")
-                .property("asset:prop:byteSize", BigInteger.valueOf(10))
-                .property("asset:prop:fileExtension", "txt")
+                .property(CoreConstants.EDC_NAMESPACE + "fileName", "test.txt")
+                .property(CoreConstants.EDC_NAMESPACE + "byteSize", BigInteger.valueOf(10))
+                .property(CoreConstants.EDC_NAMESPACE + "fileExtension", "txt")
                 .build();
         assetIndex.accept(asset, DataAddress.Builder.newInstance().type("test").build());
 
@@ -452,9 +453,9 @@ class MultipartControllerIntegrationTest {
         String assetId = UUID.randomUUID().toString();
         Asset asset = Asset.Builder.newInstance()
                 .id(assetId)
-                .property("asset:prop:fileName", "test.txt")
-                .property("asset:prop:byteSize", BigInteger.valueOf(10))
-                .property("asset:prop:fileExtension", "txt")
+                .property(CoreConstants.EDC_NAMESPACE + "fileName", "test.txt")
+                .property(CoreConstants.EDC_NAMESPACE + "byteSize", BigInteger.valueOf(10))
+                .property(CoreConstants.EDC_NAMESPACE + "fileExtension", "txt")
                 .build();
         assetIndex.accept(asset, DataAddress.Builder.newInstance().type("test").build());
 
@@ -517,9 +518,9 @@ class MultipartControllerIntegrationTest {
         String assetId = UUID.randomUUID().toString();
         Asset asset = Asset.Builder.newInstance()
                 .id(assetId)
-                .property("asset:prop:fileName", "test.txt")
-                .property("asset:prop:byteSize", BigInteger.valueOf(10))
-                .property("asset:prop:fileExtension", "txt")
+                .property(CoreConstants.EDC_NAMESPACE + "fileName", "test.txt")
+                .property(CoreConstants.EDC_NAMESPACE + "byteSize", BigInteger.valueOf(10))
+                .property(CoreConstants.EDC_NAMESPACE + "fileExtension", "txt")
                 .build();
         assetIndex.accept(asset, DataAddress.Builder.newInstance().type("test").build());
         var contractOffer = ContractOffer.Builder.newInstance()

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/MultipartControllerIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/MultipartControllerIntegrationTest.java
@@ -60,7 +60,6 @@ import org.eclipse.edc.protocol.ids.spi.types.IdsType;
 import org.eclipse.edc.protocol.ids.util.CalendarUtil;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.service.spi.result.ServiceResult;
-import org.eclipse.edc.spi.CoreConstants;
 import org.eclipse.edc.spi.asset.AssetIndex;
 import org.eclipse.edc.spi.http.EdcHttpClient;
 import org.eclipse.edc.spi.iam.ClaimToken;
@@ -92,6 +91,7 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.junit.testfixtures.TestUtils.getFreePort;
 import static org.eclipse.edc.protocol.ids.spi.domain.IdsConstants.IDS_WEBHOOK_ADDRESS_PROPERTY;
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
@@ -256,9 +256,9 @@ class MultipartControllerIntegrationTest {
         var assetId = UUID.randomUUID().toString();
         var asset = Asset.Builder.newInstance()
                 .id(assetId)
-                .property(CoreConstants.EDC_NAMESPACE + "fileName", "test.txt")
-                .property(CoreConstants.EDC_NAMESPACE + "byteSize", BigInteger.valueOf(10))
-                .property(CoreConstants.EDC_NAMESPACE + "fileExtension", "txt")
+                .property(EDC_NAMESPACE + "fileName", "test.txt")
+                .property(EDC_NAMESPACE + "byteSize", BigInteger.valueOf(10))
+                .property(EDC_NAMESPACE + "fileExtension", "txt")
                 .build();
         assetIndex.accept(asset, DataAddress.Builder.newInstance().type("test").build());
         var contractOffer = ContractOffer.Builder.newInstance()
@@ -392,9 +392,9 @@ class MultipartControllerIntegrationTest {
         String assetId = UUID.randomUUID().toString();
         Asset asset = Asset.Builder.newInstance()
                 .id(assetId)
-                .property(CoreConstants.EDC_NAMESPACE + "fileName", "test.txt")
-                .property(CoreConstants.EDC_NAMESPACE + "byteSize", BigInteger.valueOf(10))
-                .property(CoreConstants.EDC_NAMESPACE + "fileExtension", "txt")
+                .property(EDC_NAMESPACE + "fileName", "test.txt")
+                .property(EDC_NAMESPACE + "byteSize", BigInteger.valueOf(10))
+                .property(EDC_NAMESPACE + "fileExtension", "txt")
                 .build();
         assetIndex.accept(asset, DataAddress.Builder.newInstance().type("test").build());
 
@@ -453,9 +453,9 @@ class MultipartControllerIntegrationTest {
         String assetId = UUID.randomUUID().toString();
         Asset asset = Asset.Builder.newInstance()
                 .id(assetId)
-                .property(CoreConstants.EDC_NAMESPACE + "fileName", "test.txt")
-                .property(CoreConstants.EDC_NAMESPACE + "byteSize", BigInteger.valueOf(10))
-                .property(CoreConstants.EDC_NAMESPACE + "fileExtension", "txt")
+                .property(EDC_NAMESPACE + "fileName", "test.txt")
+                .property(EDC_NAMESPACE + "byteSize", BigInteger.valueOf(10))
+                .property(EDC_NAMESPACE + "fileExtension", "txt")
                 .build();
         assetIndex.accept(asset, DataAddress.Builder.newInstance().type("test").build());
 
@@ -518,9 +518,9 @@ class MultipartControllerIntegrationTest {
         String assetId = UUID.randomUUID().toString();
         Asset asset = Asset.Builder.newInstance()
                 .id(assetId)
-                .property(CoreConstants.EDC_NAMESPACE + "fileName", "test.txt")
-                .property(CoreConstants.EDC_NAMESPACE + "byteSize", BigInteger.valueOf(10))
-                .property(CoreConstants.EDC_NAMESPACE + "fileExtension", "txt")
+                .property(EDC_NAMESPACE + "fileName", "test.txt")
+                .property(EDC_NAMESPACE + "byteSize", BigInteger.valueOf(10))
+                .property(EDC_NAMESPACE + "fileExtension", "txt")
                 .build();
         assetIndex.accept(asset, DataAddress.Builder.newInstance().type("test").build());
         var contractOffer = ContractOffer.Builder.newInstance()

--- a/data-protocols/ids/ids-transform-v1/src/main/java/org/eclipse/edc/protocol/ids/transform/type/asset/TransformKeys.java
+++ b/data-protocols/ids/ids-transform-v1/src/main/java/org/eclipse/edc/protocol/ids/transform/type/asset/TransformKeys.java
@@ -15,15 +15,16 @@
 
 package org.eclipse.edc.protocol.ids.transform.type.asset;
 
-import org.eclipse.edc.spi.CoreConstants;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
+
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 
 /**
  * IDS Transform Keys from the {@link Asset} properties.
  */
 public class TransformKeys {
-    public static final String KEY_ASSET_FILE_NAME = CoreConstants.EDC_NAMESPACE + "fileName";
-    public static final String KEY_ASSET_BYTE_SIZE = CoreConstants.EDC_NAMESPACE + "byteSize";
-    public static final String KEY_ASSET_FILE_EXTENSION = CoreConstants.EDC_NAMESPACE + "fileExtension";
+    public static final String KEY_ASSET_FILE_NAME = EDC_NAMESPACE + "fileName";
+    public static final String KEY_ASSET_BYTE_SIZE = EDC_NAMESPACE + "byteSize";
+    public static final String KEY_ASSET_FILE_EXTENSION = EDC_NAMESPACE + "fileExtension";
 
 }

--- a/data-protocols/ids/ids-transform-v1/src/main/java/org/eclipse/edc/protocol/ids/transform/type/asset/TransformKeys.java
+++ b/data-protocols/ids/ids-transform-v1/src/main/java/org/eclipse/edc/protocol/ids/transform/type/asset/TransformKeys.java
@@ -15,14 +15,15 @@
 
 package org.eclipse.edc.protocol.ids.transform.type.asset;
 
+import org.eclipse.edc.spi.CoreConstants;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
 
 /**
  * IDS Transform Keys from the {@link Asset} properties.
  */
 public class TransformKeys {
-    public static final String KEY_ASSET_FILE_NAME = "asset:prop:fileName";
-    public static final String KEY_ASSET_BYTE_SIZE = "asset:prop:byteSize";
-    public static final String KEY_ASSET_FILE_EXTENSION = "asset:prop:fileExtension";
+    public static final String KEY_ASSET_FILE_NAME = CoreConstants.EDC_NAMESPACE + "fileName";
+    public static final String KEY_ASSET_BYTE_SIZE = CoreConstants.EDC_NAMESPACE + "byteSize";
+    public static final String KEY_ASSET_FILE_EXTENSION = CoreConstants.EDC_NAMESPACE + "fileExtension";
 
 }

--- a/extensions/common/http/jersey-core/src/testFixtures/java/org/eclipse/edc/web/jersey/testfixtures/RestControllerTestBase.java
+++ b/extensions/common/http/jersey-core/src/testFixtures/java/org/eclipse/edc/web/jersey/testfixtures/RestControllerTestBase.java
@@ -35,14 +35,12 @@ import static org.mockito.Mockito.mock;
  */
 public abstract class RestControllerTestBase {
 
-    private JettyService jetty;
     protected final int port = getFreePort();
     protected Monitor monitor = mock(Monitor.class);
-
-    protected abstract Object controller();
+    private JettyService jetty;
 
     @BeforeEach
-    void setup() {
+    final void setup() {
         var config = new JettyConfiguration(null, null);
         config.portMapping(new PortMapping("test", port, "/"));
         jetty = new JettyService(config, monitor);
@@ -58,5 +56,7 @@ public abstract class RestControllerTestBase {
     void teardown() {
         jetty.shutdown();
     }
+
+    protected abstract Object controller();
 
 }

--- a/extensions/common/http/jersey-core/src/testFixtures/java/org/eclipse/edc/web/jersey/testfixtures/RestControllerTestBase.java
+++ b/extensions/common/http/jersey-core/src/testFixtures/java/org/eclipse/edc/web/jersey/testfixtures/RestControllerTestBase.java
@@ -40,7 +40,7 @@ public abstract class RestControllerTestBase {
     private JettyService jetty;
 
     @BeforeEach
-    final void setup() {
+    final void startJetty() {
         var config = new JettyConfiguration(null, null);
         config.portMapping(new PortMapping("test", port, "/"));
         jetty = new JettyService(config, monitor);

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/from/JsonObjectFromAssetTransformer.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/from/JsonObjectFromAssetTransformer.java
@@ -24,12 +24,8 @@ import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Map;
-
-import static java.util.stream.Collectors.toMap;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 
 public class JsonObjectFromAssetTransformer extends AbstractJsonLdTransformer<Asset, JsonObject> {
     private final ObjectMapper mapper;
@@ -46,13 +42,7 @@ public class JsonObjectFromAssetTransformer extends AbstractJsonLdTransformer<As
         var builder = jsonFactory.createObjectBuilder();
         builder.add(ID, asset.getId());
         builder.add(TYPE, PropertyAndTypeNames.EDC_ASSET_TYPE);
-
-        // replace the special asset properties, starting with "asset:prop:", with the EDC_SCHEMA
-        var props = asset.getProperties().entrySet().stream()
-                .collect(toMap(entry -> entry.getKey().replace("asset:prop:", EDC_NAMESPACE), Map.Entry::getValue));
-
-        transformProperties(props, builder, mapper, context);
-
+        transformProperties(asset.getProperties(), builder, mapper, context);
         return builder.build();
     }
 }

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToAssetTransformer.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToAssetTransformer.java
@@ -28,7 +28,7 @@ import org.jetbrains.annotations.Nullable;
  * Converts from an {@link Asset} as a {@link JsonObject} in JSON-LD expanded form to an {@link Asset}.
  */
 public class JsonObjectToAssetTransformer extends AbstractJsonLdTransformer<JsonObject, Asset> {
-    protected JsonObjectToAssetTransformer() {
+    public JsonObjectToAssetTransformer() {
         super(JsonObject.class, Asset.class);
     }
 
@@ -47,14 +47,6 @@ public class JsonObjectToAssetTransformer extends AbstractJsonLdTransformer<Json
             visitProperties(props, (k, val) -> transformProperties(k, val, builder, context));
 
             //parse known properties:
-        } else if (PropertyAndTypeNames.EDC_ASSET_NAME.equals(key)) {
-            transformString(jsonValue, builder::name, context);
-        } else if (PropertyAndTypeNames.EDC_ASSET_DESCRIPTION.equals(key)) {
-            transformString(jsonValue, builder::description, context);
-        } else if (PropertyAndTypeNames.EDC_ASSET_VERSION.equals(key)) {
-            transformString(jsonValue, builder::version, context);
-        } else if (PropertyAndTypeNames.EDC_ASSET_CONTENTTYPE.equals(key)) {
-            transformString(jsonValue, builder::contentType, context);
         } else {
             builder.property(key, transformGenericProperty(jsonValue, context));
         }

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToAssetTransformerTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToAssetTransformerTest.java
@@ -79,12 +79,12 @@ class JsonObjectToAssetTransformerTest {
         AbstractResultAssert.assertThat(asset).withFailMessage(asset::getFailureDetail).isSucceeded();
         assertThat(asset.getContent().getProperties())
                 .hasSize(5)
-                .hasFieldOrPropertyWithValue(Asset.PROPERTY_ID, TEST_ASSET_ID)
-                .hasFieldOrPropertyWithValue(Asset.PROPERTY_ID, asset.getContent().getId())
-                .hasFieldOrPropertyWithValue(Asset.PROPERTY_NAME, TEST_ASSET_NAME)
-                .hasFieldOrPropertyWithValue(Asset.PROPERTY_DESCRIPTION, TEST_ASSET_DESCRIPTION)
-                .hasFieldOrPropertyWithValue(Asset.PROPERTY_CONTENT_TYPE, TEST_ASSET_CONTENTTYPE)
-                .hasFieldOrPropertyWithValue(Asset.PROPERTY_VERSION, TEST_ASSET_VERSION);
+                .containsEntry(Asset.PROPERTY_ID, TEST_ASSET_ID)
+                .containsEntry(Asset.PROPERTY_ID, asset.getContent().getId())
+                .containsEntry(Asset.PROPERTY_NAME, TEST_ASSET_NAME)
+                .containsEntry(Asset.PROPERTY_DESCRIPTION, TEST_ASSET_DESCRIPTION)
+                .containsEntry(Asset.PROPERTY_CONTENT_TYPE, TEST_ASSET_CONTENTTYPE)
+                .containsEntry(Asset.PROPERTY_VERSION, TEST_ASSET_VERSION);
     }
 
     @Test
@@ -121,9 +121,10 @@ class JsonObjectToAssetTransformerTest {
         var asset = typeTransformerRegistry.transform(jsonObj, Asset.class);
 
         assertThat(asset.getContent().getProperties()).hasSize(2)
-                .hasFieldOrPropertyWithValue(Asset.PROPERTY_ID, asset.getContent().getId())
-                .hasFieldOrPropertyWithValue(Asset.PROPERTY_VERSION, TEST_ASSET_VERSION);
+                .containsEntry(Asset.PROPERTY_ID, TEST_ASSET_ID)
+                .containsEntry(Asset.PROPERTY_VERSION, TEST_ASSET_VERSION);
 
+        assertThat(asset.getContent().getProperties().get(Asset.PROPERTY_ID)).isEqualTo(asset.getContent().getId());
     }
 
     @Test

--- a/extensions/control-plane/api/management-api/asset-api/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/asset-api/build.gradle.kts
@@ -20,8 +20,11 @@ plugins {
 
 dependencies {
     api(project(":spi:control-plane:control-plane-spi"))
+    api(project(":spi:common:json-ld-spi"))
+    implementation(project(":extensions:common:json-ld"))
     implementation(project(":extensions:common:api:api-core"))
     implementation(project(":extensions:common:api:management-api-configuration"))
+    implementation(project(":extensions:common:http:jersey-core"))
 
     implementation(libs.jakarta.rsApi)
 

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApiExtension.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApiExtension.java
@@ -29,7 +29,11 @@ import org.eclipse.edc.spi.asset.DataAddressResolver;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.web.jersey.ObjectMapperProvider;
 import org.eclipse.edc.web.spi.WebService;
+
+import static org.eclipse.edc.jsonld.JsonLdExtension.TYPE_MANAGER_CONTEXT_JSON_LD;
 
 @Extension(value = AssetApiExtension.NAME)
 public class AssetApiExtension implements ServiceExtension {
@@ -50,6 +54,12 @@ public class AssetApiExtension implements ServiceExtension {
 
     @Inject
     private DataAddressResolver dataAddressResolver;
+    @Inject
+    private ManagementApiConfiguration configuration;
+
+    @Inject
+    private TypeManager typeManager;
+
 
     @Override
     public String name() {
@@ -66,7 +76,10 @@ public class AssetApiExtension implements ServiceExtension {
         transformerRegistry.register(new DataAddressDtoToDataAddressTransformer());
         transformerRegistry.register(new DataAddressToDataAddressDtoTransformer());
 
+        var jsonLdMapper = typeManager.getMapper(TYPE_MANAGER_CONTEXT_JSON_LD);
+        webService.registerResource(configuration.getContextAlias(), new ObjectMapperProvider(jsonLdMapper));
         webService.registerResource(config.getContextAlias(), new AssetApiController(monitor, assetService, dataAddressResolver, transformerRegistry));
+        webService.registerResource(config.getContextAlias(), new AssetNewApiController(assetService, dataAddressResolver, transformerRegistry));
     }
 
 }

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApiExtension.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApiExtension.java
@@ -28,8 +28,8 @@ import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.asset.DataAddressResolver;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
-import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.web.jersey.ObjectMapperProvider;
 import org.eclipse.edc.web.spi.WebService;
 

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetNewApi.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetNewApi.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
  *
  */
 
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.api.management.asset;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -24,18 +25,19 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.eclipse.edc.api.model.IdResponseDto;
 import org.eclipse.edc.api.query.QuerySpecDto;
-import org.eclipse.edc.connector.api.management.asset.model.AssetEntryDto;
+import org.eclipse.edc.connector.api.management.asset.model.AssetEntryNewDto;
 import org.eclipse.edc.connector.api.management.asset.model.AssetResponseDto;
+import org.eclipse.edc.connector.api.management.asset.model.AssetResponseNewDto;
 import org.eclipse.edc.connector.api.management.asset.model.AssetUpdateRequestDto;
 import org.eclipse.edc.connector.api.management.asset.model.DataAddressDto;
 import org.eclipse.edc.web.spi.ApiErrorDetail;
 
 import java.util.List;
 
-@OpenAPIDefinition
+@OpenAPIDefinition(info = @Info(description = "This contains both the current and the new Asset API, which accepts JSON-LD and will become the standard API once the Dataspace Protocol is stable. " +
+        "The new Asset API is prefixed with /v2, and the old endpoints have been deprecated. At that time of switching, the old API will be removed, and this API will be available without the /v2 prefix.", title = "Asset API"))
 @Tag(name = "Asset")
-@Deprecated(since = "milestone9")
-public interface AssetApi {
+public interface AssetNewApi {
 
     @Operation(description = "Creates a new asset together with a data address",
             responses = {
@@ -44,22 +46,9 @@ public interface AssetApi {
                     @ApiResponse(responseCode = "400", description = "Request body was malformed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))),
                     @ApiResponse(responseCode = "409", description = "Could not create asset, because an asset with that ID already exists",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))) },
-            deprecated = true
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))) }
     )
-    @Deprecated(since = "milestone9")
-    IdResponseDto createAsset(@Valid AssetEntryDto assetEntryDto);
-
-    @Operation(description = "Gets all assets according to a particular query",
-            responses = {
-                    @ApiResponse(responseCode = "200",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = AssetResponseDto.class)))),
-                    @ApiResponse(responseCode = "400", description = "Request body was malformed",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
-            }, deprecated = true
-    )
-    @Deprecated(since = "milestone9")
-    List<AssetResponseDto> getAllAssets(@Valid QuerySpecDto querySpecDto);
+    IdResponseDto createAsset(@Valid AssetEntryNewDto assetEntryDto);
 
     @Operation(description = " all assets according to a particular query",
             responses = {
@@ -67,10 +56,8 @@ public interface AssetApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = AssetResponseDto.class)))),
                     @ApiResponse(responseCode = "400", description = "Request body was malformed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
-            }, deprecated = true
-    )
-    @Deprecated(since = "milestone9")
-    List<AssetResponseDto> requestAssets(@Valid QuerySpecDto querySpecDto);
+            })
+    List<AssetResponseNewDto> requestAssets(@Valid QuerySpecDto querySpecDto);
 
     @Operation(description = "Gets an asset with the given ID",
             responses = {
@@ -82,7 +69,7 @@ public interface AssetApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
             }
     )
-    AssetResponseDto getAsset(String id);
+    AssetResponseNewDto getAsset(String id);
 
     @Operation(description = "Removes an asset with the given ID if possible. Deleting an asset is only possible if that asset is not yet referenced " +
             "by a contract agreement, in which case an error is returned. " +
@@ -95,9 +82,7 @@ public interface AssetApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))),
                     @ApiResponse(responseCode = "409", description = "The asset cannot be deleted, because it is referenced by a contract agreement",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
-            }, deprecated = true
-    )
-    @Deprecated(since = "milestone9")
+            })
     void removeAsset(String id);
 
     @Operation(description = "Updates an asset with the given ID if it exists. If the asset is not found, no further action is taken. " +
@@ -107,9 +92,7 @@ public interface AssetApi {
                     @ApiResponse(responseCode = "404", description = "Asset could not be updated, because it does not exist."),
                     @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))),
-            }, deprecated = true
-    )
-    @Deprecated(since = "milestone9")
+            })
     void updateAsset(String assetId, @Valid AssetUpdateRequestDto asset);
 
     @Operation(description = "Updates a DataAddress for an asset with the given ID.",
@@ -119,9 +102,7 @@ public interface AssetApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))),
                     @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))),
-            }, deprecated = true
-    )
-    @Deprecated(since = "milestone9")
+            })
     void updateDataAddress(String assetId, @Valid DataAddressDto dataAddress);
 
 
@@ -133,9 +114,6 @@ public interface AssetApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))),
                     @ApiResponse(responseCode = "404", description = "An asset with the given ID does not exist",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
-            }, deprecated = true
-    )
-    @Deprecated(since = "milestone9")
+            })
     DataAddressDto getAssetDataAddress(String id);
 }
-

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetNewApiController.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetNewApiController.java
@@ -1,0 +1,190 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.asset;
+
+import jakarta.json.JsonObject;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import org.eclipse.edc.api.model.IdResponseDto;
+import org.eclipse.edc.api.query.QuerySpecDto;
+import org.eclipse.edc.connector.api.management.asset.model.AssetEntryNewDto;
+import org.eclipse.edc.connector.api.management.asset.model.AssetResponseNewDto;
+import org.eclipse.edc.connector.api.management.asset.model.AssetUpdateRequestDto;
+import org.eclipse.edc.connector.api.management.asset.model.AssetUpdateRequestWrapperDto;
+import org.eclipse.edc.connector.api.management.asset.model.DataAddressDto;
+import org.eclipse.edc.connector.spi.asset.AssetService;
+import org.eclipse.edc.jsonld.util.JsonLdUtil;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.asset.DataAddressResolver;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.asset.Asset;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.web.spi.exception.InvalidRequestException;
+import org.eclipse.edc.web.spi.exception.ObjectNotFoundException;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static java.util.Optional.of;
+import static java.util.Optional.ofNullable;
+import static java.util.stream.Collectors.toList;
+import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMapper;
+
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
+@Path("/v2/assets")
+public class AssetNewApiController implements AssetNewApi {
+    private final TypeTransformerRegistry transformerRegistry;
+    private final AssetService service;
+    private final DataAddressResolver dataAddressResolver;
+
+    public AssetNewApiController(AssetService service, DataAddressResolver dataAddressResolver, TypeTransformerRegistry transformerRegistry) {
+        this.transformerRegistry = transformerRegistry;
+        this.service = service;
+        this.dataAddressResolver = dataAddressResolver;
+    }
+
+    @POST
+    @Override
+    public IdResponseDto createAsset(@Valid AssetEntryNewDto assetEntryDto) {
+        var expandedJson = JsonLdUtil.expand(assetEntryDto.getAsset());
+        if (expandedJson.size() == 0) throw new InvalidRequestException("Invalid asset!");
+
+        var expandedJsonAsset = expandedJson.getJsonObject(0);
+        var assetResult = transformerRegistry.transform(expandedJsonAsset, Asset.class);
+        var dataAddressResult = transformerRegistry.transform(assetEntryDto.getDataAddress(), DataAddress.class);
+
+        if (assetResult.failed() || dataAddressResult.failed()) {
+            var errorMessages = Stream.concat(assetResult.getFailureMessages().stream(), dataAddressResult.getFailureMessages().stream());
+            throw new InvalidRequestException(errorMessages.collect(toList()));
+        }
+
+        var dataAddress = dataAddressResult.getContent();
+        var asset = assetResult.getContent();
+
+        var resultContent = service.create(asset, dataAddress).orElseThrow(exceptionMapper(Asset.class, asset.getId()));
+
+        return IdResponseDto.Builder.newInstance()
+                .id(resultContent.getId())
+                .createdAt(resultContent.getCreatedAt())
+                .build();
+    }
+
+    @POST
+    @Path("/request")
+    @Override
+    public List<AssetResponseNewDto> requestAssets(@Valid QuerySpecDto querySpecDto) {
+        return queryAssets(ofNullable(querySpecDto).orElse(QuerySpecDto.Builder.newInstance().build()));
+    }
+
+    @GET
+    @Path("{id}")
+    @Override
+    public AssetResponseNewDto getAsset(@PathParam("id") String id) {
+        var obj = of(id)
+                .map(it -> service.findById(id))
+                .map(it -> transformerRegistry.transform(it, JsonObject.class))
+                .filter(Result::succeeded)
+                .map(Result::getContent)
+                .orElseThrow(() -> new ObjectNotFoundException(Asset.class, id));
+        return Optional.ofNullable(expand(obj))
+                .orElseThrow(() -> new EdcException("Error expanding asset"));
+    }
+
+    @DELETE
+    @Path("{id}")
+    @Override
+    public void removeAsset(@PathParam("id") String id) {
+        service.delete(id).orElseThrow(exceptionMapper(Asset.class, id));
+    }
+
+    @PUT
+    @Path("{assetId}")
+    @Override
+    public void updateAsset(@PathParam("assetId") String assetId, @Valid AssetUpdateRequestDto asset) {
+        var wrapper = AssetUpdateRequestWrapperDto.Builder.newInstance().updateRequest(asset).assetId(assetId).build();
+        var assetResult = transformerRegistry.transform(wrapper, Asset.class);
+        if (assetResult.failed()) {
+            throw new InvalidRequestException(assetResult.getFailureMessages());
+        }
+        service.update(assetResult.getContent())
+                .orElseThrow(exceptionMapper(Asset.class, assetId));
+    }
+
+    @PUT
+    @Path("{assetId}/dataaddress")
+    @Override
+    public void updateDataAddress(@PathParam("assetId") String assetId, @Valid DataAddressDto dataAddress) {
+        var dataAddressResult = transformerRegistry.transform(dataAddress, DataAddress.class);
+        if (dataAddressResult.failed()) {
+            throw new InvalidRequestException(dataAddressResult.getFailureMessages());
+        }
+        service.update(assetId, dataAddressResult.getContent())
+                .orElseThrow(exceptionMapper(DataAddress.class, assetId));
+    }
+
+    @GET
+    @Path("{id}/address")
+    @Override
+    public DataAddressDto getAssetDataAddress(@PathParam("id") String id) {
+        return of(id)
+                .map(it -> dataAddressResolver.resolveForAsset(id))
+                .map(it -> transformerRegistry.transform(it, DataAddressDto.class))
+                .filter(Result::succeeded)
+                .map(Result::getContent)
+                .orElseThrow(() -> new ObjectNotFoundException(Asset.class, id));
+    }
+
+    private List<AssetResponseNewDto> queryAssets(QuerySpecDto querySpecDto) {
+        var transformationResult = transformerRegistry.transform(querySpecDto, QuerySpec.class);
+        if (transformationResult.failed()) {
+            throw new InvalidRequestException(transformationResult.getFailureMessages());
+        }
+
+        var spec = transformationResult.getContent();
+
+        try (var assets = service.query(spec).orElseThrow(exceptionMapper(QuerySpec.class, null))) {
+            return assets
+                    .map(it -> transformerRegistry.transform(it, JsonObject.class))
+                    .filter(Result::succeeded)
+                    .map(Result::getContent)
+                    .map(this::expand)
+                    .filter(Objects::nonNull)
+                    .collect(toList());
+        }
+    }
+
+    private AssetResponseNewDto expand(JsonObject jsonObject) {
+        var expanded = JsonLdUtil.expand(jsonObject);
+        if (expanded.size() > 0) {
+            return AssetResponseNewDto.Builder.newInstance().asset(expanded.getJsonObject(0)).build();
+        }
+        return null;
+    }
+
+
+}

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/model/AssetEntryNewDto.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/model/AssetEntryNewDto.java
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.asset.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.json.JsonObject;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+@JsonDeserialize(builder = AssetEntryNewDto.Builder.class)
+public class AssetEntryNewDto {
+    @NotNull(message = "asset cannot be null")
+    private JsonObject asset;
+
+    @NotNull(message = "dataAddress cannot be null")
+    @Valid
+    private DataAddressDto dataAddress;
+
+    public DataAddressDto getDataAddress() {
+        return dataAddress;
+    }
+
+    @Schema(implementation = Object.class, description = "A JSON structure in JSON-LD format containing the Asset's properties. Cannot be null.")
+    public JsonObject getAsset() {
+        return asset;
+    }
+
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static final class Builder {
+
+        private final AssetEntryNewDto assetEntryDto;
+
+        private Builder() {
+            assetEntryDto = new AssetEntryNewDto();
+        }
+
+        @JsonCreator
+        public static AssetEntryNewDto.Builder newInstance() {
+            return new AssetEntryNewDto.Builder();
+        }
+
+        public AssetEntryNewDto.Builder asset(JsonObject asset) {
+            assetEntryDto.asset = asset;
+            return this;
+        }
+
+        public AssetEntryNewDto.Builder dataAddress(DataAddressDto dataAddress) {
+            assetEntryDto.dataAddress = dataAddress;
+            return this;
+        }
+
+        public AssetEntryNewDto build() {
+            return assetEntryDto;
+        }
+    }
+}

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/model/AssetResponseNewDto.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/model/AssetResponseNewDto.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.asset.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.api.model.BaseResponseDto;
+
+@JsonDeserialize(builder = AssetResponseNewDto.Builder.class)
+public class AssetResponseNewDto extends BaseResponseDto {
+    private JsonObject asset;
+
+    @Schema(implementation = Object.class, description = "A JSON structure in JSON-LD format containing the Asset's properties.")
+    public JsonObject getAsset() {
+        return asset;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder extends BaseResponseDto.Builder<AssetResponseNewDto, AssetResponseNewDto.Builder> {
+
+        private Builder() {
+            super(new AssetResponseNewDto());
+        }
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder asset(JsonObject asset) {
+            dto.asset = asset;
+            return this;
+        }
+
+        @Override
+        public Builder self() {
+            return this;
+        }
+    }
+}

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/model/AssetUpdateRequestNewDto.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/model/AssetUpdateRequestNewDto.java
@@ -1,0 +1,18 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.asset.model;
+
+public class AssetUpdateRequestNewDto {
+}

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/AssetApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/AssetApiControllerTest.java
@@ -54,16 +54,11 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ApiTest
-public class AssetApiControllerIntegrationTest extends RestControllerTestBase {
+public class AssetApiControllerTest extends RestControllerTestBase {
 
     private final AssetService service = mock(AssetService.class);
     private final DataAddressResolver dataAddressResolver = mock(DataAddressResolver.class);
     private final TypeTransformerRegistry transformerRegistry = mock(TypeTransformerRegistry.class);
-
-    @Override
-    protected Object controller() {
-        return new AssetApiController(monitor, service, dataAddressResolver, transformerRegistry);
-    }
 
     @Test
     void getAllAssets() {
@@ -477,6 +472,11 @@ public class AssetApiControllerIntegrationTest extends RestControllerTestBase {
                 .then()
                 .statusCode(400);
         verifyNoInteractions(service);
+    }
+
+    @Override
+    protected Object controller() {
+        return new AssetApiController(monitor, service, dataAddressResolver, transformerRegistry);
     }
 
     private AssetEntryDto createAssetEntryDto() {

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/AssetNewApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/AssetNewApiControllerTest.java
@@ -1,0 +1,490 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.asset;
+
+import io.restassured.specification.RequestSpecification;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import org.eclipse.edc.api.query.QuerySpecDto;
+import org.eclipse.edc.connector.api.management.asset.model.AssetEntryNewDto;
+import org.eclipse.edc.connector.api.management.asset.model.AssetResponseDto;
+import org.eclipse.edc.connector.api.management.asset.model.AssetResponseNewDto;
+import org.eclipse.edc.connector.api.management.asset.model.AssetUpdateRequestDto;
+import org.eclipse.edc.connector.api.management.asset.model.AssetUpdateRequestWrapperDto;
+import org.eclipse.edc.connector.api.management.asset.model.DataAddressDto;
+import org.eclipse.edc.connector.spi.asset.AssetService;
+import org.eclipse.edc.junit.annotations.ApiTest;
+import org.eclipse.edc.service.spi.result.ServiceResult;
+import org.eclipse.edc.spi.asset.DataAddressResolver;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.asset.Asset;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.EDC_ASSET_TYPE;
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ApiTest
+class AssetNewApiControllerTest extends RestControllerTestBase {
+
+    private static final String TEST_ASSET_ID = "test-asset-id";
+    private static final String TEST_ASSET_CONTENTTYPE = "application/json";
+    private static final String TEST_ASSET_DESCRIPTION = "test description";
+    private static final String TEST_ASSET_VERSION = "0.4.2";
+    private static final String TEST_ASSET_NAME = "test-asset";
+    private final AssetService service = mock(AssetService.class);
+    private final DataAddressResolver dataAddressResolver = mock(DataAddressResolver.class);
+    private final TypeTransformerRegistry transformerRegistry = mock(TypeTransformerRegistry.class);
+
+    @Test
+    void requestAsset() {
+        when(service.query(any()))
+                .thenReturn(ServiceResult.success(Stream.of(Asset.Builder.newInstance().build())));
+        when(transformerRegistry.transform(isA(Asset.class), eq(JsonObject.class)))
+                .thenReturn(Result.success(createAssetJson().build()));
+        when(transformerRegistry.transform(isA(QuerySpecDto.class), eq(QuerySpec.class)))
+                .thenReturn(Result.success(QuerySpec.Builder.newInstance().offset(10).build()));
+
+        baseRequest()
+                .contentType(JSON)
+                .post("/assets/request")
+                .then()
+                .log().ifError()
+                .statusCode(200)
+                .contentType(JSON)
+                .body("size()", is(1));
+        verify(service).query(argThat(s -> s.getOffset() == 10));
+        verify(transformerRegistry).transform(isA(Asset.class), eq(JsonObject.class));
+        verify(transformerRegistry).transform(isA(QuerySpecDto.class), eq(QuerySpec.class));
+    }
+
+    @Test
+    void requestAsset_filtersOutFailedTransforms() {
+        when(service.query(any()))
+                .thenReturn(ServiceResult.success(Stream.of(Asset.Builder.newInstance().build())));
+        when(transformerRegistry.transform(isA(QuerySpecDto.class), eq(QuerySpec.class)))
+                .thenReturn(Result.success(QuerySpec.Builder.newInstance().offset(10).build()));
+        when(transformerRegistry.transform(isA(Asset.class), eq(JsonObject.class)))
+                .thenReturn(Result.failure("failed to transform"));
+
+        baseRequest()
+                .contentType(JSON)
+                .post("/assets/request")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .body("size()", is(0));
+    }
+
+    @Test
+    void requestAsset_shouldReturnBadRequest_whenQueryIsInvalid() {
+        baseRequest()
+                .body(Map.of("offset", -1))
+                .contentType(JSON)
+                .post("/assets/request")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    void requestAsset_shouldReturnBadRequest_whenQueryTransformFails() {
+        when(transformerRegistry.transform(isA(QuerySpecDto.class), eq(QuerySpec.class)))
+                .thenReturn(Result.failure("error"));
+        when(service.query(any())).thenReturn(ServiceResult.success());
+
+        baseRequest()
+                .contentType(JSON)
+                .post("/assets/request")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    void requestAsset_shouldReturnBadRequest_whenServiceReturnsBadRequest() {
+        when(transformerRegistry.transform(isA(QuerySpecDto.class), eq(QuerySpec.class)))
+                .thenReturn(Result.success(QuerySpec.Builder.newInstance().build()));
+        when(service.query(any())).thenReturn(ServiceResult.badRequest());
+
+        baseRequest()
+                .contentType(JSON)
+                .post("/assets/request")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    void getSingleAsset() {
+        var asset = Asset.Builder.newInstance().property("key", "value").build();
+        when(service.findById("id")).thenReturn(asset);
+        var jobj = createAssetJson().build();
+        when(transformerRegistry.transform(isA(Asset.class), eq(JsonObject.class))).thenReturn(Result.success(jobj));
+
+        var response = baseRequest()
+                .get("/assets/id")
+                .then()
+                .statusCode(200)
+                .contentType(JSON);
+        var dto = response.extract().body().as(AssetResponseNewDto.class);
+        assertThat(dto.getAsset()).isNotNull();
+        verify(transformerRegistry).transform(isA(Asset.class), eq(JsonObject.class));
+    }
+
+    @Test
+    void getSingleAsset_notFound() {
+        when(service.findById(any())).thenReturn(null);
+
+        baseRequest()
+                .get("/assets/not-existent-id")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    void getAssetById_shouldReturnNotFound_whenTransformFails() {
+        when(service.findById("id")).thenReturn(Asset.Builder.newInstance().build());
+        when(transformerRegistry.transform(isA(Asset.class), eq(AssetResponseDto.class))).thenReturn(Result.failure("failure"));
+
+        baseRequest()
+                .get("/assets/id")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    void createAsset() {
+        var assetEntry = createAssetEntryDto();
+        var asset = createAssetBuilder().build();
+        when(transformerRegistry.transform(isA(JsonObject.class), eq(Asset.class))).thenReturn(Result.success(asset));
+        when(transformerRegistry.transform(isA(DataAddressDto.class), eq(DataAddress.class))).thenReturn(Result.success(DataAddress.Builder.newInstance().type("any").build()));
+        when(service.create(any(), any())).thenReturn(ServiceResult.success(asset));
+
+        var resp = baseRequest()
+                .contentType(JSON)
+                .body(assetEntry)
+                .post("/assets")
+                .then();
+        resp.statusCode(200)
+                .contentType(JSON)
+                .body("id", is(TEST_ASSET_ID))
+                .body("createdAt", greaterThan(0L));
+
+        verify(transformerRegistry).transform(any(), eq(Asset.class));
+        verify(transformerRegistry).transform(any(), eq(DataAddress.class));
+        verify(service).create(isA(Asset.class), isA(DataAddress.class));
+    }
+
+    @Test
+    void createAsset_shouldReturnBadRequest_whenDataAddressIsNull() {
+        var assetDto = createAssetJson().build();
+        var assetEntryDto = AssetEntryNewDto.Builder.newInstance().asset(assetDto).dataAddress(null).build();
+
+        baseRequest()
+                .body(assetEntryDto)
+                .contentType(JSON)
+                .post("/assets")
+                .then()
+                .statusCode(400);
+        verifyNoInteractions(service);
+    }
+
+    @Test
+    void createAsset_shouldReturnBadRequest_whenTransformFails() {
+        when(transformerRegistry.transform(isA(JsonObject.class), eq(Asset.class))).thenReturn(Result.failure("failed"));
+        when(transformerRegistry.transform(isA(DataAddressDto.class), eq(DataAddress.class))).thenReturn(Result.failure("failed"));
+
+        baseRequest()
+                .body(createAssetEntryDto())
+                .contentType(JSON)
+                .post("/assets")
+                .then()
+                .statusCode(400);
+        verify(service, never()).create(any(), any());
+    }
+
+    @Test
+    void createAsset_alreadyExists() {
+        var asset = createAssetBuilder().build();
+        when(transformerRegistry.transform(isA(JsonObject.class), eq(Asset.class))).thenReturn(Result.success(asset));
+        when(transformerRegistry.transform(isA(DataAddressDto.class), eq(DataAddress.class))).thenReturn(Result.success(DataAddress.Builder.newInstance().type("any").build()));
+        when(service.create(any(), any())).thenReturn(ServiceResult.conflict("already exists"));
+
+        baseRequest()
+                .body(createAssetEntryDto())
+                .contentType(JSON)
+                .post("/assets")
+                .then()
+                .statusCode(409);
+    }
+
+    @Test
+    void createAsset_emptyAttributes() {
+        when(transformerRegistry.transform(isA(JsonObject.class), eq(Asset.class))).thenReturn(Result.failure("Cannot be transformed"));
+        when(transformerRegistry.transform(isA(DataAddressDto.class), eq(DataAddress.class))).thenReturn(Result.success(DataAddress.Builder.newInstance().type("any").build()));
+        var assetEntryDto = AssetEntryNewDto.Builder.newInstance()
+                .asset(Json.createObjectBuilder().build())
+                .dataAddress(DataAddressDto.Builder.newInstance().properties(Map.of("type", "any")).build())
+                .build();
+
+        baseRequest()
+                .body(assetEntryDto)
+                .contentType(JSON)
+                .post("/assets")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    void deleteAsset() {
+        when(service.delete("assetId"))
+                .thenReturn(ServiceResult.success(createAssetBuilder().build()));
+
+        baseRequest()
+                .contentType(JSON)
+                .delete("/assets/assetId")
+                .then()
+                .statusCode(204);
+        verify(service).delete("assetId");
+    }
+
+    @Test
+    void deleteAsset_notExists() {
+        when(service.delete(any())).thenReturn(ServiceResult.notFound("not found"));
+
+        baseRequest()
+                .contentType(JSON)
+                .delete("/assets/not-existent-id")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    void deleteAsset_conflicts() {
+        when(service.delete(any())).thenReturn(ServiceResult.conflict("conflict"));
+
+        baseRequest()
+                .contentType(JSON)
+                .delete("/assets/id")
+                .then()
+                .statusCode(409);
+    }
+
+    @Test
+    void getAssetAddress() {
+        when(dataAddressResolver.resolveForAsset("id"))
+                .thenReturn(DataAddress.Builder.newInstance().type("any").build());
+        var dataAddressDto = DataAddressDto.Builder.newInstance().properties(Map.of("key", "value")).build();
+        when(transformerRegistry.transform(isA(DataAddress.class), eq(DataAddressDto.class)))
+                .thenReturn(Result.success(dataAddressDto));
+
+        baseRequest()
+                .get("/assets/id/address")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .body("properties.size()", greaterThan(0));
+        verify(transformerRegistry).transform(isA(DataAddress.class), eq(DataAddressDto.class));
+    }
+
+    @Test
+    void getAssetAddress_notFound() {
+        when(dataAddressResolver.resolveForAsset(any())).thenReturn(null);
+
+        baseRequest()
+                .get("/assets/not-existent-id/address")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    void updateAsset_whenExists() {
+        var assetEntry = AssetUpdateRequestDto.Builder.newInstance()
+                .properties(Map.of("key1", "value1"))
+                .build();
+        var asset = Asset.Builder.newInstance().property("key1", "value1").build();
+        when(transformerRegistry.transform(isA(AssetUpdateRequestWrapperDto.class), eq(Asset.class)))
+                .thenReturn(Result.success(asset));
+        when(service.update(any(Asset.class))).thenReturn(ServiceResult.success());
+
+        baseRequest()
+                .body(assetEntry)
+                .contentType(JSON)
+                .put("/assets/assetId")
+                .then()
+                .statusCode(204);
+        verify(service).update(eq(asset));
+    }
+
+    @Test
+    void updateAsset_shouldReturnNotFound_whenItDoesNotExists() {
+        var assetEntry = AssetUpdateRequestDto.Builder.newInstance()
+                .properties(Map.of("key1", "value1"))
+                .build();
+        var asset = Asset.Builder.newInstance().property("key1", "value1").build();
+        when(transformerRegistry.transform(isA(AssetUpdateRequestWrapperDto.class), eq(Asset.class)))
+                .thenReturn(Result.success(asset));
+        when(service.update(any(Asset.class))).thenReturn(ServiceResult.notFound("not found"));
+
+        baseRequest()
+                .body(assetEntry)
+                .contentType(JSON)
+                .put("/assets/assetId")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    void updateAsset_shouldReturnBadRequest_whenTransformFails() {
+        var assetEntry = AssetUpdateRequestDto.Builder.newInstance()
+                .properties(Map.of("key1", "value1"))
+                .build();
+        when(transformerRegistry.transform(isA(AssetUpdateRequestWrapperDto.class), eq(Asset.class)))
+                .thenReturn(Result.failure("error"));
+
+        baseRequest()
+                .body(assetEntry)
+                .contentType(JSON)
+                .put("/assets/assetId")
+                .then()
+                .statusCode(400);
+        verifyNoInteractions(service);
+    }
+
+    @Test
+    void updateDataAddress_whenAssetExists() {
+        var dataAddressDto = DataAddressDto.Builder.newInstance()
+                .properties(Map.of("type", "test-type"))
+                .build();
+        var dataAddress = DataAddress.Builder.newInstance().type("test-type").property("key1", "value1").build();
+        when(transformerRegistry.transform(isA(DataAddressDto.class), eq(DataAddress.class)))
+                .thenReturn(Result.success(dataAddress));
+        when(service.update(any(), any(DataAddress.class))).thenReturn(ServiceResult.success());
+
+        baseRequest()
+                .body(dataAddressDto)
+                .contentType(JSON)
+                .put("/assets/assetId/dataaddress")
+                .then()
+                .statusCode(204);
+        verify(service).update(eq("assetId"), eq(dataAddress));
+    }
+
+    @Test
+    void updateDataAddress_shouldReturnNotFound_whenItDoesNotExists() {
+        var dataAddressDto = DataAddressDto.Builder.newInstance()
+                .properties(Map.of("type", "test-type"))
+                .build();
+        var dataAddress = DataAddress.Builder.newInstance().type("test-type").property("key1", "value1").build();
+        when(transformerRegistry.transform(isA(DataAddressDto.class), eq(DataAddress.class))).thenReturn(Result.success(dataAddress));
+        when(service.update(any(), any(DataAddress.class))).thenReturn(ServiceResult.notFound("not found"));
+
+        baseRequest()
+                .body(dataAddressDto)
+                .contentType(JSON)
+                .put("/assets/assetId/dataaddress")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    void updateDataAddress_shouldReturnBadRequest_whenTransformationFails() {
+        var dataAddressDto = DataAddressDto.Builder.newInstance()
+                .properties(Map.of("type", "test-type"))
+                .build();
+        when(transformerRegistry.transform(isA(DataAddressDto.class), eq(DataAddress.class)))
+                .thenReturn(Result.failure("error"));
+
+        baseRequest()
+                .body(dataAddressDto)
+                .contentType(JSON)
+                .put("/assets/assetId/dataaddress")
+                .then()
+                .statusCode(400);
+        verifyNoInteractions(service);
+    }
+
+    @Override
+    protected Object controller() {
+        return new AssetNewApiController(service, dataAddressResolver, transformerRegistry);
+    }
+
+    private AssetEntryNewDto createAssetEntryDto() {
+        return AssetEntryNewDto.Builder.newInstance()
+                .asset(createAssetJson().build())
+                .dataAddress(DataAddressDto.Builder.newInstance().properties(Map.of("type", "any")).build())
+                .build();
+    }
+
+    private JsonObjectBuilder createAssetJson() {
+        return Json.createObjectBuilder()
+                .add(CONTEXT, createContextBuilder().build())
+                .add(TYPE, EDC_ASSET_TYPE)
+                .add(ID, TEST_ASSET_ID)
+                .add("properties", createPropertiesBuilder().build());
+    }
+
+    private JsonObjectBuilder createPropertiesBuilder() {
+        return Json.createObjectBuilder()
+                .add("name", TEST_ASSET_NAME)
+                .add("description", TEST_ASSET_DESCRIPTION)
+                .add("edc:version", TEST_ASSET_VERSION)
+                .add("contenttype", TEST_ASSET_CONTENTTYPE);
+    }
+
+    private JsonObjectBuilder createContextBuilder() {
+        return Json.createObjectBuilder()
+                .add(VOCAB, EDC_NAMESPACE)
+                .add("edc", EDC_NAMESPACE);
+    }
+
+    private RequestSpecification baseRequest() {
+        return given()
+                .baseUri("http://localhost:" + port + "/v2")
+                .when();
+    }
+
+    private Asset.Builder createAssetBuilder() {
+        return Asset.Builder.newInstance()
+                .name(TEST_ASSET_NAME)
+                .id(TEST_ASSET_ID)
+                .contentType(TEST_ASSET_CONTENTTYPE)
+                .description(TEST_ASSET_DESCRIPTION)
+                .version(TEST_ASSET_VERSION);
+    }
+}

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/AssetNewApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/AssetNewApiControllerTest.java
@@ -314,7 +314,7 @@ class AssetNewApiControllerTest extends RestControllerTestBase {
                 .thenReturn(Result.success(dataAddressDto));
 
         baseRequest()
-                .get("/assets/id/address")
+                .get("/assets/id/dataaddress")
                 .then()
                 .statusCode(200)
                 .contentType(JSON)

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/model/AssetEntryNewDtoTest.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/model/AssetEntryNewDtoTest.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2022 ZF Friedrichshafen AG
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       ZF Friedrichshafen AG - Initial API and Implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.asset.model;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static jakarta.json.Json.createObjectBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
+import static org.eclipse.edc.jsonld.util.JacksonJsonLd.createObjectMapper;
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
+
+public class AssetEntryNewDtoTest {
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = createObjectMapper();
+    }
+
+    @Test
+    void verifySerialization() throws JsonProcessingException {
+
+        var assetDto = createObjectBuilder()
+                .add(TYPE, EDC_NAMESPACE + "Asset")
+                .add(ID, "test-asset-id")
+                .add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE).build()) //default namespace
+                .add(EDC_NAMESPACE + "properties", createObjectBuilder()
+                        .add(EDC_NAMESPACE + "name", "test-name"))
+                .build();
+        var dataAddress = DataAddressDto.Builder.newInstance().properties(Collections.singletonMap("type", "test-type")).build();
+        var assetEntryDto = AssetEntryNewDto.Builder.newInstance().asset(assetDto).dataAddress(dataAddress).build();
+
+        var str = objectMapper.writeValueAsString(assetEntryDto);
+
+        assertThat(str).isNotNull();
+
+        var deserialized = objectMapper.readValue(str, AssetEntryNewDto.class);
+        assertThat(deserialized).usingRecursiveComparison().isEqualTo(assetEntryDto);
+    }
+}

--- a/extensions/control-plane/store/cosmos/asset-index-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/assetindex/model/AssetDocument.java
+++ b/extensions/control-plane/store/cosmos/asset-index-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/assetindex/model/AssetDocument.java
@@ -19,12 +19,13 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import org.eclipse.edc.azure.cosmos.CosmosDocument;
-import org.eclipse.edc.spi.CoreConstants;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
 
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 
 @JsonTypeName("dataspaceconnector:assetdocument")
 public class AssetDocument extends CosmosDocument<Map<String, Object>> {
@@ -47,7 +48,7 @@ public class AssetDocument extends CosmosDocument<Map<String, Object>> {
                          @JsonProperty("dataAddress") DataAddress dataAddress,
                          @JsonProperty("createdAt") long createdAt) {
         super(wrappedInstance, partitionKey);
-        id = wrappedInstance.get(sanitize(CoreConstants.EDC_NAMESPACE) + "id").toString();
+        id = wrappedInstance.get(sanitize(EDC_NAMESPACE) + "id").toString();
         this.dataAddress = dataAddress;
         this.createdAt = createdAt;
     }

--- a/extensions/control-plane/store/cosmos/asset-index-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/assetindex/model/AssetDocument.java
+++ b/extensions/control-plane/store/cosmos/asset-index-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/assetindex/model/AssetDocument.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import org.eclipse.edc.azure.cosmos.CosmosDocument;
+import org.eclipse.edc.spi.CoreConstants;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
 
@@ -46,7 +47,7 @@ public class AssetDocument extends CosmosDocument<Map<String, Object>> {
                          @JsonProperty("dataAddress") DataAddress dataAddress,
                          @JsonProperty("createdAt") long createdAt) {
         super(wrappedInstance, partitionKey);
-        id = wrappedInstance.get("asset_prop_id").toString();
+        id = wrappedInstance.get(sanitize(CoreConstants.EDC_NAMESPACE) + "id").toString();
         this.dataAddress = dataAddress;
         this.createdAt = createdAt;
     }

--- a/extensions/control-plane/store/cosmos/asset-index-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/assetindex/model/AssetDocumentSerializationTest.java
+++ b/extensions/control-plane/store/cosmos/asset-index-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/assetindex/model/AssetDocumentSerializationTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.connector.store.azure.cosmos.assetindex.model;
 
-import org.eclipse.edc.spi.CoreConstants;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
@@ -23,10 +22,11 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.azure.cosmos.CosmosDocument.sanitize;
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 
 class AssetDocumentSerializationTest {
 
-    private static final String PREFIX = CoreConstants.EDC_NAMESPACE;
+    private static final String PREFIX = EDC_NAMESPACE;
     private TypeManager typeManager;
 
     private static Asset createAsset() {

--- a/extensions/control-plane/store/cosmos/asset-index-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/assetindex/model/AssetDocumentSerializationTest.java
+++ b/extensions/control-plane/store/cosmos/asset-index-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/assetindex/model/AssetDocumentSerializationTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.connector.store.azure.cosmos.assetindex.model;
 
+import org.eclipse.edc.spi.CoreConstants;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
@@ -21,9 +22,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.azure.cosmos.CosmosDocument.sanitize;
 
 class AssetDocumentSerializationTest {
 
+    private static final String PREFIX = CoreConstants.EDC_NAMESPACE;
     private TypeManager typeManager;
 
     private static Asset createAsset() {
@@ -50,12 +53,13 @@ class AssetDocumentSerializationTest {
 
         String s = typeManager.writeValueAsString(document);
 
+        var prefix = sanitize(PREFIX);
         assertThat(s).isNotNull()
                 .contains("\"partitionKey\":\"partitionkey-test\"")
-                .contains("\"asset_prop_id\":\"id-test\"")
-                .contains("\"asset_prop_name\":\"node-test\"")
-                .contains("\"asset_prop_version\":\"123\"")
-                .contains("\"asset_prop_contenttype\":\"application/json\"")
+                .contains("\"" + prefix + "id\":\"id-test\"")
+                .contains("\"" + prefix + "name\":\"node-test\"")
+                .contains("\"" + prefix + "version\":\"123\"")
+                .contains("\"" + prefix + "contenttype\":\"application/json\"")
                 .contains("\"foo\":\"bar\"")
                 .contains("\"wrappedInstance\":")
                 .contains("\"id\":\"id-test\"");

--- a/extensions/control-plane/store/cosmos/transfer-process-store-cosmos/src/test/resources/raw_json.json
+++ b/extensions/control-plane/store/cosmos/transfer-process-store-cosmos/src/test/resources/raw_json.json
@@ -15,8 +15,8 @@
       "connectorId": null,
       "asset": {
         "properties": {
-          "asset:prop:policy-id": "test-policyId",
-          "asset:prop:id": "asset-id"
+          "https://foo.bar.org/ds/schema/policy-id": "test-policyId",
+          "https://foo.bar.org/ds/schema/id": "asset-id"
         }
       },
       "dataDestination": {

--- a/resources/openapi/yaml/dsp-negotiation-api.yaml
+++ b/resources/openapi/yaml/dsp-negotiation-api.yaml
@@ -1,0 +1,380 @@
+openapi: 3.0.1
+paths:
+  /negotiations/request:
+    post:
+      operationId: initiateNegotiation
+      parameters:
+      - in: header
+        name: Authorization
+        schema:
+          type: string
+          example: null
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                $ref: '#/components/schemas/JsonValue'
+              example: null
+              properties:
+                empty:
+                  type: boolean
+                  example: null
+                valueType:
+                  type: string
+                  enum:
+                  - ARRAY
+                  - OBJECT
+                  - STRING
+                  - NUMBER
+                  - "TRUE"
+                  - "FALSE"
+                  - "NULL"
+                  example: null
+        description: https://w3id.org/dspace/v0.8/ContractRequestMessage
+        required: true
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: object
+                  example: null
+                example: null
+          description: default response
+  /negotiations/{id}:
+    get:
+      operationId: getNegotiation
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+          example: null
+      - in: header
+        name: Authorization
+        schema:
+          type: string
+          example: null
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: object
+                  example: null
+                example: null
+          description: default response
+  /negotiations/{id}/agreement:
+    post:
+      operationId: createAgreement
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+          example: null
+      - in: header
+        name: Authorization
+        schema:
+          type: string
+          example: null
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                $ref: '#/components/schemas/JsonValue'
+              example: null
+              properties:
+                empty:
+                  type: boolean
+                  example: null
+                valueType:
+                  type: string
+                  enum:
+                  - ARRAY
+                  - OBJECT
+                  - STRING
+                  - NUMBER
+                  - "TRUE"
+                  - "FALSE"
+                  - "NULL"
+                  example: null
+        description: https://w3id.org/dspace/v0.8/ContractAgreementMessage
+        required: true
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+  /negotiations/{id}/agreement/verification:
+    post:
+      operationId: verifyAgreement
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+          example: null
+      - in: header
+        name: Authorization
+        schema:
+          type: string
+          example: null
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                $ref: '#/components/schemas/JsonValue'
+              example: null
+              properties:
+                empty:
+                  type: boolean
+                  example: null
+                valueType:
+                  type: string
+                  enum:
+                  - ARRAY
+                  - OBJECT
+                  - STRING
+                  - NUMBER
+                  - "TRUE"
+                  - "FALSE"
+                  - "NULL"
+                  example: null
+        description: https://w3id.org/dspace/v0.8/ContractAgreementVerificationMessage
+        required: true
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+  /negotiations/{id}/events:
+    post:
+      operationId: createEvent
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+          example: null
+      - in: header
+        name: Authorization
+        schema:
+          type: string
+          example: null
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                $ref: '#/components/schemas/JsonValue'
+              example: null
+              properties:
+                empty:
+                  type: boolean
+                  example: null
+                valueType:
+                  type: string
+                  enum:
+                  - ARRAY
+                  - OBJECT
+                  - STRING
+                  - NUMBER
+                  - "TRUE"
+                  - "FALSE"
+                  - "NULL"
+                  example: null
+        description: https://w3id.org/dspace/v0.8/ContractNegotiationEventMessage
+        required: true
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+  /negotiations/{id}/offers:
+    post:
+      operationId: providerOffer
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+          example: null
+      - in: header
+        name: Authorization
+        schema:
+          type: string
+          example: null
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                $ref: '#/components/schemas/JsonValue'
+              example: null
+              properties:
+                empty:
+                  type: boolean
+                  example: null
+                valueType:
+                  type: string
+                  enum:
+                  - ARRAY
+                  - OBJECT
+                  - STRING
+                  - NUMBER
+                  - "TRUE"
+                  - "FALSE"
+                  - "NULL"
+                  example: null
+        description: https://w3id.org/dspace/v0.8/ContractOfferMessage
+        required: true
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+  /negotiations/{id}/request:
+    post:
+      operationId: consumerOffer
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+          example: null
+      - in: header
+        name: Authorization
+        schema:
+          type: string
+          example: null
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                $ref: '#/components/schemas/JsonValue'
+              example: null
+              properties:
+                empty:
+                  type: boolean
+                  example: null
+                valueType:
+                  type: string
+                  enum:
+                  - ARRAY
+                  - OBJECT
+                  - STRING
+                  - NUMBER
+                  - "TRUE"
+                  - "FALSE"
+                  - "NULL"
+                  example: null
+        description: https://w3id.org/dspace/v0.8/ContractRequestMessage
+        required: true
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+  /negotiations/{id}/termination:
+    post:
+      operationId: terminateNegotiation
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+          example: null
+      - in: header
+        name: Authorization
+        schema:
+          type: string
+          example: null
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                $ref: '#/components/schemas/JsonValue'
+              example: null
+              properties:
+                empty:
+                  type: boolean
+                  example: null
+                valueType:
+                  type: string
+                  enum:
+                  - ARRAY
+                  - OBJECT
+                  - STRING
+                  - NUMBER
+                  - "TRUE"
+                  - "FALSE"
+                  - "NULL"
+                  example: null
+        description: https://w3id.org/dspace/v0.8/ContractNegotiationTerminationMessage
+        required: true
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+components:
+  schemas:
+    JsonObject:
+      type: object
+      additionalProperties:
+        $ref: '#/components/schemas/JsonValue'
+      example: null
+      properties:
+        empty:
+          type: boolean
+          example: null
+        valueType:
+          type: string
+          enum:
+          - ARRAY
+          - OBJECT
+          - STRING
+          - NUMBER
+          - "TRUE"
+          - "FALSE"
+          - "NULL"
+          example: null
+    JsonValue:
+      type: object
+      example: null
+      properties:
+        valueType:
+          type: string
+          enum:
+          - ARRAY
+          - OBJECT
+          - STRING
+          - NUMBER
+          - "TRUE"
+          - "FALSE"
+          - "NULL"
+          example: null

--- a/resources/openapi/yaml/management-api/asset-api.yaml
+++ b/resources/openapi/yaml/management-api/asset-api.yaml
@@ -1,4 +1,11 @@
 openapi: 3.0.1
+info:
+  description: "This contains both the current and the new Asset API, which accepts\
+    \ JSON-LD and will become the standard API once the Dataspace Protocol is stable.\
+    \ The new Asset API is prefixed with /v2, and the old endpoints have been deprecated.\
+    \ At that time of switching, the old API will be removed, and this API will be\
+    \ available without the /v2 prefix."
+  title: Asset API
 paths:
   /assets:
     get:
@@ -57,6 +64,7 @@ paths:
       tags:
       - Asset
     post:
+      deprecated: true
       description: Creates a new asset together with a data address
       operationId: createAsset
       requestBody:
@@ -95,6 +103,7 @@ paths:
       - Asset
   /assets/request:
     post:
+      deprecated: true
       description: ' all assets according to a particular query'
       operationId: requestAssets
       requestBody:
@@ -124,6 +133,7 @@ paths:
       - Asset
   /assets/{assetId}:
     put:
+      deprecated: true
       description: "Updates an asset with the given ID if it exists. If the asset\
         \ is not found, no further action is taken. DANGER ZONE: Note that updating\
         \ assets can have unexpected results, especially for contract offers that\
@@ -159,6 +169,7 @@ paths:
       - Asset
   /assets/{assetId}/dataaddress:
     put:
+      deprecated: true
       description: Updates a DataAddress for an asset with the given ID.
       operationId: updateDataAddress
       parameters:
@@ -198,6 +209,7 @@ paths:
       - Asset
   /assets/{id}:
     delete:
+      deprecated: true
       description: "Removes an asset with the given ID if possible. Deleting an asset\
         \ is only possible if that asset is not yet referenced by a contract agreement,\
         \ in which case an error is returned. DANGER ZONE: Note that deleting assets\
@@ -245,6 +257,7 @@ paths:
       tags:
       - Asset
     get:
+      deprecated: true
       description: Gets an asset with the given ID
       operationId: getAsset
       parameters:
@@ -283,8 +296,273 @@ paths:
       - Asset
   /assets/{id}/address:
     get:
+      deprecated: true
       description: Gets a data address of an asset with the given ID
       operationId: getAssetDataAddress
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+          example: null
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataAddressDto'
+          description: The data address
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: "Request was malformed, e.g. id was null"
+        "404":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: An asset with the given ID does not exist
+      tags:
+      - Asset
+  /v2/assets:
+    post:
+      description: Creates a new asset together with a data address
+      operationId: createAsset_1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssetEntryNewDto'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdResponseDto'
+          description: Asset was created successfully. Returns the asset Id and created
+            timestamp
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: Request body was malformed
+        "409":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: "Could not create asset, because an asset with that ID already\
+            \ exists"
+      tags:
+      - Asset
+  /v2/assets/request:
+    post:
+      description: ' all assets according to a particular query'
+      operationId: requestAssets_1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QuerySpecDto'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/AssetResponseDto'
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: Request body was malformed
+      tags:
+      - Asset
+  /v2/assets/{assetId}:
+    put:
+      description: "Updates an asset with the given ID if it exists. If the asset\
+        \ is not found, no further action is taken. DANGER ZONE: Note that updating\
+        \ assets can have unexpected results, especially for contract offers that\
+        \ have been sent out or are ongoing in contract negotiations."
+      operationId: updateAsset_1
+      parameters:
+      - in: path
+        name: assetId
+        required: true
+        schema:
+          type: string
+          example: null
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssetUpdateRequestDto'
+      responses:
+        "200":
+          description: Asset was updated successfully
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: "Request was malformed, e.g. id was null"
+        "404":
+          description: "Asset could not be updated, because it does not exist."
+      tags:
+      - Asset
+  /v2/assets/{assetId}/dataaddress:
+    put:
+      description: Updates a DataAddress for an asset with the given ID.
+      operationId: updateDataAddress_1
+      parameters:
+      - in: path
+        name: assetId
+        required: true
+        schema:
+          type: string
+          example: null
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DataAddressDto'
+      responses:
+        "200":
+          description: Asset was updated successfully
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: "Request was malformed, e.g. id was null"
+        "404":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: An asset with the given ID does not exist
+      tags:
+      - Asset
+  /v2/assets/{id}:
+    delete:
+      description: "Removes an asset with the given ID if possible. Deleting an asset\
+        \ is only possible if that asset is not yet referenced by a contract agreement,\
+        \ in which case an error is returned. DANGER ZONE: Note that deleting assets\
+        \ can have unexpected results, especially for contract offers that have been\
+        \ sent out or ongoing or contract negotiations."
+      operationId: removeAsset_1
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+          example: null
+      responses:
+        "200":
+          description: Asset was deleted successfully
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: "Request was malformed, e.g. id was null"
+        "404":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: An asset with the given ID does not exist
+        "409":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: "The asset cannot be deleted, because it is referenced by a\
+            \ contract agreement"
+      tags:
+      - Asset
+    get:
+      description: Gets an asset with the given ID
+      operationId: getAsset_1
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+          example: null
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetResponseDto'
+          description: The asset
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: "Request was malformed, e.g. id was null"
+        "404":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: An asset with the given ID does not exist
+      tags:
+      - Asset
+  /v2/assets/{id}/address:
+    get:
+      description: Gets a data address of an asset with the given ID
+      operationId: getAssetDataAddress_1
       parameters:
       - in: path
         name: id
@@ -363,6 +641,20 @@ components:
       required:
       - asset
       - dataAddress
+    AssetEntryNewDto:
+      type: object
+      example: null
+      properties:
+        asset:
+          type: object
+          description: A JSON structure in JSON-LD format containing the Asset's properties.
+            Cannot be null.
+          example: null
+        dataAddress:
+          $ref: '#/components/schemas/DataAddressDto'
+      required:
+      - asset
+      - dataAddress
     AssetResponseDto:
       type: object
       example: null
@@ -379,6 +671,18 @@ components:
           additionalProperties:
             type: object
             example: null
+          example: null
+    AssetResponseNewDto:
+      type: object
+      example: null
+      properties:
+        asset:
+          type: object
+          description: A JSON structure in JSON-LD format containing the Asset's properties.
+          example: null
+        createdAt:
+          type: integer
+          format: int64
           example: null
     AssetUpdateRequestDto:
       type: object

--- a/resources/openapi/yaml/management-api/asset-api.yaml
+++ b/resources/openapi/yaml/management-api/asset-api.yaml
@@ -559,7 +559,7 @@ paths:
           description: An asset with the given ID does not exist
       tags:
       - Asset
-  /v2/assets/{id}/address:
+  /v2/assets/{id}/dataaddress:
     get:
       description: Gets a data address of an asset with the given ID
       operationId: getAssetDataAddress_1

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/Result.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/Result.java
@@ -52,18 +52,11 @@ public class Result<T> extends AbstractResult<T, Failure, Result<T>> {
      * Converts a {@link Optional} into a result, interpreting the Optional's value as content.
      *
      * @return {@link Result#failure(String)} if the Optional is empty, {@link Result#success(Object)} using the
-     *         Optional's value otherwise.
+     * Optional's value otherwise.
      */
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     public static <T> Result<T> from(Optional<T> opt) {
         return opt.map(Result::success).orElse(Result.failure("Empty optional"));
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    @NotNull
-    protected <R1 extends AbstractResult<C1, Failure, R1>, C1> R1 newInstance(@Nullable C1 content, @Nullable Failure failure) {
-        return (R1) new Result<>(content, failure);
     }
 
     /**
@@ -72,7 +65,7 @@ public class Result<T> extends AbstractResult<T, Failure, Result<T>> {
      * all failure messages, no content. If both results are failures, the merged result will contain failure messages
      * of {@code this} result, then the failure messages of {@code other}.
      */
-    public Result<T> merge(Result<T> other) {
+    public <R> Result<R> merge(Result<?> other) {
         if (succeeded() && other.succeeded()) {
             return new Result<>(null, null);
         } else {
@@ -130,6 +123,13 @@ public class Result<T> extends AbstractResult<T, Failure, Result<T>> {
      */
     public Optional<T> asOptional() {
         return succeeded() && getContent() != null ? Optional.of(getContent()) : Optional.empty();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    @NotNull
+    protected <R1 extends AbstractResult<C1, Failure, R1>, C1> R1 newInstance(@Nullable C1 content, @Nullable Failure failure) {
+        return (R1) new Result<>(content, failure);
     }
 
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/Result.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/Result.java
@@ -51,8 +51,7 @@ public class Result<T> extends AbstractResult<T, Failure, Result<T>> {
     /**
      * Converts a {@link Optional} into a result, interpreting the Optional's value as content.
      *
-     * @return {@link Result#failure(String)} if the Optional is empty, {@link Result#success(Object)} using the
-     * Optional's value otherwise.
+     * @return {@link Result#failure(String)} if the Optional is empty, {@link Result#success(Object)} using the Optional's value otherwise.
      */
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     public static <T> Result<T> from(Optional<T> opt) {

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/DataAddress.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/DataAddress.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 
 import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 
+
 /**
  * An address that can be used resolve a data location. Data addresses are used throughout the system. For example, an asset has a data address used to resolve its contents,
  * which may be in an external store. A data address can also be used as a destination to send data during a transfer.

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/asset/Asset.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/asset/Asset.java
@@ -25,6 +25,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
+import static java.util.Optional.ofNullable;
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
+
 
 /**
  * The {@link Asset} contains the metadata and describes the data itself or a collection of data.
@@ -32,12 +35,14 @@ import java.util.UUID;
 @JsonDeserialize(builder = Asset.Builder.class)
 public class Asset extends Entity {
 
-    @Deprecated(since = "Do not use anymore. The ID should be accessed through the getter")
-    public static final String PROPERTY_ID = "asset:prop:id";
-    public static final String PROPERTY_NAME = "asset:prop:name";
-    public static final String PROPERTY_DESCRIPTION = "asset:prop:description";
-    public static final String PROPERTY_VERSION = "asset:prop:version";
-    public static final String PROPERTY_CONTENT_TYPE = "asset:prop:contenttype";
+    public static final String PROPERTY_ID = EDC_NAMESPACE + "id";
+    public static final String PROPERTY_NAME = EDC_NAMESPACE + "name";
+    public static final String PROPERTY_DESCRIPTION = EDC_NAMESPACE + "description";
+    public static final String PROPERTY_VERSION = EDC_NAMESPACE + "version";
+    public static final String PROPERTY_CONTENT_TYPE = EDC_NAMESPACE + "contenttype";
+
+    @Deprecated(since = "milestone9")
+    private static final String DEPRECATED_PROPERTY_PREFIX = "asset:prop:";
 
     private final Map<String, Object> properties;
 
@@ -47,27 +52,28 @@ public class Asset extends Entity {
 
     @Override
     public String getId() {
-        return id == null ? getPropertyAsString(PROPERTY_ID) : id;
+        return id == null ? ofNullable(getPropertyAsString(PROPERTY_ID)).orElse(getPropertyAsString(DEPRECATED_PROPERTY_PREFIX + id)) : id;
     }
 
     @JsonIgnore
     public String getName() {
-        return getPropertyAsString(PROPERTY_NAME);
+        return ofNullable(getPropertyAsString(PROPERTY_NAME))
+                .orElse(getPropertyAsString(DEPRECATED_PROPERTY_PREFIX + "name"));
     }
 
     @JsonIgnore
     public String getDescription() {
-        return getPropertyAsString(PROPERTY_DESCRIPTION);
+        return ofNullable(getPropertyAsString(PROPERTY_DESCRIPTION)).orElse(getPropertyAsString(DEPRECATED_PROPERTY_PREFIX + "description"));
     }
 
     @JsonIgnore
     public String getVersion() {
-        return getPropertyAsString(PROPERTY_VERSION);
+        return ofNullable(getPropertyAsString(PROPERTY_VERSION)).orElse(getPropertyAsString(DEPRECATED_PROPERTY_PREFIX + "version"));
     }
 
     @JsonIgnore
     public String getContentType() {
-        return getPropertyAsString(PROPERTY_CONTENT_TYPE);
+        return ofNullable(getPropertyAsString(PROPERTY_CONTENT_TYPE)).orElse(getPropertyAsString(DEPRECATED_PROPERTY_PREFIX + "contenttype"));
     }
 
     public Map<String, Object> getProperties() {

--- a/spi/common/core-spi/src/test/resources/serialized_asset.json
+++ b/spi/common/core-spi/src/test/resources/serialized_asset.json
@@ -1,8 +1,8 @@
 {
   "properties": {
-    "asset:prop:contenttype": "application/json",
-    "asset:prop:version": "1.0",
-    "asset:prop:id": "abcd123",
+    "https://foo.bar.org/ds/schema/contenttype": "application/json",
+    "https://foo.bar.org/ds/schema/version": "1.0",
+    "https://foo.bar.org/ds/schema/id": "abcd123",
     "anotherProperty": "some value",
     "numberVal": 42069
   },

--- a/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/PropertyAndTypeNames.java
+++ b/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/PropertyAndTypeNames.java
@@ -31,10 +31,6 @@ public interface PropertyAndTypeNames {
 
     String EDC_ASSET_TYPE = EDC_NAMESPACE + "Asset";
     String EDC_ASSET_PROPERTIES = EDC_NAMESPACE + "properties";
-    String EDC_ASSET_NAME = EDC_NAMESPACE + "name";
-    String EDC_ASSET_DESCRIPTION = EDC_NAMESPACE + "description";
-    String EDC_ASSET_VERSION = EDC_NAMESPACE + "version";
-    String EDC_ASSET_CONTENTTYPE = EDC_NAMESPACE + "contenttype";
 
     String DCAT_DATA_SERVICE_ATTRIBUTE = DCAT_SCHEMA + "service";
     String DCAT_DATASET_ATTRIBUTE = DCAT_SCHEMA + "dataset";

--- a/system-tests/azure-tests/src/testFixtures/java/org/eclipse/edc/test/system/local/BlobTransferUtils.java
+++ b/system-tests/azure-tests/src/testFixtures/java/org/eclipse/edc/test/system/local/BlobTransferUtils.java
@@ -21,6 +21,7 @@ import org.eclipse.edc.policy.model.Action;
 import org.eclipse.edc.policy.model.Permission;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.policy.model.PolicyType;
+import org.eclipse.edc.spi.CoreConstants;
 import org.eclipse.edc.spi.asset.AssetSelectorExpression;
 import org.jetbrains.annotations.NotNull;
 
@@ -49,10 +50,10 @@ public class BlobTransferUtils {
                 "asset", Map.of(
                         "id", PROVIDER_ASSET_ID,
                         "properties", Map.of(
-                                "asset:prop:name", PROVIDER_ASSET_ID,
-                                "asset:prop:contenttype", "text/plain",
-                                "asset:prop:version", "1.0",
-                                "asset:prop:id", PROVIDER_ASSET_ID,
+                                CoreConstants.EDC_NAMESPACE + "name", PROVIDER_ASSET_ID,
+                                CoreConstants.EDC_NAMESPACE + "contenttype", "text/plain",
+                                CoreConstants.EDC_NAMESPACE + "version", "1.0",
+                                CoreConstants.EDC_NAMESPACE + "id", PROVIDER_ASSET_ID,
                                 "type", "AzureStorage"
                         )
                 ),
@@ -90,7 +91,7 @@ public class BlobTransferUtils {
     public static void createContractDefinition(String policyId) {
 
         var criteria = AssetSelectorExpression.Builder.newInstance()
-                .constraint("asset:prop:id",
+                .constraint(CoreConstants.EDC_NAMESPACE + "id",
                         "=",
                         PROVIDER_ASSET_ID)
                 .build();

--- a/system-tests/azure-tests/src/testFixtures/java/org/eclipse/edc/test/system/local/BlobTransferUtils.java
+++ b/system-tests/azure-tests/src/testFixtures/java/org/eclipse/edc/test/system/local/BlobTransferUtils.java
@@ -21,7 +21,6 @@ import org.eclipse.edc.policy.model.Action;
 import org.eclipse.edc.policy.model.Permission;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.policy.model.PolicyType;
-import org.eclipse.edc.spi.CoreConstants;
 import org.eclipse.edc.spi.asset.AssetSelectorExpression;
 import org.jetbrains.annotations.NotNull;
 
@@ -31,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 import static org.eclipse.edc.test.system.local.TransferRuntimeConfiguration.PROVIDER_ASSET_FILE;
 import static org.eclipse.edc.test.system.local.TransferRuntimeConfiguration.PROVIDER_ASSET_ID;
 import static org.eclipse.edc.test.system.local.TransferRuntimeConfiguration.PROVIDER_CONNECTOR_MANAGEMENT_URL;
@@ -50,10 +50,10 @@ public class BlobTransferUtils {
                 "asset", Map.of(
                         "id", PROVIDER_ASSET_ID,
                         "properties", Map.of(
-                                CoreConstants.EDC_NAMESPACE + "name", PROVIDER_ASSET_ID,
-                                CoreConstants.EDC_NAMESPACE + "contenttype", "text/plain",
-                                CoreConstants.EDC_NAMESPACE + "version", "1.0",
-                                CoreConstants.EDC_NAMESPACE + "id", PROVIDER_ASSET_ID,
+                                EDC_NAMESPACE + "name", PROVIDER_ASSET_ID,
+                                EDC_NAMESPACE + "contenttype", "text/plain",
+                                EDC_NAMESPACE + "version", "1.0",
+                                EDC_NAMESPACE + "id", PROVIDER_ASSET_ID,
                                 "type", "AzureStorage"
                         )
                 ),
@@ -91,7 +91,7 @@ public class BlobTransferUtils {
     public static void createContractDefinition(String policyId) {
 
         var criteria = AssetSelectorExpression.Builder.newInstance()
-                .constraint(CoreConstants.EDC_NAMESPACE + "id",
+                .constraint(EDC_NAMESPACE + "id",
                         "=",
                         PROVIDER_ASSET_ID)
                 .build();

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/Participant.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/Participant.java
@@ -19,7 +19,6 @@ import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
 import org.eclipse.edc.connector.transfer.spi.types.TransferType;
 import org.eclipse.edc.policy.model.PolicyRegistrationTypes;
-import org.eclipse.edc.spi.CoreConstants;
 import org.eclipse.edc.spi.asset.AssetSelectorExpression;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.spi.types.domain.DataAddress;
@@ -42,6 +41,7 @@ import static java.io.File.separator;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.eclipse.edc.junit.testfixtures.TestUtils.getFreePort;
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 
 public class Participant {
     private static final String IDS_PATH = "/api/v1/ids";
@@ -71,8 +71,8 @@ public class Participant {
                 "asset", Map.of(
                         "id", assetId,
                         "properties", Map.of(
-                                CoreConstants.EDC_NAMESPACE + "id", assetId,
-                                CoreConstants.EDC_NAMESPACE + "description", "description"
+                                EDC_NAMESPACE + "id", assetId,
+                                EDC_NAMESPACE + "description", "description"
                         )
                 ),
                 "dataAddress", Map.of(
@@ -109,7 +109,7 @@ public class Participant {
                 "accessPolicyId", accessPolicyId,
                 "validity", String.valueOf(contractValidityDurationSeconds),
                 "contractPolicyId", contractPolicyId,
-                "criteria", AssetSelectorExpression.Builder.newInstance().constraint(CoreConstants.EDC_NAMESPACE + "id", "=", assetId).build().getCriteria()
+                "criteria", AssetSelectorExpression.Builder.newInstance().constraint(EDC_NAMESPACE + "id", "=", assetId).build().getCriteria()
         );
 
         given()

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/Participant.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/Participant.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
 import org.eclipse.edc.connector.transfer.spi.types.TransferType;
 import org.eclipse.edc.policy.model.PolicyRegistrationTypes;
+import org.eclipse.edc.spi.CoreConstants;
 import org.eclipse.edc.spi.asset.AssetSelectorExpression;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.spi.types.domain.DataAddress;
@@ -70,8 +71,8 @@ public class Participant {
                 "asset", Map.of(
                         "id", assetId,
                         "properties", Map.of(
-                                "asset:prop:id", assetId,
-                                "asset:prop:description", "description"
+                                CoreConstants.EDC_NAMESPACE + "id", assetId,
+                                CoreConstants.EDC_NAMESPACE + "description", "description"
                         )
                 ),
                 "dataAddress", Map.of(
@@ -108,7 +109,7 @@ public class Participant {
                 "accessPolicyId", accessPolicyId,
                 "validity", String.valueOf(contractValidityDurationSeconds),
                 "contractPolicyId", contractPolicyId,
-                "criteria", AssetSelectorExpression.Builder.newInstance().constraint("asset:prop:id", "=", assetId).build().getCriteria()
+                "criteria", AssetSelectorExpression.Builder.newInstance().constraint(CoreConstants.EDC_NAMESPACE + "id", "=", assetId).build().getCriteria()
         );
 
         given()
@@ -247,7 +248,6 @@ public class Participant {
 
     public void registerDataPlane() {
         var body = Map.of(
-                "edctype", "dataspaceconnector:dataplaneinstance",
                 "id", UUID.randomUUID().toString(),
                 "url", dataPlaneControl + "/transfer",
                 "allowedSourceTypes", List.of("HttpData", "HttpProvision"),

--- a/system-tests/management-api/management-api-test-runner/build.gradle.kts
+++ b/system-tests/management-api/management-api-test-runner/build.gradle.kts
@@ -18,6 +18,13 @@ plugins {
 
 dependencies {
     testImplementation(project(":core:common:junit"))
+    // gives access to the Json LD models, etc.
+    testImplementation(project(":spi:common:json-ld-spi"))
+
+    //useful for generic DTOs etc.
+    testImplementation(project(":extensions:common:api:api-core"))
+    //we need the JacksonJsonLd util class
+    testImplementation(project(":extensions:common:json-ld"))
 
     testImplementation(libs.restAssured)
     testImplementation(libs.assertj)

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/AssetApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/AssetApiEndToEndTest.java
@@ -1,0 +1,150 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.e2e.managementapi;
+
+import io.restassured.common.mapper.TypeRef;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import jakarta.json.Json;
+import jakarta.json.JsonObjectBuilder;
+import org.eclipse.edc.api.model.CriterionDto;
+import org.eclipse.edc.api.model.IdResponseDto;
+import org.eclipse.edc.api.query.QuerySpecDto;
+import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.spi.asset.AssetIndex;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.asset.Asset;
+import org.eclipse.edc.spi.types.domain.asset.AssetEntry;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.EDC_ASSET_TYPE;
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
+import static org.hamcrest.Matchers.is;
+
+@EndToEndTest
+public class AssetApiEndToEndTest extends BaseManagementApiEndToEndTest {
+
+    private static final String TEST_ASSET_ID = "test-asset-id";
+    private static final String TEST_ASSET_CONTENTTYPE = "application/json";
+    private static final String TEST_ASSET_DESCRIPTION = "test description";
+    private static final String TEST_ASSET_VERSION = "0.4.2";
+    private static final String TEST_ASSET_NAME = "test-asset";
+
+    @Test
+    @Disabled(value = "Can enable once we have a unified transformer registry")
+    void getAssetById() {
+        //insert one asset into the index
+        controlPlane.getContext().getService(AssetIndex.class)
+                .accept(new AssetEntry(Asset.Builder.newInstance().id("test-asset").build(),
+                        DataAddress.Builder.newInstance().type("test-type").build()));
+
+        var body = baseRequest()
+                .get("/test-asset")
+                .then()
+                .statusCode(200)
+                .extract().body().as(new TypeRef<Map<String, Object>>() {
+                });
+
+        assertThat(body).isNotNull();
+        assertThat(body).containsKey("asset");
+        assertThat(body.get("asset")).isInstanceOf(Map.class);
+        Map<String, Object> asset = (Map<String, Object>) body.get("asset");
+        assertThat(asset.get(Asset.PROPERTY_ID).toString()).contains("test-asset");
+    }
+
+    @Test
+    @Disabled(value = "Can enable once we have a unified transformer registry")
+    void createAsset_shouldBeStored() {
+
+        var assetJson = Json.createObjectBuilder()
+                .add(CONTEXT, createContextBuilder().build())
+                .add(TYPE, EDC_ASSET_TYPE)
+                .add(ID, TEST_ASSET_ID)
+                .add("properties", createPropertiesBuilder().build())
+                .build();
+
+        var json = Map.of("asset", assetJson,
+                "dataAddress", Map.of("properties", Map.of("type", "test-type")));
+
+        var id = baseRequest()
+                .contentType(ContentType.JSON)
+                .body(json)
+                .post()
+                .then()
+                .log().ifError()
+                .statusCode(200)
+                .extract().body().as(IdResponseDto.class);
+
+        assertThat(id).isNotNull().extracting(IdResponseDto::getId).isEqualTo("test-asset-id");
+        var assetIndex = controlPlane.getContext().getService(AssetIndex.class);
+
+        assertThat(assetIndex.countAssets(List.of())).isEqualTo(1);
+        assertThat(assetIndex.findById("test-asset-id")).isNotNull();
+    }
+
+    @Test
+    @Disabled(value = "Can enable once we have a unified transformer registry")
+    void queryAsset_byContentType() {
+        //insert one asset into the index
+        controlPlane.getContext().getService(AssetIndex.class)
+                .accept(new AssetEntry(Asset.Builder.newInstance().id("test-asset").contentType("application/octet-stream").build(),
+                        DataAddress.Builder.newInstance().type("test-type").build()));
+
+        // create the query by content type
+        //TODO: once the queryspec dto is JSON-LD aware, we can just use "contentype", and the JSON-LD expansion takes care of prefixing the namespace
+        var byContentType = CriterionDto.Builder.newInstance().operandLeft(Asset.PROPERTY_CONTENT_TYPE).operator("=").operandRight("application/octet-stream").build();
+        var query = QuerySpecDto.Builder.newInstance().filterExpression(List.of(byContentType)).build();
+
+        baseRequest()
+                .contentType(ContentType.JSON)
+                .body(query)
+                .post("/request")
+                .then()
+                .log().ifError()
+                .statusCode(200)
+                .body("size()", is(1));
+
+    }
+
+    private JsonObjectBuilder createPropertiesBuilder() {
+        return Json.createObjectBuilder()
+                .add("name", TEST_ASSET_NAME)
+                .add("description", TEST_ASSET_DESCRIPTION)
+                .add("edc:version", TEST_ASSET_VERSION)
+                .add("contenttype", TEST_ASSET_CONTENTTYPE);
+    }
+
+    private JsonObjectBuilder createContextBuilder() {
+        return Json.createObjectBuilder()
+                .add(VOCAB, EDC_NAMESPACE)
+                .add("edc", EDC_NAMESPACE);
+    }
+
+    private RequestSpecification baseRequest() {
+        return given()
+                .baseUri("http://localhost:" + PORT + "/management/v2/assets")
+                .when();
+    }
+}

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/AssetApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/AssetApiEndToEndTest.java
@@ -27,7 +27,6 @@ import org.eclipse.edc.spi.asset.AssetIndex;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.eclipse.edc.spi.types.domain.asset.AssetEntry;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -53,7 +52,6 @@ public class AssetApiEndToEndTest extends BaseManagementApiEndToEndTest {
     private static final String TEST_ASSET_NAME = "test-asset";
 
     @Test
-    @Disabled(value = "Can enable once we have a unified transformer registry")
     void getAssetById() {
         //insert one asset into the index
         controlPlane.getContext().getService(AssetIndex.class)
@@ -75,7 +73,6 @@ public class AssetApiEndToEndTest extends BaseManagementApiEndToEndTest {
     }
 
     @Test
-    @Disabled(value = "Can enable once we have a unified transformer registry")
     void createAsset_shouldBeStored() {
 
         var assetJson = Json.createObjectBuilder()
@@ -105,7 +102,6 @@ public class AssetApiEndToEndTest extends BaseManagementApiEndToEndTest {
     }
 
     @Test
-    @Disabled(value = "Can enable once we have a unified transformer registry")
     void queryAsset_byContentType() {
         //insert one asset into the index
         controlPlane.getContext().getService(AssetIndex.class)

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/AssetApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/AssetApiEndToEndTest.java
@@ -20,7 +20,6 @@ import io.restassured.specification.RequestSpecification;
 import jakarta.json.Json;
 import jakarta.json.JsonObjectBuilder;
 import org.eclipse.edc.api.model.CriterionDto;
-import org.eclipse.edc.api.model.IdResponseDto;
 import org.eclipse.edc.api.query.QuerySpecDto;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.spi.asset.AssetIndex;
@@ -92,9 +91,7 @@ public class AssetApiEndToEndTest extends BaseManagementApiEndToEndTest {
                 .then()
                 .log().ifError()
                 .statusCode(200)
-                .extract().body().as(IdResponseDto.class);
-
-        assertThat(id).isNotNull().extracting(IdResponseDto::getId).isEqualTo("test-asset-id");
+                .body("id", is("test-asset-id"));
         var assetIndex = controlPlane.getContext().getService(AssetIndex.class);
 
         assertThat(assetIndex.countAssets(List.of())).isEqualTo(1);

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/AssetApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/AssetApiEndToEndTest.java
@@ -84,7 +84,7 @@ public class AssetApiEndToEndTest extends BaseManagementApiEndToEndTest {
         var json = Map.of("asset", assetJson,
                 "dataAddress", Map.of("properties", Map.of("type", "test-type")));
 
-        var id = baseRequest()
+        baseRequest()
                 .contentType(ContentType.JSON)
                 .body(json)
                 .post()

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/BaseManagementApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/BaseManagementApiEndToEndTest.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.e2e.managementapi;
+
+import org.eclipse.edc.junit.extensions.EdcRuntimeExtension;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.HashMap;
+import java.util.UUID;
+
+import static org.eclipse.edc.junit.testfixtures.TestUtils.getFreePort;
+
+public abstract class BaseManagementApiEndToEndTest {
+    public static final int PORT = getFreePort();
+    @RegisterExtension
+    static EdcRuntimeExtension controlPlane = new EdcRuntimeExtension(
+            ":system-tests:management-api:management-api-test-runtime",
+            "control-plane",
+            new HashMap<>() {
+                {
+                    put("edc.ids.id", "urn:connector:" + UUID.randomUUID());
+                    put("web.http.path", "/");
+                    put("web.http.protocol.path", "/protocol");
+                    put("web.http.protocol.port", String.valueOf(getFreePort()));
+                    put("web.http.port", String.valueOf(getFreePort()));
+                    put("web.http.management.path", "/management");
+                    put("web.http.management.port", String.valueOf(PORT));
+                }
+            }
+    );
+}

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/PolicyDefinitionApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/PolicyDefinitionApiEndToEndTest.java
@@ -16,37 +16,15 @@ package org.eclipse.edc.test.e2e.managementapi;
 
 import io.restassured.http.ContentType;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
-import org.eclipse.edc.junit.extensions.EdcRuntimeExtension;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
-
-import java.util.HashMap;
-import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
-import static org.eclipse.edc.junit.testfixtures.TestUtils.getFreePort;
 
 @EndToEndTest
-public class PolicyDefinitionApiEndToEndTest {
+public class PolicyDefinitionApiEndToEndTest extends BaseManagementApiEndToEndTest {
 
-    public static final int PORT = getFreePort();
-
-    @RegisterExtension
-    static EdcRuntimeExtension controlPlane = new EdcRuntimeExtension(
-            ":system-tests:management-api:management-api-test-runtime",
-            "control-plane",
-            new HashMap<>() {
-                {
-                    put("edc.ids.id", "urn:connector:" + UUID.randomUUID());
-                    put("web.http.path", "/");
-                    put("web.http.port", String.valueOf(getFreePort()));
-                    put("web.http.management.path", "/management");
-                    put("web.http.management.port", String.valueOf(PORT));
-                }
-            }
-    );
-
-    @Test // stub test just to verify structure
+    // stub test just to verify structure
+    @Test
     void shouldReturnBadRequest() {
         given()
                 .port(PORT)

--- a/system-tests/management-api/management-api-test-runtime/build.gradle.kts
+++ b/system-tests/management-api/management-api-test-runtime/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     implementation(project(":core:common:jwt-core"))
     implementation(project(":core:control-plane:control-plane-core"))
     implementation(project(":data-protocols:ids"))
+    implementation(project(":data-protocols:dsp"))
     implementation(project(":extensions:common:http"))
     implementation(project(":extensions:common:iam:iam-mock"))
     implementation(project(":extensions:control-plane:api:management-api"))


### PR DESCRIPTION
## What this PR changes/adds

adds a new API controller for `Asset` manipulation, and registers it to the management context.

Note that the _new_ API is available under the `/v2/assets` path!

## Why it does that

allow parallel existence of the "old" asset API and the JSON-LD-aware new Asset API.

## Further notes

- added a `:data-protocols:dsp` BOM, because it did not yet exist
- `QuerySpecDto` is not yet JSON-LD-ified, that will come in a subsequent PR
- The `AssetNewApiEndToEndTests` can be re-enabled once we have unified transformer registries


**IMPORTANT: please note that the old Asset property prefix `asset:prop:` was REPLACED by a JSON-LD namespace prefix in expanded form (i.e. a URL). _Some_ backwards compatibility was maintained, but due to the wide-spread impact we CANNOT guarantee full backwards compatibility!!**

**PLEASE DO NOT USE `asset:prop:` anymore, use the `CoreConstants.EDC_NAMESPACE` constant! This change was necessary as prepararoty work to accommodate for JSON-LD namespace expansion when issuing queries.**


## Linked Issue(s)

Closes #2767 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
