### PR TITLE
refactor(dsp): use supplier notation for logging

### DIFF
--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-api/src/main/java/org/eclipse/edc/protocol/dsp/catalog/api/DspCatalogApiExtension.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-api/src/main/java/org/eclipse/edc/protocol/dsp/catalog/api/DspCatalogApiExtension.java
@@ -66,7 +66,7 @@ public class DspCatalogApiExtension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
         var mapper = typeManager.getMapper(JSON_LD);
         var dspCallbackAddress = apiConfiguration.getDspCallbackAddress();
-        var catalogController = new CatalogController(mapper, identityService, transformerRegistry, dspCallbackAddress, service, jsonLdService);
+        var catalogController = new CatalogController(context.getMonitor(), mapper, identityService, transformerRegistry, dspCallbackAddress, service, jsonLdService);
         webService.registerResource(apiConfiguration.getContextAlias(), catalogController);
 
         dataServiceRegistry.register(DataService.Builder.newInstance()

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-api/src/main/java/org/eclipse/edc/protocol/dsp/catalog/api/controller/CatalogController.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-api/src/main/java/org/eclipse/edc/protocol/dsp/catalog/api/controller/CatalogController.java
@@ -29,6 +29,7 @@ import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.iam.IdentityService;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.web.spi.exception.AuthenticationFailedException;
 import org.eclipse.edc.web.spi.exception.InvalidRequestException;
@@ -50,6 +51,8 @@ import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMa
 @Produces({ MediaType.APPLICATION_JSON })
 @Path(BASE_PATH)
 public class CatalogController {
+    
+    private final Monitor monitor;
     private final ObjectMapper mapper;
     private final IdentityService identityService;
     private final TypeTransformerRegistry transformerRegistry;
@@ -57,9 +60,10 @@ public class CatalogController {
     private final CatalogProtocolService service;
     private final JsonLd jsonLdService;
 
-    public CatalogController(ObjectMapper mapper, IdentityService identityService,
+    public CatalogController(Monitor monitor, ObjectMapper mapper, IdentityService identityService,
                              TypeTransformerRegistry transformerRegistry, String dspCallbackAddress,
                              CatalogProtocolService service, JsonLd jsonLdService) {
+        this.monitor = monitor;
         this.mapper = mapper;
         this.identityService = identityService;
         this.transformerRegistry = transformerRegistry;
@@ -71,6 +75,8 @@ public class CatalogController {
     @POST
     @Path(CATALOG_REQUEST)
     public Map<String, Object> getCatalog(JsonObject jsonObject, @HeaderParam(AUTHORIZATION) String token) {
+        monitor.debug(() -> "DSP: Incoming catalog request.");
+        
         var tokenRepresentation = TokenRepresentation.Builder.newInstance()
                 .token(token)
                 .build();

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-api/src/test/java/org/eclipse/edc/protocol/dsp/catalog/api/controller/CatalogControllerTest.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-api/src/test/java/org/eclipse/edc/protocol/dsp/catalog/api/controller/CatalogControllerTest.java
@@ -59,6 +59,7 @@ import static org.mockito.Mockito.when;
 
 class CatalogControllerTest {
 
+    private final Monitor monitor = mock(Monitor.class);
     private final ObjectMapper mapper = mock(ObjectMapper.class);
     private final IdentityService identityService = mock(IdentityService.class);
     private final TypeTransformerRegistry transformerRegistry = mock(TypeTransformerRegistry.class);
@@ -80,7 +81,7 @@ class CatalogControllerTest {
         jsonLdService.registerNamespace(DCT_PREFIX, DCT_SCHEMA);
         jsonLdService.registerNamespace(ODRL_PREFIX, ODRL_SCHEMA);
         jsonLdService.registerNamespace(DSPACE_PREFIX, DSPACE_SCHEMA);
-        controller = new CatalogController(mapper, identityService, transformerRegistry, callbackAddress, service, jsonLdService);
+        controller = new CatalogController(monitor, mapper, identityService, transformerRegistry, callbackAddress, service, jsonLdService);
 
         request = Json.createObjectBuilder()
                 .add(TYPE, DSPACE_CATALOG_REQUEST_TYPE)

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/api/controller/DspNegotiationController.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/api/controller/DspNegotiationController.java
@@ -105,7 +105,7 @@ public class DspNegotiationController {
     @GET
     @Path("{id}")
     public Map<String, Object> getNegotiation(@PathParam("id") String id, @HeaderParam(AUTHORIZATION) String token) {
-        monitor.debug(format("DSP: Incoming request for contract negotiation with id %s", id));
+        monitor.debug(() -> format("DSP: Incoming request for contract negotiation with id %s", id));
 
         checkAndReturnAuthToken(token);
 
@@ -121,7 +121,7 @@ public class DspNegotiationController {
     @POST
     @Path(INITIAL_CONTRACT_REQUEST)
     public Map<String, Object> initiateNegotiation(@RequestBody(description = DSPACE_NEGOTIATION_CONTRACT_REQUEST_MESSAGE, required = true) JsonObject body, @HeaderParam(AUTHORIZATION) String token) {
-        monitor.debug("DSP: Incoming ContractRequestMessage for initiating a contract negotiation.");
+        monitor.debug(() -> "DSP: Incoming ContractRequestMessage for initiating a contract negotiation.");
 
         var negotiation = processMessage(token, Optional.empty(), body, DSPACE_NEGOTIATION_CONTRACT_REQUEST_MESSAGE, ContractRequestMessage.class, protocolService::notifyRequested);
 
@@ -142,7 +142,7 @@ public class DspNegotiationController {
     @POST
     @Path("{id}" + CONTRACT_REQUEST)
     public void consumerOffer(@PathParam("id") String id, @RequestBody(description = DSPACE_NEGOTIATION_CONTRACT_REQUEST_MESSAGE, required = true) JsonObject body, @HeaderParam(AUTHORIZATION) String token) {
-        monitor.debug(format("DSP: Incoming ContractRequestMessage for process %s", id));
+        monitor.debug(() -> format("DSP: Incoming ContractRequestMessage for process %s", id));
 
         processMessage(token, Optional.of(id), body, DSPACE_NEGOTIATION_CONTRACT_REQUEST_MESSAGE, ContractRequestMessage.class, protocolService::notifyRequested);
     }
@@ -157,7 +157,7 @@ public class DspNegotiationController {
     @POST
     @Path("{id}" + EVENT)
     public void createEvent(@PathParam("id") String id, @RequestBody(description = DSPACE_NEGOTIATION_EVENT_MESSAGE, required = true) JsonObject body, @HeaderParam(AUTHORIZATION) String token) {
-        monitor.debug(format("DSP: Incoming ContractNegotiationEventMessage for process %s", id));
+        monitor.debug(() -> format("DSP: Incoming ContractNegotiationEventMessage for process %s", id));
 
         var claimToken = checkAndReturnAuthToken(token);
         var expandedResult = jsonLdService.expand(body);
@@ -190,7 +190,7 @@ public class DspNegotiationController {
     @POST
     @Path("{id}" + AGREEMENT + VERIFICATION)
     public void verifyAgreement(@PathParam("id") String id, @RequestBody(description = DSPACE_NEGOTIATION_AGREEMENT_VERIFICATION_MESSAGE, required = true) JsonObject body, @HeaderParam(AUTHORIZATION) String token) {
-        monitor.debug(format("DSP: Incoming ContractAgreementVerificationMessage for process %s", id));
+        monitor.debug(() -> format("DSP: Incoming ContractAgreementVerificationMessage for process %s", id));
 
         processMessage(token, Optional.of(id), body, DSPACE_NEGOTIATION_AGREEMENT_VERIFICATION_MESSAGE, ContractAgreementVerificationMessage.class, protocolService::notifyVerified);
     }
@@ -205,7 +205,7 @@ public class DspNegotiationController {
     @POST
     @Path("{id}" + TERMINATION)
     public void terminateNegotiation(@PathParam("id") String id, @RequestBody(description = DSPACE_NEGOTIATION_TERMINATION_MESSAGE, required = true) JsonObject body, @HeaderParam(AUTHORIZATION) String token) {
-        monitor.debug(format("DSP: Incoming ContractNegotiationTerminationMessage for process %s", id));
+        monitor.debug(() -> format("DSP: Incoming ContractNegotiationTerminationMessage for process %s", id));
 
         processMessage(token, Optional.of(id), body, DSPACE_NEGOTIATION_TERMINATION_MESSAGE, ContractNegotiationTerminationMessage.class, protocolService::notifyTerminated);
     }
@@ -221,7 +221,7 @@ public class DspNegotiationController {
     @Path("{id}" + CONTRACT_OFFER)
 
     public void providerOffer(@PathParam("id") String id, @RequestBody(description = DSPACE_NEGOTIATION_CONTRACT_OFFER_MESSAGE, required = true) JsonObject body, @HeaderParam(AUTHORIZATION) String token) {
-        monitor.debug(format("DSP: Incoming ContractOfferMessage for process %s", id));
+        monitor.debug(() -> format("DSP: Incoming ContractOfferMessage for process %s", id));
 
         checkAndReturnAuthToken(token);
 
@@ -238,7 +238,7 @@ public class DspNegotiationController {
     @POST
     @Path("{id}" + AGREEMENT)
     public void createAgreement(@PathParam("id") String id, @RequestBody(description = DSPACE_NEGOTIATION_AGREEMENT_MESSAGE, required = true) JsonObject body, @HeaderParam(AUTHORIZATION) String token) {
-        monitor.debug(format("DSP: Incoming ContractAgreementMessage for process %s", id));
+        monitor.debug(() -> format("DSP: Incoming ContractAgreementMessage for process %s", id));
 
         processMessage(token, Optional.of(id), body, DSPACE_NEGOTIATION_AGREEMENT_MESSAGE, ContractAgreementMessage.class, protocolService::notifyAgreed);
     }

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-api/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/api/controller/DspTransferProcessApiController.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-api/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/api/controller/DspTransferProcessApiController.java
@@ -98,7 +98,7 @@ public class DspTransferProcessApiController {
     @GET
     @Path("/{id}")
     public JsonObject getTransferProcess(@PathParam("id") String id) {
-        monitor.debug(format("DSP: Incoming request for transfer process with id %s", id));
+        monitor.debug(() -> format("DSP: Incoming request for transfer process with id %s", id));
 
         throw new UnsupportedOperationException("Getting a transfer process not yet supported.");
     }
@@ -172,7 +172,7 @@ public class DspTransferProcessApiController {
     @POST
     @Path("{id}" + TRANSFER_SUSPENSION)
     public void transferProcessSuspension(@PathParam("id") String id) {
-        monitor.debug(format("DSP: Incoming TransferSuspensionMessage for transfer process %s", id));
+        monitor.debug(() -> format("DSP: Incoming TransferSuspensionMessage for transfer process %s", id));
 
         throw new UnsupportedOperationException("Suspension not yet supported.");
     }
@@ -193,9 +193,9 @@ public class DspTransferProcessApiController {
      * @return the transfer process returned by the service call
      */
     private <M extends TransferRemoteMessage> TransferProcess handleMessage(JsonObject request, Optional<String> processId, String token, String expectedType,
-                                                                            Class<M> messageClass, BiFunction<M, ClaimToken, ServiceResult<TransferProcess>> serviceCall) {
-        processId.ifPresentOrElse(id -> monitor.debug(format("DSP: Incoming %s for transfer process %s", messageClass.getSimpleName(), id)),
-                () -> monitor.debug(format("DSP: Incoming %s for initiating a transfer process", messageClass.getSimpleName())));
+                                                                 Class<M> messageClass, BiFunction<M, ClaimToken, ServiceResult<TransferProcess>> serviceCall) {
+        processId.ifPresentOrElse(id ->  monitor.debug(() -> format("DSP: Incoming %s for transfer process %s", messageClass.getSimpleName(), id)),
+                () -> monitor.debug(() -> format("DSP: Incoming %s for initiating a transfer process", messageClass.getSimpleName())));
 
         var claimToken = checkAuthToken(token);
 


### PR DESCRIPTION
## What this PR changes/adds

Uses the `Monitor's` supplier notation for debug logging in `dsp` controllers.

## Why it does that

So that `format()` is only evaluated if debug logging is enabled.

## Checklist

- [ ] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
