### PR TITLE
feat(dsp): add transformer for JsonObjectToDataAddress

### DIFF
--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/DspTransferProcessTransformExtension.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/DspTransferProcessTransformExtension.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.protocol.dsp.transferprocess.transformer;
 
 import jakarta.json.Json;
 import org.eclipse.edc.jsonld.spi.transformer.JsonLdTransformerRegistry;
+import org.eclipse.edc.jsonld.transformer.to.JsonObjectToDataAddressTransformer;
 import org.eclipse.edc.protocol.dsp.transferprocess.transformer.type.from.JsonObjectFromDataAddressTransformer;
 import org.eclipse.edc.protocol.dsp.transferprocess.transformer.type.from.JsonObjectFromTransferCompletionMessageTransformer;
 import org.eclipse.edc.protocol.dsp.transferprocess.transformer.type.from.JsonObjectFromTransferProcessTransformer;
@@ -66,5 +67,6 @@ public class DspTransferProcessTransformExtension implements ServiceExtension {
         registry.register(new JsonObjectToTransferCompletionMessageTransformer());
         registry.register(new JsonObjectToTransferStartMessageTransformer());
         registry.register(new JsonObjectToTransferTerminationMessageTransformer());
+        registry.register(new JsonObjectToDataAddressTransformer());
     }
 }

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/from/JsonObjectFromDataAddressTransformer.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/from/JsonObjectFromDataAddressTransformer.java
@@ -32,10 +32,10 @@ public class JsonObjectFromDataAddressTransformer extends AbstractJsonLdTransfor
     }
 
     @Override
-    public @Nullable JsonObject transform(@NotNull DataAddress transferCompletionMessage, @NotNull TransformerContext context) {
+    public @Nullable JsonObject transform(@NotNull DataAddress dataAddress, @NotNull TransformerContext context) {
         var builder = jsonBuilderFactory.createObjectBuilder();
 
-        transferCompletionMessage.getProperties().forEach((k, v) -> builder.add(k, v));
+        dataAddress.getProperties().forEach(builder::add);
 
         return builder.build();
     }

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/from/JsonObjectFromAssetTransformer.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/from/JsonObjectFromAssetTransformer.java
@@ -17,7 +17,6 @@ package org.eclipse.edc.jsonld.transformer.from;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
-import org.eclipse.edc.jsonld.spi.Namespaces;
 import org.eclipse.edc.jsonld.spi.PropertyAndTypeNames;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
@@ -30,6 +29,7 @@ import java.util.Map;
 import static java.util.stream.Collectors.toMap;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 
 public class JsonObjectFromAssetTransformer extends AbstractJsonLdTransformer<Asset, JsonObject> {
     private final ObjectMapper mapper;
@@ -49,7 +49,7 @@ public class JsonObjectFromAssetTransformer extends AbstractJsonLdTransformer<As
 
         // replace the special asset properties, starting with "asset:prop:", with the EDC_SCHEMA
         var props = asset.getProperties().entrySet().stream()
-                .collect(toMap(entry -> entry.getKey().replace("asset:prop:", Namespaces.EDC_SCHEMA), Map.Entry::getValue));
+                .collect(toMap(entry -> entry.getKey().replace("asset:prop:", EDC_NAMESPACE), Map.Entry::getValue));
 
         transformProperties(props, builder, mapper, context);
 

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToDataAddressTransformer.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToDataAddressTransformer.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.jsonld.transformer.to;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
+
+
+/**
+ * Converts from an {@link DataAddress} as a {@link JsonObject} in JSON-LD expanded form to an {@link DataAddress}.
+ */
+public class JsonObjectToDataAddressTransformer extends AbstractJsonLdTransformer<JsonObject, DataAddress> {
+    public JsonObjectToDataAddressTransformer() {
+        super(JsonObject.class, DataAddress.class);
+    }
+
+    @Override
+    public @Nullable DataAddress transform(@NotNull JsonObject jsonObject, @NotNull TransformerContext context) {
+        var builder = DataAddress.Builder.newInstance();
+        visitProperties(jsonObject, (s, v) -> transformProperties(s, v, builder, context));
+        return builder.build();
+    }
+
+    private void transformProperties(String key, JsonValue jsonValue, DataAddress.Builder builder, TransformerContext context) {
+        if ((EDC_NAMESPACE + "properties").equals(key) && jsonValue instanceof JsonArray) {
+            var props = jsonValue.asJsonArray().getJsonObject(0);
+            visitProperties(props, (k, val) -> transformProperties(k, val, builder, context));
+        } else {
+            var object = transformGenericProperty(jsonValue, context);
+            if (object instanceof String) {
+                builder.property(key, object.toString());
+            } else {
+                context.reportProblem("DataAddress#properties can only contain Strings, but an attempt was made to put in a " + object.getClass());
+            }
+        }
+
+    }
+}

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToDataAddressTransformer.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToDataAddressTransformer.java
@@ -30,6 +30,10 @@ import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
  * Converts from an {@link DataAddress} as a {@link JsonObject} in JSON-LD expanded form to an {@link DataAddress}.
  */
 public class JsonObjectToDataAddressTransformer extends AbstractJsonLdTransformer<JsonObject, DataAddress> {
+
+    //TODO: move into a module-level constants file
+    public static final String PROPERTIES_KEY = EDC_NAMESPACE + "properties";
+
     public JsonObjectToDataAddressTransformer() {
         super(JsonObject.class, DataAddress.class);
     }
@@ -42,7 +46,7 @@ public class JsonObjectToDataAddressTransformer extends AbstractJsonLdTransforme
     }
 
     private void transformProperties(String key, JsonValue jsonValue, DataAddress.Builder builder, TransformerContext context) {
-        if ((EDC_NAMESPACE + "properties").equals(key) && jsonValue instanceof JsonArray) {
+        if ((PROPERTIES_KEY).equals(key) && jsonValue instanceof JsonArray) {
             var props = jsonValue.asJsonArray().getJsonObject(0);
             visitProperties(props, (k, val) -> transformProperties(k, val, builder, context));
         } else {

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/PayloadTransformer.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/PayloadTransformer.java
@@ -15,11 +15,12 @@
 package org.eclipse.edc.jsonld.transformer;
 
 import jakarta.json.JsonObject;
-import org.eclipse.edc.jsonld.spi.Namespaces;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 
 
 public class PayloadTransformer extends AbstractJsonLdTransformer<JsonObject, Payload> {
@@ -30,8 +31,8 @@ public class PayloadTransformer extends AbstractJsonLdTransformer<JsonObject, Pa
     @Override
     public @Nullable Payload transform(@NotNull JsonObject jsonObject, @NotNull TransformerContext context) {
         var payload = new Payload();
-        var nameObj = jsonObject.get(Namespaces.EDC_SCHEMA + "name");
-        var ageObj = jsonObject.get(Namespaces.EDC_SCHEMA + "age");
+        var nameObj = jsonObject.get(EDC_NAMESPACE + "name");
+        var ageObj = jsonObject.get(EDC_NAMESPACE + "age");
         transformString(nameObj, payload::setName, context);
         var age = (Double) transformGenericProperty(ageObj, context);
         payload.setAge(age.intValue());

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/from/JsonObjectFromAssetTransformerTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/from/JsonObjectFromAssetTransformerTest.java
@@ -16,7 +16,6 @@ package org.eclipse.edc.jsonld.transformer.from;
 
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
-import org.eclipse.edc.jsonld.spi.Namespaces;
 import org.eclipse.edc.jsonld.spi.PropertyAndTypeNames;
 import org.eclipse.edc.jsonld.transformer.Payload;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
@@ -30,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.util.JacksonJsonLd.createObjectMapper;
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 import static org.mockito.Mockito.mock;
 
 class JsonObjectFromAssetTransformerTest {
@@ -56,11 +56,11 @@ class JsonObjectFromAssetTransformerTest {
         assertThat(jsonObject).isNotNull().hasSize(7);
         assertThat(jsonObject.getJsonString(ID).getString()).isEqualTo(TEST_ASSET_ID);
         assertThat(jsonObject.getJsonString(TYPE).getString()).isEqualTo(PropertyAndTypeNames.EDC_ASSET_TYPE);
-        assertThat(jsonObject.getJsonString(Namespaces.EDC_SCHEMA + "id").getString()).isEqualTo(TEST_ASSET_ID);
-        assertThat(jsonObject.getJsonString(Namespaces.EDC_SCHEMA + "contenttype").getString()).isEqualTo(TEST_CONTENT_TYPE);
-        assertThat(jsonObject.getJsonString(Namespaces.EDC_SCHEMA + "description").getString()).isEqualTo(TEST_DESCRIPTION);
-        assertThat(jsonObject.getJsonString(Namespaces.EDC_SCHEMA + "name").getString()).isEqualTo(TEST_ASSET_NAME);
-        assertThat(jsonObject.getJsonString(Namespaces.EDC_SCHEMA + "version").getString()).isEqualTo(TEST_VERSION);
+        assertThat(jsonObject.getJsonString(EDC_NAMESPACE + "id").getString()).isEqualTo(TEST_ASSET_ID);
+        assertThat(jsonObject.getJsonString(EDC_NAMESPACE + "contenttype").getString()).isEqualTo(TEST_CONTENT_TYPE);
+        assertThat(jsonObject.getJsonString(EDC_NAMESPACE + "description").getString()).isEqualTo(TEST_DESCRIPTION);
+        assertThat(jsonObject.getJsonString(EDC_NAMESPACE + "name").getString()).isEqualTo(TEST_ASSET_NAME);
+        assertThat(jsonObject.getJsonString(EDC_NAMESPACE + "version").getString()).isEqualTo(TEST_VERSION);
     }
 
     @Test

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToAssetTransformerTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToAssetTransformerTest.java
@@ -18,9 +18,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
-import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
-import org.eclipse.edc.jsonld.spi.Namespaces;
 import org.eclipse.edc.jsonld.spi.PropertyAndTypeNames;
 import org.eclipse.edc.jsonld.spi.transformer.JsonLdTransformerRegistryImpl;
 import org.eclipse.edc.jsonld.transformer.Payload;
@@ -39,7 +37,7 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
 import static org.eclipse.edc.jsonld.util.JacksonJsonLd.createObjectMapper;
-import static org.eclipse.edc.junit.testfixtures.TestUtils.getResourceFileContentAsString;
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 
 class JsonObjectToAssetTransformerTest {
 
@@ -63,7 +61,7 @@ class JsonObjectToAssetTransformerTest {
         typeTransformerRegistry.register(new JsonValueToGenericTypeTransformer(jsonPmapper));
         typeTransformerRegistry.register(transformer);
         typeTransformerRegistry.register(new PayloadTransformer());
-        typeTransformerRegistry.registerTypeAlias(Namespaces.EDC_SCHEMA + "customPayload", Payload.class);
+        typeTransformerRegistry.registerTypeAlias(EDC_NAMESPACE + "customPayload", Payload.class);
     }
 
     @Test
@@ -103,7 +101,7 @@ class JsonObjectToAssetTransformerTest {
         AbstractResultAssert.assertThat(asset).withFailMessage(asset::getFailureDetail).isSucceeded();
         assertThat(asset.getContent().getProperties())
                 .hasSize(6)
-                .hasEntrySatisfying(Namespaces.EDC_SCHEMA + "payload", o -> assertThat(o).isInstanceOf(Payload.class)
+                .hasEntrySatisfying(EDC_NAMESPACE + "payload", o -> assertThat(o).isInstanceOf(Payload.class)
                         .hasFieldOrPropertyWithValue("age", CUSTOM_PAYLOAD_AGE)
                         .hasFieldOrPropertyWithValue("name", CUSTOM_PAYLOAD_NAME));
     }
@@ -163,22 +161,8 @@ class JsonObjectToAssetTransformerTest {
 
     private JsonObjectBuilder createContextBuilder() {
         return jsonFactory.createObjectBuilder()
-                .add(VOCAB, Namespaces.EDC_SCHEMA)
-                .add("edc", Namespaces.EDC_SCHEMA);
-    }
-
-    /**
-     * will read the resource with the given name, assuming it's JSON, and expand it to JSON-LD's expanded form.
-     */
-    private JsonObject parseJson(String filename) {
-        try {
-            var jsonLd = getResourceFileContentAsString(filename);
-            JsonObject assetJsonObject = jsonPmapper.readValue(jsonLd, JsonObject.class);
-            var expandedJsonLd = JsonLdUtil.expand(assetJsonObject).getJsonObject(0);
-            return expandedJsonLd;
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
+                .add(VOCAB, EDC_NAMESPACE)
+                .add("edc", EDC_NAMESPACE);
     }
 
 

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToDataAddressTransformerTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToDataAddressTransformerTest.java
@@ -1,0 +1,127 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.jsonld.transformer.to;
+
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonValue;
+import org.eclipse.edc.jsonld.transformer.Payload;
+import org.eclipse.edc.jsonld.util.JsonLdUtil;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static jakarta.json.Json.createObjectBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
+import static org.eclipse.edc.jsonld.util.JacksonJsonLd.createObjectMapper;
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.endsWith;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class JsonObjectToDataAddressTransformerTest {
+    private static final int CUSTOM_PAYLOAD_AGE = 34;
+    private static final String CUSTOM_PAYLOAD_NAME = "max";
+    private static final String TEST_TYPE = "test-type";
+    private static final String TEST_KEY_NAME = "test-key-name";
+    private final JsonValueToGenericTypeTransformer objectTransformer = new JsonValueToGenericTypeTransformer(createObjectMapper());
+    private JsonObjectToDataAddressTransformer transformer;
+    private TransformerContext transformerContext;
+
+    @BeforeEach
+    void setUp() {
+        transformer = new JsonObjectToDataAddressTransformer();
+        transformerContext = mock(TransformerContext.class);
+        when(transformerContext.transform(isA(JsonObject.class), eq(Object.class)))
+                .thenAnswer(i -> objectTransformer.transform(i.getArgument(0), transformerContext));
+    }
+
+    @Test
+    void transform() {
+        var json = JsonLdUtil.expand(createDataAddress().build()).getJsonObject(0);
+
+        var dataAddress = transformer.transform(json, transformerContext);
+        assertThat(dataAddress).isNotNull();
+        assertThat(dataAddress.getType()).isEqualTo(TEST_TYPE);
+        assertThat(dataAddress.getKeyName()).isEqualTo(TEST_KEY_NAME);
+    }
+
+    @Test
+    void transform_withCustomProps() {
+        var json = createDataAddress()
+                .add(EDC_NAMESPACE + "properties", createObjectBuilder()
+                        .add("my-test-prop", "some-test-value")
+                        .build())
+                .build();
+        json = JsonLdUtil.expand(json)
+                .getJsonObject(0);
+
+        var dataAddress = transformer.transform(json, transformerContext);
+        assertThat(dataAddress).isNotNull();
+        assertThat(dataAddress.getType()).isEqualTo(TEST_TYPE);
+        assertThat(dataAddress.getProperty(EDC_NAMESPACE + "my-test-prop")).isEqualTo("some-test-value");
+    }
+
+    @Test
+    void transform_withComplexCustomProps_shouldReportProblem() {
+        when(transformerContext.typeAlias(endsWith("customPayload"))).thenAnswer(i -> Payload.class);
+        when(transformerContext.transform(isA(JsonValue.class), eq(Payload.class))).thenReturn(new Payload(CUSTOM_PAYLOAD_NAME, CUSTOM_PAYLOAD_AGE));
+        var json = createDataAddress()
+                .add(EDC_NAMESPACE + "properties", createObjectBuilder()
+                        .add("payload", createPayloadBuilder().build())
+                        .build())
+                .build();
+        json = JsonLdUtil.expand(json)
+                .getJsonObject(0);
+
+        var dataAddress = transformer.transform(json, transformerContext);
+        assertThat(dataAddress).isNotNull();
+        assertThat(dataAddress.getType()).isEqualTo(TEST_TYPE);
+        assertThat(dataAddress.getKeyName()).isEqualTo(TEST_KEY_NAME);
+        assertThat(dataAddress.getProperties()).hasSize(2);
+
+        verify(transformerContext).reportProblem(any());
+    }
+
+    private JsonObjectBuilder createDataAddress() {
+        return createObjectBuilder()
+                .add(CONTEXT, createContextBuilder().build())
+                .add(TYPE, EDC_NAMESPACE + "DataAddress")
+                .add(EDC_NAMESPACE + DataAddress.TYPE, TEST_TYPE)
+                .add(EDC_NAMESPACE + DataAddress.KEY_NAME, TEST_KEY_NAME);
+    }
+
+    private JsonObjectBuilder createContextBuilder() {
+        return createObjectBuilder()
+                .add(VOCAB, EDC_NAMESPACE)
+                .add("edc", EDC_NAMESPACE);
+    }
+
+    private JsonObjectBuilder createPayloadBuilder() {
+        return createObjectBuilder()
+                .add(TYPE, "customPayload")
+                .add("name", CUSTOM_PAYLOAD_NAME)
+                .add("age", CUSTOM_PAYLOAD_AGE);
+    }
+
+}

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/CoreConstants.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/CoreConstants.java
@@ -12,20 +12,9 @@
  *
  */
 
-package org.eclipse.edc.jsonld.spi;
+package org.eclipse.edc.spi;
 
-/**
- * Well-known schema namespace definitions.
- */
-public interface Namespaces {
-
-    String DCAT_PREFIX = "dcat";
-    String DCAT_SCHEMA = "https://www.w3.org/ns/dcat/";
-
-    String ODRL_PREFIX = "odrl";
-    String ODRL_SCHEMA = "https://www.w3.org/TR/odrl-model/";
-
-    String DCT_PREFIX = "dct";
-    String DCT_SCHEMA = "https://purl.org/dc/terms/";
-
+public interface CoreConstants {
+    //todo: this must be replaced once we have a default EDC schema!
+    String EDC_NAMESPACE = "https://foo.bar.org/ds/schema/";
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/DataAddress.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/DataAddress.java
@@ -24,6 +24,9 @@ import org.jetbrains.annotations.NotNull;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 
 /**
  * An address that can be used resolve a data location. Data addresses are used throughout the system. For example, an asset has a data address used to resolve its contents,
@@ -44,7 +47,7 @@ public class DataAddress {
 
     @NotNull
     public String getType() {
-        return properties.get(TYPE);
+        return Optional.ofNullable(properties.get(EDC_NAMESPACE + TYPE)).orElseGet(() -> properties.get(TYPE));
     }
 
     @JsonIgnore
@@ -70,7 +73,13 @@ public class DataAddress {
     }
 
     public String getKeyName() {
-        return properties.get(KEY_NAME);
+        return Optional.ofNullable(properties.get(EDC_NAMESPACE + KEY_NAME)).orElseGet(() -> properties.get(KEY_NAME));
+    }
+
+    @JsonIgnore
+    public void setKeyName(String keyName) {
+        Objects.requireNonNull(keyName);
+        properties.put(KEY_NAME, keyName);
     }
 
     /**
@@ -82,12 +91,6 @@ public class DataAddress {
     @JsonIgnore
     public boolean hasProperty(String key) {
         return properties.containsKey(key);
-    }
-
-    @JsonIgnore
-    public void setKeyName(String keyName) {
-        Objects.requireNonNull(keyName);
-        properties.put(KEY_NAME, keyName);
     }
 
     @JsonPOJOBuilder(withPrefix = "")

--- a/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/PropertyAndTypeNames.java
+++ b/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/PropertyAndTypeNames.java
@@ -16,8 +16,8 @@ package org.eclipse.edc.jsonld.spi;
 
 import static org.eclipse.edc.jsonld.spi.Namespaces.DCAT_SCHEMA;
 import static org.eclipse.edc.jsonld.spi.Namespaces.DCT_SCHEMA;
-import static org.eclipse.edc.jsonld.spi.Namespaces.EDC_SCHEMA;
 import static org.eclipse.edc.jsonld.spi.Namespaces.ODRL_SCHEMA;
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 
 /**
  * Collection of DCAT, DCT and ODRL type and attribute names.
@@ -29,12 +29,12 @@ public interface PropertyAndTypeNames {
     String DCAT_DISTRIBUTION_TYPE = DCAT_SCHEMA + "Distribution";
     String DCAT_DATA_SERVICE_TYPE = DCAT_SCHEMA + "DataService";
 
-    String EDC_ASSET_TYPE = EDC_SCHEMA + "Asset";
-    String EDC_ASSET_PROPERTIES = EDC_SCHEMA + "properties";
-    String EDC_ASSET_NAME = EDC_SCHEMA + "name";
-    String EDC_ASSET_DESCRIPTION = EDC_SCHEMA + "description";
-    String EDC_ASSET_VERSION = EDC_SCHEMA + "version";
-    String EDC_ASSET_CONTENTTYPE = EDC_SCHEMA + "contenttype";
+    String EDC_ASSET_TYPE = EDC_NAMESPACE + "Asset";
+    String EDC_ASSET_PROPERTIES = EDC_NAMESPACE + "properties";
+    String EDC_ASSET_NAME = EDC_NAMESPACE + "name";
+    String EDC_ASSET_DESCRIPTION = EDC_NAMESPACE + "description";
+    String EDC_ASSET_VERSION = EDC_NAMESPACE + "version";
+    String EDC_ASSET_CONTENTTYPE = EDC_NAMESPACE + "contenttype";
 
     String DCAT_DATA_SERVICE_ATTRIBUTE = DCAT_SCHEMA + "service";
     String DCAT_DATASET_ATTRIBUTE = DCAT_SCHEMA + "dataset";


### PR DESCRIPTION
## What this PR changes/adds

Adds a `JsonObjectToDataAddressTransformer` plus tests.

## Why it does that

DataAddresses must be (JSON-LD)-type-aware, so we need a transformer for it.

## Further notes

this PR is needed for #2767 
- I had to (re-)create the `CoreConstants.java` into the `core-spi`, because we need access to the `EDC_NAMESPACE`. This is already done in PR #2807, but that is not yet merged.

## Linked Issue(s)

Needed for #2767 
Needed for #2806 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
