### PR TITLE
feat(ContractNegotiationService): restored callbacks 

### DIFF
--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -27,6 +27,7 @@ import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementV
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationTerminationMessage;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.command.ContractNegotiationCommand;
 import org.eclipse.edc.spi.response.StatusResult;
@@ -79,24 +80,26 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
      * Initiates a new {@link ContractNegotiation}. The ContractNegotiation is created and persisted, which moves it to
      * state REQUESTING.
      *
-     * @param contractOffer Container object containing all relevant request parameters.
+     * @param request Container object containing all relevant request parameters.
      * @return a {@link StatusResult}: OK
      */
     @WithSpan
     @Override
-    public StatusResult<ContractNegotiation> initiate(ContractRequestMessage contractOffer) {
+    public StatusResult<ContractNegotiation> initiate(ContractRequest request) {
         var id = UUID.randomUUID().toString();
+        var requestData = request.getRequestData();
         var negotiation = ContractNegotiation.Builder.newInstance()
                 .id(id)
                 .correlationId(id)
-                .protocol(contractOffer.getProtocol())
-                .counterPartyId(contractOffer.getConnectorId())
-                .counterPartyAddress(contractOffer.getCallbackAddress())
+                .protocol(requestData.getProtocol())
+                .counterPartyId(requestData.getConnectorId())
+                .counterPartyAddress(requestData.getCallbackAddress())
+                .callbackAddresses(request.getCallbackAddresses())
                 .traceContext(telemetry.getCurrentTraceContext())
                 .type(CONSUMER)
                 .build();
 
-        negotiation.addContractOffer(contractOffer.getContractOffer());
+        negotiation.addContractOffer(requestData.getContractOffer());
         transitionToInitial(negotiation);
 
         return StatusResult.success(negotiation);

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationServiceImpl.java
@@ -21,7 +21,7 @@ import org.eclipse.edc.connector.contract.spi.types.command.CancelNegotiationCom
 import org.eclipse.edc.connector.contract.spi.types.command.DeclineNegotiationCommand;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest;
 import org.eclipse.edc.connector.service.query.QueryValidator;
 import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationService;
 import org.eclipse.edc.service.spi.result.ServiceResult;
@@ -81,7 +81,7 @@ public class ContractNegotiationServiceImpl implements ContractNegotiationServic
     }
 
     @Override
-    public ContractNegotiation initiateNegotiation(ContractRequestMessage request) {
+    public ContractNegotiation initiateNegotiation(ContractRequest request) {
         return transactionContext.execute(() -> consumerManager.initiate(request).getContent());
     }
 

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationServiceImplTest.java
@@ -21,7 +21,8 @@ import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.contract.spi.types.command.CancelNegotiationCommand;
 import org.eclipse.edc.connector.contract.spi.types.command.DeclineNegotiationCommand;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestData;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.command.ContractNegotiationCommand;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.policy.model.Policy;
@@ -189,13 +190,15 @@ class ContractNegotiationServiceImplTest {
     @Test
     void initiateNegotiation_callsManager() {
         var contractNegotiation = createContractNegotiation("negotiationId");
-        when(consumerManager.initiate(isA(ContractRequestMessage.class))).thenReturn(StatusResult.success(contractNegotiation));
-        var request = ContractRequestMessage.Builder.newInstance()
+        when(consumerManager.initiate(isA(ContractRequest.class))).thenReturn(StatusResult.success(contractNegotiation));
+        var requestData = ContractRequestData.Builder.newInstance()
                 .connectorId("connectorId")
                 .callbackAddress("address")
                 .protocol("protocol")
                 .contractOffer(createContractOffer())
                 .build();
+
+        var request = ContractRequest.Builder.newInstance().requestData(requestData).build();
 
         var result = service.initiateNegotiation(request);
 

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiController.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiController.java
@@ -33,7 +33,7 @@ import org.eclipse.edc.connector.api.management.contractnegotiation.model.Contra
 import org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto;
 import org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationState;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest;
 import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationService;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.query.QuerySpec;
@@ -120,7 +120,7 @@ public class ContractNegotiationApiController implements ContractNegotiationApi 
     @POST
     @Override
     public IdResponseDto initiateContractNegotiation(@Valid NegotiationInitiateRequestDto initiateDto) {
-        var transformResult = transformerRegistry.transform(initiateDto, ContractRequestMessage.class);
+        var transformResult = transformerRegistry.transform(initiateDto, ContractRequest.class);
         if (transformResult.failed()) {
             throw new InvalidRequestException(transformResult.getFailureMessages());
         }

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerIntegrationTest.java
@@ -16,6 +16,7 @@
 package org.eclipse.edc.connector.api.management.contractnegotiation;
 
 import io.restassured.specification.RequestSpecification;
+import org.eclipse.edc.api.model.CallbackAddressDto;
 import org.eclipse.edc.api.model.CriterionDto;
 import org.eclipse.edc.api.query.QuerySpecDto;
 import org.eclipse.edc.catalog.spi.DataService;
@@ -216,6 +217,9 @@ class ContractNegotiationApiControllerIntegrationTest {
                 .connectorId("connector")
                 .protocol(TestRemoteMessageDispatcher.TEST_PROTOCOL)
                 .connectorAddress("callbackAddress")
+                .callbackAddresses(List.of(CallbackAddressDto.Builder.newInstance()
+                        .uri("local://test")
+                        .build()))
                 .offer(TestFunctions.createOffer())
                 .consumerId("test-consumer")
                 .providerId("test-provider")

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerTest.java
@@ -25,7 +25,8 @@ import org.eclipse.edc.connector.api.management.contractnegotiation.model.Contra
 import org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestData;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationService;
 import org.eclipse.edc.policy.model.Policy;
@@ -190,9 +191,9 @@ class ContractNegotiationApiControllerTest {
 
     @Test
     void initiateNegotiation() {
-        when(service.initiateNegotiation(isA(ContractRequestMessage.class))).thenReturn(createContractNegotiation("negotiationId"));
+        when(service.initiateNegotiation(isA(ContractRequest.class))).thenReturn(createContractNegotiation("negotiationId"));
         var contractOfferRequest = createContractOfferRequest();
-        when(transformerRegistry.transform(isA(NegotiationInitiateRequestDto.class), eq(ContractRequestMessage.class))).thenReturn(Result.success(contractOfferRequest));
+        when(transformerRegistry.transform(isA(NegotiationInitiateRequestDto.class), eq(ContractRequest.class))).thenReturn(Result.success(contractOfferRequest));
         var request = NegotiationInitiateRequestDto.Builder.newInstance()
                 .connectorId("connectorId")
                 .connectorAddress("callbackAddress")
@@ -213,7 +214,7 @@ class ContractNegotiationApiControllerTest {
 
     @Test
     void initiateNegotiation_illegalArgumentIfTransformationFails() {
-        when(service.initiateNegotiation(isA(ContractRequestMessage.class))).thenReturn(createContractNegotiation("negotiationId"));
+        when(service.initiateNegotiation(isA(ContractRequest.class))).thenReturn(createContractNegotiation("negotiationId"));
         var request = NegotiationInitiateRequestDto.Builder.newInstance()
                 .connectorId("connectorId")
                 .connectorAddress("callbackAddress")
@@ -280,7 +281,7 @@ class ContractNegotiationApiControllerTest {
     @ParameterizedTest
     @ArgumentsSource(InvalidNegotiationParameters.class)
     void initiateNegotiation_invalidRequestBody(String connectorAddress, String connectorId, String protocol, String offerId) {
-        when(transformerRegistry.transform(isA(NegotiationInitiateRequestDto.class), eq(ContractRequestMessage.class))).thenReturn(Result.failure("error"));
+        when(transformerRegistry.transform(isA(NegotiationInitiateRequestDto.class), eq(ContractRequest.class))).thenReturn(Result.failure("error"));
 
         var rq = NegotiationInitiateRequestDto.Builder.newInstance()
                 .connectorAddress(connectorAddress)
@@ -307,8 +308,8 @@ class ContractNegotiationApiControllerTest {
                 .build();
     }
 
-    private ContractRequestMessage createContractOfferRequest() {
-        return ContractRequestMessage.Builder.newInstance()
+    private ContractRequest createContractOfferRequest() {
+        var requestData = ContractRequestData.Builder.newInstance()
                 .protocol("protocol")
                 .connectorId("connectorId")
                 .callbackAddress("callbackAddress")
@@ -319,6 +320,9 @@ class ContractNegotiationApiControllerTest {
                         .contractStart(ZonedDateTime.now())
                         .contractEnd(ZonedDateTime.now().plusMonths(1))
                         .build())
+                .build();
+        return ContractRequest.Builder.newInstance()
+                .requestData(requestData)
                 .build();
     }
 

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/NegotiationInitiateRequestDtoToDataRequestTransformerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/NegotiationInitiateRequestDtoToDataRequestTransformerTest.java
@@ -26,7 +26,6 @@ import java.util.List;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.api.management.contractnegotiation.TestFunctions.createOffer;
-import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage.Type.INITIAL;
 import static org.mockito.Mockito.mock;
 
 class NegotiationInitiateRequestDtoToDataRequestTransformerTest {
@@ -63,14 +62,14 @@ class NegotiationInitiateRequestDtoToDataRequestTransformerTest {
         var request = transformer.transform(dto, context);
 
         assertThat(request).isNotNull();
-        assertThat(request.getConnectorId()).isEqualTo("connectorId");
-        assertThat(request.getCallbackAddress()).isEqualTo("address");
-        assertThat(request.getProtocol()).isEqualTo("protocol");
-        assertThat(request.getType()).isEqualTo(INITIAL);
-        assertThat(request.getContractOffer().getId()).isEqualTo("offerId");
-        assertThat(request.getContractOffer().getContractStart().toInstant()).isEqualTo(clock.instant());
-        assertThat(request.getContractOffer().getContractEnd().toInstant()).isEqualTo(clock.instant().plusSeconds(dto.getOffer().getValidity()));
-        assertThat(request.getContractOffer().getPolicy()).isNotNull();
+        assertThat(request.getRequestData().getConnectorId()).isEqualTo("connectorId");
+        assertThat(request.getRequestData().getCallbackAddress()).isEqualTo("address");
+        assertThat(request.getRequestData().getProtocol()).isEqualTo("protocol");
+        assertThat(request.getRequestData().getContractOffer().getId()).isEqualTo("offerId");
+        assertThat(request.getRequestData().getContractOffer().getContractStart().toInstant()).isEqualTo(clock.instant());
+        assertThat(request.getRequestData().getContractOffer().getContractEnd().toInstant()).isEqualTo(clock.instant().plusSeconds(dto.getOffer().getValidity()));
+        assertThat(request.getRequestData().getContractOffer().getPolicy()).isNotNull();
+        assertThat(request.getCallbackAddresses()).hasSize(1);
     }
 
     @Test
@@ -87,8 +86,8 @@ class NegotiationInitiateRequestDtoToDataRequestTransformerTest {
         var request = transformer.transform(dto, context);
 
         assertThat(request).isNotNull();
-        assertThat(request.getContractOffer().getProvider()).asString().isEqualTo(dto.getConnectorAddress());
-        assertThat(request.getContractOffer().getConsumer()).asString().isEqualTo("urn:connector:test-consumer");
+        assertThat(request.getRequestData().getContractOffer().getProvider()).asString().isEqualTo(dto.getConnectorAddress());
+        assertThat(request.getRequestData().getContractOffer().getConsumer()).asString().isEqualTo("urn:connector:test-consumer");
     }
 
     @Test
@@ -104,7 +103,7 @@ class NegotiationInitiateRequestDtoToDataRequestTransformerTest {
 
         var request = transformer.transform(dto, context);
         assertThat(request).isNotNull();
-        assertThat(request.getContractOffer().getProvider()).asString().isEqualTo("urn:connector:test-provider");
-        assertThat(request.getContractOffer().getConsumer()).asString().isEqualTo(DEFAULT_CONSUMER_ID);
+        assertThat(request.getRequestData().getContractOffer().getProvider()).asString().isEqualTo("urn:connector:test-provider");
+        assertThat(request.getRequestData().getContractOffer().getConsumer()).asString().isEqualTo(DEFAULT_CONSUMER_ID);
     }
 }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/negotiation/ConsumerContractNegotiationManager.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/negotiation/ConsumerContractNegotiationManager.java
@@ -16,7 +16,7 @@
 package org.eclipse.edc.connector.contract.spi.negotiation;
 
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import org.eclipse.edc.spi.response.StatusResult;
 
@@ -31,6 +31,6 @@ public interface ConsumerContractNegotiationManager extends ContractNegotiationM
     /**
      * Initiates a contract negotiation for the given provider offer. The offer will have been obtained from a previous contract offer request sent to the provider.
      */
-    StatusResult<ContractNegotiation> initiate(ContractRequestMessage contractOffer);
+    StatusResult<ContractNegotiation> initiate(ContractRequest request);
 
 }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequest.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequest.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.contract.spi.types.negotiation;
+
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Represent a request for contract negotiation on the consumer side. It contains the detail of the request in {@link ContractRequestData}
+ */
+public class ContractRequest {
+
+    private ContractRequestData requestData;
+    private List<CallbackAddress> callbackAddresses = new ArrayList<>();
+
+    public ContractRequestData getRequestData() {
+        return requestData;
+    }
+
+    public List<CallbackAddress> getCallbackAddresses() {
+        return callbackAddresses;
+    }
+
+    public static class Builder {
+        private final ContractRequest contractRequest;
+
+        private Builder() {
+            contractRequest = new ContractRequest();
+        }
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder requestData(ContractRequestData requestData) {
+            contractRequest.requestData = requestData;
+            return this;
+        }
+
+        public Builder callbackAddresses(List<CallbackAddress> callbackAddresses) {
+            contractRequest.callbackAddresses = callbackAddresses;
+            return this;
+        }
+
+        public ContractRequest build() {
+            Objects.requireNonNull(contractRequest.requestData, "requestData");
+            return contractRequest;
+        }
+    }
+}

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestData.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestData.java
@@ -1,0 +1,99 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.contract.spi.types.negotiation;
+
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
+
+import java.util.Objects;
+
+/**
+ * Represent the data needed for initiating contract negotiation on the consumer side
+ */
+public class ContractRequestData {
+
+    private String protocol;
+    @Deprecated(forRemoval = true)
+    private String connectorId;
+    private String callbackAddress;
+    private ContractOffer contractOffer;
+    private String dataSet;
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public String getCallbackAddress() {
+        return callbackAddress;
+    }
+
+    @Deprecated
+    public String getConnectorId() {
+        return connectorId;
+    }
+
+
+    public ContractOffer getContractOffer() {
+        return contractOffer;
+    }
+
+    public String getDataSet() {
+        return dataSet;
+    }
+
+    public static class Builder {
+        private final ContractRequestData contractRequestMessage;
+
+        private Builder() {
+            contractRequestMessage = new ContractRequestData();
+        }
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder protocol(String protocol) {
+            contractRequestMessage.protocol = protocol;
+            return this;
+        }
+
+        @Deprecated
+        public Builder connectorId(String connectorId) {
+            contractRequestMessage.connectorId = connectorId;
+            return this;
+        }
+
+        public Builder callbackAddress(String callbackAddress) {
+            contractRequestMessage.callbackAddress = callbackAddress;
+            return this;
+        }
+
+        public Builder contractOffer(ContractOffer contractOffer) {
+            contractRequestMessage.contractOffer = contractOffer;
+            return this;
+        }
+
+        public Builder dataSet(String dataSet) {
+            contractRequestMessage.dataSet = dataSet;
+            return this;
+        }
+
+        public ContractRequestData build() {
+            Objects.requireNonNull(contractRequestMessage.protocol, "protocol");
+            Objects.requireNonNull(contractRequestMessage.callbackAddress, "callbackAddress");
+            Objects.requireNonNull(contractRequestMessage.contractOffer, "contractOffer");
+            return contractRequestMessage;
+        }
+    }
+}

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/contractnegotiation/ContractNegotiationService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/contractnegotiation/ContractNegotiationService.java
@@ -16,7 +16,7 @@ package org.eclipse.edc.connector.spi.contractnegotiation;
 
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest;
 import org.eclipse.edc.service.spi.result.ServiceResult;
 import org.eclipse.edc.spi.query.QuerySpec;
 
@@ -63,7 +63,7 @@ public interface ContractNegotiationService {
      * @param request the contract offer request
      * @return the contract negotiation initiated
      */
-    ContractNegotiation initiateNegotiation(ContractRequestMessage request);
+    ContractNegotiation initiateNegotiation(ContractRequest request);
 
     /**
      * Cancel a contract negotiation


### PR DESCRIPTION
## What this PR changes/adds

This PR refactor `ContractNegotiationService` and `ConsumerContractNegotiationManager` in order to take `ContractRequest` as input for initiating a contract negotiation instead of `ContractRequestMessage` which implements  `RemoteMessage` and it's supposed to be used only when dealing with protocol communication. 

## Why it does that

Clean up, decoupling

## Further notes

We could entirely separate the classes that represent remote messages in their own modules

## Linked Issue(s)

Closes #2815 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
