### PR TITLE
feat(Asset): Private properties for asset cosmos storage

### DIFF
--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/model/AssetCreationRequestDto.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/model/AssetCreationRequestDto.java
@@ -32,9 +32,21 @@ public class AssetCreationRequestDto extends AssetRequestDto {
     }
 
     @JsonIgnore
-    @AssertTrue(message = "no empty property keys")
+    @AssertTrue(message = "no empty property keys and no duplicate keys")
     public boolean isValid() {
-        return properties != null && properties.keySet().stream().noneMatch(it -> it == null || it.isBlank());
+        //check for empty keys
+        boolean validPrivate = privateProperties != null && privateProperties.keySet().stream().noneMatch(it -> it == null || it.isBlank());
+        boolean validPublic = properties != null && properties.keySet().stream().noneMatch(it -> it == null || it.isBlank());
+
+        //check for duplicates
+        if (validPrivate && validPublic) {
+            for (String key : properties.keySet()) {
+                if (privateProperties.containsKey(key)) return false;
+            }
+            return true;
+        }
+
+        return false;
     }
 
     @JsonIgnore
@@ -48,6 +60,10 @@ public class AssetCreationRequestDto extends AssetRequestDto {
 
     public Map<String, Object> getProperties() {
         return properties;
+    }
+
+    public Map<String, Object> getPrivateProperties() {
+        return privateProperties;
     }
 
     public String getId() {

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/model/AssetRequestDto.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/model/AssetRequestDto.java
@@ -23,6 +23,9 @@ public abstract class AssetRequestDto {
     @NotNull(message = "properties cannot be null")
     protected Map<String, Object> properties;
 
+    @NotNull(message = "privateProperties cannot be null")
+    protected Map<String, Object> privateProperties;
+
     protected abstract static class Builder<A extends AssetRequestDto, B extends Builder<A, B>> {
 
         protected final A dto;
@@ -37,6 +40,11 @@ public abstract class AssetRequestDto {
             return self();
         }
 
+        public B privateProperties(Map<String, Object> privateProperties) {
+            dto.privateProperties = privateProperties;
+            return self();
+        }
+        
         public abstract B self();
 
         public A build() {

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/model/AssetResponseDto.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/model/AssetResponseDto.java
@@ -26,6 +26,8 @@ public class AssetResponseDto extends BaseResponseDto {
 
     private Map<String, Object> properties;
 
+    private Map<String, Object> privateProperties;
+
     private String id;
 
     private AssetResponseDto() {
@@ -33,6 +35,10 @@ public class AssetResponseDto extends BaseResponseDto {
 
     public Map<String, Object> getProperties() {
         return properties;
+    }
+
+    public Map<String, Object> getPrivateProperties() {
+        return privateProperties;
     }
 
     public String getId() {
@@ -53,6 +59,11 @@ public class AssetResponseDto extends BaseResponseDto {
 
         public Builder properties(Map<String, Object> properties) {
             dto.properties = properties;
+            return this;
+        }
+
+        public Builder privateProperties(Map<String, Object> privateProperties) {
+            dto.privateProperties = privateProperties;
             return this;
         }
 

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/model/AssetUpdateRequestDto.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/model/AssetUpdateRequestDto.java
@@ -30,13 +30,19 @@ public class AssetUpdateRequestDto extends AssetRequestDto {
     }
 
     @JsonIgnore
-    @AssertTrue(message = "no empty property keys")
+    @AssertTrue(message = "no empty property keys and no duplicate keys")
     public boolean isValid() {
-        return properties != null && properties.keySet().stream().noneMatch(it -> it == null || it.isBlank());
+        boolean validPrivate = privateProperties != null && privateProperties.keySet().stream().noneMatch(it -> it == null || it.isBlank());
+        boolean validPublic = properties != null && properties.keySet().stream().noneMatch(it -> it == null || it.isBlank());
+        return validPrivate && validPublic;
     }
 
     public Map<String, Object> getProperties() {
         return properties;
+    }
+
+    public Map<String, Object> getPrivateProperties() {
+        return privateProperties;
     }
 
     @JsonPOJOBuilder(withPrefix = "")

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/transform/AssetRequestDtoToAssetTransformer.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/transform/AssetRequestDtoToAssetTransformer.java
@@ -38,6 +38,7 @@ public class AssetRequestDtoToAssetTransformer implements DtoTransformer<AssetCr
         return Asset.Builder.newInstance()
                 .id(object.getId())
                 .properties(object.getProperties())
+                .privateProperties(object.getPrivateProperties())
                 .build();
     }
 }

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/transform/AssetToAssetResponseDtoTransformer.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/transform/AssetToAssetResponseDtoTransformer.java
@@ -38,6 +38,7 @@ public class AssetToAssetResponseDtoTransformer implements DtoTransformer<Asset,
         return AssetResponseDto.Builder.newInstance()
                 .id(object.getId())
                 .properties(object.getProperties())
+                .privateProperties(object.getPrivateProperties())
                 .createdAt(object.getCreatedAt())
                 .build();
     }

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/transform/AssetUpdateRequestWrapperDtoToAssetTransformer.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/transform/AssetUpdateRequestWrapperDtoToAssetTransformer.java
@@ -36,6 +36,7 @@ public class AssetUpdateRequestWrapperDtoToAssetTransformer implements DtoTransf
     public @Nullable Asset transform(@NotNull AssetUpdateRequestWrapperDto object, @NotNull TransformerContext context) {
         return Asset.Builder.newInstance()
                 .properties(object.getRequestDto().getProperties())
+                .privateProperties(object.getRequestDto().getPrivateProperties())
                 .id(object.getAssetId())
                 .build();
     }

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/transform/DataAddressDtoToDataAddressTransformer.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/transform/DataAddressDtoToDataAddressTransformer.java
@@ -35,7 +35,11 @@ public class DataAddressDtoToDataAddressTransformer implements DtoTransformer<Da
 
     @Override
     public @Nullable DataAddress transform(@NotNull DataAddressDto object, @NotNull TransformerContext context) {
-        return DataAddress.Builder.newInstance().properties(object.getProperties()).build();
+        return DataAddress
+                .Builder
+                .newInstance()
+                .properties(object.getProperties())
+                .build();
     }
 
 }

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/model/AssetCreationRequestDtoValidationTest.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/model/AssetCreationRequestDtoValidationTest.java
@@ -54,7 +54,7 @@ class AssetCreationRequestDtoValidationTest {
 
         var result = validator.validate(entry);
 
-        assertThat(result).hasSize(3).anySatisfy(cv -> assertThat(cv.getMessage()).isEqualTo("dataAddress cannot be null"));
+        assertThat(result).anySatisfy(cv -> assertThat(cv.getMessage()).isEqualTo("dataAddress cannot be null"));
     }
 
     @Test

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/asset/Asset.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/asset/Asset.java
@@ -45,9 +45,11 @@ public class Asset extends Entity {
     private static final String DEPRECATED_PROPERTY_PREFIX = "asset:prop:";
 
     private final Map<String, Object> properties;
+    private final Map<String, Object> privateProperties;
 
     protected Asset() {
         properties = new HashMap<>();
+        privateProperties = new HashMap<>();
     }
 
     @Override
@@ -87,6 +89,19 @@ public class Asset extends Entity {
 
     private String getPropertyAsString(String key) {
         var val = getProperty(key);
+        return val != null ? val.toString() : null;
+    }
+
+    public Map<String, Object> getPrivateProperties() {
+        return privateProperties;
+    }
+
+    public Object getPrivateProperty(String key) {
+        return privateProperties.get(key);
+    }
+
+    private String getPrivatePropertyAsString(String key) {
+        var val = getPrivateProperty(key);
         return val != null ? val.toString() : null;
     }
 
@@ -160,6 +175,16 @@ public class Asset extends Entity {
             return self();
         }
 
+        public B privateProperties(Map<String, Object> privateProperties) {
+            if (privateProperties == null) return self();
+            entity.privateProperties.putAll(privateProperties);
+            return self();
+        }
+
+        public B privateProperty(String key, Object value) {
+            entity.privateProperties.put(key, value);
+            return self();
+        }
     }
 
 }


### PR DESCRIPTION
## What this PR changes/adds
This PR extends the CosmosDB storage to accost private properties.

## Why it does that

The changes private properties bring, have to be reflected in all storage variations.

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
