### PR TITLE
feat: transform ODRL logical constraints

### DIFF
--- a/data-protocols/dsp/dsp-transform/src/main/java/org/eclipse/edc/protocol/dsp/transform/DspTransformExtension.java
+++ b/data-protocols/dsp/dsp-transform/src/main/java/org/eclipse/edc/protocol/dsp/transform/DspTransformExtension.java
@@ -23,12 +23,14 @@ import org.eclipse.edc.jsonld.transformer.from.JsonObjectFromDistributionTransfo
 import org.eclipse.edc.jsonld.transformer.from.JsonObjectFromPolicyTransformer;
 import org.eclipse.edc.jsonld.transformer.to.JsonObjectToActionTransformer;
 import org.eclipse.edc.jsonld.transformer.to.JsonObjectToAssetTransformer;
+import org.eclipse.edc.jsonld.transformer.to.JsonObjectToAtomicConstraintTransformer;
 import org.eclipse.edc.jsonld.transformer.to.JsonObjectToCatalogTransformer;
 import org.eclipse.edc.jsonld.transformer.to.JsonObjectToConstraintTransformer;
 import org.eclipse.edc.jsonld.transformer.to.JsonObjectToDataServiceTransformer;
 import org.eclipse.edc.jsonld.transformer.to.JsonObjectToDatasetTransformer;
 import org.eclipse.edc.jsonld.transformer.to.JsonObjectToDistributionTransformer;
 import org.eclipse.edc.jsonld.transformer.to.JsonObjectToDutyTransformer;
+import org.eclipse.edc.jsonld.transformer.to.JsonObjectToMultiplicityConstraintTransformer;
 import org.eclipse.edc.jsonld.transformer.to.JsonObjectToPermissionTransformer;
 import org.eclipse.edc.jsonld.transformer.to.JsonObjectToPolicyTransformer;
 import org.eclipse.edc.jsonld.transformer.to.JsonObjectToProhibitionTransformer;
@@ -92,6 +94,8 @@ public class DspTransformExtension implements ServiceExtension {
         registry.register(new JsonObjectToDutyTransformer());
         registry.register(new JsonObjectToActionTransformer());
         registry.register(new JsonObjectToConstraintTransformer());
+        registry.register(new JsonObjectToAtomicConstraintTransformer());
+        registry.register(new JsonObjectToMultiplicityConstraintTransformer());
         registry.register(new JsonValueToGenericTypeTransformer(mapper));
         registry.register(new JsonObjectToAssetTransformer());
     }

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToAtomicConstraintTransformer.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToAtomicConstraintTransformer.java
@@ -1,0 +1,90 @@
+/*
+ *  Copyright (c) 2023 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.jsonld.transformer.to;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonString;
+import jakarta.json.JsonValue;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.policy.model.AtomicConstraint;
+import org.eclipse.edc.policy.model.LiteralExpression;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Consumer;
+
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_LEFT_OPERAND_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_OPERATOR_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_RIGHT_OPERAND_ATTRIBUTE;
+
+/**
+ * Converts from an ODRL constraint as a {@link JsonObject} in JSON-LD expanded form to an {@link AtomicConstraint}.
+ */
+public class JsonObjectToAtomicConstraintTransformer extends AbstractJsonLdTransformer<JsonObject, AtomicConstraint> {
+    
+    public JsonObjectToAtomicConstraintTransformer() {
+        super(JsonObject.class, AtomicConstraint.class);
+    }
+    
+    @Override
+    public @Nullable AtomicConstraint transform(@NotNull JsonObject object, @NotNull TransformerContext context) {
+        var builder = AtomicConstraint.Builder.newInstance();
+        visitProperties(object, (key, value) -> transformProperties(key, value, builder, context));
+        return builderResult(builder::build, context);
+    }
+    
+    private void transformProperties(String key, JsonValue value, AtomicConstraint.Builder builder, TransformerContext context) {
+        if (ODRL_LEFT_OPERAND_ATTRIBUTE.equals(key)) {
+            transformOperand(value, builder::leftExpression, context);
+        } else if (ODRL_OPERATOR_ATTRIBUTE.equals(key)) {
+            transformOperator(value, builder, context);
+        } else if (ODRL_RIGHT_OPERAND_ATTRIBUTE.equals(key)) {
+            transformOperand(value, builder::rightExpression, context);
+        }
+    }
+    
+    private void transformOperand(JsonValue value, Consumer<LiteralExpression> builderFunction, TransformerContext context) {
+        if (value instanceof JsonObject) {
+            var object = (JsonObject) value;
+            var operand = new LiteralExpression(object.getString(VALUE));
+            builderFunction.accept(operand);
+        } else if (value instanceof JsonArray) {
+            var array = (JsonArray) value;
+            transformOperand(array.getJsonObject(0), builderFunction, context);
+        } else {
+            context.reportProblem("Invalid operand property");
+        }
+    }
+    
+    private void transformOperator(JsonValue value, AtomicConstraint.Builder builder, TransformerContext context) {
+        if (value instanceof JsonString) {
+            var string = (JsonString) value;
+            var operator = Operator.valueOf(string.getString());
+            builder.operator(operator);
+        } else if (value instanceof JsonObject) {
+            var object = (JsonObject) value;
+            transformOperator(object.getJsonString(VALUE), builder, context);
+        } else if (value instanceof JsonArray) {
+            var array = (JsonArray) value;
+            transformOperator(array.getJsonObject(0), builder, context);
+        } else {
+            context.reportProblem("Invalid operator property");
+        }
+    }
+}

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToMultiplicityConstraintTransformer.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToMultiplicityConstraintTransformer.java
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (c) 2023 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.jsonld.transformer.to;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.policy.model.AndConstraint;
+import org.eclipse.edc.policy.model.Constraint;
+import org.eclipse.edc.policy.model.MultiplicityConstraint;
+import org.eclipse.edc.policy.model.OrConstraint;
+import org.eclipse.edc.policy.model.XoneConstraint;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static java.lang.String.format;
+import static java.lang.String.join;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_AND_CONSTRAINT_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_OPERAND_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_OR_CONSTRAINT_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_XONE_CONSTRAINT_ATTRIBUTE;
+
+/**
+ * Converts from an ODRL logical constraint as a {@link JsonObject} in JSON-LD expanded form to a {@link MultiplicityConstraint}.
+ */
+public class JsonObjectToMultiplicityConstraintTransformer extends AbstractJsonLdTransformer<JsonObject, MultiplicityConstraint> {
+    
+    public JsonObjectToMultiplicityConstraintTransformer() {
+        super(JsonObject.class, MultiplicityConstraint.class);
+    }
+    
+    @Override
+    public @Nullable MultiplicityConstraint transform(@NotNull JsonObject object, @NotNull TransformerContext context) {
+        var operand = object.getJsonObject(ODRL_OPERAND_ATTRIBUTE);
+        
+        if (operand.containsKey(ODRL_AND_CONSTRAINT_ATTRIBUTE)) {
+            var builder = transformConstraints(operand.getJsonArray(ODRL_AND_CONSTRAINT_ATTRIBUTE), AndConstraint.Builder.newInstance(), context);
+            return builderResult(builder::build, context);
+        } else if (operand.containsKey(ODRL_OR_CONSTRAINT_ATTRIBUTE)) {
+            var builder = transformConstraints(operand.getJsonArray(ODRL_OR_CONSTRAINT_ATTRIBUTE), OrConstraint.Builder.newInstance(), context);
+            return builderResult(builder::build, context);
+        } else if (operand.containsKey(ODRL_XONE_CONSTRAINT_ATTRIBUTE)) {
+            var builder = transformConstraints(operand.getJsonArray(ODRL_XONE_CONSTRAINT_ATTRIBUTE), XoneConstraint.Builder.newInstance(), context);
+            return builderResult(builder::build, context);
+        } else {
+            context.reportProblem(format("Unsupported logical constraint encountered: expected one of [%s, %s, %s] but got [%s]",
+                    ODRL_AND_CONSTRAINT_ATTRIBUTE, ODRL_OR_CONSTRAINT_ATTRIBUTE, ODRL_XONE_CONSTRAINT_ATTRIBUTE,
+                    join(", ", operand.keySet())));
+            return null;
+        }
+    }
+    
+    private MultiplicityConstraint.Builder transformConstraints(JsonArray constraints, MultiplicityConstraint.Builder builder, TransformerContext context) {
+        if (constraints != null) {
+            constraints.forEach(c -> builder.constraint(context.transform(c, Constraint.class)));
+        }
+
+        return builder;
+    }
+
+}

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/from/JsonObjectFromPolicyTransformerTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/from/JsonObjectFromPolicyTransformerTest.java
@@ -40,22 +40,25 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ACTION_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ACTION_TYPE_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_AND_CONSTRAINT_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_CONSEQUENCE_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_CONSTRAINT_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_DUTY_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_INCLUDED_IN_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_LEFT_OPERAND_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_OBLIGATION_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_OPERAND_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_OPERATOR_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_OR_CONSTRAINT_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_PERMISSION_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_PROHIBITION_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_REFINEMENT_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_RIGHT_OPERAND_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_XONE_CONSTRAINT_ATTRIBUTE;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 class JsonObjectFromPolicyTransformerTest {
@@ -241,7 +244,7 @@ class JsonObjectFromPolicyTransformerTest {
     }
     
     @Test
-    void transform_andConstraint_reportProblem() {
+    void transform_andConstraint_returnJsonObject() {
         var constraint = getConstraint();
         var andConstraint = AndConstraint.Builder.newInstance().constraint(constraint).build();
         var permission = Permission.Builder.newInstance()
@@ -255,13 +258,18 @@ class JsonObjectFromPolicyTransformerTest {
         var permissionJson = result.get(ODRL_PERMISSION_ATTRIBUTE).asJsonArray().get(0).asJsonObject();
         assertThat(permissionJson.getJsonArray(ODRL_CONSTRAINT_ATTRIBUTE))
                 .isNotNull()
-                .isEmpty();
+                .hasSize(1);
         
-        verify(context, times(1)).reportProblem(anyString());
+        var constraintJson = permissionJson.getJsonArray(ODRL_CONSTRAINT_ATTRIBUTE).get(0);
+        var operandJson = constraintJson.asJsonObject().getJsonObject(ODRL_OPERAND_ATTRIBUTE);
+        assertThat(operandJson.asJsonObject().containsKey(ODRL_AND_CONSTRAINT_ATTRIBUTE));
+        assertThat(operandJson.getJsonArray(ODRL_AND_CONSTRAINT_ATTRIBUTE)).hasSize(1);
+    
+        verify(context, never()).reportProblem(anyString());
     }
     
     @Test
-    void transform_orConstraint_reportProblem() {
+    void transform_orConstraint_returnJsonObject() {
         var constraint = getConstraint();
         var orConstraint = OrConstraint.Builder.newInstance().constraint(constraint).build();
         var permission = Permission.Builder.newInstance()
@@ -275,13 +283,18 @@ class JsonObjectFromPolicyTransformerTest {
         var permissionJson = result.get(ODRL_PERMISSION_ATTRIBUTE).asJsonArray().get(0).asJsonObject();
         assertThat(permissionJson.getJsonArray(ODRL_CONSTRAINT_ATTRIBUTE))
                 .isNotNull()
-                .isEmpty();
-        
-        verify(context, times(1)).reportProblem(anyString());
+                .hasSize(1);
+    
+        var constraintJson = permissionJson.getJsonArray(ODRL_CONSTRAINT_ATTRIBUTE).get(0);
+        var operandJson = constraintJson.asJsonObject().getJsonObject(ODRL_OPERAND_ATTRIBUTE);
+        assertThat(operandJson.asJsonObject().containsKey(ODRL_OR_CONSTRAINT_ATTRIBUTE));
+        assertThat(operandJson.getJsonArray(ODRL_OR_CONSTRAINT_ATTRIBUTE)).hasSize(1);
+    
+        verify(context, never()).reportProblem(anyString());
     }
     
     @Test
-    void transform_xoneConstraint_reportProblem() {
+    void transform_xoneConstraint_returnJsonObject() {
         var constraint = getConstraint();
         var xoneConstraint = XoneConstraint.Builder.newInstance().constraint(constraint).build();
         var permission = Permission.Builder.newInstance()
@@ -295,9 +308,14 @@ class JsonObjectFromPolicyTransformerTest {
         var permissionJson = result.get(ODRL_PERMISSION_ATTRIBUTE).asJsonArray().get(0).asJsonObject();
         assertThat(permissionJson.getJsonArray(ODRL_CONSTRAINT_ATTRIBUTE))
                 .isNotNull()
-                .isEmpty();
-        
-        verify(context, times(1)).reportProblem(anyString());
+                .hasSize(1);
+    
+        var constraintJson = permissionJson.getJsonArray(ODRL_CONSTRAINT_ATTRIBUTE).get(0);
+        var operandJson = constraintJson.asJsonObject().getJsonObject(ODRL_OPERAND_ATTRIBUTE);
+        assertThat(operandJson.asJsonObject().containsKey(ODRL_XONE_CONSTRAINT_ATTRIBUTE));
+        assertThat(operandJson.getJsonArray(ODRL_XONE_CONSTRAINT_ATTRIBUTE)).hasSize(1);
+    
+        verify(context, never()).reportProblem(anyString());
     }
     
     private Action getAction() {

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToAtomicConstraintTransformerTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToAtomicConstraintTransformerTest.java
@@ -1,0 +1,140 @@
+/*
+ *  Copyright (c) 2023 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.jsonld.transformer.to;
+
+import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
+import org.eclipse.edc.policy.model.AtomicConstraint;
+import org.eclipse.edc.policy.model.LiteralExpression;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_LEFT_OPERAND_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_OPERATOR_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_RIGHT_OPERAND_ATTRIBUTE;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+class JsonObjectToAtomicConstraintTransformerTest {
+    
+    private JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
+    private TransformerContext context = mock(TransformerContext.class);
+    
+    private JsonObjectToAtomicConstraintTransformer transformer;
+    
+    @BeforeEach
+    void setUp() {
+        transformer = new JsonObjectToAtomicConstraintTransformer();
+    }
+    
+    @Test
+    void transform_attributesAsObjects_returnConstraint() {
+        var left = "left";
+        var operator = Operator.EQ;
+        var right = "right";
+        
+        var constraint = jsonFactory.createObjectBuilder()
+                .add(ODRL_LEFT_OPERAND_ATTRIBUTE, jsonFactory.createObjectBuilder()
+                        .add(VALUE, left))
+                .add(ODRL_OPERATOR_ATTRIBUTE, jsonFactory.createObjectBuilder()
+                        .add(VALUE, operator.name()))
+                .add(ODRL_RIGHT_OPERAND_ATTRIBUTE, jsonFactory.createObjectBuilder()
+                        .add(VALUE, right))
+                .build();
+        
+        var result = (AtomicConstraint) transformer.transform(constraint, context);
+        
+        assertThat(result).isNotNull();
+        assertThat(((LiteralExpression) result.getLeftExpression()).getValue()).isEqualTo(left);
+        assertThat(result.getOperator()).isEqualTo(operator);
+        assertThat(((LiteralExpression) result.getRightExpression()).getValue()).isEqualTo(right);
+        
+        verifyNoInteractions(context);
+    }
+    
+    @Test
+    void transform_attributesAsArrays_returnConstraint() {
+        var left = "left";
+        var operator = Operator.EQ;
+        var right = "right";
+        
+        var constraint = jsonFactory.createObjectBuilder()
+                .add(ODRL_LEFT_OPERAND_ATTRIBUTE, jsonFactory.createArrayBuilder()
+                        .add(jsonFactory.createObjectBuilder()
+                                .add(VALUE, left)))
+                .add(ODRL_OPERATOR_ATTRIBUTE, jsonFactory.createArrayBuilder()
+                        .add(jsonFactory.createObjectBuilder()
+                                .add(VALUE, operator.name())))
+                .add(ODRL_RIGHT_OPERAND_ATTRIBUTE, jsonFactory.createArrayBuilder()
+                        .add(jsonFactory.createObjectBuilder()
+                                .add(VALUE, right)))
+                .build();
+        
+        var result = (AtomicConstraint) transformer.transform(constraint, context);
+        
+        assertThat(result).isNotNull();
+        assertThat(((LiteralExpression) result.getLeftExpression()).getValue()).isEqualTo(left);
+        assertThat(result.getOperator()).isEqualTo(operator);
+        assertThat(((LiteralExpression) result.getRightExpression()).getValue()).isEqualTo(right);
+        
+        verifyNoInteractions(context);
+    }
+    
+    @Test
+    void transform_operatorAsString_returnConstraint() {
+        var left = "left";
+        var operator = Operator.EQ;
+        var right = "right";
+        
+        var constraint = jsonFactory.createObjectBuilder()
+                .add(ODRL_LEFT_OPERAND_ATTRIBUTE, jsonFactory.createObjectBuilder()
+                        .add(VALUE, left))
+                .add(ODRL_OPERATOR_ATTRIBUTE, operator.name())
+                .add(ODRL_RIGHT_OPERAND_ATTRIBUTE, jsonFactory.createObjectBuilder()
+                        .add(VALUE, right))
+                .build();
+        
+        var result = (AtomicConstraint) transformer.transform(constraint, context);
+        
+        assertThat(result).isNotNull();
+        assertThat(result.getOperator()).isEqualTo(operator);
+        
+        verifyNoInteractions(context);
+    }
+    
+    @Test
+    void transform_invalidAttributes_reportProblems() {
+        var jsonNumber = Json.createValue(1);
+        
+        var constraint = jsonFactory.createObjectBuilder()
+                .add(ODRL_LEFT_OPERAND_ATTRIBUTE, jsonNumber)
+                .add(ODRL_OPERATOR_ATTRIBUTE, jsonNumber)
+                .add(ODRL_RIGHT_OPERAND_ATTRIBUTE, jsonNumber)
+                .build();
+    
+        transformer.transform(constraint, context);
+        
+        verify(context, times(3)).reportProblem(anyString());
+    }
+}

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToConstraintTransformerTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToConstraintTransformerTest.java
@@ -16,9 +16,9 @@ package org.eclipse.edc.jsonld.transformer.to;
 
 import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
+import org.eclipse.edc.policy.model.AndConstraint;
 import org.eclipse.edc.policy.model.AtomicConstraint;
-import org.eclipse.edc.policy.model.LiteralExpression;
-import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.edc.policy.model.MultiplicityConstraint;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,14 +27,16 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_AND_CONSTRAINT_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_LEFT_OPERAND_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_OPERAND_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_OPERATOR_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_RIGHT_OPERAND_ATTRIBUTE;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 class JsonObjectToConstraintTransformerTest {
     
@@ -49,92 +51,47 @@ class JsonObjectToConstraintTransformerTest {
     }
     
     @Test
-    void transform_attributesAsObjects_returnConstraint() {
-        var left = "left";
-        var operator = Operator.EQ;
-        var right = "right";
-        
-        var constraint = jsonFactory.createObjectBuilder()
+    void transform_shouldCallContext_whenAtomicConstraint() {
+        var atomicConstraintJson = jsonFactory.createObjectBuilder()
                 .add(ODRL_LEFT_OPERAND_ATTRIBUTE, jsonFactory.createObjectBuilder()
-                        .add(VALUE, left))
+                        .add(VALUE, "left"))
                 .add(ODRL_OPERATOR_ATTRIBUTE, jsonFactory.createObjectBuilder()
-                        .add(VALUE, operator.name()))
+                        .add(VALUE, "EQ"))
                 .add(ODRL_RIGHT_OPERAND_ATTRIBUTE, jsonFactory.createObjectBuilder()
-                        .add(VALUE, right))
+                        .add(VALUE, "right"))
                 .build();
+        var atomicConstraint = AtomicConstraint.Builder.newInstance().build();
+        when(context.transform(atomicConstraintJson, AtomicConstraint.class)).thenReturn(atomicConstraint);
         
-        var result = (AtomicConstraint) transformer.transform(constraint, context);
+        var result = transformer.transform(atomicConstraintJson, context);
         
-        assertThat(result).isNotNull();
-        assertThat(((LiteralExpression) result.getLeftExpression()).getValue()).isEqualTo(left);
-        assertThat(result.getOperator()).isEqualTo(operator);
-        assertThat(((LiteralExpression) result.getRightExpression()).getValue()).isEqualTo(right);
-        
-        verifyNoInteractions(context);
+        assertThat(result).isEqualTo(atomicConstraint);
+        verify(context, times(1)).transform(atomicConstraintJson, AtomicConstraint.class);
     }
     
     @Test
-    void transform_attributesAsArrays_returnConstraint() {
-        var left = "left";
-        var operator = Operator.EQ;
-        var right = "right";
-        
-        var constraint = jsonFactory.createObjectBuilder()
-                .add(ODRL_LEFT_OPERAND_ATTRIBUTE, jsonFactory.createArrayBuilder()
-                        .add(jsonFactory.createObjectBuilder()
-                                .add(VALUE, left)))
-                .add(ODRL_OPERATOR_ATTRIBUTE, jsonFactory.createArrayBuilder()
-                        .add(jsonFactory.createObjectBuilder()
-                                .add(VALUE, operator.name())))
-                .add(ODRL_RIGHT_OPERAND_ATTRIBUTE, jsonFactory.createArrayBuilder()
-                        .add(jsonFactory.createObjectBuilder()
-                                .add(VALUE, right)))
+    void transform_shouldCallContext_whenLogicalConstraint() {
+        var logicalConstraintJson = jsonFactory.createObjectBuilder()
+                .add(ODRL_OPERAND_ATTRIBUTE, jsonFactory.createObjectBuilder()
+                        .add(ODRL_AND_CONSTRAINT_ATTRIBUTE, jsonFactory.createArrayBuilder().build()))
                 .build();
-        
-        var result = (AtomicConstraint) transformer.transform(constraint, context);
-        
-        assertThat(result).isNotNull();
-        assertThat(((LiteralExpression) result.getLeftExpression()).getValue()).isEqualTo(left);
-        assertThat(result.getOperator()).isEqualTo(operator);
-        assertThat(((LiteralExpression) result.getRightExpression()).getValue()).isEqualTo(right);
-        
-        verifyNoInteractions(context);
+        var andConstraint = AndConstraint.Builder.newInstance().build();
+        when(context.transform(logicalConstraintJson, MultiplicityConstraint.class)).thenReturn(andConstraint);
+    
+        var result = transformer.transform(logicalConstraintJson, context);
+    
+        assertThat(result).isEqualTo(andConstraint);
+        verify(context, times(1)).transform(logicalConstraintJson, MultiplicityConstraint.class);
     }
     
     @Test
-    void transform_operatorAsString_returnConstraint() {
-        var left = "left";
-        var operator = Operator.EQ;
-        var right = "right";
+    void transform_shouldReportProblem_whenUnknownConstraint() {
+        var invalidConstraintJson = jsonFactory.createObjectBuilder().build();
         
-        var constraint = jsonFactory.createObjectBuilder()
-                .add(ODRL_LEFT_OPERAND_ATTRIBUTE, jsonFactory.createObjectBuilder()
-                        .add(VALUE, left))
-                .add(ODRL_OPERATOR_ATTRIBUTE, operator.name())
-                .add(ODRL_RIGHT_OPERAND_ATTRIBUTE, jsonFactory.createObjectBuilder()
-                        .add(VALUE, right))
-                .build();
+        var result = transformer.transform(invalidConstraintJson, context);
         
-        var result = (AtomicConstraint) transformer.transform(constraint, context);
-        
-        assertThat(result).isNotNull();
-        assertThat(result.getOperator()).isEqualTo(operator);
-        
-        verifyNoInteractions(context);
+        assertThat(result).isNull();
+        verify(context, times(1)).reportProblem(anyString());
     }
     
-    @Test
-    void transform_invalidAttributes_reportProblems() {
-        var jsonNumber = Json.createValue(1);
-        
-        var constraint = jsonFactory.createObjectBuilder()
-                .add(ODRL_LEFT_OPERAND_ATTRIBUTE, jsonNumber)
-                .add(ODRL_OPERATOR_ATTRIBUTE, jsonNumber)
-                .add(ODRL_RIGHT_OPERAND_ATTRIBUTE, jsonNumber)
-                .build();
-    
-        transformer.transform(constraint, context);
-        
-        verify(context, times(3)).reportProblem(anyString());
-    }
 }

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToMultiplicityConstraintTransformerTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToMultiplicityConstraintTransformerTest.java
@@ -1,0 +1,137 @@
+/*
+ *  Copyright (c) 2023 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.jsonld.transformer.to;
+
+import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.policy.model.AndConstraint;
+import org.eclipse.edc.policy.model.AtomicConstraint;
+import org.eclipse.edc.policy.model.Constraint;
+import org.eclipse.edc.policy.model.MultiplicityConstraint;
+import org.eclipse.edc.policy.model.OrConstraint;
+import org.eclipse.edc.policy.model.XoneConstraint;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_AND_CONSTRAINT_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_OPERAND_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_OPERATOR_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_OR_CONSTRAINT_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_XONE_CONSTRAINT_ATTRIBUTE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class JsonObjectToMultiplicityConstraintTransformerTest {
+    
+    private JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
+    private TransformerContext context = mock(TransformerContext.class);
+    
+    private JsonObjectToMultiplicityConstraintTransformer transformer;
+    
+    @BeforeEach
+    void setUp() {
+        transformer = new JsonObjectToMultiplicityConstraintTransformer();
+    }
+    
+    @ParameterizedTest
+    @ArgumentsSource(TransformArgumentsProvider.class)
+    void transform_shouldReturnMultiplicityConstraint(String operandAttribute, Class<MultiplicityConstraint> expectedType) {
+        var constraintJson = jsonFactory.createObjectBuilder()
+                .add(ODRL_OPERATOR_ATTRIBUTE, "EQ")
+                .build();
+        var logicalConstraintJson = jsonFactory.createObjectBuilder()
+                .add(ODRL_OPERAND_ATTRIBUTE, jsonFactory.createObjectBuilder()
+                        .add(operandAttribute, jsonFactory.createArrayBuilder()
+                                .add(constraintJson)
+                                .build())
+                        .build())
+                .build();
+    
+        var atomicConstraint = AtomicConstraint.Builder.newInstance().build();
+        when(context.transform(constraintJson, Constraint.class)).thenReturn(atomicConstraint);
+    
+        var result = transformer.transform(logicalConstraintJson, context);
+    
+        assertThat(result).isInstanceOf(expectedType);
+        assertThat(result.getConstraints())
+                .isNotNull()
+                .hasSize(1)
+                .contains(atomicConstraint);
+        verify(context, times(1)).transform(constraintJson, Constraint.class);
+    }
+    
+    @ParameterizedTest
+    @ArgumentsSource(TransformArgumentsProvider.class)
+    void transform_shouldReturnEmptyMultiplicityConstraint_whenNoConstraints(String operandSubProperty,
+                                                                             Class<MultiplicityConstraint> expectedType) {
+        var logicalConstraintJson = jsonFactory.createObjectBuilder()
+                .add(ODRL_OPERAND_ATTRIBUTE, jsonFactory.createObjectBuilder()
+                        .add(operandSubProperty, jsonFactory.createArrayBuilder().build())
+                        .build())
+                .build();
+        
+        var result = transformer.transform(logicalConstraintJson, context);
+        
+        assertThat(result).isInstanceOf(expectedType);
+        assertThat(result.getConstraints())
+                .isNotNull()
+                .isEmpty();
+        verify(context, never()).transform(any(JsonObject.class), eq(Constraint.class));
+    }
+    
+    @Test
+    void transform_shouldReportProblem_whenUnknownOperandAttribute() {
+        var invalidJson = jsonFactory.createObjectBuilder()
+                .add(ODRL_OPERAND_ATTRIBUTE, jsonFactory.createObjectBuilder()
+                        .add("unknown", jsonFactory.createArrayBuilder()
+                                .build())
+                        .build())
+                .build();
+        
+        var result = transformer.transform(invalidJson, context);
+        
+        assertThat(result).isNull();
+        verify(context, times(1)).reportProblem(anyString());
+    }
+
+    static class TransformArgumentsProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+            return Stream.of(
+                    Arguments.of(ODRL_AND_CONSTRAINT_ATTRIBUTE, AndConstraint.class),
+                    Arguments.of(ODRL_OR_CONSTRAINT_ATTRIBUTE, OrConstraint.class),
+                    Arguments.of(ODRL_XONE_CONSTRAINT_ATTRIBUTE, XoneConstraint.class)
+            );
+        }
+    }
+    
+}

--- a/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/PropertyAndTypeNames.java
+++ b/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/PropertyAndTypeNames.java
@@ -65,5 +65,9 @@ public interface PropertyAndTypeNames {
     String ODRL_OPERATOR_ATTRIBUTE = ODRL_SCHEMA + "operator";
     String ODRL_RIGHT_OPERAND_ATTRIBUTE = ODRL_SCHEMA + "rightOperand";
     String ODRL_DUTY_ATTRIBUTE = ODRL_SCHEMA + "duty";
+    String ODRL_OPERAND_ATTRIBUTE = ODRL_SCHEMA + "operand";
+    String ODRL_AND_CONSTRAINT_ATTRIBUTE = ODRL_SCHEMA + "and";
+    String ODRL_OR_CONSTRAINT_ATTRIBUTE = ODRL_SCHEMA + "or";
+    String ODRL_XONE_CONSTRAINT_ATTRIBUTE = ODRL_SCHEMA + "xone";
 
 }

--- a/spi/common/policy-model/src/main/java/org/eclipse/edc/policy/model/MultiplicityConstraint.java
+++ b/spi/common/policy-model/src/main/java/org/eclipse/edc/policy/model/MultiplicityConstraint.java
@@ -35,7 +35,7 @@ public abstract class MultiplicityConstraint extends Constraint {
      */
     public abstract MultiplicityConstraint create(List<Constraint> constraints);
 
-    protected abstract static class Builder<T extends MultiplicityConstraint, B extends Builder<T, B>> {
+    public abstract static class Builder<T extends MultiplicityConstraint, B extends Builder<T, B>> {
         protected T constraint;
 
         public B constraint(Constraint constraint) {
@@ -48,6 +48,7 @@ public abstract class MultiplicityConstraint extends Constraint {
             return (B) this;
         }
 
+        public abstract T build();
     }
 
 }


### PR DESCRIPTION
## What this PR changes/adds

Adds transformation support for ODRL logical constraints/EDC mulitplicity constraints.

For direction `EDC model -> JsonObject` implements the respective visitor methods in `JsonObjectFromPolicyTransformer`.

For direction `JsonObject -> EDC model` creates two new transformers for transforming to `AtomicConstraint` and `MultiplicityConstraint` respectively. The existing `JsonObjectToConstraintTransformer` identifies the type of constraint based on its properties and delegates back to the context to transform it to the correct constraint type.

## Why it does that

To support ODRL logical constraints.

## Further notes

Makes the abstract builder in `MultiplicityConstraint` public to allow handling different builder sub types together in the transformer.

## Linked Issue(s)

Closes #2671 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
