### PR TITLE
fix: resolve dsp cyclic dependency

### DIFF
--- a/core/control-plane/catalog-core/src/main/java/org/eclipse/edc/connector/catalog/CatalogCoreExtension.java
+++ b/core/control-plane/catalog-core/src/main/java/org/eclipse/edc/connector/catalog/CatalogCoreExtension.java
@@ -14,8 +14,6 @@
 
 package org.eclipse.edc.connector.catalog;
 
-import org.eclipse.edc.catalog.spi.DataService;
-import org.eclipse.edc.catalog.spi.DataServiceRegistry;
 import org.eclipse.edc.catalog.spi.DatasetResolver;
 import org.eclipse.edc.catalog.spi.DistributionResolver;
 import org.eclipse.edc.connector.contract.spi.offer.ContractDefinitionResolver;
@@ -43,19 +41,9 @@ public class CatalogCoreExtension implements ServiceExtension {
     @Inject
     private DistributionResolver distributionResolver;
 
-    @Inject
-    private DataService dataService;
-
     @Override
     public String name() {
         return NAME;
-    }
-
-    @Provider
-    public DataServiceRegistry dataServiceRegistry() {
-        var registry = new DataServiceRegistryImpl();
-        registry.register(dataService);
-        return registry;
     }
 
     @Provider

--- a/core/control-plane/catalog-core/src/main/java/org/eclipse/edc/connector/catalog/CatalogDefaultServicesExtension.java
+++ b/core/control-plane/catalog-core/src/main/java/org/eclipse/edc/connector/catalog/CatalogDefaultServicesExtension.java
@@ -14,13 +14,14 @@
 
 package org.eclipse.edc.connector.catalog;
 
-import org.eclipse.edc.catalog.spi.DataService;
+import org.eclipse.edc.catalog.spi.DataServiceRegistry;
 import org.eclipse.edc.catalog.spi.DistributionResolver;
 import org.eclipse.edc.connector.dataplane.selector.spi.store.DataPlaneInstanceStore;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
 
 @Extension(value = CatalogDefaultServicesExtension.NAME)
 public class CatalogDefaultServicesExtension implements ServiceExtension {
@@ -28,18 +29,27 @@ public class CatalogDefaultServicesExtension implements ServiceExtension {
     public static final String NAME = "Catalog Default Services";
 
     @Inject
-    private DataService dataService;
-
-    @Inject
     private DataPlaneInstanceStore dataPlaneInstanceStore;
+    
+    private DataServiceRegistry dataServiceRegistry;
 
     @Override
     public String name() {
         return NAME;
     }
+    
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        dataServiceRegistry = new DataServiceRegistryImpl();
+    }
+    
+    @Provider
+    public DataServiceRegistry dataServiceRegistry() {
+        return dataServiceRegistry;
+    }
 
     @Provider(isDefault = true)
     public DistributionResolver distributionResolver() {
-        return new DefaultDistributionResolver(dataService, dataPlaneInstanceStore);
+        return new DefaultDistributionResolver(dataServiceRegistry, dataPlaneInstanceStore);
     }
 }

--- a/core/control-plane/catalog-core/src/test/java/org/eclipse/edc/connector/catalog/DefaultDistributionResolverTest.java
+++ b/core/control-plane/catalog-core/src/test/java/org/eclipse/edc/connector/catalog/DefaultDistributionResolverTest.java
@@ -15,27 +15,32 @@
 package org.eclipse.edc.connector.catalog;
 
 import org.eclipse.edc.catalog.spi.DataService;
+import org.eclipse.edc.catalog.spi.DataServiceRegistry;
 import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
 import org.eclipse.edc.connector.dataplane.selector.spi.store.DataPlaneInstanceStore;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
+import java.util.List;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class DefaultDistributionResolverTest {
 
     private final DataService dataService = DataService.Builder.newInstance().build();
-    private final DataPlaneInstanceStore dataPlaneInstanceStore = Mockito.mock(DataPlaneInstanceStore.class);
+    private DataServiceRegistry dataServiceRegistry = mock(DataServiceRegistry.class);
+    private final DataPlaneInstanceStore dataPlaneInstanceStore = mock(DataPlaneInstanceStore.class);
 
-    private final DefaultDistributionResolver resolver = new DefaultDistributionResolver(dataService, dataPlaneInstanceStore);
+    private final DefaultDistributionResolver resolver = new DefaultDistributionResolver(dataServiceRegistry, dataPlaneInstanceStore);
 
     @Test
     void shouldReturnDistributionForEverySupportedDestType() {
+        when(dataServiceRegistry.getDataServices()).thenReturn(List.of(dataService));
+        
         var dataPlane1 = DataPlaneInstance.Builder.newInstance().url("http://data-plane-one").allowedDestType("type1").build();
         var dataPlane2 = DataPlaneInstance.Builder.newInstance().url("http://data-plane-two").allowedDestType("type2").build();
         when(dataPlaneInstanceStore.getAll()).thenReturn(Stream.of(dataPlane1, dataPlane2));

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-api/src/main/java/org/eclipse/edc/protocol/dsp/catalog/api/DspCatalogApiExtension.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-api/src/main/java/org/eclipse/edc/protocol/dsp/catalog/api/DspCatalogApiExtension.java
@@ -15,12 +15,12 @@
 package org.eclipse.edc.protocol.dsp.catalog.api;
 
 import org.eclipse.edc.catalog.spi.DataService;
+import org.eclipse.edc.catalog.spi.DataServiceRegistry;
 import org.eclipse.edc.connector.spi.catalog.CatalogProtocolService;
 import org.eclipse.edc.protocol.dsp.api.configuration.DspApiConfiguration;
 import org.eclipse.edc.protocol.dsp.catalog.api.controller.CatalogController;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
-import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.spi.iam.IdentityService;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
@@ -50,6 +50,8 @@ public class DspCatalogApiExtension implements ServiceExtension {
     private TypeTransformerRegistry transformerRegistry;
     @Inject
     private CatalogProtocolService service;
+    @Inject
+    private DataServiceRegistry dataServiceRegistry;
     
     @Override
     public String name() {
@@ -62,13 +64,10 @@ public class DspCatalogApiExtension implements ServiceExtension {
         var dspCallbackAddress = apiConfiguration.getDspCallbackAddress();
         var catalogController = new CatalogController(mapper, identityService, transformerRegistry, dspCallbackAddress, service);
         webService.registerResource(apiConfiguration.getContextAlias(), catalogController);
-    }
-
-    @Provider
-    public DataService dataService() {
-        return DataService.Builder.newInstance()
+        
+        dataServiceRegistry.register(DataService.Builder.newInstance()
                 .terms("connector")
                 .endpointUrl(apiConfiguration.getDspCallbackAddress())
-                .build();
+                .build());
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Removes the cyclic dependency between `CatalogCoreExtension`, `ControlPlaneServicesExtensions` and `DspCatalogApiExtension`:

* Removes direct injections of `DataService`
* Provides the `DataServiceRegistry` in `CatalogDefaultServicesExtension` instead of `CatalogCoreExtension`
* In the `DspCatalogApiExtension` registers the `DataService` with the `DataServiceRegistry` instead of providing it
* Refactors the `DefaultDistributionResolver` to use the `DataServiceRegistry` instead of a `DataService` directly

## Why it does that

So that dsp modules can be used in a runtime

## Checklist

- [ ] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
