### PR TITLE
feat: adjust policy scope and adjust class generics

### DIFF
--- a/core/common/policy-engine/src/main/java/org/eclipse/edc/policy/engine/PolicyContextImpl.java
+++ b/core/common/policy-engine/src/main/java/org/eclipse/edc/policy/engine/PolicyContextImpl.java
@@ -40,11 +40,11 @@ public class PolicyContextImpl implements PolicyContext {
      * @param agent the requesting participant agent.
      * @param additionalData additional context data.
      */
-    public PolicyContextImpl(ParticipantAgent agent, Map<Class, Object> additionalData) {
+    public PolicyContextImpl(ParticipantAgent agent, Map<Class<?>, Object> additionalData) {
         this.agent = agent;
         additionalData.forEach((key, value) -> {
             try {
-                this.putContextData(key, key.cast(value));
+                additional.put(key, value);
             } catch (ClassCastException ignore) {
                 // invalid entry
             }
@@ -72,6 +72,7 @@ public class PolicyContextImpl implements PolicyContext {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T> T getContextData(Class<T> type) {
         return (T) additional.get(type);
     }

--- a/core/common/policy-engine/src/main/java/org/eclipse/edc/policy/engine/PolicyEngineImpl.java
+++ b/core/common/policy-engine/src/main/java/org/eclipse/edc/policy/engine/PolicyEngineImpl.java
@@ -66,7 +66,7 @@ public class PolicyEngineImpl implements PolicyEngine {
     }
 
     @Override
-    public Result<Policy> evaluate(String scope, Policy policy, ParticipantAgent agent, Map<Class, Object> contextInformation) {
+    public Result<Policy> evaluate(String scope, Policy policy, ParticipantAgent agent, Map<Class<?>, Object> contextInformation) {
         var context = new PolicyContextImpl(agent, contextInformation);
 
         for (BiFunction<Policy, PolicyContext, Boolean> validator : preValidators) {
@@ -126,7 +126,7 @@ public class PolicyEngineImpl implements PolicyEngine {
      * @param context the policy context.
      * @param contextInformation the initial context data.
      */
-    private void updateContextInformation(PolicyContext context, Map<Class, Object> contextInformation) {
+    private void updateContextInformation(PolicyContext context, Map<Class<?>, Object> contextInformation) {
         contextInformation.keySet().forEach(key -> contextInformation.put(key, context.getContextData(key)));
     }
 

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImpl.java
@@ -148,10 +148,10 @@ public class ContractValidationServiceImpl implements ContractValidationService 
         }
 
         // Create additional context information for policy engine to make agreement available in context
-        var contextInformation = new HashMap<Class, Object>();
+        var contextInformation = new HashMap<Class<?>, Object>();
         contextInformation.put(ContractAgreement.class, agreement);
 
-        var policyResult = policyEngine.evaluate(NEGOTIATION_SCOPE, agreement.getPolicy(), agent, contextInformation);
+        var policyResult = policyEngine.evaluate(TRANSFER_SCOPE, agreement.getPolicy(), agent, contextInformation);
         if (!policyResult.succeeded()) {
             return Result.failure(format("Policy does not fulfill the agreement %s, policy evaluation %s", agreement.getId(), policyResult.getFailureDetail()));
         }

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImplTest.java
@@ -59,6 +59,7 @@ import static java.time.ZoneOffset.UTC;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.contract.spi.validation.ContractValidationService.NEGOTIATION_SCOPE;
+import static org.eclipse.edc.connector.contract.spi.validation.ContractValidationService.TRANSFER_SCOPE;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.spi.agent.ParticipantAgent.PARTICIPANT_IDENTITY;
 import static org.mockito.ArgumentMatchers.any;
@@ -216,13 +217,13 @@ class ContractValidationServiceImplTest {
         var participantAgent = new ParticipantAgent(emptyMap(), Map.of(PARTICIPANT_IDENTITY, CONSUMER_ID));
 
         @SuppressWarnings("unchecked")
-        ArgumentCaptor<Map<Class, Object>> captor = ArgumentCaptor.forClass(Map.class);
+        ArgumentCaptor<Map<Class<?>, Object>> captor = ArgumentCaptor.forClass(Map.class);
 
         when(agentService.createFor(isA(ClaimToken.class))).thenReturn(participantAgent);
 
         when(policyStore.findById("access")).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
         when(policyStore.findById("contract")).thenReturn(PolicyDefinition.Builder.newInstance().policy(newPolicy).build());
-        when(policyEngine.evaluate(eq(NEGOTIATION_SCOPE), eq(newPolicy), isA(ParticipantAgent.class), any())).thenReturn(Result.success(newPolicy));
+        when(policyEngine.evaluate(eq(TRANSFER_SCOPE), eq(newPolicy), isA(ParticipantAgent.class), any())).thenReturn(Result.success(newPolicy));
 
         var claimToken = ClaimToken.Builder.newInstance().build();
         var agreement = createContractAgreement()
@@ -239,7 +240,7 @@ class ContractValidationServiceImplTest {
         assertThat(isValid.succeeded()).isTrue();
 
         verify(agentService).createFor(isA(ClaimToken.class));
-        verify(policyEngine).evaluate(eq(NEGOTIATION_SCOPE), eq(newPolicy), isA(ParticipantAgent.class), captor.capture());
+        verify(policyEngine).evaluate(eq(TRANSFER_SCOPE), eq(newPolicy), isA(ParticipantAgent.class), captor.capture());
 
         var context = captor.getValue();
         assertThat(context.get(ContractAgreement.class)).isNotNull().isInstanceOf(ContractAgreement.class);

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/provision/ResourceManifestGeneratorImpl.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/provision/ResourceManifestGeneratorImpl.java
@@ -71,7 +71,7 @@ public class ResourceManifestGeneratorImpl implements ResourceManifestGenerator 
         var manifestContext = new ResourceManifestContext(manifest);
 
         // Create additional context information for policy engine to make manifest context available
-        var contextInformation = new HashMap<Class, Object>();
+        var contextInformation = new HashMap<Class<?>, Object>();
         contextInformation.put(ResourceManifestContext.class, manifestContext);
 
         var result = policyEngine.evaluate(MANIFEST_VERIFICATION_SCOPE, policy, null, contextInformation);
@@ -92,7 +92,7 @@ public class ResourceManifestGeneratorImpl implements ResourceManifestGenerator 
         return ResourceManifest.Builder.newInstance().definitions(definitions).build();
     }
 
-    private ResourceManifest buildFromContextInformation(Map<Class, Object> contextInformation) {
+    private ResourceManifest buildFromContextInformation(Map<Class<?>, Object> contextInformation) {
         var manifestContext = (ResourceManifestContext) contextInformation.get(ResourceManifestContext.class);
         return ResourceManifest.Builder.newInstance().definitions(manifestContext.getDefinitions()).build();
     }

--- a/spi/common/policy-engine-spi/src/main/java/org/eclipse/edc/policy/engine/spi/PolicyEngine.java
+++ b/spi/common/policy-engine-spi/src/main/java/org/eclipse/edc/policy/engine/spi/PolicyEngine.java
@@ -64,7 +64,7 @@ public interface PolicyEngine {
      * Evaluates the given policy for an agent for the given scope using additional context information.
      * Values in the map need to be of the same type defined by the key.
      */
-    Result<Policy> evaluate(String scope, Policy policy, ParticipantAgent agent, Map<Class, Object> contextInformation);
+    Result<Policy> evaluate(String scope, Policy policy, ParticipantAgent agent, Map<Class<?>, Object> contextInformation);
 
     /**
      * Registers a function that is invoked when a policy contains an atomic constraint whose left operator expression evaluates to the given key for the specified scope.

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/validation/ContractValidationService.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/validation/ContractValidationService.java
@@ -33,6 +33,9 @@ public interface ContractValidationService {
     @PolicyScope
     String NEGOTIATION_SCOPE = "contract.negotiation";
 
+    @PolicyScope
+    String TRANSFER_SCOPE = "transfer.process";
+
     /**
      * Validates and sanitizes the contract offer for the consumer represented by the given claims.
      * <p>

--- a/spi/control-plane/control-plane-spi/build.gradle.kts
+++ b/spi/control-plane/control-plane-spi/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     api(project(":spi:common:aggregate-service-spi"))
     api(project(":spi:common:transaction-spi"))
     api(project(":spi:common:transform-spi"))
+    api(project(":spi:common:web-spi"))
     api(project(":spi:control-plane:contract-spi"))
     api(project(":spi:control-plane:transfer-data-plane-spi"))
     api(project(":spi:control-plane:policy-spi"))

--- a/spi/control-plane/control-plane-spi/build.gradle.kts
+++ b/spi/control-plane/control-plane-spi/build.gradle.kts
@@ -22,7 +22,6 @@ dependencies {
     api(project(":spi:common:aggregate-service-spi"))
     api(project(":spi:common:transaction-spi"))
     api(project(":spi:common:transform-spi"))
-    api(project(":spi:common:web-spi"))
     api(project(":spi:control-plane:contract-spi"))
     api(project(":spi:control-plane:transfer-data-plane-spi"))
     api(project(":spi:control-plane:policy-spi"))


### PR DESCRIPTION
## What this PR changes/adds

This PR adjusts `ContractValidationService.validateAgreement()` to use `TRANSFER_SCOPE` instead of `NEGOTIATION_SCOPE.` It also cleans up missing generics in some of the policy classes. 

## Linked Issue(s)

Closes #2860

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
