### PR TITLE
fix(CatalogRequestMessage): `QuerySpec` as JSON-LD

### DIFF
--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/main/java/org/eclipse/edc/protocol/dsp/catalog/transform/DspCatalogTransformExtension.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/main/java/org/eclipse/edc/protocol/dsp/catalog/transform/DspCatalogTransformExtension.java
@@ -51,7 +51,7 @@ public class DspCatalogTransformExtension implements ServiceExtension {
         var jsonFactory = Json.createBuilderFactory(Map.of());
         var mapper = typeManager.getMapper(JSON_LD);
 
-        registry.register(new JsonObjectFromCatalogRequestMessageTransformer(jsonFactory, mapper));
+        registry.register(new JsonObjectFromCatalogRequestMessageTransformer(jsonFactory));
         registry.register(new JsonObjectToCatalogRequestMessageTransformer(mapper));
     }
 }

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/main/java/org/eclipse/edc/protocol/dsp/catalog/transform/from/JsonObjectFromCatalogRequestMessageTransformer.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/main/java/org/eclipse/edc/protocol/dsp/catalog/transform/from/JsonObjectFromCatalogRequestMessageTransformer.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.protocol.dsp.catalog.transform.from;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.catalog.spi.CatalogRequestMessage;
@@ -33,12 +32,10 @@ import static org.eclipse.edc.protocol.dsp.catalog.transform.DspCatalogPropertyA
 public class JsonObjectFromCatalogRequestMessageTransformer extends AbstractJsonLdTransformer<CatalogRequestMessage, JsonObject> {
 
     private final JsonBuilderFactory jsonFactory;
-    private final ObjectMapper mapper;
 
-    public JsonObjectFromCatalogRequestMessageTransformer(JsonBuilderFactory jsonFactory, ObjectMapper mapper) {
+    public JsonObjectFromCatalogRequestMessageTransformer(JsonBuilderFactory jsonFactory) {
         super(CatalogRequestMessage.class, JsonObject.class);
         this.jsonFactory = jsonFactory;
-        this.mapper = mapper;
     }
 
     @Override

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/main/java/org/eclipse/edc/protocol/dsp/catalog/transform/from/JsonObjectFromCatalogRequestMessageTransformer.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/main/java/org/eclipse/edc/protocol/dsp/catalog/transform/from/JsonObjectFromCatalogRequestMessageTransformer.java
@@ -31,25 +31,25 @@ import static org.eclipse.edc.protocol.dsp.catalog.transform.DspCatalogPropertyA
  * Transforms a {@link CatalogRequestMessage} to a {@link JsonObject} in JSON-LD expanded form.
  */
 public class JsonObjectFromCatalogRequestMessageTransformer extends AbstractJsonLdTransformer<CatalogRequestMessage, JsonObject> {
-    
+
     private final JsonBuilderFactory jsonFactory;
     private final ObjectMapper mapper;
-    
+
     public JsonObjectFromCatalogRequestMessageTransformer(JsonBuilderFactory jsonFactory, ObjectMapper mapper) {
         super(CatalogRequestMessage.class, JsonObject.class);
         this.jsonFactory = jsonFactory;
         this.mapper = mapper;
     }
-    
+
     @Override
     public @Nullable JsonObject transform(@NotNull CatalogRequestMessage message, @NotNull TransformerContext context) {
         var builder = jsonFactory.createObjectBuilder();
         builder.add(TYPE, DSPACE_CATALOG_REQUEST_TYPE);
-        
+
         if (message.getQuerySpec() != null) {
-            builder.add(DSPACE_FILTER_PROPERTY, mapper.convertValue(message.getQuerySpec(), JsonObject.class));
+            builder.add(DSPACE_FILTER_PROPERTY, context.transform(message.getQuerySpec(), JsonObject.class));
         }
-        
+
         return builder.build();
     }
 }

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/main/java/org/eclipse/edc/protocol/dsp/catalog/transform/to/JsonObjectToCatalogRequestMessageTransformer.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/main/java/org/eclipse/edc/protocol/dsp/catalog/transform/to/JsonObjectToCatalogRequestMessageTransformer.java
@@ -15,7 +15,6 @@
 package org.eclipse.edc.protocol.dsp.catalog.transform.to;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.catalog.spi.CatalogRequestMessage;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
@@ -24,9 +23,6 @@ import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import static jakarta.json.JsonValue.ValueType.ARRAY;
-import static jakarta.json.JsonValue.ValueType.OBJECT;
-import static org.eclipse.edc.protocol.dsp.catalog.transform.DspCatalogPropertyAndTypeNames.DSPACE_CATALOG_REQUEST_TYPE;
 import static org.eclipse.edc.protocol.dsp.catalog.transform.DspCatalogPropertyAndTypeNames.DSPACE_FILTER_PROPERTY;
 
 /**
@@ -59,22 +55,6 @@ public class JsonObjectToCatalogRequestMessageTransformer extends AbstractJsonLd
         if (value == null) {
             return null;
         }
-
-        if (value instanceof JsonObject) {
-            return mapper.convertValue(value, QuerySpec.class);
-        } else if (value instanceof JsonArray) {
-            var array = (JsonArray) value;
-            return transformQuerySpec(array.getJsonObject(0), context);
-        } else {
-            context.problem()
-                    .unexpectedType()
-                    .type(DSPACE_CATALOG_REQUEST_TYPE)
-                    .property(DSPACE_FILTER_PROPERTY)
-                    .actual(value.getValueType())
-                    .expected(OBJECT)
-                    .expected(ARRAY)
-                    .report();
-            return null;
-        }
+        return transformObject(value, QuerySpec.class, context);
     }
 }

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/test/java/org/eclipse/edc/protocol/dsp/catalog/transform/from/JsonObjectFromCatalogRequestMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/test/java/org/eclipse/edc/protocol/dsp/catalog/transform/from/JsonObjectFromCatalogRequestMessageTransformerTest.java
@@ -53,7 +53,7 @@ class JsonObjectFromCatalogRequestMessageTransformerTest {
     void transform_returnJsonObject() {
         var querySpec = QuerySpec.Builder.newInstance().build();
         var querySpecJson = jsonFactory.createObjectBuilder().build();
-        when(mapper.convertValue(querySpec, JsonObject.class)).thenReturn(querySpecJson);
+        when(context.transform(querySpec, JsonObject.class)).thenReturn(querySpecJson);
 
         var message = CatalogRequestMessage.Builder.newInstance()
                 .protocol("protocol")

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/test/java/org/eclipse/edc/protocol/dsp/catalog/transform/from/JsonObjectFromCatalogRequestMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/test/java/org/eclipse/edc/protocol/dsp/catalog/transform/from/JsonObjectFromCatalogRequestMessageTransformerTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.protocol.dsp.catalog.transform.from;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
@@ -39,14 +38,13 @@ import static org.mockito.Mockito.when;
 class JsonObjectFromCatalogRequestMessageTransformerTest {
 
     private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
-    private final ObjectMapper mapper = mock(ObjectMapper.class);
     private final TransformerContext context = mock(TransformerContext.class);
 
     private JsonObjectFromCatalogRequestMessageTransformer transformer;
 
     @BeforeEach
     void setUp() {
-        transformer = new JsonObjectFromCatalogRequestMessageTransformer(jsonFactory, mapper);
+        transformer = new JsonObjectFromCatalogRequestMessageTransformer(jsonFactory);
     }
 
     @Test

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/test/java/org/eclipse/edc/protocol/dsp/catalog/transform/to/JsonObjectToCatalogRequestMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/test/java/org/eclipse/edc/protocol/dsp/catalog/transform/to/JsonObjectToCatalogRequestMessageTransformerTest.java
@@ -51,7 +51,7 @@ class JsonObjectToCatalogRequestMessageTransformerTest {
     void transform_returnCatalogRequestMessage() {
         var querySpecJson = jsonFactory.createObjectBuilder().build();
         var querySpec = QuerySpec.Builder.newInstance().build();
-        when(mapper.convertValue(querySpecJson, QuerySpec.class)).thenReturn(querySpec);
+        when(context.transform(querySpecJson, QuerySpec.class)).thenReturn(querySpec);
 
         var message = jsonFactory.createObjectBuilder()
                 .add(TYPE, DSPACE_CATALOG_REQUEST_TYPE)

--- a/data-protocols/dsp/dsp-transform/src/main/java/org/eclipse/edc/protocol/dsp/transform/DspTransformExtension.java
+++ b/data-protocols/dsp/dsp-transform/src/main/java/org/eclipse/edc/protocol/dsp/transform/DspTransformExtension.java
@@ -17,14 +17,17 @@ package org.eclipse.edc.protocol.dsp.transform;
 import jakarta.json.Json;
 import org.eclipse.edc.jsonld.transformer.from.JsonObjectFromAssetTransformer;
 import org.eclipse.edc.jsonld.transformer.from.JsonObjectFromCatalogTransformer;
+import org.eclipse.edc.jsonld.transformer.from.JsonObjectFromCriterionTransformer;
 import org.eclipse.edc.jsonld.transformer.from.JsonObjectFromDataServiceTransformer;
 import org.eclipse.edc.jsonld.transformer.from.JsonObjectFromDatasetTransformer;
 import org.eclipse.edc.jsonld.transformer.from.JsonObjectFromDistributionTransformer;
 import org.eclipse.edc.jsonld.transformer.from.JsonObjectFromPolicyTransformer;
+import org.eclipse.edc.jsonld.transformer.from.JsonObjectFromQuerySpecTransformer;
 import org.eclipse.edc.jsonld.transformer.to.JsonObjectToActionTransformer;
 import org.eclipse.edc.jsonld.transformer.to.JsonObjectToAssetTransformer;
 import org.eclipse.edc.jsonld.transformer.to.JsonObjectToCatalogTransformer;
 import org.eclipse.edc.jsonld.transformer.to.JsonObjectToConstraintTransformer;
+import org.eclipse.edc.jsonld.transformer.to.JsonObjectToCriterionTransformer;
 import org.eclipse.edc.jsonld.transformer.to.JsonObjectToDataServiceTransformer;
 import org.eclipse.edc.jsonld.transformer.to.JsonObjectToDatasetTransformer;
 import org.eclipse.edc.jsonld.transformer.to.JsonObjectToDistributionTransformer;
@@ -32,6 +35,7 @@ import org.eclipse.edc.jsonld.transformer.to.JsonObjectToDutyTransformer;
 import org.eclipse.edc.jsonld.transformer.to.JsonObjectToPermissionTransformer;
 import org.eclipse.edc.jsonld.transformer.to.JsonObjectToPolicyTransformer;
 import org.eclipse.edc.jsonld.transformer.to.JsonObjectToProhibitionTransformer;
+import org.eclipse.edc.jsonld.transformer.to.JsonObjectToQuerySpecTransformer;
 import org.eclipse.edc.jsonld.transformer.to.JsonValueToGenericTypeTransformer;
 import org.eclipse.edc.policy.model.AtomicConstraint;
 import org.eclipse.edc.policy.model.LiteralExpression;
@@ -80,6 +84,8 @@ public class DspTransformExtension implements ServiceExtension {
         registry.register(new JsonObjectFromDistributionTransformer(jsonBuilderFactory));
         registry.register(new JsonObjectFromDataServiceTransformer(jsonBuilderFactory));
         registry.register(new JsonObjectFromAssetTransformer(jsonBuilderFactory, mapper));
+        registry.register(new JsonObjectFromQuerySpecTransformer(jsonBuilderFactory));
+        registry.register(new JsonObjectFromCriterionTransformer(jsonBuilderFactory, mapper));
 
         // JSON-LD to EDC model transformers
         registry.register(new JsonObjectToCatalogTransformer());
@@ -94,5 +100,8 @@ public class DspTransformExtension implements ServiceExtension {
         registry.register(new JsonObjectToConstraintTransformer());
         registry.register(new JsonValueToGenericTypeTransformer(mapper));
         registry.register(new JsonObjectToAssetTransformer());
+        registry.register(new JsonObjectToQuerySpecTransformer());
+        registry.register(new JsonObjectToCriterionTransformer());
+
     }
 }

--- a/extensions/common/api/api-core/src/main/java/org/eclipse/edc/api/query/QuerySpecDto.java
+++ b/extensions/common/api/api-core/src/main/java/org/eclipse/edc/api/query/QuerySpecDto.java
@@ -33,7 +33,7 @@ import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 @JsonDeserialize(builder = QuerySpecDto.Builder.class)
 public class QuerySpecDto {
 
-    public static final String EDC_QUERY_SPEC_TYPE = EDC_NAMESPACE + "QuerySpec";
+    public static final String EDC_QUERY_SPEC_TYPE = EDC_NAMESPACE + "QuerySpecDto";
     public static final String EDC_QUERY_SPEC_OFFSET = EDC_NAMESPACE + "offset";
     public static final String EDC_QUERY_SPEC_LIMIT = EDC_NAMESPACE + "limit";
     public static final String EDC_QUERY_SPEC_FILTER_EXPRESSION = EDC_NAMESPACE + "filterExpression";

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/from/JsonObjectFromCriterionTransformer.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/from/JsonObjectFromCriterionTransformer.java
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.jsonld.transformer.from;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonValue;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
+
+public class JsonObjectFromCriterionTransformer extends AbstractJsonLdTransformer<Criterion, JsonObject> {
+    private final JsonBuilderFactory jsonFactory;
+    private final ObjectMapper mapper;
+
+    public JsonObjectFromCriterionTransformer(JsonBuilderFactory jsonFactory, ObjectMapper mapper) {
+        super(Criterion.class, JsonObject.class);
+        this.jsonFactory = jsonFactory;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public @Nullable JsonObject transform(@NotNull Criterion querySpec, @NotNull TransformerContext context) {
+        var builder = jsonFactory.createObjectBuilder();
+        builder.add(TYPE, Criterion.CRITERION_TYPE);
+
+        addValue(builder, Criterion.CRITERION_OPERAND_LEFT, querySpec.getOperandLeft(), context);
+
+        builder.add(Criterion.CRITERION_OPERATOR, querySpec.getOperator());
+
+        if (querySpec.getOperandRight() != null) {
+            addValue(builder, Criterion.CRITERION_OPERAND_RIGHT, querySpec.getOperandRight(), context);
+        }
+
+        return builder.build();
+    }
+
+    private void addValue(JsonObjectBuilder builder, String field, Object value, TransformerContext context) {
+        try {
+            builder.add(field, mapper.convertValue(value, JsonValue.class));
+        } catch (IllegalArgumentException e) {
+            context.problem()
+                    .invalidProperty()
+                    .type(VALUE)
+                    .property(field)
+                    .value(value != null ? value.toString() : "null")
+                    .error(e.getMessage())
+                    .report();
+        }
+    }
+}

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/from/JsonObjectFromQuerySpecTransformer.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/from/JsonObjectFromQuerySpecTransformer.java
@@ -23,8 +23,6 @@ import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import static java.util.UUID.randomUUID;
-import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 
 public class JsonObjectFromQuerySpecTransformer extends AbstractJsonLdTransformer<QuerySpec, JsonObject> {
@@ -38,7 +36,6 @@ public class JsonObjectFromQuerySpecTransformer extends AbstractJsonLdTransforme
     @Override
     public @Nullable JsonObject transform(@NotNull QuerySpec querySpec, @NotNull TransformerContext context) {
         var builder = jsonFactory.createObjectBuilder();
-        builder.add(ID, randomUUID().toString());
         builder.add(TYPE, QuerySpec.EDC_QUERY_SPEC_TYPE);
         builder.add(QuerySpec.EDC_QUERY_SPEC_LIMIT, querySpec.getLimit());
         builder.add(QuerySpec.EDC_QUERY_SPEC_OFFSET, querySpec.getOffset());

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/from/JsonObjectFromQuerySpecTransformer.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/from/JsonObjectFromQuerySpecTransformer.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.jsonld.transformer.from;
+
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static java.util.UUID.randomUUID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+
+public class JsonObjectFromQuerySpecTransformer extends AbstractJsonLdTransformer<QuerySpec, JsonObject> {
+    private final JsonBuilderFactory jsonFactory;
+
+    public JsonObjectFromQuerySpecTransformer(JsonBuilderFactory jsonFactory) {
+        super(QuerySpec.class, JsonObject.class);
+        this.jsonFactory = jsonFactory;
+    }
+
+    @Override
+    public @Nullable JsonObject transform(@NotNull QuerySpec querySpec, @NotNull TransformerContext context) {
+        var builder = jsonFactory.createObjectBuilder();
+        builder.add(ID, randomUUID().toString());
+        builder.add(TYPE, QuerySpec.EDC_QUERY_SPEC_TYPE);
+        builder.add(QuerySpec.EDC_QUERY_SPEC_LIMIT, querySpec.getLimit());
+        builder.add(QuerySpec.EDC_QUERY_SPEC_OFFSET, querySpec.getOffset());
+        builder.add(QuerySpec.EDC_QUERY_SPEC_SORT_ORDER, querySpec.getSortOrder().toString());
+
+        if (querySpec.getSortField() != null) {
+            builder.add(QuerySpec.EDC_QUERY_SPEC_SORT_FIELD, querySpec.getSortField());
+        }
+
+        var filterExpressions = querySpec.getFilterExpression().stream()
+                .map(expression -> context.transform(expression, JsonObject.class))
+                .collect(jsonFactory::createArrayBuilder, JsonArrayBuilder::add, JsonArrayBuilder::add)
+                .build();
+
+        builder.add(QuerySpec.EDC_QUERY_SPEC_FILTER_EXPRESSION, filterExpressions);
+
+        return builder.build();
+    }
+}

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToCriterionTransformer.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToCriterionTransformer.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.jsonld.transformer.to;
+
+import jakarta.json.JsonObject;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static org.eclipse.edc.spi.query.Criterion.CRITERION_OPERAND_LEFT;
+import static org.eclipse.edc.spi.query.Criterion.CRITERION_OPERAND_RIGHT;
+import static org.eclipse.edc.spi.query.Criterion.CRITERION_OPERATOR;
+
+public class JsonObjectToCriterionTransformer extends AbstractJsonLdTransformer<JsonObject, Criterion> {
+
+    public JsonObjectToCriterionTransformer() {
+        super(JsonObject.class, Criterion.class);
+    }
+
+    @Override
+    public @Nullable Criterion transform(@NotNull JsonObject input, @NotNull TransformerContext context) {
+        var builder = Criterion.Builder.newInstance();
+
+        visitProperties(input, key -> {
+            switch (key) {
+                case CRITERION_OPERAND_LEFT:
+                    return v -> builder.operandLeft(transformGenericProperty(v, context));
+                case CRITERION_OPERAND_RIGHT:
+                    return v -> builder.operandRight(transformGenericProperty(v, context));
+                case CRITERION_OPERATOR:
+                    return v -> builder.operator(transformString(v, context));
+                default:
+                    return doNothing();
+            }
+        });
+
+        return builder.build();
+    }
+
+}

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToQuerySpecTransformer.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToQuerySpecTransformer.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.jsonld.transformer.to;
+
+import jakarta.json.JsonObject;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.query.SortOrder;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_FILTER_EXPRESSION;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_LIMIT;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_OFFSET;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_SORT_FIELD;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_SORT_ORDER;
+
+public class JsonObjectToQuerySpecTransformer extends AbstractJsonLdTransformer<JsonObject, QuerySpec> {
+
+    public JsonObjectToQuerySpecTransformer() {
+        super(JsonObject.class, QuerySpec.class);
+    }
+
+    @Override
+    public @Nullable QuerySpec transform(@NotNull JsonObject input, @NotNull TransformerContext context) {
+        var builder = QuerySpec.Builder.newInstance();
+
+        visitProperties(input, key -> {
+            switch (key) {
+                case EDC_QUERY_SPEC_OFFSET:
+                    return v -> builder.offset(transformInt(v, context));
+                case EDC_QUERY_SPEC_LIMIT:
+                    return v -> builder.limit(transformInt(v, context));
+                case EDC_QUERY_SPEC_FILTER_EXPRESSION:
+                    return v -> builder.filter(transformArray(v, Criterion.class, context));
+                case EDC_QUERY_SPEC_SORT_ORDER:
+                    return v -> builder.sortOrder(SortOrder.valueOf(transformString(v, context)));
+                case EDC_QUERY_SPEC_SORT_FIELD:
+                    return v -> builder.sortField(transformString(v, context));
+                default:
+                    return doNothing();
+            }
+        });
+
+        return builder.build();
+    }
+
+}

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/from/JsonObjectFromCriterionTransformerTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/from/JsonObjectFromCriterionTransformerTest.java
@@ -1,0 +1,90 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.jsonld.transformer.from;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.json.Json;
+import jakarta.json.JsonValue;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.transform.spi.ProblemBuilder;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class JsonObjectFromCriterionTransformerTest {
+
+    private final ObjectMapper mapper = mock(ObjectMapper.class);
+    private final TransformerContext context = mock(TransformerContext.class);
+    private JsonObjectFromCriterionTransformer transformer;
+
+    @BeforeEach
+    void setUp() {
+        transformer = new JsonObjectFromCriterionTransformer(Json.createBuilderFactory(Map.of()), mapper);
+    }
+
+    @Test
+    void transform() {
+
+        var criterion = Criterion.Builder.newInstance()
+                .operandLeft("field")
+                .operator("=")
+                .operandRight("value")
+                .build();
+
+        when(mapper.convertValue(eq(criterion.getOperandLeft()), eq(JsonValue.class))).thenReturn(Json.createValue(criterion.getOperandLeft().toString()));
+        when(mapper.convertValue(eq(criterion.getOperandRight()), eq(JsonValue.class))).thenReturn(Json.createValue(criterion.getOperandRight().toString()));
+
+        var jsonObject = transformer.transform(criterion, context);
+
+        assertThat(jsonObject).isNotNull();
+
+        assertThat(jsonObject.getJsonString(Criterion.CRITERION_OPERAND_LEFT).getString()).isEqualTo(criterion.getOperandLeft());
+        assertThat(jsonObject.getJsonString(Criterion.CRITERION_OPERATOR).getString()).isEqualTo(criterion.getOperator());
+        assertThat(jsonObject.getJsonString(Criterion.CRITERION_OPERAND_RIGHT).getString()).isEqualTo(criterion.getOperandRight());
+
+    }
+
+    @Test
+    void transform_reportErrors() {
+
+        var criterion = Criterion.Builder.newInstance()
+                .operandLeft("field")
+                .operator("=")
+                .operandRight("value")
+                .build();
+
+        when(context.problem()).thenReturn(new ProblemBuilder(context));
+
+        when(mapper.convertValue(eq(criterion.getOperandLeft()), eq(JsonValue.class))).thenThrow(new IllegalArgumentException());
+        when(mapper.convertValue(eq(criterion.getOperandRight()), eq(JsonValue.class))).thenThrow(new IllegalArgumentException());
+
+        var jsonObject = transformer.transform(criterion, context);
+
+        assertThat(jsonObject).isNotNull();
+        verify(context, times(2)).reportProblem(anyString());
+
+    }
+
+}

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/from/JsonObjectFromQuerySpecTransformerTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/from/JsonObjectFromQuerySpecTransformerTest.java
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.jsonld.transformer.from;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.query.SortOrder;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class JsonObjectFromQuerySpecTransformerTest {
+
+    private JsonObjectFromQuerySpecTransformer transformer;
+
+    @BeforeEach
+    void setUp() {
+        transformer = new JsonObjectFromQuerySpecTransformer(Json.createBuilderFactory(Map.of()));
+    }
+
+    @Test
+    void transform() {
+        var querySpec = QuerySpec.Builder.newInstance()
+                .limit(10)
+                .offset(30)
+                .sortField("field")
+                .sortOrder(SortOrder.DESC)
+                .filter(List.of(Criterion.Builder.newInstance().operator("=").operandLeft("test").build()))
+                .build();
+
+        var context = mock(TransformerContext.class);
+        when(context.transform(isA(Criterion.class), eq(JsonObject.class))).thenReturn(Json.createObjectBuilder().build());
+        var jsonObject = transformer.transform(querySpec, context);
+
+        assertThat(jsonObject).isNotNull();
+
+        assertThat(jsonObject.getInt(QuerySpec.EDC_QUERY_SPEC_LIMIT)).isEqualTo(querySpec.getLimit());
+        assertThat(jsonObject.getInt(QuerySpec.EDC_QUERY_SPEC_OFFSET)).isEqualTo(querySpec.getOffset());
+        assertThat(jsonObject.getJsonString(QuerySpec.EDC_QUERY_SPEC_SORT_FIELD).getString()).isEqualTo(querySpec.getSortField());
+        assertThat(jsonObject.getJsonString(QuerySpec.EDC_QUERY_SPEC_SORT_ORDER).getString()).isEqualTo(querySpec.getSortOrder().toString());
+        assertThat(jsonObject.get(QuerySpec.EDC_QUERY_SPEC_FILTER_EXPRESSION))
+                .isNotNull()
+                .isInstanceOf(JsonArray.class)
+                .matches(v -> v.asJsonArray().size() == 1);
+
+    }
+
+}

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToCriterionTransformerTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToCriterionTransformerTest.java
@@ -21,6 +21,7 @@ import org.eclipse.edc.transform.spi.TransformerContext;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.transformer.to.TestInput.getExpanded;
 import static org.eclipse.edc.jsonld.util.JacksonJsonLd.createObjectMapper;
 import static org.eclipse.edc.spi.query.Criterion.CRITERION_OPERAND_LEFT;
 import static org.eclipse.edc.spi.query.Criterion.CRITERION_OPERAND_RIGHT;
@@ -48,7 +49,7 @@ class JsonObjectToCriterionTransformerTest {
                 .add(CRITERION_OPERATOR, "=")
                 .build();
 
-        var crit = transformer.transform(json, context);
+        var crit = transformer.transform(getExpanded(json), context);
         assertThat(crit).isNotNull();
         assertThat(crit.getOperator()).isEqualTo("=");
         assertThat(crit.getOperandLeft()).isEqualTo("foo");

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToCriterionTransformerTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToCriterionTransformerTest.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.jsonld.transformer.to;
+
+import jakarta.json.Json;
+import jakarta.json.JsonValue;
+import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.util.JacksonJsonLd.createObjectMapper;
+import static org.eclipse.edc.spi.query.Criterion.CRITERION_OPERAND_LEFT;
+import static org.eclipse.edc.spi.query.Criterion.CRITERION_OPERAND_RIGHT;
+import static org.eclipse.edc.spi.query.Criterion.CRITERION_OPERATOR;
+import static org.eclipse.edc.spi.query.Criterion.CRITERION_TYPE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+class JsonObjectToCriterionTransformerTest {
+
+    private final JsonObjectToCriterionTransformer transformer = new JsonObjectToCriterionTransformer();
+    private final JsonValueToGenericTypeTransformer genericTypeTransformer = new JsonValueToGenericTypeTransformer(createObjectMapper());
+
+    @Test
+    void transform() {
+        var context = mock(TransformerContext.class);
+        when(context.transform(any(JsonValue.class), eq(Object.class))).thenAnswer(a -> genericTypeTransformer.transform(a.getArgument(0), context));
+        var json = Json.createObjectBuilder()
+                .add(JsonLdKeywords.TYPE, CRITERION_TYPE)
+                .add(CRITERION_OPERAND_LEFT, "foo")
+                .add(CRITERION_OPERAND_RIGHT, "bar")
+                .add(CRITERION_OPERATOR, "=")
+                .build();
+
+        var crit = transformer.transform(json, context);
+        assertThat(crit).isNotNull();
+        assertThat(crit.getOperator()).isEqualTo("=");
+        assertThat(crit.getOperandLeft()).isEqualTo("foo");
+        assertThat(crit.getOperandRight()).isEqualTo("bar");
+    }
+}

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToQuerySpecTransformerTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToQuerySpecTransformerTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.transformer.to.TestInput.getExpanded;
 import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_FILTER_EXPRESSION;
 import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_LIMIT;
 import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_OFFSET;
@@ -50,8 +51,9 @@ class JsonObjectToQuerySpecTransformerTest {
     @Test
     void transform() {
         var filterExpressionJson = Json.createArrayBuilder()
-                .add(Json.createArrayBuilder().build())
+                .add(Json.createObjectBuilder().build())
                 .build();
+        
         var criterion = Criterion.Builder.newInstance().operandLeft("test").operator("=").build();
         when(context.transform(any(), eq(Criterion.class))).thenReturn(criterion);
         var json = Json.createObjectBuilder()
@@ -63,7 +65,7 @@ class JsonObjectToQuerySpecTransformerTest {
                 .add(EDC_QUERY_SPEC_SORT_FIELD, "fieldName")
                 .build();
 
-        var result = transformer.transform(json, context);
+        var result = transformer.transform(getExpanded(json), context);
 
         assertThat(result).isNotNull();
         assertThat(result.getOffset()).isEqualTo(10);

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToQuerySpecTransformerTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToQuerySpecTransformerTest.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.jsonld.transformer.to;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_FILTER_EXPRESSION;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_LIMIT;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_OFFSET;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_SORT_FIELD;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_SORT_ORDER;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE;
+import static org.eclipse.edc.spi.query.SortOrder.DESC;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class JsonObjectToQuerySpecTransformerTest {
+
+    private final JsonObjectToQuerySpecTransformer transformer = new JsonObjectToQuerySpecTransformer();
+    private final TransformerContext context = mock(TransformerContext.class);
+
+    @Test
+    void types() {
+        assertThat(transformer.getInputType()).isEqualTo(JsonObject.class);
+        assertThat(transformer.getOutputType()).isEqualTo(QuerySpec.class);
+    }
+
+    @Test
+    void transform() {
+        var filterExpressionJson = Json.createArrayBuilder()
+                .add(Json.createArrayBuilder().build())
+                .build();
+        var criterion = Criterion.Builder.newInstance().operandLeft("test").operator("=").build();
+        when(context.transform(any(), eq(Criterion.class))).thenReturn(criterion);
+        var json = Json.createObjectBuilder()
+                .add(TYPE, EDC_QUERY_SPEC_TYPE)
+                .add(EDC_QUERY_SPEC_OFFSET, 10)
+                .add(EDC_QUERY_SPEC_LIMIT, 20)
+                .add(EDC_QUERY_SPEC_FILTER_EXPRESSION, filterExpressionJson)
+                .add(EDC_QUERY_SPEC_SORT_ORDER, "DESC")
+                .add(EDC_QUERY_SPEC_SORT_FIELD, "fieldName")
+                .build();
+
+        var result = transformer.transform(json, context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getOffset()).isEqualTo(10);
+        assertThat(result.getLimit()).isEqualTo(20);
+        assertThat(result.getFilterExpression()).containsExactly(criterion);
+        assertThat(result.getSortOrder()).isEqualTo(DESC);
+        assertThat(result.getSortField()).isEqualTo("fieldName");
+        verify(context).transform(any(), eq(Criterion.class));
+    }
+
+}

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/Criterion.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/Criterion.java
@@ -14,10 +14,14 @@
 
 package org.eclipse.edc.spi.query;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
 import java.util.Objects;
 import java.util.function.Function;
 
 import static java.lang.String.format;
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 
 /**
  * This class can be used to form select expressions e.g. in SQL statements. It is a way to express those statements in
@@ -31,6 +35,11 @@ import static java.lang.String.format;
  * can be translated to {@code [select * where name = someone]}
  */
 public class Criterion {
+
+    public static final String CRITERION_OPERAND_LEFT = EDC_NAMESPACE + "operandLeft";
+    public static final String CRITERION_OPERAND_RIGHT = EDC_NAMESPACE + "operandRight";
+    public static final String CRITERION_OPERATOR = EDC_NAMESPACE + "operator";
+    public static final String CRITERION_TYPE = EDC_NAMESPACE + "Criterion";
     private Object operandLeft;
     private String operator;
     private Object operandRight;
@@ -81,5 +90,40 @@ public class Criterion {
     @Override
     public String toString() {
         return format("%s %s %s", getOperandLeft(), getOperator(), getOperandRight());
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static final class Builder {
+        private final Criterion criterion;
+
+        private Builder() {
+            this.criterion = new Criterion();
+        }
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder operandLeft(Object operandLeft) {
+            criterion.operandLeft = operandLeft;
+            return this;
+        }
+
+        public Builder operator(String operator) {
+            criterion.operator = operator;
+            return this;
+        }
+
+        public Builder operandRight(Object operandRight) {
+            criterion.operandRight = operandRight;
+            return this;
+        }
+
+        public Criterion build() {
+            Objects.requireNonNull(this.criterion.operandLeft);
+            Objects.requireNonNull(this.criterion.operator);
+            return criterion;
+        }
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/QuerySpec.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/QuerySpec.java
@@ -24,12 +24,21 @@ import java.util.Objects;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
+
 /**
  * Specifies various query parameters for collection-like queries. Typical uses include API endpoints, where the query
  * is tunnelled through to the database level.
  */
 public class QuerySpec {
 
+    public static final String EDC_QUERY_SPEC_TYPE = EDC_NAMESPACE + "QuerySpec";
+    public static final String EDC_QUERY_SPEC_OFFSET = EDC_NAMESPACE + "offset";
+    public static final String EDC_QUERY_SPEC_LIMIT = EDC_NAMESPACE + "limit";
+    public static final String EDC_QUERY_SPEC_FILTER_EXPRESSION = EDC_NAMESPACE + "filterExpression";
+    public static final String EDC_QUERY_SPEC_SORT_ORDER = EDC_NAMESPACE + "sortOrder";
+    public static final String EDC_QUERY_SPEC_SORT_FIELD = EDC_NAMESPACE + "sortField";
+    
     public static final String QUERY_SPEC = "querySpec";
 
     private int offset = 0;

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/CatalogApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/CatalogApiEndToEndTest.java
@@ -15,32 +15,49 @@
 package org.eclipse.edc.test.e2e.managementapi;
 
 import jakarta.json.Json;
+import org.eclipse.edc.connector.contract.spi.offer.store.ContractDefinitionStore;
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractDefinition;
+import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
+import org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.asset.AssetIndex;
+import org.eclipse.edc.spi.asset.AssetSelectorExpression;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.asset.Asset;
+import org.eclipse.edc.spi.types.domain.asset.AssetEntry;
 import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static org.eclipse.edc.api.model.CriterionDto.CRITERION_OPERAND_LEFT;
-import static org.eclipse.edc.api.model.CriterionDto.CRITERION_OPERAND_RIGHT;
 import static org.eclipse.edc.api.model.CriterionDto.CRITERION_OPERATOR;
 import static org.eclipse.edc.api.model.CriterionDto.CRITERION_TYPE;
 import static org.eclipse.edc.api.query.QuerySpecDto.EDC_QUERY_SPEC_FILTER_EXPRESSION;
+import static org.eclipse.edc.api.query.QuerySpecDto.EDC_QUERY_SPEC_LIMIT;
 import static org.eclipse.edc.api.query.QuerySpecDto.EDC_QUERY_SPEC_TYPE;
 import static org.eclipse.edc.catalog.spi.CatalogRequest.EDC_CATALOG_REQUEST_PROTOCOL;
 import static org.eclipse.edc.catalog.spi.CatalogRequest.EDC_CATALOG_REQUEST_PROVIDER_URL;
 import static org.eclipse.edc.catalog.spi.CatalogRequest.EDC_CATALOG_REQUEST_QUERY_SPEC;
 import static org.eclipse.edc.catalog.spi.CatalogRequest.EDC_CATALOG_REQUEST_TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
+import static org.eclipse.edc.spi.query.Criterion.CRITERION_OPERAND_RIGHT;
 import static org.hamcrest.Matchers.is;
 
 @EndToEndTest
 public class CatalogApiEndToEndTest extends BaseManagementApiEndToEndTest {
+
+    private static final String TEST_ASSET_ID = "test-asset-id";
 
     // requests the catalog to itself, to save another connector.
     private final String providerUrl = "http://localhost:" + PROTOCOL_PORT + "/protocol";
 
     @Test
     void shouldReturnCatalog_withoutQuerySpec() {
+
         var requestBody = Json.createObjectBuilder()
                 .add(TYPE, EDC_CATALOG_REQUEST_TYPE)
                 .add(EDC_CATALOG_REQUEST_PROVIDER_URL, providerUrl)
@@ -61,19 +78,48 @@ public class CatalogApiEndToEndTest extends BaseManagementApiEndToEndTest {
 
     @Test
     void shouldReturnCatalog_withQuerySpec() {
+
+        var asset = createAsset("id-1");
+        var asset1 = createAsset("id-2");
+
+        var assetIndex = controlPlane.getContext().getService(AssetIndex.class);
+        var policyDefinitionStore = controlPlane.getContext().getService(PolicyDefinitionStore.class);
+        var contractDefinitionStore = controlPlane.getContext().getService(ContractDefinitionStore.class);
+
+        var policyId = UUID.randomUUID().toString();
+
+        var cd = ContractDefinition.Builder.newInstance()
+                .id(UUID.randomUUID().toString())
+                .contractPolicyId(policyId)
+                .accessPolicyId(policyId)
+                .selectorExpression(AssetSelectorExpression.SELECT_ALL)
+                .build();
+
+        var policy = Policy.Builder.newInstance()
+                .build();
+
+        policyDefinitionStore.create(PolicyDefinition.Builder.newInstance().id(policyId).policy(policy).build());
+        contractDefinitionStore.save(cd);
+
+        assetIndex.create(new AssetEntry(asset.build(), createDataAddress().build()));
+        assetIndex.create(new AssetEntry(asset1.build(), createDataAddress().build()));
+
         var criteria = Json.createArrayBuilder()
                 .add(Json.createObjectBuilder()
                         .add(TYPE, CRITERION_TYPE)
-                        .add(CRITERION_OPERAND_LEFT, "key")
+                        .add(CRITERION_OPERAND_LEFT, EDC_NAMESPACE + "id")
                         .add(CRITERION_OPERATOR, "=")
-                        .add(CRITERION_OPERAND_RIGHT, "value")
+                        .add(CRITERION_OPERAND_RIGHT, "id-2")
                         .build()
                 )
                 .build();
+
         var querySpec = Json.createObjectBuilder()
                 .add(TYPE, EDC_QUERY_SPEC_TYPE)
                 .add(EDC_QUERY_SPEC_FILTER_EXPRESSION, criteria)
+                .add(EDC_QUERY_SPEC_LIMIT, 1)
                 .build();
+
         var requestBody = Json.createObjectBuilder()
                 .add(TYPE, EDC_CATALOG_REQUEST_TYPE)
                 .add(EDC_CATALOG_REQUEST_PROVIDER_URL, providerUrl)
@@ -90,6 +136,18 @@ public class CatalogApiEndToEndTest extends BaseManagementApiEndToEndTest {
                 .then()
                 .statusCode(200)
                 .contentType(JSON)
-                .body(TYPE, is("dcat:Catalog"));
+                .body(TYPE, is("dcat:Catalog"))
+                .body("'dcat:dataset'.'edc:id'", is("id-2"))
+                .extract().body().asString();
     }
+
+    private DataAddress.Builder createDataAddress() {
+        return DataAddress.Builder.newInstance().type("test-type");
+    }
+
+    private Asset.Builder createAsset(String id) {
+        return Asset.Builder.newInstance()
+                .id(id);
+    }
+
 }


### PR DESCRIPTION
## What this PR changes/adds

Add `QuerySpec` as JSON-LD object in `CatalogRequestMessage`

## Why it does that

fix issue on catalog query

## Further notes

I've created transformers directly for `QuerySpec` and `Criterion` which are used in `CatalogRequestMessage` and also the new controllers  `ContractNegotiationNewApiController` and `TransferProcessNewApiController`.  
I didn't change `CatalogNewApiController` since it share `CatalogRequestDto` with the old controller.
Once we remove the old controller we can use the `QuerySpec` directly in the `CatalogRequestDto`.

To make it compatible with this future refactor  the `CriterionDto.CRITERION_TYPE` has been renamed: ~~CriterionDto~~ Criterion

## Linked Issue(s)

Closes #3015 

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
