### PR TITLE
feat: introduce `ProcessRemoteMessage` and pull up id creation

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessEventDispatchTest.java
@@ -52,9 +52,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
+import static java.util.UUID.randomUUID;
 import static java.util.concurrent.CompletableFuture.failedFuture;
 import static java.util.concurrent.Executors.newSingleThreadExecutor;
 import static org.awaitility.Awaitility.await;
@@ -204,7 +204,7 @@ public class TransferProcessEventDispatchTest {
         eventRouter.register(TransferProcessEvent.class, eventSubscriber);
 
         var dataRequest = DataRequest.Builder.newInstance()
-                .id(String.valueOf(UUID.randomUUID()))
+                .id(randomUUID().toString())
                 .assetId("assetId")
                 .destinationType("any")
                 .protocol("test")
@@ -232,7 +232,7 @@ public class TransferProcessEventDispatchTest {
         eventRouter.register(TransferProcessEvent.class, eventSubscriber);
 
         var dataRequest = DataRequest.Builder.newInstance()
-                .id(String.valueOf(UUID.randomUUID()))
+                .id(String.valueOf(randomUUID()))
                 .assetId("assetId")
                 .destinationType("any")
                 .protocol("test")

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/api/controller/DspNegotiationControllerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/api/controller/DspNegotiationControllerTest.java
@@ -56,10 +56,10 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 import java.lang.reflect.Method;
 import java.time.Instant;
 import java.util.Map;
-import java.util.UUID;
 import java.util.stream.Stream;
 
 import static io.restassured.RestAssured.given;
+import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.contract.spi.types.agreement.ContractNegotiationEventMessage.Type.ACCEPTED;
 import static org.eclipse.edc.connector.contract.spi.types.agreement.ContractNegotiationEventMessage.Type.FINALIZED;
@@ -113,7 +113,7 @@ public class DspNegotiationControllerTest extends RestControllerTestBase {
 
     private static ContractAgreement contractAgreement() {
         return ContractAgreement.Builder.newInstance()
-                .id(String.valueOf(UUID.randomUUID()))
+                .id(randomUUID().toString())
                 .providerId("agentId")
                 .consumerId("agentId")
                 .assetId("assetId")
@@ -133,7 +133,7 @@ public class DspNegotiationControllerTest extends RestControllerTestBase {
 
     private static ContractOffer contractOffer() {
         return ContractOffer.Builder.newInstance()
-                .id(String.valueOf(UUID.randomUUID()))
+                .id(String.valueOf(randomUUID()))
                 .assetId("assetId")
                 .policy(policy()).build();
     }
@@ -432,7 +432,7 @@ public class DspNegotiationControllerTest extends RestControllerTestBase {
 
     private ContractNegotiation contractNegotiation() {
         return ContractNegotiation.Builder.newInstance()
-                .id(UUID.randomUUID().toString())
+                .id(randomUUID().toString())
                 .type(ContractNegotiation.Type.PROVIDER)
                 .correlationId("testId")
                 .counterPartyId("connectorId")

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-dispatcher/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/dispatcher/delegate/ContractAgreementMessageHttpDelegateTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-dispatcher/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/dispatcher/delegate/ContractAgreementMessageHttpDelegateTest.java
@@ -27,8 +27,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.UUID;
 
+import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.protocol.dsp.negotiation.dispatcher.NegotiationApiPaths.AGREEMENT;
 import static org.eclipse.edc.protocol.dsp.negotiation.dispatcher.NegotiationApiPaths.BASE_PATH;
@@ -75,7 +75,7 @@ class ContractAgreementMessageHttpDelegateTest extends DspHttpDispatcherDelegate
 
     private ContractAgreement contractAgreement() {
         return ContractAgreement.Builder.newInstance()
-                .id(String.valueOf(UUID.randomUUID()))
+                .id(randomUUID().toString())
                 .providerId("agentId")
                 .consumerId("agentId")
                 .assetId("assetId")

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-dispatcher/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/dispatcher/delegate/ContractRequestMessageHttpDelegateTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-dispatcher/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/dispatcher/delegate/ContractRequestMessageHttpDelegateTest.java
@@ -34,8 +34,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.UUID;
 
+import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.protocol.dsp.negotiation.dispatcher.NegotiationApiPaths.BASE_PATH;
 import static org.eclipse.edc.protocol.dsp.negotiation.dispatcher.NegotiationApiPaths.CONTRACT_REQUEST;
@@ -142,7 +142,7 @@ class ContractRequestMessageHttpDelegateTest extends DspHttpDispatcherDelegateTe
 
     private ContractOffer contractOffer() {
         return ContractOffer.Builder.newInstance()
-                .id(String.valueOf(UUID.randomUUID()))
+                .id(randomUUID().toString())
                 .assetId("assetId")
                 .policy(policy()).build();
     }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org.eclipse.edc.protocol.dsp.negotiation.transform/from/JsonObjectFromContractAgreementMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org.eclipse.edc.protocol.dsp.negotiation.transform/from/JsonObjectFromContractAgreementMessageTransformer.java
@@ -25,7 +25,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import static java.time.Instant.ofEpochSecond;
-import static java.util.UUID.randomUUID;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_AGREEMENT_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_AGREEMENT;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_CONSUMER_ID;
@@ -49,7 +48,7 @@ public class JsonObjectFromContractAgreementMessageTransformer extends AbstractJ
     @Override
     public @Nullable JsonObject transform(@NotNull ContractAgreementMessage agreementMessage, @NotNull TransformerContext context) {
         var builder = jsonFactory.createObjectBuilder();
-        builder.add(JsonLdKeywords.ID, randomUUID().toString());
+        builder.add(JsonLdKeywords.ID, agreementMessage.getId());
         builder.add(JsonLdKeywords.TYPE, DSPACE_NEGOTIATION_AGREEMENT_MESSAGE);
 
         builder.add(DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID, agreementMessage.getProcessId());

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org.eclipse.edc.protocol.dsp.negotiation.transform/from/JsonObjectFromContractAgreementVerificationMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org.eclipse.edc.protocol.dsp.negotiation.transform/from/JsonObjectFromContractAgreementVerificationMessageTransformer.java
@@ -23,7 +23,6 @@ import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import static java.util.UUID.randomUUID;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_AGREEMENT_VERIFICATION_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID;
 
@@ -42,7 +41,7 @@ public class JsonObjectFromContractAgreementVerificationMessageTransformer exten
     @Override
     public @Nullable JsonObject transform(@NotNull ContractAgreementVerificationMessage verificationMessage, @NotNull TransformerContext context) {
         var builder = jsonFactory.createObjectBuilder();
-        builder.add(JsonLdKeywords.ID, randomUUID().toString());
+        builder.add(JsonLdKeywords.ID, verificationMessage.getId());
         builder.add(JsonLdKeywords.TYPE, DSPACE_NEGOTIATION_AGREEMENT_VERIFICATION_MESSAGE);
 
         builder.add(DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID, verificationMessage.getProcessId());

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org.eclipse.edc.protocol.dsp.negotiation.transform/from/JsonObjectFromContractNegotiationEventMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org.eclipse.edc.protocol.dsp.negotiation.transform/from/JsonObjectFromContractNegotiationEventMessageTransformer.java
@@ -23,7 +23,6 @@ import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import static java.util.UUID.randomUUID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_EVENT_MESSAGE;
@@ -48,7 +47,7 @@ public class JsonObjectFromContractNegotiationEventMessageTransformer extends Ab
     @Override
     public @Nullable JsonObject transform(@NotNull ContractNegotiationEventMessage eventMessage, @NotNull TransformerContext context) {
         var builder = jsonFactory.createObjectBuilder();
-        builder.add(ID, randomUUID().toString());
+        builder.add(ID, eventMessage.getId());
         builder.add(TYPE, DSPACE_NEGOTIATION_EVENT_MESSAGE);
 
         builder.add(DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID, eventMessage.getProcessId());

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org.eclipse.edc.protocol.dsp.negotiation.transform/from/JsonObjectFromContractNegotiationTerminationMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org.eclipse.edc.protocol.dsp.negotiation.transform/from/JsonObjectFromContractNegotiationTerminationMessageTransformer.java
@@ -22,8 +22,6 @@ import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.UUID;
-
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_CODE;
@@ -46,7 +44,7 @@ public class JsonObjectFromContractNegotiationTerminationMessageTransformer exte
     @Override
     public @Nullable JsonObject transform(@NotNull ContractNegotiationTerminationMessage terminationMessage, @NotNull TransformerContext context) {
         var builder = jsonFactory.createObjectBuilder();
-        builder.add(ID, UUID.randomUUID().toString());
+        builder.add(ID, terminationMessage.getId());
         builder.add(TYPE, DSPACE_NEGOTIATION_TERMINATION_MESSAGE);
 
         builder.add(DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID, terminationMessage.getProcessId());

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org.eclipse.edc.protocol.dsp.negotiation.transform/from/JsonObjectFromContractRequestMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org.eclipse.edc.protocol.dsp.negotiation.transform/from/JsonObjectFromContractRequestMessageTransformer.java
@@ -23,7 +23,6 @@ import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import static java.util.UUID.randomUUID;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_CONTRACT_REQUEST_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_CALLBACK_ADDRESS;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationPropertyAndTypeNames.DSPACE_NEGOTIATION_PROPERTY_DATASET;
@@ -47,7 +46,7 @@ public class JsonObjectFromContractRequestMessageTransformer extends AbstractJso
     @Override
     public @Nullable JsonObject transform(@NotNull ContractRequestMessage requestMessage, @NotNull TransformerContext context) {
         var builder = jsonFactory.createObjectBuilder();
-        builder.add(JsonLdKeywords.ID, randomUUID().toString());
+        builder.add(JsonLdKeywords.ID, requestMessage.getId());
         builder.add(JsonLdKeywords.TYPE, DSPACE_NEGOTIATION_CONTRACT_REQUEST_MESSAGE);
 
         builder.add(DSPACE_NEGOTIATION_PROPERTY_PROCESS_ID, requestMessage.getProcessId());

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/from/JsonObjectFromTransferCompletionMessageTransformer.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/from/JsonObjectFromTransferCompletionMessageTransformer.java
@@ -22,8 +22,6 @@ import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.UUID;
-
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_PROCESS_ID;
@@ -43,7 +41,7 @@ public class JsonObjectFromTransferCompletionMessageTransformer extends Abstract
     public @Nullable JsonObject transform(@NotNull TransferCompletionMessage transferCompletionMessage, @NotNull TransformerContext context) {
         var builder = jsonBuilderFactory.createObjectBuilder();
 
-        builder.add(ID, String.valueOf(UUID.randomUUID()));
+        builder.add(ID, transferCompletionMessage.getId());
         builder.add(TYPE, DSPACE_TRANSFER_COMPLETION_TYPE);
         builder.add(DSPACE_PROCESS_ID, transferCompletionMessage.getProcessId());
 

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/from/JsonObjectFromTransferRequestMessageTransformer.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/from/JsonObjectFromTransferRequestMessageTransformer.java
@@ -23,8 +23,6 @@ import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.UUID;
-
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCT_FORMAT_ATTRIBUTE;
 import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_CALLBACK_ADDRESS;
 import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_CONTRACT_AGREEMENT_ID;
@@ -47,7 +45,7 @@ public class JsonObjectFromTransferRequestMessageTransformer extends AbstractJso
     public @Nullable JsonObject transform(@NotNull TransferRequestMessage transferRequestMessage, @NotNull TransformerContext context) {
         var builder = jsonBuilderFactory.createObjectBuilder();
 
-        builder.add(JsonLdKeywords.ID, String.valueOf(UUID.randomUUID()));
+        builder.add(JsonLdKeywords.ID, transferRequestMessage.getId());
         builder.add(JsonLdKeywords.TYPE, DSPACE_TRANSFER_PROCESS_REQUEST_TYPE);
 
         builder.add(DSPACE_CONTRACT_AGREEMENT_ID, transferRequestMessage.getContractId());

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/from/JsonObjectFromTransferStartMessageTransformer.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/from/JsonObjectFromTransferStartMessageTransformer.java
@@ -22,8 +22,6 @@ import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.UUID;
-
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_DATA_ADDRESS;
@@ -43,7 +41,7 @@ public class JsonObjectFromTransferStartMessageTransformer extends AbstractJsonL
     public @Nullable JsonObject transform(@NotNull TransferStartMessage transferStartMessage, @NotNull TransformerContext context) {
         var builder = jsonBuilderFactory.createObjectBuilder();
 
-        builder.add(ID, UUID.randomUUID().toString());
+        builder.add(ID, transferStartMessage.getId());
         builder.add(TYPE, DSPACE_TRANSFER_START_TYPE);
         builder.add(DSPACE_PROCESS_ID, transferStartMessage.getProcessId());
         if (transferStartMessage.getDataAddress() != null) {

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/from/JsonObjectFromTransferTerminationMessageTransformer.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/from/JsonObjectFromTransferTerminationMessageTransformer.java
@@ -22,8 +22,6 @@ import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.UUID;
-
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessPropertyAndTypeNames.DSPACE_CODE;
@@ -44,7 +42,7 @@ public class JsonObjectFromTransferTerminationMessageTransformer extends Abstrac
     public @Nullable JsonObject transform(@NotNull TransferTerminationMessage transferTerminationMessage, @NotNull TransformerContext context) {
         var builder = jsonBuilderFactory.createObjectBuilder();
 
-        builder.add(ID, String.valueOf(UUID.randomUUID()));
+        builder.add(ID, transferTerminationMessage.getId());
         builder.add(TYPE, DSPACE_TRANSFER_TERMINATION_TYPE);
         builder.add(DSPACE_PROCESS_ID, transferTerminationMessage.getProcessId());
         if (transferTerminationMessage.getCode() != null) {

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/message/ProcessRemoteMessage.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/message/ProcessRemoteMessage.java
@@ -12,20 +12,28 @@
  *
  */
 
-package org.eclipse.edc.connector.transfer.spi.types.protocol;
+package org.eclipse.edc.spi.types.domain.message;
 
-import org.eclipse.edc.spi.types.domain.message.ProcessRemoteMessage;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * A remote message related to the TransferProcess context
+ * A remote message that conveys state modifications of a process. These messages are idempotent.
  */
-public interface TransferRemoteMessage extends ProcessRemoteMessage {
+public interface ProcessRemoteMessage extends RemoteMessage {
+
+    /**
+     * Returns the unique message id.
+     *
+     * @return the id;
+     */
+    @NotNull
+    String getId();
 
     /**
      * Returns the process id.
      *
-     * @return the processId property.
+     * @return the processId.
      */
-    @NotNull String getProcessId();
+    @NotNull
+    String getProcessId();
 }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractAgreementMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractAgreementMessage.java
@@ -16,10 +16,14 @@ package org.eclipse.edc.connector.contract.spi.types.agreement;
 
 import org.eclipse.edc.connector.contract.spi.types.protocol.ContractRemoteMessage;
 import org.eclipse.edc.policy.model.Policy;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
+import static java.util.UUID.randomUUID;
+
 public class ContractAgreementMessage implements ContractRemoteMessage {
+    private String id;
     private String protocol;
     @Deprecated(forRemoval = true)
     private String connectorId;
@@ -28,6 +32,12 @@ public class ContractAgreementMessage implements ContractRemoteMessage {
     private ContractAgreement contractAgreement;
     @Deprecated(forRemoval = true)
     private Policy policy;
+
+    @Override
+    @NotNull
+    public String getId() {
+        return id;
+    }
 
     @Override
     public String getProtocol() {
@@ -45,7 +55,7 @@ public class ContractAgreementMessage implements ContractRemoteMessage {
     }
 
     @Override
-    public String getProcessId() {
+    public @NotNull String getProcessId() {
         return processId;
     }
 
@@ -67,6 +77,11 @@ public class ContractAgreementMessage implements ContractRemoteMessage {
 
         public static Builder newInstance() {
             return new Builder();
+        }
+
+        public Builder id(String id) {
+            this.contractAgreementMessage.id = id;
+            return this;
         }
 
         public Builder protocol(String protocol) {
@@ -102,6 +117,9 @@ public class ContractAgreementMessage implements ContractRemoteMessage {
         }
 
         public ContractAgreementMessage build() {
+            if (contractAgreementMessage.id == null) {
+                contractAgreementMessage.id = randomUUID().toString();
+            }
             Objects.requireNonNull(contractAgreementMessage.protocol, "protocol");
             Objects.requireNonNull(contractAgreementMessage.contractAgreement, "contractAgreement");
             Objects.requireNonNull(contractAgreementMessage.processId, "processId");

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractAgreementVerificationMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractAgreementVerificationMessage.java
@@ -15,14 +15,24 @@
 package org.eclipse.edc.connector.contract.spi.types.agreement;
 
 import org.eclipse.edc.connector.contract.spi.types.protocol.ContractRemoteMessage;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
+import static java.util.UUID.randomUUID;
+
 public class ContractAgreementVerificationMessage implements ContractRemoteMessage {
 
+    private String id;
     private String protocol;
     private String counterPartyAddress;
     private String processId;
+
+    @NotNull
+    @Override
+    public String getId() {
+        return id;
+    }
 
     @Override
     public String getProtocol() {
@@ -35,6 +45,7 @@ public class ContractAgreementVerificationMessage implements ContractRemoteMessa
     }
 
     @Override
+    @NotNull
     public String getProcessId() {
         return processId;
     }
@@ -48,6 +59,11 @@ public class ContractAgreementVerificationMessage implements ContractRemoteMessa
 
         public static Builder newInstance() {
             return new Builder();
+        }
+
+        public Builder id(String id) {
+            this.message.id = id;
+            return this;
         }
 
         public Builder protocol(String protocol) {
@@ -66,6 +82,10 @@ public class ContractAgreementVerificationMessage implements ContractRemoteMessa
         }
 
         public ContractAgreementVerificationMessage build() {
+            if (message.id == null) {
+                message.id = randomUUID().toString();
+            }
+
             Objects.requireNonNull(message.protocol, "protocol");
             Objects.requireNonNull(message.processId, "processId");
             return message;

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractNegotiationEventMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractNegotiationEventMessage.java
@@ -19,12 +19,20 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
-public class ContractNegotiationEventMessage implements ContractRemoteMessage {
+import static java.util.UUID.randomUUID;
 
+public class ContractNegotiationEventMessage implements ContractRemoteMessage {
+    private String id;
     private String protocol;
     private String counterPartyAddress;
     private String processId;
     private Type type;
+
+    @Override
+    @NotNull
+    public String getId() {
+        return id;
+    }
 
     @Override
     public String getProtocol() {
@@ -37,6 +45,7 @@ public class ContractNegotiationEventMessage implements ContractRemoteMessage {
     }
 
     @Override
+    @NotNull
     public String getProcessId() {
         return processId;
     }
@@ -55,6 +64,11 @@ public class ContractNegotiationEventMessage implements ContractRemoteMessage {
 
         public static Builder newInstance() {
             return new Builder();
+        }
+
+        public Builder id(String id) {
+            this.message.id = id;
+            return this;
         }
 
         public Builder protocol(String protocol) {
@@ -78,6 +92,9 @@ public class ContractNegotiationEventMessage implements ContractRemoteMessage {
         }
 
         public ContractNegotiationEventMessage build() {
+            if (message.id == null) {
+                message.id = randomUUID().toString();
+            }
             Objects.requireNonNull(message.protocol, "protocol");
             Objects.requireNonNull(message.processId, "processId");
             Objects.requireNonNull(message.type, "type");

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractNegotiationTerminationMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractNegotiationTerminationMessage.java
@@ -15,12 +15,16 @@
 package org.eclipse.edc.connector.contract.spi.types.negotiation;
 
 import org.eclipse.edc.connector.contract.spi.types.protocol.ContractRemoteMessage;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
 
+import static java.util.UUID.randomUUID;
+
 public class ContractNegotiationTerminationMessage implements ContractRemoteMessage {
 
+    private String id;
     private String protocol;
     @Deprecated(forRemoval = true)
     private String connectorId;
@@ -28,6 +32,12 @@ public class ContractNegotiationTerminationMessage implements ContractRemoteMess
     private String processId;
     private String rejectionReason; // TODO change to list https://github.com/eclipse-edc/Connector/issues/2729
     private String code;
+
+    @NotNull
+    @Override
+    public String getId() {
+        return id;
+    }
 
     @Override
     public String getProtocol() {
@@ -45,6 +55,7 @@ public class ContractNegotiationTerminationMessage implements ContractRemoteMess
     }
 
     @Override
+    @NotNull
     public String getProcessId() {
         return processId;
     }
@@ -68,6 +79,11 @@ public class ContractNegotiationTerminationMessage implements ContractRemoteMess
 
         public static Builder newInstance() {
             return new Builder();
+        }
+
+        public Builder id(String id) {
+            this.contractNegotiationTerminationMessage.id = id;
+            return this;
         }
 
         public Builder protocol(String protocol) {
@@ -102,6 +118,10 @@ public class ContractNegotiationTerminationMessage implements ContractRemoteMess
         }
 
         public ContractNegotiationTerminationMessage build() {
+            if (contractNegotiationTerminationMessage.id == null) {
+                contractNegotiationTerminationMessage.id = randomUUID().toString();
+            }
+
             Objects.requireNonNull(contractNegotiationTerminationMessage.protocol, "protocol");
             Objects.requireNonNull(contractNegotiationTerminationMessage.processId, "processId");
             return contractNegotiationTerminationMessage;

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessage.java
@@ -16,15 +16,18 @@ package org.eclipse.edc.connector.contract.spi.types.negotiation;
 
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.contract.spi.types.protocol.ContractRemoteMessage;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
+import static java.util.UUID.randomUUID;
 
 /**
  * Object that wraps the contract offer and provides additional information about e.g. protocol and recipient.
  */
 public class ContractRequestMessage implements ContractRemoteMessage {
 
+    private String id;
     private Type type = Type.COUNTER_OFFER;
     private String protocol;
     @Deprecated(forRemoval = true)
@@ -35,6 +38,12 @@ public class ContractRequestMessage implements ContractRemoteMessage {
     private ContractOffer contractOffer;
     private String contractOfferId;
     private String dataSet;
+
+    @NotNull
+    @Override
+    public String getId() {
+        return id;
+    }
 
     @Override
     public String getProtocol() {
@@ -52,6 +61,7 @@ public class ContractRequestMessage implements ContractRemoteMessage {
     }
 
     @Override
+    @NotNull
     public String getProcessId() {
         return processId;
     }
@@ -92,6 +102,11 @@ public class ContractRequestMessage implements ContractRemoteMessage {
 
         public static Builder newInstance() {
             return new Builder();
+        }
+
+        public Builder id(String id) {
+            this.contractRequestMessage.id = id;
+            return this;
         }
 
         public Builder protocol(String protocol) {
@@ -141,6 +156,9 @@ public class ContractRequestMessage implements ContractRemoteMessage {
         }
 
         public ContractRequestMessage build() {
+            if (contractRequestMessage.id == null) {
+                contractRequestMessage.id = randomUUID().toString();
+            }
             requireNonNull(contractRequestMessage.protocol, "protocol");
             requireNonNull(contractRequestMessage.processId, "processId");
             if (contractRequestMessage.contractOfferId == null) {

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/protocol/ContractRemoteMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/protocol/ContractRemoteMessage.java
@@ -14,17 +14,12 @@
 
 package org.eclipse.edc.connector.contract.spi.types.protocol;
 
-import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
+import org.eclipse.edc.spi.types.domain.message.ProcessRemoteMessage;
 
 /**
  * A remote message related to the ContractNegotiation context
  */
-public interface ContractRemoteMessage extends RemoteMessage {
+public interface ContractRemoteMessage extends ProcessRemoteMessage {
 
-    /**
-     * Returns the process id.
-     *
-     * @return the processId property.
-     */
-    String getProcessId();
+
 }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferCompletionMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferCompletionMessage.java
@@ -16,8 +16,11 @@ package org.eclipse.edc.connector.transfer.spi.types.protocol;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
+
+import static java.util.UUID.randomUUID;
 
 /**
  * The {@link TransferCompletionMessage} is sent by the provider or consumer when asset transfer has completed. Note
@@ -25,10 +28,16 @@ import java.util.Objects;
  * protocol. In those cases, a {@link TransferCompletionMessage} message does not need to be sent.
  */
 public class TransferCompletionMessage implements TransferRemoteMessage {
-
+    private String id;
     private String counterPartyAddress;
     private String protocol;
     private String processId;
+
+    @NotNull
+    @Override
+    public String getId() {
+        return id;
+    }
 
     @Override
     public String getProtocol() {
@@ -40,6 +49,8 @@ public class TransferCompletionMessage implements TransferRemoteMessage {
         return counterPartyAddress;
     }
 
+    @Override
+    @NotNull
     public String getProcessId() {
         return processId;
     }
@@ -55,6 +66,11 @@ public class TransferCompletionMessage implements TransferRemoteMessage {
         @JsonCreator
         public static Builder newInstance() {
             return new Builder();
+        }
+
+        public Builder id(String id) {
+            this.message.id = id;
+            return this;
         }
 
         public Builder counterPartyAddress(String address) {
@@ -73,6 +89,10 @@ public class TransferCompletionMessage implements TransferRemoteMessage {
         }
 
         public TransferCompletionMessage build() {
+            if (message.id == null) {
+                message.id = randomUUID().toString();
+            }
+
             Objects.requireNonNull(message.protocol, "The protocol must be specified");
             Objects.requireNonNull(message.processId, "The processId must be specified");
             return message;

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferRemoteMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferRemoteMessage.java
@@ -27,5 +27,7 @@ public interface TransferRemoteMessage extends ProcessRemoteMessage {
      *
      * @return the processId property.
      */
-    @NotNull String getProcessId();
+    @Override
+    @NotNull
+    String getProcessId();
 }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferRequestMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferRequestMessage.java
@@ -17,16 +17,20 @@ package org.eclipse.edc.connector.transfer.spi.types.protocol;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+
+import static java.util.UUID.randomUUID;
 
 /**
  * The {@link TransferRequestMessage} is sent by a consumer to initiate a transfer process.
  */
 public class TransferRequestMessage implements TransferRemoteMessage {
 
+    private String id;
     private String counterPartyAddress;
     private String protocol;
     private String processId;
@@ -39,6 +43,12 @@ public class TransferRequestMessage implements TransferRemoteMessage {
     private String callbackAddress;
     private Map<String, String> properties = new HashMap<>();
 
+    @NotNull
+    @Override
+    public String getId() {
+        return id;
+    }
+
     @Override
     public String getProtocol() {
         return protocol;
@@ -50,6 +60,7 @@ public class TransferRequestMessage implements TransferRemoteMessage {
     }
 
     @Override
+    @NotNull
     public String getProcessId() {
         return processId;
     }
@@ -91,6 +102,11 @@ public class TransferRequestMessage implements TransferRemoteMessage {
         @JsonCreator
         public static Builder newInstance() {
             return new Builder();
+        }
+
+        public Builder id(String id) {
+            this.message.id = id;
+            return this;
         }
 
         public Builder processId(String processId) {
@@ -141,6 +157,10 @@ public class TransferRequestMessage implements TransferRemoteMessage {
         }
 
         public TransferRequestMessage build() {
+            if (message.id == null) {
+                message.id = randomUUID().toString();
+            }
+
             Objects.requireNonNull(message.protocol, "The protocol must be specified");
             Objects.requireNonNull(message.callbackAddress, "The callbackAddress must be specified");
             return message;

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferStartMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferStartMessage.java
@@ -17,19 +17,29 @@ package org.eclipse.edc.connector.transfer.spi.types.protocol;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
+
+import static java.util.UUID.randomUUID;
 
 /**
  * The {@link TransferStartMessage} is sent by the provider to indicate the asset transfer has been initiated.
  */
 public class TransferStartMessage implements TransferRemoteMessage {
 
+    private String id;
     private String counterPartyAddress;
     private String protocol;
     private String processId;
 
     private DataAddress dataAddress;
+
+    @NotNull
+    @Override
+    public String getId() {
+        return id;
+    }
 
     @Override
     public String getProtocol() {
@@ -42,6 +52,7 @@ public class TransferStartMessage implements TransferRemoteMessage {
     }
 
     @Override
+    @NotNull
     public String getProcessId() {
         return processId;
     }
@@ -61,6 +72,11 @@ public class TransferStartMessage implements TransferRemoteMessage {
         @JsonCreator
         public static Builder newInstance() {
             return new Builder();
+        }
+
+        public Builder id(String id) {
+            this.message.id = id;
+            return this;
         }
 
         public Builder counterPartyAddress(String counterPartyAddress) {
@@ -84,6 +100,10 @@ public class TransferStartMessage implements TransferRemoteMessage {
         }
 
         public TransferStartMessage build() {
+            if (message.id == null) {
+                message.id = randomUUID().toString();
+            }
+
             Objects.requireNonNull(message.protocol, "The protocol must be specified");
             Objects.requireNonNull(message.processId, "The processId must be specified");
             return message;

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferTerminationMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferTerminationMessage.java
@@ -16,8 +16,11 @@ package org.eclipse.edc.connector.transfer.spi.types.protocol;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
+
+import static java.util.UUID.randomUUID;
 
 /**
  * The {@link TransferTerminationMessage} is sent by the provider or consumer at any point except a terminal state to
@@ -26,6 +29,7 @@ import java.util.Objects;
  */
 public class TransferTerminationMessage implements TransferRemoteMessage {
 
+    private String id;
     private String counterPartyAddress;
     private String protocol;
     private String processId;
@@ -33,6 +37,12 @@ public class TransferTerminationMessage implements TransferRemoteMessage {
     private String code;
 
     private String reason; //TODO change to List  https://github.com/eclipse-edc/Connector/issues/2729
+
+    @NotNull
+    @Override
+    public String getId() {
+        return id;
+    }
 
     @Override
     public String getProtocol() {
@@ -45,6 +55,7 @@ public class TransferTerminationMessage implements TransferRemoteMessage {
     }
 
     @Override
+    @NotNull
     public String getProcessId() {
         return processId;
     }
@@ -68,6 +79,11 @@ public class TransferTerminationMessage implements TransferRemoteMessage {
         @JsonCreator
         public static Builder newInstance() {
             return new Builder();
+        }
+
+        public Builder id(String id) {
+            this.message.id = id;
+            return this;
         }
 
         public Builder counterPartyAddress(String counterPartyAddress) {
@@ -96,6 +112,10 @@ public class TransferTerminationMessage implements TransferRemoteMessage {
         }
 
         public TransferTerminationMessage build() {
+            if (message.id == null) {
+                message.id = randomUUID().toString();
+            }
+
             Objects.requireNonNull(message.protocol, "The protocol must be specified");
             Objects.requireNonNull(message.processId, "The processId must be specified");
             //TODO add Nullcheck for message.code Issue https://github.com/eclipse-edc/Connector/issues/2810


### PR DESCRIPTION
## What this PR changes/adds

The PR moves out id creation from the DSP transformers by introducing the `ProcessRemoteMessage` type. This is the first step for introducing end-to-end idempotency and reliability in M10.


## Linked Issue(s)

Closes #2908

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
