### PR TITLE
chore(dsp): improve contract negotiation transformer error handling and align with the spec

### DIFF
--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-dispatcher/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/dispatcher/delegate/ContractRequestMessageHttpDelegateTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-dispatcher/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/dispatcher/delegate/ContractRequestMessageHttpDelegateTest.java
@@ -42,7 +42,6 @@ import static org.eclipse.edc.protocol.dsp.negotiation.dispatcher.NegotiationApi
 import static org.eclipse.edc.protocol.dsp.negotiation.dispatcher.NegotiationApiPaths.CONTRACT_REQUEST;
 import static org.eclipse.edc.protocol.dsp.negotiation.dispatcher.NegotiationApiPaths.INITIAL_CONTRACT_REQUEST;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_CONTRACT_NEGOTIATION;
-import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_CHECKSUM;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_STATE;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_STATE_REQUESTED;
@@ -52,6 +51,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class ContractRequestMessageHttpDelegateTest extends DspHttpDispatcherDelegateTestBase<ContractRequestMessage> {
+    private static final String PROCESS_ID = "processId";
+    private static final String DATASET_ID = "datasetId";
 
     private ContractRequestMessageHttpDelegate delegate;
     private TitaniumJsonLd jsonLdService;
@@ -117,12 +118,11 @@ class ContractRequestMessageHttpDelegateTest extends DspHttpDispatcherDelegateTe
     }
 
     private ContractRequestMessage message() {
-        var value = "example";
         return ContractRequestMessage.Builder.newInstance()
-                .protocol(value)
-                .processId(value)
+                .protocol("DSP")
+                .processId(PROCESS_ID)
                 .callbackAddress("http://connector")
-                .dataSet(value)
+                .dataSet(DATASET_ID)
                 .contractOffer(contractOffer())
                 .type(ContractRequestMessage.Type.COUNTER_OFFER)
                 .build();
@@ -162,14 +162,12 @@ class ContractRequestMessageHttpDelegateTest extends DspHttpDispatcherDelegateTe
     }
 
     private JsonObject negotiation() {
-        var value = "example";
         var builder = Json.createObjectBuilder();
-        builder.add(JsonLdKeywords.ID, value);
+        builder.add(JsonLdKeywords.ID, "id1");
         builder.add(JsonLdKeywords.TYPE, DSPACE_CONTRACT_NEGOTIATION);
 
-        builder.add(DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID, value);
+        builder.add(DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID, PROCESS_ID);
         builder.add(DSPACE_NEGOTIATION_PROPERTY_STATE, DSPACE_NEGOTIATION_STATE_REQUESTED);
-        builder.add(DSPACE_NEGOTIATION_PROPERTY_CHECKSUM, value);
 
         return builder.build();
     }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-dispatcher/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/dispatcher/delegate/ContractRequestMessageHttpDelegateTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-dispatcher/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/dispatcher/delegate/ContractRequestMessageHttpDelegateTest.java
@@ -53,6 +53,7 @@ import static org.mockito.Mockito.when;
 class ContractRequestMessageHttpDelegateTest extends DspHttpDispatcherDelegateTestBase<ContractRequestMessage> {
     private static final String PROCESS_ID = "processId";
     private static final String DATASET_ID = "datasetId";
+    private static final String DSP = "DSP";
 
     private ContractRequestMessageHttpDelegate delegate;
     private TitaniumJsonLd jsonLdService;
@@ -119,7 +120,7 @@ class ContractRequestMessageHttpDelegateTest extends DspHttpDispatcherDelegateTe
 
     private ContractRequestMessage message() {
         return ContractRequestMessage.Builder.newInstance()
-                .protocol("DSP")
+                .protocol(DSP)
                 .processId(PROCESS_ID)
                 .callbackAddress("http://connector")
                 .dataSet(DATASET_ID)

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org.eclipse.edc.protocol.dsp.negotiation.transform/from/JsonObjectFromContractAgreementVerificationMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org.eclipse.edc.protocol.dsp.negotiation.transform/from/JsonObjectFromContractAgreementVerificationMessageTransformer.java
@@ -23,8 +23,7 @@ import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.UUID;
-
+import static java.util.UUID.randomUUID;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_AGREEMENT_VERIFICATION_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID;
 
@@ -41,14 +40,12 @@ public class JsonObjectFromContractAgreementVerificationMessageTransformer exten
     }
 
     @Override
-    public @Nullable JsonObject transform(@NotNull ContractAgreementVerificationMessage object, @NotNull TransformerContext context) {
+    public @Nullable JsonObject transform(@NotNull ContractAgreementVerificationMessage verificationMessage, @NotNull TransformerContext context) {
         var builder = jsonFactory.createObjectBuilder();
-        builder.add(JsonLdKeywords.ID, String.valueOf(UUID.randomUUID()));
+        builder.add(JsonLdKeywords.ID, randomUUID().toString());
         builder.add(JsonLdKeywords.TYPE, DSPACE_NEGOTIATION_AGREEMENT_VERIFICATION_MESSAGE);
 
-        builder.add(DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID, object.getProcessId());
-        // TODO add mapping of cred:credentialSubject for signature processes
-
+        builder.add(DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID, verificationMessage.getProcessId());
         return builder.build();
     }
 }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org.eclipse.edc.protocol.dsp.negotiation.transform/from/JsonObjectFromContractNegotiationEventMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org.eclipse.edc.protocol.dsp.negotiation.transform/from/JsonObjectFromContractNegotiationEventMessageTransformer.java
@@ -18,6 +18,7 @@ import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractNegotiationEventMessage;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -66,7 +67,7 @@ public class JsonObjectFromContractNegotiationEventMessageTransformer extends Ab
                 return DSPACE_NEGOTIATION_PROPERTY_EVENT_TYPE_FINALIZED;
             default:
                 // this cannot happen
-                throw new AssertionError("Unknown event type: " + message.getType());
+                throw new EdcException("Unknown event type: " + message.getType());
         }
     }
 

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org.eclipse.edc.protocol.dsp.negotiation.transform/from/JsonObjectFromContractNegotiationTerminationMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org.eclipse.edc.protocol.dsp.negotiation.transform/from/JsonObjectFromContractNegotiationTerminationMessageTransformer.java
@@ -17,7 +17,6 @@ package org.eclipse.edc.protocol.dsp.negotiation.transform.from;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationTerminationMessage;
-import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
@@ -25,6 +24,8 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
 
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_CODE;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_REASON;
@@ -43,14 +44,22 @@ public class JsonObjectFromContractNegotiationTerminationMessageTransformer exte
     }
 
     @Override
-    public @Nullable JsonObject transform(@NotNull ContractNegotiationTerminationMessage object, @NotNull TransformerContext context) {
+    public @Nullable JsonObject transform(@NotNull ContractNegotiationTerminationMessage terminationMessage, @NotNull TransformerContext context) {
         var builder = jsonFactory.createObjectBuilder();
-        builder.add(JsonLdKeywords.ID, String.valueOf(UUID.randomUUID()));
-        builder.add(JsonLdKeywords.TYPE, DSPACE_NEGOTIATION_TERMINATION_MESSAGE);
+        builder.add(ID, UUID.randomUUID().toString());
+        builder.add(TYPE, DSPACE_NEGOTIATION_TERMINATION_MESSAGE);
 
-        builder.add(DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID, object.getProcessId());
-        builder.add(DSPACE_NEGOTIATION_PROPERTY_REASON, object.getRejectionReason());
-        builder.add(DSPACE_NEGOTIATION_PROPERTY_CODE, object.getCode());
+        builder.add(DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID, terminationMessage.getProcessId());
+
+        var rejectionReason = terminationMessage.getRejectionReason();
+        if (rejectionReason != null) {
+            builder.add(DSPACE_NEGOTIATION_PROPERTY_REASON, rejectionReason);
+        }
+
+        var code = terminationMessage.getCode();
+        if (code != null) {
+            builder.add(DSPACE_NEGOTIATION_PROPERTY_CODE, code);
+        }
 
         return builder.build();
     }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org.eclipse.edc.protocol.dsp.negotiation.transform/from/JsonObjectFromContractNegotiationTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org.eclipse.edc.protocol.dsp.negotiation.transform/from/JsonObjectFromContractNegotiationTransformer.java
@@ -25,7 +25,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_CONTRACT_NEGOTIATION;
-import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_CHECKSUM;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_STATE;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_STATE_ACCEPTED;
@@ -57,7 +56,6 @@ public class JsonObjectFromContractNegotiationTransformer extends AbstractJsonLd
 
         builder.add(DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID, object.getCorrelationId());
         builder.add(DSPACE_NEGOTIATION_PROPERTY_STATE, state(object.getState(), context));
-        builder.add(DSPACE_NEGOTIATION_PROPERTY_CHECKSUM, object.getChecksum());
 
         return builder.build();
     }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org.eclipse.edc.protocol.dsp.negotiation.transform/from/JsonObjectFromContractRequestTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org.eclipse.edc.protocol.dsp.negotiation.transform/from/JsonObjectFromContractRequestTransformer.java
@@ -23,8 +23,7 @@ import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.UUID;
-
+import static java.util.UUID.randomUUID;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_CONTRACT_REQUEST_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_CALLBACK_ADDRESS;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_DATASET;
@@ -47,7 +46,7 @@ public class JsonObjectFromContractRequestTransformer extends AbstractJsonLdTran
     @Override
     public @Nullable JsonObject transform(@NotNull ContractRequestMessage object, @NotNull TransformerContext context) {
         var builder = jsonFactory.createObjectBuilder();
-        builder.add(JsonLdKeywords.ID, String.valueOf(UUID.randomUUID()));
+        builder.add(JsonLdKeywords.ID, randomUUID().toString());
         builder.add(JsonLdKeywords.TYPE, DSPACE_NEGOTIATION_CONTRACT_REQUEST_MESSAGE);
 
         builder.add(DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID, object.getProcessId());

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org.eclipse.edc.protocol.dsp.negotiation.transform/to/JsonObjectToContractAgreementVerificationMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org.eclipse.edc.protocol.dsp.negotiation.transform/to/JsonObjectToContractAgreementVerificationMessageTransformer.java
@@ -21,6 +21,7 @@ import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import static java.lang.String.format;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID;
 import static org.eclipse.edc.protocol.dsp.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP;
 
@@ -37,8 +38,10 @@ public class JsonObjectToContractAgreementVerificationMessageTransformer extends
     public @Nullable ContractAgreementVerificationMessage transform(@NotNull JsonObject object, @NotNull TransformerContext context) {
         var builder = ContractAgreementVerificationMessage.Builder.newInstance();
         builder.protocol(DATASPACE_PROTOCOL_HTTP);
-        transformString(object.get(DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID), builder::processId, context);
-        // TODO add mapping of cred:credentialSubject with signature processes
+        if (!transformMandatoryString(object.get(DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID), builder::processId, context)) {
+            context.reportProblem(format("ContractAgreementVerificationMessage is missing the '%s' property", DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID));
+            return null;
+        }
 
         return builder.build();
     }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org.eclipse.edc.protocol.dsp.negotiation.transform/to/JsonObjectToContractNegotiationTerminationMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org.eclipse.edc.protocol.dsp.negotiation.transform/to/JsonObjectToContractNegotiationTerminationMessageTransformer.java
@@ -40,11 +40,16 @@ public class JsonObjectToContractNegotiationTerminationMessageTransformer extend
     public @Nullable ContractNegotiationTerminationMessage transform(@NotNull JsonObject object, @NotNull TransformerContext context) {
         var builder = ContractNegotiationTerminationMessage.Builder.newInstance();
         builder.protocol(DATASPACE_PROTOCOL_HTTP);
+
         transformString(object.get(DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID), builder::processId, context);
-        transformString(object.get(DSPACE_NEGOTIATION_PROPERTY_CODE), builder::code, context);
+
+        var code = object.get(DSPACE_NEGOTIATION_PROPERTY_CODE);
+        if (code != null) { // optional property
+            transformString(code, builder::code, context);
+        }
 
         var reasons = object.get(DSPACE_NEGOTIATION_PROPERTY_REASON);
-        if (reasons != null) {
+        if (reasons != null) {  // optional property
             var result = typeValueArray(reasons, context);
             if (result == null) {
                 context.reportProblem(format("Cannot transform property %s in ContractNegotiationTerminationMessage", DSPACE_NEGOTIATION_PROPERTY_REASON));

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/DspNegotiationPropertyAndTypeNames.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/DspNegotiationPropertyAndTypeNames.java
@@ -43,7 +43,6 @@ public interface DspNegotiationPropertyAndTypeNames {
     String DSPACE_NEGOTIATION_PROPERTY_REASON = DSPACE_SCHEMA + "reason";
     String DSPACE_NEGOTIATION_PROPERTY_CALLBACK_ADDRESS = DSPACE_SCHEMA + "callbackAddress";
     String DSPACE_NEGOTIATION_PROPERTY_STATE = DSPACE_SCHEMA + "state";
-    String DSPACE_NEGOTIATION_PROPERTY_CHECKSUM = DSPACE_SCHEMA + "checksum";
     String DSPACE_NEGOTIATION_PROPERTY_AGREEMENT = DSPACE_SCHEMA + "agreement";
     String DSPACE_NEGOTIATION_PROPERTY_OFFER = DSPACE_SCHEMA + "offer";
     String DSPACE_NEGOTIATION_PROPERTY_DATASET = DSPACE_SCHEMA + "dataSet";
@@ -66,8 +65,4 @@ public interface DspNegotiationPropertyAndTypeNames {
     String DSPACE_NEGOTIATION_STATE_FINALIZED = DSPACE_SCHEMA + "FINALIZED";
     String DSPACE_NEGOTIATION_STATE_TERMINATED = DSPACE_SCHEMA + "TERMINATED";
 
-    // other
-
-    String CRED_CREDENTIAL_SUBJECT = "cred:credentialSubject";
-    String SEC_PROOF = "sec:proof";
 }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractAgreementMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractAgreementMessageTransformerTest.java
@@ -54,6 +54,7 @@ class JsonObjectFromContractAgreementMessageTransformerTest {
     private static final String CONSUMER_ID = "consumerId";
     private static final String PROCESS_ID = "processId";
     private static final String TIMESTAMP = "1970-01-01T00:00:00Z";
+    private static final String DSP = "dsp";
 
     private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
     private final TransformerContext context = mock(TransformerContext.class);
@@ -100,7 +101,7 @@ class JsonObjectFromContractAgreementMessageTransformerTest {
 
     private ContractAgreementMessage message() {
         return ContractAgreementMessage.Builder.newInstance()
-                .protocol("dsp")
+                .protocol(DSP)
                 .processId(PROCESS_ID)
                 .callbackAddress("https://example.com")
                 .contractAgreement(contractAgreement())

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractAgreementVerificationMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractAgreementVerificationMessageTransformerTest.java
@@ -26,10 +26,8 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.CRED_CREDENTIAL_SUBJECT;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_AGREEMENT_VERIFICATION_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID;
-import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.SEC_PROOF;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -59,12 +57,9 @@ class JsonObjectFromContractAgreementVerificationMessageTransformerTest {
         var result = transformer.transform(message, context);
 
         assertThat(result).isNotNull();
-        assertThat(result.getJsonString(ID).getString()).isNotNull();
         assertThat(result.getJsonString(ID).getString()).isNotEmpty();
         assertThat(result.getJsonString(TYPE).getString()).isEqualTo(DSPACE_NEGOTIATION_AGREEMENT_VERIFICATION_MESSAGE);
         assertThat(result.getJsonString(DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID).getString()).isEqualTo(value);
-        assertThat(result.getJsonString(CRED_CREDENTIAL_SUBJECT)).isNull();
-        assertThat(result.getJsonString(SEC_PROOF)).isNull();
 
         verify(context, never()).reportProblem(anyString());
     }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractNegotiationEventMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractNegotiationEventMessageTransformerTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.verify;
 
 class JsonObjectFromContractNegotiationEventMessageTransformerTest {
     private static final String PROCESS_ID = "processId";
+    private static final String DSP = "DSP";
 
     private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
     private final TransformerContext context = mock(TransformerContext.class);
@@ -52,7 +53,7 @@ class JsonObjectFromContractNegotiationEventMessageTransformerTest {
     @Test
     void transform() {
         var message = ContractNegotiationEventMessage.Builder.newInstance()
-                .protocol("DSP")
+                .protocol(DSP)
                 .processId(PROCESS_ID)
                 .callbackAddress("https://test.com")
                 .type(ACCEPTED)

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractNegotiationEventMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractNegotiationEventMessageTransformerTest.java
@@ -28,7 +28,6 @@ import static org.eclipse.edc.connector.contract.spi.types.agreement.ContractNeg
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_EVENT_MESSAGE;
-import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_CHECKSUM;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_EVENT_TYPE;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_EVENT_TYPE_ACCEPTED;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID;
@@ -38,6 +37,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 class JsonObjectFromContractNegotiationEventMessageTransformerTest {
+    private static final String PROCESS_ID = "processId";
 
     private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
     private final TransformerContext context = mock(TransformerContext.class);
@@ -51,24 +51,20 @@ class JsonObjectFromContractNegotiationEventMessageTransformerTest {
 
     @Test
     void transform() {
-        var value = "example";
         var message = ContractNegotiationEventMessage.Builder.newInstance()
-                .protocol(value)
-                .processId(value)
-                .callbackAddress(value)
+                .protocol("DSP")
+                .processId(PROCESS_ID)
+                .callbackAddress("https://test.com")
                 .type(ACCEPTED)
-                .checksum(value)
                 .build();
 
         var result = transformer.transform(message, context);
 
         assertThat(result).isNotNull();
-        assertThat(result.getJsonString(ID).getString()).isNotNull();
         assertThat(result.getJsonString(ID).getString()).isNotEmpty();
         assertThat(result.getJsonString(TYPE).getString()).isEqualTo(DSPACE_NEGOTIATION_EVENT_MESSAGE);
-        assertThat(result.getJsonString(DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID).getString()).isEqualTo(value);
+        assertThat(result.getJsonString(DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID).getString()).isEqualTo(PROCESS_ID);
         assertThat(result.getJsonString(DSPACE_NEGOTIATION_PROPERTY_EVENT_TYPE).getString()).isEqualTo(DSPACE_NEGOTIATION_PROPERTY_EVENT_TYPE_ACCEPTED);
-        assertThat(result.getJsonString(DSPACE_NEGOTIATION_PROPERTY_CHECKSUM).getString()).isEqualTo(value);
 
         verify(context, never()).reportProblem(anyString());
     }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractNegotiationTerminationMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractNegotiationTerminationMessageTransformerTest.java
@@ -39,6 +39,7 @@ class JsonObjectFromContractNegotiationTerminationMessageTransformerTest {
     private static final String PROCESS_ID = "processId";
     private static final String REJECTION_REASON = "rejection";
     private static final String REJECTION_CODE = "1";
+    private static final String DSP = "DSP";
 
     private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
     private final TransformerContext context = mock(TransformerContext.class);
@@ -53,7 +54,7 @@ class JsonObjectFromContractNegotiationTerminationMessageTransformerTest {
     @Test
     void transform() {
         var message = ContractNegotiationTerminationMessage.Builder.newInstance()
-                .protocol("DSP")
+                .protocol(DSP)
                 .processId(PROCESS_ID)
                 .callbackAddress("https://test.com")
                 .rejectionReason(REJECTION_REASON)
@@ -75,7 +76,7 @@ class JsonObjectFromContractNegotiationTerminationMessageTransformerTest {
     @Test
     void verify_noReasonNoCode() {
         var message = ContractNegotiationTerminationMessage.Builder.newInstance()
-                .protocol("DSP")
+                .protocol(DSP)
                 .processId(PROCESS_ID)
                 .callbackAddress("https://test.com")
                 .build();

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractNegotiationTerminationMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractNegotiationTerminationMessageTransformerTest.java
@@ -36,6 +36,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 class JsonObjectFromContractNegotiationTerminationMessageTransformerTest {
+    private static final String PROCESS_ID = "processId";
+    private static final String REJECTION_REASON = "rejection";
+    private static final String REJECTION_CODE = "1";
 
     private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
     private final TransformerContext context = mock(TransformerContext.class);
@@ -49,24 +52,40 @@ class JsonObjectFromContractNegotiationTerminationMessageTransformerTest {
 
     @Test
     void transform() {
-        var value = "example";
         var message = ContractNegotiationTerminationMessage.Builder.newInstance()
-                .protocol(value)
-                .processId(value)
-                .callbackAddress(value)
-                .rejectionReason(value)
-                .code(value)
+                .protocol("DSP")
+                .processId(PROCESS_ID)
+                .callbackAddress("https://test.com")
+                .rejectionReason(REJECTION_REASON)
+                .code(REJECTION_CODE)
                 .build();
 
         var result = transformer.transform(message, context);
 
         assertThat(result).isNotNull();
-        assertThat(result.getJsonString(ID).getString()).isNotNull();
         assertThat(result.getJsonString(ID).getString()).isNotEmpty();
         assertThat(result.getJsonString(TYPE).getString()).isEqualTo(DSPACE_NEGOTIATION_TERMINATION_MESSAGE);
-        assertThat(result.getJsonString(DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID).getString()).isEqualTo(value);
-        assertThat(result.getJsonString(DSPACE_NEGOTIATION_PROPERTY_CODE).getString()).isEqualTo(value);
-        assertThat(result.getJsonString(DSPACE_NEGOTIATION_PROPERTY_REASON).getString()).isEqualTo(value);
+        assertThat(result.getJsonString(DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID).getString()).isEqualTo(PROCESS_ID);
+        assertThat(result.getJsonString(DSPACE_NEGOTIATION_PROPERTY_CODE).getString()).isEqualTo(REJECTION_CODE);
+        assertThat(result.getJsonString(DSPACE_NEGOTIATION_PROPERTY_REASON).getString()).isEqualTo(REJECTION_REASON);
+
+        verify(context, never()).reportProblem(anyString());
+    }
+
+    @Test
+    void verify_noReasonNoCode() {
+        var message = ContractNegotiationTerminationMessage.Builder.newInstance()
+                .protocol("DSP")
+                .processId(PROCESS_ID)
+                .callbackAddress("https://test.com")
+                .build();
+
+        var result = transformer.transform(message, context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getJsonString(ID).getString()).isNotEmpty();
+        assertThat(result.getJsonString(TYPE).getString()).isEqualTo(DSPACE_NEGOTIATION_TERMINATION_MESSAGE);
+        assertThat(result.getJsonString(DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID).getString()).isEqualTo(PROCESS_ID);
 
         verify(context, never()).reportProblem(anyString());
     }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractNegotiationTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractNegotiationTransformerTest.java
@@ -28,7 +28,6 @@ import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractN
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_CONTRACT_NEGOTIATION;
-import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_CHECKSUM;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_STATE;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_STATE_REQUESTED;
@@ -69,7 +68,6 @@ class JsonObjectFromContractNegotiationTransformerTest {
         assertThat(result.getJsonString(TYPE).getString()).isEqualTo(DSPACE_CONTRACT_NEGOTIATION);
         assertThat(result.getJsonString(DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID).getString()).isEqualTo(value);
         assertThat(result.getJsonString(DSPACE_NEGOTIATION_PROPERTY_STATE).getString()).isEqualTo(DSPACE_NEGOTIATION_STATE_REQUESTED);
-        assertThat(result.getJsonString(DSPACE_NEGOTIATION_PROPERTY_CHECKSUM).getString()).isEqualTo(value);
 
         verify(context, never()).reportProblem(anyString());
     }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractAgreementMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractAgreementMessageTransformerTest.java
@@ -119,12 +119,19 @@ class JsonObjectToContractAgreementMessageTransformerTest {
 
     @Test
     void transform_invalidTimestamp() {
+        var agreement = jsonFactory.createObjectBuilder()
+                .add(JsonLdKeywords.ID, AGREEMENT_ID)
+                .add(JsonLdKeywords.TYPE, ODRL_POLICY_TYPE_AGREEMENT)
+                .add(DSPACE_NEGOTIATION_PROPERTY_CONSUMER_ID, CONSUMER_ID)
+                .add(DSPACE_NEGOTIATION_PROPERTY_PROVIDER_ID, PROVIDER_ID)
+                .add(DSPACE_NEGOTIATION_PROPERTY_TIMESTAMP, "Invalid Timestamp")
+                .build();
+
         var message = jsonFactory.createObjectBuilder()
                 .add(JsonLdKeywords.ID, "messageId")
                 .add(JsonLdKeywords.TYPE, DSPACE_NEGOTIATION_AGREEMENT_MESSAGE)
                 .add(DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID, "processId")
-                .add(DSPACE_NEGOTIATION_PROPERTY_AGREEMENT, contractAgreement())
-                .add(DSPACE_NEGOTIATION_PROPERTY_TIMESTAMP, "invalid timestamp")
+                .add(DSPACE_NEGOTIATION_PROPERTY_AGREEMENT, agreement)
                 .build();
 
         when(context.transform(any(JsonObject.class), eq(Policy.class))).thenReturn(policy());
@@ -136,11 +143,18 @@ class JsonObjectToContractAgreementMessageTransformerTest {
 
     @Test
     void transform_missingTimestamp() {
+        var agreement = jsonFactory.createObjectBuilder()
+                .add(JsonLdKeywords.ID, AGREEMENT_ID)
+                .add(JsonLdKeywords.TYPE, ODRL_POLICY_TYPE_AGREEMENT)
+                .add(DSPACE_NEGOTIATION_PROPERTY_CONSUMER_ID, CONSUMER_ID)
+                .add(DSPACE_NEGOTIATION_PROPERTY_PROVIDER_ID, PROVIDER_ID)
+                .build();
+
         var message = jsonFactory.createObjectBuilder()
                 .add(JsonLdKeywords.ID, "messageId")
                 .add(JsonLdKeywords.TYPE, DSPACE_NEGOTIATION_AGREEMENT_MESSAGE)
                 .add(DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID, "processId")
-                .add(DSPACE_NEGOTIATION_PROPERTY_AGREEMENT, contractAgreement())
+                .add(DSPACE_NEGOTIATION_PROPERTY_AGREEMENT, agreement)
                 .build();
 
         when(context.transform(any(JsonObject.class), eq(Policy.class))).thenReturn(policy());

--- a/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/transformer/AbstractJsonLdTransformer.java
+++ b/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/transformer/AbstractJsonLdTransformer.java
@@ -49,7 +49,7 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
 public abstract class AbstractJsonLdTransformer<INPUT, OUTPUT> implements JsonLdTransformer<INPUT, OUTPUT> {
     private final Class<INPUT> input;
     private final Class<OUTPUT> output;
-    
+
     protected AbstractJsonLdTransformer(Class<INPUT> input, Class<OUTPUT> output) {
         this.input = input;
         this.output = output;
@@ -69,16 +69,16 @@ public abstract class AbstractJsonLdTransformer<INPUT, OUTPUT> implements JsonLd
      * Transforms properties of a Java type. The properties are mapped to generic JSON values.
      *
      * @param properties the properties to map
-     * @param builder the builder on which to set the properties
-     * @param mapper the mapper for converting the properties
-     * @param context the transformer context
+     * @param builder    the builder on which to set the properties
+     * @param mapper     the mapper for converting the properties
+     * @param context    the transformer context
      */
     protected void transformProperties(Map<String, ?> properties, JsonObjectBuilder builder, ObjectMapper mapper, TransformerContext context) {
         if (properties == null) {
             return;
         }
 
-        properties.forEach((k, v) ->  {
+        properties.forEach((k, v) -> {
             try {
                 builder.add(k, mapper.convertValue(v, JsonValue.class));
             } catch (IllegalArgumentException e) {
@@ -121,19 +121,37 @@ public abstract class AbstractJsonLdTransformer<INPUT, OUTPUT> implements JsonLd
      * Transforms a JsonValue to a string and applies the result function. If the value parameter
      * is not of type JsonString, JsonObject or JsonArray, a problem is reported to the context.
      *
-     * @param value the value to transform
+     * @param value          the value to transform
      * @param resultFunction the function to apply to the transformation result
-     * @param context the transformer context
+     * @param context        the transformer context
      */
     protected void transformString(JsonValue value, Consumer<String> resultFunction, TransformerContext context) {
         resultFunction.accept(transformString(value, context));
     }
 
     /**
+     * Transforms a mandatory JsonValue to a string and applies the result function. If the value parameter
+     * is not of type JsonString, JsonObject or JsonArray, a problem is reported to the context.
+     *
+     * @param value          the value to transform
+     * @param resultFunction the function to apply to the transformation result
+     * @param context        the transformer context
+     * @return true if the string was present
+     */
+    protected boolean transformMandatoryString(JsonValue value, Consumer<String> resultFunction, TransformerContext context) {
+        var result = transformString(value, context);
+        if (result == null) {
+            return false;
+        }
+        resultFunction.accept(result);
+        return true;
+    }
+
+    /**
      * Transforms a JsonValue to a string and applies the result function. If the value parameter
      * is not of type JsonString, JsonObject or JsonArray, a problem is reported to the context.
      *
-     * @param value the value to transform
+     * @param value   the value to transform
      * @param context the transformer context
      * @return the string result
      */
@@ -162,7 +180,7 @@ public abstract class AbstractJsonLdTransformer<INPUT, OUTPUT> implements JsonLd
      * Transforms a JsonValue to int. If the value parameter is not of type JsonNumber, JsonObject or JsonArray,
      * a problem is reported to the context.
      *
-     * @param value the value to transform
+     * @param value   the value to transform
      * @param context the transformer context
      * @return the int value
      */
@@ -207,11 +225,11 @@ public abstract class AbstractJsonLdTransformer<INPUT, OUTPUT> implements JsonLd
      * result function is applied to every instance. If the value parameter is neither of type
      * JsonObject nor JsonArray, a problem is reported to the context.
      *
-     * @param value the value to transform
-     * @param type the desired result type
+     * @param value          the value to transform
+     * @param type           the desired result type
      * @param resultFunction the function to apply to the transformation result, if it is a single instance
-     * @param context the transformer context
-     * @param <T> the desired result type
+     * @param context        the transformer context
+     * @param <T>            the desired result type
      */
     protected <T> void transformArrayOrObject(JsonValue value, Class<T> type, Consumer<T> resultFunction,
                                               TransformerContext context) {
@@ -230,10 +248,10 @@ public abstract class AbstractJsonLdTransformer<INPUT, OUTPUT> implements JsonLd
     /**
      * Transforms a JsonValue to a List. If the value parameter is not of type JsonArray, a problem is reported to the context.
      *
-     * @param value the value to transform
-     * @param type the desired result type
+     * @param value   the value to transform
+     * @param type    the desired result type
      * @param context the transformer context
-     * @param <T> the desired result type
+     * @param <T>     the desired result type
      * @return the transformed list, null if the value type was not valid.
      */
     protected <T> List<T> transformArray(JsonValue value, Class<T> type, TransformerContext context) {
@@ -260,10 +278,10 @@ public abstract class AbstractJsonLdTransformer<INPUT, OUTPUT> implements JsonLd
      * Transforms a JsonValue to the desired output type. If the value parameter is neither of type
      * JsonObject nor JsonArray, a problem is reported to the context.
      *
-     * @param value the value to transform
-     * @param type the desired result type
+     * @param value   the value to transform
+     * @param type    the desired result type
      * @param context the transformer context
-     * @param <T> the desired result type
+     * @param <T>     the desired result type
      * @return the transformed list
      */
     protected <T> T transformObject(JsonValue value, Class<T> type, TransformerContext context) {
@@ -285,7 +303,7 @@ public abstract class AbstractJsonLdTransformer<INPUT, OUTPUT> implements JsonLd
             return null;
         }
     }
-    
+
     /**
      * Returns the {@code @id} of the JSON object.
      */
@@ -293,7 +311,7 @@ public abstract class AbstractJsonLdTransformer<INPUT, OUTPUT> implements JsonLd
         var id = object.get(ID);
         return id instanceof JsonString ? ((JsonString) id).getString() : null;
     }
-    
+
     /**
      * Returns the {@code @type} of the JSON object. If more than one type is specified, this method will return the first.
      */
@@ -303,7 +321,7 @@ public abstract class AbstractJsonLdTransformer<INPUT, OUTPUT> implements JsonLd
             context.reportProblem("Property @type not found on JSON Object");
             return null;
         }
-        
+
         if (typeNode instanceof JsonString) {
             return ((JsonString) typeNode).getString();
         } else if (typeNode instanceof JsonArray) {
@@ -318,11 +336,11 @@ public abstract class AbstractJsonLdTransformer<INPUT, OUTPUT> implements JsonLd
             }
             return ((JsonString) typeValue).getString();
         }
-        
+
         context.reportProblem("Expected @type value to be either string or array");
         return null;
     }
-    
+
     @Nullable
     protected JsonArray typeValueArray(JsonValue typeNode, TransformerContext context) {
         if (!(typeNode instanceof JsonArray)) {
@@ -336,7 +354,7 @@ public abstract class AbstractJsonLdTransformer<INPUT, OUTPUT> implements JsonLd
         }
         return array;
     }
-    
+
     /**
      * Tries to return the instance given by a supplier (a builder's build method). If this fails
      * due to validation errors, e.g. a required property is missing, reports a problem to the

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractNegotiationEventMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractNegotiationEventMessage.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.connector.contract.spi.types.agreement;
 
 import org.eclipse.edc.connector.contract.spi.types.protocol.ContractRemoteMessage;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
@@ -24,8 +25,6 @@ public class ContractNegotiationEventMessage implements ContractRemoteMessage {
     private String callbackAddress;
     private String processId;
     private Type type;
-
-    private String checksum;
 
     @Override
     public String getProtocol() {
@@ -42,12 +41,9 @@ public class ContractNegotiationEventMessage implements ContractRemoteMessage {
         return processId;
     }
 
+    @NotNull
     public Type getType() {
         return type;
-    }
-
-    public String getChecksum() {
-        return checksum;
     }
 
     public static class Builder {
@@ -78,11 +74,6 @@ public class ContractNegotiationEventMessage implements ContractRemoteMessage {
 
         public Builder type(Type type) {
             this.message.type = type;
-            return this;
-        }
-
-        public Builder checksum(String checksum) {
-            this.message.checksum = checksum;
             return this;
         }
 

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractNegotiationTerminationMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractNegotiationTerminationMessage.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.connector.contract.spi.types.negotiation;
 
 import org.eclipse.edc.connector.contract.spi.types.protocol.ContractRemoteMessage;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
 
@@ -48,10 +49,12 @@ public class ContractNegotiationTerminationMessage implements ContractRemoteMess
         return processId;
     }
 
+    @Nullable
     public String getRejectionReason() {
         return rejectionReason;
     }
 
+    @Nullable
     public String getCode() {
         return code;
     }


### PR DESCRIPTION
## What this PR changes/adds

This PR focuses on the contract negotiation transformers:

1. Improves test coverage and verifies handling of invalid messages
2. Removes  CRED_CREDENTIAL_SUBJECT and  SEC_PROOF as they should be removed from the DSP specifications
3. Remoes checksum handling as that should also be removed from the DSP specifications
4. Renames "object" variable names for clarity

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
