### PR TITLE
fix: set id same as correlationId in consumer transfer process

### DIFF
--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
@@ -73,7 +73,6 @@ import java.util.stream.Collectors;
 import static java.lang.String.format;
 import static java.lang.String.join;
 import static java.util.Collections.emptyList;
-import static java.util.UUID.randomUUID;
 import static org.eclipse.edc.connector.transfer.TransferCoreExtension.DEFAULT_BATCH_SIZE;
 import static org.eclipse.edc.connector.transfer.TransferCoreExtension.DEFAULT_ITERATION_WAIT;
 import static org.eclipse.edc.connector.transfer.TransferCoreExtension.DEFAULT_SEND_RETRY_BASE_DELAY;
@@ -179,9 +178,8 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
         if (processId != null) {
             return StatusResult.success(transferProcessStore.findById(processId));
         }
-        var id = randomUUID().toString();
         var process = TransferProcess.Builder.newInstance()
-                .id(id)
+                .id(dataRequest.getId())
                 .dataRequest(dataRequest)
                 .type(CONSUMER)
                 .clock(clock)

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/transfer/TransferProcessManagerImplTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/transfer/TransferProcessManagerImplTest.java
@@ -181,7 +181,7 @@ class TransferProcessManagerImplTest {
     }
 
     @Test
-    void verifyCallbacks() {
+    void initiateConsumerRequest() {
         when(transferProcessStore.processIdForDataRequestId("1")).thenReturn(null, "2");
         var callback = CallbackAddress.Builder.newInstance().uri("local://test").events(Set.of("test")).build();
         var dataRequest = DataRequest.Builder.newInstance().id("1").destinationType("test").build();
@@ -193,12 +193,12 @@ class TransferProcessManagerImplTest {
 
         var captor = ArgumentCaptor.forClass(TransferProcess.class);
 
-        manager.start();
         manager.initiateConsumerRequest(transferRequest);
-        manager.stop();
 
         verify(transferProcessStore, times(RETRY_LIMIT)).updateOrCreate(captor.capture());
-        assertThat(captor.getValue().getCallbackAddresses()).usingRecursiveFieldByFieldElementComparator().contains(callback);
+        var transferProcess = captor.getValue();
+        assertThat(transferProcess.getId()).isEqualTo("1").isEqualTo(transferProcess.getCorrelationId());
+        assertThat(transferProcess.getCallbackAddresses()).usingRecursiveFieldByFieldElementComparator().contains(callback);
         verify(listener).initiated(any());
     }
 


### PR DESCRIPTION
## What this PR changes/adds

set id same as correlationId in consumer transfer process, to fullfill DSP specs.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #2960 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
