### PR TITLE
fix: set target on Policy

### DIFF
--- a/core/control-plane/catalog-core/src/main/java/org/eclipse/edc/connector/catalog/DatasetResolverImpl.java
+++ b/core/control-plane/catalog-core/src/main/java/org/eclipse/edc/connector/catalog/DatasetResolverImpl.java
@@ -81,7 +81,7 @@ public class DatasetResolverImpl implements DatasetResolver {
                             .distributions(distributions)
                             .properties(asset.getProperties());
 
-                    offers.forEach(offer -> datasetBuilder.offer(offer.contractId, offer.policy));
+                    offers.forEach(offer -> datasetBuilder.offer(offer.contractId, offer.policy.withTarget(asset.getId())));
 
                     return datasetBuilder.build();
                 });

--- a/core/control-plane/catalog-core/src/test/java/org/eclipse/edc/connector/catalog/DatasetResolverImplTest.java
+++ b/core/control-plane/catalog-core/src/test/java/org/eclipse/edc/connector/catalog/DatasetResolverImplTest.java
@@ -49,6 +49,8 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
+import static org.eclipse.edc.policy.model.PolicyType.OFFER;
+import static org.eclipse.edc.policy.model.PolicyType.SET;
 import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 import static org.mockito.AdditionalMatchers.and;
 import static org.mockito.ArgumentMatchers.any;
@@ -111,8 +113,8 @@ class DatasetResolverImplTest {
 
     @Test
     void query_shouldReturnOneDataset_whenMultipleDefinitionsOnSameAsset() {
-        var policy1 = Policy.Builder.newInstance().assignee("assignee1").build();
-        var policy2 = Policy.Builder.newInstance().assignee("assignee2").build();
+        var policy1 = Policy.Builder.newInstance().type(SET).build();
+        var policy2 = Policy.Builder.newInstance().type(OFFER).build();
         when(contractDefinitionResolver.definitionsFor(any())).thenReturn(Stream.of(
                 contractDefinitionBuilder("definition1").contractPolicyId("policy1").build(),
                 contractDefinitionBuilder("definition2").contractPolicyId("policy2").build()
@@ -128,11 +130,11 @@ class DatasetResolverImplTest {
             assertThat(dataset.getOffers()).hasSize(2)
                     .anySatisfy((id, policy) -> {
                         assertThat(id).startsWith("definition1");
-                        assertThat(policy.getAssignee()).isEqualTo("assignee1");
+                        assertThat(policy.getType()).isEqualTo(SET);
                     })
                     .anySatisfy((id, policy) -> {
                         assertThat(id).startsWith("definition2");
-                        assertThat(policy.getAssignee()).isEqualTo("assignee2");
+                        assertThat(policy.getType()).isEqualTo(OFFER);
                     });
         });
     }

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToDutyTransformer.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToDutyTransformer.java
@@ -15,7 +15,6 @@
 package org.eclipse.edc.jsonld.transformer.to;
 
 import jakarta.json.JsonObject;
-import jakarta.json.JsonValue;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
 import org.eclipse.edc.policy.model.Action;
 import org.eclipse.edc.policy.model.Constraint;
@@ -27,6 +26,7 @@ import org.jetbrains.annotations.Nullable;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ACTION_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_CONSEQUENCE_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_CONSTRAINT_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIBUTE;
 
 /**
  * Converts from an ODRL duty as a {@link JsonObject} in JSON-LD expanded form to a {@link Duty}.
@@ -40,17 +40,23 @@ public class JsonObjectToDutyTransformer extends AbstractJsonLdTransformer<JsonO
     @Override
     public @Nullable Duty transform(@NotNull JsonObject object, @NotNull TransformerContext context) {
         var builder = Duty.Builder.newInstance();
-        visitProperties(object, (key, value) -> transformProperties(key, value, builder, context));
+
+        visitProperties(object, key -> {
+            switch (key) {
+                case ODRL_ACTION_ATTRIBUTE:
+                    return value -> builder.action(transformObject(value, Action.class, context));
+                case ODRL_CONSTRAINT_ATTRIBUTE:
+                    return value -> builder.constraints(transformArray(value, Constraint.class, context));
+                case ODRL_CONSEQUENCE_ATTRIBUTE:
+                    return value -> builder.consequence(transformObject(value, Duty.class, context));
+                case ODRL_TARGET_ATTRIBUTE:
+                    return value -> builder.target(transformString(value, context));
+                default:
+                    return doNothing();
+            }
+        });
+
         return builderResult(builder::build, context);
     }
-    
-    private void transformProperties(String key, JsonValue value, Duty.Builder builder, TransformerContext context) {
-        if (ODRL_ACTION_ATTRIBUTE.equals(key)) {
-            transformArrayOrObject(value, Action.class, builder::action, context);
-        } else if (ODRL_CONSTRAINT_ATTRIBUTE.equals(key)) {
-            transformArrayOrObject(value, Constraint.class, builder::constraint, context);
-        } else if (ODRL_CONSEQUENCE_ATTRIBUTE.equals(key)) {
-            transformArrayOrObject(value, Duty.class, builder::consequence, context);
-        }
-    }
+
 }

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToPermissionTransformer.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToPermissionTransformer.java
@@ -15,7 +15,6 @@
 package org.eclipse.edc.jsonld.transformer.to;
 
 import jakarta.json.JsonObject;
-import jakarta.json.JsonValue;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
 import org.eclipse.edc.policy.model.Action;
 import org.eclipse.edc.policy.model.Constraint;
@@ -28,6 +27,7 @@ import org.jetbrains.annotations.Nullable;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ACTION_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_CONSTRAINT_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_DUTY_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIBUTE;
 
 /**
  * Converts from an ODRL permission as a {@link JsonObject} in JSON-LD expanded form to a {@link Permission}.
@@ -41,17 +41,23 @@ public class JsonObjectToPermissionTransformer extends AbstractJsonLdTransformer
     @Override
     public @Nullable Permission transform(@NotNull JsonObject object, @NotNull TransformerContext context) {
         var builder = Permission.Builder.newInstance();
-        visitProperties(object, (key, value) -> transformProperties(key, value, builder, context));
+
+        visitProperties(object, key -> {
+            switch (key) {
+                case ODRL_ACTION_ATTRIBUTE:
+                    return value -> builder.action(transformObject(value, Action.class, context));
+                case ODRL_CONSTRAINT_ATTRIBUTE:
+                    return value -> builder.constraints(transformArray(value, Constraint.class, context));
+                case ODRL_DUTY_ATTRIBUTE:
+                    return value -> builder.duties(transformArray(value, Duty.class, context));
+                case ODRL_TARGET_ATTRIBUTE:
+                    return value -> builder.target(transformString(value, context));
+                default:
+                    return doNothing();
+            }
+        });
+
         return builderResult(builder::build, context);
     }
-    
-    private void transformProperties(String key, JsonValue value, Permission.Builder builder, TransformerContext context) {
-        if (ODRL_ACTION_ATTRIBUTE.equals(key)) {
-            transformArrayOrObject(value, Action.class, builder::action, context);
-        } else if (ODRL_CONSTRAINT_ATTRIBUTE.equals(key)) {
-            transformArrayOrObject(value, Constraint.class, builder::constraint, context);
-        } else if (ODRL_DUTY_ATTRIBUTE.equals(key)) {
-            transformArrayOrObject(value, Duty.class, builder::duty, context);
-        }
-    }
+
 }

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToPolicyTransformer.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToPolicyTransformer.java
@@ -15,7 +15,6 @@
 package org.eclipse.edc.jsonld.transformer.to;
 
 import jakarta.json.JsonObject;
-import jakarta.json.JsonValue;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
 import org.eclipse.edc.policy.model.Duty;
 import org.eclipse.edc.policy.model.Permission;
@@ -28,6 +27,7 @@ import org.jetbrains.annotations.Nullable;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_OBLIGATION_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_PERMISSION_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_PROHIBITION_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIBUTE;
 
 /**
  * Converts from an ODRL policy as a {@link JsonObject} in JSON-LD expanded form to a {@link Policy}.
@@ -41,19 +41,23 @@ public class JsonObjectToPolicyTransformer extends AbstractJsonLdTransformer<Jso
     @Override
     public @Nullable Policy transform(@NotNull JsonObject object, @NotNull TransformerContext context) {
         var builder = Policy.Builder.newInstance();
-        visitProperties(object, (key, value) -> transformProperties(key, value, builder, context));
+
+        visitProperties(object, key -> {
+            switch (key) {
+                case ODRL_PERMISSION_ATTRIBUTE:
+                    return v -> builder.permissions(transformArray(v, Permission.class, context));
+                case ODRL_PROHIBITION_ATTRIBUTE:
+                    return v -> builder.prohibitions(transformArray(v, Prohibition.class, context));
+                case ODRL_OBLIGATION_ATTRIBUTE:
+                    return v -> builder.duties(transformArray(v, Duty.class, context));
+                case ODRL_TARGET_ATTRIBUTE:
+                    return v -> builder.target(transformString(v, context));
+                default:
+                    return v -> builder.extensibleProperty(key, transformGenericProperty(v, context));
+            }
+        });
+
         return builderResult(builder::build, context);
     }
 
-    private void transformProperties(String key, JsonValue value, Policy.Builder builder, TransformerContext context) {
-        if (ODRL_PERMISSION_ATTRIBUTE.equals(key)) {
-            transformArrayOrObject(value, Permission.class, builder::permission, context);
-        } else if (ODRL_PROHIBITION_ATTRIBUTE.equals(key)) {
-            transformArrayOrObject(value, Prohibition.class, builder::prohibition, context);
-        } else if (ODRL_OBLIGATION_ATTRIBUTE.equals(key)) {
-            transformArrayOrObject(value, Duty.class, builder::duty, context);
-        } else {
-            builder.extensibleProperty(key, transformGenericProperty(value, context));
-        }
-    }
 }

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToProhibitionTransformer.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToProhibitionTransformer.java
@@ -15,7 +15,6 @@
 package org.eclipse.edc.jsonld.transformer.to;
 
 import jakarta.json.JsonObject;
-import jakarta.json.JsonValue;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
 import org.eclipse.edc.policy.model.Action;
 import org.eclipse.edc.policy.model.Constraint;
@@ -26,6 +25,7 @@ import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ACTION_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_CONSTRAINT_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIBUTE;
 
 /**
  * Converts from an ODRL prohibition as a {@link JsonObject} in JSON-LD expanded form to a {@link Prohibition}.
@@ -39,15 +39,21 @@ public class JsonObjectToProhibitionTransformer extends AbstractJsonLdTransforme
     @Override
     public @Nullable Prohibition transform(@NotNull JsonObject object, @NotNull TransformerContext context) {
         var builder = Prohibition.Builder.newInstance();
-        visitProperties(object, (key, value) -> transformProperties(key, value, builder, context));
+
+        visitProperties(object, key -> {
+            switch (key) {
+                case ODRL_ACTION_ATTRIBUTE:
+                    return value -> builder.action(transformObject(value, Action.class, context));
+                case ODRL_CONSTRAINT_ATTRIBUTE:
+                    return value -> builder.constraints(transformArray(value, Constraint.class, context));
+                case ODRL_TARGET_ATTRIBUTE:
+                    return value -> builder.target(transformString(value, context));
+                default:
+                    return doNothing();
+            }
+        });
+
         return builderResult(builder::build, context);
     }
-    
-    private void transformProperties(String key, JsonValue value, Prohibition.Builder builder, TransformerContext context) {
-        if (ODRL_ACTION_ATTRIBUTE.equals(key)) {
-            transformArrayOrObject(value, Action.class, builder::action, context);
-        } else if (ODRL_CONSTRAINT_ATTRIBUTE.equals(key)) {
-            transformArrayOrObject(value, Constraint.class, builder::constraint, context);
-        }
-    }
+
 }

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/from/JsonObjectFromPolicyTransformerTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/from/JsonObjectFromPolicyTransformerTest.java
@@ -51,6 +51,7 @@ import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_PERMISSION_AT
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_PROHIBITION_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_REFINEMENT_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_RIGHT_OPERAND_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIBUTE;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -59,8 +60,8 @@ import static org.mockito.Mockito.verify;
 
 class JsonObjectFromPolicyTransformerTest {
     
-    private JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
-    private TransformerContext context = mock(TransformerContext.class);
+    private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
+    private final TransformerContext context = mock(TransformerContext.class);
     
     private JsonObjectFromPolicyTransformer transformer;
     
@@ -76,6 +77,7 @@ class JsonObjectFromPolicyTransformerTest {
         var prohibition = Prohibition.Builder.newInstance().action(action).build();
         var duty = Duty.Builder.newInstance().action(action).build();
         var policy = Policy.Builder.newInstance()
+                .target("target")
                 .permission(permission)
                 .prohibition(prohibition)
                 .duty(duty)
@@ -85,6 +87,7 @@ class JsonObjectFromPolicyTransformerTest {
         
         assertThat(result).isNotNull();
         assertThat(result.getJsonString(TYPE).getString()).isEqualTo(Namespaces.ODRL_SCHEMA + "Set");
+        assertThat(result.getString(ODRL_TARGET_ATTRIBUTE)).isEqualTo("target");
     
         assertThat(result.get(ODRL_PERMISSION_ATTRIBUTE))
                 .isNotNull()
@@ -210,6 +213,7 @@ class JsonObjectFromPolicyTransformerTest {
         var action = getAction();
         var consequence = Duty.Builder.newInstance().action(action).build();
         var duty = Duty.Builder.newInstance()
+                .target("target")
                 .action(action)
                 .constraint(constraint)
                 .consequence(consequence)
@@ -219,6 +223,7 @@ class JsonObjectFromPolicyTransformerTest {
         var result = transformer.transform(policy, context);
         
         var dutyJson = result.get(ODRL_OBLIGATION_ATTRIBUTE).asJsonArray().get(0).asJsonObject();
+        assertThat(dutyJson.getString(ODRL_TARGET_ATTRIBUTE)).isEqualTo("target");
         assertThat(dutyJson.getJsonArray(ODRL_CONSTRAINT_ATTRIBUTE)).hasSize(1);
         
         var constraintJson = dutyJson.getJsonArray(ODRL_CONSTRAINT_ATTRIBUTE).get(0).asJsonObject();

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToDutyTransformerTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToDutyTransformerTest.java
@@ -32,6 +32,7 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ACTION_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_CONSEQUENCE_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_CONSTRAINT_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIBUTE;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -41,8 +42,8 @@ import static org.mockito.Mockito.when;
 
 class JsonObjectToDutyTransformerTest {
     
-    private JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
-    private TransformerContext context = mock(TransformerContext.class);
+    private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
+    private final TransformerContext context = mock(TransformerContext.class);
     
     private JsonObjectToDutyTransformer transformer;
     
@@ -53,6 +54,7 @@ class JsonObjectToDutyTransformerTest {
     private Action action;
     private Constraint constraint;
     private Duty consequence;
+    private String target;
     
     @BeforeEach
     void setUp() {
@@ -65,6 +67,7 @@ class JsonObjectToDutyTransformerTest {
         action = Action.Builder.newInstance().type("type").build();
         constraint = AtomicConstraint.Builder.newInstance().build();
         consequence = Duty.Builder.newInstance().build();
+        target = "target";
     
         when(context.transform(actionJson, Action.class)).thenReturn(action);
         when(context.transform(constraintJson, Constraint.class)).thenReturn(constraint);
@@ -77,6 +80,7 @@ class JsonObjectToDutyTransformerTest {
                 .add(ODRL_ACTION_ATTRIBUTE, actionJson)
                 .add(ODRL_CONSTRAINT_ATTRIBUTE, constraintJson)
                 .add(ODRL_CONSEQUENCE_ATTRIBUTE, consequenceJson)
+                .add(ODRL_TARGET_ATTRIBUTE, target)
                 .build();
     
         var result = transformer.transform(duty, context);
@@ -90,6 +94,7 @@ class JsonObjectToDutyTransformerTest {
                 .add(ODRL_ACTION_ATTRIBUTE, jsonFactory.createArrayBuilder().add(actionJson))
                 .add(ODRL_CONSTRAINT_ATTRIBUTE, jsonFactory.createArrayBuilder().add(constraintJson))
                 .add(ODRL_CONSEQUENCE_ATTRIBUTE, jsonFactory.createArrayBuilder().add(consequenceJson))
+                .add(ODRL_TARGET_ATTRIBUTE, jsonFactory.createArrayBuilder().add(target))
                 .build();
         
         var result = transformer.transform(duty, context);
@@ -103,7 +108,8 @@ class JsonObjectToDutyTransformerTest {
         assertThat(result.getConstraints()).hasSize(1);
         assertThat(result.getConstraints().get(0)).isEqualTo(constraint);
         assertThat(result.getConsequence()).isEqualTo(consequence);
-    
+        assertThat(result.getTarget()).isEqualTo(target);
+
         verify(context, never()).reportProblem(anyString());
         verify(context, times(1)).transform(actionJson, Action.class);
         verify(context, times(1)).transform(constraintJson, Constraint.class);

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToDutyTransformerTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToDutyTransformerTest.java
@@ -44,31 +44,22 @@ class JsonObjectToDutyTransformerTest {
     
     private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
     private final TransformerContext context = mock(TransformerContext.class);
-    
+
+    private final JsonObject actionJson = getJsonObject("action");
+    private final JsonObject constraintJson = getJsonObject("constraint");
+    private final JsonObject consequenceJson = getJsonObject("consequence");
+
+    private final Action action = Action.Builder.newInstance().type("type").build();
+    private final Constraint constraint = AtomicConstraint.Builder.newInstance().build();
+    private final Duty consequence = Duty.Builder.newInstance().build();
+    private final String target = "target";
+
     private JsonObjectToDutyTransformer transformer;
-    
-    private JsonObject actionJson;
-    private JsonObject constraintJson;
-    private JsonObject consequenceJson;
-    
-    private Action action;
-    private Constraint constraint;
-    private Duty consequence;
-    private String target;
-    
+
     @BeforeEach
     void setUp() {
         transformer = new JsonObjectToDutyTransformer();
-    
-        actionJson = getJsonObject("action");
-        constraintJson = getJsonObject("constraint");
-        consequenceJson = getJsonObject("consequence");
-        
-        action = Action.Builder.newInstance().type("type").build();
-        constraint = AtomicConstraint.Builder.newInstance().build();
-        consequence = Duty.Builder.newInstance().build();
-        target = "target";
-    
+
         when(context.transform(actionJson, Action.class)).thenReturn(action);
         when(context.transform(constraintJson, Constraint.class)).thenReturn(constraint);
         when(context.transform(consequenceJson, Duty.class)).thenReturn(consequence);

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToPermissionTransformerTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToPermissionTransformerTest.java
@@ -43,33 +43,24 @@ import static org.mockito.Mockito.when;
 
 class JsonObjectToPermissionTransformerTest {
     
-    private JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
-    private TransformerContext context = mock(TransformerContext.class);
-    
+    private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
+    private final TransformerContext context = mock(TransformerContext.class);
+
+    private final JsonObject actionJson = getJsonObject("action");
+    private final JsonObject constraintJson = getJsonObject("constraint");
+    private final JsonObject dutyJson = getJsonObject("duty");
+
+    private final Action action = Action.Builder.newInstance().type("type").build();
+    private final Constraint constraint = AtomicConstraint.Builder.newInstance().build();
+    private final Duty duty = Duty.Builder.newInstance().build();
+    private final String target = "target";
+
     private JsonObjectToPermissionTransformer transformer;
-    
-    private JsonObject actionJson;
-    private JsonObject constraintJson;
-    private JsonObject dutyJson;
-    
-    private Action action;
-    private Constraint constraint;
-    private Duty duty;
-    private String target;
-    
+
     @BeforeEach
     void setUp() {
         transformer = new JsonObjectToPermissionTransformer();
-        
-        actionJson = getJsonObject("action");
-        constraintJson = getJsonObject("constraint");
-        dutyJson = getJsonObject("duty");
-    
-        action = Action.Builder.newInstance().type("type").build();
-        constraint = AtomicConstraint.Builder.newInstance().build();
-        duty = Duty.Builder.newInstance().build();
-        target = "target";
-    
+
         when(context.transform(actionJson, Action.class)).thenReturn(action);
         when(context.transform(constraintJson, Constraint.class)).thenReturn(constraint);
         when(context.transform(dutyJson, Duty.class)).thenReturn(duty);

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToPermissionTransformerTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToPermissionTransformerTest.java
@@ -33,6 +33,7 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ACTION_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_CONSTRAINT_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_DUTY_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIBUTE;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -54,6 +55,7 @@ class JsonObjectToPermissionTransformerTest {
     private Action action;
     private Constraint constraint;
     private Duty duty;
+    private String target;
     
     @BeforeEach
     void setUp() {
@@ -66,6 +68,7 @@ class JsonObjectToPermissionTransformerTest {
         action = Action.Builder.newInstance().type("type").build();
         constraint = AtomicConstraint.Builder.newInstance().build();
         duty = Duty.Builder.newInstance().build();
+        target = "target";
     
         when(context.transform(actionJson, Action.class)).thenReturn(action);
         when(context.transform(constraintJson, Constraint.class)).thenReturn(constraint);
@@ -78,6 +81,7 @@ class JsonObjectToPermissionTransformerTest {
                 .add(ODRL_ACTION_ATTRIBUTE, actionJson)
                 .add(ODRL_CONSTRAINT_ATTRIBUTE, constraintJson)
                 .add(ODRL_DUTY_ATTRIBUTE, dutyJson)
+                .add(ODRL_TARGET_ATTRIBUTE, target)
                 .build();
     
         var result = transformer.transform(permission, context);
@@ -91,6 +95,7 @@ class JsonObjectToPermissionTransformerTest {
                  .add(ODRL_ACTION_ATTRIBUTE, jsonFactory.createArrayBuilder().add(actionJson))
                  .add(ODRL_CONSTRAINT_ATTRIBUTE, jsonFactory.createArrayBuilder().add(constraintJson))
                  .add(ODRL_DUTY_ATTRIBUTE, jsonFactory.createArrayBuilder().add(dutyJson))
+                 .add(ODRL_TARGET_ATTRIBUTE, jsonFactory.createArrayBuilder().add(target))
                  .build();
         
         var result = transformer.transform(permission, context);
@@ -105,6 +110,7 @@ class JsonObjectToPermissionTransformerTest {
         assertThat(result.getConstraints().get(0)).isEqualTo(constraint);
         assertThat(result.getDuties()).hasSize(1);
         assertThat(result.getDuties().get(0)).isEqualTo(duty);
+        assertThat(result.getTarget()).isEqualTo(target);
     
         verify(context, never()).reportProblem(anyString());
         verify(context, times(1)).transform(actionJson, Action.class);

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToPolicyTransformerTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToPolicyTransformerTest.java
@@ -38,6 +38,7 @@ import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_A
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_OFFER;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_SET;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_PROHIBITION_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIBUTE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -61,6 +62,7 @@ class JsonObjectToPolicyTransformerTest {
     private Permission permission;
     private Prohibition prohibition;
     private Duty duty;
+    private String target;
 
     @BeforeEach
     void setUp() {
@@ -74,6 +76,8 @@ class JsonObjectToPolicyTransformerTest {
         prohibition = Prohibition.Builder.newInstance().build();
         duty = Duty.Builder.newInstance().build();
 
+        target = "target";
+
         when(context.transform(permissionJson, Permission.class)).thenReturn(permission);
         when(context.transform(prohibitionJson, Prohibition.class)).thenReturn(prohibition);
         when(context.transform(dutyJson, Duty.class)).thenReturn(duty);
@@ -83,6 +87,7 @@ class JsonObjectToPolicyTransformerTest {
     void transform_withAllRuleTypesAsObjects_returnPolicy() {
         var policy = jsonFactory.createObjectBuilder()
                 .add(TYPE, ODRL_POLICY_TYPE_SET)
+                .add(ODRL_TARGET_ATTRIBUTE, target)
                 .add(ODRL_PERMISSION_ATTRIBUTE, permissionJson)
                 .add(ODRL_PROHIBITION_ATTRIBUTE, prohibitionJson)
                 .add(ODRL_OBLIGATION_ATTRIBUTE, dutyJson)
@@ -97,6 +102,7 @@ class JsonObjectToPolicyTransformerTest {
     void transform_withAllRuleTypesAsArrays_returnPolicy() {
         var policy = jsonFactory.createObjectBuilder()
                 .add(TYPE, ODRL_POLICY_TYPE_SET)
+                .add(ODRL_TARGET_ATTRIBUTE, jsonFactory.createArrayBuilder().add(target))
                 .add(ODRL_PERMISSION_ATTRIBUTE, jsonFactory.createArrayBuilder().add(permissionJson))
                 .add(ODRL_PROHIBITION_ATTRIBUTE, jsonFactory.createArrayBuilder().add(prohibitionJson))
                 .add(ODRL_OBLIGATION_ATTRIBUTE, jsonFactory.createArrayBuilder().add(dutyJson))
@@ -165,6 +171,7 @@ class JsonObjectToPolicyTransformerTest {
 
     private void assertResult(Policy result) {
         assertThat(result).isNotNull();
+        assertThat(result.getTarget()).isEqualTo(target);
         assertThat(result.getPermissions()).hasSize(1);
         assertThat(result.getPermissions().get(0)).isEqualTo(permission);
         assertThat(result.getProhibitions()).hasSize(1);

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToPolicyTransformerTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToPolicyTransformerTest.java
@@ -53,30 +53,20 @@ class JsonObjectToPolicyTransformerTest {
     private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
     private final TransformerContext context = mock(TransformerContext.class);
 
+    private final JsonObject permissionJson = getJsonObject("permission");
+    private final JsonObject prohibitionJson = getJsonObject("prohibition");
+    private final JsonObject dutyJson = getJsonObject("duty");
+
+    private final Permission permission = Permission.Builder.newInstance().build();
+    private final Prohibition prohibition = Prohibition.Builder.newInstance().build();
+    private final Duty duty = Duty.Builder.newInstance().build();
+    private final String target = "target";
+
     private JsonObjectToPolicyTransformer transformer;
-
-    private JsonObject permissionJson;
-    private JsonObject prohibitionJson;
-    private JsonObject dutyJson;
-
-    private Permission permission;
-    private Prohibition prohibition;
-    private Duty duty;
-    private String target;
 
     @BeforeEach
     void setUp() {
         transformer = new JsonObjectToPolicyTransformer();
-
-        permissionJson = getJsonObject("permission");
-        prohibitionJson = getJsonObject("prohibition");
-        dutyJson = getJsonObject("duty");
-
-        permission = Permission.Builder.newInstance().build();
-        prohibition = Prohibition.Builder.newInstance().build();
-        duty = Duty.Builder.newInstance().build();
-
-        target = "target";
 
         when(context.transform(permissionJson, Permission.class)).thenReturn(permission);
         when(context.transform(prohibitionJson, Prohibition.class)).thenReturn(prohibition);

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToProhibitionTransformerTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToProhibitionTransformerTest.java
@@ -31,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ACTION_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_CONSTRAINT_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIBUTE;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -50,6 +51,7 @@ class JsonObjectToProhibitionTransformerTest {
     
     private Action action;
     private Constraint constraint;
+    private String target;
     
     @BeforeEach
     void setUp() {
@@ -60,6 +62,7 @@ class JsonObjectToProhibitionTransformerTest {
     
         action = Action.Builder.newInstance().type("type").build();
         constraint = AtomicConstraint.Builder.newInstance().build();
+        target = "target";
     
         when(context.transform(actionJson, Action.class)).thenReturn(action);
         when(context.transform(constraintJson, Constraint.class)).thenReturn(constraint);
@@ -70,6 +73,7 @@ class JsonObjectToProhibitionTransformerTest {
         var prohibition = jsonFactory.createObjectBuilder()
                 .add(ODRL_ACTION_ATTRIBUTE, actionJson)
                 .add(ODRL_CONSTRAINT_ATTRIBUTE, constraintJson)
+                .add(ODRL_TARGET_ATTRIBUTE, target)
                 .build();
     
         var result = transformer.transform(prohibition, context);
@@ -82,6 +86,7 @@ class JsonObjectToProhibitionTransformerTest {
         var prohibition = jsonFactory.createObjectBuilder()
                  .add(ODRL_ACTION_ATTRIBUTE, jsonFactory.createArrayBuilder().add(actionJson))
                  .add(ODRL_CONSTRAINT_ATTRIBUTE, jsonFactory.createArrayBuilder().add(constraintJson))
+                 .add(ODRL_TARGET_ATTRIBUTE, jsonFactory.createArrayBuilder().add(target))
                  .build();
         
         var result = transformer.transform(prohibition, context);
@@ -94,6 +99,7 @@ class JsonObjectToProhibitionTransformerTest {
         assertThat(result.getAction()).isEqualTo(action);
         assertThat(result.getConstraints()).hasSize(1);
         assertThat(result.getConstraints().get(0)).isEqualTo(constraint);
+        assertThat(result.getTarget()).isEqualTo(target);
     
         verify(context, never()).reportProblem(anyString());
         verify(context, times(1)).transform(actionJson, Action.class);

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToProhibitionTransformerTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToProhibitionTransformerTest.java
@@ -41,29 +41,22 @@ import static org.mockito.Mockito.when;
 
 class JsonObjectToProhibitionTransformerTest {
     
-    private JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
-    private TransformerContext context = mock(TransformerContext.class);
-    
+    private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
+    private final TransformerContext context = mock(TransformerContext.class);
+
+    private final JsonObject actionJson = getJsonObject("action");
+    private final JsonObject constraintJson = getJsonObject("constraint");
+
+    private final Action action = Action.Builder.newInstance().type("type").build();
+    private final Constraint constraint = AtomicConstraint.Builder.newInstance().build();
+    private final String target = "target";
+
     private JsonObjectToProhibitionTransformer transformer;
-    
-    private JsonObject actionJson;
-    private JsonObject constraintJson;
-    
-    private Action action;
-    private Constraint constraint;
-    private String target;
-    
+
     @BeforeEach
     void setUp() {
         transformer = new JsonObjectToProhibitionTransformer();
-        
-        actionJson = getJsonObject("action");
-        constraintJson = getJsonObject("constraint");
-    
-        action = Action.Builder.newInstance().type("type").build();
-        constraint = AtomicConstraint.Builder.newInstance().build();
-        target = "target";
-    
+
         when(context.transform(actionJson, Action.class)).thenReturn(action);
         when(context.transform(constraintJson, Constraint.class)).thenReturn(constraint);
     }

--- a/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/PropertyAndTypeNames.java
+++ b/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/PropertyAndTypeNames.java
@@ -51,6 +51,7 @@ public interface PropertyAndTypeNames {
     String ODRL_POLICY_TYPE_OFFER = ODRL_SCHEMA + "Offer";
     String ODRL_POLICY_TYPE_AGREEMENT = ODRL_SCHEMA + "Agreement";
 
+    String ODRL_TARGET_ATTRIBUTE = ODRL_SCHEMA + "target";
     String ODRL_PERMISSION_ATTRIBUTE = ODRL_SCHEMA + "permission";
     String ODRL_PROHIBITION_ATTRIBUTE = ODRL_SCHEMA + "prohibition";
     String ODRL_OBLIGATION_ATTRIBUTE = ODRL_SCHEMA + "obligation";

--- a/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/transformer/AbstractJsonLdTransformer.java
+++ b/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/transformer/AbstractJsonLdTransformer.java
@@ -146,7 +146,7 @@ public abstract class AbstractJsonLdTransformer<INPUT, OUTPUT> implements JsonLd
                     .filter(Objects::nonNull)
                     .findFirst().map(it -> transformString(it, context))
                     .orElseGet(() -> {
-                        context.reportProblem(format("Invalid property. Expected to find one of @value, @id into JsonObject but got %s", value));
+                        context.reportProblem(format("Invalid property. Expected to find one of @value, @id in JsonObject but got %s", value));
                         return null;
                     });
         } else if (value instanceof JsonArray) {

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/PolicyDefinitionApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/PolicyDefinitionApiEndToEndTest.java
@@ -46,7 +46,6 @@ public class PolicyDefinitionApiEndToEndTest extends BaseManagementApiEndToEndTe
                 .contentType(JSON)
                 .post()
                 .then()
-                .statusCode(200)
                 .extract().jsonPath().getString("id");
 
         assertThat(store().findById(id)).isNotNull()


### PR DESCRIPTION
## What this PR changes/adds

Sets `target` on catalog creation, and maps it on every from/to transformer that deals with policy and rules. 

## Why it does that

dataspace-protocol

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #2911 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
