### PR TITLE
fix: avoid pointless response handling in TransferRequestDelegate

### DIFF
--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-http-dispatcher/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/dispatcher/DspTransferProcessDispatcherExtension.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-http-dispatcher/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/dispatcher/DspTransferProcessDispatcherExtension.java
@@ -15,7 +15,6 @@
 package org.eclipse.edc.protocol.dsp.transferprocess.dispatcher;
 
 
-import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.protocol.dsp.spi.dispatcher.DspHttpRemoteMessageDispatcher;
 import org.eclipse.edc.protocol.dsp.spi.serialization.JsonLdRemoteMessageSerializer;
 import org.eclipse.edc.protocol.dsp.transferprocess.dispatcher.delegate.TransferCompletionDelegate;
@@ -26,10 +25,6 @@ import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
-import org.eclipse.edc.spi.types.TypeManager;
-import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
-
-import static org.eclipse.edc.spi.CoreConstants.JSON_LD;
 
 
 /**
@@ -43,13 +38,7 @@ public class DspTransferProcessDispatcherExtension implements ServiceExtension {
     @Inject
     private DspHttpRemoteMessageDispatcher messageDispatcher;
     @Inject
-    private TypeManager typeManager;
-    @Inject
     private JsonLdRemoteMessageSerializer remoteMessageSerializer;
-    @Inject
-    private TypeTransformerRegistry transformerRegistry;
-    @Inject
-    private JsonLd jsonLdService;
 
     @Override
     public String name() {
@@ -58,7 +47,7 @@ public class DspTransferProcessDispatcherExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        messageDispatcher.registerDelegate(new TransferRequestDelegate(remoteMessageSerializer, typeManager.getMapper(JSON_LD), transformerRegistry, jsonLdService));
+        messageDispatcher.registerDelegate(new TransferRequestDelegate(remoteMessageSerializer));
         messageDispatcher.registerDelegate(new TransferCompletionDelegate(remoteMessageSerializer));
         messageDispatcher.registerDelegate(new TransferStartDelegate(remoteMessageSerializer));
         messageDispatcher.registerDelegate(new TransferTerminationDelegate(remoteMessageSerializer));

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-http-dispatcher/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/dispatcher/delegate/TransferRequestDelegate.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-http-dispatcher/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/dispatcher/delegate/TransferRequestDelegate.java
@@ -14,35 +14,22 @@
 
 package org.eclipse.edc.protocol.dsp.transferprocess.dispatcher.delegate;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.json.JsonObject;
 import okhttp3.Request;
 import okhttp3.Response;
-import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.connector.transfer.spi.types.protocol.TransferRequestMessage;
-import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.protocol.dsp.spi.dispatcher.DspHttpDispatcherDelegate;
 import org.eclipse.edc.protocol.dsp.spi.serialization.JsonLdRemoteMessageSerializer;
-import org.eclipse.edc.spi.EdcException;
-import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 
-import java.io.IOException;
 import java.util.function.Function;
 
 import static org.eclipse.edc.protocol.dsp.transferprocess.dispatcher.TransferProcessApiPaths.BASE_PATH;
 import static org.eclipse.edc.protocol.dsp.transferprocess.dispatcher.TransferProcessApiPaths.TRANSFER_INITIAL_REQUEST;
 
-public class TransferRequestDelegate extends DspHttpDispatcherDelegate<TransferRequestMessage, TransferProcess> {
+public class TransferRequestDelegate extends DspHttpDispatcherDelegate<TransferRequestMessage, JsonObject> {
 
-    private final ObjectMapper mapper;
-    private final TypeTransformerRegistry registry;
-    private final JsonLd jsonLdService;
-
-    public TransferRequestDelegate(JsonLdRemoteMessageSerializer serializer, ObjectMapper mapper, TypeTransformerRegistry registry, JsonLd jsonLdService) {
+    public TransferRequestDelegate(JsonLdRemoteMessageSerializer serializer) {
         super(serializer);
-        this.mapper = mapper;
-        this.registry = registry;
-        this.jsonLdService = jsonLdService;
     }
 
     @Override
@@ -56,19 +43,8 @@ public class TransferRequestDelegate extends DspHttpDispatcherDelegate<TransferR
     }
 
     @Override
-    public Function<Response, TransferProcess> parseResponse() {
-        return response -> {
-            try {
-                var jsonObject = mapper.readValue(response.body().bytes(), JsonObject.class);
-                var expansionResult = jsonLdService.expand(jsonObject);
-                var tp = expansionResult
-                        .map(jo -> registry.transform(jo, TransferProcess.class))
-                        .orElseThrow(f -> new EdcException("Failed to read response body from transfer request: " + f.getFailureDetail()));
-                return tp.orElseThrow(f -> new EdcException("Failed to transform response body from transfer request: " + f.getFailureDetail()));
-            } catch (RuntimeException | IOException e) {
-                throw new EdcException("Failed to read response body from contract request.", e);
-            }
-        };
+    public Function<Response, JsonObject> parseResponse() {
+        return response -> null;
     }
 
 }

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-http-dispatcher/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/dispatcher/delegate/TransferRequestDelegateTest.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-http-dispatcher/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/dispatcher/delegate/TransferRequestDelegateTest.java
@@ -14,49 +14,29 @@
 
 package org.eclipse.edc.protocol.dsp.transferprocess.dispatcher.delegate;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
-import okhttp3.Response;
-import okhttp3.ResponseBody;
-import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.connector.transfer.spi.types.protocol.TransferRequestMessage;
-import org.eclipse.edc.jsonld.TitaniumJsonLd;
 import org.eclipse.edc.protocol.dsp.spi.dispatcher.DspHttpDispatcherDelegate;
 import org.eclipse.edc.protocol.dsp.spi.testfixtures.dispatcher.DspHttpDispatcherDelegateTestBase;
-import org.eclipse.edc.spi.EdcException;
-import org.eclipse.edc.spi.monitor.Monitor;
-import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.protocol.dsp.transferprocess.dispatcher.TransferProcessApiPaths.BASE_PATH;
 import static org.eclipse.edc.protocol.dsp.transferprocess.dispatcher.TransferProcessApiPaths.TRANSFER_INITIAL_REQUEST;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 class TransferRequestDelegateTest extends DspHttpDispatcherDelegateTestBase<TransferRequestMessage> {
-
-    private final ObjectMapper mapper = mock(ObjectMapper.class);
-    private final TypeTransformerRegistry registry = mock(TypeTransformerRegistry.class);
 
     private TransferRequestDelegate delegate;
 
     @BeforeEach
     void setUp() {
-        delegate = new TransferRequestDelegate(serializer, mapper, registry, new TitaniumJsonLd(mock(Monitor.class)));
+        delegate = new TransferRequestDelegate(serializer);
     }
 
     @Test
@@ -76,63 +56,8 @@ class TransferRequestDelegateTest extends DspHttpDispatcherDelegateTestBase<Tran
     }
 
     @Test
-    void parseResponse_returnTransferProcess() throws IOException {
-        var jsonObject = getJsonObject();
-        var transferProcess = TransferProcess.Builder.newInstance().id("id").build();
-        var response = mock(Response.class);
-        var responseBody = mock(ResponseBody.class);
-        var bytes = "test".getBytes();
-
-        when(response.body()).thenReturn(responseBody);
-        when(responseBody.bytes()).thenReturn(bytes);
-        when(mapper.readValue(bytes, JsonObject.class)).thenReturn(jsonObject);
-        when(registry.transform(any(JsonObject.class), eq(TransferProcess.class))).thenReturn(Result.success(transferProcess));
-
-        var result = delegate.parseResponse().apply(response);
-
-        assertThat(result).isEqualTo(transferProcess);
-        verify(mapper, times(1)).readValue(bytes, JsonObject.class);
-        verify(registry, times(1)).transform(isA(JsonObject.class), eq(TransferProcess.class));
-    }
-
-    @Test
-    void parseResponse_transformationFails_throwException() throws IOException {
-        var jsonObject = getJsonObject();
-        var response = mock(Response.class);
-        var responseBody = mock(ResponseBody.class);
-
-        when(response.body()).thenReturn(responseBody);
-        when(responseBody.bytes()).thenReturn("test".getBytes());
-        when(mapper.readValue(any(byte[].class), eq(JsonObject.class))).thenReturn(jsonObject);
-        when(registry.transform(any(JsonObject.class), eq(TransferProcess.class))).thenReturn(Result.failure("error"));
-
-        assertThatThrownBy(() -> delegate.parseResponse().apply(response)).isInstanceOf(EdcException.class);
-    }
-
-    @Test
-    void parseResponse_expandingJsonLdFails_throwException() throws IOException {
-        // JSON is missing @context -> expanding returns empty JsonArray
-        var jsonObject = Json.createObjectBuilder()
-                .add("key", "value")
-                .build();
-        var response = mock(Response.class);
-        var responseBody = mock(ResponseBody.class);
-
-        when(response.body()).thenReturn(responseBody);
-        when(responseBody.bytes()).thenReturn("test".getBytes());
-        when(mapper.readValue(any(byte[].class), eq(JsonObject.class))).thenReturn(jsonObject);
-
-        assertThatThrownBy(() -> delegate.parseResponse().apply(response)).isInstanceOf(EdcException.class);
-    }
-
-    @Test
-    void parseResponse_responseBodyNull_throwException() {
-        testParseResponse_shouldThrowException_whenResponseBodyNull();
-    }
-
-    @Test
-    void parseResponse_readingResponseBodyFails_throwException() throws IOException {
-        testParseResponse_shouldThrowException_whenReadingResponseBodyFails();
+    void parseResponse_returnNull() {
+        testParseResponse_shouldReturnNullFunction_whenResponseBodyNotProcessed();
     }
 
     @Override


### PR DESCRIPTION
## What this PR changes/adds

that transformation would break anyway because we haven't a transformer from json to TransferProcess

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #2958 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
