### PR TITLE
chore: remove checkboxes from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,18 +8,13 @@ _Briefly state why the change was necessary._
 
 ## Further notes
 
-_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._
+_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
+signature changes, package declarations, bugs that were encountered and were fixed inline, etc._
 
 ## Linked Issue(s)
 
 Closes # <-- _insert Issue number if one exists_
 
-## Checklist
-
-- [ ] added appropriate tests?
-- [ ] performed checkstyle check locally?
-- [ ] added/updated copyright headers?
-- [ ] documented public classes/methods?
-- [ ] added/updated relevant documentation?
-- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
-- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
+_Please be sure to take a look at
+the [contributing guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request)
+and our [etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md)_


### PR DESCRIPTION
## What this PR changes/adds

Removes the checkboxes from the PR template.

## Why it does that

they became obsolete

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_
