### PR TITLE
feat(contractNegotiationApi): json-ld all endpoints on ContractNegotiationNewApi and ContractAgreementNewApi

### DIFF
--- a/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/api/management/contractagreement/ContractAgreementNewApi.java
+++ b/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/api/management/contractagreement/ContractAgreementNewApi.java
@@ -22,8 +22,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.json.JsonObject;
-import jakarta.validation.Valid;
-import org.eclipse.edc.api.query.QuerySpecDto;
 import org.eclipse.edc.connector.api.management.contractagreement.model.ContractAgreementDto;
 import org.eclipse.edc.web.spi.ApiErrorDetail;
 
@@ -41,7 +39,7 @@ public interface ContractAgreementNewApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
             }
     )
-    List<JsonObject> queryAllAgreements(@Valid QuerySpecDto querySpecDto);
+    List<JsonObject> queryAllAgreements(JsonObject querySpecDto);
 
     @Operation(description = "Gets an contract agreement with the given ID",
             responses = {

--- a/extensions/control-plane/api/management-api/contract-agreement-api/src/test/java/org/eclipse/edc/connector/api/management/contractagreement/ContractAgreementNewApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-agreement-api/src/test/java/org/eclipse/edc/connector/api/management/contractagreement/ContractAgreementNewApiControllerTest.java
@@ -21,7 +21,6 @@ import org.eclipse.edc.api.query.QuerySpecDto;
 import org.eclipse.edc.connector.api.management.contractagreement.model.ContractAgreementDto;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.spi.contractagreement.ContractAgreementService;
-import org.eclipse.edc.jsonld.TitaniumJsonLd;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.junit.annotations.ApiTest;
 import org.eclipse.edc.policy.model.Policy;
@@ -52,15 +51,21 @@ import static org.mockito.Mockito.when;
 class ContractAgreementNewApiControllerTest extends RestControllerTestBase {
 
     private final ContractAgreementService service = mock(ContractAgreementService.class);
-    private final JsonLd jsonLdService = new TitaniumJsonLd(monitor);
+    private final JsonLd jsonLdService = mock(JsonLd.class);
     private final TypeTransformerRegistry transformerRegistry = mock(TypeTransformerRegistry.class);
 
     @Test
     void queryAllAgreements_whenExists() {
+        var expanded = Json.createObjectBuilder().build();
+        var compacted = Json.createObjectBuilder().build();
+
+        when(transformerRegistry.transform(any(JsonObject.class), eq(QuerySpecDto.class))).thenReturn(Result.success(QuerySpecDto.Builder.newInstance().build()));
         when(transformerRegistry.transform(any(QuerySpecDto.class), eq(QuerySpec.class))).thenReturn(Result.success(QuerySpec.none()));
+        when(jsonLdService.expand(any())).thenReturn(Result.success(Json.createObjectBuilder().build()));
         when(service.query(any(QuerySpec.class))).thenReturn(ServiceResult.success(Stream.of(createContractAgreement("id1"), createContractAgreement("id2"))));
         when(transformerRegistry.transform(any(ContractAgreement.class), eq(ContractAgreementDto.class))).thenReturn(Result.success(createContractAgreementDto(UUID.randomUUID().toString())));
-        when(transformerRegistry.transform(any(ContractAgreementDto.class), eq(JsonObject.class))).thenReturn(Result.success(Json.createObjectBuilder().build()));
+        when(transformerRegistry.transform(any(ContractAgreementDto.class), eq(JsonObject.class))).thenReturn(Result.success(expanded));
+        when(jsonLdService.compact(expanded)).thenReturn(Result.success(compacted));
 
         baseRequest()
                 .contentType(JSON)
@@ -70,6 +75,7 @@ class ContractAgreementNewApiControllerTest extends RestControllerTestBase {
                 .statusCode(200)
                 .body("size()", equalTo(2));
 
+        verify(transformerRegistry).transform(any(JsonObject.class), eq(QuerySpecDto.class));
         verify(transformerRegistry).transform(any(QuerySpecDto.class), eq(QuerySpec.class));
         verify(service).query(any(QuerySpec.class));
         verify(transformerRegistry, times(2)).transform(any(ContractAgreement.class), eq(ContractAgreementDto.class));
@@ -79,8 +85,10 @@ class ContractAgreementNewApiControllerTest extends RestControllerTestBase {
 
     @Test
     void queryAllAgreements_whenNoneExists() {
+        when(transformerRegistry.transform(any(JsonObject.class), eq(QuerySpecDto.class))).thenReturn(Result.success(QuerySpecDto.Builder.newInstance().build()));
         when(transformerRegistry.transform(any(QuerySpecDto.class), eq(QuerySpec.class))).thenReturn(Result.success(QuerySpec.none()));
         when(service.query(any(QuerySpec.class))).thenReturn(ServiceResult.success(Stream.of()));
+        when(jsonLdService.expand(any())).thenReturn(Result.success(Json.createObjectBuilder().build()));
 
         baseRequest()
                 .contentType(JSON)
@@ -90,6 +98,7 @@ class ContractAgreementNewApiControllerTest extends RestControllerTestBase {
                 .statusCode(200)
                 .body("size()", equalTo(0));
 
+        verify(transformerRegistry).transform(any(JsonObject.class), eq(QuerySpecDto.class));
         verify(transformerRegistry).transform(any(QuerySpecDto.class), eq(QuerySpec.class));
         verify(service).query(any(QuerySpec.class));
         verify(transformerRegistry, never()).transform(any(ContractAgreement.class), eq(ContractAgreementDto.class));
@@ -99,10 +108,12 @@ class ContractAgreementNewApiControllerTest extends RestControllerTestBase {
 
     @Test
     void queryAllAgreements_whenTransformationFails() {
+        when(transformerRegistry.transform(any(JsonObject.class), eq(QuerySpecDto.class))).thenReturn(Result.success(QuerySpecDto.Builder.newInstance().build()));
         when(transformerRegistry.transform(any(QuerySpecDto.class), eq(QuerySpec.class))).thenReturn(Result.success(QuerySpec.none()));
         when(service.query(any(QuerySpec.class))).thenReturn(ServiceResult.success(Stream.of(createContractAgreement("id1"), createContractAgreement("id2"))));
         when(transformerRegistry.transform(any(ContractAgreement.class), eq(ContractAgreementDto.class))).thenReturn(Result.success(createContractAgreementDto(UUID.randomUUID().toString())));
         when(transformerRegistry.transform(any(ContractAgreementDto.class), eq(JsonObject.class))).thenReturn(Result.failure("test-failure"));
+        when(jsonLdService.expand(any())).thenReturn(Result.success(Json.createObjectBuilder().build()));
 
         baseRequest()
                 .contentType(JSON)
@@ -112,6 +123,7 @@ class ContractAgreementNewApiControllerTest extends RestControllerTestBase {
                 .statusCode(200)
                 .body("size()", equalTo(0));
 
+        verify(transformerRegistry).transform(any(JsonObject.class), eq(QuerySpecDto.class));
         verify(transformerRegistry).transform(any(QuerySpecDto.class), eq(QuerySpec.class));
         verify(service).query(any(QuerySpec.class));
         verify(transformerRegistry, times(2)).transform(any(ContractAgreement.class), eq(ContractAgreementDto.class));
@@ -125,6 +137,7 @@ class ContractAgreementNewApiControllerTest extends RestControllerTestBase {
         when(service.findById(eq("id1"))).thenReturn(createContractAgreement("id1"));
         when(transformerRegistry.transform(any(ContractAgreement.class), eq(ContractAgreementDto.class))).thenReturn(Result.success(createContractAgreementDto("id1")));
         when(transformerRegistry.transform(any(ContractAgreementDto.class), eq(JsonObject.class))).thenReturn(Result.success(Json.createObjectBuilder().build()));
+        when(jsonLdService.compact(any())).thenReturn(Result.success(Json.createObjectBuilder().build()));
 
         baseRequest()
                 .contentType(JSON)

--- a/extensions/control-plane/api/management-api/contract-agreement-api/src/test/java/org/eclipse/edc/connector/api/management/contractagreement/ContractAgreementNewApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-agreement-api/src/test/java/org/eclipse/edc/connector/api/management/contractagreement/ContractAgreementNewApiControllerTest.java
@@ -21,6 +21,7 @@ import org.eclipse.edc.api.query.QuerySpecDto;
 import org.eclipse.edc.connector.api.management.contractagreement.model.ContractAgreementDto;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.spi.contractagreement.ContractAgreementService;
+import org.eclipse.edc.jsonld.TitaniumJsonLd;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.junit.annotations.ApiTest;
 import org.eclipse.edc.policy.model.Policy;
@@ -51,21 +52,18 @@ import static org.mockito.Mockito.when;
 class ContractAgreementNewApiControllerTest extends RestControllerTestBase {
 
     private final ContractAgreementService service = mock(ContractAgreementService.class);
-    private final JsonLd jsonLdService = mock(JsonLd.class);
+    private final JsonLd jsonLdService = new TitaniumJsonLd(monitor);
     private final TypeTransformerRegistry transformerRegistry = mock(TypeTransformerRegistry.class);
 
     @Test
     void queryAllAgreements_whenExists() {
         var expanded = Json.createObjectBuilder().build();
-        var compacted = Json.createObjectBuilder().build();
 
         when(transformerRegistry.transform(any(JsonObject.class), eq(QuerySpecDto.class))).thenReturn(Result.success(QuerySpecDto.Builder.newInstance().build()));
         when(transformerRegistry.transform(any(QuerySpecDto.class), eq(QuerySpec.class))).thenReturn(Result.success(QuerySpec.none()));
-        when(jsonLdService.expand(any())).thenReturn(Result.success(Json.createObjectBuilder().build()));
         when(service.query(any(QuerySpec.class))).thenReturn(ServiceResult.success(Stream.of(createContractAgreement("id1"), createContractAgreement("id2"))));
         when(transformerRegistry.transform(any(ContractAgreement.class), eq(ContractAgreementDto.class))).thenReturn(Result.success(createContractAgreementDto(UUID.randomUUID().toString())));
         when(transformerRegistry.transform(any(ContractAgreementDto.class), eq(JsonObject.class))).thenReturn(Result.success(expanded));
-        when(jsonLdService.compact(expanded)).thenReturn(Result.success(compacted));
 
         baseRequest()
                 .contentType(JSON)
@@ -88,7 +86,6 @@ class ContractAgreementNewApiControllerTest extends RestControllerTestBase {
         when(transformerRegistry.transform(any(JsonObject.class), eq(QuerySpecDto.class))).thenReturn(Result.success(QuerySpecDto.Builder.newInstance().build()));
         when(transformerRegistry.transform(any(QuerySpecDto.class), eq(QuerySpec.class))).thenReturn(Result.success(QuerySpec.none()));
         when(service.query(any(QuerySpec.class))).thenReturn(ServiceResult.success(Stream.of()));
-        when(jsonLdService.expand(any())).thenReturn(Result.success(Json.createObjectBuilder().build()));
 
         baseRequest()
                 .contentType(JSON)
@@ -113,7 +110,6 @@ class ContractAgreementNewApiControllerTest extends RestControllerTestBase {
         when(service.query(any(QuerySpec.class))).thenReturn(ServiceResult.success(Stream.of(createContractAgreement("id1"), createContractAgreement("id2"))));
         when(transformerRegistry.transform(any(ContractAgreement.class), eq(ContractAgreementDto.class))).thenReturn(Result.success(createContractAgreementDto(UUID.randomUUID().toString())));
         when(transformerRegistry.transform(any(ContractAgreementDto.class), eq(JsonObject.class))).thenReturn(Result.failure("test-failure"));
-        when(jsonLdService.expand(any())).thenReturn(Result.success(Json.createObjectBuilder().build()));
 
         baseRequest()
                 .contentType(JSON)
@@ -137,7 +133,6 @@ class ContractAgreementNewApiControllerTest extends RestControllerTestBase {
         when(service.findById(eq("id1"))).thenReturn(createContractAgreement("id1"));
         when(transformerRegistry.transform(any(ContractAgreement.class), eq(ContractAgreementDto.class))).thenReturn(Result.success(createContractAgreementDto("id1")));
         when(transformerRegistry.transform(any(ContractAgreementDto.class), eq(JsonObject.class))).thenReturn(Result.success(Json.createObjectBuilder().build()));
-        when(jsonLdService.compact(any())).thenReturn(Result.success(Json.createObjectBuilder().build()));
 
         baseRequest()
                 .contentType(JSON)

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiExtension.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiExtension.java
@@ -21,7 +21,7 @@ import org.eclipse.edc.connector.api.management.contractnegotiation.transform.Co
 import org.eclipse.edc.connector.api.management.contractnegotiation.transform.ContractNegotiationToContractNegotiationDtoTransformer;
 import org.eclipse.edc.connector.api.management.contractnegotiation.transform.JsonObjectFromContractAgreementDtoTransformer;
 import org.eclipse.edc.connector.api.management.contractnegotiation.transform.JsonObjectFromContractNegotiationDtoTransformer;
-import org.eclipse.edc.connector.api.management.contractnegotiation.transform.JsonObjectFromStateTransformer;
+import org.eclipse.edc.connector.api.management.contractnegotiation.transform.JsonObjectFromNegotiationStateTransformer;
 import org.eclipse.edc.connector.api.management.contractnegotiation.transform.JsonObjectToNegotiationInitiateRequestDtoTransformer;
 import org.eclipse.edc.connector.api.management.contractnegotiation.transform.NegotiationInitiateRequestDtoToDataRequestTransformer;
 import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationService;
@@ -73,8 +73,8 @@ public class ContractNegotiationApiExtension implements ServiceExtension {
         transformerRegistry.register(new JsonObjectFromContractNegotiationDtoTransformer(factory));
         transformerRegistry.register(new JsonObjectFromContractAgreementDtoTransformer(factory));
         transformerRegistry.register(new JsonObjectToNegotiationInitiateRequestDtoTransformer());
-        transformerRegistry.register(new JsonObjectFromStateTransformer(factory));
-        
+        transformerRegistry.register(new JsonObjectFromNegotiationStateTransformer(factory));
+
         var monitor = context.getMonitor();
 
         webService.registerResource(config.getContextAlias(), new ContractNegotiationApiController(monitor, service, transformerRegistry));

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiExtension.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiExtension.java
@@ -21,6 +21,7 @@ import org.eclipse.edc.connector.api.management.contractnegotiation.transform.Co
 import org.eclipse.edc.connector.api.management.contractnegotiation.transform.ContractNegotiationToContractNegotiationDtoTransformer;
 import org.eclipse.edc.connector.api.management.contractnegotiation.transform.JsonObjectFromContractAgreementDtoTransformer;
 import org.eclipse.edc.connector.api.management.contractnegotiation.transform.JsonObjectFromContractNegotiationDtoTransformer;
+import org.eclipse.edc.connector.api.management.contractnegotiation.transform.JsonObjectFromStateTransformer;
 import org.eclipse.edc.connector.api.management.contractnegotiation.transform.JsonObjectToNegotiationInitiateRequestDtoTransformer;
 import org.eclipse.edc.connector.api.management.contractnegotiation.transform.NegotiationInitiateRequestDtoToDataRequestTransformer;
 import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationService;
@@ -72,7 +73,8 @@ public class ContractNegotiationApiExtension implements ServiceExtension {
         transformerRegistry.register(new JsonObjectFromContractNegotiationDtoTransformer(factory));
         transformerRegistry.register(new JsonObjectFromContractAgreementDtoTransformer(factory));
         transformerRegistry.register(new JsonObjectToNegotiationInitiateRequestDtoTransformer());
-
+        transformerRegistry.register(new JsonObjectFromStateTransformer(factory));
+        
         var monitor = context.getMonitor();
 
         webService.registerResource(config.getContextAlias(), new ContractNegotiationApiController(monitor, service, transformerRegistry));

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationNewApi.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationNewApi.java
@@ -24,9 +24,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.json.JsonObject;
-import jakarta.validation.Valid;
 import org.eclipse.edc.api.model.IdResponseDto;
-import org.eclipse.edc.api.query.QuerySpecDto;
 import org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractAgreementDto;
 import org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractNegotiationDto;
 import org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto;
@@ -46,7 +44,7 @@ public interface ContractNegotiationNewApi {
                     @ApiResponse(responseCode = "400", description = "Request was malformed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))) }
     )
-    List<JsonObject> queryNegotiations(@Valid QuerySpecDto querySpecDto);
+    List<JsonObject> queryNegotiations(JsonObject querySpecDto);
 
     @Operation(description = "Gets a contract negotiation with the given ID",
             responses = {
@@ -71,7 +69,7 @@ public interface ContractNegotiationNewApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
             }
     )
-    NegotiationState getNegotiationState(String id);
+    JsonObject getNegotiationState(String id);
 
     @Operation(description = "Gets a contract agreement for a contract negotiation with the given ID",
             responses = {
@@ -97,7 +95,7 @@ public interface ContractNegotiationNewApi {
                     @ApiResponse(responseCode = "400", description = "Request body was malformed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))),
             })
-    IdResponseDto initiateContractNegotiation(@Schema(implementation = NegotiationInitiateRequestDto.class) JsonObject requestDto);
+    JsonObject initiateContractNegotiation(@Schema(implementation = NegotiationInitiateRequestDto.class) JsonObject requestDto);
 
     @Operation(description = "Requests aborting the contract negotiation. Due to the asynchronous nature of contract negotiations, a successful " +
             "response only indicates that the request was successfully received. Clients must poll the /{id}/state endpoint to track the state.",

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationNewApiController.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationNewApiController.java
@@ -17,7 +17,6 @@
 package org.eclipse.edc.connector.api.management.contractnegotiation;
 
 import jakarta.json.JsonObject;
-import jakarta.validation.Valid;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
@@ -45,6 +44,7 @@ import org.eclipse.edc.web.spi.exception.ObjectNotFoundException;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static java.util.Optional.ofNullable;
@@ -70,10 +70,17 @@ public class ContractNegotiationNewApiController implements ContractNegotiationN
     @POST
     @Path("/request")
     @Override
-    public List<JsonObject> queryNegotiations(@Valid QuerySpecDto querySpecDto) {
-        querySpecDto = ofNullable(querySpecDto).orElse(QuerySpecDto.Builder.newInstance().build());
+    public List<JsonObject> queryNegotiations(JsonObject querySpecDto) {
 
-        var spec = transformerRegistry.transform(querySpecDto, QuerySpec.class)
+        Function<Result<JsonObject>, Result<QuerySpec>> expandedMapper =
+                expandedResult -> expandedResult
+                        .compose(jsonObject -> transformerRegistry.transform(jsonObject, QuerySpecDto.class))
+                        .compose(dto -> transformerRegistry.transform(dto, QuerySpec.class));
+
+        var spec = ofNullable(querySpecDto)
+                .map(jsonLdService::expand)
+                .map(expandedMapper)
+                .orElse(Result.success(QuerySpec.Builder.newInstance().build()))
                 .orElseThrow(InvalidRequestException::new);
 
         try (var stream = service.query(spec).orElseThrow(exceptionMapper(ContractNegotiation.class, null))) {
@@ -105,11 +112,13 @@ public class ContractNegotiationNewApiController implements ContractNegotiationN
     @GET
     @Path("/{id}/state")
     @Override
-    public NegotiationState getNegotiationState(@PathParam("id") String id) {
+    public JsonObject getNegotiationState(@PathParam("id") String id) {
         return Optional.of(id)
                 .map(service::getState)
                 .map(NegotiationState::new)
-                .orElseThrow(() -> new ObjectNotFoundException(ContractNegotiation.class, id));
+                .map(state -> transformerRegistry.transform(state, JsonObject.class).compose(jsonLdService::compact))
+                .orElseThrow(() -> new ObjectNotFoundException(ContractNegotiation.class, id))
+                .orElseThrow(failure -> new EdcException(failure.getFailureDetail()));
     }
 
     @GET
@@ -127,17 +136,22 @@ public class ContractNegotiationNewApiController implements ContractNegotiationN
 
     @POST
     @Override
-    public IdResponseDto initiateContractNegotiation(JsonObject requestObject) {
+    public JsonObject initiateContractNegotiation(JsonObject requestObject) {
         var contractRequest = transformerRegistry.transform(requestObject, NegotiationInitiateRequestDto.class)
                 .compose(dto -> transformerRegistry.transform(dto, ContractRequest.class))
                 .orElseThrow(InvalidRequestException::new);
 
 
         var contractNegotiation = service.initiateNegotiation(contractRequest);
-        return IdResponseDto.Builder.newInstance()
+
+        var responseDto = IdResponseDto.Builder.newInstance()
                 .id(contractNegotiation.getId())
                 .createdAt(contractNegotiation.getCreatedAt())
                 .build();
+
+        return transformerRegistry.transform(responseDto, JsonObject.class)
+                .compose(jsonLdService::compact)
+                .orElseThrow(f -> new EdcException("Error creating response body: " + f.getFailureDetail()));
     }
 
     @POST

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/model/NegotiationState.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/model/NegotiationState.java
@@ -16,10 +16,15 @@ package org.eclipse.edc.connector.api.management.contractnegotiation.model;
 
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates;
 
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
+
 /**
  * Wrapper for {@link ContractNegotiationStates} formatted as String. Used to format a simple string as JSON.
  */
 public class NegotiationState {
+
+    public static final String TYPE = EDC_NAMESPACE + "NegotiationState";
+    public static final String STATE = EDC_NAMESPACE + "state";
     private final String state;
 
     public NegotiationState(String state) {

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/model/NegotiationState.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/model/NegotiationState.java
@@ -23,8 +23,8 @@ import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
  */
 public class NegotiationState {
 
-    public static final String TYPE = EDC_NAMESPACE + "NegotiationState";
-    public static final String STATE = EDC_NAMESPACE + "state";
+    public static final String NEGOTIATION_STATE_TYPE = EDC_NAMESPACE + "NegotiationState";
+    public static final String NEGOTIATION_STATE_STATE = EDC_NAMESPACE + "state";
     private final String state;
 
     public NegotiationState(String state) {

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectFromNegotiationStateTransformer.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectFromNegotiationStateTransformer.java
@@ -22,12 +22,14 @@ import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationState.NEGOTIATION_STATE_STATE;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationState.NEGOTIATION_STATE_TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 
-public class JsonObjectFromStateTransformer extends AbstractJsonLdTransformer<NegotiationState, JsonObject> {
+public class JsonObjectFromNegotiationStateTransformer extends AbstractJsonLdTransformer<NegotiationState, JsonObject> {
     private final JsonBuilderFactory jsonFactory;
 
-    public JsonObjectFromStateTransformer(JsonBuilderFactory jsonFactory) {
+    public JsonObjectFromNegotiationStateTransformer(JsonBuilderFactory jsonFactory) {
         super(NegotiationState.class, JsonObject.class);
         this.jsonFactory = jsonFactory;
     }
@@ -35,8 +37,8 @@ public class JsonObjectFromStateTransformer extends AbstractJsonLdTransformer<Ne
     @Override
     public @Nullable JsonObject transform(@NotNull NegotiationState dto, @NotNull TransformerContext context) {
         return jsonFactory.createObjectBuilder()
-                .add(TYPE, NegotiationState.TYPE)
-                .add(NegotiationState.STATE, dto.getState())
+                .add(TYPE, NEGOTIATION_STATE_TYPE)
+                .add(NEGOTIATION_STATE_STATE, dto.getState())
                 .build();
     }
 }

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectFromStateTransformer.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectFromStateTransformer.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.contractnegotiation.transform;
+
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationState;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+
+public class JsonObjectFromStateTransformer extends AbstractJsonLdTransformer<NegotiationState, JsonObject> {
+    private final JsonBuilderFactory jsonFactory;
+
+    public JsonObjectFromStateTransformer(JsonBuilderFactory jsonFactory) {
+        super(NegotiationState.class, JsonObject.class);
+        this.jsonFactory = jsonFactory;
+    }
+
+    @Override
+    public @Nullable JsonObject transform(@NotNull NegotiationState dto, @NotNull TransformerContext context) {
+        return jsonFactory.createObjectBuilder()
+                .add(TYPE, NegotiationState.TYPE)
+                .add(NegotiationState.STATE, dto.getState())
+                .build();
+    }
+}

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectFromNegotiationStateTransformerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectFromNegotiationStateTransformerTest.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.contractnegotiation.transform;
+
+import jakarta.json.Json;
+import org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationState;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationState.NEGOTIATION_STATE_STATE;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationState.NEGOTIATION_STATE_TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.mockito.Mockito.mock;
+
+public class JsonObjectFromNegotiationStateTransformerTest {
+
+    private JsonObjectFromNegotiationStateTransformer transformer;
+
+
+    @BeforeEach
+    void setUp() {
+        transformer = new JsonObjectFromNegotiationStateTransformer(Json.createBuilderFactory(Map.of()));
+    }
+
+
+    @Test
+    void transform() {
+
+        var state = "FINALIZED";
+        var negotiationState = new NegotiationState(state);
+        var context = mock(TransformerContext.class);
+        var jsonObject = transformer.transform(negotiationState, context);
+
+        assertThat(jsonObject).isNotNull();
+        assertThat(jsonObject.getString(TYPE)).isEqualTo(NEGOTIATION_STATE_TYPE);
+        assertThat(jsonObject.getString(NEGOTIATION_STATE_STATE)).isEqualTo(state);
+    }
+}

--- a/resources/openapi/yaml/management-api/contract-agreement-api.yaml
+++ b/resources/openapi/yaml/management-api/contract-agreement-api.yaml
@@ -133,7 +133,25 @@ paths:
         content:
           '*/*':
             schema:
-              $ref: '#/components/schemas/QuerySpecDto'
+              type: object
+              additionalProperties:
+                $ref: '#/components/schemas/JsonValue'
+              example: null
+              properties:
+                empty:
+                  type: boolean
+                  example: null
+                valueType:
+                  type: string
+                  enum:
+                  - ARRAY
+                  - OBJECT
+                  - STRING
+                  - NUMBER
+                  - "TRUE"
+                  - "FALSE"
+                  - "NULL"
+                  example: null
       responses:
         "200":
           content:

--- a/resources/openapi/yaml/management-api/contract-negotiation-api.yaml
+++ b/resources/openapi/yaml/management-api/contract-negotiation-api.yaml
@@ -387,7 +387,25 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/QuerySpecDto'
+              type: object
+              additionalProperties:
+                $ref: '#/components/schemas/JsonValue'
+              example: null
+              properties:
+                empty:
+                  type: boolean
+                  example: null
+                valueType:
+                  type: string
+                  enum:
+                  - ARRAY
+                  - OBJECT
+                  - STRING
+                  - NUMBER
+                  - "TRUE"
+                  - "FALSE"
+                  - "NULL"
+                  example: null
       responses:
         "200":
           content:


### PR DESCRIPTION

## What this PR changes/adds

Use JSON-LD obejects in all endpoints of `ContractNegotiationNewControllerApi` and `ContractAgreementNewApi`

## Why it does that

consistency

## Linked Issue(s)

Closes #2939 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
