### PR TITLE
fix: make `ContractNegotiation` managers fetch negotiation with correct type

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.connector.service.contractnegotiation;
 
-import org.eclipse.edc.catalog.spi.DataService;
 import org.eclipse.edc.connector.contract.spi.event.contractnegotiation.ContractNegotiationAgreed;
 import org.eclipse.edc.connector.contract.spi.event.contractnegotiation.ContractNegotiationEvent;
 import org.eclipse.edc.connector.contract.spi.event.contractnegotiation.ContractNegotiationRequested;
@@ -77,7 +76,6 @@ class ContractNegotiationEventDispatchTest {
                 "edc.negotiation.provider.send.retry.limit", "0"
         ));
         extension.registerServiceMock(NegotiationWaitStrategy.class, () -> 1);
-        extension.registerServiceMock(DataService.class, mock(DataService.class));
         extension.registerServiceMock(DataPlaneInstanceStore.class, mock(DataPlaneInstanceStore.class));
     }
 

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/DefaultCriterionToPredicateConverter.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/DefaultCriterionToPredicateConverter.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.defaults.storage;
+
+import org.eclipse.edc.spi.query.BaseCriterionToPredicateConverter;
+import org.eclipse.edc.util.reflection.ReflectionUtil;
+
+/**
+ * Default concrete implementation of {@link BaseCriterionToPredicateConverter}
+ *
+ * @param <T> the object type.
+ */
+public class DefaultCriterionToPredicateConverter<T> extends BaseCriterionToPredicateConverter<T> {
+    @Override
+    protected Object property(String key, Object object) {
+        return ReflectionUtil.getFieldValueSilent(key, object);
+    }
+}

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/contractnegotiation/InMemoryContractNegotiationStore.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/contractnegotiation/InMemoryContractNegotiationStore.java
@@ -21,6 +21,7 @@ import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiat
 import org.eclipse.edc.connector.defaults.storage.InMemoryStatefulEntityStore;
 import org.eclipse.edc.connector.defaults.storage.ReflectionBasedQueryResolver;
 import org.eclipse.edc.spi.persistence.Lease;
+import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QueryResolver;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.jetbrains.annotations.NotNull;
@@ -99,8 +100,8 @@ public class InMemoryContractNegotiationStore implements ContractNegotiationStor
     }
 
     @Override
-    public @NotNull List<ContractNegotiation> nextForState(int state, int max) {
-        return store.nextForState(state, max);
+    public @NotNull List<ContractNegotiation> nextNotLeased(int max, Criterion... criteria) {
+        return store.leaseAndGet(max, criteria);
     }
 
     @NotNull
@@ -109,4 +110,5 @@ public class InMemoryContractNegotiationStore implements ContractNegotiationStor
                 .map(ContractNegotiation::getContractAgreement)
                 .filter(Objects::nonNull);
     }
+
 }

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/transferprocess/InMemoryTransferProcessStore.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/transferprocess/InMemoryTransferProcessStore.java
@@ -18,6 +18,7 @@ import org.eclipse.edc.connector.defaults.storage.InMemoryStatefulEntityStore;
 import org.eclipse.edc.connector.transfer.spi.store.TransferProcessStore;
 import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.spi.persistence.Lease;
+import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -76,11 +77,12 @@ public class InMemoryTransferProcessStore implements TransferProcessStore {
     }
 
     @Override
-    public @NotNull List<TransferProcess> nextForState(int state, int max) {
-        return store.nextForState(state, max);
+    public @NotNull List<TransferProcess> nextNotLeased(int max, Criterion... criteria) {
+        return store.leaseAndGet(max, criteria);
     }
 
     public Stream<TransferProcess> findAll() {
         return store.findAll();
     }
+
 }

--- a/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/contractnegotiation/InMemoryContractNegotiationStoreTest.java
+++ b/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/contractnegotiation/InMemoryContractNegotiationStoreTest.java
@@ -39,13 +39,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
+import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation.Type.CONSUMER;
+import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation.Type.PROVIDER;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.INITIAL;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.REQUESTED;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.REQUESTING;
+import static org.eclipse.edc.connector.defaults.storage.contractnegotiation.TestFunctions.createNegotiationBuilder;
+import static org.eclipse.edc.spi.persistence.StateEntityStore.hasState;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
@@ -64,7 +68,7 @@ class InMemoryContractNegotiationStoreTest extends ContractNegotiationStoreTestB
     @Test
     void verifyCreateDelete() {
         String id = UUID.randomUUID().toString();
-        var negotiation = TestFunctions.createNegotiationBuilder(id).build();
+        var negotiation = createNegotiationBuilder(id).build();
         negotiation.transitionInitial();
 
         store.save(negotiation);
@@ -115,34 +119,34 @@ class InMemoryContractNegotiationStoreTest extends ContractNegotiationStoreTestB
         negotiation1.transitionRequested();
         store.save(negotiation1);
 
-        var requestingNegotiations = store.nextForState(REQUESTING.code(), 1);
+        var requestingNegotiations = store.nextNotLeased(1, hasState(REQUESTING.code()));
         assertThat(requestingNegotiations).isEmpty();
 
-        var found = store.nextForState(REQUESTED.code(), 1);
+        var found = store.nextNotLeased(1, hasState(REQUESTED.code()));
         assertEquals(1, found.size());
         assertEquals(negotiation2, found.get(0));
 
-        found = store.nextForState(REQUESTED.code(), 3);
+        found = store.nextNotLeased(3, hasState(REQUESTED.code()));
         assertEquals(1, found.size());
         assertEquals(negotiation1, found.get(0));
     }
 
     @Test
-    void nextForState_shouldLeaseEntityUntilSave() {
+    void nextNotLeased_shouldLeaseEntityUntilSave() {
         var negotiation = TestFunctions.createNegotiation("any");
         negotiation.transitionInitial();
         store.save(negotiation);
 
-        var firstQueryResult = store.nextForState(INITIAL.code(), 1);
+        var firstQueryResult = store.nextNotLeased(1, hasState(INITIAL.code()));
         assertThat(firstQueryResult).hasSize(1);
 
-        var secondQueryResult = store.nextForState(INITIAL.code(), 1);
+        var secondQueryResult = store.nextNotLeased(1, hasState(INITIAL.code()));
         assertThat(secondQueryResult).hasSize(0);
 
         var retrieved = firstQueryResult.get(0);
         store.save(retrieved);
 
-        var thirdQueryResult = store.nextForState(INITIAL.code(), 1);
+        var thirdQueryResult = store.nextNotLeased(1, hasState(INITIAL.code()));
         assertThat(thirdQueryResult).hasSize(1);
     }
 
@@ -165,7 +169,7 @@ class InMemoryContractNegotiationStoreTest extends ContractNegotiationStoreTestB
         ContractNegotiation found2 = store.findById(id2);
         assertNotNull(found2);
 
-        var found = store.nextForState(INITIAL.code(), 3);
+        var found = store.nextNotLeased(3, hasState(INITIAL.code()));
         assertEquals(2, found.size());
 
     }
@@ -178,28 +182,44 @@ class InMemoryContractNegotiationStoreTest extends ContractNegotiationStoreTestB
             store.save(negotiation);
         }
 
-        List<ContractNegotiation> processes = store.nextForState(INITIAL.code(), 50);
+        List<ContractNegotiation> processes = store.nextNotLeased(50, hasState(INITIAL.code()));
 
         assertThat(processes).hasSize(50);
         assertThat(processes).allMatch(p -> p.getStateTimestamp() > 0);
     }
 
     @Test
-    void verifyNextForState_avoidsStarvation() {
+    void nextNotLeased_avoidsStarvation() {
         for (int i = 0; i < 10; i++) {
             ContractNegotiation negotiation = TestFunctions.createNegotiation("test-negotiation-" + i);
             negotiation.transitionInitial();
             store.save(negotiation);
         }
 
-        var list1 = store.nextForState(INITIAL.code(), 5);
-        var list2 = store.nextForState(INITIAL.code(), 5);
+        var list1 = store.nextNotLeased(5, hasState(INITIAL.code()));
+        var list2 = store.nextNotLeased(5, hasState(INITIAL.code()));
         assertThat(list1).isNotEqualTo(list2).doesNotContainAnyElementsOf(list2);
     }
 
     @Test
+    void nextNotLeased_typeFilter() {
+        range(0, 5).mapToObj(it -> createNegotiationBuilder("1" + it)
+                .state(REQUESTED.code())
+                .type(PROVIDER)
+                .build()).forEach(store::save);
+        range(5, 10).mapToObj(it -> createNegotiationBuilder("1" + it)
+                .state(REQUESTED.code())
+                .type(CONSUMER)
+                .build()).forEach(store::save);
+
+        var result = store.nextNotLeased(10, hasState(REQUESTED.code()), new Criterion("type", "=", "CONSUMER"));
+
+        assertThat(result).hasSize(5).allMatch(it -> it.getType() == CONSUMER);
+    }
+
+    @Test
     void findAll_noQuerySpec() {
-        IntStream.range(0, 10).forEach(i -> store.save(TestFunctions.createNegotiation("test-neg-" + i)));
+        range(0, 10).forEach(i -> store.save(TestFunctions.createNegotiation("test-neg-" + i)));
 
         var all = store.queryNegotiations(QuerySpec.Builder.newInstance().build());
         assertThat(all).hasSize(10);
@@ -208,7 +228,7 @@ class InMemoryContractNegotiationStoreTest extends ContractNegotiationStoreTestB
     @Test
     void findAll_verifyPaging() {
 
-        IntStream.range(0, 10).forEach(i -> store.save(TestFunctions.createNegotiation("test-neg-" + i)));
+        range(0, 10).forEach(i -> store.save(TestFunctions.createNegotiation("test-neg-" + i)));
 
         // page size fits
         assertThat(store.queryNegotiations(QuerySpec.Builder.newInstance().offset(3).limit(4).build())).hasSize(4);
@@ -219,19 +239,19 @@ class InMemoryContractNegotiationStoreTest extends ContractNegotiationStoreTestB
 
     @Test
     void findAll_verifyFiltering() {
-        IntStream.range(0, 10).forEach(i -> store.save(TestFunctions.createNegotiation("test-neg-" + i)));
+        range(0, 10).forEach(i -> store.save(TestFunctions.createNegotiation("test-neg-" + i)));
         assertThat(store.queryNegotiations(QuerySpec.Builder.newInstance().equalsAsContains(false).filter("id=test-neg-3").build())).extracting(ContractNegotiation::getId).containsOnly("test-neg-3");
     }
 
     @Test
     void findAll_verifyFiltering_invalidFilterExpression() {
-        IntStream.range(0, 10).forEach(i -> store.save(TestFunctions.createNegotiation("test-neg-" + i)));
+        range(0, 10).forEach(i -> store.save(TestFunctions.createNegotiation("test-neg-" + i)));
         assertThatThrownBy(() -> store.queryNegotiations(QuerySpec.Builder.newInstance().filter("something foobar other").build())).isInstanceOfAny(IllegalArgumentException.class);
     }
 
     @Test
     void findAll_verifySorting() {
-        IntStream.range(0, 10).forEach(i -> store.save(TestFunctions.createNegotiation("test-neg-" + i)));
+        range(0, 10).forEach(i -> store.save(TestFunctions.createNegotiation("test-neg-" + i)));
 
         assertThat(store.queryNegotiations(QuerySpec.Builder.newInstance().sortField("id").sortOrder(SortOrder.ASC).build())).hasSize(10).isSortedAccordingTo(Comparator.comparing(ContractNegotiation::getId));
         assertThat(store.queryNegotiations(QuerySpec.Builder.newInstance().sortField("id").sortOrder(SortOrder.DESC).build())).hasSize(10).isSortedAccordingTo((c1, c2) -> c2.getId().compareTo(c1.getId()));
@@ -239,7 +259,7 @@ class InMemoryContractNegotiationStoreTest extends ContractNegotiationStoreTestB
 
     @Test
     void findAll_verifySorting_invalidProperty() {
-        IntStream.range(0, 10).forEach(i -> store.save(TestFunctions.createNegotiation("test-neg-" + i)));
+        range(0, 10).forEach(i -> store.save(TestFunctions.createNegotiation("test-neg-" + i)));
         var query = QuerySpec.Builder.newInstance().sortField("notexist").sortOrder(SortOrder.DESC).build();
 
         var result = store.queryNegotiations(query);
@@ -249,7 +269,7 @@ class InMemoryContractNegotiationStoreTest extends ContractNegotiationStoreTestB
 
     @Test
     void queryAgreements_noQuerySpec() {
-        IntStream.range(0, 10).forEach(i -> {
+        range(0, 10).forEach(i -> {
             var contractAgreement = TestFunctions.createAgreementBuilder().id(ContractId.createContractId(UUID.randomUUID().toString(), TEST_ASSET_ID)).build();
             var negotiation = TestFunctions.createNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
             store.save(negotiation);
@@ -262,7 +282,7 @@ class InMemoryContractNegotiationStoreTest extends ContractNegotiationStoreTestB
 
     @Test
     void queryAgreements_verifyPaging() {
-        IntStream.range(0, 10).forEach(i -> {
+        range(0, 10).forEach(i -> {
             var contractAgreement = TestFunctions.createAgreementBuilder().id(ContractId.createContractId(UUID.randomUUID().toString(), TEST_ASSET_ID)).build();
             var negotiation = TestFunctions.createNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
             store.save(negotiation);
@@ -277,9 +297,9 @@ class InMemoryContractNegotiationStoreTest extends ContractNegotiationStoreTestB
 
     @Test
     void queryAgreements_verifyFiltering() {
-        IntStream.range(0, 10).forEach(i -> {
+        range(0, 10).forEach(i -> {
             var contractAgreement = TestFunctions.createAgreementBuilder().id(i + ":" + i).build();
-            var negotiation = TestFunctions.createNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
+            var negotiation = createNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
             store.save(negotiation);
         });
         var query = QuerySpec.Builder.newInstance().equalsAsContains(false).filter("id=3:3").build();
@@ -291,9 +311,9 @@ class InMemoryContractNegotiationStoreTest extends ContractNegotiationStoreTestB
 
     @Test
     void queryAgreements_verifySorting() {
-        IntStream.range(0, 9).forEach(i -> {
+        range(0, 9).forEach(i -> {
             var contractAgreement = TestFunctions.createAgreementBuilder().id(i + ":" + i).build();
-            var negotiation = TestFunctions.createNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
+            var negotiation = createNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
             store.save(negotiation);
         });
 
@@ -305,9 +325,9 @@ class InMemoryContractNegotiationStoreTest extends ContractNegotiationStoreTestB
 
     @Test
     void queryAgreements_verifySorting_invalidProperty() {
-        IntStream.range(0, 10).forEach(i -> {
+        range(0, 10).forEach(i -> {
             var contractAgreement = TestFunctions.createAgreementBuilder().id(i + ":" + i).build();
-            var negotiation = TestFunctions.createNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
+            var negotiation = createNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
             store.save(negotiation);
         });
 
@@ -319,7 +339,7 @@ class InMemoryContractNegotiationStoreTest extends ContractNegotiationStoreTestB
     @Test
     void getNegotiationsWithAgreementOnAsset_negotiationWithAgreement() {
         var agreement = TestFunctions.createAgreementBuilder().id("contract1").build();
-        var negotiation = TestFunctions.createNegotiationBuilder("negotiation1").contractAgreement(agreement).build();
+        var negotiation = createNegotiationBuilder("negotiation1").contractAgreement(agreement).build();
         var assetId = agreement.getAssetId();
 
         store.save(negotiation);
@@ -337,7 +357,7 @@ class InMemoryContractNegotiationStoreTest extends ContractNegotiationStoreTestB
     void getNegotiationsWithAgreementOnAsset_negotiationWithoutAgreement() {
         var assetId = UUID.randomUUID().toString();
         var negotiation = ContractNegotiation.Builder.newInstance()
-                .type(ContractNegotiation.Type.CONSUMER)
+                .type(CONSUMER)
                 .id("negotiation1")
                 .contractAgreement(null)
                 .correlationId("corr-negotiation1")
@@ -361,8 +381,8 @@ class InMemoryContractNegotiationStoreTest extends ContractNegotiationStoreTestB
     @Test
     void getNegotiationsWithAgreementOnAsset_multipleNegotiationsSameAsset() {
         var assetId = UUID.randomUUID().toString();
-        var negotiation1 = TestFunctions.createNegotiationBuilder("negotiation1").contractAgreement(TestFunctions.createAgreementBuilder().id("contract1").assetId(assetId).build()).build();
-        var negotiation2 = TestFunctions.createNegotiationBuilder("negotiation2").contractAgreement(TestFunctions.createAgreementBuilder().id("contract2").assetId(assetId).build()).build();
+        var negotiation1 = createNegotiationBuilder("negotiation1").contractAgreement(TestFunctions.createAgreementBuilder().id("contract1").assetId(assetId).build()).build();
+        var negotiation2 = createNegotiationBuilder("negotiation2").contractAgreement(TestFunctions.createAgreementBuilder().id("contract2").assetId(assetId).build()).build();
 
         store.save(negotiation1);
         store.save(negotiation2);
@@ -378,7 +398,7 @@ class InMemoryContractNegotiationStoreTest extends ContractNegotiationStoreTestB
 
     @Test
     void findContractAgreement_returnsNullIfAgreementDoesNotExist() {
-        store.save(TestFunctions.createNegotiationBuilder("negotiation1").build());
+        store.save(createNegotiationBuilder("negotiation1").build());
 
         var agreement = store.findContractAgreement("negotiation1");
 
@@ -396,7 +416,7 @@ class InMemoryContractNegotiationStoreTest extends ContractNegotiationStoreTestB
                 .sortField("id")
                 .limit(10).offset(5).build();
 
-        IntStream.range(0, 100)
+        range(0, 100)
                 .mapToObj(i -> org.eclipse.edc.connector.contract.spi.testfixtures.negotiation.store.TestFunctions.createNegotiation(String.valueOf(i)))
                 .forEach(cn -> getContractNegotiationStore().save(cn));
 

--- a/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/contractnegotiation/TestFunctions.java
+++ b/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/contractnegotiation/TestFunctions.java
@@ -46,7 +46,8 @@ public class TestFunctions {
                         .build()))
                 .counterPartyAddress("consumer")
                 .counterPartyId("consumerId")
-                .protocol("ids-multipart");
+                .protocol("ids-multipart")
+                .correlationId("correlationId");
     }
 
     public static ContractAgreement createAgreement() {

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
@@ -90,6 +90,7 @@ import static org.eclipse.edc.connector.transfer.spi.types.TransferProcessStates
 import static org.eclipse.edc.connector.transfer.spi.types.TransferProcessStates.STARTING;
 import static org.eclipse.edc.connector.transfer.spi.types.TransferProcessStates.TERMINATED;
 import static org.eclipse.edc.connector.transfer.spi.types.TransferProcessStates.TERMINATING;
+import static org.eclipse.edc.spi.persistence.StateEntityStore.hasState;
 
 /**
  * This transfer process manager receives a {@link TransferProcess} and transitions it through its internal state
@@ -710,7 +711,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
 
     private StateProcessorImpl<TransferProcess> processTransfersInState(TransferProcessStates state, Function<TransferProcess, Boolean> function) {
         var functionWithTraceContext = telemetry.contextPropagationMiddleware(function);
-        return new StateProcessorImpl<>(() -> transferProcessStore.nextForState(state.code(), batchSize), functionWithTraceContext);
+        return new StateProcessorImpl<>(() -> transferProcessStore.nextNotLeased(batchSize, hasState(state.code())), functionWithTraceContext);
     }
 
     private StateProcessorImpl<TransferProcessCommand> onCommands(Function<TransferProcessCommand, Boolean> process) {

--- a/docs/developer/state-machine.md
+++ b/docs/developer/state-machine.md
@@ -35,7 +35,7 @@ public void stop() { // Called from ServiceExtension shutdown() method
 }
 
 private StateProcessorImpl<StatefulEntityImpl> processEntitiesInState(State state, Function<StatefulEntityImpl, Boolean> function) {
-  return new StateProcessorImpl<>(() -> store.nextForState(state, batchSize), function);
+  return new StateProcessorImpl<>(() -> store.nextNotLeased(batchSize, hasState(state.code())), function);
 }
 
 // Processor functions should return true only if the state machine has been updated
@@ -62,7 +62,9 @@ public void save(StatefulEntityImpl instance) {
   // release lease
 }
 
-public Collection<StatefulEntityImpl> nextForState(State state, int limit) {
-  // retrieve and lease at most limit instances in state
+List<T> nextNotLeased(int max, Criterion... criteria); {
+  // retrieve and lease at most limit instances that satisfy criteria
 }
+
+
 ```

--- a/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/SqlConditionExpression.java
+++ b/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/SqlConditionExpression.java
@@ -81,16 +81,16 @@ public class SqlConditionExpression {
      * <p>
      * Note: {@link Stream} is used to allow a convenient use in a {@code flatMap} call
      */
-    public Stream<String> toStatementParameter() {
-        List<String> result = new ArrayList<>();
+    public Stream<Object> toStatementParameter() {
+        var result = new ArrayList<>();
         result.add(criterion.getOperandLeft().toString());
 
         var operandRight = criterion.getOperandRight();
         if (operandRight instanceof Iterable) {
-            var iterable = (Iterable) operandRight;
-            iterable.forEach(o -> result.add(o.toString()));
+            var iterable = (Iterable<?>) operandRight;
+            iterable.forEach(result::add);
         } else {
-            result.add(operandRight.toString());
+            result.add(operandRight);
         }
         return result.stream();
     }

--- a/extensions/common/sql/sql-lease/src/main/java/org/eclipse/edc/sql/lease/LeaseStatements.java
+++ b/extensions/common/sql/sql-lease/src/main/java/org/eclipse/edc/sql/lease/LeaseStatements.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.edc.sql.lease;
 
+import static java.lang.String.format;
+
 /**
  * Encapsulates statements and table/column names to manipulate lease entities.
  */
@@ -25,6 +27,12 @@ public interface LeaseStatements {
     String getUpdateLeaseTemplate();
 
     String getFindLeaseByEntityTemplate();
+
+    default String getNotLeasedFilter() {
+        return format("(%s IS NULL OR %s IN (SELECT %s FROM %s WHERE (? > (%s + %s))))",
+                getLeaseIdColumn(), getLeaseIdColumn(), getLeaseIdColumn(),
+                getLeaseTableName(), getLeasedAtColumn(), getLeaseDurationColumn());
+    }
 
     default String getLeaseTableName() {
         return "edc_lease";

--- a/extensions/control-plane/store/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/contractnegotiation/CosmosContractNegotiationStoreTest.java
+++ b/extensions/control-plane/store/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/contractnegotiation/CosmosContractNegotiationStoreTest.java
@@ -38,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.edc.connector.store.azure.cosmos.contractnegotiation.TestFunctions.createNegotiationBuilder;
 import static org.eclipse.edc.connector.store.azure.cosmos.contractnegotiation.TestFunctions.generateDocument;
+import static org.eclipse.edc.spi.persistence.StateEntityStore.hasState;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -152,12 +153,12 @@ class CosmosContractNegotiationStoreTest {
     }
 
     @Test
-    void nextForState() {
+    void nextNotLeased() {
         var state = ContractNegotiationStates.AGREED;
         when(cosmosDbApi.invokeStoredProcedure("nextForState", PARTITION_KEY, state.code(), 100, "test-connector"))
                 .thenReturn("[]");
 
-        var result = store.nextForState(state.code(), 100);
+        var result = store.nextNotLeased(100, hasState(state.code()));
 
         assertThat(result).isEmpty();
         verify(cosmosDbApi).invokeStoredProcedure("nextForState", PARTITION_KEY, state.code(), 100, "test-connector");

--- a/extensions/control-plane/store/cosmos/transfer-process-store-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/transferprocess/CosmosTransferProcessStore.java
+++ b/extensions/control-plane/store/cosmos/transfer-process-store-cosmos/src/main/java/org/eclipse/edc/connector/store/azure/cosmos/transferprocess/CosmosTransferProcessStore.java
@@ -32,6 +32,7 @@ import org.eclipse.edc.connector.store.azure.cosmos.transferprocess.model.Transf
 import org.eclipse.edc.connector.transfer.spi.store.TransferProcessStore;
 import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.query.SortOrder;
 import org.eclipse.edc.spi.types.TypeManager;
@@ -40,6 +41,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.time.Clock;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -172,7 +174,12 @@ public class CosmosTransferProcessStore implements TransferProcessStore {
     }
 
     @Override
-    public @NotNull List<TransferProcess> nextForState(int state, int max) {
+    public @NotNull List<TransferProcess> nextNotLeased(int max, Criterion... criteria) {
+        // TODO: https://github.com/eclipse-edc/Connector/issues/2924
+        var state = Arrays.stream(criteria).filter(it -> "state".equals(it.getOperandLeft()))
+                .findFirst().map(Criterion::getOperandRight)
+                .orElseThrow(() -> new EdcException("Missing mandatory 'state' criterion"));
+
         tracingOptions.setMaxBufferedItemCount(max);
 
         var rawJson = with(Fallback.of((String) null), rateLimitRetry, generalRetry)
@@ -191,7 +198,6 @@ public class CosmosTransferProcessStore implements TransferProcessStore {
                 .map(this::convertToDocument)
                 .map(CosmosDocument::getWrappedInstance)
                 .collect(Collectors.toList());
-
     }
 
     private Object findByIdInternal(String processId) {

--- a/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/assetindex/schema/BaseSqlDialectStatements.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/assetindex/schema/BaseSqlDialectStatements.java
@@ -135,6 +135,7 @@ public class BaseSqlDialectStatements implements AssetStatements {
 
         stmt.addParameter(querySpec.getLimit());
         stmt.addParameter(querySpec.getOffset());
+
         return stmt;
     }
 

--- a/extensions/control-plane/store/sql/asset-index-sql/src/test/java/org/eclipse/edc/connector/store/sql/assetindex/SqlConditionExpressionTest.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/test/java/org/eclipse/edc/connector/store/sql/assetindex/SqlConditionExpressionTest.java
@@ -85,4 +85,11 @@ class SqlConditionExpressionTest {
         var e2 = new SqlConditionExpression(new Criterion("key", "in", List.of("item1", "item2")));
         assertThat(e2.toStatementParameter()).containsExactly("key", "item1", "item2");
     }
+
+    @Test
+    void toStatementParameter_keepsValueType() {
+        var e = new SqlConditionExpression(new Criterion("key", "=", 3));
+
+        assertThat(e.toStatementParameter()).containsExactly("key", 3);
+    }
 }

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/docs/schema.sql
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/docs/schema.sql
@@ -46,7 +46,7 @@ CREATE TABLE IF NOT EXISTS edc_contract_negotiation
     counterparty_id      VARCHAR                                            NOT NULL,
     counterparty_address VARCHAR                                            NOT NULL,
     protocol             VARCHAR DEFAULT 'ids-multipart'::CHARACTER VARYING NOT NULL,
-    type                 INTEGER DEFAULT 0                                  NOT NULL,
+    type                 VARCHAR                                            NOT NULL,
     state                INTEGER DEFAULT 0                                  NOT NULL,
     state_count          INTEGER DEFAULT 0,
     state_timestamp      BIGINT,

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/SqlContractNegotiationStore.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/SqlContractNegotiationStore.java
@@ -36,12 +36,13 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Clock;
+import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.lang.String.format;
 import static java.util.Optional.ofNullable;
+import static java.util.stream.Collectors.toList;
 import static org.eclipse.edc.sql.SqlQueryExecutor.executeQuery;
 import static org.eclipse.edc.sql.SqlQueryExecutor.executeQuerySingle;
 
@@ -49,7 +50,6 @@ import static org.eclipse.edc.sql.SqlQueryExecutor.executeQuerySingle;
  * SQL-based implementation of the {@link ContractNegotiationStore}
  */
 public class SqlContractNegotiationStore extends AbstractSqlStore implements ContractNegotiationStore {
-
 
     private final ContractNegotiationStatements statements;
     private final SqlLeaseContextBuilder leaseContext;
@@ -79,7 +79,7 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
             // utilize the generic query api
             var query = QuerySpec.Builder.newInstance().filter(List.of(new Criterion("correlationId", "=", correlationId))).build();
             try (var stream = queryNegotiations(query)) {
-                return single(stream.collect(Collectors.toList()));
+                return single(stream.collect(toList()));
             }
         });
     }
@@ -168,14 +168,19 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
     }
 
     @Override
-    public @NotNull List<ContractNegotiation> nextForState(int state, int max) {
+    public @NotNull List<ContractNegotiation> nextNotLeased(int max, Criterion... criteria) {
         return transactionContext.execute(() -> {
-            var stmt = statements.getNextForStateTemplate();
+            var filter = Arrays.stream(criteria).collect(toList());
+            var querySpec = QuerySpec.Builder.newInstance().filter(filter).limit(max).build();
+            var statement = statements.createNegotiationsQuery(querySpec);
+            statement.addWhereClause(statements.getNotLeasedFilter());
+            statement.addParameter(clock.millis());
+
             try (
                     var connection = getConnection();
-                    var stream = executeQuery(connection, true, contractNegotiationWithAgreementMapper(connection), stmt, state, clock.millis(), max)
+                    var stream = executeQuery(getConnection(), true, contractNegotiationWithAgreementMapper(connection), statement.getQueryAsString(), statement.getParameters())
             ) {
-                var negotiations = stream.collect(Collectors.toList());
+                var negotiations = stream.collect(toList());
                 negotiations.forEach(cn -> leaseContext.withConnection(connection).acquireLease(cn.getId()));
                 return negotiations;
             } catch (SQLException e) {
@@ -228,7 +233,7 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
                 negotiation.getCorrelationId(),
                 negotiation.getCounterPartyId(),
                 negotiation.getCounterPartyAddress(),
-                negotiation.getType().ordinal(),
+                negotiation.getType().name(),
                 negotiation.getProtocol(),
                 negotiation.getState(),
                 negotiation.getStateCount(),
@@ -343,7 +348,7 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
                 .traceContext(fromJson(resultSet.getString(statements.getTraceContextColumn()), new TypeReference<>() {
                 }))
                 // will throw an exception if the value is outside the Type.values() range
-                .type(ContractNegotiation.Type.values()[resultSet.getInt(statements.getTypeColumn())])
+                .type(ContractNegotiation.Type.valueOf(resultSet.getString(statements.getTypeColumn())))
                 .createdAt(resultSet.getLong(statements.getCreatedAtColumn()))
                 .updatedAt(resultSet.getLong(statements.getUpdatedAtColumn()))
                 .build();

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/schema/BaseSqlDialectStatements.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/schema/BaseSqlDialectStatements.java
@@ -60,14 +60,6 @@ public class BaseSqlDialectStatements implements ContractNegotiationStatements {
     }
 
     @Override
-    public String getNextForStateTemplate() {
-        return format("SELECT * FROM %s\n" +
-                "WHERE %s=?\n" +
-                "  AND (%s IS NULL OR %s IN (SELECT %s FROM %s WHERE (? > (%s + %s))))\n" +
-                "LIMIT ?;", getContractNegotiationTable(), getStateColumn(), getLeaseIdColumn(), getLeaseIdColumn(), getLeaseIdColumn(), getLeaseTableName(), getLeasedAtColumn(), getLeaseDurationColumn());
-    }
-
-    @Override
     public String getSelectFromAgreementsTemplate() {
         // todo: add WHERE ... AND ... ORDER BY... statements here
         return format("SELECT * FROM %s", getContractAgreementTable());

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/schema/ContractNegotiationStatements.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/schema/ContractNegotiationStatements.java
@@ -33,8 +33,6 @@ public interface ContractNegotiationStatements extends LeaseStatements {
 
     String getDeleteTemplate();
 
-    String getNextForStateTemplate();
-
     String getSelectFromAgreementsTemplate();
 
     String getInsertAgreementTemplate();
@@ -42,27 +40,6 @@ public interface ContractNegotiationStatements extends LeaseStatements {
     String getUpdateAgreementTemplate();
 
     String getSelectNegotiationsTemplate();
-
-    @Override
-    default String getLeasedByColumn() {
-        return "leased_by";
-    }
-
-    @Override
-    default String getLeasedAtColumn() {
-        return "leased_at";
-    }
-
-    @Override
-    default String getLeaseDurationColumn() {
-        return "lease_duration";
-    }
-
-    @Override
-    default String getLeaseIdColumn() {
-        return "lease_id";
-    }
-
 
     default String getContractNegotiationTable() {
         return "edc_contract_negotiation";

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/BaseSqlDialectStatements.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/BaseSqlDialectStatements.java
@@ -77,16 +77,6 @@ public abstract class BaseSqlDialectStatements implements TransferProcessStoreSt
     }
 
     @Override
-    public String getNextForStateTemplate() {
-        return format("SELECT *, dr.%s as edc_data_request_id FROM %s LEFT OUTER JOIN %s dr ON %s.%s = dr.transfer_process_id " +
-                        "WHERE %s=? " +
-                        "AND (%s IS NULL OR %s IN (SELECT %s FROM %s WHERE (? > (%s + %s)))) " +
-                        "ORDER BY %s ASC LIMIT ? ;",
-                getDataRequestIdColumn(), getTransferProcessTableName(), getDataRequestTable(), getTransferProcessTableName(), getIdColumn(), getStateColumn(), getLeaseIdColumn(), getLeaseIdColumn(), getLeaseIdColumn(),
-                getLeaseTableName(), getLeasedAtColumn(), getLeaseDurationColumn(), getStateTimestampColumn());
-    }
-
-    @Override
     public String getUpdateTransferProcessTemplate() {
         return format("UPDATE %s SET %s=?, %s=?, %s=?, %s=?%s, %s=?, %s=?%s, %s=?%s, %s=?%s, %s=?%s, %s=?%s, %s=? WHERE %s=?",
                 getTransferProcessTableName(), getStateColumn(), getStateCountColumn(), getStateTimestampColumn(),

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/TransferProcessStoreStatements.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/TransferProcessStoreStatements.java
@@ -32,8 +32,6 @@ public interface TransferProcessStoreStatements extends LeaseStatements {
 
     String getDeleteTransferProcessTemplate();
 
-    String getNextForStateTemplate();
-
     String getUpdateTransferProcessTemplate();
 
     String getInsertDataRequestTemplate();

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/postgres/TransferProcessMapping.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/postgres/TransferProcessMapping.java
@@ -27,6 +27,7 @@ public class TransferProcessMapping extends TranslationMapping {
 
     private static final String FIELD_ID = "id";
     private static final String FIELD_TYPE = "type";
+    private static final String FIELD_STATE = "state";
     private static final String FIELD_CREATED_TIMESTAMP = "createdAt";
     private static final String FIELD_TRACECONTEXT = "traceContext";
     private static final String FIELD_ERRORDETAIL = "errorDetail";
@@ -44,6 +45,7 @@ public class TransferProcessMapping extends TranslationMapping {
     public TransferProcessMapping(TransferProcessStoreStatements statements) {
         add(FIELD_ID, statements.getIdColumn());
         add(FIELD_TYPE, statements.getTypeColumn());
+        add(FIELD_STATE, statements.getStateColumn());
         add(FIELD_CREATED_TIMESTAMP, statements.getCreatedAtColumn());
         add(FIELD_TRACECONTEXT, new JsonFieldMapping(statements.getTraceContextColumn()));
         add(FIELD_ERRORDETAIL, statements.getErrorDetailColumn());

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/transferprocess/PostgresTransferProcessStoreTest.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/transferprocess/PostgresTransferProcessStoreTest.java
@@ -59,7 +59,7 @@ class PostgresTransferProcessStoreTest extends TransferProcessStoreTestBase {
     private SqlTransferProcessStore store;
 
     @BeforeEach
-    void setUp(PostgresqlStoreSetupExtension extension) throws IOException, SQLException {
+    void setUp(PostgresqlStoreSetupExtension extension) throws IOException {
 
         var typeManager = new TypeManager();
         typeManager.registerTypes(TestFunctions.TestResourceDef.class, TestFunctions.TestProvisionedResource.class);

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/persistence/StateEntityStore.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/persistence/StateEntityStore.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.spi.persistence;
 
+import org.eclipse.edc.spi.query.Criterion;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -22,6 +23,39 @@ import java.util.List;
  * Define a store that can be used within a state machine
  */
 public interface StateEntityStore<T> {
+
+    /**
+     * Returns a {@link Criterion} to filter state
+     *
+     * @param stateCode the entity state code.
+     * @return a criterion.
+     */
+    static Criterion hasState(int stateCode) {
+        return new Criterion("state", "=", stateCode);
+    }
+
+    /**
+     * Returns a list of not leased entities that satisfy the filter criteria.
+     * <p>
+     * Implementors MUST handle these requirements: <p>
+     * <ul>
+     *     <li>
+     *         * entities should be fetched from the oldest to the newest, by a timestamp that reports the last state transition on the entity
+     *         <p><p>
+     *     </li>
+     *     <li>
+     *         * fetched entities should be leased for a configurable timeout, that will be released after the timeout expires or when the entity will be updated.
+     *         This will avoid consecutive fetches in the state machine loop
+     *         <p><p>
+     *     </li>
+     * </ul>
+     *
+     * @param max      The maximum amount of result items.
+     * @param criteria The selection criteria.
+     * @return A list of entities (at most _max_) that satisfy the selection criteria.
+     */
+    @NotNull
+    List<T> nextNotLeased(int max, Criterion... criteria);
 
     /**
      * Returns a list of entities that are in a specific state.
@@ -42,8 +76,12 @@ public interface StateEntityStore<T> {
      * @param state The state that the processes of interest should be in.
      * @param max   The maximum amount of result items.
      * @return A list of entities (at most _max_) that are in the desired state.
+     * @deprecated please use {@link #nextNotLeased(int, Criterion...)}
      */
     @NotNull
-    List<T> nextForState(int state, int max);
+    @Deprecated(since = "milestone9")
+    default List<T> nextForState(int state, int max) {
+        return nextNotLeased(max, hasState(state));
+    }
 
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/BaseCriterionToPredicateConverter.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/BaseCriterionToPredicateConverter.java
@@ -57,6 +57,12 @@ public abstract class BaseCriterionToPredicateConverter<T> implements CriterionC
             if (property == null) {
                 return false; //property does not exist on t
             }
+
+            if (property.getClass().isEnum() && criterion.getOperandRight() instanceof String) {
+                var enumProperty = (Enum<?>) property;
+                return Objects.equals(enumProperty.name(), criterion.getOperandRight());
+            }
+
             return Objects.equals(property, criterion.getOperandRight());
         };
     }

--- a/spi/common/core-spi/src/test/java/org/eclipse/edc/spi/query/BaseCriterionToPredicateConverterTest.java
+++ b/spi/common/core-spi/src/test/java/org/eclipse/edc/spi/query/BaseCriterionToPredicateConverterTest.java
@@ -21,6 +21,8 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.eclipse.edc.spi.query.BaseCriterionToPredicateConverterTest.TestEnum.ENTRY1;
+import static org.eclipse.edc.spi.query.BaseCriterionToPredicateConverterTest.TestEnum.ENTRY2;
 
 class BaseCriterionToPredicateConverterTest {
 
@@ -52,6 +54,15 @@ class BaseCriterionToPredicateConverterTest {
                 .rejects(new TestObject("third"), new TestObject(""), new TestObject(null));
     }
 
+    @Test
+    void convertEqual_enumShouldCheckEntryName() {
+        var predicate = converter.convert(new Criterion("enumValue", "=", "ENTRY2"));
+
+        assertThat(predicate)
+                .accepts(new TestObject("any", ENTRY2))
+                .rejects(new TestObject("any", ENTRY1), new TestObject("any", null));
+    }
+
     private static class TestCriterionToPredicateConverter extends BaseCriterionToPredicateConverter<TestObject> {
 
         @Override
@@ -62,9 +73,15 @@ class BaseCriterionToPredicateConverterTest {
 
     private static class TestObject {
         private final String value;
+        private final TestEnum enumValue;
 
         private TestObject(String value) {
+            this(value, TestEnum.ENTRY1);
+        }
+
+        private TestObject(String value, TestEnum enumValue) {
             this.value = value;
+            this.enumValue = enumValue;
         }
 
         @Override
@@ -73,5 +90,9 @@ class BaseCriterionToPredicateConverterTest {
                     "value='" + value + '\'' +
                     '}';
         }
+    }
+
+    public enum TestEnum {
+        ENTRY1, ENTRY2;
     }
 }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/store/TransferProcessStore.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/store/TransferProcessStore.java
@@ -59,4 +59,5 @@ public interface TransferProcessStore extends StateEntityStore<TransferProcess> 
      * to return an empty Stream, others will return an unsorted Stream, depending on the backing storage implementation.
      */
     Stream<TransferProcess> findAll(QuerySpec querySpec);
+
 }


### PR DESCRIPTION
## What this PR changes/adds

Introducing a new `nextNotLeased` method in `StateEntityStore` that will permit to filter not leased entity by a custom filter and not only by state as the `nextForState` permitted.

## Why it does that

fix bug

## Further notes

- **BREAKING CHANGE** in SQL ContractNegotiation schema. for some reason, the `type` field was not a string containing "CONSUMER" or "PROVIDER" as done for TransferProcess, but an int containing the `Type` enum ordinal value. This was not only blocking the bugfix, but also dangerous because changing the enum entries order would have been caused a data inconsistency.
  - migration suggestion: to avoid data loss the advice would be to implement a sql migration that will do:
    - create a new column called `type_temp` of type vararg
    - fill the `type_temp` with `CONSUMER` where `type` is 0 and with `PROVIDER` where `type` is 1
    - remove the `type` column
    - rename `type_temp` to `type`
- `nextForState` has been deprecated and all its usages switched to `nextNotLeased`
- `SqlConditionExpression.toStatementParameter` has been stopped from converting `Object`s to `String`s


## Linked Issue(s)

Closes #2923

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
