### PR TITLE
chore: remove Asset from ContractOffer and replace with an id reference

### DIFF
--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -186,7 +186,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
                 .providerId(negotiation.getCounterPartyId())
                 .consumerId(participantId)
                 .policy(policy)
-                .assetId(lastOffer.getAsset().getId())
+                .assetId(lastOffer.getAssetId())
                 .build();
 
         var request = ContractAgreementMessage.Builder.newInstance()

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -174,7 +174,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
                     .providerId(participantId)
                     .consumerId(negotiation.getCounterPartyId())
                     .policy(policy)
-                    .assetId(lastOffer.getAsset().getId())
+                    .assetId(lastOffer.getAssetId())
                     .build();
         } else {
             agreement = retrievedAgreement;

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/offer/ContractOfferResolverImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/offer/ContractOfferResolverImpl.java
@@ -30,7 +30,6 @@ import org.eclipse.edc.spi.agent.ParticipantAgentService;
 import org.eclipse.edc.spi.asset.AssetIndex;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.query.QuerySpec;
-import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.jetbrains.annotations.NotNull;
 
 import java.time.Clock;
@@ -116,12 +115,12 @@ public class ContractOfferResolverImpl implements ContractOfferResolver {
         return Optional.of(definition.getContractPolicyId())
                 .map(policyStore::findById)
                 .map(policyDefinition -> assetIndex.queryAssets(assetQuerySpec)
-                        .map(asset -> createContractOffer(definition, policyDefinition.getPolicy(), asset)))
+                        .map(asset -> createContractOffer(definition, policyDefinition.getPolicy(), asset.getId())))
                 .orElse(Stream.empty());
     }
 
     @NotNull
-    private ContractOffer.Builder createContractOffer(ContractDefinition definition, Policy policy, Asset asset) {
+    private ContractOffer.Builder createContractOffer(ContractDefinition definition, Policy policy, String assetId) {
 
         var start = clock.instant();
         var zone = clock.getZone();
@@ -130,8 +129,8 @@ public class ContractOfferResolverImpl implements ContractOfferResolver {
 
         return ContractOffer.Builder.newInstance()
                 .id(ContractId.createContractId(definition.getId()))
-                .policy(policy.withTarget(asset.getId()))
-                .asset(asset)
+                .policy(policy.withTarget(assetId))
+                .assetId(assetId)
                 .contractStart(contractStartTime)
                 .contractEnd(contractEndTime);
     }

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImpl.java
@@ -97,15 +97,15 @@ public class ContractValidationServiceImpl implements ContractValidationService 
                     "The ContractDefinition with id %s either does not exist or the access to it is not granted.");
         }
 
-        var targetAsset = assetIndex.findById(offer.getAsset().getId());
+        var targetAsset = assetIndex.findById(offer.getAssetId());
         if (targetAsset == null) {
-            return failure("Invalid target: " + offer.getAsset().getId());
+            return failure("Invalid target: " + offer.getAssetId());
         }
 
         // if policy target is null, default to the asset, otherwise validate it
         var policyTarget = offer.getPolicy().getTarget() != null ? offer.getPolicy().getTarget() : targetAsset.getId();
         if (!targetAsset.getId().equals(policyTarget)) {
-            return failure(format("Contract offer asset '%s' does not match policy target: %s", offer.getAsset().getId(), policyTarget));
+            return failure(format("Contract offer asset '%s' does not match policy target: %s", offer.getAssetId(), policyTarget));
         }
 
         var contractPolicyDef = policyStore.findById(contractDefinition.getContractPolicyId());
@@ -131,7 +131,7 @@ public class ContractValidationServiceImpl implements ContractValidationService 
 
         var validatedOffer = ContractOffer.Builder.newInstance()
                 .id(offer.getId())
-                .asset(targetAsset)
+                .assetId(targetAsset.getId())
                 .providerId(participantId)
                 .policy(sanitizedPolicy)
                 .contractStart(offer.getContractStart())
@@ -196,7 +196,7 @@ public class ContractValidationServiceImpl implements ContractValidationService 
             return failure("Invalid provider credentials");
         }
 
-        if (!policyEquality.test(agreement.getPolicy().withTarget(latestOffer.getAsset().getId()), latestOffer.getPolicy())) {
+        if (!policyEquality.test(agreement.getPolicy().withTarget(latestOffer.getAssetId()), latestOffer.getPolicy())) {
             return failure("Policy in the contract agreement is not equal to the one in the contract offer");
         }
 

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
@@ -33,7 +33,6 @@ import org.eclipse.edc.spi.command.CommandRunner;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.retry.ExponentialWaitStrategy;
-import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 import org.eclipse.edc.statemachine.retry.EntityRetryProcessConfiguration;
 import org.junit.jupiter.api.BeforeEach;
@@ -282,7 +281,7 @@ class ConsumerContractNegotiationManagerImplTest {
     private ContractOffer contractOffer() {
         return ContractOffer.Builder.newInstance().id("id:id")
                 .policy(Policy.Builder.newInstance().build())
-                .asset(Asset.Builder.newInstance().id("assetId").build())
+                .assetId("assetId")
                 .contractStart(ZonedDateTime.now())
                 .contractEnd(ZonedDateTime.now())
                 .build();
@@ -312,7 +311,7 @@ class ConsumerContractNegotiationManagerImplTest {
         private ContractOffer contractOffer() {
             return ContractOffer.Builder.newInstance().id("id:id")
                     .policy(Policy.Builder.newInstance().build())
-                    .asset(Asset.Builder.newInstance().id("assetId").build())
+                    .assetId("assetId")
                     .contractStart(ZonedDateTime.now())
                     .contractEnd(ZonedDateTime.now())
                     .build();

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -45,7 +45,6 @@ import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.monitor.ConsoleMonitor;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.telemetry.Telemetry;
-import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 import org.eclipse.edc.transaction.spi.NoopTransactionContext;
 import org.jetbrains.annotations.NotNull;
@@ -60,6 +59,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+import static java.util.UUID.randomUUID;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.CompletableFuture.failedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -304,7 +304,7 @@ class ContractNegotiationIntegrationTest {
                 .contractStart(ZonedDateTime.now())
                 .contractEnd(ZonedDateTime.now().plusMonths(1))
                 .providerId("provider")
-                .asset(Asset.Builder.newInstance().build())
+                .assetId(randomUUID().toString())
                 .policy(Policy.Builder.newInstance()
                         .type(PolicyType.CONTRACT)
                         .assigner("assigner")

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
@@ -36,7 +36,6 @@ import org.eclipse.edc.spi.command.CommandRunner;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.retry.ExponentialWaitStrategy;
-import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.eclipse.edc.statemachine.retry.EntityRetryProcessConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -236,7 +235,7 @@ class ProviderContractNegotiationManagerImplTest {
         private ContractOffer contractOffer() {
             return ContractOffer.Builder.newInstance().id("id:id")
                     .policy(Policy.Builder.newInstance().build())
-                    .asset(Asset.Builder.newInstance().id("assetId").build())
+                    .assetId("assetId")
                     .contractStart(ZonedDateTime.now())
                     .contractEnd(ZonedDateTime.now())
                     .build();
@@ -268,7 +267,7 @@ class ProviderContractNegotiationManagerImplTest {
         return ContractOffer.Builder.newInstance()
                 .id(ContractId.createContractId("1"))
                 .policy(Policy.Builder.newInstance().build())
-                .asset(Asset.Builder.newInstance().id("assetId").build())
+                .assetId("assetId")
                 .providerId(PROVIDER_ID)
                 .contractStart(ZonedDateTime.now())
                 .contractEnd(ZonedDateTime.now())

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/offer/ContractOfferResolverImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/offer/ContractOfferResolverImplTest.java
@@ -145,8 +145,7 @@ class ContractOfferResolverImplTest {
         var offers = contractOfferResolver.queryContractOffers(getQuery(from, to));
 
         assertThat(offers).hasSize(to - from)
-                .extracting(ContractOffer::getAsset)
-                .extracting(Asset::getId)
+                .extracting(ContractOffer::getAssetId)
                 .allSatisfy(id -> {
                     var idNumber = Integer.valueOf(id.replace("asset", ""));
                     assertThat(idNumber).isStrictlyBetween(from - 1, to);

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImplTest.java
@@ -114,7 +114,7 @@ class ContractValidationServiceImplTest {
         assertThat(result.succeeded()).isTrue();
         var validatedOffer = result.getContent().getOffer();
         assertThat(validatedOffer.getPolicy()).isNotSameAs(originalPolicy); // verify the returned policy is the sanitized one
-        assertThat(validatedOffer.getAsset()).isEqualTo(asset);
+        assertThat(validatedOffer.getAssetId()).isEqualTo(asset.getId());
         assertThat(validatedOffer.getContractStart().toInstant()).isEqualTo(clock.instant());
         assertThat(validatedOffer.getContractEnd().toInstant()).isEqualTo(clock.instant().plusSeconds(contractDefinition.getValidity()));
         assertThat(result.getContent().getConsumerIdentity()).isEqualTo(CONSUMER_ID); // verify the returned policy has the consumer id set, essential for later validation checks
@@ -462,7 +462,7 @@ class ContractValidationServiceImplTest {
         var now = ZonedDateTime.ofInstant(clock.instant(), clock.getZone());
         return ContractOffer.Builder.newInstance()
                 .id("1:2")
-                .asset(asset)
+                .assetId(asset.getId())
                 .policy(policy)
                 .providerId(PROVIDER_ID)
                 .contractStart(now)

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/catalog/CatalogServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/catalog/CatalogServiceImplTest.java
@@ -21,7 +21,6 @@ import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.query.QuerySpec;
-import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.junit.jupiter.api.Test;
 
 import java.time.ZonedDateTime;
@@ -49,7 +48,7 @@ class CatalogServiceImplTest {
         var contractOffer = ContractOffer.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
                 .policy(Policy.Builder.newInstance().build())
-                .asset(Asset.Builder.newInstance().id(UUID.randomUUID().toString()).build())
+                .assetId(UUID.randomUUID().toString())
                 .contractStart(ZonedDateTime.now())
                 .contractEnd(ZonedDateTime.now())
                 .build();

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
@@ -115,7 +115,7 @@ class ContractNegotiationEventDispatchTest {
         var now = ZonedDateTime.now();
         var contractOffer = ContractOffer.Builder.newInstance()
                 .id("contractDefinitionId:" + UUID.randomUUID())
-                .asset(Asset.Builder.newInstance().id("assetId").build())
+                .assetId("assetId")
                 .policy(policy)
                 .providerId(PROVIDER)
                 .contractStart(now)

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
@@ -36,7 +36,6 @@ import org.eclipse.edc.spi.iam.ClaimToken;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.telemetry.Telemetry;
-import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
 import org.eclipse.edc.transaction.spi.NoopTransactionContext;
 import org.eclipse.edc.transaction.spi.TransactionContext;
@@ -408,7 +407,7 @@ class ContractNegotiationProtocolServiceImplTest {
         return ContractOffer.Builder.newInstance()
                 .id(ContractId.createContractId("1"))
                 .policy(createPolicy())
-                .asset(Asset.Builder.newInstance().id("assetId").build())
+                .assetId("assetId")
                 .providerId(PROVIDER_ID)
                 .contractStart(ZonedDateTime.now())
                 .contractEnd(ZonedDateTime.now())

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationServiceImplTest.java
@@ -28,7 +28,6 @@ import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.response.StatusResult;
-import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.eclipse.edc.transaction.spi.NoopTransactionContext;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 import org.jetbrains.annotations.NotNull;
@@ -283,7 +282,7 @@ class ContractNegotiationServiceImplTest {
         return ContractOffer.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
                 .policy(Policy.Builder.newInstance().build())
-                .asset(Asset.Builder.newInstance().id("test-asset").build())
+                .assetId("test-asset")
                 .contractStart(ZonedDateTime.now())
                 .contractEnd(ZonedDateTime.now())
                 .build();

--- a/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/contractnegotiation/TestFunctions.java
+++ b/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/contractnegotiation/TestFunctions.java
@@ -19,7 +19,6 @@ import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.policy.model.Policy;
-import org.eclipse.edc.spi.types.domain.asset.Asset;
 
 import java.time.Instant;
 import java.time.ZonedDateTime;
@@ -41,7 +40,7 @@ public class TestFunctions {
                 .type(ContractNegotiation.Type.CONSUMER)
                 .contractOffers(List.of(ContractOffer.Builder.newInstance().id("contractId")
                         .policy(Policy.Builder.newInstance().build())
-                        .asset(Asset.Builder.newInstance().id("test-asset").build())
+                        .assetId("test-asset")
                         .contractStart(ZonedDateTime.now())
                         .contractEnd(ZonedDateTime.now().plusMonths(1))
                         .build()))

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/api/controller/DspNegotiationControllerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/api/controller/DspNegotiationControllerTest.java
@@ -44,7 +44,6 @@ import org.eclipse.edc.spi.iam.IdentityService;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
-import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
 import org.junit.jupiter.api.Test;
@@ -135,7 +134,7 @@ public class DspNegotiationControllerTest extends RestControllerTestBase {
     private static ContractOffer contractOffer() {
         return ContractOffer.Builder.newInstance()
                 .id(String.valueOf(UUID.randomUUID()))
-                .asset(Asset.Builder.newInstance().id("assetId").build())
+                .assetId("assetId")
                 .contractStart(ZonedDateTime.now())
                 .contractEnd(ZonedDateTime.now())
                 .policy(policy()).build();

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-dispatcher/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/dispatcher/delegate/ContractRequestMessageHttpDelegateTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-dispatcher/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/dispatcher/delegate/ContractRequestMessageHttpDelegateTest.java
@@ -30,7 +30,6 @@ import org.eclipse.edc.policy.model.Prohibition;
 import org.eclipse.edc.protocol.dsp.spi.dispatcher.DspHttpDispatcherDelegate;
 import org.eclipse.edc.protocol.dsp.spi.testfixtures.dispatcher.DspHttpDispatcherDelegateTestBase;
 import org.eclipse.edc.spi.monitor.Monitor;
-import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -144,7 +143,7 @@ class ContractRequestMessageHttpDelegateTest extends DspHttpDispatcherDelegateTe
     private ContractOffer contractOffer() {
         return ContractOffer.Builder.newInstance()
                 .id(String.valueOf(UUID.randomUUID()))
-                .asset(Asset.Builder.newInstance().id("assetId").build())
+                .assetId("assetId")
                 .contractStart(ZonedDateTime.now())
                 .contractEnd(ZonedDateTime.now())
                 .policy(policy()).build();

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org.eclipse.edc.protocol.dsp.negotiation.transform/from/JsonObjectFromContractRequestTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org.eclipse.edc.protocol.dsp.negotiation.transform/from/JsonObjectFromContractRequestTransformer.java
@@ -51,7 +51,7 @@ public class JsonObjectFromContractRequestTransformer extends AbstractJsonLdTran
         builder.add(JsonLdKeywords.TYPE, DSPACE_NEGOTIATION_CONTRACT_REQUEST_MESSAGE);
 
         builder.add(DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID, object.getProcessId());
-        builder.add(DSPACE_NEGOTIATION_PROPERTY_DATASET, object.getContractOffer().getAsset().getId());
+        builder.add(DSPACE_NEGOTIATION_PROPERTY_DATASET, object.getContractOffer().getAssetId());
         builder.add(DSPACE_NEGOTIATION_PROPERTY_CALLBACK_ADDRESS, object.getCallbackAddress());
 
         var policy = context.transform(object.getContractOffer().getPolicy(), JsonObject.class);

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org.eclipse.edc.protocol.dsp.negotiation.transform/to/JsonObjectToContractRequestMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org.eclipse.edc.protocol.dsp.negotiation.transform/to/JsonObjectToContractRequestMessageTransformer.java
@@ -19,7 +19,6 @@ import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestM
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
 import org.eclipse.edc.policy.model.Policy;
-import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -64,7 +63,7 @@ public class JsonObjectToContractRequestMessageTransformer extends AbstractJsonL
     private ContractOffer contractOffer(JsonObject offer, Policy policy) {
         var builder = ContractOffer.Builder.newInstance();
         builder.id(nodeId(offer));
-        builder.asset(Asset.Builder.newInstance().id(policy.getTarget()).build());
+        builder.assetId(policy.getTarget());
         builder.policy(policy);
 
         return builder.build();

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractRequestMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractRequestMessageTransformerTest.java
@@ -24,7 +24,6 @@ import org.eclipse.edc.policy.model.Duty;
 import org.eclipse.edc.policy.model.Permission;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.policy.model.Prohibition;
-import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -111,7 +110,7 @@ class JsonObjectFromContractRequestMessageTransformerTest {
     private ContractOffer contractOffer() {
         return ContractOffer.Builder.newInstance()
                 .id(String.valueOf(UUID.randomUUID()))
-                .asset(Asset.Builder.newInstance().id("assetId").build())
+                .assetId("assetId")
                 .policy(policy()).build();
     }
 

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractRequestMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractRequestMessageTransformerTest.java
@@ -84,7 +84,7 @@ class JsonObjectToContractRequestMessageTransformerTest {
         assertThat(result.getContractOffer()).isNotNull();
         assertThat(result.getContractOffer().getClass()).isEqualTo(ContractOffer.class);
         assertThat(result.getContractOffer().getPolicy()).isNotNull();
-        assertThat(result.getContractOffer().getAsset().getId()).isEqualTo("target");
+        assertThat(result.getContractOffer().getAssetId()).isEqualTo("target");
 
         verify(context, never()).reportProblem(anyString());
     }

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/client/MultipartDispatcherIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/client/MultipartDispatcherIntegrationTest.java
@@ -254,7 +254,7 @@ class MultipartDispatcherIntegrationTest {
                 .id(id)
                 .providerId("provider")
                 .policy(Policy.Builder.newInstance().build())
-                .asset(Asset.Builder.newInstance().id("test-asset").build())
+                .assetId("test-asset")
                 .contractStart(ZonedDateTime.now())
                 .contractEnd(ZonedDateTime.now().plusMonths(1))
                 .build();

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/sender/type/MultipartContractOfferSenderTest.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/sender/type/MultipartContractOfferSenderTest.java
@@ -29,7 +29,6 @@ import org.eclipse.edc.protocol.ids.transform.type.contract.ContractOfferToIdsCo
 import org.eclipse.edc.protocol.ids.transform.type.policy.ActionToIdsActionTransformer;
 import org.eclipse.edc.protocol.ids.transform.type.policy.PermissionToIdsPermissionTransformer;
 import org.eclipse.edc.spi.types.TypeManager;
-import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -89,7 +88,7 @@ class MultipartContractOfferSenderTest {
                 .contractOffer(ContractOffer.Builder.newInstance()
                         .id("contract-offer")
                         .policy(policy)
-                        .asset(Asset.Builder.newInstance().id("asset-id").build())
+                        .assetId("asset-id")
                         .providerId("providerId")
                         .contractStart(ZonedDateTime.now())
                         .contractEnd(ZonedDateTime.now().plusMonths(1))

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/MultipartControllerIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/MultipartControllerIntegrationTest.java
@@ -263,7 +263,7 @@ class MultipartControllerIntegrationTest {
         assetIndex.create(asset, DataAddress.Builder.newInstance().type("test").build());
         var contractOffer = ContractOffer.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
-                .asset(asset)
+                .assetId(asset.getId())
                 .policy(createEverythingAllowedPolicy())
                 .providerId("provider")
                 .contractStart(ZonedDateTime.now())
@@ -526,7 +526,7 @@ class MultipartControllerIntegrationTest {
         assetIndex.create(asset, DataAddress.Builder.newInstance().type("test").build());
         var contractOffer = ContractOffer.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
-                .asset(asset)
+                .assetId(asset.getId())
                 .policy(createEverythingAllowedPolicy())
                 .providerId("provider")
                 .contractStart(ZonedDateTime.now())

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/handler/DescriptionRequestHandlerTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/handler/DescriptionRequestHandlerTest.java
@@ -194,7 +194,7 @@ class DescriptionRequestHandlerTest {
         var contractOffer = ContractOffer.Builder.newInstance()
                 .id("id")
                 .policy(Policy.Builder.newInstance().build())
-                .asset(Asset.Builder.newInstance().id("test-asset").build())
+                .assetId("test-asset")
                 .contractStart(ZonedDateTime.now())
                 .contractEnd(ZonedDateTime.now().plusMonths(1))
                 .build();

--- a/data-protocols/ids/ids-core/src/test/java/org/eclipse/edc/protocol/ids/service/CatalogServiceImplTest.java
+++ b/data-protocols/ids/ids-core/src/test/java/org/eclipse/edc/protocol/ids/service/CatalogServiceImplTest.java
@@ -21,7 +21,6 @@ import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.protocol.ids.spi.types.container.DescriptionRequest;
 import org.eclipse.edc.spi.iam.ClaimToken;
 import org.eclipse.edc.spi.query.QuerySpec;
-import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -67,7 +66,7 @@ class CatalogServiceImplTest {
     private static ContractOffer createContractOffer(String id) {
         return ContractOffer.Builder.newInstance()
                 .policy(Policy.Builder.newInstance().build())
-                .asset(Asset.Builder.newInstance().id("test-asset").build())
+                .assetId("test-asset")
                 .id(id)
                 .contractStart(ZonedDateTime.now())
                 .contractEnd(ZonedDateTime.now().plusMonths(1))

--- a/data-protocols/ids/ids-transform-v1/src/main/java/org/eclipse/edc/protocol/ids/transform/IdsTransformServiceExtension.java
+++ b/data-protocols/ids/ids-transform-v1/src/main/java/org/eclipse/edc/protocol/ids/transform/IdsTransformServiceExtension.java
@@ -47,6 +47,7 @@ import org.eclipse.edc.protocol.ids.transform.type.policy.ProhibitionFromIdsProh
 import org.eclipse.edc.protocol.ids.transform.type.policy.ProhibitionToIdsProhibitionTransformer;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.asset.AssetIndex;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
@@ -57,6 +58,9 @@ import java.util.Arrays;
 public class IdsTransformServiceExtension implements ServiceExtension {
 
     public static final String NAME = "IDS Transform Extension";
+
+    @Inject
+    private AssetIndex assetIndex;
 
     @Inject
     private TypeTransformerRegistry registry;
@@ -78,7 +82,7 @@ public class IdsTransformServiceExtension implements ServiceExtension {
                 new ConstraintToIdsLogicalConstraintTransformer(),
                 new ContractOfferToIdsContractOfferTransformer(),
                 new ContractAgreementToIdsContractAgreementTransformer(),
-                new CatalogToIdsResourceCatalogTransformer(),
+                new CatalogToIdsResourceCatalogTransformer(assetIndex),
                 new DutyToIdsDutyTransformer(),
                 new ExpressionToIdsLeftOperandTransformer(),
                 new ExpressionToIdsRdfResourceTransformer(),

--- a/data-protocols/ids/ids-transform-v1/src/main/java/org/eclipse/edc/protocol/ids/transform/type/contract/ContractOfferFromIdsContractOfferOrRequestTransformer.java
+++ b/data-protocols/ids/ids-transform-v1/src/main/java/org/eclipse/edc/protocol/ids/transform/type/contract/ContractOfferFromIdsContractOfferOrRequestTransformer.java
@@ -84,7 +84,7 @@ public class ContractOfferFromIdsContractOfferOrRequestTransformer implements Id
         var contractOfferBuilder = ContractOffer.Builder.newInstance()
                 .policy(policy)
                 .providerId(contract.getProvider().toString())
-                .asset(asset);
+                .assetId(asset.getId());
 
         var result = IdsId.from(contract.getId().toString());
         if (result.failed()) {

--- a/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/edc/protocol/ids/transform/CatalogToIdsResourceCatalogTransformerTest.java
+++ b/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/edc/protocol/ids/transform/CatalogToIdsResourceCatalogTransformerTest.java
@@ -21,6 +21,8 @@ import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.protocol.ids.spi.types.container.OfferedAsset;
 import org.eclipse.edc.protocol.ids.transform.type.connector.CatalogToIdsResourceCatalogTransformer;
+import org.eclipse.edc.spi.asset.AssetIndex;
+import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import java.net.URI;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -45,11 +48,13 @@ class CatalogToIdsResourceCatalogTransformerTest {
     private CatalogToIdsResourceCatalogTransformer transformer;
 
     private TransformerContext context;
+    private AssetIndex assetIndex;
 
     @BeforeEach
     void setUp() {
-        transformer = new CatalogToIdsResourceCatalogTransformer();
         context = mock(TransformerContext.class);
+        assetIndex = mock(AssetIndex.class);
+        transformer = new CatalogToIdsResourceCatalogTransformer(assetIndex);
     }
 
     @Test
@@ -64,6 +69,8 @@ class CatalogToIdsResourceCatalogTransformerTest {
                 .contractOffers(List.of(o1, o2))
                 .build();
         when(context.transform(isA(OfferedAsset.class), eq(Resource.class))).thenReturn(resource);
+        //noinspection unchecked
+        when(assetIndex.queryAssets(isA(QuerySpec.class))).thenReturn(Stream.of(a1, a2));
 
         var result = transformer.transform(catalog, context);
 
@@ -71,12 +78,13 @@ class CatalogToIdsResourceCatalogTransformerTest {
         assertThat(result.getId()).isEqualTo(EXPECTED_CATALOG_ID);
         assertThat(result.getOfferedResource()).hasSize(2);
         verify(context, times(2)).transform(isA(OfferedAsset.class), eq(Resource.class));
+        verify(assetIndex).queryAssets(isA(QuerySpec.class));
     }
 
     private static ContractOffer createContractOffer(String id, Asset asset) {
         return ContractOffer.Builder.newInstance()
                 .id(id)
-                .asset(asset)
+                .assetId(asset.getId())
                 .policy(Policy.Builder.newInstance().build())
                 .contractStart(ZonedDateTime.now())
                 .contractEnd(ZonedDateTime.now())

--- a/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/edc/protocol/ids/transform/ContractOfferToIdsContractOfferTransformerTest.java
+++ b/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/edc/protocol/ids/transform/ContractOfferToIdsContractOfferTransformerTest.java
@@ -21,7 +21,6 @@ import org.eclipse.edc.policy.model.Permission;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.policy.model.Prohibition;
 import org.eclipse.edc.protocol.ids.transform.type.contract.ContractOfferToIdsContractOfferTransformer;
-import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,7 +41,6 @@ class ContractOfferToIdsContractOfferTransformerTest {
     private static final String CONTRACT_OFFER_ID = "456uz984390236s";
     private static final URI OFFER_ID = URI.create("urn:contractoffer:" + CONTRACT_OFFER_ID);
     private static final String PROVIDER_ID = "https://provider.com/";
-    private static final String CONSUMER_ID = "https://consumer.com/";
 
     private ContractOfferToIdsContractOfferTransformer transformer;
 
@@ -96,7 +94,7 @@ class ContractOfferToIdsContractOfferTransformerTest {
         return ContractOffer.Builder.newInstance()
                 .id(CONTRACT_OFFER_ID)
                 .policy(policy)
-                .asset(Asset.Builder.newInstance().id("test-asset").build())
+                .assetId("test-asset")
                 .providerId(PROVIDER_ID)
                 .contractStart(ZonedDateTime.now())
                 .contractEnd(ZonedDateTime.now().plusMonths(1))

--- a/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/edc/protocol/ids/transform/OfferedAssetToIdsResourceTransformerTest.java
+++ b/data-protocols/ids/ids-transform-v1/src/test/java/org/eclipse/edc/protocol/ids/transform/OfferedAssetToIdsResourceTransformerTest.java
@@ -56,7 +56,7 @@ class OfferedAssetToIdsResourceTransformerTest {
         return ContractOffer.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
                 .policy(Policy.Builder.newInstance().build())
-                .asset(Asset.Builder.newInstance().id("test-asset").build())
+                .assetId("test-asset")
                 .contractStart(ZonedDateTime.now())
                 .contractEnd(ZonedDateTime.now().plusMonths(1))
                 .build();

--- a/extensions/control-plane/api/management-api/catalog-api/src/test/java/org/eclipse/edc/connector/api/management/catalog/CatalogApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/test/java/org/eclipse/edc/connector/api/management/catalog/CatalogApiControllerIntegrationTest.java
@@ -33,7 +33,6 @@ import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.query.SortOrder;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
-import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -70,7 +69,7 @@ class CatalogApiControllerIntegrationTest {
         return ContractOffer.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
                 .policy(Policy.Builder.newInstance().build())
-                .asset(Asset.Builder.newInstance().id(UUID.randomUUID().toString()).build())
+                .assetId(UUID.randomUUID().toString())
                 .contractStart(ZonedDateTime.now())
                 .contractEnd(ZonedDateTime.now().plusMonths(1))
                 .build();

--- a/extensions/control-plane/api/management-api/catalog-api/src/test/java/org/eclipse/edc/connector/api/management/catalog/CatalogApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/test/java/org/eclipse/edc/connector/api/management/catalog/CatalogApiControllerTest.java
@@ -26,7 +26,6 @@ import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.query.SortOrder;
 import org.eclipse.edc.spi.result.Result;
-import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,8 +33,8 @@ import org.mockito.Mockito;
 
 import java.time.ZonedDateTime;
 import java.util.List;
-import java.util.UUID;
 
+import static java.util.UUID.randomUUID;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.CompletableFuture.failedFuture;
 import static org.mockito.ArgumentMatchers.any;
@@ -109,9 +108,9 @@ class CatalogApiControllerTest {
 
     private static ContractOffer createContractOffer() {
         return ContractOffer.Builder.newInstance()
-                .id(UUID.randomUUID().toString())
+                .id(randomUUID().toString())
                 .policy(Policy.Builder.newInstance().build())
-                .asset(Asset.Builder.newInstance().id(UUID.randomUUID().toString()).build())
+                .assetId(randomUUID().toString())
                 .contractStart(ZonedDateTime.now())
                 .contractEnd(ZonedDateTime.now().plusMonths(1))
                 .build();

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/NegotiationInitiateRequestDtoToDataRequestTransformer.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/NegotiationInitiateRequestDtoToDataRequestTransformer.java
@@ -19,7 +19,6 @@ import org.eclipse.edc.connector.api.management.contractnegotiation.model.Negoti
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestData;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
-import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
@@ -61,7 +60,7 @@ public class NegotiationInitiateRequestDtoToDataRequestTransformer implements Dt
         var now = ZonedDateTime.ofInstant(clock.instant(), clock.getZone());
         var contractOffer = ContractOffer.Builder.newInstance()
                 .id(object.getOffer().getOfferId())
-                .asset(Asset.Builder.newInstance().id(object.getOffer().getAssetId()).build())
+                .assetId(object.getOffer().getAssetId())
                 .providerId(getId(object.getProviderId(), object.getConnectorAddress()))
                 .policy(object.getOffer().getPolicy())
                 .contractStart(now)

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerTest.java
@@ -33,7 +33,6 @@ import org.eclipse.edc.service.spi.result.ServiceResult;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.Result;
-import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.web.spi.exception.InvalidRequestException;
 import org.eclipse.edc.web.spi.exception.ObjectConflictException;
@@ -316,7 +315,7 @@ class ContractNegotiationApiControllerTest {
                 .contractOffer(ContractOffer.Builder.newInstance()
                         .id(UUID.randomUUID().toString())
                         .policy(Policy.Builder.newInstance().build())
-                        .asset(Asset.Builder.newInstance().id("test-asset").build())
+                        .assetId("test-asset")
                         .contractStart(ZonedDateTime.now())
                         .contractEnd(ZonedDateTime.now().plusMonths(1))
                         .build())

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationNewApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationNewApiControllerTest.java
@@ -36,7 +36,6 @@ import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.service.spi.result.ServiceResult;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.Result;
-import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
@@ -44,11 +43,11 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.UUID;
 import java.util.stream.Stream;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
+import static java.util.UUID.randomUUID;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -331,7 +330,7 @@ class ContractNegotiationNewApiControllerTest extends RestControllerTestBase {
                                 .callbackAddress("test-cb")
                                 .contractOffer(ContractOffer.Builder.newInstance()
                                         .id("test-offer-id")
-                                        .asset(Asset.Builder.newInstance().build())
+                                        .assetId(randomUUID().toString())
                                         .policy(Policy.Builder.newInstance().build())
                                         .build())
                                 .build())
@@ -468,7 +467,7 @@ class ContractNegotiationNewApiControllerTest extends RestControllerTestBase {
                 .id(negotiationId)
                 .consumerId("test-consumer")
                 .providerId("test-provider")
-                .assetId(UUID.randomUUID().toString())
+                .assetId(randomUUID().toString())
                 .policy(Policy.Builder.newInstance().build())
                 .build();
     }
@@ -476,7 +475,7 @@ class ContractNegotiationNewApiControllerTest extends RestControllerTestBase {
     private ContractNegotiation.Builder createContractNegotiationBuilder(String negotiationId) {
         return ContractNegotiation.Builder.newInstance()
                 .id(negotiationId)
-                .counterPartyId(UUID.randomUUID().toString())
+                .counterPartyId(randomUUID().toString())
                 .counterPartyAddress("address")
                 .callbackAddresses(List.of(CallbackAddress.Builder.newInstance()
                         .uri("local://test")

--- a/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
+++ b/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
@@ -52,8 +52,8 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.ZonedDateTime;
 import java.util.Map;
-import java.util.UUID;
 
+import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.eclipse.edc.connector.provision.http.HttpProvisionerFixtures.PROVISIONER_CONFIG;
@@ -141,15 +141,15 @@ public class HttpProvisionerExtensionEndToEndTest {
                 .build();
 
         var contractOffer = ContractOffer.Builder.newInstance()
-                .id(UUID.randomUUID().toString())
-                .asset(Asset.Builder.newInstance().build())
+                .id(randomUUID().toString())
+                .assetId(randomUUID().toString())
                 .policy(policy)
                 .contractStart(ZonedDateTime.now())
                 .contractEnd(ZonedDateTime.now())
                 .build();
         return ContractNegotiation.Builder.newInstance()
-                .id(UUID.randomUUID().toString())
-                .counterPartyId(UUID.randomUUID().toString())
+                .id(randomUUID().toString())
+                .counterPartyId(randomUUID().toString())
                 .counterPartyAddress("test")
                 .protocol("test")
                 .contractAgreement(contractAgreement)
@@ -166,7 +166,7 @@ public class HttpProvisionerExtensionEndToEndTest {
 
     private TransferRequestMessage createTransferRequestMessage() {
         return TransferRequestMessage.Builder.newInstance()
-                .id(UUID.randomUUID().toString())
+                .id(randomUUID().toString())
                 .dataDestination(DataAddress.Builder.newInstance().type("test").build())
                 .protocol("any")
                 .callbackAddress("http://any")

--- a/extensions/control-plane/store/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/contractnegotiation/CosmosContractNegotiationStoreIntegrationTest.java
+++ b/extensions/control-plane/store/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/contractnegotiation/CosmosContractNegotiationStoreIntegrationTest.java
@@ -40,7 +40,6 @@ import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.query.SortOrder;
 import org.eclipse.edc.spi.types.TypeManager;
-import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -86,7 +85,6 @@ class CosmosContractNegotiationStoreIntegrationTest extends ContractNegotiationS
 
         var response = client.createDatabaseIfNotExists(DATABASE_NAME);
         database = client.getDatabase(response.getProperties().getId());
-
     }
 
     @AfterAll
@@ -207,7 +205,7 @@ class CosmosContractNegotiationStoreIntegrationTest extends ContractNegotiationS
                 .contractStart(ZonedDateTime.now())
                 .contractEnd(ZonedDateTime.now().plus(365, ChronoUnit.DAYS))
                 .policy(Policy.Builder.newInstance().build())
-                .asset(Asset.Builder.newInstance().build()).id("new-offer-1")
+                .assetId("new-offer-1")
                 .build();
         negotiation.getContractOffers().add(newOffer);
         store.save(negotiation);

--- a/resources/openapi/yaml/management-api/catalog-api.yaml
+++ b/resources/openapi/yaml/management-api/catalog-api.yaml
@@ -100,23 +100,6 @@ components:
         type:
           type: string
           example: null
-    Asset:
-      type: object
-      example: null
-      properties:
-        createdAt:
-          type: integer
-          format: int64
-          example: null
-        id:
-          type: string
-          example: null
-        properties:
-          type: object
-          additionalProperties:
-            type: object
-            example: null
-          example: null
     Catalog:
       type: object
       example: null
@@ -174,8 +157,9 @@ components:
       type: object
       example: null
       properties:
-        asset:
-          $ref: '#/components/schemas/Asset'
+        assetId:
+          type: string
+          example: null
         contractEnd:
           type: string
           format: date-time

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/offer/ContractOffer.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/offer/ContractOffer.java
@@ -18,7 +18,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.eclipse.edc.policy.model.Policy;
-import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -41,7 +40,7 @@ public class ContractOffer {
     /**
      * The offered asset
      */
-    private Asset asset;
+    private String assetId;
     /**
      * The participant who provides the offered data
      */
@@ -102,8 +101,8 @@ public class ContractOffer {
     }
 
     @NotNull
-    public Asset getAsset() {
-        return asset;
+    public String getAssetId() {
+        return assetId;
     }
 
     @NotNull
@@ -113,7 +112,7 @@ public class ContractOffer {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, policy, asset, providerId, offerStart, offerEnd, contractStart, contractEnd);
+        return Objects.hash(id, policy, assetId, providerId, offerStart, offerEnd, contractStart, contractEnd);
     }
 
     @Override
@@ -125,7 +124,7 @@ public class ContractOffer {
             return false;
         }
         ContractOffer that = (ContractOffer) o;
-        return Objects.equals(id, that.id) && Objects.equals(policy, that.policy) && Objects.equals(asset, that.asset) && Objects.equals(providerId, that.providerId) &&
+        return Objects.equals(id, that.id) && Objects.equals(policy, that.policy) && Objects.equals(assetId, that.assetId) && Objects.equals(providerId, that.providerId) &&
                 Objects.equals(offerStart, that.offerStart) && Objects.equals(offerEnd, that.offerEnd) &&
                 Objects.equals(contractStart, that.contractStart) && Objects.equals(contractEnd, that.contractEnd);
     }
@@ -154,8 +153,8 @@ public class ContractOffer {
             return this;
         }
 
-        public Builder asset(Asset asset) {
-            contractOffer.asset = asset;
+        public Builder assetId(String assetId) {
+            contractOffer.assetId = assetId;
             return this;
         }
 
@@ -188,7 +187,7 @@ public class ContractOffer {
 
         public ContractOffer build() {
             Objects.requireNonNull(contractOffer.id);
-            Objects.requireNonNull(contractOffer.asset, "Asset must not be null");
+            Objects.requireNonNull(contractOffer.assetId, "Asset id must not be null");
             Objects.requireNonNull(contractOffer.policy, "Policy must not be null");
             return contractOffer;
         }

--- a/spi/control-plane/contract-spi/src/test/java/org/eclipse/edc/connector/contract/spi/types/offer/ContractOfferTest.java
+++ b/spi/control-plane/contract-spi/src/test/java/org/eclipse/edc/connector/contract/spi/types/offer/ContractOfferTest.java
@@ -15,7 +15,6 @@
 package org.eclipse.edc.connector.contract.spi.types.offer;
 
 import org.eclipse.edc.policy.model.Policy;
-import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.junit.jupiter.api.Test;
 
 import java.time.ZonedDateTime;
@@ -32,7 +31,7 @@ class ContractOfferTest {
     @Test
     void verifyPolicyNotNull() {
         assertThatThrownBy(() -> ContractOffer.Builder.newInstance().id("some-id")
-                .asset(Asset.Builder.newInstance().id("test-assetId").build())
+                .assetId("test-assetId")
                 .contractStart(ZonedDateTime.now())
                 .contractEnd(ZonedDateTime.now().plusMonths(1))
                 .build())
@@ -42,12 +41,13 @@ class ContractOfferTest {
 
     @Test
     void verifyAssetNotNull() {
-        assertThatThrownBy(() -> ContractOffer.Builder.newInstance().id("some-id")
+        assertThatThrownBy(() -> ContractOffer.Builder.newInstance()
+                .id("some-id")
                 .policy(Policy.Builder.newInstance().build())
                 .contractStart(ZonedDateTime.now())
                 .contractEnd(ZonedDateTime.now().plusMonths(1))
                 .build())
                 .isInstanceOf(NullPointerException.class)
-                .hasMessage("Asset must not be null");
+                .hasMessage("Asset id must not be null");
     }
 }

--- a/system-tests/azure-tests/src/testFixtures/java/org/eclipse/edc/test/system/local/BlobTransferConfiguration.java
+++ b/system-tests/azure-tests/src/testFixtures/java/org/eclipse/edc/test/system/local/BlobTransferConfiguration.java
@@ -65,7 +65,7 @@ public class BlobTransferConfiguration implements TransferConfiguration {
     public NegotiationInitiateRequestDto createNegotiationRequest(ContractOffer offer) {
         var policy = Policy.Builder.newInstance()
                 .permission(Permission.Builder.newInstance()
-                        .target(offer.getAsset().getId())
+                        .target(offer.getAssetId())
                         .action(Action.Builder.newInstance().type("USE").build())
                         .build())
                 .type(PolicyType.SET)
@@ -73,7 +73,7 @@ public class BlobTransferConfiguration implements TransferConfiguration {
 
         var offerDescription = ContractOfferDescription.Builder.newInstance()
                 .offerId(offer.getId())
-                .assetId(offer.getAsset().getId())
+                .assetId(offer.getAssetId())
                 .policy(policy)
                 .validity(CONTRACT_VALIDITY)
                 .build();
@@ -91,7 +91,7 @@ public class BlobTransferConfiguration implements TransferConfiguration {
     @Override
     public TransferRequestDto createTransferRequest(ContractOffer offer, String contractAgreementId) {
         return TransferRequestDto.Builder.newInstance()
-                .assetId(offer.getAsset().getId())
+                .assetId(offer.getAssetId())
                 .connectorId("consumer")
                 .protocol("ids-multipart")
                 .managedResources(true)

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/AbstractEndToEndTransfer.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/AbstractEndToEndTransfer.java
@@ -55,7 +55,7 @@ public abstract class AbstractEndToEndTransfer {
         var contractOffer = catalog
                 .getContractOffers()
                 .stream()
-                .filter(o -> o.getAsset().getId().equals(assetId))
+                .filter(o -> o.getAssetId().equals(assetId))
                 .findFirst()
                 .get();
         var contractAgreementId = CONSUMER.negotiateContract(PROVIDER, contractOffer);
@@ -95,7 +95,7 @@ public abstract class AbstractEndToEndTransfer {
         var contractOffer = catalog
                 .getContractOffers()
                 .stream()
-                .filter(o -> o.getAsset().getId().equals(assetId))
+                .filter(o -> o.getAssetId().equals(assetId))
                 .findFirst()
                 .get();
         var contractAgreementId = CONSUMER.negotiateContract(PROVIDER, contractOffer);
@@ -123,7 +123,7 @@ public abstract class AbstractEndToEndTransfer {
         var contractOffer = catalog
                 .getContractOffers()
                 .stream()
-                .filter(o -> o.getAsset().getId().equals(assetId))
+                .filter(o -> o.getAssetId().equals(assetId))
                 .findFirst()
                 .get();
         var contractAgreementId = CONSUMER.negotiateContract(PROVIDER, contractOffer);
@@ -161,7 +161,7 @@ public abstract class AbstractEndToEndTransfer {
         var contractOffer = catalog
                 .getContractOffers()
                 .stream()
-                .filter(o -> o.getAsset().getId().equals(assetId))
+                .filter(o -> o.getAssetId().equals(assetId))
                 .findFirst()
                 .get();
         var contractAgreementId = CONSUMER.negotiateContract(PROVIDER, contractOffer);

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/Participant.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/Participant.java
@@ -139,7 +139,7 @@ public class Participant {
                 "protocol", "ids-multipart",
                 "offer", Map.of(
                         "offerId", contractOffer.getId(),
-                        "assetId", contractOffer.getAsset().getId(),
+                        "assetId", contractOffer.getAssetId(),
                         "policy", contractOffer.getPolicy()
                 )
         );
@@ -157,7 +157,7 @@ public class Participant {
         var contractAgreementId = getContractAgreementId(negotiationId);
 
         var assetId = getContractAgreementField(contractAgreementId, "assetId");
-        assertThat(assetId).isEqualTo(contractOffer.getAsset().getId());
+        assertThat(assetId).isEqualTo(contractOffer.getAssetId());
 
         return contractAgreementId;
     }

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractNegotiationApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractNegotiationApiEndToEndTest.java
@@ -25,7 +25,6 @@ import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiat
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.policy.model.Policy;
-import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 import org.junit.jupiter.api.Test;
 
@@ -33,10 +32,10 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
+import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.TERMINATED;
@@ -229,7 +228,7 @@ public class ContractNegotiationApiEndToEndTest extends BaseManagementApiEndToEn
     private ContractNegotiation.Builder createContractNegotiationBuilder(String negotiationId) {
         return ContractNegotiation.Builder.newInstance()
                 .id(negotiationId)
-                .counterPartyId(UUID.randomUUID().toString())
+                .counterPartyId(randomUUID().toString())
                 .counterPartyAddress("address")
                 .callbackAddresses(List.of(CallbackAddress.Builder.newInstance()
                         .uri("local://test")
@@ -242,7 +241,7 @@ public class ContractNegotiationApiEndToEndTest extends BaseManagementApiEndToEn
     private ContractOffer.Builder contractOfferBuilder() {
         return ContractOffer.Builder.newInstance()
                 .id("test-offer-id")
-                .asset(Asset.Builder.newInstance().build())
+                .assetId(randomUUID().toString())
                 .policy(Policy.Builder.newInstance().build());
     }
 
@@ -250,9 +249,9 @@ public class ContractNegotiationApiEndToEndTest extends BaseManagementApiEndToEn
     private ContractAgreement createContractAgreement(String negotiationId) {
         return ContractAgreement.Builder.newInstance()
                 .id(negotiationId)
-                .assetId(UUID.randomUUID().toString())
-                .consumerId(UUID.randomUUID() + "-consumer")
-                .providerId(UUID.randomUUID() + "-provider")
+                .assetId(randomUUID().toString())
+                .consumerId(randomUUID() + "-consumer")
+                .providerId(randomUUID() + "-provider")
                 .policy(Policy.Builder.newInstance().build())
                 .build();
     }

--- a/system-tests/tests/src/testFixtures/java/org/eclipse/edc/test/system/utils/FileTransferConfiguration.java
+++ b/system-tests/tests/src/testFixtures/java/org/eclipse/edc/test/system/utils/FileTransferConfiguration.java
@@ -56,7 +56,7 @@ public class FileTransferConfiguration implements TransferConfiguration {
     public NegotiationInitiateRequestDto createNegotiationRequest(ContractOffer offer) {
         var policy = Policy.Builder.newInstance()
                 .permission(Permission.Builder.newInstance()
-                        .target(offer.getAsset().getId())
+                        .target(offer.getAssetId())
                         .action(Action.Builder.newInstance().type("USE").build())
                         .build())
                 .type(PolicyType.SET)
@@ -64,7 +64,7 @@ public class FileTransferConfiguration implements TransferConfiguration {
 
         var offerDescription = ContractOfferDescription.Builder.newInstance()
                 .offerId(offer.getId())
-                .assetId(offer.getAsset().getId())
+                .assetId(offer.getAssetId())
                 .policy(policy)
                 .validity(CONTRACT_VALIDITY)
                 .build();
@@ -82,7 +82,7 @@ public class FileTransferConfiguration implements TransferConfiguration {
     @Override
     public TransferRequestDto createTransferRequest(ContractOffer offer, String contractAgreementId) {
         return TransferRequestDto.Builder.newInstance()
-                .assetId(offer.getAsset().getId())
+                .assetId(offer.getAssetId())
                 .connectorId("consumer")
                 .protocol("ids-multipart")
                 .managedResources(false)


### PR DESCRIPTION
## What this PR changes/adds

Removes the direct Asset reference from ContractOffer and replaces it with an id reference. ContractOffer.getAsset() is also renamed to ContractOffer.getAssetId().

## Why it does that

It is not necessary to directly reference the Asset.

## Linked Issue(s)

Closes #2889

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
