### PR TITLE
fix(dsp): stack overflow in transfer start transformer

### DIFF
--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/from/JsonObjectFromTransferStartMessageTransformer.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/from/JsonObjectFromTransferStartMessageTransformer.java
@@ -47,7 +47,7 @@ public class JsonObjectFromTransferStartMessageTransformer extends AbstractJsonL
         builder.add(TYPE, DSPACE_TRANSFER_START_TYPE);
         builder.add(DSPACE_PROCESSID_TYPE, transferStartMessage.getProcessId());
         if (transferStartMessage.getDataAddress() != null) {
-            builder.add(DSPACE_DATA_ADDRESS_TYPE, context.transform(transferStartMessage, JsonObject.class));
+            builder.add(DSPACE_DATA_ADDRESS_TYPE, context.transform(transferStartMessage.getDataAddress(), JsonObject.class));
         }
 
         return builder.build();

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/from/JsonObjectFromTransferStartMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/from/JsonObjectFromTransferStartMessageTransformerTest.java
@@ -16,9 +16,11 @@ package org.eclipse.edc.protocol.dsp.transferprocess.transformer.from;
 
 import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.transfer.spi.types.protocol.TransferStartMessage;
 import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
 import org.eclipse.edc.protocol.dsp.transferprocess.transformer.type.from.JsonObjectFromTransferStartMessageTransformer;
+import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,13 +28,15 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_DATA_ADDRESS_TYPE;
 import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_PROCESSID_TYPE;
 import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_TRANSFER_START_TYPE;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-
+import static org.mockito.Mockito.when;
 
 class JsonObjectFromTransferStartMessageTransformerTest {
 
@@ -50,22 +54,26 @@ class JsonObjectFromTransferStartMessageTransformerTest {
         transformer = new JsonObjectFromTransferStartMessageTransformer(jsonFactory);
     }
 
-
-
     @Test
     void transformTransferStartMessage() {
+        var dataAddress = DataAddress.Builder.newInstance().type("type").build();
         var message = TransferStartMessage.Builder.newInstance()
                 .processId(processId)
                 .protocol(protocol)
+                .dataAddress(dataAddress)
                 .build();
+        
+        var dataAddressJson = jsonFactory.createObjectBuilder().build();
+        when(context.transform(dataAddress, JsonObject.class)).thenReturn(dataAddressJson);
 
         var result = transformer.transform(message, context);
 
         assertThat(result).isNotNull();
         assertThat(result.getJsonString(JsonLdKeywords.TYPE).getString()).isEqualTo(DSPACE_TRANSFER_START_TYPE);
         assertThat(result.getJsonString(DSPACE_PROCESSID_TYPE).getString()).isEqualTo(processId);
-        //TODO Add missing fields (dataAddress) from Spec Issue https://github.com/eclipse-edc/Connector/issues/2727
+        assertThat(result.getJsonObject(DSPACE_DATA_ADDRESS_TYPE)).isEqualTo(dataAddressJson);
 
+        verify(context, times(1)).transform(dataAddress, JsonObject.class);
         verify(context, never()).reportProblem(anyString());
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

In the `JsonObjectFromTransferStartMessageTransformer` calls the context to transform the message's `DataAddress` instead of the message itself.

## Why it does that

To avoid stack overflow error

## Linked Issue(s)

Closes #2974 

## Checklist

- [x] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
