### PR TITLE
fix(gradle.properties): increases maximum heap size during gradle build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,3 +10,4 @@ metaModelVersion=0.0.1-SNAPSHOT
 edcScmConnection=scm:git:git@github.com:eclipse-edc/Connector.git
 edcWebsiteUrl=https://github.com/eclipse-edc/Connector.git
 edcScmUrl=https://github.com/eclipse-edc/Connector.git
+org.gradle.jvmargs=-Xmx2048m


### PR DESCRIPTION
## What this PR changes/adds

This PR adds a line in the `gradle.properties` file that increses the heap size during the build to 2048MB.

## Why it does that

Without this change, the automatic and manual building in the IDE will fail with an error message, that there is not enough space on the heap.

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
