### PR TITLE
fix: make DSP dispatcher fails if response code is not 200

### DIFF
--- a/data-protocols/dsp/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/dispatcher/DspHttpRemoteMessageDispatcherImpl.java
+++ b/data-protocols/dsp/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/dispatcher/DspHttpRemoteMessageDispatcherImpl.java
@@ -21,14 +21,16 @@ import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.http.EdcHttpClient;
 import org.eclipse.edc.spi.iam.IdentityService;
 import org.eclipse.edc.spi.iam.TokenParameters;
-import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import static java.lang.String.format;
+import static java.util.concurrent.CompletableFuture.failedFuture;
+import static org.eclipse.edc.spi.http.FallbackFactories.statusMustBe;
 
 /**
  * Dispatches remote messages using the dataspace protocol. Uses {@link DspHttpDispatcherDelegate}s
@@ -36,9 +38,9 @@ import static java.lang.String.format;
  */
 public class DspHttpRemoteMessageDispatcherImpl implements DspHttpRemoteMessageDispatcher {
 
-    private Map<Class<? extends RemoteMessage>, DspHttpDispatcherDelegate> delegates;
-    private EdcHttpClient httpClient;
-    private IdentityService identityService;
+    private final Map<Class<? extends RemoteMessage>, DspHttpDispatcherDelegate<?, ?>> delegates;
+    private final EdcHttpClient httpClient;
+    private final IdentityService identityService;
 
     public DspHttpRemoteMessageDispatcherImpl(EdcHttpClient httpClient, IdentityService identityService) {
         this.httpClient = httpClient;
@@ -70,28 +72,25 @@ public class DspHttpRemoteMessageDispatcherImpl implements DspHttpRemoteMessageD
     public <T, M extends RemoteMessage> CompletableFuture<T> send(Class<T> responseType, M message) {
         var delegate = (DspHttpDispatcherDelegate<M, T>) delegates.get(message.getClass());
         if (delegate == null) {
-            throw new EdcException(format("No DSP message dispatcher found for message type %s", message.getClass()));
+            return failedFuture(new EdcException(format("No DSP message dispatcher found for message type %s", message.getClass())));
         }
 
         var request = delegate.buildRequest(message);
 
-        var token = obtainToken(message);
-        var requestWithAuth = request.newBuilder()
-                .header("Authorization", token.getToken())
-                .build();
-
-        return httpClient.executeAsync(requestWithAuth, delegate.parseResponse());
-    }
-
-    private TokenRepresentation obtainToken(RemoteMessage message) {
         var tokenParameters = TokenParameters.Builder.newInstance()
                 .audience(message.getCounterPartyAddress())
                 .build();
         var tokenResult = identityService.obtainClientCredentials(tokenParameters);
         if (tokenResult.failed()) {
-            throw new EdcException(format("Unable to obtain credentials: %s", String.join(", ", tokenResult.getFailureMessages())));
+            return failedFuture(new EdcException(format("Unable to obtain credentials: %s", String.join(", ", tokenResult.getFailureMessages()))));
         }
 
-        return tokenResult.getContent();
+        var token = tokenResult.getContent();
+        var requestWithAuth = request.newBuilder()
+                .header("Authorization", token.getToken())
+                .build();
+
+        return httpClient.executeAsync(requestWithAuth, List.of(statusMustBe(200)), delegate.parseResponse());
     }
+
 }

--- a/data-protocols/dsp/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/dispatcher/DspHttpRemoteMessageDispatcherImplTest.java
+++ b/data-protocols/dsp/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/dispatcher/DspHttpRemoteMessageDispatcherImplTest.java
@@ -28,11 +28,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.edc.protocol.dsp.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -44,9 +43,9 @@ import static org.mockito.Mockito.when;
 
 class DspHttpRemoteMessageDispatcherImplTest {
 
-    private EdcHttpClient httpClient = mock(EdcHttpClient.class);
-    private IdentityService identityService = mock(IdentityService.class);
-    private DspHttpDispatcherDelegate<TestMessage, String> delegate = mock(DspHttpDispatcherDelegate.class);
+    private final EdcHttpClient httpClient = mock(EdcHttpClient.class);
+    private final IdentityService identityService = mock(IdentityService.class);
+    private final DspHttpDispatcherDelegate<TestMessage, String> delegate = mock(DspHttpDispatcherDelegate.class);
 
     private DspHttpRemoteMessageDispatcher dispatcher;
 
@@ -63,14 +62,14 @@ class DspHttpRemoteMessageDispatcherImplTest {
     }
 
     @Test
-    void send_sendRequestViaHttpClient() throws ExecutionException, InterruptedException {
+    void send_sendRequestViaHttpClient() {
         var responseBody = "response";
         Function<Response, String> responseFunction = response -> responseBody;
         var authToken = "token";
 
         when(delegate.buildRequest(any())).thenReturn(new Request.Builder().url("http://url").build());
         when(delegate.parseResponse()).thenReturn(responseFunction);
-        when(httpClient.executeAsync(any(), any())).thenReturn(CompletableFuture.completedFuture(responseBody));
+        when(httpClient.executeAsync(any(), any(), any())).thenReturn(CompletableFuture.completedFuture(responseBody));
         when(identityService.obtainClientCredentials(any()))
                 .thenReturn(Result.success(TokenRepresentation.Builder.newInstance().token(authToken).build()));
 
@@ -79,29 +78,34 @@ class DspHttpRemoteMessageDispatcherImplTest {
         var message = new TestMessage();
         var result = dispatcher.send(String.class, message);
 
-        assertThat(result.get()).isEqualTo(responseBody);
+        assertThat(result).succeedsWithin(5, TimeUnit.SECONDS).isEqualTo(responseBody);
 
         verify(delegate).buildRequest(message);
         verify(identityService).obtainClientCredentials(argThat(tr -> tr.getAudience().equals(message.getCounterPartyAddress())));
-        verify(httpClient).executeAsync(argThat(r -> r.headers().get("Authorization").equals(authToken)), eq(responseFunction));
+        verify(httpClient).executeAsync(argThat(r -> authToken.equals(r.headers().get("Authorization"))), any(), eq(responseFunction));
     }
 
     @Test
     void send_noDelegateFound_throwException() {
-        assertThatThrownBy(() -> dispatcher.send(String.class, new TestMessage())).isInstanceOf(EdcException.class);
+        assertThat(dispatcher.send(String.class, new TestMessage())).failsWithin(5, TimeUnit.SECONDS)
+                .withThrowableThat().withCauseInstanceOf(EdcException.class).withMessageContaining("found");
+
         verifyNoInteractions(httpClient);
     }
 
     @Test
     void send_failedToObtainToken_throwException() {
+        dispatcher.registerDelegate(delegate);
         when(delegate.buildRequest(any())).thenReturn(new Request.Builder().url("http://url").build());
         when(identityService.obtainClientCredentials(any())).thenReturn(Result.failure("error"));
 
-        assertThatThrownBy(() -> dispatcher.send(String.class, new TestMessage())).isInstanceOf(EdcException.class);
+        assertThat(dispatcher.send(String.class, new TestMessage())).failsWithin(5, TimeUnit.SECONDS)
+                .withThrowableThat().withCauseInstanceOf(EdcException.class).withMessageContaining("credentials");
+
         verifyNoInteractions(httpClient);
     }
 
-    class TestMessage implements RemoteMessage {
+    static class TestMessage implements RemoteMessage {
         @Override
         public String getProtocol() {
             return null;

--- a/spi/common/http-spi/src/main/java/org/eclipse/edc/spi/http/EdcHttpClient.java
+++ b/spi/common/http-spi/src/main/java/org/eclipse/edc/spi/http/EdcHttpClient.java
@@ -51,7 +51,8 @@ public interface EdcHttpClient {
      * Accepts a list of {@link FallbackFactories} that could apply retry in particular occasions.
      *
      * @param request the {@link Request}.
-     *                @param mappingFunction the function that will be applied to the {@link Response}.
+     * @param fallbacks a list of fallbacks to be applied.
+     * @param mappingFunction the function that will be applied to the {@link Response}.
      * @return a {@link Result}, containing the object returned by the mappingFunction
      */
     <T> Result<T> execute(Request request, List<FallbackFactory> fallbacks, Function<Response, Result<T>> mappingFunction);
@@ -65,6 +66,18 @@ public interface EdcHttpClient {
      * @param <T> the result value.
      */
     <T> CompletableFuture<T> executeAsync(Request request, Function<Response, T> mappingFunction);
+
+    /**
+     * Executes the specified request asynchronously, maps the response with the mappingFunction.
+     * ccepts a list of {@link FallbackFactories} that could apply retry in particular occasions.
+     *
+     * @param request the {@link Request}.
+     * @param fallbacks a list of fallbacks to be applied.
+     * @param mappingFunction the function that will be applied to the {@link Response}.
+     * @return a {@link CompletableFuture} containing the result value.
+     * @param <T> the result value.
+     */
+    <T> CompletableFuture<T> executeAsync(Request request, List<FallbackFactory> fallbacks, Function<Response, T> mappingFunction);
 
     /**
      * Returns a new client instance with a custom dns server set.


### PR DESCRIPTION
## What this PR changes/adds

Make `DspHttpRemoteMessageDispatcherImpl` fails if response status is not 200.

## Why it does that

dsp

## Further notes



## Linked Issue(s)

Closes #2987 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
