### PR TITLE
chore: fix typo and improve javadoc

### DIFF
--- a/spi/common/transform-spi/src/main/java/org/eclipse/edc/transform/spi/TransformerContext.java
+++ b/spi/common/transform-spi/src/main/java/org/eclipse/edc/transform/spi/TransformerContext.java
@@ -19,13 +19,12 @@ import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 /**
- * A context used to report problems and perform recursive transformation of a type tree.
- * If a problem is reported, the transformation will fail.
+ * A context used to perform recursive transformation of a type tree.If a problem is reported, the transformation will fail.
  */
 public interface TransformerContext {
 
     /**
-     * Returns if problems have been problems reported during the transformation.
+     * Returns if problems have been reported during the transformation.
      */
     boolean hasProblems();
 


### PR DESCRIPTION
## What this PR changes/adds

Fixes a minor doc typo and cleans up the class javadoc.

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
