### PR TITLE
feat: add consumer/provider id support for DSP messages

### DIFF
--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org.eclipse.edc.protocol.dsp.negotiation.transform/from/JsonObjectFromContractAgreementMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org.eclipse.edc.protocol.dsp.negotiation.transform/from/JsonObjectFromContractAgreementMessageTransformer.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.protocol.dsp.negotiation.transform.from;
 
+import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementMessage;
@@ -27,7 +28,9 @@ import java.util.UUID;
 
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_AGREEMENT_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_AGREEMENT;
+import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_CONSUMER_ID;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_PROVIDER_ID;
 
 
 /**
@@ -50,11 +53,20 @@ public class JsonObjectFromContractAgreementMessageTransformer extends AbstractJ
 
         builder.add(DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID, object.getProcessId());
 
-        var policy = context.transform(object.getContractAgreement().getPolicy(), JsonObject.class);
+        var agreement = object.getContractAgreement();
+
+        var policy = context.transform(agreement.getPolicy(), JsonObject.class);
         if (policy == null) {
             context.reportProblem("Cannot transform from ContractAgreementMessage with null policy");
             return null;
         }
+
+        // add the consumer and provider ids to the agreement
+        var copiedPolicy = Json.createObjectBuilder();
+        policy.forEach(copiedPolicy::add);
+        policy = copiedPolicy.add(DSPACE_NEGOTIATION_PROPERTY_CONSUMER_ID, agreement.getConsumerId())
+                .add(DSPACE_NEGOTIATION_PROPERTY_PROVIDER_ID, agreement.getProviderId())
+                .build();
 
         builder.add(DSPACE_NEGOTIATION_PROPERTY_AGREEMENT, policy);
 

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/DspNegotiationPropertyAndTypeNames.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/DspNegotiationPropertyAndTypeNames.java
@@ -48,6 +48,8 @@ public interface DspNegotiationPropertyAndTypeNames {
     String DSPACE_NEGOTIATION_PROPERTY_OFFER = DSPACE_SCHEMA + "offer";
     String DSPACE_NEGOTIATION_PROPERTY_DATASET = DSPACE_SCHEMA + "dataSet";
     String DSPACE_NEGOTIATION_PROPERTY_TIMESTAMP = DSPACE_SCHEMA + "timestamp";
+    String DSPACE_NEGOTIATION_PROPERTY_CONSUMER_ID = DSPACE_SCHEMA + "consumerId";
+    String DSPACE_NEGOTIATION_PROPERTY_PROVIDER_ID = DSPACE_SCHEMA + "providerId";
 
     // event types
 

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractAgreementMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractAgreementMessageTransformerTest.java
@@ -36,7 +36,9 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_AGREEMENT_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_AGREEMENT;
+import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_CONSUMER_ID;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_PROVIDER_ID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -47,6 +49,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class JsonObjectFromContractAgreementMessageTransformerTest {
+    private static final String PROVIDER_ID = "providerId";
+    private static final String CONSUMER_ID = "consumerId";
 
     private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
     private final TransformerContext context = mock(TransformerContext.class);
@@ -80,7 +84,12 @@ class JsonObjectFromContractAgreementMessageTransformerTest {
         assertThat(result.getJsonString(ID).getString()).isNotEmpty();
         assertThat(result.getJsonString(TYPE).getString()).isEqualTo(DSPACE_NEGOTIATION_AGREEMENT_MESSAGE);
         assertThat(result.getJsonString(DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID).getString()).isEqualTo(value);
-        assertThat(result.getJsonObject(DSPACE_NEGOTIATION_PROPERTY_AGREEMENT)).isNotNull();
+
+        var jsonAgreement = result.getJsonObject(DSPACE_NEGOTIATION_PROPERTY_AGREEMENT);
+        assertThat(jsonAgreement).isNotNull();
+
+        assertThat(jsonAgreement.getJsonString(DSPACE_NEGOTIATION_PROPERTY_CONSUMER_ID).getString()).isEqualTo(CONSUMER_ID);
+        assertThat(jsonAgreement.getJsonString(DSPACE_NEGOTIATION_PROPERTY_PROVIDER_ID).getString()).isEqualTo(PROVIDER_ID);
 
         verify(context, never()).reportProblem(anyString());
     }
@@ -106,8 +115,8 @@ class JsonObjectFromContractAgreementMessageTransformerTest {
     private ContractAgreement contractAgreement() {
         return ContractAgreement.Builder.newInstance()
                 .id(String.valueOf(UUID.randomUUID()))
-                .providerId("agentId")
-                .consumerId("agentId")
+                .providerId(PROVIDER_ID)
+                .consumerId(CONSUMER_ID)
                 .assetId("assetId")
                 .policy(policy()).build();
     }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractAgreementMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractAgreementMessageTransformerTest.java
@@ -35,7 +35,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_AGREEMENT;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_AGREEMENT_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_AGREEMENT;
+import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_CONSUMER_ID;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_PROVIDER_ID;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_TIMESTAMP;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -47,6 +49,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class JsonObjectToContractAgreementMessageTransformerTest {
+    private static final String CONSUMER_ID = "consumerId";
+    private static final String PROVIDER_ID = "providerId";
+    private static final String AGREEMENT_ID = "agreementId";
+    private static final String PROCESS_ID = "processId";
+    private static final String MESSAGE_ID = "messageId";
 
     private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
     private final TransformerContext context = mock(TransformerContext.class);
@@ -60,11 +67,10 @@ class JsonObjectToContractAgreementMessageTransformerTest {
 
     @Test
     void transform() {
-        var value = "example";
         var message = jsonFactory.createObjectBuilder()
-                .add(JsonLdKeywords.ID, value)
+                .add(JsonLdKeywords.ID, MESSAGE_ID)
                 .add(JsonLdKeywords.TYPE, DSPACE_NEGOTIATION_AGREEMENT_MESSAGE)
-                .add(DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID, value)
+                .add(DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID, PROCESS_ID)
                 .add(DSPACE_NEGOTIATION_PROPERTY_AGREEMENT, contractAgreement())
                 .add(DSPACE_NEGOTIATION_PROPERTY_TIMESTAMP, "123")
                 .build();
@@ -76,10 +82,12 @@ class JsonObjectToContractAgreementMessageTransformerTest {
         assertThat(result).isNotNull();
         assertThat(result.getClass()).isEqualTo(ContractAgreementMessage.class);
         assertThat(result.getProtocol()).isNotEmpty();
-        assertThat(result.getProcessId()).isEqualTo(value);
+        assertThat(result.getProcessId()).isEqualTo(PROCESS_ID);
         assertThat(result.getContractAgreement()).isNotNull();
         assertThat(result.getContractAgreement().getClass()).isEqualTo(ContractAgreement.class);
-        assertThat(result.getContractAgreement().getId()).isEqualTo(value);
+        assertThat(result.getContractAgreement().getId()).isEqualTo(AGREEMENT_ID);
+        assertThat(result.getContractAgreement().getConsumerId()).isEqualTo(CONSUMER_ID);
+        assertThat(result.getContractAgreement().getProviderId()).isEqualTo(PROVIDER_ID);
         assertThat(result.getContractAgreement().getAssetId()).isEqualTo("target");
 
         verify(context, never()).reportProblem(anyString());
@@ -123,7 +131,10 @@ class JsonObjectToContractAgreementMessageTransformerTest {
 
     private JsonObject contractAgreement() {
         return jsonFactory.createObjectBuilder()
+                .add(JsonLdKeywords.ID, AGREEMENT_ID)
                 .add(JsonLdKeywords.TYPE, ODRL_POLICY_TYPE_AGREEMENT)
+                .add(DSPACE_NEGOTIATION_PROPERTY_CONSUMER_ID, CONSUMER_ID)
+                .add(DSPACE_NEGOTIATION_PROPERTY_PROVIDER_ID, PROVIDER_ID)
                 .build();
     }
 


### PR DESCRIPTION
## What this PR changes/adds

Add consumer and provider ids to the DSP contract agreement.
 
## Linked Issue(s)

Closes #2895 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
