### PR TITLE
feat(EndpointDataReferenceReceiver): backward compatibility via TranserStarted event

### DIFF
--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/TransferCoreExtension.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/TransferCoreExtension.java
@@ -30,6 +30,7 @@ import org.eclipse.edc.connector.transfer.provision.ResourceManifestGeneratorImp
 import org.eclipse.edc.connector.transfer.spi.TransferProcessManager;
 import org.eclipse.edc.connector.transfer.spi.edr.EndpointDataReferenceReceiverRegistry;
 import org.eclipse.edc.connector.transfer.spi.edr.EndpointDataReferenceTransformerRegistry;
+import org.eclipse.edc.connector.transfer.spi.event.TransferProcessStarted;
 import org.eclipse.edc.connector.transfer.spi.flow.DataFlowManager;
 import org.eclipse.edc.connector.transfer.spi.observe.TransferProcessObservable;
 import org.eclipse.edc.connector.transfer.spi.provision.ProvisionManager;
@@ -164,6 +165,8 @@ public class TransferCoreExtension implements ServiceExtension {
         // Register a default EndpointDataReferenceTransformer that can be overridden in extensions.
         var endpointDataReferenceTransformerRegistry = new EndpointDataReferenceTransformerRegistryImpl();
         context.registerService(EndpointDataReferenceTransformerRegistry.class, endpointDataReferenceTransformerRegistry);
+        // Integration with the new DSP protocol
+        eventRouter.register(TransferProcessStarted.class, endpointDataReferenceReceiverRegistry);
 
         var commandQueue = new BoundedCommandQueue<TransferProcessCommand>(10);
         var observable = new TransferProcessObservableImpl();

--- a/extensions/control-plane/transfer/transfer-data-plane/src/main/java/org/eclipse/edc/connector/transfer/dataplane/flow/ConsumerPullTransferDataFlowController.java
+++ b/extensions/control-plane/transfer/transfer-data-plane/src/main/java/org/eclipse/edc/connector/transfer/dataplane/flow/ConsumerPullTransferDataFlowController.java
@@ -83,11 +83,15 @@ public class ConsumerPullTransferDataFlowController implements DataFlowControlle
                 .build();
 
 
-        // TODO this should be removed once the new dsp lands
-        return dispatcherRegistry.send(Object.class, request)
-                .thenApply(o -> StatusResult.success(createResponse(edr)))
-                .exceptionally(throwable -> StatusResult.failure(ResponseStatus.ERROR_RETRY, "Transfer failed: " + throwable.getMessage()))
-                .join();
+        var response = createResponse(edr);
+        if ("ids-multipart".equals(dataRequest.getProtocol())) {
+            return dispatcherRegistry.send(Object.class, request)
+                    .thenApply(o -> StatusResult.success(response))
+                    .exceptionally(throwable -> StatusResult.failure(ResponseStatus.ERROR_RETRY, "Transfer failed: " + throwable.getMessage()))
+                    .join();
+        } else {
+            return StatusResult.success(response);
+        }
     }
 
     private DataFlowResponse createResponse(EndpointDataReference edr) {

--- a/extensions/control-plane/transfer/transfer-data-plane/src/test/java/org/eclipse/edc/connector/transfer/dataplane/flow/ConsumerPullTransferDataFlowControllerTest.java
+++ b/extensions/control-plane/transfer/transfer-data-plane/src/test/java/org/eclipse/edc/connector/transfer/dataplane/flow/ConsumerPullTransferDataFlowControllerTest.java
@@ -22,7 +22,6 @@ import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.eclipse.edc.spi.types.domain.edr.EndpointDataAddressConstants;
 import org.eclipse.edc.spi.types.domain.edr.EndpointDataReference;
 import org.eclipse.edc.spi.types.domain.edr.EndpointDataReferenceMessage;
 import org.junit.jupiter.api.BeforeEach;
@@ -111,11 +110,11 @@ class ConsumerPullTransferDataFlowControllerTest {
 
         var dataFlowResponse = result.getContent();
         assertThat(dataFlowResponse.getDataAddress()).isNotNull().satisfies(address -> {
-            assertThat(address.getType()).isEqualTo(EndpointDataAddressConstants.TYPE);
-            assertThat(address.getProperty(EndpointDataAddressConstants.ENDPOINT)).isEqualTo(edr.getEndpoint());
-            assertThat(address.getProperty(EndpointDataAddressConstants.AUTH_KEY)).isEqualTo(edr.getAuthKey());
-            assertThat(address.getProperty(EndpointDataAddressConstants.ID)).isEqualTo(edr.getId());
-            assertThat(address.getProperty(EndpointDataAddressConstants.AUTH_CODE)).isEqualTo(edr.getAuthCode());
+            assertThat(address.getType()).isEqualTo(EndpointDataReference.EDR_SIMPLE_TYPE);
+            assertThat(address.getProperty(EndpointDataReference.ENDPOINT)).isEqualTo(edr.getEndpoint());
+            assertThat(address.getProperty(EndpointDataReference.AUTH_KEY)).isEqualTo(edr.getAuthKey());
+            assertThat(address.getProperty(EndpointDataReference.ID)).isEqualTo(edr.getId());
+            assertThat(address.getProperty(EndpointDataReference.AUTH_CODE)).isEqualTo(edr.getAuthCode());
             assertThat(address.getProperties()).containsAllEntriesOf(edr.getProperties());
         });
 

--- a/extensions/control-plane/transfer/transfer-data-plane/src/test/java/org/eclipse/edc/connector/transfer/dataplane/flow/ConsumerPullTransferDataFlowControllerTest.java
+++ b/extensions/control-plane/transfer/transfer-data-plane/src/test/java/org/eclipse/edc/connector/transfer/dataplane/flow/ConsumerPullTransferDataFlowControllerTest.java
@@ -63,7 +63,7 @@ class ConsumerPullTransferDataFlowControllerTest {
     private static DataRequest createDataRequest() {
         return DataRequest.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
-                .protocol("test-protocol")
+                .protocol("ids-multipart")
                 .contractId(UUID.randomUUID().toString())
                 .assetId(UUID.randomUUID().toString())
                 .connectorAddress("test.connector.address")

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/edr/EndpointDataAddressConstants.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/edr/EndpointDataAddressConstants.java
@@ -22,38 +22,30 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
-import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
+import static org.eclipse.edc.spi.types.domain.edr.EndpointDataReference.AUTH_CODE;
+import static org.eclipse.edc.spi.types.domain.edr.EndpointDataReference.AUTH_KEY;
+import static org.eclipse.edc.spi.types.domain.edr.EndpointDataReference.Builder;
+import static org.eclipse.edc.spi.types.domain.edr.EndpointDataReference.EDR_SIMPLE_TYPE;
+import static org.eclipse.edc.spi.types.domain.edr.EndpointDataReference.ENDPOINT;
+import static org.eclipse.edc.spi.types.domain.edr.EndpointDataReference.ID;
 
 /**
  * Constants for {@link EndpointDataReference} mapping to {@link DataAddress}
  */
 public class EndpointDataAddressConstants {
-
-    public static final String TYPE = "EDR";
-    public static final String ID = "id";
-    public static final String AUTH_CODE = "authCode";
-    public static final String AUTH_KEY = "authKey";
-    public static final String ENDPOINT = "endpoint";
-    public static final String TYPE_FIELD = "type";
-
     private static final Set<String> PROPERTIES = Set.of(
             ID,
-            EDC_NAMESPACE + ID,
-            TYPE_FIELD,
-            EDC_NAMESPACE + TYPE_FIELD,
-            AUTH_CODE,
-            EDC_NAMESPACE + AUTH_CODE,
             ENDPOINT,
-            EDC_NAMESPACE + ENDPOINT,
-            AUTH_KEY,
-            EDC_NAMESPACE + AUTH_KEY);
+            AUTH_CODE,
+            DataAddress.TYPE,
+            AUTH_KEY);
 
     private EndpointDataAddressConstants() {
     }
 
     public static DataAddress from(EndpointDataReference edr) {
         return DataAddress.Builder.newInstance()
-                .type(TYPE)
+                .type(EDR_SIMPLE_TYPE)
                 .property(ID, edr.getId())
                 .property(AUTH_CODE, edr.getAuthCode())
                 .property(AUTH_KEY, edr.getAuthKey())
@@ -64,7 +56,7 @@ public class EndpointDataAddressConstants {
 
     public static Result<EndpointDataReference> to(DataAddress address) {
 
-        if (!address.getType().equals(TYPE)) {
+        if (!address.getType().equals(EDR_SIMPLE_TYPE)) {
             return Result.failure(format("Failed to convert data address with type %s to an EDR", address.getType()));
         }
 
@@ -72,7 +64,7 @@ public class EndpointDataAddressConstants {
                 .filter(entry -> !PROPERTIES.contains(entry.getKey()))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
-        var edr = EndpointDataReference.Builder.newInstance()
+        var edr = Builder.newInstance()
                 .id(address.getProperty(ID))
                 .authCode(address.getProperty(AUTH_CODE))
                 .authKey(address.getProperty(AUTH_KEY))

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/edr/EndpointDataReference.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/edr/EndpointDataReference.java
@@ -26,13 +26,22 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
+
 /**
  * Describes an endpoint serving data.
  */
 @JsonDeserialize(builder = EndpointDataReference.Builder.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class EndpointDataReference {
+
+    public static final String EDR_SIMPLE_TYPE = "EDR";
+    public static final String EDR_TYPE = EDC_NAMESPACE + EDR_SIMPLE_TYPE;
     
+    public static final String ID = EDC_NAMESPACE + "id";
+    public static final String AUTH_CODE = EDC_NAMESPACE + "authCode";
+    public static final String AUTH_KEY = EDC_NAMESPACE + "authKey";
+    public static final String ENDPOINT = EDC_NAMESPACE + "endpoint";
     private final String id;
     private final String endpoint;
     private final String authKey;

--- a/spi/common/core-spi/src/test/java/org/eclipse/edc/spi/types/domain/edr/EndpointDataAddressConstantsTest.java
+++ b/spi/common/core-spi/src/test/java/org/eclipse/edc/spi/types/domain/edr/EndpointDataAddressConstantsTest.java
@@ -24,7 +24,7 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class EndpointDataAddressConstantsTest {
-    
+
     @Test
     void from_shouldConvertEdrToDataAddress() {
 
@@ -33,11 +33,11 @@ public class EndpointDataAddressConstantsTest {
 
 
         assertThat(dataAddress.getProperties()).containsAllEntriesOf(inputEdr.getProperties());
-        assertThat(dataAddress.getType()).isEqualTo(EndpointDataAddressConstants.TYPE);
-        assertThat(dataAddress.getProperty(EndpointDataAddressConstants.ID)).isEqualTo(inputEdr.getId());
-        assertThat(dataAddress.getProperty(EndpointDataAddressConstants.AUTH_KEY)).isEqualTo(inputEdr.getAuthKey());
-        assertThat(dataAddress.getProperty(EndpointDataAddressConstants.AUTH_CODE)).isEqualTo(inputEdr.getAuthCode());
-        assertThat(dataAddress.getProperty(EndpointDataAddressConstants.ENDPOINT)).isEqualTo(inputEdr.getEndpoint());
+        assertThat(dataAddress.getType()).isEqualTo(EndpointDataReference.EDR_SIMPLE_TYPE);
+        assertThat(dataAddress.getProperty(EndpointDataReference.ID)).isEqualTo(inputEdr.getId());
+        assertThat(dataAddress.getProperty(EndpointDataReference.AUTH_KEY)).isEqualTo(inputEdr.getAuthKey());
+        assertThat(dataAddress.getProperty(EndpointDataReference.AUTH_CODE)).isEqualTo(inputEdr.getAuthCode());
+        assertThat(dataAddress.getProperty(EndpointDataReference.ENDPOINT)).isEqualTo(inputEdr.getEndpoint());
 
     }
 


### PR DESCRIPTION
## What this PR changes/adds

Implements the backward compatibility with `EndpointDataReferenceReceiver` on the new `dsp` protocol.

## Why it does that

backward compatibility

## Further notes

The `EndpointDataReferenceReceiverRegistryImpl` now implements an `EventSubscriber` that operates 
on the `TransferStarted` event. If the event contains the `dataAddress`(EDR) it will forward it to the registered
receiver.
 
## Linked Issue(s)

Closes #2926

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
