### PR TITLE
fix(JsonObjectToNegotiationInitiateRequestDto): fix with expanded json-ld

### DIFF
--- a/extensions/common/api/api-core/src/main/java/org/eclipse/edc/api/transformer/JsonObjectToCallbackAddressDtoTransformer.java
+++ b/extensions/common/api/api-core/src/main/java/org/eclipse/edc/api/transformer/JsonObjectToCallbackAddressDtoTransformer.java
@@ -48,14 +48,14 @@ public class JsonObjectToCallbackAddressDtoTransformer extends AbstractJsonLdTra
     private void setProperties(String key, JsonValue value, CallbackAddressDto.Builder builder, TransformerContext context) {
         switch (key) {
             case IS_TRANSACTIONAL:
-                builder.transactional(Boolean.parseBoolean(value.toString()));
+                builder.transactional(transformBoolean(value, context));
                 break;
             case URI:
                 transformString(value, builder::uri, context);
                 break;
             case EVENTS:
                 var evt = new HashSet<String>();
-                transformArrayOrObject(value, String.class, evt::add, context);
+                visitArray(value, v -> evt.add(transformString(v, context)), context);
                 builder.events(evt);
                 break;
             case AUTH_KEY:

--- a/extensions/common/api/api-core/src/test/java/org/eclipse/edc/api/transformer/JsonObjectToCallbackAddressDtoTransformerTest.java
+++ b/extensions/common/api/api-core/src/test/java/org/eclipse/edc/api/transformer/JsonObjectToCallbackAddressDtoTransformerTest.java
@@ -15,7 +15,10 @@
 package org.eclipse.edc.api.transformer;
 
 import jakarta.json.Json;
+import org.eclipse.edc.jsonld.TitaniumJsonLd;
+import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.jsonld.transformer.to.JsonValueToGenericTypeTransformer;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,6 +37,7 @@ import static org.mockito.Mockito.when;
 
 class JsonObjectToCallbackAddressDtoTransformerTest {
 
+    private final JsonLd jsonLd = new TitaniumJsonLd(mock(Monitor.class));
     private JsonObjectToCallbackAddressDtoTransformer transformer;
 
     @BeforeEach
@@ -59,7 +63,7 @@ class JsonObjectToCallbackAddressDtoTransformerTest {
         var genericTransformer = new JsonValueToGenericTypeTransformer(createObjectMapper());
         when(contextMock.transform(any(), eq(String.class))).thenAnswer(a -> genericTransformer.transform(a.getArgument(0), contextMock));
 
-        var cba = transformer.transform(jobj, contextMock);
+        var cba = transformer.transform(jsonLd.expand(jobj).getContent(), contextMock);
 
         assertThat(cba).isNotNull();
         assertThat(cba.getEvents()).containsExactlyInAnyOrder("foo", "bar", "baz");

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiExtension.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiExtension.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.connector.api.management.contractnegotiation.transform.Co
 import org.eclipse.edc.connector.api.management.contractnegotiation.transform.JsonObjectFromContractAgreementDtoTransformer;
 import org.eclipse.edc.connector.api.management.contractnegotiation.transform.JsonObjectFromContractNegotiationDtoTransformer;
 import org.eclipse.edc.connector.api.management.contractnegotiation.transform.JsonObjectFromNegotiationStateTransformer;
+import org.eclipse.edc.connector.api.management.contractnegotiation.transform.JsonObjectToContractOfferDescriptionTransformer;
 import org.eclipse.edc.connector.api.management.contractnegotiation.transform.JsonObjectToNegotiationInitiateRequestDtoTransformer;
 import org.eclipse.edc.connector.api.management.contractnegotiation.transform.NegotiationInitiateRequestDtoToDataRequestTransformer;
 import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationService;
@@ -74,6 +75,7 @@ public class ContractNegotiationApiExtension implements ServiceExtension {
         transformerRegistry.register(new JsonObjectFromContractAgreementDtoTransformer(factory));
         transformerRegistry.register(new JsonObjectToNegotiationInitiateRequestDtoTransformer());
         transformerRegistry.register(new JsonObjectFromNegotiationStateTransformer(factory));
+        transformerRegistry.register(new JsonObjectToContractOfferDescriptionTransformer());
 
         var monitor = context.getMonitor();
 

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationNewApiController.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationNewApiController.java
@@ -137,7 +137,8 @@ public class ContractNegotiationNewApiController implements ContractNegotiationN
     @POST
     @Override
     public JsonObject initiateContractNegotiation(JsonObject requestObject) {
-        var contractRequest = transformerRegistry.transform(requestObject, NegotiationInitiateRequestDto.class)
+        var contractRequest = jsonLdService.expand(requestObject)
+                .compose(expanded -> transformerRegistry.transform(expanded, NegotiationInitiateRequestDto.class))
                 .compose(dto -> transformerRegistry.transform(dto, ContractRequest.class))
                 .orElseThrow(InvalidRequestException::new);
 

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/model/ContractOfferDescription.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/model/ContractOfferDescription.java
@@ -22,7 +22,14 @@ import org.eclipse.edc.policy.model.Policy;
 
 import java.util.concurrent.TimeUnit;
 
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
+
 public class ContractOfferDescription {
+
+    public static final String TYPE = EDC_NAMESPACE + "ContractOfferDescription";
+    public static final String OFFER_ID = EDC_NAMESPACE + "offerId";
+    public static final String ASSET_ID = EDC_NAMESPACE + "assetId";
+    public static final String POLICY = EDC_NAMESPACE + "policy";
 
     /**
      * Default validity is set to one year.

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectToContractOfferDescriptionTransformer.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectToContractOfferDescriptionTransformer.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.contractnegotiation.transform;
+
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractOfferDescription;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractOfferDescription.ASSET_ID;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractOfferDescription.OFFER_ID;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractOfferDescription.POLICY;
+
+
+public class JsonObjectToContractOfferDescriptionTransformer extends AbstractJsonLdTransformer<JsonObject, ContractOfferDescription> {
+
+    public JsonObjectToContractOfferDescriptionTransformer() {
+        super(JsonObject.class, ContractOfferDescription.class);
+    }
+
+    @Override
+    public @Nullable ContractOfferDescription transform(@NotNull JsonObject jsonObject, @NotNull TransformerContext context) {
+        var builder = ContractOfferDescription.Builder.newInstance();
+
+        visitProperties(jsonObject, (k, v) -> setProperties(k, v, builder, context));
+        return builder.build();
+    }
+
+    private void setProperties(String key, JsonValue value, ContractOfferDescription.Builder builder, TransformerContext context) {
+        switch (key) {
+            case OFFER_ID:
+                transformString(value, builder::offerId, context);
+                break;
+            case ASSET_ID:
+                transformString(value, builder::assetId, context);
+                break;
+            case POLICY:
+                transformArrayOrObject(value, Policy.class, builder::policy, context);
+                break;
+            default:
+                context.reportProblem("Cannot convert key " + key + " as it is not known");
+                break;
+        }
+    }
+}

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectToNegotiationInitiateRequestDtoTransformer.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectToNegotiationInitiateRequestDtoTransformer.java
@@ -20,21 +20,17 @@ import org.eclipse.edc.api.model.CallbackAddressDto;
 import org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractOfferDescription;
 import org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
-import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 
-import static org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto.ASSET_ID;
 import static org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto.CALLBACK_ADDRESSES;
 import static org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto.CONNECTOR_ADDRESS;
 import static org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto.CONNECTOR_ID;
 import static org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto.CONSUMER_ID;
 import static org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto.OFFER;
-import static org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto.OFFER_ID;
-import static org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto.POLICY;
 import static org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto.PROTOCOL;
 import static org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto.PROVIDER_ID;
 
@@ -77,10 +73,7 @@ public class JsonObjectToNegotiationInitiateRequestDtoTransformer extends Abstra
                 builder.callbackAddresses(addresses);
                 break;
             case OFFER:
-                transformString(value.asJsonObject().get(OFFER_ID), contractOfferDesc::offerId, context);
-                transformString(value.asJsonObject().get(ASSET_ID), contractOfferDesc::assetId, context);
-                contractOfferDesc.policy(context.transform(value.asJsonObject().get(POLICY), Policy.class));
-                builder.offer(contractOfferDesc.build());
+                transformArrayOrObject(value, ContractOfferDescription.class, builder::offer, context);
                 break;
             default:
                 context.reportProblem("Cannot convert key " + key + " as it is not known");

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectToContractOfferDescriptionTransformerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectToContractOfferDescriptionTransformerTest.java
@@ -1,0 +1,91 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.contractnegotiation.transform;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractOfferDescription;
+import org.eclipse.edc.jsonld.TitaniumJsonLd;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractOfferDescription.ASSET_ID;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractOfferDescription.OFFER_ID;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractOfferDescription.POLICY;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_OBLIGATION_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_PERMISSION_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_SET;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_PROHIBITION_ATTRIBUTE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class JsonObjectToContractOfferDescriptionTransformerTest {
+    
+    private final JsonLd jsonLd = new TitaniumJsonLd(mock(Monitor.class));
+    private JsonObjectToContractOfferDescriptionTransformer transformer;
+
+    @BeforeEach
+    void setUp() {
+        transformer = new JsonObjectToContractOfferDescriptionTransformer();
+    }
+
+    @Test
+    void transform() {
+        var jsonObject = Json.createObjectBuilder()
+                .add(TYPE, ContractOfferDescription.TYPE)
+                .add(OFFER_ID, "test-offer-id")
+                .add(ASSET_ID, "test-asset")
+                .add(POLICY, createPolicy())
+                .build();
+
+        var context = mock(TransformerContext.class);
+        when(context.transform(any(JsonValue.class), eq(Policy.class))).thenReturn(Policy.Builder.newInstance().build());
+
+        var dto = transformer.transform(jsonLd.expand(jsonObject).getContent(), context);
+
+        assertThat(dto).isNotNull();
+        assertThat(dto.getOfferId()).isEqualTo("test-offer-id");
+        assertThat(dto.getAssetId()).isEqualTo("test-asset");
+        assertThat(dto.getPolicy()).isNotNull();
+
+    }
+
+    private JsonObject createPolicy() {
+        var permissionJson = getJsonObject("permission");
+        var prohibitionJson = getJsonObject("prohibition");
+        var dutyJson = getJsonObject("duty");
+        return Json.createObjectBuilder()
+                .add(TYPE, ODRL_POLICY_TYPE_SET)
+                .add(ODRL_PERMISSION_ATTRIBUTE, permissionJson)
+                .add(ODRL_PROHIBITION_ATTRIBUTE, prohibitionJson)
+                .add(ODRL_OBLIGATION_ATTRIBUTE, dutyJson)
+                .build();
+    }
+
+    private JsonObject getJsonObject(String type) {
+        return Json.createObjectBuilder()
+                .add(TYPE, type)
+                .build();
+    }
+}

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectToNegotiationInitiateRequestDtoTransformerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectToNegotiationInitiateRequestDtoTransformerTest.java
@@ -17,9 +17,13 @@ package org.eclipse.edc.connector.api.management.contractnegotiation.transform;
 import jakarta.json.Json;
 import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
 import org.eclipse.edc.api.model.CallbackAddressDto;
+import org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractOfferDescription;
 import org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationInitiateRequestDto;
-import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.jsonld.TitaniumJsonLd;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.junit.jupiter.api.BeforeEach;
@@ -53,7 +57,7 @@ import static org.mockito.Mockito.when;
 
 class JsonObjectToNegotiationInitiateRequestDtoTransformerTest {
 
-
+    private final JsonLd jsonLd = new TitaniumJsonLd(mock(Monitor.class));
     private JsonObjectToNegotiationInitiateRequestDtoTransformer transformer;
 
     @BeforeEach
@@ -79,7 +83,8 @@ class JsonObjectToNegotiationInitiateRequestDtoTransformerTest {
                 .build();
 
         var context = mock(TransformerContext.class);
-        when(context.transform(any(JsonObject.class), eq(Policy.class))).thenReturn(Policy.Builder.newInstance().build());
+        when(context.transform(any(JsonValue.class), eq(ContractOfferDescription.class))).thenReturn(ContractOfferDescription.Builder.newInstance().build());
+
         when(context.transform(any(JsonObject.class), eq(CallbackAddress.class))).thenReturn(CallbackAddress.Builder.newInstance()
                 .uri("http://test.local")
                 .events(Set.of("foo", "bar"))
@@ -90,7 +95,7 @@ class JsonObjectToNegotiationInitiateRequestDtoTransformerTest {
                 .events(Set.of("foo", "bar"))
                 .transactional(true)
                 .build());
-        var dto = transformer.transform(jsonObject, context);
+        var dto = transformer.transform(jsonLd.expand(jsonObject).getContent(), context);
 
         assertThat(dto).isNotNull();
         assertThat(dto.getCallbackAddresses()).isNotEmpty();
@@ -99,9 +104,7 @@ class JsonObjectToNegotiationInitiateRequestDtoTransformerTest {
         assertThat(dto.getConnectorId()).isEqualTo("test-conn-id");
         assertThat(dto.getProviderId()).isEqualTo("test-provider-id");
         assertThat(dto.getConsumerId()).isEqualTo("test-consumer-id");
-        assertThat(dto.getOffer().getOfferId()).isEqualTo("test-offer-id");
-        assertThat(dto.getOffer().getAssetId()).isEqualTo("test-asset");
-        assertThat(dto.getOffer().getPolicy()).isNotNull();
+        assertThat(dto.getOffer()).isNotNull();
 
     }
 


### PR DESCRIPTION
## What this PR changes/adds

Fix `JsonObjectToNegotiationInitiateRequestDto` when json-ld is expanded

## Further notes

Also fixed in this PR `JsonObjectToCallbackAddressDtoTransformer` when deserializing `events` field and added json-ld expasion on `ContractNegotiationNewApiController#initiateContractNegotiation`

## Linked Issue(s)

Closes #2994 

## Checklist

- [x] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
