### PR TITLE
fix: map processId in `JsonObjectToTransferRequestMessageTransformer`

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImpl.java
@@ -115,7 +115,7 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
     @NotNull
     private ServiceResult<TransferProcess> requestedAction(TransferRequestMessage message) {
         var dataRequest = DataRequest.Builder.newInstance()
-                .id(message.getId())
+                .id(message.getProcessId())
                 .protocol(message.getProtocol())
                 .connectorId(message.getConnectorId())
                 .connectorAddress(message.getCallbackAddress())

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImplTest.java
@@ -95,7 +95,7 @@ class TransferProcessProtocolServiceImplTest {
     @Test
     void notifyRequested_validAgreement_shouldInitiateTransfer() {
         var message = TransferRequestMessage.Builder.newInstance()
-                .id("processId")
+                .processId("processId")
                 .protocol("protocol")
                 .callbackAddress("http://any")
                 .dataDestination(DataAddress.Builder.newInstance().type("any").build())
@@ -119,7 +119,7 @@ class TransferProcessProtocolServiceImplTest {
     @Test
     void notifyRequested_doNothingIfProcessAlreadyExist() {
         var message = TransferRequestMessage.Builder.newInstance()
-                .id("processId")
+                .processId("processId")
                 .protocol("protocol")
                 .callbackAddress("http://any")
                 .dataDestination(DataAddress.Builder.newInstance().type("any").build())

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
@@ -386,7 +386,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
         var dataRequest = process.getDataRequest();
 
         var message = TransferRequestMessage.Builder.newInstance()
-                .id(dataRequest.getId())
+                .processId(dataRequest.getId())
                 .protocol(dataRequest.getProtocol())
                 .connectorId(dataRequest.getConnectorId())
                 .counterPartyAddress(dataRequest.getConnectorAddress())

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-api/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/api/controller/DspTransferProcessApiControllerTest.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-api/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/api/controller/DspTransferProcessApiControllerTest.java
@@ -111,7 +111,7 @@ class DspTransferProcessApiControllerTest extends RestControllerTestBase {
     private static TransferRequestMessage transferRequestMessage() {
         return TransferRequestMessage.Builder.newInstance()
                 .protocol("protocol")
-                .id(PROCESS_ID)
+                .processId(PROCESS_ID)
                 .callbackAddress("http://connector")
                 .counterPartyAddress("http://connector")
                 .build();

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-http-dispatcher/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/dispatcher/delegate/TransferRequestDelegateTest.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-http-dispatcher/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/dispatcher/delegate/TransferRequestDelegateTest.java
@@ -142,7 +142,7 @@ class TransferRequestDelegateTest extends DspHttpDispatcherDelegateTestBase<Tran
 
     private TransferRequestMessage message() {
         return TransferRequestMessage.Builder.newInstance()
-                .id("testId")
+                .processId("testId")
                 .protocol("dataspace-protocol")
                 .callbackAddress("http://test-connector-address")
                 .counterPartyAddress("http://test-connector-address")

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/from/JsonObjectFromTransferRequestMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/from/JsonObjectFromTransferRequestMessageTransformerTest.java
@@ -84,7 +84,7 @@ class JsonObjectFromTransferRequestMessageTransformerTest {
         properties.put("key", "value");
 
         var message = TransferRequestMessage.Builder.newInstance()
-                .id(id)
+                .processId(id)
                 .properties(properties)
                 .callbackAddress(callbackAddress)
                 .contractId(contractId)
@@ -111,7 +111,7 @@ class JsonObjectFromTransferRequestMessageTransformerTest {
         properties.put("key", "value");
 
         var message = TransferRequestMessage.Builder.newInstance()
-                .id(id)
+                .processId(id)
                 .properties(properties)
                 .callbackAddress(callbackAddress)
                 .contractId(contractId)

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/to/JsonObjectToTransferRequestMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/to/JsonObjectToTransferRequestMessageTransformerTest.java
@@ -27,6 +27,7 @@ import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCT_FORMAT_ATTRIBU
 import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_CALLBACK_ADDRESS_TYPE;
 import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_CONTRACT_AGREEMENT_TYPE;
 import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_DATA_ADDRESS_TYPE;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_PROCESSID_TYPE;
 import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_TRANSFERPROCESS_REQUEST_TYPE;
 import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.to.TestInput.getExpanded;
 import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
@@ -41,7 +42,7 @@ class JsonObjectToTransferRequestMessageTransformerTest {
     private final String contractId = "TestContreactID";
     private final String destinationType = "dspace:s3+push";
 
-    private TransformerContext context = mock(TransformerContext.class);
+    private final TransformerContext context = mock(TransformerContext.class);
 
     private JsonObjectToTransferRequestMessageTransformer transformer;
 
@@ -58,6 +59,7 @@ class JsonObjectToTransferRequestMessageTransformerTest {
                 .add(DCT_FORMAT_ATTRIBUTE, destinationType)
                 .add(DSPACE_DATA_ADDRESS_TYPE, Json.createObjectBuilder().build())
                 .add(DSPACE_CALLBACK_ADDRESS_TYPE, callbackAddress)
+                .add(DSPACE_PROCESSID_TYPE, "processId")
                 .build();
 
         var result = transformer.transform(getExpanded(json), context);
@@ -66,6 +68,7 @@ class JsonObjectToTransferRequestMessageTransformerTest {
         assertThat(result.getContractId()).isEqualTo(contractId);
         assertThat(result.getDataDestination().getType()).isEqualTo(destinationType);
         assertThat(result.getCallbackAddress()).isEqualTo(callbackAddress);
+        assertThat(result.getProcessId()).isEqualTo("processId");
 
         verify(context, never()).reportProblem(anyString());
     }
@@ -78,6 +81,7 @@ class JsonObjectToTransferRequestMessageTransformerTest {
                 .add(DCT_FORMAT_ATTRIBUTE, destinationType)
                 .add(DSPACE_DATA_ADDRESS_TYPE, createDataAddress())
                 .add(DSPACE_CALLBACK_ADDRESS_TYPE, callbackAddress)
+                .add(DSPACE_PROCESSID_TYPE, "processId")
                 .build();
 
         var result = transformer.transform(getExpanded(json), context);

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/sender/type/MultipartTransferRequestSender.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/sender/type/MultipartTransferRequestSender.java
@@ -74,7 +74,7 @@ public class MultipartTransferRequestSender implements MultipartSenderDelegate<T
                 .type(IdsType.CONTRACT_AGREEMENT)
                 .build().toUri();
 
-        var artifactRequestId = request.getId() != null ? request.getId() : UUID.randomUUID().toString();
+        var artifactRequestId = request.getProcessId() != null ? request.getProcessId() : UUID.randomUUID().toString();
         var message = new ArtifactRequestMessageBuilder(URI.create(artifactRequestId))
                 ._modelVersion_(IdsConstants.INFORMATION_MODEL_VERSION)
                 ._issued_(CalendarUtil.gregorianNow())

--- a/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/sender/type/MultipartTransferRequestSenderTest.java
+++ b/data-protocols/ids/ids-api-multipart-dispatcher-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/dispatcher/sender/type/MultipartTransferRequestSenderTest.java
@@ -68,7 +68,7 @@ class MultipartTransferRequestSenderTest {
         var message = sender.buildMessageHeader(request, token);
 
         assertThat(message).isInstanceOf(ArtifactRequestMessage.class);
-        assertThat(message.getId()).hasToString(request.getId());
+        assertThat(message.getId()).hasToString(request.getProcessId());
         assertThat(message.getModelVersion()).isEqualTo(IdsConstants.INFORMATION_MODEL_VERSION);
         assertThat(message.getSecurityToken()).isEqualTo(token);
         assertThat(message.getIssuerConnector()).isEqualTo(senderContext.getConnectorId().toUri());
@@ -93,7 +93,7 @@ class MultipartTransferRequestSenderTest {
 
     private static TransferRequestMessage createRequest() {
         return TransferRequestMessage.Builder.newInstance()
-                .id(UUID.randomUUID().toString())
+                .processId(UUID.randomUUID().toString())
                 .contractId(UUID.randomUUID().toString())
                 .assetId(UUID.randomUUID().toString())
                 .dataDestination(DataAddress.Builder.newInstance().type("test").build())

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/handler/ArtifactRequestHandler.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/main/java/org/eclipse/edc/protocol/ids/api/multipart/handler/ArtifactRequestHandler.java
@@ -144,7 +144,7 @@ public class ArtifactRequestHandler implements Handler {
         }
 
         var requestMessage = TransferRequestMessage.Builder.newInstance()
-                .id(message.getId().toString())
+                .processId(message.getId().toString())
                 .protocol(MessageProtocol.IDS_MULTIPART)
                 .connectorId(connectorId.toString())
                 .callbackAddress(idsWebhookAddress)

--- a/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/handler/ArtifactRequestHandlerTest.java
+++ b/data-protocols/ids/ids-api-multipart-endpoint-v1/src/test/java/org/eclipse/edc/protocol/ids/api/multipart/handler/ArtifactRequestHandlerTest.java
@@ -109,7 +109,7 @@ class ArtifactRequestHandlerTest {
 
         var requestMessage = trCapture.getValue();
 
-        assertThat(requestMessage.getId()).hasToString(artifactRequestId);
+        assertThat(requestMessage.getProcessId()).hasToString(artifactRequestId);
         assertThat(requestMessage.getDataDestination().getKeyName()).isEqualTo(destination.getKeyName());
         assertThat(requestMessage.getConnectorId()).isEqualTo(connectorId.toString());
         assertThat(requestMessage.getAssetId()).isEqualTo(agreement.getAssetId());

--- a/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
+++ b/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
@@ -166,7 +166,7 @@ public class HttpProvisionerExtensionEndToEndTest {
 
     private TransferRequestMessage createTransferRequestMessage() {
         return TransferRequestMessage.Builder.newInstance()
-                .id(randomUUID().toString())
+                .processId(randomUUID().toString())
                 .dataDestination(DataAddress.Builder.newInstance().type("test").build())
                 .protocol("any")
                 .counterPartyAddress("http://any")

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferRequestMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferRequestMessage.java
@@ -29,7 +29,7 @@ public class TransferRequestMessage implements TransferRemoteMessage {
 
     private String counterPartyAddress;
     private String protocol;
-    private String id;
+    private String processId;
     private String contractId;
     @Deprecated(forRemoval = true)
     private String assetId;
@@ -51,7 +51,7 @@ public class TransferRequestMessage implements TransferRemoteMessage {
 
     @Override
     public String getProcessId() {
-        return id;
+        return processId;
     }
 
     @Deprecated
@@ -61,10 +61,6 @@ public class TransferRequestMessage implements TransferRemoteMessage {
 
     public String getContractId() {
         return contractId;
-    }
-
-    public String getId() {
-        return id;
     }
 
     @Deprecated
@@ -97,8 +93,8 @@ public class TransferRequestMessage implements TransferRemoteMessage {
             return new Builder();
         }
 
-        public Builder id(String id) {
-            message.id = id;
+        public Builder processId(String processId) {
+            message.processId = processId;
             return this;
         }
 


### PR DESCRIPTION
## What this PR changes/adds

Rename `id` to `processId` in `TransferRequestMessage`
Map it correctly

## Why it does that

bugfix

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #2968

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
