### PR TITLE
feat(asset): enable querying assets by custom properties

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/asset/AssetQueryValidator.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/asset/AssetQueryValidator.java
@@ -18,31 +18,27 @@ import org.eclipse.edc.connector.service.query.QueryValidator;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
 
-import java.util.List;
+import java.util.regex.Pattern;
 
 import static java.lang.String.format;
 
 class AssetQueryValidator extends QueryValidator {
-    private static final List<String> KNOWN_PROPERTIES = List.of(
-            Asset.PROPERTY_ID,
-            Asset.PROPERTY_NAME,
-            Asset.PROPERTY_DESCRIPTION,
-            Asset.PROPERTY_VERSION,
-            Asset.PROPERTY_CONTENT_TYPE
-    );
+    private static final Pattern VALID_QUERY_PATH_REGEX = Pattern.compile("^[A-Za-z_]+.*$");
 
     AssetQueryValidator() {
         super(Asset.class);
     }
 
     /**
-     * The only valid paths are named properties from {@link Asset}
+     * Only paths are valid that start with either a character or an '_'
      *
-     * @param path The path. Cannot start or end with a "."
+     * @param path The path. Cannot start with anything other chan A-Za-z_
      */
     @Override
     protected Result<Void> isValid(String path) {
-        return KNOWN_PROPERTIES.contains(path) ? Result.success() :
-                Result.failure(format("Currently only named properties of Asset are supported, and %s isn't one of them.", path));
+        if (VALID_QUERY_PATH_REGEX.matcher(path).matches()) {
+            return Result.success();
+        }
+        return Result.failure(format("The query path must start with a letter or an '_' but was '%s'", path));
     }
 }

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/asset/AssetQueryValidatorTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/asset/AssetQueryValidatorTest.java
@@ -14,10 +14,13 @@
 
 package org.eclipse.edc.connector.service.asset;
 
+import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
@@ -32,24 +35,27 @@ class AssetQueryValidatorTest {
             Asset.PROPERTY_NAME,
             Asset.PROPERTY_DESCRIPTION,
             Asset.PROPERTY_VERSION,
-            Asset.PROPERTY_CONTENT_TYPE
+            Asset.PROPERTY_CONTENT_TYPE,
+            "someCustomVal",
+            "_anotherValidVal",
+
     })
     void validate_validProperty(String key) {
-        var query = QuerySpec.Builder.newInstance().filter(key + "=someval").build();
-        assertThat(validator.validate(query).succeeded())
-                .isTrue();
+        var query = QuerySpec.Builder.newInstance().filter(List.of(new Criterion(key, "=", "someval"))).build();
+        assertThat(validator.validate(query).succeeded()).isTrue();
     }
 
     @ParameterizedTest
     @ValueSource(strings = {
-            "asset_prop_id in (foo, bar)", // invalid key
-            "customProp=whatever", // no custom properties supported
-            EDC_NAMESPACE + "id.=something", // trailing dot
-            "." + EDC_NAMESPACE + ":id=something" // leading dot
+            "+asset_prop_id", // leading +
+            "  customProp", // leading space
+            "." + EDC_NAMESPACE + "id", // leading dot
+            "/someValue", //leading slash
+            "42ValidValues" //leading number
     })
-    void validate_invalidProperty(String filter) {
+    void validate_invalidProperty(String key) {
         var query = QuerySpec.Builder.newInstance()
-                .filter(filter)
+                .filter(List.of(new Criterion(key, "=", "something")))
                 .build();
 
         assertThat(validator.validate(query).failed()).isTrue();

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/asset/AssetServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/asset/AssetServiceImplTest.java
@@ -106,8 +106,8 @@ class AssetServiceImplTest {
 
     @ParameterizedTest
     @ValueSource(strings = {
-            "asset_prop_id in (foo, bar)", // invalid key
-            "customProp=whatever", // no custom properties supported
+            "  asset_prop_id in (foo, bar)", // invalid leading whitespace
+            ".customProp=whatever", // invalid leading dot
     })
     void query_invalidFilter(String filter) {
         var query = QuerySpec.Builder.newInstance()


### PR DESCRIPTION
## What this PR changes/adds

Change the `AssetQueryValidator` so that it allows for any query path, not just known `Asset` properties.

However, query paths (= left-operands) must start with a letter or an underscore.


## Why it does that

This will be needed for more complex `AssetSelectorExpression`s.

## Further notes

- I added a test to the `AssetIndexTestBase` that performs a complex query on a nested JSON structure.

## Linked Issue(s)

Closes .

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
