### PR TITLE
fix: map ING status for ContractNegotiation in DSP

### DIFF
--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org.eclipse.edc.protocol.dsp.negotiation.transform/from/JsonObjectFromContractNegotiationTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org.eclipse.edc.protocol.dsp.negotiation.transform/from/JsonObjectFromContractNegotiationTransformer.java
@@ -18,12 +18,13 @@ import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates;
-import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_CONTRACT_NEGOTIATION;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_STATE;
@@ -50,30 +51,35 @@ public class JsonObjectFromContractNegotiationTransformer extends AbstractJsonLd
 
     @Override
     public @Nullable JsonObject transform(@NotNull ContractNegotiation contractNegotiation, @NotNull TransformerContext context) {
-        var builder = jsonFactory.createObjectBuilder();
-        builder.add(JsonLdKeywords.ID, contractNegotiation.getCorrelationId());
-        builder.add(JsonLdKeywords.TYPE, DSPACE_CONTRACT_NEGOTIATION);
-
-        builder.add(DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID, contractNegotiation.getCorrelationId());
-        builder.add(DSPACE_NEGOTIATION_PROPERTY_STATE, state(contractNegotiation.getState(), context));
-
-        return builder.build();
+        return jsonFactory.createObjectBuilder()
+                .add(ID, contractNegotiation.getCorrelationId())
+                .add(TYPE, DSPACE_CONTRACT_NEGOTIATION)
+                .add(DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID, contractNegotiation.getCorrelationId())
+                .add(DSPACE_NEGOTIATION_PROPERTY_STATE, state(contractNegotiation.getState(), context))
+                .build();
     }
 
     private String state(Integer state, TransformerContext context) {
         switch (ContractNegotiationStates.from(state)) {
+            case REQUESTING:
             case REQUESTED:
                 return DSPACE_NEGOTIATION_STATE_REQUESTED;
+            case OFFERING:
             case OFFERED:
                 return DSPACE_NEGOTIATION_STATE_OFFERED;
+            case ACCEPTING:
             case ACCEPTED:
                 return DSPACE_NEGOTIATION_STATE_ACCEPTED;
+            case AGREEING:
             case AGREED:
                 return DSPACE_NEGOTIATION_STATE_AGREED;
+            case VERIFYING:
             case VERIFIED:
                 return DSPACE_NEGOTIATION_STATE_VERIFIED;
+            case FINALIZING:
             case FINALIZED:
                 return DSPACE_NEGOTIATION_STATE_FINALIZED;
+            case TERMINATING:
             case TERMINATED:
                 return DSPACE_NEGOTIATION_STATE_TERMINATED;
             default:

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractNegotiationTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractNegotiationTransformerTest.java
@@ -17,20 +17,46 @@ package org.eclipse.edc.protocol.dsp.negotiation.transform.from;
 import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.ACCEPTED;
+import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.ACCEPTING;
+import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.AGREED;
+import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.AGREEING;
+import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.FINALIZED;
+import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.FINALIZING;
+import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.OFFERED;
+import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.OFFERING;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.REQUESTED;
+import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.REQUESTING;
+import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.TERMINATED;
+import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.TERMINATING;
+import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.VERIFIED;
+import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.VERIFYING;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_CONTRACT_NEGOTIATION;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_STATE;
+import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_STATE_ACCEPTED;
+import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_STATE_AGREED;
+import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_STATE_FINALIZED;
+import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_STATE_OFFERED;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_STATE_REQUESTED;
+import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_STATE_TERMINATED;
+import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_STATE_VERIFIED;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -64,11 +90,55 @@ class JsonObjectFromContractNegotiationTransformerTest {
         var result = transformer.transform(negotiation, context);
 
         assertThat(result).isNotNull();
-        assertThat(result.getJsonString(ID).getString()).isEqualTo(value);
-        assertThat(result.getJsonString(TYPE).getString()).isEqualTo(DSPACE_CONTRACT_NEGOTIATION);
-        assertThat(result.getJsonString(DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID).getString()).isEqualTo(value);
-        assertThat(result.getJsonString(DSPACE_NEGOTIATION_PROPERTY_STATE).getString()).isEqualTo(DSPACE_NEGOTIATION_STATE_REQUESTED);
+        assertThat(result.getString(ID)).isEqualTo(value);
+        assertThat(result.getString(TYPE)).isEqualTo(DSPACE_CONTRACT_NEGOTIATION);
+        assertThat(result.getString(DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID)).isEqualTo(value);
 
         verify(context, never()).reportProblem(anyString());
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(Status.class)
+    void transform_status(ContractNegotiationStates inputState, String expectedDspState) {
+        var value = "example";
+        var negotiation = ContractNegotiation.Builder.newInstance()
+                .id(value)
+                .correlationId(value)
+                .counterPartyId("counterPartyId")
+                .counterPartyAddress("counterPartyAddress")
+                .protocol("protocol")
+                .state(inputState.code())
+                .checksum(value)
+                .build();
+
+        var result = transformer.transform(negotiation, context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getString(DSPACE_NEGOTIATION_PROPERTY_STATE)).isEqualTo(expectedDspState);
+
+        verify(context, never()).reportProblem(anyString());
+    }
+
+    public static class Status implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                    Arguments.arguments(REQUESTING, DSPACE_NEGOTIATION_STATE_REQUESTED),
+                    Arguments.arguments(REQUESTED, DSPACE_NEGOTIATION_STATE_REQUESTED),
+                    Arguments.arguments(OFFERING, DSPACE_NEGOTIATION_STATE_OFFERED),
+                    Arguments.arguments(OFFERED, DSPACE_NEGOTIATION_STATE_OFFERED),
+                    Arguments.arguments(ACCEPTING, DSPACE_NEGOTIATION_STATE_ACCEPTED),
+                    Arguments.arguments(ACCEPTED, DSPACE_NEGOTIATION_STATE_ACCEPTED),
+                    Arguments.arguments(AGREEING, DSPACE_NEGOTIATION_STATE_AGREED),
+                    Arguments.arguments(AGREED, DSPACE_NEGOTIATION_STATE_AGREED),
+                    Arguments.arguments(VERIFYING, DSPACE_NEGOTIATION_STATE_VERIFIED),
+                    Arguments.arguments(VERIFIED, DSPACE_NEGOTIATION_STATE_VERIFIED),
+                    Arguments.arguments(FINALIZING, DSPACE_NEGOTIATION_STATE_FINALIZED),
+                    Arguments.arguments(FINALIZED, DSPACE_NEGOTIATION_STATE_FINALIZED),
+                    Arguments.arguments(TERMINATING, DSPACE_NEGOTIATION_STATE_TERMINATED),
+                    Arguments.arguments(TERMINATED, DSPACE_NEGOTIATION_STATE_TERMINATED)
+            );
+        }
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Maps `*ING` status for ContractNegotiation in DSP transformer

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #2978 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
