### PR TITLE
docs: add missing package-info.java files to SPI modules

### DIFF
--- a/spi/common/aggregate-service-spi/src/main/java/org/eclipse/edc/service/spi/package-info.java
+++ b/spi/common/aggregate-service-spi/src/main/java/org/eclipse/edc/service/spi/package-info.java
@@ -1,0 +1,18 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+@Spi(value = "aggregate services")
+package org.eclipse.edc.service.spi;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Spi;

--- a/spi/common/catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/package-info.java
+++ b/spi/common/catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/package-info.java
@@ -1,0 +1,18 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+@Spi(value = "Catalog services")
+package org.eclipse.edc.catalog.spi;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Spi;

--- a/spi/common/http-spi/src/main/java/org/eclipse/edc/spi/package-info.java
+++ b/spi/common/http-spi/src/main/java/org/eclipse/edc/spi/package-info.java
@@ -1,0 +1,18 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+@Spi(value = "Http services")
+package org.eclipse.edc.spi;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Spi;

--- a/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/package-info.java
+++ b/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/package-info.java
@@ -1,0 +1,18 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+@Spi(value = "Json ID services")
+package org.eclipse.edc.jsonld.spi;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Spi;

--- a/spi/common/policy-model/src/main/java/org/eclipse/edc/policy/model/spi/package-info.java
+++ b/spi/common/policy-model/src/main/java/org/eclipse/edc/policy/model/spi/package-info.java
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+@Spi(value = "Policy Model services")
+package org.eclipse.edc.policy.model.spi;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Spi;

--- a/spi/common/transform-spi/src/main/java/org/eclipse/edc/transform/spi/package-info.java
+++ b/spi/common/transform-spi/src/main/java/org/eclipse/edc/transform/spi/package-info.java
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+@Spi(value = "Transform services")
+package org.eclipse.edc.transform.spi;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Spi;

--- a/spi/control-plane/asset-spi/src/main/java/org/eclipse/edc/connector/asset/spi/package-info.java
+++ b/spi/control-plane/asset-spi/src/main/java/org/eclipse/edc/connector/asset/spi/package-info.java
@@ -1,0 +1,18 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+@Spi(value = "Asset services")
+package org.eclipse.edc.connector.asset.spi;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Spi;

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/package-info.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/package-info.java
@@ -1,0 +1,18 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+@Spi(value = "Control Plane services")
+package org.eclipse.edc.connector.spi;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Spi;

--- a/spi/data-plane/data-plane-http-spi/src/main/java/org/eclipse/edc/connector/dataplane/http/spi/package-info.java
+++ b/spi/data-plane/data-plane-http-spi/src/main/java/org/eclipse/edc/connector/dataplane/http/spi/package-info.java
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+@Spi(value = "DataPlane Http services")
+package org.eclipse.edc.connector.dataplane.http.spi;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Spi;


### PR DESCRIPTION
## What this PR changes/adds

Add the missing package-info.java files to the SPI modules
## Why it does that

Clearify the identity of SPI modules 
## Further notes


## Linked Issue(s)

ref #2710 
## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
