### PR TITLE
feat(CoreServicesExtension): move types registration to the prepare phase

### DIFF
--- a/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/CoreServicesExtension.java
+++ b/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/CoreServicesExtension.java
@@ -106,7 +106,6 @@ public class CoreServicesExtension implements ServiceExtension {
         healthCheckService = new HealthCheckServiceImpl(config, executorInstrumentation);
         ruleBindingRegistry = new RuleBindingRegistryImpl();
 
-        PolicyRegistrationTypes.TYPES.forEach(typeManager::registerTypes);
     }
 
     @Override
@@ -118,6 +117,11 @@ public class CoreServicesExtension implements ServiceExtension {
     public void shutdown() {
         healthCheckService.stop();
         ServiceExtension.super.shutdown();
+    }
+
+    @Override
+    public void prepare() {
+        PolicyRegistrationTypes.TYPES.forEach(typeManager::registerTypes);
     }
 
     @Provider

--- a/core/common/connector-core/src/test/java/org/eclipse/edc/connector/core/CoreServicesExtensionTest.java
+++ b/core/common/connector-core/src/test/java/org/eclipse/edc/connector/core/CoreServicesExtensionTest.java
@@ -59,6 +59,7 @@ class CoreServicesExtensionTest {
     @Test
     void verifyPolicyTypesAreRegistered() {
         extension.initialize(context);
+        extension.prepare();
         PolicyRegistrationTypes.TYPES.forEach(t -> verify(typeManager).registerTypes(t));
     }
 


### PR DESCRIPTION
## What this PR changes/adds

Moves the `PolicyRegistrationTypes.TYPES` registration in the `CoreServicesExtension#prepare` phase

## Why it does that

To make sure types are registered correctly in all available mappers.

## Linked Issue(s)

Closes #2843 

## Checklist

- [ ] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
