### PR TITLE
feat: separate multiple state transitions

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
@@ -65,15 +65,14 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
     @WithSpan
     @NotNull
     public ServiceResult<ContractNegotiation> notifyRequested(ContractRequestMessage message, ClaimToken claimToken) {
-        return transactionContext.execute(() ->
-                validateOffer(message, claimToken)
-                        .compose(validatedOffer -> createNegotiation(message, validatedOffer)).onSuccess(negotiation -> {
-                            negotiation.transitionRequested();
-                            monitor.debug(() -> "[Provider] Contract offer received. Will be approved automatically.");
-                            negotiation.transitionAgreeing(); // automatic agree
-                            update(negotiation);
-                            observable.invokeForEach(l -> l.requested(negotiation));
-                        }));
+        return transactionContext.execute(() -> validateOffer(message, claimToken)
+                    .compose(validatedOffer -> createNegotiation(message, validatedOffer))
+                    .onSuccess(negotiation -> {
+                        monitor.debug(() -> "[Provider] Contract offer received.");
+                        negotiation.transitionRequested();
+                        update(negotiation);
+                        observable.invokeForEach(l -> l.requested(negotiation));
+                    }));
     }
 
     @Override

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
@@ -56,7 +56,6 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation.Type.PROVIDER;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.AGREED;
-import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.AGREEING;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.FINALIZED;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.REQUESTED;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.TERMINATED;
@@ -113,7 +112,7 @@ class ContractNegotiationProtocolServiceImplTest {
         var calls = ArgumentCaptor.forClass(ContractNegotiation.class);
         verify(store).save(calls.capture());
         assertThat(calls.getAllValues()).anySatisfy(n -> {
-            assertThat(n.getState()).isEqualTo(AGREEING.code());
+            assertThat(n.getState()).isEqualTo(REQUESTED.code());
             assertThat(n.getCounterPartyId()).isEqualTo(message.getConnectorId());
             assertThat(n.getCounterPartyAddress()).isEqualTo(message.getCallbackAddress());
             assertThat(n.getProtocol()).isEqualTo(message.getProtocol());


### PR DESCRIPTION
## What this PR changes/adds

Avoid the Contract service protocol to do a multiple state transition (REQUESTED and AGREEING).
service -> transition to REQUESTED
manager -> transition to AGREEING 

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #2962 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
