### PR TITLE
chore: add W3ID compliant identifier

### DIFF
--- a/extensions/control-plane/store/cosmos/transfer-process-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/transferprocess/model/TransferProcessDocumentSerializationTest.java
+++ b/extensions/control-plane/store/cosmos/transfer-process-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/transferprocess/model/TransferProcessDocumentSerializationTest.java
@@ -49,8 +49,8 @@ class TransferProcessDocumentSerializationTest {
         assertThat(s).contains("\"type\":\"CONSUMER\"");
         assertThat(s).contains("\"errorDetail\":null");
         assertThat(s).contains("\"destinationType\":\"Test Address Type\"");
-        assertThat(s).contains("\"https://foo.bar.org/ds/schema/keyName\":\"Test Key Name\"");
-        assertThat(s).contains("\"https://foo.bar.org/ds/schema/type\":\"Test Address Type\"");
+        assertThat(s).contains("\"https://w3id.org/edc/v0.0.1/ns/keyName\":\"Test Key Name\"");
+        assertThat(s).contains("\"https://w3id.org/edc/v0.0.1/ns/type\":\"Test Address Type\"");
     }
 
     @Test

--- a/extensions/control-plane/store/cosmos/transfer-process-store-cosmos/src/test/resources/raw_json.json
+++ b/extensions/control-plane/store/cosmos/transfer-process-store-cosmos/src/test/resources/raw_json.json
@@ -15,8 +15,8 @@
       "connectorId": null,
       "asset": {
         "properties": {
-          "https://foo.bar.org/ds/schema/policy-id": "test-policyId",
-          "https://foo.bar.org/ds/schema/id": "asset-id"
+          "https://w3id.org/edc/v0.0.1/ns/policy-id": "test-policyId",
+          "https://w3id.org/edc/v0.0.1/ns/id": "asset-id"
         }
       },
       "dataDestination": {

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/CoreConstants.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/CoreConstants.java
@@ -17,6 +17,5 @@ package org.eclipse.edc.spi;
 public interface CoreConstants {
     String JSON_LD = "json-ld";
     String EDC_PREFIX = "edc";
-    //todo: this must be replaced once we have a default EDC schema!
-    String EDC_NAMESPACE = "https://foo.bar.org/ds/schema/";
+    String EDC_NAMESPACE = "https://w3id.org/edc/v0.0.1/ns/";
 }

--- a/spi/common/core-spi/src/test/resources/serialized_asset.json
+++ b/spi/common/core-spi/src/test/resources/serialized_asset.json
@@ -1,8 +1,8 @@
 {
   "properties": {
-    "https://foo.bar.org/ds/schema/contenttype": "application/json",
-    "https://foo.bar.org/ds/schema/version": "1.0",
-    "https://foo.bar.org/ds/schema/id": "abcd123",
+    "https://w3id.org/edc/v0.0.1/ns/contenttype": "application/json",
+    "https://w3id.org/edc/v0.0.1/ns/version": "1.0",
+    "https://w3id.org/edc/v0.0.1/ns/id": "abcd123",
     "anotherProperty": "some value",
     "numberVal": 42069
   },

--- a/system-tests/management-api/management-api-test-runner/src/test/resources/policy-definition.json
+++ b/system-tests/management-api/management-api-test-runner/src/test/resources/policy-definition.json
@@ -1,6 +1,6 @@
 {
   "@context": {
-    "edc": "https://foo.bar.org/ds/schema/",
+    "edc": "https://w3id.org/edc/v0.0.1/ns/",
     "uid": "@id",
     "type": "@type",
     "PolicyDefinition": "edc:PolicyDefinition",


### PR DESCRIPTION
## What this PR changes/adds

Creates a (ficticious) W3ID namespace for EDC.

I based the namespace on [this](https://w3id.org/) recommendation, but did not create a pull request there. As far as I understood this is only necessary if permanent redirection is required.


## Why it does that

We must have a unique and immutable namespace

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
