### PR TITLE
feat(dsp): add a titanium-based impl of the JsonLd service

### DIFF
--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/JsonLdExtension.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/JsonLdExtension.java
@@ -14,11 +14,13 @@
 
 package org.eclipse.edc.jsonld;
 
+import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.jsonld.spi.transformer.JsonLdTransformer;
 import org.eclipse.edc.jsonld.util.JacksonJsonLd;
 import org.eclipse.edc.runtime.metamodel.annotation.BaseExtension;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
@@ -32,7 +34,7 @@ import org.eclipse.edc.spi.types.TypeManager;
 @BaseExtension
 @Extension(value = JsonLdExtension.NAME)
 public class JsonLdExtension implements ServiceExtension {
-    
+
     public static final String NAME = "JSON-LD Extension";
     public static final String TYPE_MANAGER_CONTEXT_JSON_LD = "json-ld";
 
@@ -47,6 +49,11 @@ public class JsonLdExtension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
         typeManager.registerContext(TYPE_MANAGER_CONTEXT_JSON_LD, JacksonJsonLd.createObjectMapper());
+    }
+
+    @Provider
+    public JsonLd createJsonLdService(ServiceExtensionContext context) {
+        return new TitaniumJsonLd(context.getMonitor());
     }
 
 }

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/TitaniumJsonLd.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/TitaniumJsonLd.java
@@ -44,7 +44,10 @@ public class TitaniumJsonLd implements JsonLd {
         try {
             var document = JsonDocument.of(json);
             var expanded = com.apicatalog.jsonld.JsonLd.expand(document).get();
-            return Result.success(expanded.getJsonObject(0));
+            if (expanded.size() > 0) {
+                return Result.success(expanded.getJsonObject(0));
+            }
+            return Result.success(Json.createObjectBuilder().build());
         } catch (JsonLdError error) {
             monitor.warning("Error expanding JSON-LD structure", error);
             return Result.failure(error.getMessage());

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/TitaniumJsonLd.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/TitaniumJsonLd.java
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.jsonld;
+
+import com.apicatalog.jsonld.JsonLdError;
+import com.apicatalog.jsonld.document.JsonDocument;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.result.Result;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
+
+/**
+ * Implementation of the {@link JsonLd} interface that uses the Titanium library for all JSON-LD operations.
+ */
+public class TitaniumJsonLd implements JsonLd {
+    private final Monitor monitor;
+    private final Map<String, String> additionalNamespaces;
+
+    public TitaniumJsonLd(Monitor monitor) {
+        this.monitor = monitor;
+        additionalNamespaces = new HashMap<>();
+    }
+
+    @Override
+    public Result<JsonObject> expand(JsonObject json) {
+        try {
+            var document = JsonDocument.of(json);
+            var expanded = com.apicatalog.jsonld.JsonLd.expand(document).get();
+            return Result.success(expanded.getJsonObject(0));
+        } catch (JsonLdError error) {
+            monitor.warning("Error expanding JSON-LD structure", error);
+            return Result.failure(error.getMessage());
+        }
+    }
+
+    @Override
+    public Result<JsonObject> compact(JsonObject json) {
+        try {
+            var document = JsonDocument.of(json);
+            var jsonFactory = Json.createBuilderFactory(Map.of());
+            var contextDocument = JsonDocument.of(jsonFactory.createObjectBuilder()
+                    .add(CONTEXT, createContextObject())
+                    .build());
+            var compacted = com.apicatalog.jsonld.JsonLd.compact(document, contextDocument).get();
+            return Result.success(compacted);
+        } catch (JsonLdError e) {
+            monitor.warning("Error compacting JSON-LD structure", e);
+            return Result.failure(e.getMessage());
+        }
+    }
+
+    @Override
+    public void registerNamespace(String prefix, String contextIri) {
+        additionalNamespaces.put(prefix, contextIri);
+    }
+
+    private JsonObject createContextObject() {
+        var builder = Json.createObjectBuilder();
+        additionalNamespaces.forEach(builder::add);
+        return builder.build();
+    }
+}

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/util/JsonLdUtil.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/util/JsonLdUtil.java
@@ -24,10 +24,12 @@ import org.eclipse.edc.spi.EdcException;
 
 import java.util.Map;
 
+@Deprecated
 public class JsonLdUtil {
-    
-    private JsonLdUtil() { }
-    
+
+    private JsonLdUtil() {
+    }
+
     /**
      * Expands a JSON-LD structure. When expanding, the prefixes for attributes are resolved using
      * the context entries. and replaced by the respective context reference.
@@ -43,13 +45,13 @@ public class JsonLdUtil {
             throw new EdcException("Failed to expand JSON-LD", e);
         }
     }
-    
+
     /**
      * Compacts a JSON-LD structure. When compacting, the context references of attributes are
      * replaced by the respective context prefixes. A context object for resolving the prefixes
      * is added to the structure.
      *
-     * @param object the structure to compact
+     * @param object  the structure to compact
      * @param context the context for compacting
      * @return the compacted structure
      */
@@ -65,5 +67,5 @@ public class JsonLdUtil {
             throw new EdcException("Failed to compact JSON-LD", e);
         }
     }
-    
+
 }

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/TitaniumJsonLdTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/TitaniumJsonLdTest.java
@@ -1,0 +1,111 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.jsonld;
+
+import jakarta.json.Json;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.junit.jupiter.api.Test;
+
+import static jakarta.json.Json.createArrayBuilder;
+import static jakarta.json.Json.createObjectBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
+import static org.mockito.Mockito.mock;
+
+class TitaniumJsonLdTest {
+
+    private final TitaniumJsonLd service = new TitaniumJsonLd(mock(Monitor.class));
+
+    @Test
+    void expand() {
+        var jsonObject = createObjectBuilder()
+                .add("test:item", createObjectBuilder()
+                        .add(TYPE, "https://some.test.type/schema/")
+                        .add("test:key1", "value1")
+                        .add("key2", "value2") // will not be contained in the expanded JSON, it lacks the prefix
+                        .build())
+                .build();
+
+        var expanded = service.expand(jsonObject);
+        assertThat(expanded.succeeded()).isTrue();
+        assertThat(expanded.getContent().toString())
+                .contains("test:item")
+                .contains("test:key1")
+                .contains("@value\":\"value1\"")
+                .doesNotContain("key2")
+                .doesNotContain("value2");
+    }
+
+    @Test
+    void expand_withCustomContext() {
+        var jsonObject = createObjectBuilder()
+                .add(CONTEXT, createObjectBuilder().add("custom", "https://custom.namespace.org/schema/").build())
+                .add("test:item", createObjectBuilder()
+                        .add(TYPE, "https://some.test.type/schema/")
+                        .add("test:key1", "value1")
+                        .add("custom:key2", "value2") // will not be contained in the expanded JSON, it lacks the prefix
+                        .build())
+                .build();
+
+        var expanded = service.expand(jsonObject);
+        assertThat(expanded.succeeded()).isTrue();
+        assertThat(expanded.getContent().toString())
+                .contains("test:item")
+                .contains("test:key1")
+                .contains("@value\":\"value1\"")
+                .contains("https://custom.namespace.org/schema/key2")
+                .contains("@value\":\"value2\"");
+    }
+
+    @Test
+    void compact() {
+        var ns = "https://test.org/schema/";
+        var expanded = Json.createObjectBuilder()
+                .add(ns + "item", createObjectBuilder()
+                        .add(TYPE, ns + "TestItem")
+                        .add(ns + "key1", createArrayBuilder().add(createObjectBuilder().add(VALUE, "value1").build()).build())
+                        .add(ns + "key2", createArrayBuilder().add(createObjectBuilder().add(VALUE, "value2").build()).build()))
+                .build();
+
+        var compacted = service.compact(expanded);
+
+        assertThat(compacted.succeeded()).isTrue();
+        assertThat(compacted.getContent().getJsonObject(ns + "item")).isNotNull();
+        assertThat(compacted.getContent().getJsonObject(ns + "item").getJsonString(ns + "key1").getString()).isEqualTo("value1");
+        assertThat(compacted.getContent().getJsonObject(ns + "item").getJsonString(ns + "key2").getString()).isEqualTo("value2");
+    }
+
+    @Test
+    void compact_withCustomContext() {
+        var ns = "https://test.org/schema/";
+        var prefix = "customContext";
+        var expanded = createObjectBuilder()
+                .add(ns + "item", createObjectBuilder()
+                        .add(TYPE, ns + "TestItem")
+                        .add(ns + "key1", createArrayBuilder().add(createObjectBuilder().add(VALUE, "value1").build()).build())
+                        .add(ns + "key2", createArrayBuilder().add(createObjectBuilder().add(VALUE, "value2").build()).build()))
+                .build();
+
+        service.registerNamespace(prefix, ns);
+        var compacted = service.compact(expanded);
+
+        assertThat(compacted.succeeded()).isTrue();
+        assertThat(compacted.getContent().getJsonObject(prefix + ":item")).isNotNull();
+        assertThat(compacted.getContent().getJsonObject(prefix + ":item").getJsonString(prefix + ":key1").getString()).isEqualTo("value1");
+        assertThat(compacted.getContent().getJsonObject(prefix + ":item").getJsonString(prefix + ":key2").getString()).isEqualTo("value2");
+    }
+}

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/TitaniumJsonLdTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/TitaniumJsonLdTest.java
@@ -51,6 +51,13 @@ class TitaniumJsonLdTest {
     }
 
     @Test
+    void expand_withEmptyArray() {
+        var expanded = service.expand(createObjectBuilder().build());
+        assertThat(expanded.succeeded()).isTrue();
+        assertThat(expanded.getContent()).isEmpty();
+    }
+
+    @Test
     void expand_withCustomContext() {
         var jsonObject = createObjectBuilder()
                 .add(CONTEXT, createObjectBuilder().add("custom", "https://custom.namespace.org/schema/").build())


### PR DESCRIPTION
## What this PR changes/adds

Implements the `JsonLd` service

## Why it does that

replace the static `JsonLdUtil`, allow for registering additional namespaces.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #2830
Closes #2832 

## Checklist

- [x] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
