### PR TITLE
feat(Callbacks): propagate the EDR in dataAddress form with events

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImpl.java
@@ -20,6 +20,7 @@ import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiat
 import org.eclipse.edc.connector.contract.spi.validation.ContractValidationService;
 import org.eclipse.edc.connector.spi.transferprocess.TransferProcessProtocolService;
 import org.eclipse.edc.connector.transfer.spi.observe.TransferProcessObservable;
+import org.eclipse.edc.connector.transfer.spi.observe.TransferProcessStartedData;
 import org.eclipse.edc.connector.transfer.spi.store.TransferProcessStore;
 import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
 import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
@@ -149,7 +150,10 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
             observable.invokeForEach(l -> l.preStarted(transferProcess));
             transferProcess.transitionStarted();
             update(transferProcess);
-            observable.invokeForEach(l -> l.started(transferProcess));
+            var transferStartedData = TransferProcessStartedData.Builder.newInstance()
+                    .dataAddress(message.getDataAddress())
+                    .build();
+            observable.invokeForEach(l -> l.started(transferProcess, transferStartedData));
             return ServiceResult.success(transferProcess);
         } else {
             return ServiceResult.conflict(format("Cannot process %s because %s", message.getClass().getSimpleName(), "transfer cannot be started"));

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/listener/TransferProcessEventListener.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/listener/TransferProcessEventListener.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.connector.transfer.listener;
 
 import org.eclipse.edc.connector.transfer.spi.observe.TransferProcessListener;
+import org.eclipse.edc.connector.transfer.spi.observe.TransferProcessStartedData;
 import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.spi.event.EventEnvelope;
 import org.eclipse.edc.spi.event.EventRouter;
@@ -85,9 +86,10 @@ public class TransferProcessEventListener implements TransferProcessListener {
     }
 
     @Override
-    public void started(TransferProcess process) {
+    public void started(TransferProcess process, TransferProcessStartedData additionalData) {
         var event = TransferProcessStarted.Builder.newInstance()
                 .transferProcessId(process.getId())
+                .dataAddress(additionalData.getDataAddress())
                 .callbackAddresses(process.getCallbackAddresses())
                 .build();
 

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
@@ -20,6 +20,7 @@ import org.eclipse.edc.connector.policy.spi.store.PolicyArchive;
 import org.eclipse.edc.connector.transfer.spi.TransferProcessManager;
 import org.eclipse.edc.connector.transfer.spi.flow.DataFlowManager;
 import org.eclipse.edc.connector.transfer.spi.observe.TransferProcessObservable;
+import org.eclipse.edc.connector.transfer.spi.observe.TransferProcessStartedData;
 import org.eclipse.edc.connector.transfer.spi.provision.ProvisionManager;
 import org.eclipse.edc.connector.transfer.spi.provision.ResourceManifestGenerator;
 import org.eclipse.edc.connector.transfer.spi.status.StatusCheckerRegistry;
@@ -741,7 +742,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
         process.transitionStarted();
         observable.invokeForEach(l -> l.preStarted(process));
         update(process);
-        observable.invokeForEach(l -> l.started(process));
+        observable.invokeForEach(l -> l.started(process, TransferProcessStartedData.Builder.newInstance().build()));
     }
 
     private void transitionToCompleting(TransferProcess process) {

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/transfer/TransferProcessManagerImplTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/transfer/TransferProcessManagerImplTest.java
@@ -478,7 +478,7 @@ class TransferProcessManagerImplTest {
             verify(dispatcherRegistry).send(any(), captor.capture());
             assertThat(captor.getValue().getDataAddress()).usingRecursiveComparison().isEqualTo(dataFlowResponse.getDataAddress());
             verify(transferProcessStore).save(argThat(p -> p.getState() == STARTED.code()));
-            verify(listener).started(process);
+            verify(listener).started(eq(process), any());
         });
     }
 

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/transferprocess/TransferProcessStarted.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/transferprocess/TransferProcessStarted.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.spi.event.transferprocess;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.spi.types.domain.DataAddress;
 
 /**
  * This event is raised when the TransferProcess has been started.
@@ -24,7 +25,14 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 @JsonDeserialize(builder = TransferProcessStarted.Builder.class)
 public class TransferProcessStarted extends TransferProcessEvent {
 
+
+    private DataAddress dataAddress;
+
     private TransferProcessStarted() {
+    }
+
+    public DataAddress getDataAddress() {
+        return dataAddress;
     }
 
     @Override
@@ -42,6 +50,11 @@ public class TransferProcessStarted extends TransferProcessEvent {
         @JsonCreator
         public static Builder newInstance() {
             return new Builder();
+        }
+
+        public Builder dataAddress(DataAddress dataAddress) {
+            event.dataAddress = dataAddress;
+            return this;
         }
 
         @Override

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/observe/TransferProcessListener.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/observe/TransferProcessListener.java
@@ -194,7 +194,7 @@ public interface TransferProcessListener {
      *
      * @param process the transfer process that has been started.
      */
-    default void started(TransferProcess process) {
+    default void started(TransferProcess process, TransferProcessStartedData additionalData) {
 
     }
 

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/observe/TransferProcessStartedData.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/observe/TransferProcessStartedData.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.transfer.spi.observe;
+
+import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+
+/**
+ * Additional data when calling {@link TransferProcessListener#started} not stored in the {@link TransferProcess}
+ */
+public class TransferProcessStartedData {
+
+    private DataAddress dataAddress;
+
+    private TransferProcessStartedData() {
+    }
+
+    public DataAddress getDataAddress() {
+        return dataAddress;
+    }
+
+    public static class Builder {
+
+        private final TransferProcessStartedData data;
+
+        private Builder(TransferProcessStartedData data) {
+            this.data = data;
+        }
+
+        public static Builder newInstance() {
+            return new Builder(new TransferProcessStartedData());
+        }
+        
+        public Builder dataAddress(DataAddress dataAddress) {
+            data.dataAddress = dataAddress;
+            return this;
+        }
+
+        public TransferProcessStartedData build() {
+            return data;
+        }
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

Adds the `dataAddress` field on `TransferProcessStarted` event which will be populated on consumer side upon receiving the dsp message about the transfer process started

## Why it does that

Support for EDR in callbacks

## Linked Issue(s)

Closes #2819 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
