### PR TITLE
feat(Callbacks): implements static callbacks configuration extension

### DIFF
--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/ControlPlaneDefaultServicesExtension.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/ControlPlaneDefaultServicesExtension.java
@@ -16,12 +16,14 @@ package org.eclipse.edc.connector;
 
 import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.connector.contract.spi.offer.store.ContractDefinitionStore;
+import org.eclipse.edc.connector.defaults.callback.CallbackRegistryImpl;
 import org.eclipse.edc.connector.defaults.storage.assetindex.InMemoryAssetIndex;
 import org.eclipse.edc.connector.defaults.storage.contractdefinition.InMemoryContractDefinitionStore;
 import org.eclipse.edc.connector.defaults.storage.contractnegotiation.InMemoryContractNegotiationStore;
 import org.eclipse.edc.connector.defaults.storage.policydefinition.InMemoryPolicyDefinitionStore;
 import org.eclipse.edc.connector.defaults.storage.transferprocess.InMemoryTransferProcessStore;
 import org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore;
+import org.eclipse.edc.connector.spi.callback.CallbackRegistry;
 import org.eclipse.edc.connector.transfer.spi.store.TransferProcessStore;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
@@ -75,6 +77,11 @@ public class ControlPlaneDefaultServicesExtension implements ServiceExtension {
     @Provider(isDefault = true)
     public PolicyDefinitionStore defaultPolicyStore() {
         return new InMemoryPolicyDefinitionStore(new LockManager(new ReentrantReadWriteLock(true)));
+    }
+
+    @Provider(isDefault = true)
+    public CallbackRegistry defaultCallbackRegistry() {
+        return new CallbackRegistryImpl();
     }
 
     private ContractDefinitionStore getContractDefinitionStore() {

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/callback/CallbackRegistryImpl.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/callback/CallbackRegistryImpl.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.defaults.callback;
+
+import org.eclipse.edc.connector.spi.callback.CallbackRegistry;
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class CallbackRegistryImpl implements CallbackRegistry {
+
+    private final List<CallbackAddress> callbackAddresses = new ArrayList<>();
+
+    @Override
+    public void register(CallbackAddress address) {
+        callbackAddresses.add(address);
+    }
+
+    @Override
+    public List<CallbackAddress> resolve(String eventName) {
+        return callbackAddresses.stream()
+                .filter(callbackAddress -> callbackAddress.getEvents().stream().anyMatch(eventName::startsWith))
+                .collect(Collectors.toList());
+    }
+}

--- a/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/callback/CallbackRegistryImplTest.java
+++ b/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/callback/CallbackRegistryImplTest.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.defaults.callback;
+
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CallbackRegistryImplTest {
+
+    CallbackRegistryImpl callbackRegistry = new CallbackRegistryImpl();
+
+    @Test
+    void resolve_shouldReturnsMatchedCallbacks() {
+
+        var cb1 = CallbackAddress.Builder.newInstance()
+                .uri("http://url1")
+                .transactional(false)
+                .events(Set.of("transfer", "contract"))
+                .build();
+        var cb2 = CallbackAddress.Builder.newInstance()
+                .uri("http://url2")
+                .transactional(false)
+                .events(Set.of("asset", "policy"))
+                .authCodeId("codeId")
+                .authKey("key")
+                .build();
+
+        var cb3 = CallbackAddress.Builder.newInstance()
+                .uri("http://url3")
+                .transactional(true)
+                .events(Set.of("transfer"))
+                .build();
+
+        Stream.of(cb1, cb2, cb3).forEach(callbackRegistry::register);
+
+        assertThat(callbackRegistry.resolve("transfer"))
+                .hasSize(2)
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("events")
+                .containsExactly(cb1, cb3);
+
+        assertThat(callbackRegistry.resolve("asset"))
+                .hasSize(1)
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("events")
+                .containsExactly(cb2)
+                .first()
+                .satisfies(callbackAddress -> assertThat(callbackAddress.getEvents()).containsExactlyInAnyOrder("asset", "policy"));
+    }
+}

--- a/extensions/common/api/api-core/src/main/java/org/eclipse/edc/api/model/CallbackAddressDto.java
+++ b/extensions/common/api/api-core/src/main/java/org/eclipse/edc/api/model/CallbackAddressDto.java
@@ -38,10 +38,13 @@ public class CallbackAddressDto {
 
     private boolean transactional;
 
+    private String authKey;
+    private String authCodeId;
+
     private CallbackAddressDto() {
 
     }
-    
+
     public boolean isTransactional() {
         return transactional;
     }
@@ -54,6 +57,13 @@ public class CallbackAddressDto {
         return uri;
     }
 
+    public String getAuthCodeId() {
+        return authCodeId;
+    }
+
+    public String getAuthKey() {
+        return authKey;
+    }
 
     @JsonPOJOBuilder(withPrefix = "")
     public static final class Builder {
@@ -84,7 +94,16 @@ public class CallbackAddressDto {
             return this;
         }
 
+        public Builder authKey(String authKey) {
+            dto.authKey = authKey;
+            return this;
+        }
 
+        public Builder authCodeId(String authCodeId) {
+            dto.authCodeId = authCodeId;
+            return this;
+        }
+        
         public CallbackAddressDto build() {
             return dto;
         }

--- a/extensions/common/api/api-core/src/main/java/org/eclipse/edc/api/transformer/CallbackAddressDtoToCallbackAddressTransformer.java
+++ b/extensions/common/api/api-core/src/main/java/org/eclipse/edc/api/transformer/CallbackAddressDtoToCallbackAddressTransformer.java
@@ -38,6 +38,8 @@ public class CallbackAddressDtoToCallbackAddressTransformer implements DtoTransf
                 .uri(object.getUri())
                 .events(object.getEvents())
                 .transactional(object.isTransactional())
+                .authCodeId(object.getAuthCodeId())
+                .authKey(object.getAuthKey())
                 .build();
     }
 }

--- a/extensions/common/api/api-core/src/main/java/org/eclipse/edc/api/transformer/JsonObjectFromCallbackAddressTransformer.java
+++ b/extensions/common/api/api-core/src/main/java/org/eclipse/edc/api/transformer/JsonObjectFromCallbackAddressTransformer.java
@@ -25,7 +25,10 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Set;
 
+import static java.util.Optional.ofNullable;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.AUTH_CODE_ID;
+import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.AUTH_KEY;
 import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.CALLBACKADDRESS_TYPE;
 import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.EVENTS;
 import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.IS_TRANSACTIONAL;
@@ -43,11 +46,15 @@ public class JsonObjectFromCallbackAddressTransformer extends AbstractJsonLdTran
     @Override
     public @Nullable JsonObject transform(@NotNull CallbackAddress callbackAddress, @NotNull TransformerContext context) {
         var builder = jsonFactory.createObjectBuilder();
-        return builder.add(TYPE, CALLBACKADDRESS_TYPE)
+        builder.add(TYPE, CALLBACKADDRESS_TYPE)
                 .add(IS_TRANSACTIONAL, callbackAddress.isTransactional())
                 .add(URI, callbackAddress.getUri())
-                .add(EVENTS, asArray(callbackAddress.getEvents()))
-                .build();
+                .add(EVENTS, asArray(callbackAddress.getEvents()));
+
+        ofNullable(callbackAddress.getAuthKey()).ifPresent((authKey) -> builder.add(AUTH_KEY, authKey));
+        ofNullable(callbackAddress.getAuthCodeId()).ifPresent((authCodeId) -> builder.add(AUTH_CODE_ID, authCodeId));
+
+        return builder.build();
     }
 
     private JsonArrayBuilder asArray(Set<String> events) {

--- a/extensions/common/api/api-core/src/main/java/org/eclipse/edc/api/transformer/JsonObjectToCallbackAddressDtoTransformer.java
+++ b/extensions/common/api/api-core/src/main/java/org/eclipse/edc/api/transformer/JsonObjectToCallbackAddressDtoTransformer.java
@@ -24,6 +24,8 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.HashSet;
 
+import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.AUTH_CODE_ID;
+import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.AUTH_KEY;
 import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.EVENTS;
 import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.IS_TRANSACTIONAL;
 import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.URI;
@@ -55,6 +57,12 @@ public class JsonObjectToCallbackAddressDtoTransformer extends AbstractJsonLdTra
                 var evt = new HashSet<String>();
                 transformArrayOrObject(value, String.class, evt::add, context);
                 builder.events(evt);
+                break;
+            case AUTH_KEY:
+                transformString(value, builder::authKey, context);
+                break;
+            case AUTH_CODE_ID:
+                transformString(value, builder::authCodeId, context);
                 break;
             default:
                 context.reportProblem("Cannot convert key " + key + " as it is not known");

--- a/extensions/common/api/api-core/src/test/java/org/eclipse/edc/api/transformer/CallbackAddressDtoToCallbackAddressTransformerTest.java
+++ b/extensions/common/api/api-core/src/test/java/org/eclipse/edc/api/transformer/CallbackAddressDtoToCallbackAddressTransformerTest.java
@@ -40,6 +40,8 @@ class CallbackAddressDtoToCallbackAddressTransformerTest {
                 .uri("http://test")
                 .events(Set.of("event"))
                 .transactional(true)
+                .authCodeId("code")
+                .authKey("key")
                 .build();
 
         var callback = transformer.transform(dto, context);

--- a/extensions/common/api/api-core/src/test/java/org/eclipse/edc/api/transformer/JsonObjectFromCallbackAddressTransformerTest.java
+++ b/extensions/common/api/api-core/src/test/java/org/eclipse/edc/api/transformer/JsonObjectFromCallbackAddressTransformerTest.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.AUTH_CODE_ID;
+import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.AUTH_KEY;
 import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.EVENTS;
 import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.IS_TRANSACTIONAL;
 import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.URI;
@@ -45,6 +47,8 @@ class JsonObjectFromCallbackAddressTransformerTest {
                 .uri("http://test.local")
                 .events(Set.of("foo", "bar", "baz"))
                 .transactional(true)
+                .authKey("key")
+                .authCodeId("codeId")
                 .build();
 
         var json = transformer.transform(callbackAddr, mock(TransformerContext.class));
@@ -52,5 +56,8 @@ class JsonObjectFromCallbackAddressTransformerTest {
         assertThat(json.getJsonString(URI).getString()).isEqualTo("http://test.local");
         assertThat(json.get(IS_TRANSACTIONAL).toString()).isEqualTo("true");
         assertThat(json.getJsonArray(EVENTS)).hasSize(3);
+        assertThat(json.getJsonString(AUTH_KEY).getString()).isEqualTo("key");
+        assertThat(json.getJsonString(AUTH_CODE_ID).getString()).isEqualTo("codeId");
+
     }
 }

--- a/extensions/common/api/api-core/src/test/java/org/eclipse/edc/api/transformer/JsonObjectToCallbackAddressDtoTransformerTest.java
+++ b/extensions/common/api/api-core/src/test/java/org/eclipse/edc/api/transformer/JsonObjectToCallbackAddressDtoTransformerTest.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.util.JacksonJsonLd.createObjectMapper;
+import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.AUTH_CODE_ID;
+import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.AUTH_KEY;
 import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.EVENTS;
 import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.IS_TRANSACTIONAL;
 import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.URI;
@@ -49,6 +51,8 @@ class JsonObjectToCallbackAddressDtoTransformerTest {
                         .add("bar")
                         .add("baz")
                         .build())
+                .add(AUTH_CODE_ID, "code")
+                .add(AUTH_KEY, "key")
                 .build();
 
         var contextMock = mock(TransformerContext.class);
@@ -61,5 +65,7 @@ class JsonObjectToCallbackAddressDtoTransformerTest {
         assertThat(cba.getEvents()).containsExactlyInAnyOrder("foo", "bar", "baz");
         assertThat(cba.getUri()).isEqualTo("http://test.local/");
         assertThat(cba.isTransactional()).isTrue();
+        assertThat(cba.getAuthKey()).isEqualTo("key");
+        assertThat(cba.getAuthCodeId()).isEqualTo("code");
     }
 }

--- a/extensions/control-plane/callback/callback-event-dispatcher/src/main/java/org/eclipse/edc/connector/callback/dispatcher/CallbackEventDispatcher.java
+++ b/extensions/control-plane/callback/callback-event-dispatcher/src/main/java/org/eclipse/edc/connector/callback/dispatcher/CallbackEventDispatcher.java
@@ -31,7 +31,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.lang.String.format;
-import static java.util.Optional.ofNullable;
 
 /**
  * Subscriber for invoking callbacks associated to {@link Event}. If the {@link CallbackAddress#getEvents()} matches
@@ -80,9 +79,7 @@ public class CallbackEventDispatcher implements EventSubscriber {
     }
 
     private <E extends Event> List<CallbackAddress> getCallbacks(EventEnvelope<E> eventEnvelope) {
-        var staticCallbacks = ofNullable(callbackRegistry)
-                .map(registry -> registry.resolve(eventEnvelope.getPayload().name()).stream())
-                .orElseGet(Stream::empty);
+        var staticCallbacks = callbackRegistry.resolve(eventEnvelope.getPayload().name()).stream();
         var dynamicCallbacks =
                 eventEnvelope.getPayload().getCallbackAddresses()
                         .stream();

--- a/extensions/control-plane/callback/callback-event-dispatcher/src/main/java/org/eclipse/edc/connector/callback/dispatcher/CallbackEventDispatcherExtension.java
+++ b/extensions/control-plane/callback/callback-event-dispatcher/src/main/java/org/eclipse/edc/connector/callback/dispatcher/CallbackEventDispatcherExtension.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.callback.dispatcher;
 
 import org.eclipse.edc.connector.callback.CallbackProtocolResolverRegistryImpl;
 import org.eclipse.edc.connector.spi.callback.CallbackProtocolResolverRegistry;
+import org.eclipse.edc.connector.spi.callback.CallbackRegistry;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provides;
@@ -41,11 +42,13 @@ public class CallbackEventDispatcherExtension implements ServiceExtension {
     @Inject
     Monitor monitor;
 
+    @Inject(required = false)
+    CallbackRegistry callbackRegistry;
+
     @Override
     public String name() {
         return NAME;
     }
-
 
     @Override
     public void initialize(ServiceExtensionContext context) {
@@ -54,8 +57,8 @@ public class CallbackEventDispatcherExtension implements ServiceExtension {
         context.registerService(CallbackProtocolResolverRegistry.class, resolverRegistry);
 
         // Event listener for invoking callbacks in sync (transactional) and async (not transactional)
-        router.registerSync(Event.class, new CallbackEventDispatcher(dispatcherRegistry, resolverRegistry, true, monitor));
-        router.register(Event.class, new CallbackEventDispatcher(dispatcherRegistry, resolverRegistry, false, monitor));
+        router.registerSync(Event.class, new CallbackEventDispatcher(dispatcherRegistry, callbackRegistry, resolverRegistry, true, monitor));
+        router.register(Event.class, new CallbackEventDispatcher(dispatcherRegistry, callbackRegistry, resolverRegistry, false, monitor));
 
     }
 }

--- a/extensions/control-plane/callback/callback-event-dispatcher/src/main/java/org/eclipse/edc/connector/callback/dispatcher/CallbackEventDispatcherExtension.java
+++ b/extensions/control-plane/callback/callback-event-dispatcher/src/main/java/org/eclipse/edc/connector/callback/dispatcher/CallbackEventDispatcherExtension.java
@@ -42,7 +42,6 @@ public class CallbackEventDispatcherExtension implements ServiceExtension {
     @Inject
     Monitor monitor;
 
-    @Inject(required = false)
     CallbackRegistry callbackRegistry;
 
     @Override

--- a/extensions/control-plane/callback/callback-event-dispatcher/src/test/java/org/eclipse/edc/connector/callback/dispatcher/CallbackEventDispatcherTest.java
+++ b/extensions/control-plane/callback/callback-event-dispatcher/src/test/java/org/eclipse/edc/connector/callback/dispatcher/CallbackEventDispatcherTest.java
@@ -36,7 +36,10 @@ import java.util.concurrent.CompletableFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 public class CallbackEventDispatcherTest {
 
@@ -110,7 +113,7 @@ public class CallbackEventDispatcherTest {
                 .build();
 
         assertThatThrownBy(() -> dispatcher.on(envelope(event))).isInstanceOf(EdcException.class);
-        
+
     }
 
     @ParameterizedTest

--- a/extensions/control-plane/callback/callback-event-dispatcher/src/test/java/org/eclipse/edc/connector/callback/dispatcher/CallbackEventDispatcherTest.java
+++ b/extensions/control-plane/callback/callback-event-dispatcher/src/test/java/org/eclipse/edc/connector/callback/dispatcher/CallbackEventDispatcherTest.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.callback.dispatcher;
 
 import org.eclipse.edc.connector.spi.callback.CallbackEventRemoteMessage;
 import org.eclipse.edc.connector.spi.callback.CallbackProtocolResolverRegistry;
+import org.eclipse.edc.connector.spi.callback.CallbackRegistry;
 import org.eclipse.edc.connector.transfer.spi.event.TransferProcessCompleted;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.event.Event;
@@ -46,11 +47,14 @@ public class CallbackEventDispatcherTest {
     RemoteMessageDispatcherRegistry registry = mock(RemoteMessageDispatcherRegistry.class);
 
     CallbackProtocolResolverRegistry resolverRegistry = mock(CallbackProtocolResolverRegistry.class);
+
+    CallbackRegistry callbackRegistry = mock(CallbackRegistry.class);
+
     Monitor monitor = mock(Monitor.class);
 
     @Test
     void verifyShouldNotDispatch() {
-        dispatcher = new CallbackEventDispatcher(registry, resolverRegistry, true, monitor);
+        dispatcher = new CallbackEventDispatcher(registry, callbackRegistry, resolverRegistry, true, monitor);
         when(resolverRegistry.resolve("local")).thenReturn("local");
 
 
@@ -63,7 +67,7 @@ public class CallbackEventDispatcherTest {
 
     @Test
     void verifyDispatchShouldThrowException() {
-        dispatcher = new CallbackEventDispatcher(registry, resolverRegistry, true, monitor);
+        dispatcher = new CallbackEventDispatcher(registry, callbackRegistry, resolverRegistry, true, monitor);
         when(resolverRegistry.resolve("local")).thenReturn("local");
 
         when(registry.send(any(), any())).thenReturn(CompletableFuture.failedFuture(new RuntimeException("Test")));
@@ -94,7 +98,7 @@ public class CallbackEventDispatcherTest {
         @SuppressWarnings("unchecked")
         ArgumentCaptor<CallbackEventRemoteMessage<TransferProcessCompleted>> captor = ArgumentCaptor.forClass(CallbackEventRemoteMessage.class);
 
-        dispatcher = new CallbackEventDispatcher(registry, resolverRegistry, transactional, monitor);
+        dispatcher = new CallbackEventDispatcher(registry, callbackRegistry, resolverRegistry, transactional, monitor);
 
         var callback = CallbackAddress.Builder.newInstance()
                 .uri("local://test")
@@ -122,7 +126,7 @@ public class CallbackEventDispatcherTest {
     @ValueSource(booleans = { true, false })
     void verifyShouldNotDispatchWithDifferentTransactionalConfiguration(boolean transactional) {
 
-        dispatcher = new CallbackEventDispatcher(registry, resolverRegistry, transactional, monitor);
+        dispatcher = new CallbackEventDispatcher(registry, callbackRegistry, resolverRegistry, transactional, monitor);
         when(resolverRegistry.resolve("local")).thenReturn("local");
 
 

--- a/extensions/control-plane/callback/callback-http-dispatcher/src/main/java/org/eclipse/edc/connector/callback/dispatcher/http/CallbackEventDispatcherHttpExtension.java
+++ b/extensions/control-plane/callback/callback-http-dispatcher/src/main/java/org/eclipse/edc/connector/callback/dispatcher/http/CallbackEventDispatcherHttpExtension.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.http.EdcHttpClient;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
+import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
@@ -39,6 +40,10 @@ public class CallbackEventDispatcherHttpExtension implements ServiceExtension {
     @Inject
     private CallbackProtocolResolverRegistry resolverRegistry;
 
+    @Inject
+    private Vault vault;
+
+
     @Override
     public String name() {
         return NAME;
@@ -50,7 +55,7 @@ public class CallbackEventDispatcherHttpExtension implements ServiceExtension {
         resolverRegistry.registerResolver(this::resolveScheme);
 
         var baseDispatcher = new GenericHttpRemoteDispatcherImpl(client);
-        baseDispatcher.registerDelegate(new CallbackEventRemoteMessageDispatcher(typeManager.getMapper()));
+        baseDispatcher.registerDelegate(new CallbackEventRemoteMessageDispatcher(typeManager.getMapper(), vault));
 
         registry.register(baseDispatcher);
     }

--- a/extensions/control-plane/callback/callback-static-endpoint/REAME.md
+++ b/extensions/control-plane/callback/callback-static-endpoint/REAME.md
@@ -1,0 +1,33 @@
+# Static Callbacks Extension
+
+This extension priovides an implementation and configuration for static callbacks outlined in this [DecisionRecord](https://github.com/eclipse-edc/Connector/tree/main/docs/developer/decision-records/2023-02-28-processing-callbacks#static-endpoints) 
+The callacks are built on top of the EDC event system. When an event is fired in EDC all registered callacks will be invoked.
+
+## Configuration
+
+| Parameter name                        | Description                                                                                     | Mandatory | Default value |
+|---------------------------------------|-------------------------------------------------------------------------------------------------|-----------|---------------|
+| `edc.callback.<name>.uri`             | The address used to dispatch a callback notification                                            | true      | null          |
+| `edc.callback.<name>.events`          | The comma separated events on which the callback should be invoked.                             | true      | null          |
+| `edc.callback.<name>.transactional`   | If the callback should be invoked inside the transactional boundaries of the configured events. | false     | false         |
+| `edc.callback.<name>.auth-key`        | Transport specific header to use for sending an authentication value.                           | false     | null          |
+| `edc.callback.<name>.auth-code-id`    | The id for the authorization value that will be resolved by the Vault.                          | false     | null          |
+
+
+Example configuration with two callbacks:
+
+```bash
+edc.callback.endpoint1.uri=http://localhost:8080/hooks
+edc.callback.endpoint1.events=contract.negotiation,transfer.process
+edc.callback.endpoint1.transactional=true
+
+edc.callback.endpoint2.uri=http://localhost:8081/hooks
+edc.callback.endpoint2.events=contract.negotiation.finalized,transfer.process.completed
+edc.callback.endpoint2.transactional=false
+edc.callback.endpoint2.auth-key=X-API-KEY
+edc.callback.endpoint2.auth-code-id=mysecret
+```
+
+The first one `endpoint1` will be invoked transactionally in all events emitted from the `ContractNegotiation` and `TransferProcess` state machines.
+
+The second one will only be invoked asynchronously only when a `ContractNegotiatin` is finalized and a `TransferProcess` is completed.

--- a/extensions/control-plane/callback/callback-static-endpoint/build.gradle.kts
+++ b/extensions/control-plane/callback/callback-static-endpoint/build.gradle.kts
@@ -1,0 +1,10 @@
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(project(":spi:common:core-spi"))
+    api(project(":spi:control-plane:control-plane-spi"))
+
+    testImplementation(project(":core:common:junit"))
+}

--- a/extensions/control-plane/callback/callback-static-endpoint/src/main/java/org/eclipse/edc/connector/callback/staticendpoint/CallbackStaticEndpointExtension.java
+++ b/extensions/control-plane/callback/callback-static-endpoint/src/main/java/org/eclipse/edc/connector/callback/staticendpoint/CallbackStaticEndpointExtension.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.callback.staticendpoint;
+
+import org.eclipse.edc.connector.spi.callback.CallbackRegistry;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.system.configuration.Config;
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+/**
+ * Extension for configuring the static endpoints for callbacks
+ */
+public class CallbackStaticEndpointExtension implements ServiceExtension {
+
+    public static final String EDC_CALLBACK_SETTING_PREFIX = "edc.callback";
+    public static final String EDC_CALLBACK_URI = "uri";
+    public static final String EDC_CALLBACK_EVENTS = "events";
+    public static final String EDC_CALLBACK_TRANSACTIONAL = "transactional";
+    public static final String EDC_CALLBACK_AUTH_KEY = "auth-key";
+    public static final String EDC_CALLBACK_AUTH_CODE_ID = "auth-code-id";
+
+    @Inject
+    private CallbackRegistry callbackRegistry;
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        context.getConfig(EDC_CALLBACK_SETTING_PREFIX)
+                .partition()
+                .map(this::configureCallback)
+                .forEach(callbackRegistry::register);
+
+    }
+
+    public CallbackAddress configureCallback(Config config) {
+        var events = Arrays.stream(config.getString(EDC_CALLBACK_EVENTS).split(","))
+                .map(String::trim)
+                .collect(Collectors.toSet());
+
+        return CallbackAddress.Builder.newInstance()
+                .uri(config.getString(EDC_CALLBACK_URI))
+                .transactional(config.getBoolean(EDC_CALLBACK_TRANSACTIONAL, false))
+                .authKey(config.getString(EDC_CALLBACK_AUTH_KEY, null))
+                .authCodeId(config.getString(EDC_CALLBACK_AUTH_CODE_ID, null))
+                .events(events)
+                .build();
+    }
+
+}

--- a/extensions/control-plane/callback/callback-static-endpoint/src/main/java/org/eclipse/edc/connector/callback/staticendpoint/CallbackStaticEndpointExtension.java
+++ b/extensions/control-plane/callback/callback-static-endpoint/src/main/java/org/eclipse/edc/connector/callback/staticendpoint/CallbackStaticEndpointExtension.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.connector.callback.staticendpoint;
 
 import org.eclipse.edc.connector.spi.callback.CallbackRegistry;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
@@ -27,6 +28,7 @@ import java.util.stream.Collectors;
 /**
  * Extension for configuring the static endpoints for callbacks
  */
+@Extension(CallbackStaticEndpointExtension.NAME)
 public class CallbackStaticEndpointExtension implements ServiceExtension {
 
     public static final String EDC_CALLBACK_SETTING_PREFIX = "edc.callback";
@@ -35,7 +37,7 @@ public class CallbackStaticEndpointExtension implements ServiceExtension {
     public static final String EDC_CALLBACK_TRANSACTIONAL = "transactional";
     public static final String EDC_CALLBACK_AUTH_KEY = "auth-key";
     public static final String EDC_CALLBACK_AUTH_CODE_ID = "auth-code-id";
-
+    static final String NAME = "Static callbacks extension";
     @Inject
     private CallbackRegistry callbackRegistry;
 
@@ -46,6 +48,11 @@ public class CallbackStaticEndpointExtension implements ServiceExtension {
                 .map(this::configureCallback)
                 .forEach(callbackRegistry::register);
 
+    }
+
+    @Override
+    public String name() {
+        return NAME;
     }
 
     public CallbackAddress configureCallback(Config config) {

--- a/extensions/control-plane/callback/callback-static-endpoint/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/control-plane/callback/callback-static-endpoint/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,16 @@
+#
+#  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+#
+#
+
+org.eclipse.edc.connector.callback.staticendpoint.CallbackStaticEndpointExtension
+

--- a/extensions/control-plane/callback/callback-static-endpoint/src/test/java/org/eclipse/edc/connector/callback/staticendpoint/CallbackStaticEndpointExtensionTest.java
+++ b/extensions/control-plane/callback/callback-static-endpoint/src/test/java/org/eclipse/edc/connector/callback/staticendpoint/CallbackStaticEndpointExtensionTest.java
@@ -43,11 +43,7 @@ import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.edc.connector.callback.staticendpoint.CallbackStaticEndpointExtension.EDC_CALLBACK_SETTING_PREFIX;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(DependencyInjectionExtension.class)
 public class CallbackStaticEndpointExtensionTest {
@@ -64,7 +60,7 @@ public class CallbackStaticEndpointExtensionTest {
         extension = factory.constructInstance(CallbackStaticEndpointExtension.class);
         this.context = spy(context);
     }
-    
+
     @Test
     void initialize_shouldConfigureMultipleCallbacks() {
 
@@ -125,7 +121,7 @@ public class CallbackStaticEndpointExtensionTest {
 
         var config = new HashMap<String, String>();
 
-        config.put(format("edc.callback.%s.url", name), callbackAddress.getUri());
+        config.put(format("edc.callback.%s.uri", name), callbackAddress.getUri());
         config.put(format("edc.callback.%s.transactional", name), String.valueOf(callbackAddress.isTransactional()));
 
         if (callbackAddress.getEvents().size() > 0) {

--- a/extensions/control-plane/callback/callback-static-endpoint/src/test/java/org/eclipse/edc/connector/callback/staticendpoint/CallbackStaticEndpointExtensionTest.java
+++ b/extensions/control-plane/callback/callback-static-endpoint/src/test/java/org/eclipse/edc/connector/callback/staticendpoint/CallbackStaticEndpointExtensionTest.java
@@ -43,7 +43,11 @@ import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.edc.connector.callback.staticendpoint.CallbackStaticEndpointExtension.EDC_CALLBACK_SETTING_PREFIX;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(DependencyInjectionExtension.class)
 public class CallbackStaticEndpointExtensionTest {

--- a/extensions/control-plane/callback/callback-static-endpoint/src/test/java/org/eclipse/edc/connector/callback/staticendpoint/CallbackStaticEndpointExtensionTest.java
+++ b/extensions/control-plane/callback/callback-static-endpoint/src/test/java/org/eclipse/edc/connector/callback/staticendpoint/CallbackStaticEndpointExtensionTest.java
@@ -1,0 +1,157 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.callback.staticendpoint;
+
+import org.eclipse.edc.connector.spi.callback.CallbackRegistry;
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.system.configuration.Config;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+import org.eclipse.edc.spi.system.injection.ObjectFactory;
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.mockito.ArgumentCaptor;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.eclipse.edc.connector.callback.staticendpoint.CallbackStaticEndpointExtension.EDC_CALLBACK_SETTING_PREFIX;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(DependencyInjectionExtension.class)
+public class CallbackStaticEndpointExtensionTest {
+
+    CallbackStaticEndpointExtension extension;
+
+    CallbackRegistry callbackRegistry = mock(CallbackRegistry.class);
+
+    ServiceExtensionContext context;
+
+    @BeforeEach
+    void setUp(ServiceExtensionContext context, ObjectFactory factory) {
+        context.registerService(CallbackRegistry.class, callbackRegistry);
+        extension = factory.constructInstance(CallbackStaticEndpointExtension.class);
+        this.context = spy(context);
+    }
+    
+    @Test
+    void initialize_shouldConfigureMultipleCallbacks() {
+
+        var cb1 = CallbackAddress.Builder.newInstance()
+                .uri("http://url1")
+                .transactional(false)
+                .events(Set.of("transfer", "contract"))
+                .build();
+        var cb2 = CallbackAddress.Builder.newInstance()
+                .uri("http://url2")
+                .transactional(false)
+                .events(Set.of("asset", "policy"))
+                .authCodeId("codeId")
+                .authKey("key")
+                .build();
+
+        var cb3 = CallbackAddress.Builder.newInstance()
+                .uri("http://url3")
+                .transactional(true)
+                .events(Set.of("transfer"))
+                .build();
+
+        var callbacks = List.of(cb1, cb2, cb3);
+
+        var cfg = IntStream.range(0, callbacks.size())
+                .mapToObj(idx -> configureCallback(format("endpoint%s", idx), callbacks.get(idx)))
+                .map(ConfigFactory::fromMap)
+                .reduce(Config::merge)
+                .orElseGet(ConfigFactory::empty);
+
+        when(context.getConfig(EDC_CALLBACK_SETTING_PREFIX)).thenReturn(cfg.getConfig(EDC_CALLBACK_SETTING_PREFIX));
+
+        extension.initialize(context);
+
+        var captor = ArgumentCaptor.forClass(CallbackAddress.class);
+
+        verify(callbackRegistry, times(callbacks.size())).register(captor.capture());
+
+        assertThat(captor.getAllValues()).usingRecursiveFieldByFieldElementComparatorIgnoringFields("events")
+                .containsExactlyInAnyOrder(cb1, cb2, cb3);
+
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(CallbackArgumentProvider.class)
+    void initialize_shouldThrow_WhenWrongConfiguration(Map<String, String> callbackConfig) {
+
+        var cfg = ConfigFactory.fromMap(callbackConfig);
+
+        when(context.getConfig(EDC_CALLBACK_SETTING_PREFIX)).thenReturn(cfg.getConfig(EDC_CALLBACK_SETTING_PREFIX));
+
+        assertThatThrownBy(() -> extension.initialize(context))
+                .isInstanceOf(EdcException.class);
+
+    }
+
+    private Map<String, String> configureCallback(String name, CallbackAddress callbackAddress) {
+
+        var config = new HashMap<String, String>();
+
+        config.put(format("edc.callback.%s.url", name), callbackAddress.getUri());
+        config.put(format("edc.callback.%s.transactional", name), String.valueOf(callbackAddress.isTransactional()));
+
+        if (callbackAddress.getEvents().size() > 0) {
+            config.put(format("edc.callback.%s.events", name), String.join(", ", callbackAddress.getEvents()));
+        }
+
+        if (callbackAddress.getAuthCodeId() != null) {
+            config.put(format("edc.callback.%s.auth-code-id", name), "codeId");
+        }
+        if (callbackAddress.getAuthKey() != null) {
+            config.put(format("edc.callback.%s.auth-key", name), "key");
+        }
+        return config;
+    }
+
+    static class CallbackArgumentProvider implements ArgumentsProvider {
+        CallbackArgumentProvider() {
+        }
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                    Map.of("edc.callback.cb.url", "url", "edc.callback.events", "test"),
+                    Map.of("edc.callback.cb.transactional", "false", "edc.callback.events", "test"),
+                    Map.of("edc.callback.cb.url", "url", "edc.callback.transactional", "false")
+            ).map(Arguments::arguments);
+        }
+    }
+}

--- a/extensions/control-plane/callback/callback-static-endpoint/src/test/java/org/eclipse/edc/connector/callback/staticendpoint/CallbackStaticEndpointExtensionTest.java
+++ b/extensions/control-plane/callback/callback-static-endpoint/src/test/java/org/eclipse/edc/connector/callback/staticendpoint/CallbackStaticEndpointExtensionTest.java
@@ -38,7 +38,10 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.edc.connector.callback.staticendpoint.CallbackStaticEndpointExtension.EDC_CALLBACK_SETTING_PREFIX;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(DependencyInjectionExtension.class)
 public class CallbackStaticEndpointExtensionTest {

--- a/resources/openapi/yaml/management-api/contract-negotiation-api.yaml
+++ b/resources/openapi/yaml/management-api/contract-negotiation-api.yaml
@@ -640,6 +640,12 @@ components:
       type: object
       example: null
       properties:
+        authCodeId:
+          type: string
+          example: null
+        authKey:
+          type: string
+          example: null
         events:
           type: array
           example: null
@@ -657,6 +663,12 @@ components:
       type: object
       example: null
       properties:
+        authCodeId:
+          type: string
+          example: null
+        authKey:
+          type: string
+          example: null
         events:
           type: array
           example: null

--- a/resources/openapi/yaml/management-api/transfer-process-api.yaml
+++ b/resources/openapi/yaml/management-api/transfer-process-api.yaml
@@ -598,6 +598,12 @@ components:
       type: object
       example: null
       properties:
+        authCodeId:
+          type: string
+          example: null
+        authKey:
+          type: string
+          example: null
         events:
           type: array
           example: null

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -166,6 +166,7 @@ include(":extensions:control-plane:store:sql:policy-definition-store-sql")
 include(":extensions:control-plane:store:sql:transfer-process-store-sql")
 include(":extensions:control-plane:callback:callback-event-dispatcher")
 include(":extensions:control-plane:callback:callback-http-dispatcher")
+include(":extensions:control-plane:callback:callback-static-endpoint")
 
 
 include(":extensions:data-plane:data-plane-api")

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/callback/CallbackAddress.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/callback/CallbackAddress.java
@@ -36,9 +36,15 @@ public class CallbackAddress {
     public static final String URI = EDC_NAMESPACE + "uri";
     public static final String EVENTS = EDC_NAMESPACE + "events";
 
+    public static final String AUTH_KEY = EDC_NAMESPACE + "authKey";
+    public static final String AUTH_CODE_ID = EDC_NAMESPACE + "authCodeId";
+    
     private String uri;
     private Set<String> events = new HashSet<>();
     private boolean transactional;
+
+    private String authKey;
+    private String authCodeId;
 
 
     public Set<String> getEvents() {
@@ -51,6 +57,14 @@ public class CallbackAddress {
 
     public boolean isTransactional() {
         return transactional;
+    }
+
+    public String getAuthCodeId() {
+        return authCodeId;
+    }
+
+    public String getAuthKey() {
+        return authKey;
     }
 
     @JsonPOJOBuilder(withPrefix = "")
@@ -80,6 +94,16 @@ public class CallbackAddress {
 
         public Builder transactional(boolean transactional) {
             callbackAddress.transactional = transactional;
+            return this;
+        }
+
+        public Builder authKey(String authKey) {
+            callbackAddress.authKey = authKey;
+            return this;
+        }
+
+        public Builder authCodeId(String authCodeId) {
+            callbackAddress.authCodeId = authCodeId;
             return this;
         }
 

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/callback/CallbackEventRemoteMessage.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/callback/CallbackEventRemoteMessage.java
@@ -25,13 +25,12 @@ import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
  */
 public class CallbackEventRemoteMessage<T extends Event> implements RemoteMessage {
 
-    private final String connectorAddress;
     private final String protocol;
-
     private final EventEnvelope<T> envelope;
+    private final CallbackAddress callbackAddress;
 
     public CallbackEventRemoteMessage(CallbackAddress callbackAddress, EventEnvelope<T> envelope, String protocol) {
-        this.connectorAddress = callbackAddress.getUri();
+        this.callbackAddress = callbackAddress;
         this.protocol = protocol;
         this.envelope = envelope;
     }
@@ -43,7 +42,15 @@ public class CallbackEventRemoteMessage<T extends Event> implements RemoteMessag
 
     @Override
     public String getCallbackAddress() {
-        return connectorAddress;
+        return callbackAddress.getUri();
+    }
+
+    public String getAuthKey() {
+        return callbackAddress.getAuthKey();
+    }
+
+    public String getAuthCodeId() {
+        return callbackAddress.getAuthCodeId();
     }
 
     public EventEnvelope<T> getEventEnvelope() {

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/callback/CallbackRegistry.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/callback/CallbackRegistry.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.spi.callback;
+
+import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
+
+import java.util.List;
+
+/**
+ * Registry for static callbacks
+ */
+@ExtensionPoint
+public interface CallbackRegistry {
+
+    /**
+     * Register a callback
+     *
+     * @param address The {@link CallbackAddress}
+     */
+    void register(CallbackAddress address);
+
+    /**
+     * Returns all the callbacks associated with the input event
+     *
+     * @param event The event
+     * @return The list of callbacks
+     */
+    List<CallbackAddress> resolve(String event);
+}


### PR DESCRIPTION
## What this PR changes/adds

Implements static callbacks as outlined in this [Decision Record](https://github.com/eclipse-edc/Connector/tree/main/docs/developer/decision-records/2023-02-28-processing-callbacks#static-endpoints)

## Why it does that

Completes the callback feature with static configurable ones 

## Further notes

The auth support via `Vault` has been also added to the dynamic callbacks

## Linked Issue(s)

Closes #2627 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
