### PR TITLE
feat: add contractnegotiation api for jsonld objects

### DIFF
--- a/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionApiExtension.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionApiExtension.java
@@ -69,6 +69,6 @@ public class ContractDefinitionApiExtension implements ServiceExtension {
         var monitor = context.getMonitor();
 
         webService.registerResource(config.getContextAlias(), new ContractDefinitionApiController(monitor, service, transformerRegistry));
-        webService.registerResource(config.getContextAlias(), new ContractDefinitionNewApiController(jsonLdService, transformerRegistry, service));
+        webService.registerResource(config.getContextAlias(), new ContractDefinitionNewApiController(jsonLdService, transformerRegistry, service, monitor));
     }
 }

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionNewApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionNewApiControllerTest.java
@@ -342,7 +342,7 @@ class ContractDefinitionNewApiControllerTest extends RestControllerTestBase {
 
     @Override
     protected Object controller() {
-        return new ContractDefinitionNewApiController(jsonLd, transformerRegistry, service);
+        return new ContractDefinitionNewApiController(jsonLd, transformerRegistry, service, monitor);
     }
 
     private JsonArrayBuilder createCriterionBuilder() {

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     testImplementation(project(":core:data-plane-selector:data-plane-selector-core"))
     testImplementation(project(":extensions:common:http"))
     testImplementation(project(":core:common:junit"))
+    testImplementation(testFixtures(project(":extensions:common:http:jersey-core")))
 
     testImplementation(libs.restAssured)
     testImplementation(libs.awaitility)

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationNewApi.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationNewApi.java
@@ -48,7 +48,7 @@ public interface ContractNegotiationNewApi {
     )
     List<JsonObject> queryNegotiations(@Valid QuerySpecDto querySpecDto);
 
-    @Operation(description = "Gets an contract negotiation with the given ID",
+    @Operation(description = "Gets a contract negotiation with the given ID",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The contract negotiation",
                             content = @Content(schema = @Schema(implementation = ContractNegotiationDto.class))),

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationNewApi.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationNewApi.java
@@ -23,6 +23,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.json.JsonObject;
 import jakarta.validation.Valid;
 import org.eclipse.edc.api.model.IdResponseDto;
 import org.eclipse.edc.api.query.QuerySpecDto;
@@ -36,30 +37,16 @@ import java.util.List;
 
 @OpenAPIDefinition
 @Tag(name = "Contract Negotiation")
-@Deprecated(since = "milestone9")
-public interface ContractNegotiationApi {
+public interface ContractNegotiationNewApi {
 
     @Operation(description = "Returns all contract negotiations according to a query",
             responses = {
                     @ApiResponse(responseCode = "200",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ContractNegotiationDto.class)))),
                     @ApiResponse(responseCode = "400", description = "Request was malformed",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))) },
-            deprecated = true
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))) }
     )
-    @Deprecated
-    List<ContractNegotiationDto> getNegotiations(@Valid QuerySpecDto querySpecDto);
-
-    @Operation(description = "Returns all contract negotiations according to a query",
-            responses = {
-                    @ApiResponse(responseCode = "200",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ContractNegotiationDto.class)))),
-                    @ApiResponse(responseCode = "400", description = "Request was malformed",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))) },
-            deprecated = true
-    )
-    @Deprecated(since = "milestone9")
-    List<ContractNegotiationDto> queryNegotiations(@Valid QuerySpecDto querySpecDto);
+    List<JsonObject> queryNegotiations(@Valid QuerySpecDto querySpecDto);
 
     @Operation(description = "Gets an contract negotiation with the given ID",
             responses = {
@@ -69,11 +56,9 @@ public interface ContractNegotiationApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))),
                     @ApiResponse(responseCode = "404", description = "An contract negotiation with the given ID does not exist",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
-            },
-            deprecated = true
+            }
     )
-    @Deprecated(since = "milestone9")
-    ContractNegotiationDto getNegotiation(String id);
+    JsonObject getNegotiation(String id);
 
     @Operation(description = "Gets the state of a contract negotiation with the given ID",
             operationId = "getNegotiationState",
@@ -84,10 +69,8 @@ public interface ContractNegotiationApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))),
                     @ApiResponse(responseCode = "404", description = "An contract negotiation with the given ID does not exist",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
-            },
-            deprecated = true
+            }
     )
-    @Deprecated(since = "milestone9")
     NegotiationState getNegotiationState(String id);
 
     @Operation(description = "Gets a contract agreement for a contract negotiation with the given ID",
@@ -98,11 +81,9 @@ public interface ContractNegotiationApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))),
                     @ApiResponse(responseCode = "404", description = "An contract negotiation with the given ID does not exist",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
-            },
-            deprecated = true
+            }
     )
-    @Deprecated(since = "milestone9")
-    ContractAgreementDto getAgreementForNegotiation(String negotiationId);
+    JsonObject getAgreementForNegotiation(String negotiationId);
 
     @Operation(description = "Initiates a contract negotiation for a given offer and with the given counter part. Please note that successfully invoking this endpoint " +
             "only means that the negotiation was initiated. Clients must poll the /{id}/state endpoint to track the state",
@@ -115,12 +96,8 @@ public interface ContractNegotiationApi {
                     ),
                     @ApiResponse(responseCode = "400", description = "Request body was malformed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))),
-            },
-            deprecated = true
-    )
-    @Deprecated(since = "milestone9")
-    IdResponseDto initiateContractNegotiation(@Valid NegotiationInitiateRequestDto initiateDto);
-
+            })
+    IdResponseDto initiateContractNegotiation(@Schema(implementation = NegotiationInitiateRequestDto.class) JsonObject requestDto);
 
     @Operation(description = "Requests aborting the contract negotiation. Due to the asynchronous nature of contract negotiations, a successful " +
             "response only indicates that the request was successfully received. Clients must poll the /{id}/state endpoint to track the state.",
@@ -131,10 +108,7 @@ public interface ContractNegotiationApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))),
                     @ApiResponse(responseCode = "404", description = "A contract negotiation with the given ID does not exist",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
-            },
-            deprecated = true
-    )
-    @Deprecated(since = "milestone9")
+            })
     void cancelNegotiation(String id);
 
     @Operation(description = "Requests cancelling the contract negotiation. Due to the asynchronous nature of contract negotiations, a successful " +
@@ -146,9 +120,7 @@ public interface ContractNegotiationApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))),
                     @ApiResponse(responseCode = "404", description = "A contract negotiation with the given ID does not exist",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
-            },
-            deprecated = true
+            }
     )
-    @Deprecated(since = "milestone9")
     void declineNegotiation(String id);
 }

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationNewApiController.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationNewApiController.java
@@ -1,0 +1,160 @@
+/*
+ *  Copyright (c) 2022 ZF Friedrichshafen AG
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       ZF Friedrichshafen AG - Initial API and Implementation
+ *       Microsoft Corporation - Added initiate-negotiation endpoint
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Improvements
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.contractnegotiation;
+
+import jakarta.json.JsonObject;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.edc.api.model.IdResponseDto;
+import org.eclipse.edc.api.query.QuerySpecDto;
+import org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractAgreementDto;
+import org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractNegotiationDto;
+import org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto;
+import org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationState;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest;
+import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationService;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.web.spi.exception.InvalidRequestException;
+import org.eclipse.edc.web.spi.exception.ObjectNotFoundException;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static java.util.Optional.ofNullable;
+import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMapper;
+
+@Consumes({ MediaType.APPLICATION_JSON })
+@Produces({ MediaType.APPLICATION_JSON })
+
+@Path("/v2/contractnegotiations")
+public class ContractNegotiationNewApiController implements ContractNegotiationNewApi {
+    private final ContractNegotiationService service;
+    private final TypeTransformerRegistry transformerRegistry;
+    private final JsonLd jsonLdService;
+    private final Monitor monitor;
+
+    public ContractNegotiationNewApiController(ContractNegotiationService service, TypeTransformerRegistry transformerRegistry, JsonLd jsonLdService, Monitor monitor) {
+        this.service = service;
+        this.transformerRegistry = transformerRegistry;
+        this.jsonLdService = jsonLdService;
+        this.monitor = monitor;
+    }
+
+    @POST
+    @Path("/request")
+    @Override
+    public List<JsonObject> queryNegotiations(@Valid QuerySpecDto querySpecDto) {
+        querySpecDto = ofNullable(querySpecDto).orElse(QuerySpecDto.Builder.newInstance().build());
+
+        var spec = transformerRegistry.transform(querySpecDto, QuerySpec.class)
+                .orElseThrow(InvalidRequestException::new);
+
+        try (var stream = service.query(spec).orElseThrow(exceptionMapper(ContractNegotiation.class, null))) {
+            return stream
+                    .map(it -> transformerRegistry.transform(it, ContractNegotiationDto.class)
+                            .compose(dto -> transformerRegistry.transform(dto, JsonObject.class))
+                            .compose(jsonLdService::compact))
+                    .peek(this::logIfError)
+                    .filter(Result::succeeded)
+                    .map(Result::getContent)
+                    .collect(Collectors.toList());
+        }
+    }
+
+    @GET
+    @Path("/{id}")
+    @Override
+    public JsonObject getNegotiation(@PathParam("id") String id) {
+
+        return Optional.of(id)
+                .map(service::findbyId)
+                .map(it -> transformerRegistry.transform(it, ContractNegotiationDto.class)
+                        .compose(dto -> transformerRegistry.transform(dto, JsonObject.class))
+                        .compose(jsonLdService::compact)
+                        .orElseThrow(InvalidRequestException::new))
+                .orElseThrow(() -> new ObjectNotFoundException(ContractNegotiation.class, id));
+    }
+
+    @GET
+    @Path("/{id}/state")
+    @Override
+    public NegotiationState getNegotiationState(@PathParam("id") String id) {
+        return Optional.of(id)
+                .map(service::getState)
+                .map(NegotiationState::new)
+                .orElseThrow(() -> new ObjectNotFoundException(ContractNegotiation.class, id));
+    }
+
+    @GET
+    @Path("/{id}/agreement")
+    @Override
+    public JsonObject getAgreementForNegotiation(@PathParam("id") String negotiationId) {
+        return Optional.of(negotiationId)
+                .map(service::getForNegotiation)
+                .map(it -> transformerRegistry.transform(it, ContractAgreementDto.class)
+                        .compose(dto -> transformerRegistry.transform(dto, JsonObject.class))
+                        .compose(jsonLdService::compact)
+                        .orElseThrow(InvalidRequestException::new))
+                .orElseThrow(() -> new ObjectNotFoundException(ContractNegotiation.class, negotiationId));
+    }
+
+    @POST
+    @Override
+    public IdResponseDto initiateContractNegotiation(JsonObject requestObject) {
+        var contractRequest = transformerRegistry.transform(requestObject, NegotiationInitiateRequestDto.class)
+                .compose(dto -> transformerRegistry.transform(dto, ContractRequest.class))
+                .orElseThrow(InvalidRequestException::new);
+
+
+        var contractNegotiation = service.initiateNegotiation(contractRequest);
+        return IdResponseDto.Builder.newInstance()
+                .id(contractNegotiation.getId())
+                .createdAt(contractNegotiation.getCreatedAt())
+                .build();
+    }
+
+    @POST
+    @Path("/{id}/cancel")
+    @Override
+    public void cancelNegotiation(@PathParam("id") String id) {
+        service.cancel(id).orElseThrow(exceptionMapper(ContractNegotiation.class, id));
+    }
+
+    @POST
+    @Path("/{id}/decline")
+    @Override
+    public void declineNegotiation(@PathParam("id") String id) {
+        service.decline(id).orElseThrow(exceptionMapper(ContractNegotiation.class, id));
+    }
+
+
+    private void logIfError(Result<?> result) {
+        result.onFailure(f -> monitor.warning(f.getFailureDetail()));
+    }
+}

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/model/ContractAgreementDto.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/model/ContractAgreementDto.java
@@ -20,7 +20,18 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import org.eclipse.edc.policy.model.Policy;
 
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
+
 public class ContractAgreementDto {
+    public static final String TYPE = EDC_NAMESPACE + "ContractAgreementDto";
+    public static final String CONTRACT_AGREEMENT_ASSETID = EDC_NAMESPACE + "assetId";
+    public static final String CONTRACT_AGREEMENT_PROVIDER_AGENTID = EDC_NAMESPACE + "providerAgentId";
+    public static final String CONTRACT_AGREEMENT_CONSUMER_AGENTID = EDC_NAMESPACE + "consumerAgentId";
+    public static final String CONTRACT_AGREEMENT_SIGNING_DATE = EDC_NAMESPACE + "contractSigningDate";
+    public static final String CONTRACT_AGREEMENT_START_DATE = EDC_NAMESPACE + "contractStartDate";
+    public static final String CONTRACT_AGREEMENT_END_DATE = EDC_NAMESPACE + "contractEndDate";
+    public static final String CONTRACT_AGREEMENT_POLICY = EDC_NAMESPACE + "policy";
+
     @NotNull(message = "id cannot be null")
     private String id;
     @NotNull(message = "providerAgentId cannot be null")

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/model/ContractNegotiationDto.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/model/ContractNegotiationDto.java
@@ -24,8 +24,20 @@ import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
+
 @JsonDeserialize(builder = ContractNegotiationDto.Builder.class)
 public class ContractNegotiationDto extends MutableDto {
+    // constants used for JSON-LD transformation
+    public static final String CONTRACT_NEGOTIATION_TYPE = EDC_NAMESPACE + "ContractNegotiationDto";
+    public static final String CONTRACT_NEGOTIATION_AGREEMENT_ID = EDC_NAMESPACE + "contractAgreementId";
+    public static final String CONTRACT_NEGOTIATION_COUNTERPARTY_ADDR = EDC_NAMESPACE + "counterPartyAddress";
+    public static final String CONTRACT_NEGOTIATION_ERRORDETAIL = EDC_NAMESPACE + "errorDetail";
+    public static final String CONTRACT_NEGOTIATION_PROTOCOL = EDC_NAMESPACE + "protocol";
+    public static final String CONTRACT_NEGOTIATION_STATE = EDC_NAMESPACE + "state";
+    public static final String CONTRACT_NEGOTIATION_NEG_TYPE = EDC_NAMESPACE + "type";
+    public static final String CONTRACT_NEGOTIATION_CALLBACK_ADDR = EDC_NAMESPACE + "callbackAddresses";
+
     private String contractAgreementId; // is null until state == CONFIRMED
     private String counterPartyAddress;
     private String errorDetail;

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/model/NegotiationInitiateRequestDto.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/model/NegotiationInitiateRequestDto.java
@@ -21,7 +21,21 @@ import org.eclipse.edc.api.model.CallbackAddressDto;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
+
 public class NegotiationInitiateRequestDto {
+    public static final String TYPE = EDC_NAMESPACE + "NegotiationInitiateRequestDto";
+    public static final String CONNECTOR_ADDRESS = EDC_NAMESPACE + "connectorAddress";
+    public static final String PROTOCOL = EDC_NAMESPACE + "protocol";
+    public static final String CONNECTOR_ID = EDC_NAMESPACE + "connectorId";
+    public static final String PROVIDER_ID = EDC_NAMESPACE + "providerId";
+    public static final String CONSUMER_ID = EDC_NAMESPACE + "consumerId";
+    public static final String OFFER = EDC_NAMESPACE + "offer";
+    public static final String CALLBACK_ADDRESSES = EDC_NAMESPACE + "callbackAddresses";
+    public static final String OFFER_ID = EDC_NAMESPACE + "offerId";
+    public static final String ASSET_ID = EDC_NAMESPACE + "assetId";
+    public static final String POLICY = EDC_NAMESPACE + "policy";
+
     @NotBlank(message = "connectorAddress is mandatory")
     private String connectorAddress; // TODO change to callbackAddress
     @NotBlank(message = "protocol is mandatory")

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectFromCallbackAddressTransformer.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectFromCallbackAddressTransformer.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.contractnegotiation.transform;
+
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Set;
+
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.CALLBACKADDRESS_TYPE;
+import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.EVENTS;
+import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.IS_TRANSACTIONAL;
+import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.URI;
+
+public class JsonObjectFromCallbackAddressTransformer extends AbstractJsonLdTransformer<CallbackAddress, JsonObject> {
+
+    private final JsonBuilderFactory jsonFactory;
+
+    public JsonObjectFromCallbackAddressTransformer(JsonBuilderFactory jsonFactory) {
+        super(CallbackAddress.class, JsonObject.class);
+        this.jsonFactory = jsonFactory;
+    }
+
+    @Override
+    public @Nullable JsonObject transform(@NotNull CallbackAddress callbackAddress, @NotNull TransformerContext context) {
+        var builder = jsonFactory.createObjectBuilder();
+        return builder.add(TYPE, CALLBACKADDRESS_TYPE)
+                .add(IS_TRANSACTIONAL, callbackAddress.isTransactional())
+                .add(URI, callbackAddress.getUri())
+                .add(EVENTS, asArray(callbackAddress.getEvents()))
+                .build();
+    }
+
+    private JsonArrayBuilder asArray(Set<String> events) {
+        var bldr = jsonFactory.createArrayBuilder();
+        events.forEach(bldr::add);
+        return bldr;
+    }
+}

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectFromContractAgreementDtoTransformer.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectFromContractAgreementDtoTransformer.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.contractnegotiation.transform;
+
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractAgreementDto;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractAgreementDto.CONTRACT_AGREEMENT_ASSETID;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractAgreementDto.CONTRACT_AGREEMENT_CONSUMER_AGENTID;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractAgreementDto.CONTRACT_AGREEMENT_END_DATE;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractAgreementDto.CONTRACT_AGREEMENT_POLICY;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractAgreementDto.CONTRACT_AGREEMENT_PROVIDER_AGENTID;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractAgreementDto.CONTRACT_AGREEMENT_SIGNING_DATE;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractAgreementDto.CONTRACT_AGREEMENT_START_DATE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+
+public class JsonObjectFromContractAgreementDtoTransformer extends AbstractJsonLdTransformer<ContractAgreementDto, JsonObject> {
+    private final JsonBuilderFactory jsonFactory;
+
+    public JsonObjectFromContractAgreementDtoTransformer(JsonBuilderFactory jsonFactory) {
+        super(ContractAgreementDto.class, JsonObject.class);
+        this.jsonFactory = jsonFactory;
+    }
+
+    @Override
+    public @Nullable JsonObject transform(@NotNull ContractAgreementDto dto, @NotNull TransformerContext context) {
+
+        var bldr = jsonFactory.createObjectBuilder();
+        bldr.add(TYPE, ContractAgreementDto.TYPE)
+                .add(ID, dto.getId())
+                .add(CONTRACT_AGREEMENT_ASSETID, dto.getAssetId())
+                .add(CONTRACT_AGREEMENT_POLICY, context.transform(dto.getPolicy(), JsonObject.class))
+                .add(CONTRACT_AGREEMENT_START_DATE, dto.getContractStartDate())
+                .add(CONTRACT_AGREEMENT_SIGNING_DATE, dto.getContractSigningDate())
+                .add(CONTRACT_AGREEMENT_END_DATE, dto.getContractEndDate())
+                .add(CONTRACT_AGREEMENT_CONSUMER_AGENTID, dto.getConsumerAgentId())
+                .add(CONTRACT_AGREEMENT_PROVIDER_AGENTID, dto.getProviderAgentId());
+        return bldr.build();
+    }
+}

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectFromContractNegotiationDtoTransformer.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectFromContractNegotiationDtoTransformer.java
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.contractnegotiation.transform;
+
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractNegotiationDto;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+import static java.util.Optional.ofNullable;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractNegotiationDto.CONTRACT_NEGOTIATION_AGREEMENT_ID;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractNegotiationDto.CONTRACT_NEGOTIATION_CALLBACK_ADDR;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractNegotiationDto.CONTRACT_NEGOTIATION_COUNTERPARTY_ADDR;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractNegotiationDto.CONTRACT_NEGOTIATION_ERRORDETAIL;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractNegotiationDto.CONTRACT_NEGOTIATION_NEG_TYPE;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractNegotiationDto.CONTRACT_NEGOTIATION_PROTOCOL;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractNegotiationDto.CONTRACT_NEGOTIATION_STATE;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractNegotiationDto.CONTRACT_NEGOTIATION_TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+
+public class JsonObjectFromContractNegotiationDtoTransformer extends AbstractJsonLdTransformer<ContractNegotiationDto, JsonObject> {
+
+    private final JsonBuilderFactory jsonFactory;
+
+    public JsonObjectFromContractNegotiationDtoTransformer(JsonBuilderFactory jsonFactory) {
+        super(ContractNegotiationDto.class, JsonObject.class);
+        this.jsonFactory = jsonFactory;
+    }
+
+    @Override
+    public @Nullable JsonObject transform(@NotNull ContractNegotiationDto dto, @NotNull TransformerContext context) {
+        var builder = jsonFactory.createObjectBuilder();
+        builder.add(TYPE, CONTRACT_NEGOTIATION_TYPE)
+                .add(ID, dto.getId())
+                .add(CONTRACT_NEGOTIATION_NEG_TYPE, dto.getType().toString())
+                .add(CONTRACT_NEGOTIATION_PROTOCOL, dto.getProtocol())
+                .add(CONTRACT_NEGOTIATION_STATE, dto.getState())
+                .add(CONTRACT_NEGOTIATION_COUNTERPARTY_ADDR, dto.getCounterPartyAddress())
+                .add(CONTRACT_NEGOTIATION_CALLBACK_ADDR, asArray(dto.getCallbackAddresses(), context));
+        ofNullable(dto.getContractAgreementId()).ifPresent(s -> builder.add(CONTRACT_NEGOTIATION_AGREEMENT_ID, s));
+        ofNullable(dto.getErrorDetail()).ifPresent(s -> builder.add(CONTRACT_NEGOTIATION_ERRORDETAIL, s));
+
+
+        return builder.build();
+    }
+
+    private JsonArrayBuilder asArray(List<CallbackAddress> callbackAddresses, TransformerContext context) {
+        var bldr = jsonFactory.createArrayBuilder();
+        callbackAddresses.stream()
+                .map(cba -> context.transform(cba, JsonObject.class))
+                .forEach(bldr::add);
+
+        return bldr;
+    }
+}

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectToCallbackAddressDtoTransformer.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectToCallbackAddressDtoTransformer.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.contractnegotiation.transform;
+
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import org.eclipse.edc.api.model.CallbackAddressDto;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashSet;
+
+import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.EVENTS;
+import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.IS_TRANSACTIONAL;
+import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.URI;
+
+public class JsonObjectToCallbackAddressDtoTransformer extends AbstractJsonLdTransformer<JsonObject, CallbackAddressDto> {
+
+    public JsonObjectToCallbackAddressDtoTransformer() {
+        super(JsonObject.class, CallbackAddressDto.class);
+    }
+
+    @Override
+    public @Nullable CallbackAddressDto transform(@NotNull JsonObject jsonObject, @NotNull TransformerContext context) {
+        var builder = CallbackAddressDto.Builder.newInstance();
+
+        visitProperties(jsonObject, (key, value) -> setProperties(key, value, builder, context));
+
+        return builder.build();
+    }
+
+    private void setProperties(String key, JsonValue value, CallbackAddressDto.Builder builder, TransformerContext context) {
+        switch (key) {
+            case IS_TRANSACTIONAL:
+                builder.transactional(Boolean.parseBoolean(value.toString()));
+                break;
+            case URI:
+                transformString(value, builder::uri, context);
+                break;
+            case EVENTS:
+                var evt = new HashSet<String>();
+                transformArrayOrObject(value, String.class, evt::add, context);
+                builder.events(evt);
+                break;
+            default:
+                context.reportProblem("Cannot convert key " + key + " as it is not known");
+                break;
+        }
+    }
+}

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectToNegotiationInitiateRequestDtoTransformer.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectToNegotiationInitiateRequestDtoTransformer.java
@@ -1,0 +1,90 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.contractnegotiation.transform;
+
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import org.eclipse.edc.api.model.CallbackAddressDto;
+import org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractOfferDescription;
+import org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto.ASSET_ID;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto.CALLBACK_ADDRESSES;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto.CONNECTOR_ADDRESS;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto.CONNECTOR_ID;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto.CONSUMER_ID;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto.OFFER;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto.OFFER_ID;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto.POLICY;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto.PROTOCOL;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto.PROVIDER_ID;
+
+public class JsonObjectToNegotiationInitiateRequestDtoTransformer extends AbstractJsonLdTransformer<JsonObject, NegotiationInitiateRequestDto> {
+
+    public JsonObjectToNegotiationInitiateRequestDtoTransformer() {
+        super(JsonObject.class, NegotiationInitiateRequestDto.class);
+    }
+
+    @Override
+    public @Nullable NegotiationInitiateRequestDto transform(@NotNull JsonObject jsonObject, @NotNull TransformerContext context) {
+        var builder = NegotiationInitiateRequestDto.Builder.newInstance();
+
+        visitProperties(jsonObject, (k, v) -> setProperties(k, v, builder, context));
+        return builder.build();
+    }
+
+    private void setProperties(String key, JsonValue value, NegotiationInitiateRequestDto.Builder builder, TransformerContext context) {
+
+        var contractOfferDesc = ContractOfferDescription.Builder.newInstance();
+        switch (key) {
+            case CONNECTOR_ADDRESS:
+                transformString(value, builder::connectorAddress, context);
+                break;
+            case PROTOCOL:
+                transformString(value, builder::protocol, context);
+                break;
+            case CONNECTOR_ID:
+                transformString(value, builder::connectorId, context);
+                break;
+            case PROVIDER_ID:
+                transformString(value, builder::providerId, context);
+                break;
+            case CONSUMER_ID:
+                transformString(value, builder::consumerId, context);
+                break;
+            case CALLBACK_ADDRESSES:
+                var addresses = new ArrayList<CallbackAddressDto>();
+                transformArrayOrObject(value, CallbackAddressDto.class, addresses::add, context);
+                builder.callbackAddresses(addresses);
+                break;
+            case OFFER:
+                transformString(value.asJsonObject().get(OFFER_ID), contractOfferDesc::offerId, context);
+                transformString(value.asJsonObject().get(ASSET_ID), contractOfferDesc::assetId, context);
+                contractOfferDesc.policy(context.transform(value.asJsonObject().get(POLICY), Policy.class));
+                builder.offer(contractOfferDesc.build());
+                break;
+            default:
+                context.reportProblem("Cannot convert key " + key + " as it is not known");
+                break;
+        }
+    }
+}

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationNewApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationNewApiControllerTest.java
@@ -466,6 +466,8 @@ class ContractNegotiationNewApiControllerTest extends RestControllerTestBase {
     private ContractAgreement createContractAgreement(String negotiationId) {
         return ContractAgreement.Builder.newInstance()
                 .id(negotiationId)
+                .consumerId("test-consumer")
+                .providerId("test-provider")
                 .assetId(UUID.randomUUID().toString())
                 .policy(Policy.Builder.newInstance().build())
                 .build();

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationNewApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationNewApiControllerTest.java
@@ -1,0 +1,496 @@
+/*
+ *  Copyright (c) 2022 - 2022 ZF Friedrichshafen AG
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       ZF Friedrichshafen AG - Initial API and Implementation
+ *       Microsoft Corporation - Added initiate-negotiation endpoint tests
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.contractnegotiation;
+
+import io.restassured.specification.RequestSpecification;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.api.query.QuerySpecDto;
+import org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractAgreementDto;
+import org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractNegotiationDto;
+import org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto;
+import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestData;
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
+import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationService;
+import org.eclipse.edc.jsonld.TitaniumJsonLd;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.service.spi.result.ServiceResult;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.types.domain.asset.Asset;
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+class ContractNegotiationNewApiControllerTest extends RestControllerTestBase {
+    private final ContractNegotiationService service = mock(ContractNegotiationService.class);
+    private final TypeTransformerRegistry transformerRegistry = mock(TypeTransformerRegistry.class);
+    private final JsonLd jsonLd = new TitaniumJsonLd(monitor);
+
+    @Test
+    void getAllContractNegotiations() {
+
+        when(service.query(any(QuerySpec.class))).thenReturn(ServiceResult.success(Stream.of(
+                createContractNegotiation("cn1"),
+                createContractNegotiation("cn2")
+        )));
+        when(transformerRegistry.transform(any(QuerySpecDto.class), eq(QuerySpec.class))).thenReturn(Result.success(QuerySpec.none()));
+        when(transformerRegistry.transform(any(ContractNegotiation.class), eq(ContractNegotiationDto.class)))
+                .thenReturn(Result.success(createContractNegotiationDto().build()));
+        when(transformerRegistry.transform(any(ContractNegotiationDto.class), eq(JsonObject.class)))
+                .thenReturn(Result.success(Json.createObjectBuilder().build()));
+
+        baseRequest()
+                .contentType(JSON)
+                .post("/request")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .body("size()", is(2));
+
+        verify(service).query(any(QuerySpec.class));
+        verify(transformerRegistry).transform(any(QuerySpecDto.class), eq(QuerySpec.class));
+        verify(transformerRegistry, times(2)).transform(any(ContractNegotiation.class), eq(ContractNegotiationDto.class));
+        verify(transformerRegistry, times(2)).transform(any(ContractNegotiationDto.class), eq(JsonObject.class));
+    }
+
+    @Test
+    void getAllContractNegotiations_queryTransformationFails() {
+
+        when(service.query(any(QuerySpec.class))).thenReturn(ServiceResult.success(Stream.of(
+                createContractNegotiation("cn1"),
+                createContractNegotiation("cn2")
+        )));
+        when(transformerRegistry.transform(any(QuerySpecDto.class), eq(QuerySpec.class))).thenReturn(Result.failure("test-failure"));
+
+        baseRequest()
+                .contentType(JSON)
+                .post("/request")
+                .then()
+                .statusCode(400);
+
+        verify(transformerRegistry).transform(any(QuerySpecDto.class), eq(QuerySpec.class));
+        verifyNoInteractions(service);
+        verifyNoMoreInteractions(transformerRegistry);
+    }
+
+    @Test
+    void getAllContractNegotiations_dtoTransformationFails() {
+
+        when(service.query(any(QuerySpec.class))).thenReturn(ServiceResult.success(Stream.of(
+                createContractNegotiation("cn1"),
+                createContractNegotiation("cn2")
+        )));
+        when(transformerRegistry.transform(any(QuerySpecDto.class), eq(QuerySpec.class))).thenReturn(Result.success(QuerySpec.none()));
+        when(transformerRegistry.transform(any(ContractNegotiation.class), eq(ContractNegotiationDto.class)))
+                .thenReturn(Result.failure("test-failure"));
+
+
+        baseRequest()
+                .contentType(JSON)
+                .post("/request")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .body("size()", is(0));
+
+
+        verify(transformerRegistry).transform(any(QuerySpecDto.class), eq(QuerySpec.class));
+        verify(transformerRegistry, times(2)).transform(any(ContractNegotiation.class), eq(ContractNegotiationDto.class));
+        verify(service).query(any(QuerySpec.class));
+        verifyNoMoreInteractions(transformerRegistry);
+    }
+
+    @Test
+    void getAllContractNegotiations_singleFailure_shouldLogError() {
+
+        when(service.query(any(QuerySpec.class))).thenReturn(ServiceResult.success(Stream.of(
+                createContractNegotiation("cn1"),
+                createContractNegotiation("cn2")
+        )));
+        when(transformerRegistry.transform(any(QuerySpecDto.class), eq(QuerySpec.class))).thenReturn(Result.success(QuerySpec.none()));
+        when(transformerRegistry.transform(any(ContractNegotiation.class), eq(ContractNegotiationDto.class)))
+                .thenReturn(Result.success(createContractNegotiationDto().build()));
+        when(transformerRegistry.transform(any(ContractNegotiationDto.class), eq(JsonObject.class)))
+                .thenReturn(Result.success(Json.createObjectBuilder().build()))
+                .thenReturn(Result.failure("test-failure"));
+
+        baseRequest()
+                .contentType(JSON)
+                .post("/request")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .body("size()", is(1));
+
+        verify(service).query(any(QuerySpec.class));
+        verify(transformerRegistry).transform(any(QuerySpecDto.class), eq(QuerySpec.class));
+        verify(transformerRegistry, times(2)).transform(any(ContractNegotiation.class), eq(ContractNegotiationDto.class));
+        verify(transformerRegistry, times(2)).transform(any(ContractNegotiationDto.class), eq(JsonObject.class));
+        verify(monitor).warning(contains("test-failure"));
+    }
+
+    @Test
+    void getAllContractNegotiations_jsonObjectTransformationFails() {
+
+        when(service.query(any(QuerySpec.class))).thenReturn(ServiceResult.success(Stream.of(
+                createContractNegotiation("cn1"),
+                createContractNegotiation("cn2")
+        )));
+        when(transformerRegistry.transform(any(QuerySpecDto.class), eq(QuerySpec.class))).thenReturn(Result.success(QuerySpec.none()));
+        when(transformerRegistry.transform(any(ContractNegotiation.class), eq(ContractNegotiationDto.class)))
+                .thenReturn(Result.success(createContractNegotiationDto().build()));
+        when(transformerRegistry.transform(any(ContractNegotiationDto.class), eq(JsonObject.class)))
+                .thenReturn(Result.failure("test-failure"));
+
+        baseRequest()
+                .contentType(JSON)
+                .post("/request")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .body("size()", is(0));
+
+
+        verify(service).query(any(QuerySpec.class));
+        verify(transformerRegistry).transform(any(QuerySpecDto.class), eq(QuerySpec.class));
+        verify(transformerRegistry, times(2)).transform(any(ContractNegotiation.class), eq(ContractNegotiationDto.class));
+        verify(transformerRegistry, times(2)).transform(any(ContractNegotiationDto.class), eq(JsonObject.class));
+    }
+
+    @Test
+    void getById() {
+        when(service.findbyId(anyString())).thenReturn(createContractNegotiation("cn1"));
+        when(transformerRegistry.transform(any(ContractNegotiation.class), eq(ContractNegotiationDto.class)))
+                .thenReturn(Result.success(createContractNegotiationDto().build()));
+        when(transformerRegistry.transform(any(ContractNegotiationDto.class), eq(JsonObject.class)))
+                .thenReturn(Result.success(Json.createObjectBuilder().build()));
+
+        baseRequest()
+                .get("/cn1")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .body(notNullValue());
+
+        verify(service).findbyId(anyString());
+        verify(transformerRegistry).transform(any(ContractNegotiation.class), eq(ContractNegotiationDto.class));
+        verify(transformerRegistry).transform(any(ContractNegotiationDto.class), eq(JsonObject.class));
+    }
+
+    @Test
+    void getById_notFound() {
+        when(service.findbyId(anyString())).thenReturn(null);
+
+        baseRequest()
+                .get("/cn1")
+                .then()
+                .statusCode(404)
+                .contentType(JSON)
+                .body(notNullValue());
+
+        verify(service).findbyId(anyString());
+        verifyNoInteractions(transformerRegistry);
+    }
+
+    @Test
+    void getById_transformationFails() {
+        when(service.findbyId(eq("cn1"))).thenReturn(createContractNegotiation("cn1"));
+        when(transformerRegistry.transform(any(ContractNegotiation.class), eq(ContractNegotiationDto.class)))
+                .thenReturn(Result.success(createContractNegotiationDto().build()));
+        when(transformerRegistry.transform(any(ContractNegotiationDto.class), eq(JsonObject.class)))
+                .thenReturn(Result.failure("test-failure"));
+
+        baseRequest()
+                .get("/cn1")
+                .then()
+                .statusCode(400)
+                .contentType(JSON)
+                .body(notNullValue());
+
+        verify(service).findbyId(anyString());
+        verify(transformerRegistry).transform(any(ContractNegotiation.class), eq(ContractNegotiationDto.class));
+        verify(transformerRegistry).transform(any(ContractNegotiationDto.class), eq(JsonObject.class));
+    }
+
+
+    @Test
+    void getSingleContractNegotationState() {
+        when(service.getState(eq("cn1"))).thenReturn("REQUESTED");
+        baseRequest()
+                .get("/cn1/state")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .body(Matchers.containsString("REQUESTED"));
+        verify(service).getState(eq("cn1"));
+        verifyNoMoreInteractions(service, transformerRegistry);
+    }
+
+    @Test
+    void getSingleContractNegotationAgreement() {
+        when(service.getForNegotiation(eq("cn1"))).thenReturn(createContractAgreement("cn1"));
+        when(transformerRegistry.transform(any(ContractAgreement.class), eq(ContractAgreementDto.class)))
+                .thenReturn(Result.success(ContractAgreementDto.Builder.newInstance().build()));
+        when(transformerRegistry.transform(any(ContractAgreementDto.class), eq(JsonObject.class)))
+                .thenReturn(Result.success(Json.createObjectBuilder().build()));
+
+        baseRequest()
+                .get("/cn1/agreement")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .body(notNullValue());
+
+        verify(service).getForNegotiation(eq("cn1"));
+        verify(transformerRegistry).transform(any(ContractAgreement.class), eq(ContractAgreementDto.class));
+        verify(transformerRegistry).transform(any(ContractAgreementDto.class), eq(JsonObject.class));
+        verifyNoMoreInteractions(transformerRegistry, service);
+    }
+
+    @Test
+    void getSingleContractNegotationAgreement_transformationFails() {
+
+        when(service.getForNegotiation(eq("cn1"))).thenReturn(createContractAgreement("cn1"));
+        when(transformerRegistry.transform(any(ContractAgreement.class), eq(ContractAgreementDto.class)))
+                .thenReturn(Result.failure("test-failure"));
+
+        baseRequest()
+                .get("/cn1/agreement")
+                .then()
+                .statusCode(400);
+
+        verify(service).getForNegotiation(eq("cn1"));
+        verify(transformerRegistry).transform(any(ContractAgreement.class), eq(ContractAgreementDto.class));
+        verifyNoMoreInteractions(transformerRegistry, service);
+    }
+
+    @Test
+    void getSingleContractNegotationAgreement_whenNoneFound() {
+        when(service.getForNegotiation(eq("cn1"))).thenReturn(null);
+
+        baseRequest()
+                .get("/cn1/agreement")
+                .then()
+                .statusCode(404)
+                .contentType(JSON)
+                .body(notNullValue());
+
+        verify(service).getForNegotiation(eq("cn1"));
+        verifyNoMoreInteractions(transformerRegistry, service);
+    }
+
+    @Test
+    void initiate() {
+        when(transformerRegistry.transform(any(JsonObject.class), eq(NegotiationInitiateRequestDto.class))).thenReturn(Result.success(NegotiationInitiateRequestDto.Builder.newInstance().build()));
+        when(transformerRegistry.transform(any(NegotiationInitiateRequestDto.class), eq(ContractRequest.class))).thenReturn(Result.success(
+                ContractRequest.Builder.newInstance()
+                        .requestData(ContractRequestData.Builder.newInstance()
+                                .protocol("test-protocol")
+                                .callbackAddress("test-cb")
+                                .contractOffer(ContractOffer.Builder.newInstance()
+                                        .id("test-offer-id")
+                                        .asset(Asset.Builder.newInstance().build())
+                                        .policy(Policy.Builder.newInstance().build())
+                                        .build())
+                                .build())
+                        .build()));
+        when(service.initiateNegotiation(any(ContractRequest.class))).thenReturn(createContractNegotiation("cn1"));
+
+        baseRequest()
+                .contentType(JSON)
+                .body(Json.createObjectBuilder().build())
+                .post()
+                .then()
+                .statusCode(200)
+                .body(containsString("\"id\":\"cn1\""));
+
+        verify(service).initiateNegotiation(any());
+        verify(transformerRegistry).transform(any(JsonObject.class), eq(NegotiationInitiateRequestDto.class));
+        verify(transformerRegistry).transform(any(NegotiationInitiateRequestDto.class), eq(ContractRequest.class));
+        verifyNoMoreInteractions(transformerRegistry, service);
+    }
+
+    @Test
+    void initiate_invalidRequest() {
+        when(transformerRegistry.transform(any(JsonObject.class), eq(NegotiationInitiateRequestDto.class))).thenReturn(Result.failure("test-failure"));
+
+        baseRequest()
+                .contentType(JSON)
+                .body(Json.createObjectBuilder().build())
+                .post()
+                .then()
+                .statusCode(400);
+        verify(transformerRegistry).transform(any(JsonObject.class), eq(NegotiationInitiateRequestDto.class));
+        verifyNoMoreInteractions(transformerRegistry, service);
+    }
+
+
+    @Test
+    void cancel() {
+        when(service.cancel(eq("cn1"))).thenReturn(ServiceResult.success(createContractNegotiation("cn1")));
+        baseRequest()
+                .contentType(JSON)
+                .post("/cn1/cancel")
+                .then()
+                .statusCode(204);
+    }
+
+    @Test
+    void cancel_failed() {
+        when(service.cancel(eq("cn1"))).thenReturn(ServiceResult.badRequest("test-failure"));
+        baseRequest()
+                .contentType(JSON)
+                .post("/cn1/cancel")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    void cancel_notFound() {
+        when(service.cancel(eq("cn1"))).thenReturn(ServiceResult.notFound("test-failure"));
+        baseRequest()
+                .contentType(JSON)
+                .post("/cn1/cancel")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    void cancel_conflict() {
+        when(service.cancel(eq("cn1"))).thenReturn(ServiceResult.conflict("test-failure"));
+        baseRequest()
+                .contentType(JSON)
+                .post("/cn1/cancel")
+                .then()
+                .statusCode(409);
+    }
+
+    @Test
+    void decline() {
+        when(service.decline(eq("cn1"))).thenReturn(ServiceResult.success(createContractNegotiation("cn1")));
+        baseRequest()
+                .contentType(JSON)
+                .post("/cn1/decline")
+                .then()
+                .statusCode(204);
+    }
+
+    @Test
+    void decline_failed() {
+        when(service.decline(eq("cn1"))).thenReturn(ServiceResult.badRequest("test-failure"));
+        baseRequest()
+                .contentType(JSON)
+                .post("/cn1/decline")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    void decline_notFound() {
+        when(service.decline(eq("cn1"))).thenReturn(ServiceResult.notFound("test-failure"));
+        baseRequest()
+                .contentType(JSON)
+                .post("/cn1/decline")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    void decline_conflict() {
+        when(service.decline(eq("cn1"))).thenReturn(ServiceResult.conflict("test-failure"));
+        baseRequest()
+                .contentType(JSON)
+                .post("/cn1/decline")
+                .then()
+                .statusCode(409);
+    }
+
+    @Override
+    protected Object controller() {
+        return new ContractNegotiationNewApiController(service, transformerRegistry, jsonLd, monitor);
+    }
+
+    private RequestSpecification baseRequest() {
+        return given()
+                .baseUri("http://localhost:" + port + "/v2/contractnegotiations")
+                .when();
+    }
+
+    private ContractNegotiation createContractNegotiation(String negotiationId) {
+        return createContractNegotiationBuilder(negotiationId)
+                .build();
+    }
+
+    private ContractAgreement createContractAgreement(String negotiationId) {
+        return ContractAgreement.Builder.newInstance()
+                .id(negotiationId)
+                .assetId(UUID.randomUUID().toString())
+                .policy(Policy.Builder.newInstance().build())
+                .build();
+    }
+
+    private ContractNegotiation.Builder createContractNegotiationBuilder(String negotiationId) {
+        return ContractNegotiation.Builder.newInstance()
+                .id(negotiationId)
+                .counterPartyId(UUID.randomUUID().toString())
+                .counterPartyAddress("address")
+                .callbackAddresses(List.of(CallbackAddress.Builder.newInstance()
+                        .uri("local://test")
+                        .build()))
+                .protocol("protocol");
+    }
+
+    private ContractNegotiationDto.Builder createContractNegotiationDto() {
+        return ContractNegotiationDto.Builder.newInstance()
+                .id("test-id")
+                .contractAgreementId("agreement-id")
+                .counterPartyAddress("test-counterparty")
+                .type(ContractNegotiation.Type.PROVIDER)
+                .protocol("test-protocol")
+                .callbackAddresses(List.of(new CallbackAddress()))
+                .state(ContractNegotiationStates.INITIAL.toString());
+
+    }
+}

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectFromCallbackAddressTransformerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectFromCallbackAddressTransformerTest.java
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.contractnegotiation.transform;
+
+
+import jakarta.json.Json;
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.EVENTS;
+import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.IS_TRANSACTIONAL;
+import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.URI;
+import static org.mockito.Mockito.mock;
+
+class JsonObjectFromCallbackAddressTransformerTest {
+
+    private JsonObjectFromCallbackAddressTransformer transformer;
+
+    @BeforeEach
+    void setup() {
+        transformer = new JsonObjectFromCallbackAddressTransformer(Json.createBuilderFactory(Map.of()));
+    }
+
+    @Test
+    void transform() {
+        var callbackAddr = CallbackAddress.Builder.newInstance()
+                .uri("http://test.local")
+                .events(Set.of("foo", "bar", "baz"))
+                .transactional(true)
+                .build();
+
+        var json = transformer.transform(callbackAddr, mock(TransformerContext.class));
+        assertThat(json).isNotNull();
+        assertThat(json.getJsonString(URI).getString()).isEqualTo("http://test.local");
+        assertThat(json.get(IS_TRANSACTIONAL).toString()).isEqualTo("true");
+        assertThat(json.getJsonArray(EVENTS)).hasSize(3);
+    }
+}

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectFromContractAgreementDtoTransformerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectFromContractAgreementDtoTransformerTest.java
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.contractnegotiation.transform;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonString;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractAgreementDto.Builder;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractAgreementDto.CONTRACT_AGREEMENT_ASSETID;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractAgreementDto.CONTRACT_AGREEMENT_CONSUMER_AGENTID;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractAgreementDto.CONTRACT_AGREEMENT_POLICY;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractAgreementDto.CONTRACT_AGREEMENT_PROVIDER_AGENTID;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class JsonObjectFromContractAgreementDtoTransformerTest {
+
+    private JsonObjectFromContractAgreementDtoTransformer transformer;
+
+    @BeforeEach
+    void setUp() {
+        transformer = new JsonObjectFromContractAgreementDtoTransformer(Json.createBuilderFactory(Map.of()));
+    }
+
+    @Test
+    void transform() {
+        var agreement = Builder.newInstance()
+                .id("test-id")
+                .providerAgentId("test-provider")
+                .consumerAgentId("test-consumer")
+                .assetId("test-asset")
+                .policy(Policy.Builder.newInstance().build())
+                .build();
+        var context = mock(TransformerContext.class);
+        when(context.transform(any(Policy.class), eq(JsonObject.class))).thenReturn(Json.createObjectBuilder().build());
+
+        var jobj = transformer.transform(agreement, context);
+        assertThat(jobj).isNotNull();
+        assertThat(jobj.getJsonString(CONTRACT_AGREEMENT_ASSETID)).extracting(JsonString::getString).isEqualTo("test-asset");
+        assertThat(jobj.getJsonString(CONTRACT_AGREEMENT_PROVIDER_AGENTID)).extracting(JsonString::getString).isEqualTo("test-provider");
+        assertThat(jobj.getJsonString(CONTRACT_AGREEMENT_CONSUMER_AGENTID)).extracting(JsonString::getString).isEqualTo("test-consumer");
+        assertThat(jobj.getJsonObject(CONTRACT_AGREEMENT_POLICY)).isNotNull();
+    }
+}

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectFromContractNegotiationDtoTransformerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectFromContractNegotiationDtoTransformerTest.java
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.contractnegotiation.transform;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractNegotiationDto.Builder;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractNegotiationDto.CONTRACT_NEGOTIATION_AGREEMENT_ID;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractNegotiationDto.CONTRACT_NEGOTIATION_COUNTERPARTY_ADDR;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractNegotiationDto.CONTRACT_NEGOTIATION_NEG_TYPE;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractNegotiationDto.CONTRACT_NEGOTIATION_PROTOCOL;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractNegotiationDto.CONTRACT_NEGOTIATION_STATE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class JsonObjectFromContractNegotiationDtoTransformerTest {
+
+    private JsonObjectFromContractNegotiationDtoTransformer transformer;
+    private TransformerContext context;
+
+    @BeforeEach
+    void setUp() {
+        context = mock(TransformerContext.class);
+        when(context.transform(any(CallbackAddress.class), eq(JsonObject.class))).thenReturn(Json.createObjectBuilder().build());
+        transformer = new JsonObjectFromContractNegotiationDtoTransformer(Json.createBuilderFactory(Map.of()));
+    }
+
+    @Test
+    void transform() {
+        var cn = Builder.newInstance()
+                .id("test-id")
+                .counterPartyAddress("address")
+                .contractAgreementId("test-agreement")
+                .state("test-state")
+                .callbackAddresses(List.of(
+                        CallbackAddress.Builder.newInstance()
+                                .uri("local://test")
+                                .build()))
+                .protocol("protocol").build();
+
+        var jsonObject = transformer.transform(cn, context);
+        assertThat(jsonObject).isNotNull();
+        assertThat(jsonObject.getJsonString(CONTRACT_NEGOTIATION_STATE).getString()).isEqualTo("test-state");
+        assertThat(jsonObject.getJsonString(CONTRACT_NEGOTIATION_COUNTERPARTY_ADDR).getString()).isEqualTo("address");
+        assertThat(jsonObject.getJsonString(CONTRACT_NEGOTIATION_AGREEMENT_ID).getString()).isEqualTo("test-agreement");
+        assertThat(jsonObject.getJsonString(ID).getString()).isEqualTo("test-id");
+        assertThat(jsonObject.getJsonString(CONTRACT_NEGOTIATION_NEG_TYPE).getString()).isEqualTo("CONSUMER");
+        assertThat(jsonObject.getJsonString(CONTRACT_NEGOTIATION_PROTOCOL).getString()).isEqualTo("protocol");
+    }
+}

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectToCallbackAddressDtoTransformerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectToCallbackAddressDtoTransformerTest.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.contractnegotiation.transform;
+
+import jakarta.json.Json;
+import org.eclipse.edc.jsonld.transformer.to.JsonValueToGenericTypeTransformer;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.util.JacksonJsonLd.createObjectMapper;
+import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.EVENTS;
+import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.IS_TRANSACTIONAL;
+import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.URI;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class JsonObjectToCallbackAddressDtoTransformerTest {
+
+    private JsonObjectToCallbackAddressDtoTransformer transformer;
+
+    @BeforeEach
+    void setUp() {
+        transformer = new JsonObjectToCallbackAddressDtoTransformer();
+    }
+
+    @Test
+    void transform() {
+        var jobj = Json.createObjectBuilder()
+                .add(IS_TRANSACTIONAL, true)
+                .add(URI, "http://test.local/")
+                .add(EVENTS, Json.createArrayBuilder()
+                        .add("foo")
+                        .add("bar")
+                        .add("baz")
+                        .build())
+                .build();
+
+        var contextMock = mock(TransformerContext.class);
+        var genericTransformer = new JsonValueToGenericTypeTransformer(createObjectMapper());
+        when(contextMock.transform(any(), eq(String.class))).thenAnswer(a -> genericTransformer.transform(a.getArgument(0), contextMock));
+
+        var cba = transformer.transform(jobj, contextMock);
+
+        assertThat(cba).isNotNull();
+        assertThat(cba.getEvents()).containsExactlyInAnyOrder("foo", "bar", "baz");
+        assertThat(cba.getUri()).isEqualTo("http://test.local/");
+        assertThat(cba.isTransactional()).isTrue();
+    }
+}

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectToNegotiationInitiateRequestDtoTransformerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectToNegotiationInitiateRequestDtoTransformerTest.java
@@ -1,0 +1,133 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.contractnegotiation.transform;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.api.model.CallbackAddressDto;
+import org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto.ASSET_ID;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto.CALLBACK_ADDRESSES;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto.CONNECTOR_ADDRESS;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto.CONNECTOR_ID;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto.CONSUMER_ID;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto.OFFER;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto.OFFER_ID;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto.POLICY;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto.PROTOCOL;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto.PROVIDER_ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_OBLIGATION_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_PERMISSION_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_SET;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_PROHIBITION_ATTRIBUTE;
+import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.EVENTS;
+import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.IS_TRANSACTIONAL;
+import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.URI;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class JsonObjectToNegotiationInitiateRequestDtoTransformerTest {
+
+
+    private JsonObjectToNegotiationInitiateRequestDtoTransformer transformer;
+
+    @BeforeEach
+    void setUp() {
+        transformer = new JsonObjectToNegotiationInitiateRequestDtoTransformer();
+    }
+
+    @Test
+    void transform() {
+        var jsonObject = Json.createObjectBuilder()
+                .add(TYPE, NegotiationInitiateRequestDto.TYPE)
+                .add(CONNECTOR_ADDRESS, "test-address")
+                .add(PROTOCOL, "test-protocol")
+                .add(CONNECTOR_ID, "test-conn-id")
+                .add(PROVIDER_ID, "test-provider-id")
+                .add(CONSUMER_ID, "test-consumer-id")
+                .add(CALLBACK_ADDRESSES, createCallbackAddress())
+                .add(OFFER, Json.createObjectBuilder()
+                        .add(OFFER_ID, "test-offer-id")
+                        .add(ASSET_ID, "test-asset")
+                        .add(POLICY, createPolicy())
+                        .build())
+                .build();
+
+        var context = mock(TransformerContext.class);
+        when(context.transform(any(JsonObject.class), eq(Policy.class))).thenReturn(Policy.Builder.newInstance().build());
+        when(context.transform(any(JsonObject.class), eq(CallbackAddress.class))).thenReturn(CallbackAddress.Builder.newInstance()
+                .uri("http://test.local")
+                .events(Set.of("foo", "bar"))
+                .transactional(true)
+                .build());
+        when(context.transform(any(CallbackAddress.class), eq(CallbackAddressDto.class))).thenReturn(CallbackAddressDto.Builder.newInstance()
+                .uri("http://test.local")
+                .events(Set.of("foo", "bar"))
+                .transactional(true)
+                .build());
+        var dto = transformer.transform(jsonObject, context);
+
+        assertThat(dto).isNotNull();
+        assertThat(dto.getCallbackAddresses()).isNotEmpty();
+        assertThat(dto.getProtocol()).isEqualTo("test-protocol");
+        assertThat(dto.getConnectorAddress()).isEqualTo("test-address");
+        assertThat(dto.getConnectorId()).isEqualTo("test-conn-id");
+        assertThat(dto.getProviderId()).isEqualTo("test-provider-id");
+        assertThat(dto.getConsumerId()).isEqualTo("test-consumer-id");
+        assertThat(dto.getOffer().getOfferId()).isEqualTo("test-offer-id");
+        assertThat(dto.getOffer().getAssetId()).isEqualTo("test-asset");
+        assertThat(dto.getOffer().getPolicy()).isNotNull();
+
+    }
+
+    private JsonArrayBuilder createCallbackAddress() {
+        var builder = Json.createArrayBuilder();
+        return builder.add(Json.createObjectBuilder()
+                .add(IS_TRANSACTIONAL, true)
+                .add(URI, "http://test.local/")
+                .add(EVENTS, Json.createArrayBuilder().build()));
+    }
+
+    private JsonObject createPolicy() {
+        var permissionJson = getJsonObject("permission");
+        var prohibitionJson = getJsonObject("prohibition");
+        var dutyJson = getJsonObject("duty");
+        return Json.createObjectBuilder()
+                .add(TYPE, ODRL_POLICY_TYPE_SET)
+                .add(ODRL_PERMISSION_ATTRIBUTE, permissionJson)
+                .add(ODRL_PROHIBITION_ATTRIBUTE, prohibitionJson)
+                .add(ODRL_OBLIGATION_ATTRIBUTE, dutyJson)
+                .build();
+    }
+
+    private JsonObject getJsonObject(String type) {
+        return Json.createObjectBuilder()
+                .add(TYPE, type)
+                .build();
+    }
+}

--- a/resources/openapi/yaml/management-api/contract-negotiation-api.yaml
+++ b/resources/openapi/yaml/management-api/contract-negotiation-api.yaml
@@ -410,7 +410,7 @@ paths:
       - Contract Negotiation
   /v2/contractnegotiations/{id}:
     get:
-      description: Gets an contract negotiation with the given ID
+      description: Gets a contract negotiation with the given ID
       operationId: getNegotiation_1
       parameters:
       - in: path

--- a/resources/openapi/yaml/management-api/contract-negotiation-api.yaml
+++ b/resources/openapi/yaml/management-api/contract-negotiation-api.yaml
@@ -57,6 +57,7 @@ paths:
       tags:
       - Contract Negotiation
     post:
+      deprecated: true
       description: "Initiates a contract negotiation for a given offer and with the\
         \ given counter part. Please note that successfully invoking this endpoint\
         \ only means that the negotiation was initiated. Clients must poll the /{id}/state\
@@ -93,6 +94,7 @@ paths:
       - Contract Negotiation
   /contractnegotiations/request:
     post:
+      deprecated: true
       description: Returns all contract negotiations according to a query
       operationId: queryNegotiations
       requestBody:
@@ -122,6 +124,7 @@ paths:
       - Contract Negotiation
   /contractnegotiations/{id}:
     get:
+      deprecated: true
       description: Gets an contract negotiation with the given ID
       operationId: getNegotiation
       parameters:
@@ -160,6 +163,7 @@ paths:
       - Contract Negotiation
   /contractnegotiations/{id}/agreement:
     get:
+      deprecated: true
       description: Gets a contract agreement for a contract negotiation with the given
         ID
       operationId: getAgreementForNegotiation
@@ -200,6 +204,7 @@ paths:
       - Contract Negotiation
   /contractnegotiations/{id}/cancel:
     post:
+      deprecated: true
       description: "Requests aborting the contract negotiation. Due to the asynchronous\
         \ nature of contract negotiations, a successful response only indicates that\
         \ the request was successfully received. Clients must poll the /{id}/state\
@@ -241,6 +246,7 @@ paths:
       - Contract Negotiation
   /contractnegotiations/{id}/decline:
     post:
+      deprecated: true
       description: "Requests cancelling the contract negotiation. Due to the asynchronous\
         \ nature of contract negotiations, a successful response only indicates that\
         \ the request was successfully received. Clients must poll the /{id}/state\
@@ -282,8 +288,290 @@ paths:
       - Contract Negotiation
   /contractnegotiations/{id}/state:
     get:
+      deprecated: true
       description: Gets the state of a contract negotiation with the given ID
       operationId: getNegotiationState
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+          example: null
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NegotiationState'
+          description: The contract negotiation's state
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: "Request was malformed, e.g. id was null"
+        "404":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: An contract negotiation with the given ID does not exist
+      tags:
+      - Contract Negotiation
+  /v2/contractnegotiations:
+    post:
+      description: "Initiates a contract negotiation for a given offer and with the\
+        \ given counter part. Please note that successfully invoking this endpoint\
+        \ only means that the negotiation was initiated. Clients must poll the /{id}/state\
+        \ endpoint to track the state"
+      operationId: initiateContractNegotiation_1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                $ref: '#/components/schemas/NegotiationInitiateRequestDto'
+              example: null
+              properties:
+                empty:
+                  type: boolean
+                  example: null
+                valueType:
+                  type: string
+                  enum:
+                  - ARRAY
+                  - OBJECT
+                  - STRING
+                  - NUMBER
+                  - "TRUE"
+                  - "FALSE"
+                  - "NULL"
+                  example: null
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdResponseDto'
+          description: The negotiation was successfully initiated. Returns the contract
+            negotiation ID and created timestamp
+          links:
+            poll-state:
+              operationId: getNegotiationState
+              parameters:
+                id: $response.body#/id
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: Request body was malformed
+      tags:
+      - Contract Negotiation
+  /v2/contractnegotiations/request:
+    post:
+      description: Returns all contract negotiations according to a query
+      operationId: queryNegotiations_1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QuerySpecDto'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ContractNegotiationDto'
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: Request was malformed
+      tags:
+      - Contract Negotiation
+  /v2/contractnegotiations/{id}:
+    get:
+      description: Gets an contract negotiation with the given ID
+      operationId: getNegotiation_1
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+          example: null
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContractNegotiationDto'
+          description: The contract negotiation
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: "Request was malformed, e.g. id was null"
+        "404":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: An contract negotiation with the given ID does not exist
+      tags:
+      - Contract Negotiation
+  /v2/contractnegotiations/{id}/agreement:
+    get:
+      description: Gets a contract agreement for a contract negotiation with the given
+        ID
+      operationId: getAgreementForNegotiation_1
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+          example: null
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContractAgreementDto'
+          description: "The contract agreement that is attached to the negotiation,\
+            \ or null"
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: "Request was malformed, e.g. id was null"
+        "404":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: An contract negotiation with the given ID does not exist
+      tags:
+      - Contract Negotiation
+  /v2/contractnegotiations/{id}/cancel:
+    post:
+      description: "Requests aborting the contract negotiation. Due to the asynchronous\
+        \ nature of contract negotiations, a successful response only indicates that\
+        \ the request was successfully received. Clients must poll the /{id}/state\
+        \ endpoint to track the state."
+      operationId: cancelNegotiation_1
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+          example: null
+      responses:
+        "200":
+          description: Request to cancel the Contract negotiation was successfully
+            received
+          links:
+            poll-state:
+              operationId: getNegotiationState
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: "Request was malformed, e.g. id was null"
+        "404":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: A contract negotiation with the given ID does not exist
+      tags:
+      - Contract Negotiation
+  /v2/contractnegotiations/{id}/decline:
+    post:
+      description: "Requests cancelling the contract negotiation. Due to the asynchronous\
+        \ nature of contract negotiations, a successful response only indicates that\
+        \ the request was successfully received. Clients must poll the /{id}/state\
+        \ endpoint to track the state."
+      operationId: declineNegotiation_1
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+          example: null
+      responses:
+        "200":
+          description: Request to decline the Contract negotiation was successfully
+            received
+          links:
+            poll-state:
+              operationId: getNegotiationState
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: "Request was malformed, e.g. id was null"
+        "404":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: A contract negotiation with the given ID does not exist
+      tags:
+      - Contract Negotiation
+  /v2/contractnegotiations/{id}/state:
+    get:
+      description: Gets the state of a contract negotiation with the given ID
+      operationId: getNegotiationState_1
       parameters:
       - in: path
         name: id
@@ -546,6 +834,41 @@ components:
           example: null
         id:
           type: string
+          example: null
+    JsonObject:
+      type: object
+      additionalProperties:
+        $ref: '#/components/schemas/JsonValue'
+      example: null
+      properties:
+        empty:
+          type: boolean
+          example: null
+        valueType:
+          type: string
+          enum:
+          - ARRAY
+          - OBJECT
+          - STRING
+          - NUMBER
+          - "TRUE"
+          - "FALSE"
+          - "NULL"
+          example: null
+    JsonValue:
+      type: object
+      example: null
+      properties:
+        valueType:
+          type: string
+          enum:
+          - ARRAY
+          - OBJECT
+          - STRING
+          - NUMBER
+          - "TRUE"
+          - "FALSE"
+          - "NULL"
           example: null
     NegotiationInitiateRequestDto:
       type: object

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/callback/CallbackAddress.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/callback/CallbackAddress.java
@@ -22,6 +22,8 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
+
 /**
  * The {@link CallbackAddress} contains information about users configured callbacks
  * that can be invoked in various state of the requests processing according to the filter provided
@@ -29,11 +31,13 @@ import java.util.Set;
  */
 @JsonDeserialize(builder = CallbackAddress.Builder.class)
 public class CallbackAddress {
+    public static final String CALLBACKADDRESS_TYPE = EDC_NAMESPACE + "CallbackAddress";
+    public static final String IS_TRANSACTIONAL = EDC_NAMESPACE + "transactional";
+    public static final String URI = EDC_NAMESPACE + "uri";
+    public static final String EVENTS = EDC_NAMESPACE + "events";
 
     private String uri;
-
     private Set<String> events = new HashSet<>();
-
     private boolean transactional;
 
 

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractNegotiationApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractNegotiationApiEndToEndTest.java
@@ -251,6 +251,8 @@ public class ContractNegotiationApiEndToEndTest extends BaseManagementApiEndToEn
         return ContractAgreement.Builder.newInstance()
                 .id(negotiationId)
                 .assetId(UUID.randomUUID().toString())
+                .consumerId(UUID.randomUUID() + "-consumer")
+                .providerId(UUID.randomUUID() + "-provider")
                 .policy(Policy.Builder.newInstance().build())
                 .build();
     }

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractNegotiationApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractNegotiationApiEndToEndTest.java
@@ -1,0 +1,283 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.e2e.managementapi;
+
+import io.restassured.specification.RequestSpecification;
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
+import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates;
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
+import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.types.domain.asset.Asset;
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.TERMINATED;
+import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.TERMINATING;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_OBLIGATION_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_PERMISSION_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_OFFER;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_PROHIBITION_ATTRIBUTE;
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
+import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.EVENTS;
+import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.IS_TRANSACTIONAL;
+import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.URI;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+@EndToEndTest
+public class ContractNegotiationApiEndToEndTest extends BaseManagementApiEndToEndTest {
+
+    // these constants must be identical to the ones defined in NegotiationInitiateRequestDto
+    public static final String INITIATE_TYPE = EDC_NAMESPACE + "NegotiationInitiateRequestDto";
+    public static final String CONNECTOR_ADDRESS = EDC_NAMESPACE + "connectorAddress";
+    public static final String PROTOCOL = EDC_NAMESPACE + "protocol";
+    public static final String CONNECTOR_ID = EDC_NAMESPACE + "connectorId";
+    public static final String PROVIDER_ID = EDC_NAMESPACE + "providerId";
+    public static final String CONSUMER_ID = EDC_NAMESPACE + "consumerId";
+    public static final String OFFER = EDC_NAMESPACE + "offer";
+    public static final String CALLBACK_ADDRESSES = EDC_NAMESPACE + "callbackAddresses";
+    public static final String OFFER_ID = EDC_NAMESPACE + "offerId";
+    public static final String ASSET_ID = EDC_NAMESPACE + "assetId";
+    public static final String POLICY = EDC_NAMESPACE + "policy";
+
+
+    @Test
+    void getAll() {
+        var store = controlPlane.getContext().getService(ContractNegotiationStore.class);
+        store.save(createContractNegotiation("cn1"));
+        store.save(createContractNegotiation("cn2"));
+
+        var jsonPath = baseRequest()
+                .contentType(JSON)
+                .post("/request")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .body("size()", is(2))
+                .extract().jsonPath();
+
+        // must use bracket notation when using keys with a colon
+        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors
+        assertThat((String) jsonPath.get("[0]['edc:counterPartyAddress']")).isEqualTo("address");
+        assertThat((String) jsonPath.get("[0].@id")).isIn("cn1", "cn2");
+        assertThat((String) jsonPath.get("[1].@id")).isIn("cn1", "cn2");
+
+    }
+
+    @Test
+    void getById() {
+        var store = controlPlane.getContext().getService(ContractNegotiationStore.class);
+        store.save(createContractNegotiation("cn1"));
+
+        var json = baseRequest()
+                .contentType(JSON)
+                .get("cn1")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .extract().jsonPath();
+
+        assertThat((String) json.get("@id")).isEqualTo("cn1");
+    }
+
+    @Test
+    void getState() {
+        var store = controlPlane.getContext().getService(ContractNegotiationStore.class);
+        var state = ContractNegotiationStates.FINALIZED.code(); // all other states could be modified by the state machine
+        store.save(createContractNegotiationBuilder("cn1").state(state).build());
+
+        var json = baseRequest()
+                .contentType(JSON)
+                .get("cn1/state")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .extract().jsonPath();
+
+        assertThat((String) json.get("state")).isEqualTo("FINALIZED");
+    }
+
+    @Test
+    void getAgreementForNegotiation() {
+        var store = controlPlane.getContext().getService(ContractNegotiationStore.class);
+        var agreement = createContractAgreement("cn1");
+        store.save(createContractNegotiationBuilder("cn1").contractAgreement(agreement).build());
+
+        var json = baseRequest()
+                .contentType(JSON)
+                .get("cn1/agreement")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .extract().jsonPath();
+
+        assertThat(json.getString("@id")).isEqualTo("cn1");
+        assertThat((Object) json.get("'edc:policy'")).isNotNull().isInstanceOf(Map.class);
+        assertThat(json.getString("'edc:assetId'")).isEqualTo(agreement.getAssetId());
+    }
+
+    @Test
+    void initiateNegotiation() {
+
+        var requestJson = Json.createObjectBuilder()
+                .add(TYPE, INITIATE_TYPE)
+                .add(CONNECTOR_ADDRESS, "test-address")
+                .add(PROTOCOL, "test-protocol")
+                .add(CONNECTOR_ID, "test-conn-id")
+                .add(PROVIDER_ID, "test-provider-id")
+                .add(CONSUMER_ID, "test-consumer-id")
+                .add(CALLBACK_ADDRESSES, createCallbackAddress())
+                .add(OFFER, Json.createObjectBuilder()
+                        .add(OFFER_ID, "test-offer-id")
+                        .add(ASSET_ID, "test-asset")
+                        .add(POLICY, createPolicy())
+                        .build())
+                .build();
+
+        var jsonPath = baseRequest()
+                .contentType(JSON)
+                .body(requestJson)
+                .post()
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .body("id", notNullValue())
+                .extract().body().jsonPath();
+
+        var id = jsonPath.getString("id");
+
+        var store = controlPlane.getContext().getService(ContractNegotiationStore.class);
+        assertThat(store.findById(id)).isNotNull();
+
+    }
+
+    @Test
+    void cancel() {
+        var store = controlPlane.getContext().getService(ContractNegotiationStore.class);
+        store.save(createContractNegotiationBuilder("cn1").build());
+
+        baseRequest()
+                .contentType(JSON)
+                .post("cn1/cancel")
+                .then()
+                .statusCode(204);
+
+        await()
+                .atMost(Duration.ofSeconds(10))
+                .untilAsserted(() -> assertThat(store.findById("cn1")).isNotNull()
+                        .extracting(ContractNegotiation::getState)
+                        .isIn(TERMINATING.code(), TERMINATED.code()));
+    }
+
+    @Test
+    void decline() {
+        var store = controlPlane.getContext().getService(ContractNegotiationStore.class);
+        store.save(createContractNegotiationBuilder("cn1").build());
+
+        baseRequest()
+                .contentType(JSON)
+                .post("cn1/decline")
+                .then()
+                .statusCode(204);
+        await()
+                .atMost(Duration.ofSeconds(30))
+                .untilAsserted(() -> assertThat(store.findById("cn1")).isNotNull()
+                        .extracting(ContractNegotiation::getState)
+                        .isIn(TERMINATING.code(), TERMINATED.code()));
+    }
+
+    private RequestSpecification baseRequest() {
+        return given()
+                .baseUri("http://localhost:" + PORT + "/management/v2/contractnegotiations")
+                .when();
+    }
+
+    private ContractNegotiation createContractNegotiation(String negotiationId) {
+        return createContractNegotiationBuilder(negotiationId)
+                .build();
+    }
+
+    private ContractNegotiation.Builder createContractNegotiationBuilder(String negotiationId) {
+        return ContractNegotiation.Builder.newInstance()
+                .id(negotiationId)
+                .counterPartyId(UUID.randomUUID().toString())
+                .counterPartyAddress("address")
+                .callbackAddresses(List.of(CallbackAddress.Builder.newInstance()
+                        .uri("local://test")
+                        .events(Set.of("test-event1", "test-event2"))
+                        .build()))
+                .protocol("dataspace-protocol-http")
+                .contractOffer(contractOfferBuilder().build());
+    }
+
+    private ContractOffer.Builder contractOfferBuilder() {
+        return ContractOffer.Builder.newInstance()
+                .id("test-offer-id")
+                .asset(Asset.Builder.newInstance().build())
+                .policy(Policy.Builder.newInstance().build());
+    }
+
+
+    private ContractAgreement createContractAgreement(String negotiationId) {
+        return ContractAgreement.Builder.newInstance()
+                .id(negotiationId)
+                .assetId(UUID.randomUUID().toString())
+                .policy(Policy.Builder.newInstance().build())
+                .build();
+    }
+
+    private JsonArrayBuilder createCallbackAddress() {
+        var builder = Json.createArrayBuilder();
+        return builder.add(Json.createObjectBuilder()
+                .add(IS_TRANSACTIONAL, true)
+                .add(URI, "http://test.local/")
+                .add(EVENTS, Json.createArrayBuilder().build()));
+    }
+
+    private JsonObject createPolicy() {
+        var permissionJson = getJsonObject("permission");
+        var prohibitionJson = getJsonObject("prohibition");
+        var dutyJson = getJsonObject("duty");
+        return Json.createObjectBuilder()
+                .add(TYPE, ODRL_POLICY_TYPE_OFFER)
+                .add(ODRL_PERMISSION_ATTRIBUTE, permissionJson)
+                .add(ODRL_PROHIBITION_ATTRIBUTE, prohibitionJson)
+                .add(ODRL_OBLIGATION_ATTRIBUTE, dutyJson)
+                .build();
+    }
+
+    private JsonObject getJsonObject(String type) {
+        return Json.createObjectBuilder()
+                .add(TYPE, type)
+                .build();
+    }
+}

--- a/system-tests/runtimes/file-transfer-provider/build.gradle.kts
+++ b/system-tests/runtimes/file-transfer-provider/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
 
     implementation(project(":extensions:common:configuration:configuration-filesystem"))
     implementation(project(":extensions:common:iam:iam-mock"))
+    implementation(project(":extensions:common:json-ld"))
 
     implementation(project(":data-protocols:ids"))
 }


### PR DESCRIPTION
## What this PR changes/adds

This PR adds the new (json-ld-aware) contract negotiation API as well as several new transformers:
- JsonObject <- CallbackAddress
- JsonObject <- ContractAgreement
- JsonObject <- ContractNegotiation
- JsonObject -> CallbackAddressDto
- JsonObject -> NegotiationInitiateRequest

## Why it does that

Json-LD-ification of the API, needed for the new DSP

## Further notes

.

## Linked Issue(s)

Closes #2838 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
