### PR TITLE
fix: make query infrastructure for namespaced properties more flexibl…

### DIFF
--- a/extensions/common/azure/azure-cosmos-core/src/main/java/org/eclipse/edc/azure/cosmos/dialect/ConditionExpression.java
+++ b/extensions/common/azure/azure-cosmos-core/src/main/java/org/eclipse/edc/azure/cosmos/dialect/ConditionExpression.java
@@ -186,6 +186,8 @@ public abstract class ConditionExpression {
                 .replace(".", "_")
                 .replace("[", "")
                 .replace("]", "")
+                .replace("/", "")
+                .replace("//", "")
                 .replaceAll("[0-9]", "");
     }
 

--- a/extensions/common/azure/azure-cosmos-core/src/main/java/org/eclipse/edc/azure/cosmos/dialect/CosmosConstants.java
+++ b/extensions/common/azure/azure-cosmos-core/src/main/java/org/eclipse/edc/azure/cosmos/dialect/CosmosConstants.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.azure.cosmos.dialect;
+
+import java.util.List;
+
+/**
+ * Provides some constant values that are relevant in the realm of CosmosDB
+ */
+public interface CosmosConstants {
+    List<String> ILLEGAL_CHARACTERS = List.of("\\", "/", "$", "%", "&");
+    String WHERE = "WHERE";
+    String AND = "AND";
+    String LIMIT = "LIMIT";
+    String OFFSET = "OFFSET";
+    String ORDER_BY = "ORDER BY";
+
+    static boolean hasIllegalCharacters(String inputStr) {
+        return ILLEGAL_CHARACTERS.stream().anyMatch(inputStr::contains);
+    }
+
+}

--- a/extensions/common/azure/azure-cosmos-core/src/main/java/org/eclipse/edc/azure/cosmos/dialect/LimitClause.java
+++ b/extensions/common/azure/azure-cosmos-core/src/main/java/org/eclipse/edc/azure/cosmos/dialect/LimitClause.java
@@ -32,6 +32,6 @@ class LimitClause implements Clause {
 
     @Override
     public String asString() {
-        return limit != null ? "LIMIT " + limit : "";
+        return limit != null ? CosmosConstants.LIMIT + " " + limit : "";
     }
 }

--- a/extensions/common/azure/azure-cosmos-core/src/main/java/org/eclipse/edc/azure/cosmos/dialect/OffsetClause.java
+++ b/extensions/common/azure/azure-cosmos-core/src/main/java/org/eclipse/edc/azure/cosmos/dialect/OffsetClause.java
@@ -34,6 +34,6 @@ class OffsetClause implements Clause {
 
     @Override
     public String asString() {
-        return offset != null ? format("OFFSET %d", offset) : "";
+        return offset != null ? format(CosmosConstants.OFFSET + " %d", offset) : "";
     }
 }

--- a/extensions/common/azure/azure-cosmos-core/src/main/java/org/eclipse/edc/azure/cosmos/dialect/OrderByClause.java
+++ b/extensions/common/azure/azure-cosmos-core/src/main/java/org/eclipse/edc/azure/cosmos/dialect/OrderByClause.java
@@ -17,6 +17,8 @@ package org.eclipse.edc.azure.cosmos.dialect;
 import org.jetbrains.annotations.NotNull;
 
 import static java.lang.String.format;
+import static org.eclipse.edc.azure.cosmos.dialect.CosmosConstants.ORDER_BY;
+import static org.eclipse.edc.azure.cosmos.dialect.CosmosConstants.hasIllegalCharacters;
 
 /**
  * Represents in a structural way an ORDER BY clause in an SQL statement.
@@ -52,7 +54,19 @@ class OrderByClause implements Clause {
 
     @Override
     public String asString() {
-        return orderField != null ? format("ORDER BY %s%s %s", getPrefix(), orderField, sortAsc ? "ASC" : "DESC") : "";
+        return orderField != null ? getOrderByExpression() : "";
+    }
+
+    private String getOrderByExpression() {
+
+
+        if (hasIllegalCharacters(orderField)) {
+            var pfx = objectPrefix != null ? objectPrefix : "";
+            return format(ORDER_BY + " %s[\"%s\"] %s", pfx, orderField, sortAsc ? "ASC" : "DESC");
+        } else {
+            var pfx = objectPrefix != null ? objectPrefix + "." : "";
+            return format(ORDER_BY + " %s%s %s", pfx, orderField, sortAsc ? "ASC" : "DESC");
+        }
     }
 
     @NotNull

--- a/extensions/common/azure/azure-cosmos-core/src/test/java/org/eclipse/edc/azure/cosmos/dialect/WhereClauseTest.java
+++ b/extensions/common/azure/azure-cosmos-core/src/test/java/org/eclipse/edc/azure/cosmos/dialect/WhereClauseTest.java
@@ -80,7 +80,7 @@ class WhereClauseTest {
         assertThat(wc.getParameters()).hasSize(4)
                 .anyMatch(p -> p.getName().equals("@foo0") && p.getValue(String.class).equals("bar1"))
                 .anyMatch(p -> p.getName().equals("@foo1") && p.getValue(String.class).equals("bar2"))
-                .anyMatch(p -> p.getName().equals("@foo0") && p.getValue(String.class).equals("blubb"))
-                .anyMatch(p -> p.getName().equals("@foo1") && p.getValue(String.class).equals("blabb"));
+                .anyMatch(p -> p.getName().equals("@foo0_1") && p.getValue(String.class).equals("blubb"))
+                .anyMatch(p -> p.getName().equals("@foo1_1") && p.getValue(String.class).equals("blabb"));
     }
 }


### PR DESCRIPTION
…e and robust

## What this PR changes/adds

Makes the query assembly subsystem a bit more robust against "illegal characters", which were introduced with namespaced asset properties.

For that, I used indexed accessors rather than named accessors, ie. `c["$some@bject"]` vs `c.$some@bject`.


## Why it does that

fix a bug where a 400 was returned by cosmosDB because of illegal query keys.

## Further notes

- I attempted to leave as much untouched as possible, but eventually we can possibly switch over to full indexed query 
- I introduced `CosmosConstants.java`, which contains keywords, literals, etc.

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
