### PR TITLE
refactor(dsp): make handleResult return a Result

### DIFF
--- a/spi/common/aggregate-service-spi/src/main/java/org/eclipse/edc/service/spi/result/ServiceFailure.java
+++ b/spi/common/aggregate-service-spi/src/main/java/org/eclipse/edc/service/spi/result/ServiceFailure.java
@@ -31,6 +31,6 @@ public class ServiceFailure extends Failure {
     }
 
     public enum Reason {
-        NOT_FOUND, CONFLICT, BAD_REQUEST
+        NOT_FOUND, CONFLICT, BAD_REQUEST, UNAUTHORIZED
     }
 }

--- a/spi/common/aggregate-service-spi/src/main/java/org/eclipse/edc/service/spi/result/ServiceResult.java
+++ b/spi/common/aggregate-service-spi/src/main/java/org/eclipse/edc/service/spi/result/ServiceResult.java
@@ -24,6 +24,7 @@ import java.util.List;
 import static org.eclipse.edc.service.spi.result.ServiceFailure.Reason.BAD_REQUEST;
 import static org.eclipse.edc.service.spi.result.ServiceFailure.Reason.CONFLICT;
 import static org.eclipse.edc.service.spi.result.ServiceFailure.Reason.NOT_FOUND;
+import static org.eclipse.edc.service.spi.result.ServiceFailure.Reason.UNAUTHORIZED;
 
 public class ServiceResult<T> extends AbstractResult<T, ServiceFailure, ServiceResult<T>> {
 
@@ -81,6 +82,10 @@ public class ServiceResult<T> extends AbstractResult<T, ServiceFailure, ServiceR
             default:
                 return badRequest(storeResult.getFailureDetail());
         }
+    }
+
+    public static <T> ServiceResult<T> unauthorized(List<String> failureMessages) {
+        return new ServiceResult<>(null, new ServiceFailure(failureMessages, UNAUTHORIZED));
     }
 
     public ServiceFailure.Reason reason() {


### PR DESCRIPTION
## What this PR changes/adds

Refactors the `handleMessage` method of two controllers (`DspNegotiation...` and `DspTransferProcess...`) such that errors are conveyed using instances of `Result` rather than exceptions.

## Why it does that

Make code cleaner and more efficient.

## Further notes



## Linked Issue(s)

Closes #3026 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
