### PR TITLE
fix: policy transformation processing expanded Json-Ld

### DIFF
--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-api/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/api/controller/DspTransferProcessApiController.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-api/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/api/controller/DspTransferProcessApiController.java
@@ -54,8 +54,8 @@ import static org.eclipse.edc.protocol.dsp.transferprocess.api.TransferProcessAp
 import static org.eclipse.edc.protocol.dsp.transferprocess.api.TransferProcessApiPaths.TRANSFER_START;
 import static org.eclipse.edc.protocol.dsp.transferprocess.api.TransferProcessApiPaths.TRANSFER_SUSPENSION;
 import static org.eclipse.edc.protocol.dsp.transferprocess.api.TransferProcessApiPaths.TRANSFER_TERMINATION;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_TRANSFERPROCESS_REQUEST_TYPE;
 import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_TRANSFER_COMPLETION_TYPE;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_TRANSFER_PROCESS_REQUEST_TYPE;
 import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_TRANSFER_START_TYPE;
 import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_TRANSFER_TERMINATION_TYPE;
 import static org.eclipse.edc.protocol.dsp.transform.util.TypeUtil.isOfExpectedType;
@@ -65,8 +65,8 @@ import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMa
  * Provides the endpoints for receiving messages regarding transfers, like initiating, completing
  * and terminating a transfer process.
  */
-@Consumes({ MediaType.APPLICATION_JSON })
-@Produces({ MediaType.APPLICATION_JSON })
+@Consumes({MediaType.APPLICATION_JSON})
+@Produces({MediaType.APPLICATION_JSON})
 @Path(BASE_PATH)
 public class DspTransferProcessApiController {
 
@@ -113,7 +113,7 @@ public class DspTransferProcessApiController {
     @POST
     @Path(TRANSFER_INITIAL_REQUEST)
     public Map<String, Object> initiateTransferProcess(JsonObject jsonObject, @HeaderParam(HttpHeaders.AUTHORIZATION) String token) {
-        var transferProcess = handleMessage(jsonObject, Optional.empty(), token, DSPACE_TRANSFERPROCESS_REQUEST_TYPE, TransferRequestMessage.class, protocolService::notifyRequested);
+        var transferProcess = handleMessage(jsonObject, Optional.empty(), token, DSPACE_TRANSFER_PROCESS_REQUEST_TYPE, TransferRequestMessage.class, protocolService::notifyRequested);
 
         var transferProcessJson = registry.transform(transferProcess, JsonObject.class)
                 .orElseThrow(failure -> new EdcException(format("Response could not be created: %s", failure.getFailureDetail())));
@@ -193,8 +193,8 @@ public class DspTransferProcessApiController {
      * @return the transfer process returned by the service call
      */
     private <M extends TransferRemoteMessage> TransferProcess handleMessage(JsonObject request, Optional<String> processId, String token, String expectedType,
-                                                                 Class<M> messageClass, BiFunction<M, ClaimToken, ServiceResult<TransferProcess>> serviceCall) {
-        processId.ifPresentOrElse(id ->  monitor.debug(() -> format("DSP: Incoming %s for transfer process %s", messageClass.getSimpleName(), id)),
+                                                                            Class<M> messageClass, BiFunction<M, ClaimToken, ServiceResult<TransferProcess>> serviceCall) {
+        processId.ifPresentOrElse(id -> monitor.debug(() -> format("DSP: Incoming %s for transfer process %s", messageClass.getSimpleName(), id)),
                 () -> monitor.debug(() -> format("DSP: Incoming %s for initiating a transfer process", messageClass.getSimpleName())));
 
         var claimToken = checkAuthToken(token);

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-api/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/api/controller/DspTransferProcessApiControllerTest.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-api/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/api/controller/DspTransferProcessApiControllerTest.java
@@ -57,8 +57,8 @@ import static org.eclipse.edc.protocol.dsp.transferprocess.api.TransferProcessAp
 import static org.eclipse.edc.protocol.dsp.transferprocess.api.TransferProcessApiPaths.TRANSFER_START;
 import static org.eclipse.edc.protocol.dsp.transferprocess.api.TransferProcessApiPaths.TRANSFER_SUSPENSION;
 import static org.eclipse.edc.protocol.dsp.transferprocess.api.TransferProcessApiPaths.TRANSFER_TERMINATION;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_TRANSFERPROCESS_REQUEST_TYPE;
 import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_TRANSFER_COMPLETION_TYPE;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_TRANSFER_PROCESS_REQUEST_TYPE;
 import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_TRANSFER_START_TYPE;
 import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_TRANSFER_TERMINATION_TYPE;
 import static org.hamcrest.Matchers.is;
@@ -87,7 +87,7 @@ class DspTransferProcessApiControllerTest extends RestControllerTestBase {
     }
 
     private static JsonObject transferRequestJson() {
-        return Json.createObjectBuilder().add(TYPE, DSPACE_TRANSFERPROCESS_REQUEST_TYPE).build();
+        return Json.createObjectBuilder().add(TYPE, DSPACE_TRANSFER_PROCESS_REQUEST_TYPE).build();
     }
 
     private static JsonObject transferStartJson() {

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/DspTransferProcessPropertyAndTypeNames.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/DspTransferProcessPropertyAndTypeNames.java
@@ -21,7 +21,7 @@ import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
  */
 public interface DspTransferProcessPropertyAndTypeNames {
 
-    String DSPACE_TRANSFERPROCESS_REQUEST_TYPE = DSPACE_SCHEMA + "TransferRequestMessage";
+    String DSPACE_TRANSFER_PROCESS_REQUEST_TYPE = DSPACE_SCHEMA + "TransferRequestMessage";
 
     String DSPACE_TRANSFER_START_TYPE = DSPACE_SCHEMA + "TransferStartMessage";
 
@@ -29,21 +29,21 @@ public interface DspTransferProcessPropertyAndTypeNames {
 
     String DSPACE_TRANSFER_TERMINATION_TYPE = DSPACE_SCHEMA + "TransferTerminationMessage";
 
-    String DSPACE_TRANSFERPROCESS_TYPE = DSPACE_SCHEMA + "TransferProcess";
+    String DSPACE_TRANSFER_PROCESS_TYPE = DSPACE_SCHEMA + "TransferProcess";
 
-    String DSPACE_CONTRACT_AGREEMENT_TYPE = DSPACE_SCHEMA + "agreementId";
+    String DSPACE_CONTRACT_AGREEMENT_ID = DSPACE_SCHEMA + "agreementId";
 
-    String DSPACE_CALLBACK_ADDRESS_TYPE = DSPACE_SCHEMA + "callbackAddress";
+    String DSPACE_CALLBACK_ADDRESS = DSPACE_SCHEMA + "callbackAddress";
 
-    String DSPACE_PROCESSID_TYPE = DSPACE_SCHEMA + "processId";
+    String DSPACE_PROCESS_ID = DSPACE_SCHEMA + "processId";
 
-    String DSPACE_DATA_ADDRESS_TYPE = DSPACE_SCHEMA + "dataAddress";
+    String DSPACE_DATA_ADDRESS = DSPACE_SCHEMA + "dataAddress";
 
-    String DSPACE_CORRELATIONID_TYPE = DSPACE_SCHEMA + "correlationId";
+    String DSPACE_CORRELATION_ID = DSPACE_SCHEMA + "correlationId";
 
-    String DSPACE_STATE_TYPE = DSPACE_SCHEMA + "state";
+    String DSPACE_STATE = DSPACE_SCHEMA + "state";
 
-    String DSPACE_REASON_TYPE = DSPACE_SCHEMA + "reason";
+    String DSPACE_REASON = DSPACE_SCHEMA + "reason";
 
-    String DSPACE_CODE_TYPE = DSPACE_SCHEMA + "code";
+    String DSPACE_CODE = DSPACE_SCHEMA + "code";
 }

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/from/JsonObjectFromTransferCompletionMessageTransformer.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/from/JsonObjectFromTransferCompletionMessageTransformer.java
@@ -26,7 +26,7 @@ import java.util.UUID;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_PROCESSID_TYPE;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_PROCESS_ID;
 import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_TRANSFER_COMPLETION_TYPE;
 
 
@@ -45,7 +45,7 @@ public class JsonObjectFromTransferCompletionMessageTransformer extends Abstract
 
         builder.add(ID, String.valueOf(UUID.randomUUID()));
         builder.add(TYPE, DSPACE_TRANSFER_COMPLETION_TYPE);
-        builder.add(DSPACE_PROCESSID_TYPE, transferCompletionMessage.getProcessId());
+        builder.add(DSPACE_PROCESS_ID, transferCompletionMessage.getProcessId());
 
         return builder.build();
     }

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/from/JsonObjectFromTransferProcessTransformer.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/from/JsonObjectFromTransferProcessTransformer.java
@@ -25,9 +25,9 @@ import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_CORRELATIONID_TYPE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_STATE_TYPE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_TRANSFERPROCESS_TYPE;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_CORRELATION_ID;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_STATE;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_TRANSFER_PROCESS_TYPE;
 
 public class JsonObjectFromTransferProcessTransformer extends AbstractJsonLdTransformer<TransferProcess, JsonObject> {
 
@@ -43,9 +43,9 @@ public class JsonObjectFromTransferProcessTransformer extends AbstractJsonLdTran
         var builder = jsonBuilderFactory.createObjectBuilder();
 
         builder.add(ID, transferProcess.getId());
-        builder.add(TYPE, DSPACE_TRANSFERPROCESS_TYPE);
-        builder.add(DSPACE_CORRELATIONID_TYPE, transferProcess.getCorrelationId());
-        builder.add(DSPACE_STATE_TYPE, TransferProcessStates.from(transferProcess.getState()).name());
+        builder.add(TYPE, DSPACE_TRANSFER_PROCESS_TYPE);
+        builder.add(DSPACE_CORRELATION_ID, transferProcess.getCorrelationId());
+        builder.add(DSPACE_STATE, TransferProcessStates.from(transferProcess.getState()).name());
 
         return builder.build();
     }

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/from/JsonObjectFromTransferRequestMessageTransformer.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/from/JsonObjectFromTransferRequestMessageTransformer.java
@@ -26,11 +26,11 @@ import org.jetbrains.annotations.Nullable;
 import java.util.UUID;
 
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCT_FORMAT_ATTRIBUTE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_CALLBACK_ADDRESS_TYPE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_CONTRACT_AGREEMENT_TYPE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_DATA_ADDRESS_TYPE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_PROCESSID_TYPE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_TRANSFERPROCESS_REQUEST_TYPE;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_CALLBACK_ADDRESS;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_CONTRACT_AGREEMENT_ID;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_DATA_ADDRESS;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_TRANSFER_PROCESS_REQUEST_TYPE;
 
 
 public class JsonObjectFromTransferRequestMessageTransformer extends AbstractJsonLdTransformer<TransferRequestMessage, JsonObject> {
@@ -48,15 +48,15 @@ public class JsonObjectFromTransferRequestMessageTransformer extends AbstractJso
         var builder = jsonBuilderFactory.createObjectBuilder();
 
         builder.add(JsonLdKeywords.ID, String.valueOf(UUID.randomUUID()));
-        builder.add(JsonLdKeywords.TYPE, DSPACE_TRANSFERPROCESS_REQUEST_TYPE);
+        builder.add(JsonLdKeywords.TYPE, DSPACE_TRANSFER_PROCESS_REQUEST_TYPE);
 
-        builder.add(DSPACE_CONTRACT_AGREEMENT_TYPE, transferRequestMessage.getContractId());
+        builder.add(DSPACE_CONTRACT_AGREEMENT_ID, transferRequestMessage.getContractId());
         builder.add(DCT_FORMAT_ATTRIBUTE, transferRequestMessage.getDataDestination().getType());
-        builder.add(DSPACE_CALLBACK_ADDRESS_TYPE, transferRequestMessage.getCallbackAddress());
-        builder.add(DSPACE_PROCESSID_TYPE, transferRequestMessage.getProcessId());
+        builder.add(DSPACE_CALLBACK_ADDRESS, transferRequestMessage.getCallbackAddress());
+        builder.add(DSPACE_PROCESS_ID, transferRequestMessage.getProcessId());
 
         if (transferRequestMessage.getDataDestination().getProperties().size() > 1) {
-            builder.add(DSPACE_DATA_ADDRESS_TYPE, context.transform(transferRequestMessage.getDataDestination(), JsonObject.class));
+            builder.add(DSPACE_DATA_ADDRESS, context.transform(transferRequestMessage.getDataDestination(), JsonObject.class));
         }
         return builder.build();
     }

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/from/JsonObjectFromTransferStartMessageTransformer.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/from/JsonObjectFromTransferStartMessageTransformer.java
@@ -26,8 +26,8 @@ import java.util.UUID;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_DATA_ADDRESS_TYPE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_PROCESSID_TYPE;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_DATA_ADDRESS;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_PROCESS_ID;
 import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_TRANSFER_START_TYPE;
 
 public class JsonObjectFromTransferStartMessageTransformer extends AbstractJsonLdTransformer<TransferStartMessage, JsonObject> {
@@ -45,9 +45,9 @@ public class JsonObjectFromTransferStartMessageTransformer extends AbstractJsonL
 
         builder.add(ID, UUID.randomUUID().toString());
         builder.add(TYPE, DSPACE_TRANSFER_START_TYPE);
-        builder.add(DSPACE_PROCESSID_TYPE, transferStartMessage.getProcessId());
+        builder.add(DSPACE_PROCESS_ID, transferStartMessage.getProcessId());
         if (transferStartMessage.getDataAddress() != null) {
-            builder.add(DSPACE_DATA_ADDRESS_TYPE, context.transform(transferStartMessage.getDataAddress(), JsonObject.class));
+            builder.add(DSPACE_DATA_ADDRESS, context.transform(transferStartMessage.getDataAddress(), JsonObject.class));
         }
 
         return builder.build();

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/from/JsonObjectFromTransferTerminationMessageTransformer.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/from/JsonObjectFromTransferTerminationMessageTransformer.java
@@ -26,9 +26,9 @@ import java.util.UUID;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_CODE_TYPE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_PROCESSID_TYPE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_REASON_TYPE;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_CODE;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_REASON;
 import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_TRANSFER_TERMINATION_TYPE;
 
 public class JsonObjectFromTransferTerminationMessageTransformer extends AbstractJsonLdTransformer<TransferTerminationMessage, JsonObject> {
@@ -46,12 +46,12 @@ public class JsonObjectFromTransferTerminationMessageTransformer extends Abstrac
 
         builder.add(ID, String.valueOf(UUID.randomUUID()));
         builder.add(TYPE, DSPACE_TRANSFER_TERMINATION_TYPE);
-        builder.add(DSPACE_PROCESSID_TYPE, transferTerminationMessage.getProcessId());
+        builder.add(DSPACE_PROCESS_ID, transferTerminationMessage.getProcessId());
         if (transferTerminationMessage.getCode() != null) {
-            builder.add(DSPACE_CODE_TYPE, transferTerminationMessage.getCode());
+            builder.add(DSPACE_CODE, transferTerminationMessage.getCode());
         }
         if (transferTerminationMessage.getReason() != null) {
-            builder.add(DSPACE_REASON_TYPE, transferTerminationMessage.getReason());
+            builder.add(DSPACE_REASON, transferTerminationMessage.getReason());
         }
 
         return builder.build();

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/to/JsonObjectToTransferCompletionMessageTransformer.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/to/JsonObjectToTransferCompletionMessageTransformer.java
@@ -22,7 +22,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.protocol.dsp.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_PROCESSID_TYPE;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_PROCESS_ID;
 
 public class JsonObjectToTransferCompletionMessageTransformer extends AbstractJsonLdTransformer<JsonObject, TransferCompletionMessage> {
 
@@ -36,7 +36,7 @@ public class JsonObjectToTransferCompletionMessageTransformer extends AbstractJs
 
         transferCompletionMessageBuilder.protocol(DATASPACE_PROTOCOL_HTTP);
 
-        transformString(messageObject.get(DSPACE_PROCESSID_TYPE), transferCompletionMessageBuilder::processId, context);
+        transformString(messageObject.get(DSPACE_PROCESS_ID), transferCompletionMessageBuilder::processId, context);
 
         return transferCompletionMessageBuilder.build();
 

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/to/JsonObjectToTransferRequestMessageTransformer.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/to/JsonObjectToTransferRequestMessageTransformer.java
@@ -25,9 +25,9 @@ import org.jetbrains.annotations.Nullable;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCT_FORMAT_ATTRIBUTE;
 import static org.eclipse.edc.protocol.dsp.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP;
 import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_CALLBACK_ADDRESS;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_CONTRACT_AGREEMENT_ID;
 import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_DATA_ADDRESS;
 import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_PROCESS_ID;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_CONTRACT_AGREEMENT_ID;
 
 public class JsonObjectToTransferRequestMessageTransformer extends AbstractJsonLdTransformer<JsonObject, TransferRequestMessage> {
 

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/to/JsonObjectToTransferRequestMessageTransformer.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/to/JsonObjectToTransferRequestMessageTransformer.java
@@ -24,10 +24,10 @@ import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCT_FORMAT_ATTRIBUTE;
 import static org.eclipse.edc.protocol.dsp.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_CALLBACK_ADDRESS_TYPE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_CONTRACT_AGREEMENT_TYPE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_DATA_ADDRESS_TYPE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_PROCESSID_TYPE;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_CALLBACK_ADDRESS;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_DATA_ADDRESS;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_CONTRACT_AGREEMENT_ID;
 
 public class JsonObjectToTransferRequestMessageTransformer extends AbstractJsonLdTransformer<JsonObject, TransferRequestMessage> {
 
@@ -37,22 +37,22 @@ public class JsonObjectToTransferRequestMessageTransformer extends AbstractJsonL
 
     @Override
     public @Nullable TransferRequestMessage transform(@NotNull JsonObject messageObject, @NotNull TransformerContext context) {
-        var builder = TransferRequestMessage.Builder.newInstance();
+        var transferRequestMessageBuilder = TransferRequestMessage.Builder.newInstance();
 
-        builder.protocol(DATASPACE_PROTOCOL_HTTP);
+        transferRequestMessageBuilder.protocol(DATASPACE_PROTOCOL_HTTP);
 
         visitProperties(messageObject, k -> {
             switch (k) {
-                case DSPACE_PROCESSID_TYPE: return v -> builder.processId(transformString(v, context));
-                case DSPACE_CONTRACT_AGREEMENT_TYPE: return v -> builder.contractId(transformString(v, context));
-                case DSPACE_CALLBACK_ADDRESS_TYPE: return v -> builder.callbackAddress(transformString(v, context));
+                case DSPACE_PROCESS_ID: return v -> transferRequestMessageBuilder.processId(transformString(v, context));
+                case DSPACE_CONTRACT_AGREEMENT_ID: return v -> transferRequestMessageBuilder.contractId(transformString(v, context));
+                case DSPACE_CALLBACK_ADDRESS: return v -> transferRequestMessageBuilder.callbackAddress(transformString(v, context));
                 default: return doNothing();
             }
         });
 
-        builder.dataDestination(createDataAddress(messageObject, context));
+        transferRequestMessageBuilder.dataDestination(createDataAddress(messageObject, context));
 
-        return builder.build();
+        return transferRequestMessageBuilder.build();
     }
 
     // TODO replace with JsonObjectToDataAddressTransformer
@@ -61,7 +61,7 @@ public class JsonObjectToTransferRequestMessageTransformer extends AbstractJsonL
 
         transformString(requestObject.get(DCT_FORMAT_ATTRIBUTE), dataAddressBuilder::type, context);
 
-        var dataAddressObject = returnJsonObject(requestObject.get(DSPACE_DATA_ADDRESS_TYPE), context, DSPACE_DATA_ADDRESS_TYPE, false);
+        var dataAddressObject = returnJsonObject(requestObject.get(DSPACE_DATA_ADDRESS), context, DSPACE_DATA_ADDRESS, false);
         if (dataAddressObject != null) {
             dataAddressObject.forEach((key, value) -> transformString(value, v -> dataAddressBuilder.property(key, v), context));
         }

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/to/JsonObjectToTransferStartMessageTransformer.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/to/JsonObjectToTransferStartMessageTransformer.java
@@ -23,8 +23,8 @@ import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_DATA_ADDRESS_TYPE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_PROCESSID_TYPE;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_DATA_ADDRESS;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_PROCESS_ID;
 
 public class JsonObjectToTransferStartMessageTransformer extends AbstractJsonLdTransformer<JsonObject, TransferStartMessage> {
 
@@ -38,9 +38,9 @@ public class JsonObjectToTransferStartMessageTransformer extends AbstractJsonLdT
 
         transferStartMessageBuilder.protocol(HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP);
 
-        transformString(messageObject.get(DSPACE_PROCESSID_TYPE), transferStartMessageBuilder::processId, context);
+        transformString(messageObject.get(DSPACE_PROCESS_ID), transferStartMessageBuilder::processId, context);
 
-        var dataAddressObject = returnJsonObject(messageObject.get(DSPACE_DATA_ADDRESS_TYPE), context, DSPACE_DATA_ADDRESS_TYPE, false);
+        var dataAddressObject = returnJsonObject(messageObject.get(DSPACE_DATA_ADDRESS), context, DSPACE_DATA_ADDRESS, false);
         if (dataAddressObject != null) {
             transferStartMessageBuilder.dataAddress(context.transform(dataAddressObject, DataAddress.class));
         }

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/to/JsonObjectToTransferTerminationMessageTransformer.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/to/JsonObjectToTransferTerminationMessageTransformer.java
@@ -23,9 +23,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import static java.lang.String.format;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_CODE_TYPE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_PROCESSID_TYPE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_REASON_TYPE;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_CODE;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_REASON;
 
 public class JsonObjectToTransferTerminationMessageTransformer extends AbstractJsonLdTransformer<JsonObject, TransferTerminationMessage> {
 
@@ -39,17 +39,17 @@ public class JsonObjectToTransferTerminationMessageTransformer extends AbstractJ
 
         transferTerminationMessageBuilder.protocol(HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP);
 
-        transformString(messageObject.get(DSPACE_PROCESSID_TYPE), transferTerminationMessageBuilder::processId, context);
+        transformString(messageObject.get(DSPACE_PROCESS_ID), transferTerminationMessageBuilder::processId, context);
 
-        if (messageObject.containsKey(DSPACE_CODE_TYPE)) {
-            transformString(messageObject.get(DSPACE_CODE_TYPE), transferTerminationMessageBuilder::code, context);
+        if (messageObject.containsKey(DSPACE_CODE)) {
+            transformString(messageObject.get(DSPACE_CODE), transferTerminationMessageBuilder::code, context);
         }
 
-        var reasons = messageObject.get(DSPACE_REASON_TYPE);
+        var reasons = messageObject.get(DSPACE_REASON);
         if (reasons != null) {  // optional property
             var result = typeValueArray(reasons, context);
             if (result == null) {
-                context.reportProblem(format("Cannot transform property %s in ContractNegotiationTerminationMessage", DSPACE_REASON_TYPE));
+                context.reportProblem(format("Cannot transform property %s in ContractNegotiationTerminationMessage", DSPACE_REASON));
             } else {
                 if (result.size() > 0) {
                     transferTerminationMessageBuilder.reason(result.toString());

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/from/JsonObjectFromTransferCompletionMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/from/JsonObjectFromTransferCompletionMessageTransformerTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_PROCESSID_TYPE;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_PROCESS_ID;
 import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_TRANSFER_COMPLETION_TYPE;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -57,7 +57,7 @@ class JsonObjectFromTransferCompletionMessageTransformerTest {
 
         assertThat(result).isNotNull();
         assertThat(result.getJsonString(JsonLdKeywords.TYPE).getString()).isEqualTo(DSPACE_TRANSFER_COMPLETION_TYPE);
-        assertThat(result.getJsonString(DSPACE_PROCESSID_TYPE).getString()).isEqualTo("TestID");
+        assertThat(result.getJsonString(DSPACE_PROCESS_ID).getString()).isEqualTo("TestID");
 
         verify(context, never()).reportProblem(anyString());
     }

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/from/JsonObjectFromTransferProcessTransformerTest.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/from/JsonObjectFromTransferProcessTransformerTest.java
@@ -29,9 +29,9 @@ import java.util.ArrayList;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_CORRELATIONID_TYPE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_STATE_TYPE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_TRANSFERPROCESS_TYPE;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_CORRELATION_ID;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_STATE;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_TRANSFER_PROCESS_TYPE;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -73,10 +73,10 @@ class JsonObjectFromTransferProcessTransformerTest {
         var result = transformer.transform(transferProcess, context);
 
         assertThat(result).isNotNull();
-        assertThat(result.getJsonString(JsonLdKeywords.TYPE).getString()).isEqualTo(DSPACE_TRANSFERPROCESS_TYPE);
+        assertThat(result.getJsonString(JsonLdKeywords.TYPE).getString()).isEqualTo(DSPACE_TRANSFER_PROCESS_TYPE);
         assertThat(result.getJsonString(JsonLdKeywords.ID).getString()).isEqualTo("transferProcessID");
-        assertThat(result.getJsonString(DSPACE_STATE_TYPE).getString()).isEqualTo("INITIAL");
-        assertThat(result.getJsonString(DSPACE_CORRELATIONID_TYPE).getString()).isEqualTo("dataRequestID");
+        assertThat(result.getJsonString(DSPACE_STATE).getString()).isEqualTo("INITIAL");
+        assertThat(result.getJsonString(DSPACE_CORRELATION_ID).getString()).isEqualTo("dataRequestID");
 
         verify(context, never()).reportProblem(anyString());
     }

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/from/JsonObjectFromTransferRequestMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/from/JsonObjectFromTransferRequestMessageTransformerTest.java
@@ -31,11 +31,11 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCT_FORMAT_ATTRIBUTE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_CALLBACK_ADDRESS_TYPE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_CONTRACT_AGREEMENT_TYPE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_DATA_ADDRESS_TYPE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_PROCESSID_TYPE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_TRANSFERPROCESS_REQUEST_TYPE;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_CALLBACK_ADDRESS;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_CONTRACT_AGREEMENT_ID;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_DATA_ADDRESS;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_TRANSFER_PROCESS_REQUEST_TYPE;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
@@ -95,12 +95,12 @@ class JsonObjectFromTransferRequestMessageTransformerTest {
         var result = transformer.transform(message, context);
 
         Assertions.assertNotNull(result);
-        assertThat(result.getJsonString(JsonLdKeywords.TYPE).getString()).isEqualTo(DSPACE_TRANSFERPROCESS_REQUEST_TYPE);
-        assertThat(result.getJsonString(DSPACE_CONTRACT_AGREEMENT_TYPE).getString()).isEqualTo(contractId);
+        assertThat(result.getJsonString(JsonLdKeywords.TYPE).getString()).isEqualTo(DSPACE_TRANSFER_PROCESS_REQUEST_TYPE);
+        assertThat(result.getJsonString(DSPACE_CONTRACT_AGREEMENT_ID).getString()).isEqualTo(contractId);
         assertThat(result.getJsonString(DCT_FORMAT_ATTRIBUTE).getString()).isEqualTo(dataAddressType);
-        assertThat(result.getJsonString(DSPACE_CALLBACK_ADDRESS_TYPE).getString()).isEqualTo(callbackAddress);
-        assertThat(result.getJsonString(DSPACE_PROCESSID_TYPE).getString()).isEqualTo(id);
-        assertThat(result.getJsonObject(DSPACE_DATA_ADDRESS_TYPE).getString("keyName")).isEqualTo(dataAddressKey);
+        assertThat(result.getJsonString(DSPACE_CALLBACK_ADDRESS).getString()).isEqualTo(callbackAddress);
+        assertThat(result.getJsonString(DSPACE_PROCESS_ID).getString()).isEqualTo(id);
+        assertThat(result.getJsonObject(DSPACE_DATA_ADDRESS).getString("keyName")).isEqualTo(dataAddressKey);
 
         verify(context, never()).reportProblem(anyString());
     }
@@ -122,12 +122,12 @@ class JsonObjectFromTransferRequestMessageTransformerTest {
         var result = transformer.transform(message, context);
 
         assertThat(result).isNotNull();
-        assertThat(result.getJsonString(JsonLdKeywords.TYPE).getString()).isEqualTo(DSPACE_TRANSFERPROCESS_REQUEST_TYPE);
-        assertThat(result.getJsonString(DSPACE_CONTRACT_AGREEMENT_TYPE).getString()).isEqualTo(contractId);
+        assertThat(result.getJsonString(JsonLdKeywords.TYPE).getString()).isEqualTo(DSPACE_TRANSFER_PROCESS_REQUEST_TYPE);
+        assertThat(result.getJsonString(DSPACE_CONTRACT_AGREEMENT_ID).getString()).isEqualTo(contractId);
         assertThat(result.getJsonString(DCT_FORMAT_ATTRIBUTE).getString()).isEqualTo(dataAddressType);
-        assertThat(result.getJsonString(DSPACE_CALLBACK_ADDRESS_TYPE).getString()).isEqualTo(callbackAddress);
-        assertThat(result.getJsonString(DSPACE_PROCESSID_TYPE).getString()).isEqualTo(id);
-        assertThat(result.getJsonObject(DSPACE_DATA_ADDRESS_TYPE)).isEqualTo(null);
+        assertThat(result.getJsonString(DSPACE_CALLBACK_ADDRESS).getString()).isEqualTo(callbackAddress);
+        assertThat(result.getJsonString(DSPACE_PROCESS_ID).getString()).isEqualTo(id);
+        assertThat(result.getJsonObject(DSPACE_DATA_ADDRESS)).isEqualTo(null);
 
         verify(context, never()).reportProblem(anyString());
     }

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/from/JsonObjectFromTransferStartMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/from/JsonObjectFromTransferStartMessageTransformerTest.java
@@ -28,8 +28,8 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_DATA_ADDRESS_TYPE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_PROCESSID_TYPE;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_DATA_ADDRESS;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_PROCESS_ID;
 import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_TRANSFER_START_TYPE;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -62,7 +62,7 @@ class JsonObjectFromTransferStartMessageTransformerTest {
                 .protocol(protocol)
                 .dataAddress(dataAddress)
                 .build();
-        
+
         var dataAddressJson = jsonFactory.createObjectBuilder().build();
         when(context.transform(dataAddress, JsonObject.class)).thenReturn(dataAddressJson);
 
@@ -70,8 +70,8 @@ class JsonObjectFromTransferStartMessageTransformerTest {
 
         assertThat(result).isNotNull();
         assertThat(result.getJsonString(JsonLdKeywords.TYPE).getString()).isEqualTo(DSPACE_TRANSFER_START_TYPE);
-        assertThat(result.getJsonString(DSPACE_PROCESSID_TYPE).getString()).isEqualTo(processId);
-        assertThat(result.getJsonObject(DSPACE_DATA_ADDRESS_TYPE)).isEqualTo(dataAddressJson);
+        assertThat(result.getJsonString(DSPACE_PROCESS_ID).getString()).isEqualTo(processId);
+        assertThat(result.getJsonObject(DSPACE_DATA_ADDRESS)).isEqualTo(dataAddressJson);
 
         verify(context, times(1)).transform(dataAddress, JsonObject.class);
         verify(context, never()).reportProblem(anyString());

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/from/JsonObjectFromTransferTerminationMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/from/JsonObjectFromTransferTerminationMessageTransformerTest.java
@@ -26,9 +26,9 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_CODE_TYPE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_PROCESSID_TYPE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_REASON_TYPE;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_CODE;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_REASON;
 import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_TRANSFER_TERMINATION_TYPE;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -61,9 +61,9 @@ class JsonObjectFromTransferTerminationMessageTransformerTest {
 
         assertThat(result).isNotNull();
         assertThat(result.getJsonString(JsonLdKeywords.TYPE).getString()).isEqualTo(DSPACE_TRANSFER_TERMINATION_TYPE);
-        assertThat(result.getJsonString(DSPACE_PROCESSID_TYPE).getString()).isEqualTo("TestID");
-        assertThat(result.getJsonString(DSPACE_CODE_TYPE).getString()).isEqualTo("testCode");
-        assertThat(result.getJsonString(DSPACE_REASON_TYPE).getString()).isEqualTo("testReason");
+        assertThat(result.getJsonString(DSPACE_PROCESS_ID).getString()).isEqualTo("TestID");
+        assertThat(result.getJsonString(DSPACE_CODE).getString()).isEqualTo("testCode");
+        assertThat(result.getJsonString(DSPACE_REASON).getString()).isEqualTo("testReason");
 
         verify(context, never()).reportProblem(anyString());
     }

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/to/JsonObjectToTransferCompletionMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/to/JsonObjectToTransferCompletionMessageTransformerTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_PROCESSID_TYPE;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_PROCESS_ID;
 import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_TRANSFER_COMPLETION_TYPE;
 import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.to.TestInput.getExpanded;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -49,7 +49,7 @@ class JsonObjectToTransferCompletionMessageTransformerTest {
 
         var json = Json.createObjectBuilder()
                 .add(TYPE, DSPACE_TRANSFER_COMPLETION_TYPE)
-                .add(DSPACE_PROCESSID_TYPE, processId)
+                .add(DSPACE_PROCESS_ID, processId)
                 .build();
 
         var result = transformer.transform(getExpanded(json), context);

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/to/JsonObjectToTransferRequestMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/to/JsonObjectToTransferRequestMessageTransformerTest.java
@@ -24,11 +24,11 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCT_FORMAT_ATTRIBUTE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_CALLBACK_ADDRESS_TYPE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_CONTRACT_AGREEMENT_TYPE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_DATA_ADDRESS_TYPE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_PROCESSID_TYPE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_TRANSFERPROCESS_REQUEST_TYPE;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_CALLBACK_ADDRESS;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_CONTRACT_AGREEMENT_ID;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_DATA_ADDRESS;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_TRANSFER_PROCESS_REQUEST_TYPE;
 import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.to.TestInput.getExpanded;
 import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -54,12 +54,12 @@ class JsonObjectToTransferRequestMessageTransformerTest {
     @Test
     void jsonObjectToTransferRequestWithoutDataAddress() {
         var json = Json.createObjectBuilder()
-                .add(TYPE, DSPACE_TRANSFERPROCESS_REQUEST_TYPE)
-                .add(DSPACE_CONTRACT_AGREEMENT_TYPE, contractId)
+                .add(TYPE, DSPACE_TRANSFER_PROCESS_REQUEST_TYPE)
+                .add(DSPACE_CONTRACT_AGREEMENT_ID, contractId)
                 .add(DCT_FORMAT_ATTRIBUTE, destinationType)
-                .add(DSPACE_DATA_ADDRESS_TYPE, Json.createObjectBuilder().build())
-                .add(DSPACE_CALLBACK_ADDRESS_TYPE, callbackAddress)
-                .add(DSPACE_PROCESSID_TYPE, "processId")
+                .add(DSPACE_DATA_ADDRESS, Json.createObjectBuilder().build())
+                .add(DSPACE_CALLBACK_ADDRESS, callbackAddress)
+                .add(DSPACE_PROCESS_ID, "processId")
                 .build();
 
         var result = transformer.transform(getExpanded(json), context);
@@ -76,12 +76,12 @@ class JsonObjectToTransferRequestMessageTransformerTest {
     @Test
     void jsonObjectToTransferRequestWithDataAddress() {
         var json = Json.createObjectBuilder()
-                .add(TYPE, DSPACE_TRANSFERPROCESS_REQUEST_TYPE)
-                .add(DSPACE_CONTRACT_AGREEMENT_TYPE, contractId)
+                .add(TYPE, DSPACE_TRANSFER_PROCESS_REQUEST_TYPE)
+                .add(DSPACE_CONTRACT_AGREEMENT_ID, contractId)
                 .add(DCT_FORMAT_ATTRIBUTE, destinationType)
-                .add(DSPACE_DATA_ADDRESS_TYPE, createDataAddress())
-                .add(DSPACE_CALLBACK_ADDRESS_TYPE, callbackAddress)
-                .add(DSPACE_PROCESSID_TYPE, "processId")
+                .add(DSPACE_DATA_ADDRESS, createDataAddress())
+                .add(DSPACE_CALLBACK_ADDRESS, callbackAddress)
+                .add(DSPACE_PROCESS_ID, "processId")
                 .build();
 
         var result = transformer.transform(getExpanded(json), context);

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/to/JsonObjectToTransferStartMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/to/JsonObjectToTransferStartMessageTransformerTest.java
@@ -25,8 +25,8 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.protocol.dsp.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_DATA_ADDRESS_TYPE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_PROCESSID_TYPE;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_DATA_ADDRESS;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_PROCESS_ID;
 import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_TRANSFER_START_TYPE;
 import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.to.TestInput.getExpanded;
 import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
@@ -55,7 +55,7 @@ class JsonObjectToTransferStartMessageTransformerTest {
     void jsonObjectToTransferStartMessage() {
         var json = Json.createObjectBuilder()
                 .add(TYPE, DSPACE_TRANSFER_START_TYPE)
-                .add(DSPACE_PROCESSID_TYPE, processId)
+                .add(DSPACE_PROCESS_ID, processId)
                 .build();
 
         var result = transformer.transform(getExpanded(json), context);
@@ -73,8 +73,8 @@ class JsonObjectToTransferStartMessageTransformerTest {
         var dataAddressObject = Json.createObjectBuilder().add(EDC_NAMESPACE + "type", "AWS").build();
         var json = Json.createObjectBuilder()
                 .add(TYPE, DSPACE_TRANSFER_START_TYPE)
-                .add(DSPACE_PROCESSID_TYPE, processId)
-                .add(DSPACE_DATA_ADDRESS_TYPE, dataAddressObject)
+                .add(DSPACE_PROCESS_ID, processId)
+                .add(DSPACE_DATA_ADDRESS, dataAddressObject)
                 .build();
 
         var dataAddress = DataAddress.Builder.newInstance().type("AWS").build();
@@ -96,8 +96,8 @@ class JsonObjectToTransferStartMessageTransformerTest {
     void jsonObjectToTransferStartMessageWithEmptyDataAddress() {
         var json = Json.createObjectBuilder()
                 .add(TYPE, DSPACE_TRANSFER_START_TYPE)
-                .add(DSPACE_PROCESSID_TYPE, processId)
-                .add(DSPACE_DATA_ADDRESS_TYPE, Json.createObjectBuilder().build())
+                .add(DSPACE_PROCESS_ID, processId)
+                .add(DSPACE_DATA_ADDRESS, Json.createObjectBuilder().build())
                 .build();
 
         var result = transformer.transform(getExpanded(json), context);

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/to/JsonObjectToTransferTerminationMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/to/JsonObjectToTransferTerminationMessageTransformerTest.java
@@ -27,9 +27,9 @@ import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_CODE_TYPE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_PROCESSID_TYPE;
-import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_REASON_TYPE;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_CODE;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_REASON;
 import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_TRANSFER_TERMINATION_TYPE;
 import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.to.TestInput.getExpanded;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -59,9 +59,9 @@ class JsonObjectToTransferTerminationMessageTransformerTest {
 
         var json = Json.createObjectBuilder()
                 .add(TYPE, DSPACE_TRANSFER_TERMINATION_TYPE)
-                .add(DSPACE_PROCESSID_TYPE, "TestProcessId")
-                .add(DSPACE_CODE_TYPE, "testCode")
-                .add(DSPACE_REASON_TYPE, Json.createBuilderFactory(Map.of()).createArrayBuilder().add(reasonArray).build())
+                .add(DSPACE_PROCESS_ID, "TestProcessId")
+                .add(DSPACE_CODE, "testCode")
+                .add(DSPACE_REASON, Json.createBuilderFactory(Map.of()).createArrayBuilder().add(reasonArray).build())
                 .build();
 
         var result = transformer.transform(getExpanded(json), context);

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToMultiplicityConstraintTransformer.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToMultiplicityConstraintTransformer.java
@@ -37,15 +37,17 @@ import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_XONE_CONSTRAI
  * Converts from an ODRL logical constraint as a {@link JsonObject} in JSON-LD expanded form to a {@link MultiplicityConstraint}.
  */
 public class JsonObjectToMultiplicityConstraintTransformer extends AbstractJsonLdTransformer<JsonObject, MultiplicityConstraint> {
-    
+
     public JsonObjectToMultiplicityConstraintTransformer() {
         super(JsonObject.class, MultiplicityConstraint.class);
     }
-    
+
     @Override
     public @Nullable MultiplicityConstraint transform(@NotNull JsonObject object, @NotNull TransformerContext context) {
-        var operand = object.getJsonObject(ODRL_OPERAND_ATTRIBUTE);
-        
+        var operand = returnMandatoryJsonObject(object.get(ODRL_OPERAND_ATTRIBUTE), context, ODRL_OPERAND_ATTRIBUTE);
+        if (operand == null) {
+            return null;
+        }
         if (operand.containsKey(ODRL_AND_CONSTRAINT_ATTRIBUTE)) {
             var builder = transformConstraints(operand.getJsonArray(ODRL_AND_CONSTRAINT_ATTRIBUTE), AndConstraint.Builder.newInstance(), context);
             return builderResult(builder::build, context);
@@ -62,8 +64,8 @@ public class JsonObjectToMultiplicityConstraintTransformer extends AbstractJsonL
             return null;
         }
     }
-    
-    private MultiplicityConstraint.Builder transformConstraints(JsonArray constraints, MultiplicityConstraint.Builder builder, TransformerContext context) {
+
+    private MultiplicityConstraint.Builder<?, ?> transformConstraints(JsonArray constraints, MultiplicityConstraint.Builder<?, ?> builder, TransformerContext context) {
         if (constraints != null) {
             constraints.forEach(c -> builder.constraint(context.transform(c, Constraint.class)));
         }

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToActionTransformerTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToActionTransformerTest.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.jsonld.transformer.to;
 import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
+import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
 import org.eclipse.edc.policy.model.AtomicConstraint;
 import org.eclipse.edc.policy.model.Constraint;
 import org.eclipse.edc.policy.model.LiteralExpression;
@@ -32,6 +33,7 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ACTION_TYPE_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_INCLUDED_IN_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_REFINEMENT_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.transformer.to.TestInput.getExpanded;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -43,36 +45,35 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class JsonObjectToActionTransformerTest {
-    
+
     private JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
     private TransformerContext context = mock(TransformerContext.class);
-    
+
     private JsonObjectToActionTransformer transformer;
-    
+
     @BeforeEach
     void setUp() {
         transformer = new JsonObjectToActionTransformer();
     }
-    
+
     @Test
     void transform_onlyActionType_returnAction() {
-        var action = jsonFactory.createObjectBuilder()
-                .add(ODRL_ACTION_TYPE_ATTRIBUTE, "USE")
-                .build();
-    
-        var result = transformer.transform(action, context);
-    
+        var action = jsonFactory.createObjectBuilder().add(ODRL_ACTION_TYPE_ATTRIBUTE, "USE").build();
+
+        var result = transformer.transform(getExpanded(action), context);
+
         assertThat(result).isNotNull();
         assertThat(result.getType()).isEqualTo("USE");
         assertThat(result.getIncludedIn()).isNull();
         assertThat(result.getConstraint()).isNull();
-        
+
         verifyNoInteractions(context);
     }
 
     @Test
     void transform_onlyId_returnAction() {
         var action = jsonFactory.createObjectBuilder()
+                .add(JsonLdKeywords.CONTEXT, JsonObject.EMPTY_JSON_OBJECT)
                 .add(ID, "use")
                 .build();
 
@@ -85,7 +86,7 @@ class JsonObjectToActionTransformerTest {
 
         verifyNoInteractions(context);
     }
-    
+
     @Test
     void transform_allAttributes_returnAction() {
         var constraint = AtomicConstraint.Builder.newInstance()
@@ -94,30 +95,30 @@ class JsonObjectToActionTransformerTest {
                 .rightExpression(new LiteralExpression("right"))
                 .build();
         when(context.transform(any(JsonObject.class), eq(Constraint.class))).thenReturn(constraint);
-        
+
         var action = jsonFactory.createObjectBuilder()
                 .add(ODRL_ACTION_TYPE_ATTRIBUTE, "USE")
                 .add(ODRL_INCLUDED_IN_ATTRIBUTE, "includedIn")
                 .add(ODRL_REFINEMENT_ATTRIBUTE, jsonFactory.createObjectBuilder().build())
                 .build();
-        
-        var result = transformer.transform(action, context);
-        
+
+        var result = transformer.transform(getExpanded(action), context);
+
         assertThat(result).isNotNull();
         assertThat(result.getType()).isEqualTo("USE");
         assertThat(result.getIncludedIn()).isEqualTo("includedIn");
         assertThat(result.getConstraint()).isEqualTo(constraint);
-        
+
         verify(context, never()).reportProblem(anyString());
         verify(context, times(1)).transform(any(JsonObject.class), eq(Constraint.class));
     }
-    
+
     @Test
     void transform_requiredAttributesMissing_reportProblem() {
         var action = jsonFactory.createObjectBuilder().build();
-    
+
         var result = transformer.transform(action, context);
-    
+
         assertThat(result).isNull();
         verify(context, times(1)).reportProblem(anyString());
     }

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToAssetTransformerTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToAssetTransformerTest.java
@@ -38,6 +38,7 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
+import static org.eclipse.edc.jsonld.transformer.to.TestInput.getExpanded;
 import static org.eclipse.edc.jsonld.util.JacksonJsonLd.createObjectMapper;
 import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 import static org.eclipse.edc.spi.CoreConstants.EDC_PREFIX;
@@ -85,7 +86,7 @@ class JsonObjectToAssetTransformerTest {
                 .add("properties", createPropertiesBuilder().build())
                 .build();
         jsonObj = expand(jsonObj);
-        var asset = typeTransformerRegistry.transform(jsonObj, Asset.class);
+        var asset = typeTransformerRegistry.transform(getExpanded(jsonObj), Asset.class);
 
         AbstractResultAssert.assertThat(asset).withFailMessage(asset::getFailureDetail).isSucceeded();
         assertThat(asset.getContent().getProperties())
@@ -135,7 +136,7 @@ class JsonObjectToAssetTransformerTest {
                         .build())
                 .build();
         jsonObj = expand(jsonObj);
-        var asset = typeTransformerRegistry.transform(jsonObj, Asset.class);
+        var asset = typeTransformerRegistry.transform(getExpanded(jsonObj), Asset.class);
         AbstractResultAssert.assertThat(asset).withFailMessage(asset::getFailureDetail).isSucceeded();
         assertThat(asset.getContent().getProperties())
                 .hasSize(6)
@@ -155,7 +156,7 @@ class JsonObjectToAssetTransformerTest {
                 .build();
         jsonObj = expand(jsonObj);
 
-        var asset = typeTransformerRegistry.transform(jsonObj, Asset.class);
+        var asset = typeTransformerRegistry.transform(getExpanded(jsonObj), Asset.class);
 
         assertThat(asset.getContent().getProperties()).hasSize(2)
                 .containsEntry(PROPERTY_ID, TEST_ASSET_ID)
@@ -170,12 +171,10 @@ class JsonObjectToAssetTransformerTest {
                 .add(CONTEXT, createContextBuilder().addNull(EDC_PREFIX).build())
                 .add(TYPE, EDC_ASSET_TYPE)
                 .add(ID, TEST_ASSET_ID)
-                .add("properties", createPropertiesBuilder()
-                        .add("payload", createPayloadBuilder().build())
-                        .build())
+                .add("properties", createPropertiesBuilder().add("payload", createPayloadBuilder().build()).build())
                 .build();
         jsonObj = expand(jsonObj);
-        var asset = typeTransformerRegistry.transform(jsonObj, Asset.class);
+        var asset = typeTransformerRegistry.transform(getExpanded(jsonObj), Asset.class);
 
         AbstractResultAssert.assertThat(asset).withFailMessage(asset::getFailureDetail).isSucceeded();
         assertThat(asset.getContent().getVersion()).isNull();

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToAtomicConstraintTransformerTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToAtomicConstraintTransformerTest.java
@@ -16,125 +16,99 @@ package org.eclipse.edc.jsonld.transformer.to;
 
 import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
 import org.eclipse.edc.policy.model.AtomicConstraint;
 import org.eclipse.edc.policy.model.LiteralExpression;
-import org.eclipse.edc.policy.model.Operator;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_LEFT_OPERAND_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_OPERATOR_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_RIGHT_OPERAND_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.transformer.to.TestInput.getExpanded;
+import static org.eclipse.edc.policy.model.Operator.EQ;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 class JsonObjectToAtomicConstraintTransformerTest {
-    
+    private static final String LEFT_VALUE = "left";
+    private static final String RIGHT_VALUE = "right";
+
     private JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
     private TransformerContext context = mock(TransformerContext.class);
-    
+
     private JsonObjectToAtomicConstraintTransformer transformer;
-    
+
     @BeforeEach
     void setUp() {
         transformer = new JsonObjectToAtomicConstraintTransformer();
     }
-    
-    @Test
-    void transform_attributesAsObjects_returnConstraint() {
-        var left = "left";
-        var operator = Operator.EQ;
-        var right = "right";
-        
-        var constraint = jsonFactory.createObjectBuilder()
-                .add(ODRL_LEFT_OPERAND_ATTRIBUTE, jsonFactory.createObjectBuilder()
-                        .add(VALUE, left))
-                .add(ODRL_OPERATOR_ATTRIBUTE, jsonFactory.createObjectBuilder()
-                        .add(VALUE, operator.name()))
-                .add(ODRL_RIGHT_OPERAND_ATTRIBUTE, jsonFactory.createObjectBuilder()
-                        .add(VALUE, right))
-                .build();
-        
-        var result = (AtomicConstraint) transformer.transform(constraint, context);
-        
+
+    @ParameterizedTest
+    @MethodSource("jsonSource")
+    void transform_operatorAsString_returnConstraint(JsonObject constraint) {
+
+        when(context.hasProblems()).thenReturn(false);
+
+        var result = (AtomicConstraint) transformer.transform(getExpanded(constraint), context);
+
         assertThat(result).isNotNull();
-        assertThat(((LiteralExpression) result.getLeftExpression()).getValue()).isEqualTo(left);
-        assertThat(result.getOperator()).isEqualTo(operator);
-        assertThat(((LiteralExpression) result.getRightExpression()).getValue()).isEqualTo(right);
-        
-        verifyNoInteractions(context);
+        assertThat(result.getLeftExpression())
+                .asInstanceOf(type(LiteralExpression.class))
+                .satisfies(le -> assertThat(le.getValue()).isEqualTo(LEFT_VALUE));
+        assertThat(result.getOperator()).isEqualTo(EQ);
+        assertThat(result.getRightExpression())
+                .asInstanceOf(type(LiteralExpression.class))
+                .satisfies(re -> assertThat(re.getValue()).isEqualTo(RIGHT_VALUE));
+
+        verify(context).hasProblems();
     }
-    
-    @Test
-    void transform_attributesAsArrays_returnConstraint() {
-        var left = "left";
-        var operator = Operator.EQ;
-        var right = "right";
-        
-        var constraint = jsonFactory.createObjectBuilder()
-                .add(ODRL_LEFT_OPERAND_ATTRIBUTE, jsonFactory.createArrayBuilder()
-                        .add(jsonFactory.createObjectBuilder()
-                                .add(VALUE, left)))
-                .add(ODRL_OPERATOR_ATTRIBUTE, jsonFactory.createArrayBuilder()
-                        .add(jsonFactory.createObjectBuilder()
-                                .add(VALUE, operator.name())))
-                .add(ODRL_RIGHT_OPERAND_ATTRIBUTE, jsonFactory.createArrayBuilder()
-                        .add(jsonFactory.createObjectBuilder()
-                                .add(VALUE, right)))
-                .build();
-        
-        var result = (AtomicConstraint) transformer.transform(constraint, context);
-        
-        assertThat(result).isNotNull();
-        assertThat(((LiteralExpression) result.getLeftExpression()).getValue()).isEqualTo(left);
-        assertThat(result.getOperator()).isEqualTo(operator);
-        assertThat(((LiteralExpression) result.getRightExpression()).getValue()).isEqualTo(right);
-        
-        verifyNoInteractions(context);
-    }
-    
-    @Test
-    void transform_operatorAsString_returnConstraint() {
-        var left = "left";
-        var operator = Operator.EQ;
-        var right = "right";
-        
-        var constraint = jsonFactory.createObjectBuilder()
-                .add(ODRL_LEFT_OPERAND_ATTRIBUTE, jsonFactory.createObjectBuilder()
-                        .add(VALUE, left))
-                .add(ODRL_OPERATOR_ATTRIBUTE, operator.name())
-                .add(ODRL_RIGHT_OPERAND_ATTRIBUTE, jsonFactory.createObjectBuilder()
-                        .add(VALUE, right))
-                .build();
-        
-        var result = (AtomicConstraint) transformer.transform(constraint, context);
-        
-        assertThat(result).isNotNull();
-        assertThat(result.getOperator()).isEqualTo(operator);
-        
-        verifyNoInteractions(context);
-    }
-    
+
     @Test
     void transform_invalidAttributes_reportProblems() {
         var jsonNumber = Json.createValue(1);
-        
+
         var constraint = jsonFactory.createObjectBuilder()
                 .add(ODRL_LEFT_OPERAND_ATTRIBUTE, jsonNumber)
                 .add(ODRL_OPERATOR_ATTRIBUTE, jsonNumber)
                 .add(ODRL_RIGHT_OPERAND_ATTRIBUTE, jsonNumber)
                 .build();
-    
-        transformer.transform(constraint, context);
-        
+
+        transformer.transform(getExpanded(constraint), context);
+
         verify(context, times(3)).reportProblem(anyString());
     }
+
+    static Stream<JsonObject> jsonSource() {
+        var jsonFactory = Json.createBuilderFactory(Map.of());
+        return Stream.of(
+                // as object
+                jsonFactory.createObjectBuilder()
+                        .add(ODRL_LEFT_OPERAND_ATTRIBUTE, jsonFactory.createObjectBuilder().add(VALUE, LEFT_VALUE))
+                        .add(ODRL_OPERATOR_ATTRIBUTE, EQ.name())
+                        .add(ODRL_RIGHT_OPERAND_ATTRIBUTE, jsonFactory.createObjectBuilder().add(VALUE, RIGHT_VALUE))
+                        .build(),
+
+                // as arrays
+                jsonFactory.createObjectBuilder()
+                        .add(ODRL_LEFT_OPERAND_ATTRIBUTE, jsonFactory.createArrayBuilder().add(jsonFactory.createObjectBuilder().add(VALUE, LEFT_VALUE)))
+                        .add(ODRL_OPERATOR_ATTRIBUTE, jsonFactory.createArrayBuilder().add(jsonFactory.createObjectBuilder().add(VALUE, EQ.name())))
+                        .add(ODRL_RIGHT_OPERAND_ATTRIBUTE, jsonFactory.createArrayBuilder().add(jsonFactory.createObjectBuilder().add(VALUE, RIGHT_VALUE)))
+                        .build()
+        );
+    }
+
+
 }

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToCatalogTransformerTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToCatalogTransformerTest.java
@@ -34,9 +34,11 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_CATALOG_TYPE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DATASET_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DATA_SERVICE_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.transformer.to.TestInput.getExpanded;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -60,12 +62,9 @@ class JsonObjectToCatalogTransformerTest {
 
     @Test
     void transform_emptyCatalog_returnCatalog() {
-        var catalog = jsonFactory.createObjectBuilder()
-                .add(ID, CATALOG_ID)
-                .add(TYPE, DCAT_CATALOG_TYPE)
-                .build();
+        var catalog = jsonFactory.createObjectBuilder().add(ID, CATALOG_ID).add(TYPE, DCAT_CATALOG_TYPE).build();
 
-        var result = transformer.transform(catalog, context);
+        var result = transformer.transform(getExpanded(catalog), context);
 
         assertThat(result).isNotNull();
         assertThat(result.getId()).isEqualTo(CATALOG_ID);
@@ -88,7 +87,7 @@ class JsonObjectToCatalogTransformerTest {
                 .add(propertyKey, propertyValue)
                 .build();
 
-        var result = transformer.transform(catalog, context);
+        var result = transformer.transform(getExpanded(catalog), context);
 
         assertThat(result).isNotNull();
         assertThat(result.getId()).isEqualTo(CATALOG_ID);
@@ -125,7 +124,7 @@ class JsonObjectToCatalogTransformerTest {
                 .add(DCAT_DATA_SERVICE_ATTRIBUTE, dataServiceJson)
                 .build();
 
-        var result = transformer.transform(catalog, context);
+        var result = transformer.transform(getExpanded(catalog), context);
 
         assertThat(result).isNotNull();
         assertThat(result.getId()).isEqualTo(CATALOG_ID);
@@ -135,25 +134,21 @@ class JsonObjectToCatalogTransformerTest {
         assertThat(result.getDataServices().get(0)).isEqualTo(dataService);
 
         verify(context, never()).reportProblem(anyString());
-        verify(context, times(1)).transform(dataSetJson, Dataset.class);
-        verify(context, times(1)).transform(dataServiceJson, DataService.class);
+        verify(context, times(1)).transform(isA(JsonObject.class), eq(Dataset.class));
+        verify(context, times(1)).transform(isA(JsonObject.class), eq(DataService.class));
     }
 
     @Test
     void transform_invalidType_reportProblem() {
-        var catalog = jsonFactory.createObjectBuilder()
-                .add(TYPE, "not-a-catalog")
-                .build();
+        var catalog = jsonFactory.createObjectBuilder().add(TYPE, "not-a-catalog").build();
 
-        transformer.transform(catalog, context);
+        transformer.transform(getExpanded(catalog), context);
 
         verify(context, never()).reportProblem(anyString());
     }
 
     private JsonObject getJsonObject(String type) {
-        return jsonFactory.createObjectBuilder()
-                .add(TYPE, type)
-                .build();
+        return jsonFactory.createObjectBuilder().add(TYPE, type).build();
     }
 
 }

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToConstraintTransformerTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToConstraintTransformerTest.java
@@ -16,6 +16,8 @@ package org.eclipse.edc.jsonld.transformer.to;
 
 import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
 import org.eclipse.edc.policy.model.AndConstraint;
 import org.eclipse.edc.policy.model.AtomicConstraint;
 import org.eclipse.edc.policy.model.MultiplicityConstraint;
@@ -27,71 +29,77 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
+import static org.eclipse.edc.jsonld.spi.Namespaces.ODRL_SCHEMA;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_AND_CONSTRAINT_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_LEFT_OPERAND_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_OPERAND_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_OPERATOR_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_RIGHT_OPERAND_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.transformer.to.TestInput.getExpanded;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class JsonObjectToConstraintTransformerTest {
-    
+
     private JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
     private TransformerContext context = mock(TransformerContext.class);
-    
+
     private JsonObjectToConstraintTransformer transformer;
-    
+
     @BeforeEach
     void setUp() {
         transformer = new JsonObjectToConstraintTransformer();
     }
-    
+
     @Test
     void transform_shouldCallContext_whenAtomicConstraint() {
         var atomicConstraintJson = jsonFactory.createObjectBuilder()
-                .add(ODRL_LEFT_OPERAND_ATTRIBUTE, jsonFactory.createObjectBuilder()
-                        .add(VALUE, "left"))
-                .add(ODRL_OPERATOR_ATTRIBUTE, jsonFactory.createObjectBuilder()
-                        .add(VALUE, "EQ"))
-                .add(ODRL_RIGHT_OPERAND_ATTRIBUTE, jsonFactory.createObjectBuilder()
-                        .add(VALUE, "right"))
+                .add(ODRL_LEFT_OPERAND_ATTRIBUTE, jsonFactory.createObjectBuilder().add(VALUE, "left"))
+                .add(ODRL_OPERATOR_ATTRIBUTE, jsonFactory.createObjectBuilder().add(VALUE, "EQ"))
+                .add(ODRL_RIGHT_OPERAND_ATTRIBUTE, jsonFactory.createObjectBuilder().add(VALUE, "right"))
                 .build();
         var atomicConstraint = AtomicConstraint.Builder.newInstance().build();
-        when(context.transform(atomicConstraintJson, AtomicConstraint.class)).thenReturn(atomicConstraint);
-        
-        var result = transformer.transform(atomicConstraintJson, context);
-        
+        when(context.transform(isA(JsonObject.class), eq(AtomicConstraint.class))).thenReturn(atomicConstraint);
+
+        var result = transformer.transform(getExpanded(atomicConstraintJson), context);
+
         assertThat(result).isEqualTo(atomicConstraint);
-        verify(context, times(1)).transform(atomicConstraintJson, AtomicConstraint.class);
+        verify(context, times(1)).transform(isA(JsonObject.class), eq(AtomicConstraint.class));
     }
-    
+
     @Test
     void transform_shouldCallContext_whenLogicalConstraint() {
+        var operand = jsonFactory.createObjectBuilder().add(ODRL_AND_CONSTRAINT_ATTRIBUTE, jsonFactory.createArrayBuilder().build());
         var logicalConstraintJson = jsonFactory.createObjectBuilder()
-                .add(ODRL_OPERAND_ATTRIBUTE, jsonFactory.createObjectBuilder()
-                        .add(ODRL_AND_CONSTRAINT_ATTRIBUTE, jsonFactory.createArrayBuilder().build()))
+                .add(JsonLdKeywords.CONTEXT, JsonObject.EMPTY_JSON_OBJECT)
+                .add(ODRL_OPERAND_ATTRIBUTE, operand)
                 .build();
         var andConstraint = AndConstraint.Builder.newInstance().build();
-        when(context.transform(logicalConstraintJson, MultiplicityConstraint.class)).thenReturn(andConstraint);
-    
-        var result = transformer.transform(logicalConstraintJson, context);
-    
+
+        when(context.transform(isA(JsonObject.class), eq(MultiplicityConstraint.class))).thenReturn(andConstraint);
+
+        var result = transformer.transform(getExpanded(logicalConstraintJson), context);
+
         assertThat(result).isEqualTo(andConstraint);
-        verify(context, times(1)).transform(logicalConstraintJson, MultiplicityConstraint.class);
+        verify(context, times(1)).transform(isA(JsonObject.class), eq(MultiplicityConstraint.class));
     }
-    
+
     @Test
     void transform_shouldReportProblem_whenUnknownConstraint() {
-        var invalidConstraintJson = jsonFactory.createObjectBuilder().build();
-        
-        var result = transformer.transform(invalidConstraintJson, context);
-        
+        var invalidConstraintJson = jsonFactory.createObjectBuilder()
+                .add(JsonLdKeywords.CONTEXT, JsonObject.EMPTY_JSON_OBJECT)
+                .add(ODRL_SCHEMA + "invalid", "invalid")
+                .build();
+
+        var result = transformer.transform(getExpanded(invalidConstraintJson), context);
+
         assertThat(result).isNull();
         verify(context, times(1)).reportProblem(anyString());
     }
-    
+
 }

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToDataServiceTransformerTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToDataServiceTransformerTest.java
@@ -28,6 +28,7 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DATA_SERVICE_TYPE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCT_ENDPOINT_URL_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCT_TERMS_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.transformer.to.TestInput.getExpanded;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -60,7 +61,7 @@ class JsonObjectToDataServiceTransformerTest {
                 .add(DCT_ENDPOINT_URL_ATTRIBUTE, url)
                 .build();
 
-        var result = transformer.transform(dataService, context);
+        var result = transformer.transform(getExpanded(dataService), context);
 
         assertThat(result).isNotNull();
         assertThat(result.getId()).isEqualTo(DATA_SERVICE_ID);
@@ -72,11 +73,9 @@ class JsonObjectToDataServiceTransformerTest {
 
     @Test
     void transform_invalidType_reportProblem() {
-        var dataService = jsonFactory.createObjectBuilder()
-                .add(TYPE, "not-a-data-service")
-                .build();
+        var dataService = jsonFactory.createObjectBuilder().add(TYPE, "not-a-data-service").build();
 
-        transformer.transform(dataService, context);
+        transformer.transform(getExpanded(dataService), context);
 
         verify(context, never()).reportProblem(anyString());
     }

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToDatasetTransformerTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToDatasetTransformerTest.java
@@ -33,9 +33,11 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DATASET_TYPE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DISTRIBUTION_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.transformer.to.TestInput.getExpanded;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -43,67 +45,67 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class JsonObjectToDatasetTransformerTest {
-    
+
     private static final String DATASET_ID = "datasetId";
-    
+
     private JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
     private TransformerContext context = mock(TransformerContext.class);
-    
+
     private JsonObjectToDatasetTransformer transformer;
-    
+
     private Policy policy;
     private Distribution distribution;
-    
+
     @BeforeEach
     void setUp() {
         transformer = new JsonObjectToDatasetTransformer();
-    
+
         policy = Policy.Builder.newInstance().build();
         distribution = Distribution.Builder.newInstance()
                 .format("format")
                 .dataService(DataService.Builder.newInstance().build())
                 .build();
-    
+
         when(context.transform(any(JsonObject.class), eq(Policy.class)))
                 .thenReturn(policy);
         when(context.transform(any(JsonObject.class), eq(Distribution.class)))
                 .thenReturn(distribution);
     }
-    
+
     @Test
     void transform_returnDataset() {
         var policyId = "policy-id";
         var policyJson = getJsonObject(policyId, "policy");
         var distributionJson = getJsonObject("data-service-id", "dataService");
-        
+
         var dataset = jsonFactory.createObjectBuilder()
                 .add(ID, DATASET_ID)
                 .add(TYPE, DCAT_DATASET_TYPE)
                 .add(ODRL_POLICY_ATTRIBUTE, policyJson)
                 .add(DCAT_DISTRIBUTION_ATTRIBUTE, distributionJson)
                 .build();
-        
-        var result = transformer.transform(dataset, context);
-        
+
+        var result = transformer.transform(getExpanded(dataset), context);
+
         assertThat(result).isNotNull();
         assertThat(result.getId()).isEqualTo(DATASET_ID);
         assertThat(result.getOffers()).hasSize(1);
         assertThat(result.getOffers()).containsEntry(policyId, policy);
         assertThat(result.getDistributions()).hasSize(1);
         assertThat(result.getDistributions().get(0)).isEqualTo(distribution);
-        
+
         verify(context, never()).reportProblem(anyString());
-        verify(context, times(1)).transform(policyJson, Policy.class);
-        verify(context, times(1)).transform(distributionJson, Distribution.class);
+        verify(context, times(1)).transform(isA(JsonObject.class), eq(Policy.class));
+        verify(context, times(1)).transform(isA(JsonObject.class), eq(Distribution.class));
     }
-    
+
     @Test
     void transform_datasetWithAdditionalProperty_returnDataset() {
         var propertyKey = "dataset:prop:key";
         var propertyValue = "value";
-        
+
         when(context.transform(any(JsonValue.class), eq(Object.class))).thenReturn(propertyValue);
-        
+
         var dataset = jsonFactory.createObjectBuilder()
                 .add(ID, DATASET_ID)
                 .add(TYPE, DCAT_DATASET_TYPE)
@@ -111,47 +113,47 @@ class JsonObjectToDatasetTransformerTest {
                 .add(DCAT_DISTRIBUTION_ATTRIBUTE, jsonFactory.createObjectBuilder().build())
                 .add(propertyKey, propertyValue)
                 .build();
-        
-        var result = transformer.transform(dataset, context);
-        
+
+        var result = transformer.transform(getExpanded(dataset), context);
+
         assertThat(result).isNotNull();
         assertThat(result.getId()).isEqualTo(DATASET_ID);
         assertThat(result.getProperties()).hasSize(1);
         assertThat(result.getProperties()).containsEntry(propertyKey, propertyValue);
-    
+
         verify(context, never()).reportProblem(anyString());
         verify(context, times(1)).transform(any(JsonValue.class), eq(Object.class));
     }
-    
+
     @Test
     void transform_invalidType_reportProblem() {
         var dataset = jsonFactory.createObjectBuilder()
                 .add(TYPE, "not-a-dataset")
                 .build();
-    
-        transformer.transform(dataset, context);
-        
+
+        transformer.transform(getExpanded(dataset), context);
+
         verify(context, times(1)).reportProblem(anyString());
     }
-    
+
     @Test
     void transform_requiredAttributesMissing_reportProblem() {
         var dataset = jsonFactory.createObjectBuilder()
                 .add(ID, DATASET_ID)
                 .add(TYPE, DCAT_DATASET_TYPE)
                 .build();
-        
-        var result = transformer.transform(dataset, context);
-        
+
+        var result = transformer.transform(getExpanded(dataset), context);
+
         assertThat(result).isNull();
         verify(context, times(1)).reportProblem(anyString());
     }
-    
+
     private JsonObject getJsonObject(String id, String type) {
         return jsonFactory.createObjectBuilder()
                 .add(ID, id)
                 .add(TYPE, type)
                 .build();
     }
-    
+
 }

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToDistributionTransformerTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToDistributionTransformerTest.java
@@ -27,6 +27,7 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_ACCESS_SERVICE_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DISTRIBUTION_TYPE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCT_FORMAT_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.transformer.to.TestInput.getExpanded;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -34,57 +35,57 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 class JsonObjectToDistributionTransformerTest {
-    
+
     private JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
     private TransformerContext context = mock(TransformerContext.class);
-    
+
     private JsonObjectToDistributionTransformer transformer;
-    
+
     @BeforeEach
     void setUp() {
         transformer = new JsonObjectToDistributionTransformer();
     }
-    
+
     @Test
     void transform_returnDistribution() {
         var format = "format";
         var dataServiceId = "dataServiceId";
-        
+
         var distribution = jsonFactory.createObjectBuilder()
                 .add(TYPE, DCAT_DISTRIBUTION_TYPE)
                 .add(DCT_FORMAT_ATTRIBUTE, format)
                 .add(DCAT_ACCESS_SERVICE_ATTRIBUTE, dataServiceId)
                 .build();
-    
-        var result = transformer.transform(distribution, context);
-    
+
+        var result = transformer.transform(getExpanded(distribution), context);
+
         assertThat(result).isNotNull();
         assertThat(result.getFormat()).isEqualTo(format);
         assertThat(result.getDataService()).isNotNull()
                 .matches(ds -> ds.getId().equals(dataServiceId) && ds.getTerms() == null && ds.getEndpointUrl() == null);
-        
+
         verifyNoInteractions(context);
     }
-    
+
     @Test
     void transform_invalidType_reportProblem() {
         var distribution = jsonFactory.createObjectBuilder()
                 .add(TYPE, "not-a-distribution")
                 .build();
-    
-        transformer.transform(distribution, context);
-        
+
+        transformer.transform(getExpanded(distribution), context);
+
         verify(context, times(1)).reportProblem(anyString());
     }
-    
+
     @Test
     void transform_requiredAttributesMissing_reportProblem() {
         var distribution = jsonFactory.createObjectBuilder()
                 .add(TYPE, DCAT_DISTRIBUTION_TYPE)
                 .build();
-        
-        var result = transformer.transform(distribution, context);
-    
+
+        var result = transformer.transform(getExpanded(distribution), context);
+
         assertThat(result).isNull();
         verify(context, times(1)).reportProblem(anyString());
     }

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToMultiplicityConstraintTransformerTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToMultiplicityConstraintTransformerTest.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.jsonld.transformer.to;
 import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
+import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
 import org.eclipse.edc.policy.model.AndConstraint;
 import org.eclipse.edc.policy.model.AtomicConstraint;
 import org.eclipse.edc.policy.model.Constraint;
@@ -36,14 +37,17 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.Namespaces.ODRL_SCHEMA;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_AND_CONSTRAINT_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_OPERAND_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_OPERATOR_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_OR_CONSTRAINT_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_XONE_CONSTRAINT_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.transformer.to.TestInput.getExpanded;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -51,81 +55,75 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class JsonObjectToMultiplicityConstraintTransformerTest {
-    
+
     private JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
     private TransformerContext context = mock(TransformerContext.class);
-    
+
     private JsonObjectToMultiplicityConstraintTransformer transformer;
-    
+
     @BeforeEach
     void setUp() {
         transformer = new JsonObjectToMultiplicityConstraintTransformer();
     }
-    
+
     @ParameterizedTest
     @ArgumentsSource(TransformArgumentsProvider.class)
     void transform_shouldReturnMultiplicityConstraint(String operandAttribute, Class<MultiplicityConstraint> expectedType) {
-        var constraintJson = jsonFactory.createObjectBuilder()
-                .add(ODRL_OPERATOR_ATTRIBUTE, "EQ")
-                .build();
+        var constraintJson = jsonFactory.createObjectBuilder().add(ODRL_OPERATOR_ATTRIBUTE, "EQ").build();
+        var operand = jsonFactory.createObjectBuilder().add(operandAttribute, jsonFactory.createArrayBuilder().add(constraintJson).build()).build();
         var logicalConstraintJson = jsonFactory.createObjectBuilder()
-                .add(ODRL_OPERAND_ATTRIBUTE, jsonFactory.createObjectBuilder()
-                        .add(operandAttribute, jsonFactory.createArrayBuilder()
-                                .add(constraintJson)
-                                .build())
-                        .build())
+                .add(ODRL_OPERAND_ATTRIBUTE, operand)
                 .build();
-    
+
         var atomicConstraint = AtomicConstraint.Builder.newInstance().build();
-        when(context.transform(constraintJson, Constraint.class)).thenReturn(atomicConstraint);
-    
-        var result = transformer.transform(logicalConstraintJson, context);
-    
+        when(context.transform(isA(JsonObject.class), eq(Constraint.class))).thenReturn(atomicConstraint);
+
+        var result = transformer.transform(getExpanded(logicalConstraintJson), context);
+
+        assertThat(result).isNotNull();
         assertThat(result).isInstanceOf(expectedType);
         assertThat(result.getConstraints())
                 .isNotNull()
                 .hasSize(1)
                 .contains(atomicConstraint);
-        verify(context, times(1)).transform(constraintJson, Constraint.class);
+        verify(context, times(1)).transform(isA(JsonObject.class), eq(Constraint.class));
     }
-    
+
     @ParameterizedTest
     @ArgumentsSource(TransformArgumentsProvider.class)
-    void transform_shouldReturnEmptyMultiplicityConstraint_whenNoConstraints(String operandSubProperty,
-                                                                             Class<MultiplicityConstraint> expectedType) {
+    void transform_shouldReturnEmptyMultiplicityConstraint_whenNoConstraints(String operandSubProperty, Class<MultiplicityConstraint> expectedType) {
+        var operand = jsonFactory.createObjectBuilder().add(operandSubProperty, jsonFactory.createArrayBuilder().build()).build();
         var logicalConstraintJson = jsonFactory.createObjectBuilder()
-                .add(ODRL_OPERAND_ATTRIBUTE, jsonFactory.createObjectBuilder()
-                        .add(operandSubProperty, jsonFactory.createArrayBuilder().build())
-                        .build())
+                .add(ODRL_OPERAND_ATTRIBUTE, operand)
                 .build();
-        
-        var result = transformer.transform(logicalConstraintJson, context);
-        
+
+        var result = transformer.transform(getExpanded(logicalConstraintJson), context);
+
+        assertThat(result).isNotNull();
         assertThat(result).isInstanceOf(expectedType);
-        assertThat(result.getConstraints())
-                .isNotNull()
-                .isEmpty();
+        assertThat(result.getConstraints()).isNotNull().isEmpty();
         verify(context, never()).transform(any(JsonObject.class), eq(Constraint.class));
     }
-    
+
     @Test
     void transform_shouldReportProblem_whenUnknownOperandAttribute() {
-        var invalidJson = jsonFactory.createObjectBuilder()
-                .add(ODRL_OPERAND_ATTRIBUTE, jsonFactory.createObjectBuilder()
-                        .add("unknown", jsonFactory.createArrayBuilder()
-                                .build())
-                        .build())
+        var operand = jsonFactory.createObjectBuilder()
+                .add(ODRL_SCHEMA + "unknown", jsonFactory.createArrayBuilder().build())
                 .build();
-        
-        var result = transformer.transform(invalidJson, context);
-        
+        var invalidJson = jsonFactory.createObjectBuilder()
+                .add(JsonLdKeywords.CONTEXT, JsonObject.EMPTY_JSON_OBJECT)
+                .add(ODRL_OPERAND_ATTRIBUTE, operand)
+                .build();
+
+        var result = transformer.transform(getExpanded(invalidJson), context);
+
         assertThat(result).isNull();
         verify(context, times(1)).reportProblem(anyString());
     }
 
     static class TransformArgumentsProvider implements ArgumentsProvider {
         @Override
-        public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
             return Stream.of(
                     Arguments.of(ODRL_AND_CONSTRAINT_ATTRIBUTE, AndConstraint.class),
                     Arguments.of(ODRL_OR_CONSTRAINT_ATTRIBUTE, OrConstraint.class),
@@ -133,5 +131,5 @@ class JsonObjectToMultiplicityConstraintTransformerTest {
             );
         }
     }
-    
+
 }

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToPermissionTransformerTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToPermissionTransformerTest.java
@@ -15,18 +15,18 @@
 package org.eclipse.edc.jsonld.transformer.to;
 
 import jakarta.json.Json;
-import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.policy.model.Action;
 import org.eclipse.edc.policy.model.AtomicConstraint;
 import org.eclipse.edc.policy.model.Constraint;
 import org.eclipse.edc.policy.model.Duty;
-import org.eclipse.edc.policy.model.Permission;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
@@ -34,7 +34,10 @@ import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ACTION_ATTRIB
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_CONSTRAINT_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_DUTY_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.transformer.to.TestInput.getExpanded;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -42,18 +45,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class JsonObjectToPermissionTransformerTest {
-    
-    private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
-    private final TransformerContext context = mock(TransformerContext.class);
+    private static final String TARGET = "target";
 
-    private final JsonObject actionJson = getJsonObject("action");
-    private final JsonObject constraintJson = getJsonObject("constraint");
-    private final JsonObject dutyJson = getJsonObject("duty");
+    private final TransformerContext context = mock(TransformerContext.class);
 
     private final Action action = Action.Builder.newInstance().type("type").build();
     private final Constraint constraint = AtomicConstraint.Builder.newInstance().build();
     private final Duty duty = Duty.Builder.newInstance().build();
-    private final String target = "target";
 
     private JsonObjectToPermissionTransformer transformer;
 
@@ -61,58 +59,55 @@ class JsonObjectToPermissionTransformerTest {
     void setUp() {
         transformer = new JsonObjectToPermissionTransformer();
 
-        when(context.transform(actionJson, Action.class)).thenReturn(action);
-        when(context.transform(constraintJson, Constraint.class)).thenReturn(constraint);
-        when(context.transform(dutyJson, Duty.class)).thenReturn(duty);
+        when(context.transform(isA(JsonObject.class), eq(Action.class))).thenReturn(action);
+        when(context.transform(isA(JsonObject.class), eq(Constraint.class))).thenReturn(constraint);
+        when(context.transform(isA(JsonObject.class), eq(Duty.class))).thenReturn(duty);
     }
-    
-    @Test
-    void transform_attributesAsObjects_returnPermission() {
-        var permission = jsonFactory.createObjectBuilder()
-                .add(ODRL_ACTION_ATTRIBUTE, actionJson)
-                .add(ODRL_CONSTRAINT_ATTRIBUTE, constraintJson)
-                .add(ODRL_DUTY_ATTRIBUTE, dutyJson)
-                .add(ODRL_TARGET_ATTRIBUTE, target)
-                .build();
-    
-        var result = transformer.transform(permission, context);
-    
-        assertResult(result);
-    }
-    
-    @Test
-    void transform_attributesAsArrays_returnPermission() {
-        var permission = jsonFactory.createObjectBuilder()
-                 .add(ODRL_ACTION_ATTRIBUTE, jsonFactory.createArrayBuilder().add(actionJson))
-                 .add(ODRL_CONSTRAINT_ATTRIBUTE, jsonFactory.createArrayBuilder().add(constraintJson))
-                 .add(ODRL_DUTY_ATTRIBUTE, jsonFactory.createArrayBuilder().add(dutyJson))
-                 .add(ODRL_TARGET_ATTRIBUTE, jsonFactory.createArrayBuilder().add(target))
-                 .build();
-        
-        var result = transformer.transform(permission, context);
-        
-        assertResult(result);
-    }
-    
-    private void assertResult(Permission result) {
+
+    @ParameterizedTest
+    @MethodSource("jsonSource")
+    void transform_attributesAsObjects_returnPermission(JsonObject permission) {
+
+        var result = transformer.transform(getExpanded(permission), context);
+
         assertThat(result).isNotNull();
         assertThat(result.getAction()).isEqualTo(action);
         assertThat(result.getConstraints()).hasSize(1);
         assertThat(result.getConstraints().get(0)).isEqualTo(constraint);
         assertThat(result.getDuties()).hasSize(1);
         assertThat(result.getDuties().get(0)).isEqualTo(duty);
-        assertThat(result.getTarget()).isEqualTo(target);
-    
+        assertThat(result.getTarget()).isEqualTo(TARGET);
+
         verify(context, never()).reportProblem(anyString());
-        verify(context, times(1)).transform(actionJson, Action.class);
-        verify(context, times(1)).transform(constraintJson, Constraint.class);
-        verify(context, times(1)).transform(dutyJson, Duty.class);
+        verify(context, times(1)).transform(isA(JsonObject.class), eq(Action.class));
+        verify(context, times(1)).transform(isA(JsonObject.class), eq(Constraint.class));
+        verify(context, times(1)).transform(isA(JsonObject.class), eq(Duty.class));
     }
-    
-    private JsonObject getJsonObject(String type) {
-        return jsonFactory.createObjectBuilder()
-                .add(TYPE, type)
-                .build();
+
+    static Stream<JsonObject> jsonSource() {
+        var jsonFactory = Json.createBuilderFactory(Map.of());
+        var actionJson = jsonFactory.createObjectBuilder().add(TYPE, "action");
+        var constraintJson = jsonFactory.createObjectBuilder().add(TYPE, "constraint");
+        var dutyJson = jsonFactory.createObjectBuilder().add(TYPE, "duty");
+
+        return Stream.of(
+                // as object
+                jsonFactory.createObjectBuilder()
+                        .add(ODRL_ACTION_ATTRIBUTE, actionJson)
+                        .add(ODRL_CONSTRAINT_ATTRIBUTE, constraintJson)
+                        .add(ODRL_DUTY_ATTRIBUTE, dutyJson)
+                        .add(ODRL_TARGET_ATTRIBUTE, TARGET)
+                        .build(),
+
+                // as array
+                jsonFactory.createObjectBuilder()
+                        .add(ODRL_ACTION_ATTRIBUTE, jsonFactory.createArrayBuilder().add(actionJson))
+                        .add(ODRL_CONSTRAINT_ATTRIBUTE, jsonFactory.createArrayBuilder().add(constraintJson))
+                        .add(ODRL_DUTY_ATTRIBUTE, jsonFactory.createArrayBuilder().add(dutyJson))
+                        .add(ODRL_TARGET_ATTRIBUTE, jsonFactory.createArrayBuilder().add(TARGET))
+                        .build()
+
+        );
     }
-    
+
 }

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToProhibitionTransformerTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToProhibitionTransformerTest.java
@@ -15,24 +15,27 @@
 package org.eclipse.edc.jsonld.transformer.to;
 
 import jakarta.json.Json;
-import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.policy.model.Action;
 import org.eclipse.edc.policy.model.AtomicConstraint;
 import org.eclipse.edc.policy.model.Constraint;
-import org.eclipse.edc.policy.model.Prohibition;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ACTION_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_CONSTRAINT_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.transformer.to.TestInput.getExpanded;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -40,16 +43,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class JsonObjectToProhibitionTransformerTest {
-    
-    private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
-    private final TransformerContext context = mock(TransformerContext.class);
+    private static final String TARGET = "target";
 
-    private final JsonObject actionJson = getJsonObject("action");
-    private final JsonObject constraintJson = getJsonObject("constraint");
+    private final TransformerContext context = mock(TransformerContext.class);
 
     private final Action action = Action.Builder.newInstance().type("type").build();
     private final Constraint constraint = AtomicConstraint.Builder.newInstance().build();
-    private final String target = "target";
 
     private JsonObjectToProhibitionTransformer transformer;
 
@@ -57,52 +56,47 @@ class JsonObjectToProhibitionTransformerTest {
     void setUp() {
         transformer = new JsonObjectToProhibitionTransformer();
 
-        when(context.transform(actionJson, Action.class)).thenReturn(action);
-        when(context.transform(constraintJson, Constraint.class)).thenReturn(constraint);
+        when(context.transform(isA(JsonObject.class), eq(Action.class))).thenReturn(action);
+        when(context.transform(isA(JsonObject.class), eq(Constraint.class))).thenReturn(constraint);
     }
-    
-    @Test
-    void transform_attributesAsObjects_returnPermission() {
-        var prohibition = jsonFactory.createObjectBuilder()
-                .add(ODRL_ACTION_ATTRIBUTE, actionJson)
-                .add(ODRL_CONSTRAINT_ATTRIBUTE, constraintJson)
-                .add(ODRL_TARGET_ATTRIBUTE, target)
-                .build();
-    
-        var result = transformer.transform(prohibition, context);
-    
-        assertResult(result);
-    }
-    
-    @Test
-    void transform_attributesAsArrays_returnPermission() {
-        var prohibition = jsonFactory.createObjectBuilder()
-                 .add(ODRL_ACTION_ATTRIBUTE, jsonFactory.createArrayBuilder().add(actionJson))
-                 .add(ODRL_CONSTRAINT_ATTRIBUTE, jsonFactory.createArrayBuilder().add(constraintJson))
-                 .add(ODRL_TARGET_ATTRIBUTE, jsonFactory.createArrayBuilder().add(target))
-                 .build();
-        
-        var result = transformer.transform(prohibition, context);
-        
-        assertResult(result);
-    }
-    
-    private void assertResult(Prohibition result) {
+
+    @ParameterizedTest
+    @MethodSource("jsonSource")
+    void transform_attributesAsObjects_returnPermission(JsonObject prohibition) {
+        var result = transformer.transform(getExpanded(prohibition), context);
+
         assertThat(result).isNotNull();
         assertThat(result.getAction()).isEqualTo(action);
         assertThat(result.getConstraints()).hasSize(1);
         assertThat(result.getConstraints().get(0)).isEqualTo(constraint);
-        assertThat(result.getTarget()).isEqualTo(target);
-    
+        assertThat(result.getTarget()).isEqualTo(TARGET);
+
         verify(context, never()).reportProblem(anyString());
-        verify(context, times(1)).transform(actionJson, Action.class);
-        verify(context, times(1)).transform(constraintJson, Constraint.class);
+        verify(context, times(1)).transform(isA(JsonObject.class), eq(Action.class));
+        verify(context, times(1)).transform(isA(JsonObject.class), eq(Constraint.class));
     }
-    
-    private JsonObject getJsonObject(String type) {
-        return jsonFactory.createObjectBuilder()
-                .add(TYPE, type)
-                .build();
+
+    static Stream<JsonObject> jsonSource() {
+        var jsonFactory = Json.createBuilderFactory(Map.of());
+        var actionJson = jsonFactory.createObjectBuilder().add(TYPE, "action");
+        var constraintJson = jsonFactory.createObjectBuilder().add(TYPE, "constraint");
+
+        return Stream.of(
+                // object
+                jsonFactory.createObjectBuilder()
+                        .add(ODRL_ACTION_ATTRIBUTE, actionJson)
+                        .add(ODRL_CONSTRAINT_ATTRIBUTE, constraintJson)
+                        .add(ODRL_TARGET_ATTRIBUTE, TARGET)
+                        .build(),
+
+                // array version
+                jsonFactory.createObjectBuilder()
+                        .add(ODRL_ACTION_ATTRIBUTE, jsonFactory.createArrayBuilder().add(actionJson))
+                        .add(ODRL_CONSTRAINT_ATTRIBUTE, jsonFactory.createArrayBuilder().add(constraintJson))
+                        .add(ODRL_TARGET_ATTRIBUTE, jsonFactory.createArrayBuilder().add(TARGET))
+                        .build()
+
+        );
     }
-    
+
 }

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonValueToGenericPropertyTransformerTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonValueToGenericPropertyTransformerTest.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,7 +27,10 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
+import static org.eclipse.edc.jsonld.spi.Namespaces.ODRL_SCHEMA;
+import static org.eclipse.edc.jsonld.transformer.to.TestInput.getExpanded;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -36,110 +40,112 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class JsonValueToGenericPropertyTransformerTest {
-    
+
     private ObjectMapper mapper = mock(ObjectMapper.class);
     private TransformerContext context = mock(TransformerContext.class);
     private JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
-    
+
     private JsonValueToGenericTypeTransformer transformer;
-    
+
     @BeforeEach
     void setUp() {
         transformer = new JsonValueToGenericTypeTransformer(mapper);
     }
-    
+
     @Test
     void transform_jsonObjectWithoutValueField_returnObject() throws JsonProcessingException {
-        var jsonObject = jsonFactory.createObjectBuilder().build();
+        var jsonObject = jsonFactory.createObjectBuilder()
+                .add(CONTEXT, JsonObject.EMPTY_JSON_OBJECT)
+                .add(ODRL_SCHEMA + "someProperty", "someProperty")
+                .build();
+
         var object = new Object();
-        
+
         when(mapper.readValue(anyString(), eq(Object.class))).thenReturn(object);
-        
-        var result = transformer.transform(jsonObject, context);
-        
-        assertThat(result).isNotNull()
-                .isInstanceOf(Object.class)
-                .isEqualTo(object);
-        
+
+        var result = transformer.transform(getExpanded(jsonObject), context);
+
+        assertThat(result).isNotNull().isInstanceOf(Object.class).isEqualTo(object);
+
         verifyNoInteractions(context);
+        verify(mapper).readValue(anyString(), eq(Object.class));
     }
-    
+
     @Test
     void transform_jsonObjectWithValueField_returnObject() throws JsonProcessingException {
         var value = "value";
         var jsonObject = jsonFactory.createObjectBuilder()
                 .add(VALUE, value)
                 .build();
-        
+
         when(mapper.readValue(anyString(), eq(Object.class))).thenReturn(value);
-        
+
+        // note: do not expand is it is already in expanded form
         var result = transformer.transform(jsonObject, context);
-        
-        assertThat(result).isNotNull()
-                .isInstanceOf(String.class)
-                .hasToString(value);
-        
+
+        assertThat(result).isNotNull().isInstanceOf(String.class).hasToString(value);
+
         verifyNoInteractions(context);
     }
-    
+
     @Test
     void transform_jsonObject_errorMappingToJavaType_reportProblem() throws JsonProcessingException {
-        var jsonObject = jsonFactory.createObjectBuilder().build();
-        
+        var jsonObject = jsonFactory.createObjectBuilder()
+                .add(CONTEXT, JsonObject.EMPTY_JSON_OBJECT)
+                .add(ODRL_SCHEMA + "property", "someProperty")
+                .build();
+
         when(mapper.readValue(anyString(), eq(Object.class))).thenThrow(JsonProcessingException.class);
-        
-        var result = transformer.transform(jsonObject, context);
-        
+
+        var result = transformer.transform(getExpanded(jsonObject), context);
+
         assertThat(result).isNull();
         verify(context, times(1)).reportProblem(anyString());
+        verify(mapper).readValue(anyString(), eq(Object.class));
     }
-    
+
     @Test
     void transform_jsonArray_returnList() throws JsonProcessingException {
         var value = "value";
+        // include a string, int and object to transform in the array
         var jsonArray = jsonFactory.createArrayBuilder()
-                .add(jsonFactory.createObjectBuilder()
-                        .add(VALUE, value)
-                        .build())
+                .add(jsonFactory.createObjectBuilder().add(VALUE, value).build())
+                .add(jsonFactory.createObjectBuilder().add(VALUE, 1).build())
+                .add(jsonFactory.createObjectBuilder().add(ODRL_SCHEMA + "someProperty", "test").build())
                 .build();
         when(mapper.readValue(anyString(), eq(Object.class))).thenReturn(value);
-    
+
         var result = transformer.transform(jsonArray, context);
-    
+
         assertThat(result).isNotNull().isInstanceOf(List.class);
-        assertThat((List<?>) result).hasSize(1);
-        assertThat(((List<?>) result).get(0))
-                .isInstanceOf(String.class)
-                .hasToString(value);
-    
+        assertThat((List<?>) result).hasSize(3);
+        assertThat(((List<?>) result).get(0)).isInstanceOf(String.class).hasToString(value);
+
         verifyNoInteractions(context);
+        verify(mapper).readValue(anyString(), eq(Object.class));
     }
-    
+
     @Test
     void transform_jsonString_returnString() {
         var value = "value";
         var jsonString = Json.createValue(value);
-    
+
         var result = transformer.transform(jsonString, context);
-    
-        assertThat(result).isNotNull()
-                .isInstanceOf(String.class)
-                .hasToString(value);
-    
+
+        assertThat(result).isNotNull().isInstanceOf(String.class).hasToString(value);
+
         verifyNoInteractions(context);
     }
-    
+
     @Test
     void transform_jsonNumber_returnNumber() {
         var value = 42.0;
         var jsonNumber = Json.createValue(value);
-    
+
         var result = transformer.transform(jsonNumber, context);
-    
-        assertThat(result).isNotNull()
-                .isInstanceOf(Double.class)
-                .matches(o -> ((Double) o) == value);
-    
+
+        assertThat(result).isNotNull().isInstanceOf(Double.class).matches(o -> ((Double) o) == value);
+
         verifyNoInteractions(context);
     }
 }

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/TestInput.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/TestInput.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.jsonld.transformer.to;
+
+import com.apicatalog.jsonld.document.JsonDocument;
+import jakarta.json.JsonObject;
+
+import static com.apicatalog.jsonld.JsonLd.expand;
+
+/**
+ * Functions for shaping test input.
+ */
+public class TestInput {
+
+    /**
+     * Expands test input as Json-ld is required to be in this form
+     */
+    public static JsonObject getExpanded(JsonObject message) {
+        try {
+            return expand(JsonDocument.of(message)).get().asJsonArray().getJsonObject(0);
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private TestInput() {
+    }
+}

--- a/spi/common/policy-model/src/main/java/org/eclipse/edc/policy/model/LiteralExpression.java
+++ b/spi/common/policy-model/src/main/java/org/eclipse/edc/policy/model/LiteralExpression.java
@@ -35,7 +35,7 @@ public class LiteralExpression extends Expression {
 
     @Override
     public String toString() {
-        return value + "'";
+        return "'" + value + "'";
     }
 
     @NotNull


### PR DESCRIPTION
## What this PR changes/adds

Fixes bugs in the policy transformers, mostly dealing with handling expanded Json-Ld. It also cleans up transform constant naming.

## Linked Issue(s)

Closes #2989

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
