### PR TITLE
chore(Callbacks): move callback package from core-spi to control-plane-spi

### DIFF
--- a/extensions/control-plane/callback/callback-event-dispatcher/build.gradle.kts
+++ b/extensions/control-plane/callback/callback-event-dispatcher/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 
 dependencies {
     api(project(":spi:common:core-spi"))
+    api(project(":spi:control-plane:control-plane-spi"))
 
     testImplementation(project(":core:common:junit"))
 }

--- a/extensions/control-plane/callback/callback-event-dispatcher/src/main/java/org/eclipse/edc/connector/callback/CallbackProtocolResolverRegistryImpl.java
+++ b/extensions/control-plane/callback/callback-event-dispatcher/src/main/java/org/eclipse/edc/connector/callback/CallbackProtocolResolverRegistryImpl.java
@@ -14,8 +14,9 @@
 
 package org.eclipse.edc.connector.callback;
 
-import org.eclipse.edc.spi.callback.CallbackProtocolResolver;
-import org.eclipse.edc.spi.callback.CallbackProtocolResolverRegistry;
+
+import org.eclipse.edc.connector.spi.callback.CallbackProtocolResolver;
+import org.eclipse.edc.connector.spi.callback.CallbackProtocolResolverRegistry;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/extensions/control-plane/callback/callback-event-dispatcher/src/main/java/org/eclipse/edc/connector/callback/dispatcher/CallbackEventDispatcher.java
+++ b/extensions/control-plane/callback/callback-event-dispatcher/src/main/java/org/eclipse/edc/connector/callback/dispatcher/CallbackEventDispatcher.java
@@ -14,9 +14,9 @@
 
 package org.eclipse.edc.connector.callback.dispatcher;
 
+import org.eclipse.edc.connector.spi.callback.CallbackEventRemoteMessage;
+import org.eclipse.edc.connector.spi.callback.CallbackProtocolResolverRegistry;
 import org.eclipse.edc.spi.EdcException;
-import org.eclipse.edc.spi.callback.CallbackEventRemoteMessage;
-import org.eclipse.edc.spi.callback.CallbackProtocolResolverRegistry;
 import org.eclipse.edc.spi.event.Event;
 import org.eclipse.edc.spi.event.EventEnvelope;
 import org.eclipse.edc.spi.event.EventSubscriber;

--- a/extensions/control-plane/callback/callback-event-dispatcher/src/main/java/org/eclipse/edc/connector/callback/dispatcher/CallbackEventDispatcherExtension.java
+++ b/extensions/control-plane/callback/callback-event-dispatcher/src/main/java/org/eclipse/edc/connector/callback/dispatcher/CallbackEventDispatcherExtension.java
@@ -15,10 +15,10 @@
 package org.eclipse.edc.connector.callback.dispatcher;
 
 import org.eclipse.edc.connector.callback.CallbackProtocolResolverRegistryImpl;
+import org.eclipse.edc.connector.spi.callback.CallbackProtocolResolverRegistry;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provides;
-import org.eclipse.edc.spi.callback.CallbackProtocolResolverRegistry;
 import org.eclipse.edc.spi.event.Event;
 import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;

--- a/extensions/control-plane/callback/callback-event-dispatcher/src/test/java/org/eclipse/edc/connector/callback/dispatcher/CallbackEventDispatcherTest.java
+++ b/extensions/control-plane/callback/callback-event-dispatcher/src/test/java/org/eclipse/edc/connector/callback/dispatcher/CallbackEventDispatcherTest.java
@@ -14,9 +14,9 @@
 
 package org.eclipse.edc.connector.callback.dispatcher;
 
+import org.eclipse.edc.connector.spi.callback.CallbackEventRemoteMessage;
+import org.eclipse.edc.connector.spi.callback.CallbackProtocolResolverRegistry;
 import org.eclipse.edc.spi.EdcException;
-import org.eclipse.edc.spi.callback.CallbackEventRemoteMessage;
-import org.eclipse.edc.spi.callback.CallbackProtocolResolverRegistry;
 import org.eclipse.edc.spi.event.Event;
 import org.eclipse.edc.spi.event.EventEnvelope;
 import org.eclipse.edc.spi.event.transferprocess.TransferProcessCompleted;

--- a/extensions/control-plane/callback/callback-http-dispatcher/build.gradle.kts
+++ b/extensions/control-plane/callback/callback-http-dispatcher/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 dependencies {
     api(project(":spi:common:core-spi"))
     api(project(":spi:common:http-spi"))
+    api(project(":spi:control-plane:control-plane-spi"))
 
 
     testImplementation(libs.mockserver.netty)

--- a/extensions/control-plane/callback/callback-http-dispatcher/src/main/java/org/eclipse/edc/connector/callback/dispatcher/http/CallbackEventDispatcherHttpExtension.java
+++ b/extensions/control-plane/callback/callback-http-dispatcher/src/main/java/org/eclipse/edc/connector/callback/dispatcher/http/CallbackEventDispatcherHttpExtension.java
@@ -14,9 +14,9 @@
 
 package org.eclipse.edc.connector.callback.dispatcher.http;
 
+import org.eclipse.edc.connector.spi.callback.CallbackProtocolResolverRegistry;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
-import org.eclipse.edc.spi.callback.CallbackProtocolResolverRegistry;
 import org.eclipse.edc.spi.http.EdcHttpClient;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.system.ServiceExtension;

--- a/extensions/control-plane/callback/callback-http-dispatcher/src/main/java/org/eclipse/edc/connector/callback/dispatcher/http/CallbackEventRemoteMessageDispatcher.java
+++ b/extensions/control-plane/callback/callback-http-dispatcher/src/main/java/org/eclipse/edc/connector/callback/dispatcher/http/CallbackEventRemoteMessageDispatcher.java
@@ -20,8 +20,8 @@ import okhttp3.MediaType;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+import org.eclipse.edc.connector.spi.callback.CallbackEventRemoteMessage;
 import org.eclipse.edc.spi.EdcException;
-import org.eclipse.edc.spi.callback.CallbackEventRemoteMessage;
 
 import java.util.function.Function;
 

--- a/extensions/control-plane/callback/callback-http-dispatcher/src/test/java/org/eclipse/edc/connector/callback/dispatcher/http/GenericHttpRemoteDispatcherWrapperTest.java
+++ b/extensions/control-plane/callback/callback-http-dispatcher/src/test/java/org/eclipse/edc/connector/callback/dispatcher/http/GenericHttpRemoteDispatcherWrapperTest.java
@@ -16,8 +16,8 @@ package org.eclipse.edc.connector.callback.dispatcher.http;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
+import org.eclipse.edc.connector.spi.callback.CallbackEventRemoteMessage;
 import org.eclipse.edc.spi.EdcException;
-import org.eclipse.edc.spi.callback.CallbackEventRemoteMessage;
 import org.eclipse.edc.spi.event.EventEnvelope;
 import org.eclipse.edc.spi.event.transferprocess.TransferProcessCompleted;
 import org.eclipse.edc.spi.http.EdcHttpClient;

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/callback/CallbackEventRemoteMessage.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/callback/CallbackEventRemoteMessage.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.spi.callback;
+package org.eclipse.edc.connector.spi.callback;
 
 import org.eclipse.edc.spi.event.Event;
 import org.eclipse.edc.spi.event.EventEnvelope;

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/callback/CallbackProtocolResolver.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/callback/CallbackProtocolResolver.java
@@ -12,14 +12,14 @@
  *
  */
 
-package org.eclipse.edc.spi.callback;
+package org.eclipse.edc.connector.spi.callback;
 
 import org.eclipse.edc.spi.message.RemoteMessageDispatcher;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 
 /**
- *  The resolver translate the scheme part {@link CallbackAddress#getUri()} to an internal
- *  naming of {@link RemoteMessageDispatcher#protocol()} ()}
+ * The resolver translate the scheme part {@link CallbackAddress#getUri()} to an internal
+ * naming of {@link RemoteMessageDispatcher#protocol()} ()}
  */
 @FunctionalInterface
 public interface CallbackProtocolResolver {

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/callback/CallbackProtocolResolverRegistry.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/callback/CallbackProtocolResolverRegistry.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.spi.callback;
+package org.eclipse.edc.connector.spi.callback;
 
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcher;


### PR DESCRIPTION

## What this PR changes/adds

Move callback package from core-spi to control-plane-spi

## Why it does that

cleanup

## Linked Issue(s)

Closes #2851 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
