### PR TITLE
feat: make ContractOffer IDs include the AssetID

### DIFF
--- a/core/control-plane/catalog-core/src/main/java/org/eclipse/edc/connector/catalog/DatasetResolverImpl.java
+++ b/core/control-plane/catalog-core/src/main/java/org/eclipse/edc/connector/catalog/DatasetResolverImpl.java
@@ -65,7 +65,7 @@ public class DatasetResolverImpl implements DatasetResolver {
                                     .map(predicateConverter::convert)
                                     .reduce(x -> true, Predicate::and)
                                     .test(asset))
-                            .map(this::createOffer)
+                            .map(contractDefinition -> createOffer(contractDefinition, asset.getId()))
                             .filter(Objects::nonNull)
                             .collect(toList());
                     return new ProtoDataset(asset, offers);
@@ -87,12 +87,12 @@ public class DatasetResolverImpl implements DatasetResolver {
                 });
     }
 
-    private Offer createOffer(ContractDefinition definition) {
+    private Offer createOffer(ContractDefinition definition, String assetId) {
         var policyDefinition = policyDefinitionStore.findById(definition.getContractPolicyId());
         if (policyDefinition == null) {
             return null;
         }
-        var contractId = ContractId.createContractId(definition.getId());
+        var contractId = ContractId.createContractId(definition.getId(), assetId);
         return new Offer(contractId, policyDefinition.getPolicy());
     }
 

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -179,7 +179,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
 
         var policy = lastOffer.getPolicy();
         var agreement = ContractAgreement.Builder.newInstance()
-                .id(ContractId.createContractId(definitionId))
+                .id(ContractId.createContractId(definitionId, lastOffer.getAssetId()))
                 .contractStartDate(lastOffer.getContractStart().toEpochSecond())
                 .contractEndDate(lastOffer.getContractEnd().toEpochSecond())
                 .contractSigningDate(clock.instant().getEpochSecond())

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -167,7 +167,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
             policy = lastOffer.getPolicy();
 
             agreement = ContractAgreement.Builder.newInstance()
-                    .id(ContractId.createContractId(definitionId))
+                    .id(ContractId.createContractId(definitionId, lastOffer.getAssetId()))
                     .contractStartDate(lastOffer.getContractStart().toEpochSecond())
                     .contractEndDate(lastOffer.getContractEnd().toEpochSecond())
                     .contractSigningDate(clock.instant().getEpochSecond())

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/offer/ContractOfferResolverImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/offer/ContractOfferResolverImpl.java
@@ -128,7 +128,7 @@ public class ContractOfferResolverImpl implements ContractOfferResolver {
         var contractStartTime = ZonedDateTime.ofInstant(start, zone);
 
         return ContractOffer.Builder.newInstance()
-                .id(ContractId.createContractId(definition.getId()))
+                .id(ContractId.createContractId(definition.getId(), assetId))
                 .policy(policy.withTarget(assetId))
                 .assetId(assetId)
                 .contractStart(contractStartTime)

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
@@ -279,7 +279,7 @@ class ConsumerContractNegotiationManagerImplTest {
     }
 
     private ContractOffer contractOffer() {
-        return ContractOffer.Builder.newInstance().id("id:id")
+        return ContractOffer.Builder.newInstance().id("id:assetId:random")
                 .policy(Policy.Builder.newInstance().build())
                 .assetId("assetId")
                 .contractStart(ZonedDateTime.now())
@@ -309,7 +309,7 @@ class ConsumerContractNegotiationManagerImplTest {
         }
 
         private ContractOffer contractOffer() {
-            return ContractOffer.Builder.newInstance().id("id:id")
+            return ContractOffer.Builder.newInstance().id("id:assetId:random")
                     .policy(Policy.Builder.newInstance().build())
                     .assetId("assetId")
                     .contractStart(ZonedDateTime.now())

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -300,7 +300,7 @@ class ContractNegotiationIntegrationTest {
      */
     private ContractOffer getContractOffer() {
         return ContractOffer.Builder.newInstance()
-                .id(ContractId.createContractId("1"))
+                .id(ContractId.createContractId("1", "test-asset-id"))
                 .contractStart(ZonedDateTime.now())
                 .contractEnd(ZonedDateTime.now().plusMonths(1))
                 .providerId("provider")

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
@@ -211,6 +211,38 @@ class ProviderContractNegotiationManagerImplTest {
         });
     }
 
+    private ContractNegotiation.Builder contractNegotiationBuilder() {
+        return ContractNegotiation.Builder.newInstance()
+                .id(UUID.randomUUID().toString())
+                .type(ContractNegotiation.Type.PROVIDER)
+                .correlationId("processId")
+                .counterPartyId("connectorId")
+                .counterPartyAddress("callbackAddress")
+                .protocol("protocol")
+                .state(400)
+                .stateTimestamp(Instant.now().toEpochMilli());
+    }
+
+    private ContractAgreement.Builder contractAgreementBuilder() {
+        return ContractAgreement.Builder.newInstance()
+                .id(ContractId.createContractId(UUID.randomUUID().toString(), "test-asset-id"))
+                .providerId("any")
+                .consumerId("any")
+                .assetId("default")
+                .policy(Policy.Builder.newInstance().build());
+    }
+
+    private ContractOffer contractOffer() {
+        return ContractOffer.Builder.newInstance()
+                .id(ContractId.createContractId("1", "test-asset-id"))
+                .policy(Policy.Builder.newInstance().build())
+                .assetId("assetId")
+                .providerId(PROVIDER_ID)
+                .contractStart(ZonedDateTime.now())
+                .contractEnd(ZonedDateTime.now())
+                .build();
+    }
+
     private static class DispatchFailureArguments implements ArgumentsProvider {
 
         private static final int RETRIES_NOT_EXHAUSTED = RETRY_LIMIT;
@@ -233,45 +265,13 @@ class ProviderContractNegotiationManagerImplTest {
         }
 
         private ContractOffer contractOffer() {
-            return ContractOffer.Builder.newInstance().id("id:id")
+            return ContractOffer.Builder.newInstance().id("id:assetId:random")
                     .policy(Policy.Builder.newInstance().build())
                     .assetId("assetId")
                     .contractStart(ZonedDateTime.now())
                     .contractEnd(ZonedDateTime.now())
                     .build();
         }
-    }
-
-    private ContractNegotiation.Builder contractNegotiationBuilder() {
-        return ContractNegotiation.Builder.newInstance()
-                .id(UUID.randomUUID().toString())
-                .type(ContractNegotiation.Type.PROVIDER)
-                .correlationId("processId")
-                .counterPartyId("connectorId")
-                .counterPartyAddress("callbackAddress")
-                .protocol("protocol")
-                .state(400)
-                .stateTimestamp(Instant.now().toEpochMilli());
-    }
-
-    private ContractAgreement.Builder contractAgreementBuilder() {
-        return ContractAgreement.Builder.newInstance()
-                .id(ContractId.createContractId(UUID.randomUUID().toString()))
-                .providerId("any")
-                .consumerId("any")
-                .assetId("default")
-                .policy(Policy.Builder.newInstance().build());
-    }
-
-    private ContractOffer contractOffer() {
-        return ContractOffer.Builder.newInstance()
-                .id(ContractId.createContractId("1"))
-                .policy(Policy.Builder.newInstance().build())
-                .assetId("assetId")
-                .providerId(PROVIDER_ID)
-                .contractStart(ZonedDateTime.now())
-                .contractEnd(ZonedDateTime.now())
-                .build();
     }
 
 }

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImplTest.java
@@ -264,7 +264,7 @@ class ContractValidationServiceImplTest {
                 .contractStartDate(now.getEpochSecond())
                 .contractEndDate(now.plus(1, ChronoUnit.DAYS).getEpochSecond())
                 .contractSigningDate(now.getEpochSecond())
-                .id("1:2")
+                .id("1:2:3")
                 .consumerId(CONSUMER_ID)
                 .build();
 
@@ -298,7 +298,7 @@ class ContractValidationServiceImplTest {
                 .contractStartDate(now.getEpochSecond())
                 .contractEndDate(now.plus(1, ChronoUnit.DAYS).getEpochSecond())
                 .contractSigningDate(now.getEpochSecond())
-                .id("1:2")
+                .id("1:2:3")
                 .consumerId(CONSUMER_ID)
                 .build();
 
@@ -338,7 +338,7 @@ class ContractValidationServiceImplTest {
 
     @Test
     void validateConfirmed_succeed() {
-        var agreement = createContractAgreement().id("1:2").build();
+        var agreement = createContractAgreement().id("1:2:3").build();
         var offer = createContractOffer();
         var token = ClaimToken.Builder.newInstance().build();
 
@@ -355,7 +355,7 @@ class ContractValidationServiceImplTest {
 
     @Test
     void validateConfirmed_failsIfOfferIsNull() {
-        var agreement = createContractAgreement().id("1:2").build();
+        var agreement = createContractAgreement().id("1:2:3").build();
         var token = ClaimToken.Builder.newInstance().build();
 
         var result = validationService.validateConfirmed(token, agreement, null);
@@ -368,7 +368,7 @@ class ContractValidationServiceImplTest {
     @ValueSource(strings = { CONSUMER_ID })
     @NullSource
     void validateConfirmed_failsIfInvalidClaims(String counterPartyId) {
-        var agreement = createContractAgreement().id("1:2").build();
+        var agreement = createContractAgreement().id("1:2:3").build();
         var offer = createContractOffer();
         var token = ClaimToken.Builder.newInstance().build();
 
@@ -397,7 +397,7 @@ class ContractValidationServiceImplTest {
 
     @Test
     void validateConfirmed_failsIfPoliciesAreNotEqual() {
-        var agreement = createContractAgreement().id("1:2").build();
+        var agreement = createContractAgreement().id("1:2:3").build();
         var offer = createContractOffer();
         var token = ClaimToken.Builder.newInstance().build();
 
@@ -483,7 +483,7 @@ class ContractValidationServiceImplTest {
 
         var claimToken = ClaimToken.Builder.newInstance().build();
         var agreement = createContractAgreement()
-                .id("1:2")
+                .id("1:2:3")
                 .contractSigningDate(signingDate)
                 .contractStartDate(startDate)
                 .contractEndDate(endDate)
@@ -495,7 +495,7 @@ class ContractValidationServiceImplTest {
     private ContractOffer createContractOffer(Asset asset, Policy policy, long validity) {
         var now = ZonedDateTime.ofInstant(clock.instant(), clock.getZone());
         return ContractOffer.Builder.newInstance()
-                .id("1:2")
+                .id("1:2:3")
                 .assetId(asset.getId())
                 .policy(policy)
                 .providerId(PROVIDER_ID)

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
@@ -103,7 +103,7 @@ class ContractNegotiationEventDispatchTest {
         policyDefinitionStore.create(PolicyDefinition.Builder.newInstance().id("policyId").policy(policy).build());
         assetIndex.create(Asset.Builder.newInstance().id("assetId").build(), DataAddress.Builder.newInstance().type("any").build());
 
-        service.notifyRequested(createContractOfferRequest(policy), token);
+        service.notifyRequested(createContractOfferRequest(policy, "assetId"), token);
 
         await().untilAsserted(() -> {
             verify(eventSubscriber).on(argThat(isEnvelopeOf(ContractNegotiationRequested.class)));
@@ -111,10 +111,10 @@ class ContractNegotiationEventDispatchTest {
         });
     }
 
-    private ContractRequestMessage createContractOfferRequest(Policy policy) {
+    private ContractRequestMessage createContractOfferRequest(Policy policy, String assetId) {
         var now = ZonedDateTime.now();
         var contractOffer = ContractOffer.Builder.newInstance()
-                .id("contractDefinitionId:" + UUID.randomUUID())
+                .id("contractDefinitionId:" + assetId + ":" + UUID.randomUUID())
                 .assetId("assetId")
                 .policy(policy)
                 .providerId(PROVIDER)

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
@@ -331,6 +331,51 @@ class ContractNegotiationProtocolServiceImplTest {
         verify(store, never()).save(any());
     }
 
+    private ClaimToken claimToken() {
+        return ClaimToken.Builder.newInstance()
+                .claim("key", "value")
+                .build();
+    }
+
+    private ContractNegotiation createContractNegotiationRequested() {
+        var lastOffer = contractOffer();
+
+        return contractNegotiationBuilder()
+                .state(REQUESTED.code())
+                .contractOffer(lastOffer)
+                .build();
+    }
+
+    private ContractNegotiation.Builder contractNegotiationBuilder() {
+        return ContractNegotiation.Builder.newInstance()
+                .id(UUID.randomUUID().toString())
+                .correlationId("processId")
+                .counterPartyId("connectorId")
+                .counterPartyAddress("callbackAddress")
+                .protocol("protocol")
+                .stateTimestamp(Instant.now().toEpochMilli());
+    }
+
+    private Policy createPolicy() {
+        return Policy.Builder.newInstance().build();
+    }
+
+    private ContractOffer contractOffer() {
+        return ContractOffer.Builder.newInstance()
+                .id(ContractId.createContractId("1", "test-asset-id"))
+                .policy(createPolicy())
+                .assetId("assetId")
+                .providerId(PROVIDER_ID)
+                .contractStart(ZonedDateTime.now())
+                .contractEnd(ZonedDateTime.now())
+                .build();
+    }
+
+    @FunctionalInterface
+    private interface MethodCall<M extends RemoteMessage> {
+        ServiceResult<?> call(ContractNegotiationProtocolService service, M message, ClaimToken token);
+    }
+
     private static class NotFoundArguments implements ArgumentsProvider {
 
         @Override
@@ -367,50 +412,5 @@ class ContractNegotiationProtocolServiceImplTest {
                             .build())
             );
         }
-    }
-
-    @FunctionalInterface
-    private interface MethodCall<M extends RemoteMessage> {
-        ServiceResult<?> call(ContractNegotiationProtocolService service, M message, ClaimToken token);
-    }
-
-    private ClaimToken claimToken() {
-        return ClaimToken.Builder.newInstance()
-                .claim("key", "value")
-                .build();
-    }
-
-    private ContractNegotiation createContractNegotiationRequested() {
-        var lastOffer = contractOffer();
-
-        return contractNegotiationBuilder()
-                .state(REQUESTED.code())
-                .contractOffer(lastOffer)
-                .build();
-    }
-
-    private ContractNegotiation.Builder contractNegotiationBuilder() {
-        return ContractNegotiation.Builder.newInstance()
-                .id(UUID.randomUUID().toString())
-                .correlationId("processId")
-                .counterPartyId("connectorId")
-                .counterPartyAddress("callbackAddress")
-                .protocol("protocol")
-                .stateTimestamp(Instant.now().toEpochMilli());
-    }
-
-    private Policy createPolicy() {
-        return Policy.Builder.newInstance().build();
-    }
-
-    private ContractOffer contractOffer() {
-        return ContractOffer.Builder.newInstance()
-                .id(ContractId.createContractId("1"))
-                .policy(createPolicy())
-                .assetId("assetId")
-                .providerId(PROVIDER_ID)
-                .contractStart(ZonedDateTime.now())
-                .contractEnd(ZonedDateTime.now())
-                .build();
     }
 }

--- a/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/contractnegotiation/InMemoryContractNegotiationStoreTest.java
+++ b/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/contractnegotiation/InMemoryContractNegotiationStoreTest.java
@@ -52,6 +52,7 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 class InMemoryContractNegotiationStoreTest extends ContractNegotiationStoreTestBase {
+    private static final String TEST_ASSET_ID = "test-asset-id";
     private final Map<String, Lease> leases = new HashMap<>();
     private InMemoryContractNegotiationStore store;
 
@@ -249,7 +250,7 @@ class InMemoryContractNegotiationStoreTest extends ContractNegotiationStoreTestB
     @Test
     void queryAgreements_noQuerySpec() {
         IntStream.range(0, 10).forEach(i -> {
-            var contractAgreement = TestFunctions.createAgreementBuilder().id(ContractId.createContractId(UUID.randomUUID().toString())).build();
+            var contractAgreement = TestFunctions.createAgreementBuilder().id(ContractId.createContractId(UUID.randomUUID().toString(), TEST_ASSET_ID)).build();
             var negotiation = TestFunctions.createNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
             store.save(negotiation);
         });
@@ -262,7 +263,7 @@ class InMemoryContractNegotiationStoreTest extends ContractNegotiationStoreTestB
     @Test
     void queryAgreements_verifyPaging() {
         IntStream.range(0, 10).forEach(i -> {
-            var contractAgreement = TestFunctions.createAgreementBuilder().id(ContractId.createContractId(UUID.randomUUID().toString())).build();
+            var contractAgreement = TestFunctions.createAgreementBuilder().id(ContractId.createContractId(UUID.randomUUID().toString(), TEST_ASSET_ID)).build();
             var negotiation = TestFunctions.createNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
             store.save(negotiation);
         });
@@ -396,7 +397,7 @@ class InMemoryContractNegotiationStoreTest extends ContractNegotiationStoreTestB
                 .limit(10).offset(5).build();
 
         IntStream.range(0, 100)
-                .mapToObj(i -> org.eclipse.edc.connector.contract.spi.testfixtures.negotiation.store.TestFunctions.createNegotiation("" + i))
+                .mapToObj(i -> org.eclipse.edc.connector.contract.spi.testfixtures.negotiation.store.TestFunctions.createNegotiation(String.valueOf(i)))
                 .forEach(cn -> getContractNegotiationStore().save(cn));
 
         var result = getContractNegotiationStore().queryNegotiations(querySpec).collect(Collectors.toList());

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/client/MultipartDispatcherIntegrationTest.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/client/MultipartDispatcherIntegrationTest.java
@@ -134,7 +134,7 @@ class MultipartDispatcherIntegrationTest {
                 .contractSigningDate(Instant.now().getEpochSecond())
                 .contractStartDate(Instant.now().getEpochSecond())
                 .contractEndDate(Instant.now().plus(1, ChronoUnit.DAYS).getEpochSecond())
-                .id("1:2").build());
+                .id("1:2:3").build());
         when(validationService.validateAgreement(any(), any(ContractAgreement.class))).thenReturn(Result.success(null));
 
         var request = TransferRequestMessage.Builder.newInstance()

--- a/extensions/control-plane/store/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/contractnegotiation/CosmosContractNegotiationStoreIntegrationTest.java
+++ b/extensions/control-plane/store/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/contractnegotiation/CosmosContractNegotiationStoreIntegrationTest.java
@@ -467,7 +467,7 @@ class CosmosContractNegotiationStoreIntegrationTest extends ContractNegotiationS
     @Test
     void queryAgreements_noQuerySpec() {
         IntStream.range(0, 10).forEach(i -> {
-            var contractAgreement = createContractBuilder().id(ContractId.createContractId(UUID.randomUUID().toString())).build();
+            var contractAgreement = createContractBuilder().id(ContractId.createContractId(UUID.randomUUID().toString(), "test-asset-id")).build();
             var negotiation = createNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
             store.save(negotiation);
         });
@@ -480,7 +480,7 @@ class CosmosContractNegotiationStoreIntegrationTest extends ContractNegotiationS
     @Test
     void queryAgreements_verifyPaging() {
         IntStream.range(0, 10).forEach(i -> {
-            var contractAgreement = createContractBuilder().id(ContractId.createContractId(UUID.randomUUID().toString())).build();
+            var contractAgreement = createContractBuilder().id(ContractId.createContractId(UUID.randomUUID().toString(), "test-asset-id")).build();
             var negotiation = createNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
             store.save(negotiation);
         });

--- a/extensions/control-plane/store/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/contractnegotiation/TestFunctions.java
+++ b/extensions/control-plane/store/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/contractnegotiation/TestFunctions.java
@@ -63,7 +63,7 @@ public class TestFunctions {
     }
 
     public static ContractAgreement.Builder createContractBuilder() {
-        return createContractBuilder("1:2");
+        return createContractBuilder("1:2:3");
     }
 
     public static ContractAgreement.Builder createContractBuilder(String id) {

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/PostgresContractNegotiationStoreTest.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/PostgresContractNegotiationStoreTest.java
@@ -58,6 +58,7 @@ import static org.eclipse.edc.connector.contract.spi.testfixtures.negotiation.st
 @ExtendWith(PostgresqlStoreSetupExtension.class)
 class PostgresContractNegotiationStoreTest extends ContractNegotiationStoreTestBase {
 
+    private static final String TEST_ASSET_ID = "test-asset-id";
     private SqlContractNegotiationStore store;
     private LeaseUtil leaseUtil;
 
@@ -160,7 +161,7 @@ class PostgresContractNegotiationStoreTest extends ContractNegotiationStoreTestB
     @Test
     void queryAgreements_withQuerySpec() {
         IntStream.range(0, 10).forEach(i -> {
-            var contractAgreement = createContractBuilder(ContractId.createContractId(UUID.randomUUID().toString()))
+            var contractAgreement = createContractBuilder(ContractId.createContractId(UUID.randomUUID().toString(), TEST_ASSET_ID))
                     .assetId("asset-" + i)
                     .build();
             var negotiation = createNegotiation(UUID.randomUUID().toString(), contractAgreement);
@@ -176,7 +177,7 @@ class PostgresContractNegotiationStoreTest extends ContractNegotiationStoreTestB
     @Test
     void queryAgreements_withQuerySpec_invalidOperand() {
         IntStream.range(0, 10).forEach(i -> {
-            var contractAgreement = createContractBuilder(ContractId.createContractId(UUID.randomUUID().toString()))
+            var contractAgreement = createContractBuilder(ContractId.createContractId(UUID.randomUUID().toString(), TEST_ASSET_ID))
                     .assetId("asset-" + i)
                     .build();
             var negotiation = createNegotiation(UUID.randomUUID().toString(), contractAgreement);
@@ -190,7 +191,7 @@ class PostgresContractNegotiationStoreTest extends ContractNegotiationStoreTestB
     @Test
     void queryAgreements_withQuerySpec_noFilter() {
         IntStream.range(0, 10).forEach(i -> {
-            var contractAgreement = createContractBuilder(ContractId.createContractId(UUID.randomUUID().toString()))
+            var contractAgreement = createContractBuilder(ContractId.createContractId(UUID.randomUUID().toString(), TEST_ASSET_ID))
                     .assetId("asset-" + i)
                     .build();
             var negotiation = createNegotiation(UUID.randomUUID().toString(), contractAgreement);
@@ -204,7 +205,7 @@ class PostgresContractNegotiationStoreTest extends ContractNegotiationStoreTestB
     @Test
     void queryAgreements_withQuerySpec_invalidValue() {
         IntStream.range(0, 10).forEach(i -> {
-            var contractAgreement = createContractBuilder(ContractId.createContractId(UUID.randomUUID().toString()))
+            var contractAgreement = createContractBuilder(ContractId.createContractId(UUID.randomUUID().toString(), TEST_ASSET_ID))
                     .assetId("asset-" + i)
                     .build();
             var negotiation = createNegotiation(UUID.randomUUID().toString(), contractAgreement);

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/ContractId.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/ContractId.java
@@ -26,18 +26,24 @@ import java.util.UUID;
 public final class ContractId {
 
     private static final int DEFINITION_PART = 0;
+    private static final int ASSET_ID_PART = 1;
     private static final String DELIMITER = ":";
     private final String value;
+
+    private ContractId(String value) {
+        this.value = value;
+    }
 
     /**
      * Returns a new id given the definition part
      *
      * @param definitionPart the part that will be used as prefix of the id
+     * @param assetId        The ID of the asset that is contained in the offer
      * @return a {@link String} that represent the contract id
      */
     @NotNull
-    public static String createContractId(String definitionPart) {
-        return definitionPart + DELIMITER + UUID.randomUUID();
+    public static String createContractId(String definitionPart, String assetId) {
+        return definitionPart + DELIMITER + assetId + DELIMITER + UUID.randomUUID();
     }
 
     /**
@@ -51,10 +57,6 @@ public final class ContractId {
         return new ContractId(id);
     }
 
-    private ContractId(String value) {
-        this.value = value;
-    }
-
     /**
      * The id is valid if it follows the following scheme: [definition-id]:UUID
      *
@@ -62,7 +64,7 @@ public final class ContractId {
      */
     public boolean isValid() {
         var parts = parseContractId(value);
-        return parts.length == 2;
+        return parts.length == 3;
     }
 
     /**
@@ -73,6 +75,16 @@ public final class ContractId {
     public String definitionPart() {
         var parts = parseContractId(value);
         return parts[DEFINITION_PART];
+    }
+
+    /**
+     * The asset-id part of the id
+     *
+     * @return The definition part of the id
+     */
+    public String assetIdPart() {
+        var parts = parseContractId(value);
+        return parts[ASSET_ID_PART];
     }
 
     private String[] parseContractId(@NotNull String id) {

--- a/spi/control-plane/contract-spi/src/test/java/org/eclipse/edc/connector/contract/spi/types/ContractIdTest.java
+++ b/spi/control-plane/contract-spi/src/test/java/org/eclipse/edc/connector/contract/spi/types/ContractIdTest.java
@@ -16,14 +16,17 @@ package org.eclipse.edc.connector.contract.spi.types;
 
 import org.eclipse.edc.connector.contract.spi.ContractId;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ContractIdTest {
 
-    @Test
-    void isValid() {
-        var id = ContractId.parse("thisis:a:validid");
+    @ParameterizedTest
+    @ValueSource(strings = { "this:is:valid", "this:is:valid:" })
+    void isValid(String idString) {
+        var id = ContractId.parse(idString);
 
         assertThat(id.isValid()).isTrue();
     }
@@ -40,17 +43,24 @@ class ContractIdTest {
         assertThat(id.isValid()).isFalse();
     }
 
-    @Test
-    void isValid_falseIfTooManyColonsPresent() {
-        var id = ContractId.parse("thisis:a:very:invalidid");
-
+    @ParameterizedTest
+    @ValueSource(strings = { "thisis:a:very:invalidid", ":this:is:invalid" })
+    void isValid_falseIfTooManyColonsPresent(String idString) {
+        var id = ContractId.parse(idString);
         assertThat(id.isValid()).isFalse();
     }
 
     @Test
     void definitionPart_returnsTheFirstPartOfTheId() {
-        var id = ContractId.parse("definitionPart:agreementPart");
+        var id = ContractId.parse("definitionPart:assetPart:agreementPart");
 
         assertThat(id.definitionPart()).isEqualTo("definitionPart");
+    }
+
+    @Test
+    void assetIdPart_returnsSecondPartOfTheId() {
+        var id = ContractId.parse("definitionPart:assetPart:agreementPart");
+
+        assertThat(id.assetIdPart()).isEqualTo("assetPart");
     }
 }

--- a/spi/control-plane/contract-spi/src/test/java/org/eclipse/edc/connector/contract/spi/types/ContractIdTest.java
+++ b/spi/control-plane/contract-spi/src/test/java/org/eclipse/edc/connector/contract/spi/types/ContractIdTest.java
@@ -23,9 +23,14 @@ class ContractIdTest {
 
     @Test
     void isValid() {
-        var id = ContractId.parse("thisis:avalidid");
+        var id = ContractId.parse("thisis:a:validid");
 
         assertThat(id.isValid()).isTrue();
+    }
+
+    @Test
+    void isValid_tooFewParts() {
+        assertThat(ContractId.parse("thisis:invalid").isValid()).isFalse();
     }
 
     @Test
@@ -37,7 +42,7 @@ class ContractIdTest {
 
     @Test
     void isValid_falseIfTooManyColonsPresent() {
-        var id = ContractId.parse("thisis:an:invalidid");
+        var id = ContractId.parse("thisis:a:very:invalidid");
 
         assertThat(id.isValid()).isFalse();
     }

--- a/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/negotiation/store/ContractNegotiationStoreTestBase.java
+++ b/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/negotiation/store/ContractNegotiationStoreTestBase.java
@@ -44,6 +44,7 @@ import static org.eclipse.edc.connector.contract.spi.testfixtures.negotiation.st
 
 public abstract class ContractNegotiationStoreTestBase {
     protected static final String CONNECTOR_NAME = "test-connector";
+    private static final String ASSET_ID = "TEST_ASSET_ID";
 
     @Test
     @DisplayName("Verify that an entity is found by ID")
@@ -393,7 +394,7 @@ public abstract class ContractNegotiationStoreTestBase {
                 .limit(10).offset(5).build();
 
         IntStream.range(0, 100)
-                .mapToObj(i -> createNegotiation("" + i))
+                .mapToObj(i -> createNegotiation(String.valueOf(i)))
                 .forEach(cn -> getContractNegotiationStore().save(cn));
 
         var result = getContractNegotiationStore().queryNegotiations(querySpec);
@@ -409,7 +410,7 @@ public abstract class ContractNegotiationStoreTestBase {
                 .limit(10).offset(5).build();
 
         IntStream.range(0, 100)
-                .mapToObj(i -> createNegotiation("" + i))
+                .mapToObj(i -> createNegotiation(String.valueOf(i)))
                 .forEach(cn -> getContractNegotiationStore().save(cn));
 
         var result = getContractNegotiationStore().queryNegotiations(querySpec);
@@ -480,7 +481,7 @@ public abstract class ContractNegotiationStoreTestBase {
         IntStream.range(0, 100)
                 .mapToObj(i -> {
                     var agreement = createContract("contract" + i);
-                    return createNegotiation("" + i, agreement);
+                    return createNegotiation(String.valueOf(i), agreement);
                 })
                 .forEach(cn -> getContractNegotiationStore().save(cn));
 
@@ -495,7 +496,7 @@ public abstract class ContractNegotiationStoreTestBase {
         var querySpec = QuerySpec.Builder.newInstance().limit(10).offset(50).build();
 
         IntStream.range(0, 10)
-                .mapToObj(i -> createNegotiation("" + i))
+                .mapToObj(i -> createNegotiation(String.valueOf(i)))
                 .forEach(cn -> getContractNegotiationStore().save(cn));
 
         var result = getContractNegotiationStore().queryNegotiations(querySpec);
@@ -565,7 +566,7 @@ public abstract class ContractNegotiationStoreTestBase {
     @Test
     @DisplayName("Verify that nextForState returns the agreement")
     void nextForState_withAgreement() {
-        var contractAgreement = createContract(ContractId.createContractId(UUID.randomUUID().toString()));
+        var contractAgreement = createContract(ContractId.createContractId(UUID.randomUUID().toString(), ASSET_ID));
         var negotiation = createNegotiationBuilder(UUID.randomUUID().toString())
                 .contractAgreement(contractAgreement)
                 .state(ContractNegotiationStates.AGREED.code())
@@ -582,7 +583,7 @@ public abstract class ContractNegotiationStoreTestBase {
     @Test
     void queryAgreements_noQuerySpec() {
         IntStream.range(0, 10).forEach(i -> {
-            var contractAgreement = createContract(ContractId.createContractId(UUID.randomUUID().toString()));
+            var contractAgreement = createContract(ContractId.createContractId(UUID.randomUUID().toString(), ASSET_ID));
             var negotiation = createNegotiation(UUID.randomUUID().toString(), contractAgreement);
             getContractNegotiationStore().save(negotiation);
         });
@@ -595,7 +596,7 @@ public abstract class ContractNegotiationStoreTestBase {
     @Test
     void queryAgreements_verifyPaging() {
         IntStream.range(0, 10).forEach(i -> {
-            var contractAgreement = createContract(ContractId.createContractId(UUID.randomUUID().toString()));
+            var contractAgreement = createContract(ContractId.createContractId(UUID.randomUUID().toString(), ASSET_ID));
             var negotiation = createNegotiation(UUID.randomUUID().toString(), contractAgreement);
             getContractNegotiationStore().save(negotiation);
         });


### PR DESCRIPTION
## What this PR changes/adds

This PR encodes the Asset-ID into the ContractOffer ID

## Why it does that

provider runtimes should be able to restore one particular offer, and for that, they need both the ContractDefinition-ID _and_ the Asset-ID

## Further notes

.

## Linked Issue(s)

Closes #2929 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
