### PR TITLE
refactor: remove `QuerySpec.Builder.filter` deprecated method

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionServiceImpl.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import static java.lang.String.format;
+import static org.eclipse.edc.spi.query.Criterion.criterion;
 
 public class PolicyDefinitionServiceImpl implements PolicyDefinitionService {
 
@@ -75,11 +76,10 @@ public class PolicyDefinitionServiceImpl implements PolicyDefinitionService {
 
     @Override
     public @NotNull ServiceResult<PolicyDefinition> deleteById(String policyId) {
-
-        var contractFilter = format("contractPolicyId = %s ", policyId);
-        var accessFilter = format("accessPolicyId = %s ", policyId);
-
         return transactionContext.execute(() -> {
+
+            var contractFilter = criterion("contractPolicyId", "=", policyId);
+            var accessFilter = criterion("accessPolicyId", "=", policyId);
 
             var queryContractPolicyFilter = QuerySpec.Builder.newInstance().filter(contractFilter).build();
             try (var contractDefinitionOnPolicy = contractDefinitionStore.findAll(queryContractPolicyFilter)) {
@@ -87,7 +87,6 @@ public class PolicyDefinitionServiceImpl implements PolicyDefinitionService {
                     return ServiceResult.conflict(format("PolicyDefinition %s cannot be deleted as it is referenced by at least one contract definition", policyId));
                 }
             }
-
 
             var queryAccessPolicyFilter = QuerySpec.Builder.newInstance().filter(accessFilter).build();
             try (var accessDefinitionOnPolicy = contractDefinitionStore.findAll(queryAccessPolicyFilter)) {

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractdefinition/ContractDefinitionServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractdefinition/ContractDefinitionServiceImplTest.java
@@ -20,6 +20,7 @@ import org.eclipse.edc.connector.contract.spi.definition.observe.ContractDefinit
 import org.eclipse.edc.connector.contract.spi.offer.store.ContractDefinitionStore;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractDefinition;
 import org.eclipse.edc.spi.asset.AssetSelectorExpression;
+import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.StoreResult;
 import org.eclipse.edc.transaction.spi.NoopTransactionContext;
@@ -27,8 +28,11 @@ import org.eclipse.edc.transaction.spi.TransactionContext;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import java.util.UUID;
 import java.util.function.Predicate;
@@ -37,6 +41,8 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.service.spi.result.ServiceFailure.Reason.CONFLICT;
 import static org.eclipse.edc.service.spi.result.ServiceFailure.Reason.NOT_FOUND;
+import static org.eclipse.edc.spi.query.Criterion.criterion;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -94,11 +100,8 @@ class ContractDefinitionServiceImplTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {
-            "selectorExpression.criteria.leftHand=foo", //invalid path
-            "accessPolicyId'LIKE/**/?/**/LIMIT/**/?/**/OFFSET/**/?;DROP/**/TABLE/**/test/**/--%20=%20ABC--", //some SQL injection
-    })
-    void query_invalidFilter(String invalidFilter) {
+    @ArgumentsSource(InvalidFilters.class)
+    void query_invalidFilter(Criterion invalidFilter) {
         var query = QuerySpec.Builder.newInstance()
                 .filter(invalidFilter)
                 .build();
@@ -106,12 +109,8 @@ class ContractDefinitionServiceImplTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {
-            "selectorExpression.criteria.operandLeft=foo", //invalid path
-            "selectorExpression.criteria.operator=LIKE", //invalid path
-            "selectorExpression.criteria.operandRight=bar" //invalid path
-    })
-    void query_validFilter(String validFilter) {
+    @ArgumentsSource(ValidFilters.class)
+    void query_validFilter(Criterion validFilter) {
         var query = QuerySpec.Builder.newInstance()
                 .filter(validFilter)
                 .build();
@@ -205,6 +204,27 @@ class ContractDefinitionServiceImplTest {
         assertThat(updated.failed()).isTrue();
         assertThat(updated.reason()).isEqualTo(NOT_FOUND);
         verify(listener, never()).updated(any());
+    }
+
+    private static class InvalidFilters implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                    arguments(criterion("selectorExpression.criteria.leftHand", "=", "foo")), // invalid path
+                    arguments(criterion("accessPolicyId'LIKE/**/?/**/LIMIT/**/?/**/OFFSET/**/?;DROP/**/TABLE/**/test/**/--%20", "=", "%20ABC--")) //some SQL injection
+            );
+        }
+    }
+
+    private static class ValidFilters implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                    arguments(criterion("selectorExpression.criteria.operandLeft", "=", "foo")),
+                    arguments(criterion("selectorExpression.criteria.operator", "=", "LIKE")),
+                    arguments(criterion("selectorExpression.criteria.operandRight", "=", "bar"))
+            );
+        }
     }
 
     @NotNull

--- a/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/ReflectionBasedQueryResolverTest.java
+++ b/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/ReflectionBasedQueryResolverTest.java
@@ -30,6 +30,7 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.eclipse.edc.spi.query.Criterion.criterion;
 
 class ReflectionBasedQueryResolverTest {
 
@@ -39,7 +40,7 @@ class ReflectionBasedQueryResolverTest {
     void verifyQuery_noFilters() {
         var stream = IntStream.range(0, 10).mapToObj(FakeItem::new);
 
-        QuerySpec spec = QuerySpec.Builder.newInstance().build();
+        var spec = QuerySpec.Builder.newInstance().build();
         assertThat(queryResolver.query(stream, spec)).hasSize(10);
     }
 
@@ -49,7 +50,7 @@ class ReflectionBasedQueryResolverTest {
                 IntStream.range(0, 5).mapToObj(i -> new FakeItem(i, "Alice")),
                 IntStream.range(5, 10).mapToObj(i -> new FakeItem(i, "Bob")));
 
-        QuerySpec spec = QuerySpec.Builder.newInstance().filter("name=Alice").build();
+        var spec = QuerySpec.Builder.newInstance().filter(criterion("name", "=", "Alice")).build();
         assertThat(queryResolver.query(stream, spec)).hasSize(5).extracting(FakeItem::getName).containsOnly("Alice");
     }
 
@@ -59,7 +60,7 @@ class ReflectionBasedQueryResolverTest {
                 IntStream.range(0, 5).mapToObj(i -> new FakeItem(i, "Alice")),
                 IntStream.range(5, 10).mapToObj(i -> new FakeItem(i, "Bob")));
 
-        QuerySpec spec = QuerySpec.Builder.newInstance().filter(List.of(new Criterion("name", "=", "Bob"))).build();
+        var spec = QuerySpec.Builder.newInstance().filter(List.of(new Criterion("name", "=", "Bob"))).build();
         Collection<FakeItem> actual = queryResolver.query(stream, spec).collect(Collectors.toList());
         assertThat(actual).hasSize(5).extracting(FakeItem::getName).containsOnly("Bob");
     }
@@ -68,7 +69,7 @@ class ReflectionBasedQueryResolverTest {
     void verifyQuery_sortDesc() {
         var stream = IntStream.range(0, 10).mapToObj(FakeItem::new);
 
-        QuerySpec spec = QuerySpec.Builder.newInstance().sortField("id").sortOrder(SortOrder.DESC).build();
+        var spec = QuerySpec.Builder.newInstance().sortField("id").sortOrder(SortOrder.DESC).build();
         assertThat(queryResolver.query(stream, spec)).hasSize(10).isSortedAccordingTo(Comparator.comparing(FakeItem::getId).reversed());
     }
 
@@ -76,7 +77,7 @@ class ReflectionBasedQueryResolverTest {
     void verifyQuery_sortAsc() {
         var stream = IntStream.range(0, 10).mapToObj(FakeItem::new);
 
-        QuerySpec spec = QuerySpec.Builder.newInstance().sortField("id").sortOrder(SortOrder.ASC).build();
+        var spec = QuerySpec.Builder.newInstance().sortField("id").sortOrder(SortOrder.ASC).build();
         assertThat(queryResolver.query(stream, spec)).hasSize(10).isSortedAccordingTo(Comparator.comparing(FakeItem::getId));
     }
 
@@ -84,7 +85,7 @@ class ReflectionBasedQueryResolverTest {
     void verifyQuery_invalidSortField() {
         var stream = IntStream.range(0, 10).mapToObj(FakeItem::new);
 
-        QuerySpec spec = QuerySpec.Builder.newInstance().sortField("xyz").sortOrder(SortOrder.ASC).build();
+        var spec = QuerySpec.Builder.newInstance().sortField("xyz").sortOrder(SortOrder.ASC).build();
         assertThat(queryResolver.query(stream, spec)).isEmpty();
     }
 
@@ -92,7 +93,7 @@ class ReflectionBasedQueryResolverTest {
     void verifyQuery_offsetAndLimit() {
         var stream = IntStream.range(0, 10).mapToObj(FakeItem::new);
 
-        QuerySpec spec = QuerySpec.Builder.newInstance().offset(1).limit(2).build();
+        var spec = QuerySpec.Builder.newInstance().offset(1).limit(2).build();
         assertThat(queryResolver.query(stream, spec)).extracting(FakeItem::getId).containsExactly(1, 2);
     }
 
@@ -100,7 +101,7 @@ class ReflectionBasedQueryResolverTest {
     void verifyQuery_allFilters() {
         var stream = IntStream.range(0, 10).mapToObj(FakeItem::new);
 
-        QuerySpec spec = QuerySpec.Builder.newInstance().sortField("id").sortOrder(SortOrder.DESC).offset(1).limit(2).build();
+        var spec = QuerySpec.Builder.newInstance().sortField("id").sortOrder(SortOrder.DESC).offset(1).limit(2).build();
         assertThat(queryResolver.query(stream, spec)).extracting(FakeItem::getId).containsExactly(8, 7);
     }
 

--- a/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/assetindex/InMemoryAssetIndexTest.java
+++ b/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/assetindex/InMemoryAssetIndexTest.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.spi.query.Criterion.criterion;
 import static org.eclipse.edc.spi.result.StoreFailure.Reason.NOT_FOUND;
 
 class InMemoryAssetIndexTest extends AssetIndexTestBase {
@@ -102,7 +103,7 @@ class InMemoryAssetIndexTest extends AssetIndexTestBase {
                 .peek(a -> index.create(a, createDataAddress(a)))
                 .collect(Collectors.toList());
 
-        var spec = QuerySpec.Builder.newInstance().equalsAsContains(false).filter(Asset.PROPERTY_ID + " = id1").build();
+        var spec = QuerySpec.Builder.newInstance().filter(criterion(Asset.PROPERTY_ID, "=", "id1")).build();
         assertThat(index.queryAssets(spec)).hasSize(1).containsExactly(assets.get(1));
     }
 

--- a/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/contractnegotiation/InMemoryContractNegotiationStoreTest.java
+++ b/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/contractnegotiation/InMemoryContractNegotiationStoreTest.java
@@ -50,6 +50,7 @@ import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractN
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.REQUESTING;
 import static org.eclipse.edc.connector.defaults.storage.contractnegotiation.TestFunctions.createNegotiationBuilder;
 import static org.eclipse.edc.spi.persistence.StateEntityStore.hasState;
+import static org.eclipse.edc.spi.query.Criterion.criterion;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
@@ -240,13 +241,17 @@ class InMemoryContractNegotiationStoreTest extends ContractNegotiationStoreTestB
     @Test
     void findAll_verifyFiltering() {
         range(0, 10).forEach(i -> store.save(TestFunctions.createNegotiation("test-neg-" + i)));
-        assertThat(store.queryNegotiations(QuerySpec.Builder.newInstance().equalsAsContains(false).filter("id=test-neg-3").build())).extracting(ContractNegotiation::getId).containsOnly("test-neg-3");
+        var querySpec = QuerySpec.Builder.newInstance().filter(criterion("id", "=", "test-neg-3")).build();
+
+        assertThat(store.queryNegotiations(querySpec)).extracting(ContractNegotiation::getId).containsOnly("test-neg-3");
     }
 
     @Test
     void findAll_verifyFiltering_invalidFilterExpression() {
         range(0, 10).forEach(i -> store.save(TestFunctions.createNegotiation("test-neg-" + i)));
-        assertThatThrownBy(() -> store.queryNegotiations(QuerySpec.Builder.newInstance().filter("something foobar other").build())).isInstanceOfAny(IllegalArgumentException.class);
+        var querySpec = QuerySpec.Builder.newInstance().filter(criterion("something", "foobar", "other")).build();
+
+        assertThatThrownBy(() -> store.queryNegotiations(querySpec)).isInstanceOfAny(IllegalArgumentException.class);
     }
 
     @Test
@@ -302,7 +307,7 @@ class InMemoryContractNegotiationStoreTest extends ContractNegotiationStoreTestB
             var negotiation = createNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
             store.save(negotiation);
         });
-        var query = QuerySpec.Builder.newInstance().equalsAsContains(false).filter("id=3:3").build();
+        var query = QuerySpec.Builder.newInstance().filter(criterion("id", "=", "3:3")).build();
 
         var result = store.queryAgreements(query);
 

--- a/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/policydefinition/InMemoryPolicyDefinitionStoreTest.java
+++ b/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/policydefinition/InMemoryPolicyDefinitionStoreTest.java
@@ -31,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.edc.connector.policy.spi.testfixtures.TestFunctions.createPolicy;
+import static org.eclipse.edc.spi.query.Criterion.criterion;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
@@ -84,7 +85,7 @@ class InMemoryPolicyDefinitionStoreTest extends PolicyDefinitionStoreTestBase {
     void findAll_verifyFiltering_invalidFilterExpression() {
         IntStream.range(0, 10).mapToObj(i -> createPolicy("test-id")).forEach(d -> getPolicyDefinitionStore().create(d));
 
-        var query = QuerySpec.Builder.newInstance().filter("something contains other").build();
+        var query = QuerySpec.Builder.newInstance().filter(criterion("something", "contains", "other")).build();
 
         assertThatThrownBy(() -> getPolicyDefinitionStore().findAll(query)).isInstanceOfAny(EdcPersistenceException.class);
     }

--- a/extensions/common/api/api-core/src/main/java/org/eclipse/edc/api/model/QuerySpecDto.java
+++ b/extensions/common/api/api-core/src/main/java/org/eclipse/edc/api/model/QuerySpecDto.java
@@ -47,11 +47,7 @@ public class QuerySpecDto extends BaseDto {
     @Positive(message = "limit must be greater than 0")
     private Integer limit = 50;
 
-    @QueryParam("filter")
-    @Deprecated
-    private String filter;
-
-    private List<CriterionDto> filterExpression = new ArrayList<>();
+    private final List<CriterionDto> filterExpression = new ArrayList<>();
 
     @QueryParam("sort")
     private SortOrder sortOrder = SortOrder.ASC;
@@ -67,11 +63,6 @@ public class QuerySpecDto extends BaseDto {
         return limit;
     }
 
-    @Deprecated
-    public String getFilter() {
-        return filter;
-    }
-
     public SortOrder getSortOrder() {
         return sortOrder;
     }
@@ -83,10 +74,6 @@ public class QuerySpecDto extends BaseDto {
     @JsonIgnore
     @AssertTrue
     public boolean isValid() {
-        if (filter != null && filter.isBlank()) {
-            return false;
-        }
-
         return sortField == null || !sortField.isBlank();
     }
 
@@ -127,14 +114,13 @@ public class QuerySpecDto extends BaseDto {
             return this;
         }
 
-        @Deprecated
-        public Builder filter(String filter) {
-            querySpec.filter = filter;
+        public Builder filter(CriterionDto criterion) {
+            querySpec.filterExpression.add(criterion);
             return this;
         }
 
         public Builder filterExpression(List<CriterionDto> filterExpression) {
-            querySpec.filterExpression = filterExpression;
+            querySpec.filterExpression.addAll(filterExpression);
             return this;
         }
 

--- a/extensions/common/api/api-core/src/test/java/org/eclipse/edc/api/query/QuerySpecDtoValidationTest.java
+++ b/extensions/common/api/api-core/src/test/java/org/eclipse/edc/api/query/QuerySpecDtoValidationTest.java
@@ -62,15 +62,6 @@ class QuerySpecDtoValidationTest {
     }
 
     @Test
-    void filterShouldNotBeBlank() {
-        var querySpec = QuerySpecDto.Builder.newInstance().filter("  ").build();
-
-        var result = validator.validate(querySpec);
-
-        assertThat(result).isNotEmpty();
-    }
-
-    @Test
     void sortFieldShouldNotBeBlank() {
         var querySpec = QuerySpecDto.Builder.newInstance().sortField("  ").build();
 

--- a/extensions/control-plane/api/management-api/contract-agreement-api/src/test/java/org/eclipse/edc/connector/api/management/contractagreement/ContractAgreementApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-agreement-api/src/test/java/org/eclipse/edc/connector/api/management/contractagreement/ContractAgreementApiControllerTest.java
@@ -108,7 +108,7 @@ class ContractAgreementApiControllerTest {
         when(transformerRegistry.transform(any(), eq(ContractAgreementDto.class))).thenReturn(Result.success(dto));
         when(transformerRegistry.transform(isA(QuerySpecDto.class), eq(QuerySpec.class)))
                 .thenReturn(Result.success(QuerySpec.Builder.newInstance().offset(10).build()));
-        var querySpec = QuerySpecDto.Builder.newInstance().filter("invalid=foobar").build();
+        var querySpec = QuerySpecDto.Builder.newInstance().filter(CriterionDto.from("invalid", "=", "foobar")).build();
 
         assertThatThrownBy(() -> controller.getAllAgreements(querySpec)).isInstanceOf(InvalidRequestException.class);
 

--- a/extensions/control-plane/store/cosmos/asset-index-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/assetindex/CosmosAssetIndexTest.java
+++ b/extensions/control-plane/store/cosmos/asset-index-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/assetindex/CosmosAssetIndexTest.java
@@ -37,6 +37,7 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.eclipse.edc.spi.query.Criterion.criterion;
 import static org.eclipse.edc.spi.result.StoreFailure.Reason.NOT_FOUND;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -180,7 +181,7 @@ class CosmosAssetIndexTest {
         List<Asset> assets = assetIndex.queryAssets(QuerySpec.Builder.newInstance()
                         .offset(5)
                         .limit(100)
-                        .filter("someField=randomValue")
+                        .filter(criterion("someField", "=", "randomValue"))
                         .build())
                 .collect(Collectors.toList());
 

--- a/extensions/control-plane/store/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/contractdefinition/CosmosContractDefinitionStoreTest.java
+++ b/extensions/control-plane/store/cosmos/contract-definition-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/contractdefinition/CosmosContractDefinitionStoreTest.java
@@ -40,6 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.edc.connector.store.azure.cosmos.contractdefinition.TestFunctions.generateDefinition;
 import static org.eclipse.edc.connector.store.azure.cosmos.contractdefinition.TestFunctions.generateDocument;
+import static org.eclipse.edc.spi.query.Criterion.criterion;
 import static org.eclipse.edc.spi.result.StoreFailure.Reason.NOT_FOUND;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isA;
@@ -197,7 +198,7 @@ class CosmosContractDefinitionStoreTest {
         var doc = generateDocument(TEST_PART_KEY);
         when(cosmosDbApiMock.queryItems(any(SqlQuerySpec.class))).thenReturn(Stream.of(doc));
 
-        var all = store.findAll(QuerySpec.Builder.newInstance().filter("id=" + doc.getId()).build());
+        var all = store.findAll(QuerySpec.Builder.newInstance().filter(criterion("id", "=", doc.getId())).build());
         assertThat(all).hasSize(1).extracting(ContractDefinition::getId).containsOnly(doc.getId());
         verify(cosmosDbApiMock).queryItems(any(SqlQuerySpec.class));
         verifyNoMoreInteractions(cosmosDbApiMock);
@@ -205,7 +206,9 @@ class CosmosContractDefinitionStoreTest {
 
     @Test
     void findAll_verifyFiltering_invalidFilterExpression() {
-        assertThatThrownBy(() -> store.findAll(QuerySpec.Builder.newInstance().filter("something foobar other").build())).isInstanceOfAny(IllegalArgumentException.class);
+        var querySpec = QuerySpec.Builder.newInstance().filter(criterion("something", "foobar", "other")).build();
+
+        assertThatThrownBy(() -> store.findAll(querySpec)).isInstanceOfAny(IllegalArgumentException.class);
     }
 
     @Test

--- a/extensions/control-plane/store/cosmos/policy-definition-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/policydefinition/CosmosPolicyDefinitionStoreIntegrationTest.java
+++ b/extensions/control-plane/store/cosmos/policy-definition-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/policydefinition/CosmosPolicyDefinitionStoreIntegrationTest.java
@@ -49,6 +49,7 @@ import java.util.stream.IntStream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.store.azure.cosmos.policydefinition.TestFunctions.generateDocument;
 import static org.eclipse.edc.connector.store.azure.cosmos.policydefinition.TestFunctions.generatePolicy;
+import static org.eclipse.edc.spi.query.Criterion.criterion;
 import static org.eclipse.edc.spi.result.StoreFailure.Reason.ALREADY_EXISTS;
 import static org.mockito.Mockito.mock;
 
@@ -222,10 +223,9 @@ public class CosmosPolicyDefinitionStoreIntegrationTest extends PolicyDefinition
     @Test
     void findAll_verifyFiltering() {
         var documents = IntStream.range(0, 10).mapToObj(i -> generateDocument(TEST_PARTITION_KEY)).peek(d -> container.createItem(d)).collect(Collectors.toList());
-
         var expectedId = documents.get(3).getId();
+        var query = QuerySpec.Builder.newInstance().filter(criterion("id", "=", expectedId)).build();
 
-        var query = QuerySpec.Builder.newInstance().filter("id=" + expectedId).build();
         assertThat(store.findAll(query)).extracting(PolicyDefinition::getUid).containsOnly(expectedId);
     }
 
@@ -233,7 +233,7 @@ public class CosmosPolicyDefinitionStoreIntegrationTest extends PolicyDefinition
     void findAll_verifyFiltering_unsuccessfulFilterExpression() {
         IntStream.range(0, 10).mapToObj(i -> generateDocument(TEST_PARTITION_KEY)).forEach(d -> container.createItem(d));
 
-        var query = QuerySpec.Builder.newInstance().filter("something = other").build();
+        var query = QuerySpec.Builder.newInstance().filter(criterion("something", "=", "other")).build();
 
         assertThat(store.findAll(query)).isEmpty();
     }

--- a/extensions/control-plane/store/cosmos/transfer-process-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/transferprocess/CosmosTransferProcessStoreIntegrationTest.java
+++ b/extensions/control-plane/store/cosmos/transfer-process-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/transferprocess/CosmosTransferProcessStoreIntegrationTest.java
@@ -64,6 +64,7 @@ import static org.eclipse.edc.connector.store.azure.cosmos.transferprocess.TestH
 import static org.eclipse.edc.connector.transfer.spi.types.TransferProcessStates.INITIAL;
 import static org.eclipse.edc.connector.transfer.spi.types.TransferProcessStates.STARTED;
 import static org.eclipse.edc.spi.persistence.StateEntityStore.hasState;
+import static org.eclipse.edc.spi.query.Criterion.criterion;
 
 @AzureCosmosDbIntegrationTest
 class CosmosTransferProcessStoreIntegrationTest extends TransferProcessStoreTestBase {
@@ -548,7 +549,8 @@ class CosmosTransferProcessStoreIntegrationTest extends TransferProcessStoreTest
 
         var expectedId = documents.get(3).getId();
 
-        var query = QuerySpec.Builder.newInstance().filter("id=" + expectedId).build();
+        var query = QuerySpec.Builder.newInstance().filter(criterion("id", "=", expectedId)).build();
+
         assertThat(store.findAll(query)).extracting(TransferProcess::getId).containsOnly(expectedId);
     }
 
@@ -556,7 +558,7 @@ class CosmosTransferProcessStoreIntegrationTest extends TransferProcessStoreTest
     void findAll_verifyFiltering_invalidFilterExpression() {
         IntStream.range(0, 10).mapToObj(i -> createTransferProcessDocument("tp" + i, partitionKey)).forEach(d -> container.createItem(d));
 
-        var query = QuerySpec.Builder.newInstance().filter("something contains other").build();
+        var query = QuerySpec.Builder.newInstance().filter(criterion("something", "contains", "other")).build();
 
         assertThatThrownBy(() -> store.findAll(query)).isInstanceOfAny(IllegalArgumentException.class).hasMessage("Cannot build WHERE clause, reason: unsupported operator contains");
     }
@@ -565,7 +567,7 @@ class CosmosTransferProcessStoreIntegrationTest extends TransferProcessStoreTest
     void findAll_verifyFiltering_unsuccessfulFilterExpression() {
         IntStream.range(0, 10).mapToObj(i -> createTransferProcessDocument("tp" + i, partitionKey)).forEach(d -> container.createItem(d));
 
-        var query = QuerySpec.Builder.newInstance().filter("something = other").build();
+        var query = QuerySpec.Builder.newInstance().filter(criterion("something", "=", "other")).build();
 
         assertThat(store.findAll(query)).isEmpty();
     }

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/PostgresContractNegotiationStoreTest.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/PostgresContractNegotiationStoreTest.java
@@ -55,6 +55,7 @@ import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractN
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation.Type.PROVIDER;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.REQUESTED;
 import static org.eclipse.edc.spi.persistence.StateEntityStore.hasState;
+import static org.eclipse.edc.spi.query.Criterion.criterion;
 
 /**
  * This test aims to verify those parts of the contract negotiation store, that are specific to Postgres, e.g. JSON
@@ -99,7 +100,7 @@ class PostgresContractNegotiationStoreTest extends ContractNegotiationStoreTestB
         store.save(negotiation1);
         store.save(negotiation2);
 
-        var expression = "contractAgreement.id = agr1";
+        var expression = criterion("contractAgreement.id", "=", "agr1");
         var query = QuerySpec.Builder.newInstance().filter(expression).build();
         var result = store.queryNegotiations(query).collect(Collectors.toList());
 
@@ -132,7 +133,7 @@ class PostgresContractNegotiationStoreTest extends ContractNegotiationStoreTestB
         store.save(negotiation1);
         store.save(negotiation2);
 
-        var expression = "contractAgreement.policy.assignee = test-assignee";
+        var expression = criterion("contractAgreement.policy.assignee", "=", "test-assignee");
         var query = QuerySpec.Builder.newInstance().filter(expression).build();
         var result = store.queryNegotiations(query).collect(Collectors.toList());
 
@@ -145,7 +146,7 @@ class PostgresContractNegotiationStoreTest extends ContractNegotiationStoreTestB
         var negotiation1 = createNegotiation("neg1", agreement1);
         store.save(negotiation1);
 
-        var expression = "contractAgreement.notexist = agr1";
+        var expression = criterion("contractAgreement.notexist", "=", "agr1");
         var query = QuerySpec.Builder.newInstance().filter(expression).build();
         assertThatThrownBy(() -> store.queryNegotiations(query))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -158,7 +159,7 @@ class PostgresContractNegotiationStoreTest extends ContractNegotiationStoreTestB
         var negotiation1 = createNegotiation("neg1", agreement1);
         store.save(negotiation1);
 
-        var expression = "contractAgreement.policy.permissions.notexist = foobar";
+        var expression = criterion("contractAgreement.policy.permissions.notexist", "=", "foobar");
         var query = QuerySpec.Builder.newInstance().filter(expression).build();
         assertThat(store.queryNegotiations(query)).isEmpty();
     }
@@ -173,7 +174,7 @@ class PostgresContractNegotiationStoreTest extends ContractNegotiationStoreTestB
             store.save(negotiation);
         });
 
-        var query = QuerySpec.Builder.newInstance().filter("assetId = asset-2").build();
+        var query = QuerySpec.Builder.newInstance().filter(criterion("assetId", "=", "asset-2")).build();
         var all = store.queryAgreements(query);
 
         assertThat(all).hasSize(1);
@@ -189,7 +190,7 @@ class PostgresContractNegotiationStoreTest extends ContractNegotiationStoreTestB
             store.save(negotiation);
         });
 
-        var query = QuerySpec.Builder.newInstance().filter("notexistprop = asset-2").build();
+        var query = QuerySpec.Builder.newInstance().filter(criterion("notexistprop", "=", "asset-2")).build();
         assertThatThrownBy(() -> store.queryAgreements(query));
     }
 
@@ -217,7 +218,7 @@ class PostgresContractNegotiationStoreTest extends ContractNegotiationStoreTestB
             store.save(negotiation);
         });
 
-        var query = QuerySpec.Builder.newInstance().filter("assetId = notexist").build();
+        var query = QuerySpec.Builder.newInstance().filter(criterion("assetId", "=", "notexist")).build();
         assertThat(store.queryAgreements(query)).isEmpty();
     }
 

--- a/extensions/control-plane/store/sql/policy-definition-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/policydefinition/PostgresPolicyDefinitionStoreTest.java
+++ b/extensions/control-plane/store/sql/policy-definition-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/policydefinition/PostgresPolicyDefinitionStoreTest.java
@@ -38,7 +38,7 @@ import java.util.stream.IntStream;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.edc.connector.policy.spi.testfixtures.TestFunctions.createPolicy;
 import static org.eclipse.edc.connector.policy.spi.testfixtures.TestFunctions.createPolicyBuilder;
-import static org.eclipse.edc.connector.policy.spi.testfixtures.TestFunctions.createQuery;
+import static org.eclipse.edc.spi.query.Criterion.criterion;
 
 /**
  * This test aims to verify those parts of the policy definition store, that are specific to Postgres, e.g. JSON query
@@ -80,7 +80,8 @@ class PostgresPolicyDefinitionStoreTest extends PolicyDefinitionStoreTestBase {
         getPolicyDefinitionStore().create(policyDef1);
 
         // query by prohibition assignee
-        assertThatThrownBy(() -> getPolicyDefinitionStore().findAll(createQuery("notexist=foobar")))
+        var querySpec = QuerySpec.Builder.newInstance().filter(criterion("notexist", "=", "foobar")).build();
+        assertThatThrownBy(() -> getPolicyDefinitionStore().findAll(querySpec))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageStartingWith("Translation failed for Model");
     }

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/SqlTransferProcessStore.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/SqlTransferProcessStore.java
@@ -179,8 +179,8 @@ public class SqlTransferProcessStore extends AbstractSqlStore implements Transfe
 
     private @Nullable TransferProcess findByIdInternal(Connection conn, String id) {
         return transactionContext.execute(() -> {
-            var q = QuerySpec.Builder.newInstance().filter("id = " + id).build();
-            return single(executeQuery(conn, q).collect(toList()));
+            var querySpec = QuerySpec.Builder.newInstance().filter(Criterion.criterion("id", "=", id)).build();
+            return single(executeQuery(conn, querySpec).collect(toList()));
         });
     }
 

--- a/resources/openapi/openapi.yaml
+++ b/resources/openapi/openapi.yaml
@@ -47,14 +47,6 @@ paths:
           type: integer
           format: int32
           example: null
-      - name: filter
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          example: null
       - name: sort
         in: query
         required: false
@@ -453,14 +445,6 @@ paths:
           type: integer
           format: int32
           example: null
-      - name: filter
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          example: null
       - name: sort
         in: query
         required: false
@@ -596,14 +580,6 @@ paths:
           type: integer
           format: int32
           example: null
-      - name: filter
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          example: null
       - name: sort
         in: query
         required: false
@@ -737,14 +713,6 @@ paths:
         schema:
           type: integer
           format: int32
-          example: null
-      - name: filter
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
           example: null
       - name: sort
         in: query
@@ -998,14 +966,6 @@ paths:
         schema:
           type: integer
           format: int32
-          example: null
-      - name: filter
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
           example: null
       - name: sort
         in: query
@@ -1395,14 +1355,6 @@ paths:
           type: integer
           format: int32
           example: null
-      - name: filter
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          example: null
       - name: sort
         in: query
         required: false
@@ -1725,14 +1677,6 @@ paths:
         schema:
           type: integer
           format: int32
-          example: null
-      - name: filter
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
           example: null
       - name: sort
         in: query
@@ -4393,9 +4337,6 @@ components:
           type: object
           example: null
         '@type':
-          type: string
-          example: null
-        filter:
           type: string
           example: null
         filterExpression:

--- a/resources/openapi/yaml/management-api/asset-api.yaml
+++ b/resources/openapi/yaml/management-api/asset-api.yaml
@@ -26,11 +26,6 @@ paths:
           format: int32
           example: null
       - in: query
-        name: filter
-        schema:
-          type: string
-          example: null
-      - in: query
         name: sort
         schema:
           type: string
@@ -842,9 +837,6 @@ components:
           type: object
           example: null
         '@type':
-          type: string
-          example: null
-        filter:
           type: string
           example: null
         filterExpression:

--- a/resources/openapi/yaml/management-api/catalog-api.yaml
+++ b/resources/openapi/yaml/management-api/catalog-api.yaml
@@ -24,11 +24,6 @@ paths:
           format: int32
           example: null
       - in: query
-        name: filter
-        schema:
-          type: string
-          example: null
-      - in: query
         name: sort
         schema:
           type: string
@@ -397,9 +392,6 @@ components:
           type: object
           example: null
         '@type':
-          type: string
-          example: null
-        filter:
           type: string
           example: null
         filterExpression:

--- a/resources/openapi/yaml/management-api/contract-agreement-api.yaml
+++ b/resources/openapi/yaml/management-api/contract-agreement-api.yaml
@@ -19,11 +19,6 @@ paths:
           format: int32
           example: null
       - in: query
-        name: filter
-        schema:
-          type: string
-          example: null
-      - in: query
         name: sort
         schema:
           type: string
@@ -445,9 +440,6 @@ components:
           type: object
           example: null
         '@type':
-          type: string
-          example: null
-        filter:
           type: string
           example: null
         filterExpression:

--- a/resources/openapi/yaml/management-api/contract-definition-api.yaml
+++ b/resources/openapi/yaml/management-api/contract-definition-api.yaml
@@ -19,11 +19,6 @@ paths:
           format: int32
           example: null
       - in: query
-        name: filter
-        schema:
-          type: string
-          example: null
-      - in: query
         name: sort
         schema:
           type: string
@@ -569,9 +564,6 @@ components:
           type: object
           example: null
         '@type':
-          type: string
-          example: null
-        filter:
           type: string
           example: null
         filterExpression:

--- a/resources/openapi/yaml/management-api/contract-negotiation-api.yaml
+++ b/resources/openapi/yaml/management-api/contract-negotiation-api.yaml
@@ -19,11 +19,6 @@ paths:
           format: int32
           example: null
       - in: query
-        name: filter
-        schema:
-          type: string
-          example: null
-      - in: query
         name: sort
         schema:
           type: string
@@ -1024,9 +1019,6 @@ components:
           type: object
           example: null
         '@type':
-          type: string
-          example: null
-        filter:
           type: string
           example: null
         filterExpression:

--- a/resources/openapi/yaml/management-api/policy-definition-api.yaml
+++ b/resources/openapi/yaml/management-api/policy-definition-api.yaml
@@ -19,11 +19,6 @@ paths:
           format: int32
           example: null
       - in: query
-        name: filter
-        schema:
-          type: string
-          example: null
-      - in: query
         name: sort
         schema:
           type: string
@@ -717,9 +712,6 @@ components:
           type: object
           example: null
         '@type':
-          type: string
-          example: null
-        filter:
           type: string
           example: null
         filterExpression:

--- a/resources/openapi/yaml/management-api/transfer-process-api.yaml
+++ b/resources/openapi/yaml/management-api/transfer-process-api.yaml
@@ -19,11 +19,6 @@ paths:
           format: int32
           example: null
       - in: query
-        name: filter
-        schema:
-          type: string
-          example: null
-      - in: query
         name: sort
         schema:
           type: string
@@ -752,9 +747,6 @@ components:
           type: object
           example: null
         '@type':
-          type: string
-          example: null
-        filter:
           type: string
           example: null
         filterExpression:

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/Criterion.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/Criterion.java
@@ -48,6 +48,10 @@ public class Criterion {
         //for json serialization
     }
 
+    public static Criterion criterion(Object operandLeft, String operator, Object operandRight) {
+        return new Criterion(operandLeft, operator, operandRight);
+    }
+
     public Criterion(Object left, String op, Object right) {
         operandLeft = Objects.requireNonNull(left);
         operator = Objects.requireNonNull(op);

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/QuerySpec.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/QuerySpec.java
@@ -18,11 +18,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.eclipse.edc.spi.message.Range;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 
@@ -39,11 +36,9 @@ public class QuerySpec {
     public static final String EDC_QUERY_SPEC_SORT_ORDER = EDC_NAMESPACE + "sortOrder";
     public static final String EDC_QUERY_SPEC_SORT_FIELD = EDC_NAMESPACE + "sortField";
     
-    public static final String QUERY_SPEC = "querySpec";
-
     private int offset = 0;
     private int limit = 50;
-    private List<Criterion> filterExpression = new ArrayList<>();
+    private final List<Criterion> filterExpression = new ArrayList<>();
     private SortOrder sortOrder = SortOrder.ASC;
     private String sortField;
 
@@ -119,9 +114,7 @@ public class QuerySpec {
     }
 
     public static final class Builder {
-        private static final String EQUALS_EXPRESSION_PATTERN = "[^\\s\\\\]*(\\s*)=(\\s*)[^\\\\]*";
         private final QuerySpec querySpec;
-        private boolean equalsAsContains = false;
 
         private Builder() {
             querySpec = new QuerySpec();
@@ -161,11 +154,6 @@ public class QuerySpec {
             return this;
         }
 
-        public Builder equalsAsContains(boolean equalsAsContains) {
-            this.equalsAsContains = equalsAsContains;
-            return this;
-        }
-
         public Builder filter(Criterion criterion) {
             querySpec.filterExpression.add(criterion);
             return this;
@@ -175,34 +163,6 @@ public class QuerySpec {
             if (criteria != null) {
                 querySpec.filterExpression.addAll(criteria);
             }
-            return this;
-        }
-
-        @Deprecated
-        public Builder filter(String filterExpression) {
-
-            if (filterExpression != null) {
-                if (Pattern.matches(EQUALS_EXPRESSION_PATTERN, filterExpression)) { // something like X = Y
-                    // we'll interpret the "=" as "contains" if desired
-                    var tokens = filterExpression.split("=", 2);
-                    var left = tokens[0].trim();
-                    var right = tokens[1].trim();
-                    var op = equalsAsContains ? "contains" : "=";
-                    querySpec.filterExpression = List.of(new Criterion(left, op, right));
-                } else {
-                    var s = filterExpression.split(" +", 3);
-
-                    //generic LEFT OPERAND RIGHT expression
-                    if (s.length >= 3) {
-                        var rh = Arrays.stream(s, 2, s.length).collect(Collectors.joining(" "));
-                        querySpec.filterExpression = List.of(new Criterion(s[0], s[1], rh));
-                    } else {
-                        // unsupported filter expression
-                        throw new IllegalArgumentException("Cannot convert " + filterExpression + " into a Criterion");
-                    }
-                }
-            }
-
             return this;
         }
 

--- a/spi/common/core-spi/src/test/java/org/eclipse/edc/spi/query/QuerySpecTest.java
+++ b/spi/common/core-spi/src/test/java/org/eclipse/edc/spi/query/QuerySpecTest.java
@@ -16,8 +16,6 @@ package org.eclipse.edc.spi.query;
 
 import org.eclipse.edc.spi.message.Range;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.List;
 
@@ -45,68 +43,12 @@ class QuerySpecTest {
         assertion.extracting(QuerySpec::getSortField).isNull();
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = { "name=foo", "name = foo", "name =      foo", "name contains foo" })
-    void verifyEquals_whenEqualsAsContainsFilterExpressions(String equalityExp) {
-        var spec = QuerySpec.Builder.newInstance().equalsAsContains(true).filter(equalityExp).build();
-        assertThat(spec.getFilterExpression()).hasSize(1).containsOnly(new Criterion("name", "contains", "foo"));
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = { "name=foo", "name = foo", "name =      foo" })
-    void verifyEquals_whenEqualsFilterExpressions(String equalityExp) {
-        var spec = QuerySpec.Builder.newInstance().equalsAsContains(false).filter(equalityExp).build();
-        assertThat(spec.getFilterExpression()).hasSize(1).containsOnly(new Criterion("name", "=", "foo"));
-    }
-
-    @Test
-    void verifyFilterExpression() {
-        var spec = QuerySpec.Builder.newInstance().filter("age < 14").build();
-        assertThat(spec.getFilterExpression()).hasSize(1).containsOnly(new Criterion("age", "<", "14"));
-
-        var spec2 = QuerySpec.Builder.newInstance().filter("age     <   14").build();
-        assertThat(spec2.getFilterExpression()).hasSize(1).containsOnly(new Criterion("age", "<", "14"));
-
-        var spec3 = QuerySpec.Builder.newInstance().filter("description endsWith 'foobar'").build();
-        assertThat(spec3.getFilterExpression()).hasSize(1).containsOnly(new Criterion("description", "endsWith", "'foobar'"));
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = { "age<14", "namecontainssomething", "id_like_14" })
-    void verify_invalidFilterExpression(String expr) {
-        assertThatThrownBy(() -> QuerySpec.Builder.newInstance().filter(expr).build()).isInstanceOf(IllegalArgumentException.class);
-    }
-
     @Test
     void verify_filterExprNull() {
         List<Criterion> filter = null;
         var qs = QuerySpec.Builder.newInstance().filter(filter).build();
 
         assertThat(qs.getFilterExpression()).isNotNull().isEmpty();
-    }
-
-    @Test
-    void verify_filterEqualsWithValueContainsEqualsSign() {
-        var spec = QuerySpec.Builder.newInstance().equalsAsContains(true).filter("additionalProp1=a/b=c/d").build();
-        assertThat(spec.getFilterExpression()).hasSize(1).containsOnly(new Criterion("additionalProp1", "contains", "a/b=c/d"));
-
-        var spec2 = QuerySpec.Builder.newInstance().equalsAsContains(false).filter("additionalProp1=a/b=c/d").build();
-        assertThat(spec2.getFilterExpression()).hasSize(1).containsOnly(new Criterion("additionalProp1", "=", "a/b=c/d"));
-    }
-
-    @Test
-    void verify_filterEqualsWithValueContainsSpaces() {
-        var spec = QuerySpec.Builder.newInstance().equalsAsContains(true).filter("additionalProp1=a/b c/d").build();
-        assertThat(spec.getFilterExpression()).hasSize(1).containsOnly(new Criterion("additionalProp1", "contains", "a/b c/d"));
-
-        var spec2 = QuerySpec.Builder.newInstance().equalsAsContains(false).filter("additionalProp1=a/b c/d").build();
-        assertThat(spec2.getFilterExpression()).hasSize(1).containsOnly(new Criterion("additionalProp1", "=", "a/b c/d"));
-    }
-
-    @Test
-    void verify_filterWithValueContainsSpaces() {
-        var spec = QuerySpec.Builder.newInstance().filter("key instanceof some value").build();
-        assertThat(spec.getFilterExpression()).hasSize(1).containsOnly(new Criterion("key", "instanceof", "some value"));
     }
 
     @Test

--- a/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/offer/store/ContractDefinitionStoreTestBase.java
+++ b/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/offer/store/ContractDefinitionStoreTestBase.java
@@ -38,7 +38,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.edc.connector.contract.spi.testfixtures.offer.store.TestFunctions.createContractDefinition;
@@ -212,7 +211,7 @@ public abstract class ContractDefinitionStoreTestBase {
         saveContractDefinitions(definitionsExpected);
 
         var spec = QuerySpec.Builder.newInstance()
-                .filter("accessPolicyId = policy4")
+                .filter(Criterion.criterion("accessPolicyId", "=", "policy4"))
                 .build();
 
         var definitionsRetrieved = getContractDefinitionStore().findAll(spec);
@@ -341,14 +340,21 @@ public abstract class ContractDefinitionStoreTestBase {
     @Test
     void findAll_verifyFiltering() {
         IntStream.range(0, 10).mapToObj(i -> createContractDefinition("id" + i)).forEach(getContractDefinitionStore()::save);
-        assertThat(getContractDefinitionStore().findAll(QuerySpec.Builder.newInstance().equalsAsContains(false).filter("id=id3").build())).extracting(ContractDefinition::getId)
-                .containsOnly("id3");
+        var criterion = Criterion.criterion("id", "=", "id3");
+        var querySpec = QuerySpec.Builder.newInstance().filter(criterion).build();
+
+        var result = getContractDefinitionStore().findAll(querySpec);
+
+        assertThat(result).extracting(ContractDefinition::getId).containsOnly("id3");
     }
 
     @Test
     void findAll_verifyFiltering_invalidFilterExpression() {
         IntStream.range(0, 10).mapToObj(i -> createContractDefinition("id" + i)).forEach(getContractDefinitionStore()::save);
-        assertThatThrownBy(() -> getContractDefinitionStore().findAll(QuerySpec.Builder.newInstance().filter("something foobar other").build())).isInstanceOfAny(IllegalArgumentException.class);
+        var criterion = Criterion.criterion("something", "foobar", "other");
+        var querySpec = QuerySpec.Builder.newInstance().filter(criterion).build();
+
+        assertThatThrownBy(() -> getContractDefinitionStore().findAll(querySpec)).isInstanceOfAny(IllegalArgumentException.class);
     }
 
     @Test
@@ -370,7 +376,7 @@ public abstract class ContractDefinitionStoreTestBase {
         saveContractDefinitions(definitionsExpected);
 
         var spec = QuerySpec.Builder.newInstance()
-                .filter(format("selectorExpression.criteria.operandLeft = %s", Asset.PROPERTY_ID))
+                .filter(Criterion.criterion("selectorExpression.criteria.operandLeft", "=", Asset.PROPERTY_ID))
                 .build();
 
         var definitionsRetrieved = getContractDefinitionStore().findAll(spec);
@@ -389,7 +395,7 @@ public abstract class ContractDefinitionStoreTestBase {
         saveContractDefinitions(definitionsExpected);
 
         var spec = QuerySpec.Builder.newInstance()
-                .filter("selectorExpression.criteria.operandRight = foobar-asset")
+                .filter(Criterion.criterion("selectorExpression.criteria.operandRight", "=", "foobar-asset"))
                 .build();
 
         var definitionsRetrieved = getContractDefinitionStore().findAll(spec);
@@ -464,7 +470,7 @@ public abstract class ContractDefinitionStoreTestBase {
         var json = new ObjectMapper().writeValueAsString(new Criterion(Asset.PROPERTY_ID, "=", "foobar-asset"));
 
         var spec = QuerySpec.Builder.newInstance()
-                .filter("selectorExpression.criteria = " + json)
+                .filter(Criterion.criterion("selectorExpression.criteria", "=", json))
                 .build();
 
         assertThat(getContractDefinitionStore().findAll(spec)).hasSize(1)
@@ -481,7 +487,7 @@ public abstract class ContractDefinitionStoreTestBase {
         saveContractDefinitions(definitionsExpected);
 
         var spec = QuerySpec.Builder.newInstance()
-                .filter("selectorExpression.criteria[0].operandRight = foobar-asset")
+                .filter(Criterion.criterion("selectorExpression.criteria[0].operandRight", "=", "foobar-asset"))
                 .build();
 
         var definitionsRetrieved = getContractDefinitionStore().findAll(spec);
@@ -500,7 +506,7 @@ public abstract class ContractDefinitionStoreTestBase {
         saveContractDefinitions(definitionsExpected);
 
         var spec = QuerySpec.Builder.newInstance()
-                .filter("selectorExpression.criteria[1].operandRight = foobar-asset")
+                .filter(Criterion.criterion("selectorExpression.criteria[1].operandRight", "=", "foobar-asset"))
                 .build();
 
         var definitionsRetrieved = getContractDefinitionStore().findAll(spec);

--- a/spi/control-plane/policy-spi/src/testFixtures/java/org/eclipse/edc/connector/policy/spi/testfixtures/TestFunctions.java
+++ b/spi/control-plane/policy-spi/src/testFixtures/java/org/eclipse/edc/connector/policy/spi/testfixtures/TestFunctions.java
@@ -24,14 +24,12 @@ import org.eclipse.edc.policy.model.Permission;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.policy.model.PolicyType;
 import org.eclipse.edc.policy.model.Prohibition;
-import org.eclipse.edc.spi.query.QuerySpec;
 
 import java.time.Clock;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-;
 
 public class TestFunctions {
     public static PolicyDefinition createPolicy(String id) {
@@ -96,7 +94,4 @@ public class TestFunctions {
                 .build();
     }
 
-    public static QuerySpec createQuery(String filterExpression) {
-        return QuerySpec.Builder.newInstance().filter(filterExpression).build();
-    }
 }

--- a/spi/control-plane/policy-spi/src/testFixtures/java/org/eclipse/edc/connector/policy/spi/testfixtures/store/PolicyDefinitionStoreTestBase.java
+++ b/spi/control-plane/policy-spi/src/testFixtures/java/org/eclipse/edc/connector/policy/spi/testfixtures/store/PolicyDefinitionStoreTestBase.java
@@ -15,7 +15,6 @@
 
 package org.eclipse.edc.connector.policy.spi.testfixtures.store;
 
-import org.assertj.core.api.Assertions;
 import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
 import org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore;
 import org.eclipse.edc.policy.model.Action;
@@ -23,6 +22,7 @@ import org.eclipse.edc.policy.model.Duty;
 import org.eclipse.edc.policy.model.Permission;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.policy.model.Prohibition;
+import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.query.SortOrder;
 import org.eclipse.edc.spi.result.StoreResult;
@@ -43,7 +43,6 @@ import static org.eclipse.edc.connector.policy.spi.testfixtures.TestFunctions.cr
 import static org.eclipse.edc.connector.policy.spi.testfixtures.TestFunctions.createPolicy;
 import static org.eclipse.edc.connector.policy.spi.testfixtures.TestFunctions.createPolicyBuilder;
 import static org.eclipse.edc.connector.policy.spi.testfixtures.TestFunctions.createProhibitionBuilder;
-import static org.eclipse.edc.connector.policy.spi.testfixtures.TestFunctions.createQuery;
 import static org.eclipse.edc.spi.result.StoreFailure.Reason.ALREADY_EXISTS;
 import static org.eclipse.edc.spi.result.StoreFailure.Reason.NOT_FOUND;
 
@@ -104,8 +103,8 @@ public abstract class PolicyDefinitionStoreTestBase {
 
         var policyFromDb = store.findAll(spec);
 
-        Assertions.assertThat(policyFromDb).hasSize(1).first()
-                .satisfies(policy -> Assertions.assertThat(policy.getPolicy().getTarget()).isEqualTo("Target1"))
+        assertThat(policyFromDb).hasSize(1).first()
+                .satisfies(policy -> assertThat(policy.getPolicy().getTarget()).isEqualTo("Target1"))
                 .extracting(PolicyDefinition::getCreatedAt).isEqualTo(policy1.getCreatedAt());
     }
 
@@ -144,9 +143,10 @@ public abstract class PolicyDefinitionStoreTestBase {
 
     @Test
     void update_whenPolicyNotExists() {
-        var policy = createPolicy("test-id");
         var updated = createPolicy("another-id");
+
         var result = getPolicyDefinitionStore().update(updated);
+
         assertThat(result).extracting(StoreResult::reason).isEqualTo(NOT_FOUND);
     }
 
@@ -239,7 +239,7 @@ public abstract class PolicyDefinitionStoreTestBase {
     @Test
     @DisplayName("Find policy by ID when not exists")
     void findById_whenNonexistent() {
-        Assertions.assertThat(getPolicyDefinitionStore().findById("nonexistent")).isNull();
+        assertThat(getPolicyDefinitionStore().findById("nonexistent")).isNull();
     }
 
     @Test
@@ -257,7 +257,7 @@ public abstract class PolicyDefinitionStoreTestBase {
 
         var policiesFromDb = getPolicyDefinitionStore().findAll(spec);
 
-        Assertions.assertThat(policiesFromDb).hasSize(limit);
+        assertThat(policiesFromDb).hasSize(limit);
     }
 
     @Test
@@ -274,7 +274,7 @@ public abstract class PolicyDefinitionStoreTestBase {
 
         var policiesFromDb = getPolicyDefinitionStore().findAll(spec);
 
-        Assertions.assertThat(policiesFromDb).isEmpty();
+        assertThat(policiesFromDb).isEmpty();
     }
 
     @Test
@@ -292,7 +292,7 @@ public abstract class PolicyDefinitionStoreTestBase {
 
         var policiesFromDb = getPolicyDefinitionStore().findAll(spec);
 
-        Assertions.assertThat(policiesFromDb).size().isLessThanOrEqualTo(limit);
+        assertThat(policiesFromDb).size().isLessThanOrEqualTo(limit);
     }
 
     @Test
@@ -331,16 +331,16 @@ public abstract class PolicyDefinitionStoreTestBase {
         getPolicyDefinitionStore().create(policyDef);
 
         // query by prohibition assignee
-        var query = createQuery("policy.prohibitions.assignee=test-assignee");
+        var query = createQuery(Criterion.criterion("policy.prohibitions.assignee", "=", "test-assignee"));
         var result = getPolicyDefinitionStore().findAll(query);
-        Assertions.assertThat(result).hasSize(1)
+        assertThat(result).hasSize(1)
                 .usingRecursiveFieldByFieldElementComparator()
                 .containsExactly(policyDef);
 
         //query by prohibition action constraint
-        var query2 = createQuery("policy.prohibitions.action.constraint.leftExpression.value=foo");
+        var query2 = createQuery(Criterion.criterion("policy.prohibitions.action.constraint.leftExpression.value", "=", "foo"));
         var result2 = getPolicyDefinitionStore().findAll(query2);
-        Assertions.assertThat(result2).hasSize(1)
+        assertThat(result2).hasSize(1)
                 .usingRecursiveFieldByFieldElementComparator()
                 .containsExactly(policyDef);
     }
@@ -358,8 +358,8 @@ public abstract class PolicyDefinitionStoreTestBase {
         getPolicyDefinitionStore().create(policyDef);
 
         // query by prohibition assignee
-        var query = createQuery("policy.prohibitions.fooBarProperty=someval");
-        Assertions.assertThat(getPolicyDefinitionStore().findAll(query)).isEmpty();
+        var query = createQuery(Criterion.criterion("policy.prohibitions.fooBarProperty", "=", "someval"));
+        assertThat(getPolicyDefinitionStore().findAll(query)).isEmpty();
     }
 
     @Test
@@ -376,9 +376,9 @@ public abstract class PolicyDefinitionStoreTestBase {
         getPolicyDefinitionStore().create(policyDef);
 
         // query by prohibition assignee
-        var query = createQuery("policy.prohibitions.action.constraint.leftExpression.value=someval");
+        var query = createQuery(Criterion.criterion("policy.prohibitions.action.constraint.leftExpression.value", "=", "someval"));
         var result = getPolicyDefinitionStore().findAll(query);
-        Assertions.assertThat(result).isEmpty();
+        assertThat(result).isEmpty();
     }
 
     @Test
@@ -395,16 +395,16 @@ public abstract class PolicyDefinitionStoreTestBase {
         getPolicyDefinitionStore().create(policyDef);
 
         // query by prohibition assignee
-        var query = createQuery("policy.permissions.assignee=test-assignee");
+        var query = createQuery(Criterion.criterion("policy.permissions.assignee", "=", "test-assignee"));
         var result = getPolicyDefinitionStore().findAll(query);
-        Assertions.assertThat(result).hasSize(1)
+        assertThat(result).hasSize(1)
                 .usingRecursiveFieldByFieldElementComparator()
                 .containsExactly(policyDef);
 
         //query by prohibition action constraint
-        var query2 = createQuery("policy.permissions.action.constraint.leftExpression.value=foo");
+        var query2 = createQuery(Criterion.criterion("policy.permissions.action.constraint.leftExpression.value", "=", "foo"));
         var result2 = getPolicyDefinitionStore().findAll(query2);
-        Assertions.assertThat(result2).hasSize(1)
+        assertThat(result2).hasSize(1)
                 .usingRecursiveFieldByFieldElementComparator()
                 .containsExactly(policyDef);
     }
@@ -422,8 +422,8 @@ public abstract class PolicyDefinitionStoreTestBase {
         getPolicyDefinitionStore().create(policyDef);
 
         // query by prohibition assignee
-        var query = createQuery("policy.permissions.fooBarProperty=someval");
-        Assertions.assertThat(getPolicyDefinitionStore().findAll(query)).isEmpty();
+        var query = createQuery(Criterion.criterion("policy.permissions.fooBarProperty", "=", "someval"));
+        assertThat(getPolicyDefinitionStore().findAll(query)).isEmpty();
     }
 
     @Test
@@ -439,9 +439,9 @@ public abstract class PolicyDefinitionStoreTestBase {
         getPolicyDefinitionStore().create(policyDef);
 
         // query by prohibition assignee
-        var query = createQuery("policy.permissions.action.constraint.leftExpression=someval");
+        var query = createQuery(Criterion.criterion("policy.permissions.action.constraint.leftExpression", "=", "someval"));
         var result = getPolicyDefinitionStore().findAll(query);
-        Assertions.assertThat(result).isEmpty();
+        assertThat(result).isEmpty();
     }
 
     @Test
@@ -459,16 +459,16 @@ public abstract class PolicyDefinitionStoreTestBase {
         getPolicyDefinitionStore().create(createPolicy("another-policy"));
 
         // query by prohibition assignee
-        var query = createQuery("policy.obligations.assignee=test-assignee");
+        var query = createQuery(Criterion.criterion("policy.obligations.assignee", "=", "test-assignee"));
         var result = getPolicyDefinitionStore().findAll(query);
-        Assertions.assertThat(result).hasSize(1)
+        assertThat(result).hasSize(1)
                 .usingRecursiveFieldByFieldElementComparator()
                 .containsExactly(policyDef);
 
         //query by prohibition action constraint
-        var query2 = createQuery("policy.obligations.action.constraint.rightExpression.value=bar");
+        var query2 = createQuery(Criterion.criterion("policy.obligations.action.constraint.rightExpression.value", "=", "bar"));
         var result2 = getPolicyDefinitionStore().findAll(query2);
-        Assertions.assertThat(result2).hasSize(1)
+        assertThat(result2).hasSize(1)
                 .usingRecursiveFieldByFieldElementComparator()
                 .containsExactly(policyDef);
     }
@@ -486,8 +486,8 @@ public abstract class PolicyDefinitionStoreTestBase {
         getPolicyDefinitionStore().create(policyDef);
 
         // query by prohibition assignee
-        var query = createQuery("policy.obligations.fooBarProperty=someval");
-        Assertions.assertThat(getPolicyDefinitionStore().findAll(query)).isEmpty();
+        var query = createQuery(Criterion.criterion("policy.obligations.fooBarProperty", "=", "someval"));
+        assertThat(getPolicyDefinitionStore().findAll(query)).isEmpty();
     }
 
     @Test
@@ -504,9 +504,9 @@ public abstract class PolicyDefinitionStoreTestBase {
         getPolicyDefinitionStore().create(policyDef);
 
         // query by prohibition assignee
-        var query = createQuery("policy.obligations.action.constraint.rightExpression.value=notexist");
+        var query = createQuery(Criterion.criterion("policy.obligations.action.constraint.rightExpression.value", "=", "notexist"));
         var result = getPolicyDefinitionStore().findAll(query);
-        Assertions.assertThat(result).isEmpty();
+        assertThat(result).isEmpty();
     }
 
     @Test
@@ -527,7 +527,7 @@ public abstract class PolicyDefinitionStoreTestBase {
         getPolicyDefinitionStore().create(policyDef2);
 
         // query by prohibition assignee
-        Assertions.assertThat(getPolicyDefinitionStore().findAll(createQuery("policy.assignee=test-assignee")))
+        assertThat(getPolicyDefinitionStore().findAll(createQuery(Criterion.criterion("policy.assignee", "=", "test-assignee"))))
                 .hasSize(1)
                 .usingRecursiveFieldByFieldElementComparator()
                 .containsExactly(policyDef1);
@@ -544,8 +544,9 @@ public abstract class PolicyDefinitionStoreTestBase {
         getPolicyDefinitionStore().create(policyDef1);
 
         // query by prohibition assignee
-        Assertions.assertThat(getPolicyDefinitionStore().findAll(createQuery("policy.assigner=notexist")))
-                .isEmpty();
+        var query = createQuery(Criterion.criterion("policy.assigner", "=", "notexist"));
+
+        assertThat(getPolicyDefinitionStore().findAll(query)).isEmpty();
     }
 
     @Test
@@ -558,7 +559,7 @@ public abstract class PolicyDefinitionStoreTestBase {
         getPolicyDefinitionStore().create(policy3);
 
         var list = getPolicyDefinitionStore().findAll(QuerySpec.Builder.newInstance().limit(3).offset(1).build()).collect(Collectors.toList());
-        Assertions.assertThat(list).hasSize(2).usingRecursiveFieldByFieldElementComparator().isSubsetOf(policy1, policy2, policy3);
+        assertThat(list).hasSize(2).usingRecursiveFieldByFieldElementComparator().isSubsetOf(policy1, policy2, policy3);
     }
 
     @Test
@@ -570,7 +571,9 @@ public abstract class PolicyDefinitionStoreTestBase {
         getPolicyDefinitionStore().create(policy2);
         getPolicyDefinitionStore().create(policy3);
 
-        Assertions.assertThat(getPolicyDefinitionStore().findAll(QuerySpec.Builder.newInstance().filter("id=" + policy1.getUid()).build())).usingRecursiveFieldByFieldElementComparator().containsExactly(policy1);
+        var querySpec = QuerySpec.Builder.newInstance().filter(Criterion.criterion("id", "=", policy1.getUid())).build();
+
+        assertThat(getPolicyDefinitionStore().findAll(querySpec)).usingRecursiveFieldByFieldElementComparator().containsExactly(policy1);
     }
 
     @Test
@@ -584,7 +587,7 @@ public abstract class PolicyDefinitionStoreTestBase {
         getPolicyDefinitionStore().create(policy2);
         getPolicyDefinitionStore().create(policy3);
 
-        Assertions.assertThat(getPolicyDefinitionStore().findAll(QuerySpec.Builder.newInstance().sortField("id").sortOrder(SortOrder.ASC).build())).usingRecursiveFieldByFieldElementComparator().containsExactly(policy2, policy3, policy1);
+        assertThat(getPolicyDefinitionStore().findAll(QuerySpec.Builder.newInstance().sortField("id").sortOrder(SortOrder.ASC).build())).usingRecursiveFieldByFieldElementComparator().containsExactly(policy2, policy3, policy1);
     }
 
     @Test
@@ -602,20 +605,20 @@ public abstract class PolicyDefinitionStoreTestBase {
         getPolicyDefinitionStore().create(policyY);
 
         QuerySpec uid = QuerySpec.Builder.newInstance()
-                .filter("policy.target=target1")
+                .filter(Criterion.criterion("policy.target", "=", "target1"))
                 .sortField("id")
                 .sortOrder(SortOrder.DESC)
                 .offset(1)
                 .limit(1)
                 .build();
-        Assertions.assertThat(getPolicyDefinitionStore().findAll(uid)).usingRecursiveFieldByFieldElementComparator().containsExactly(policy3);
+        assertThat(getPolicyDefinitionStore().findAll(uid)).usingRecursiveFieldByFieldElementComparator().containsExactly(policy3);
     }
 
     @Test
     void findAll_verifyFiltering_invalidFilterExpression() {
         IntStream.range(0, 10).mapToObj(i -> createPolicy(getRandomId())).forEach(d -> getPolicyDefinitionStore().create(d));
 
-        var query = QuerySpec.Builder.newInstance().filter("something contains other").build();
+        var query = QuerySpec.Builder.newInstance().filter(Criterion.criterion("something", "contains", "other")).build();
 
         assertThatThrownBy(() -> getPolicyDefinitionStore().findAll(query)).isInstanceOf(IllegalArgumentException.class);
     }
@@ -623,14 +626,12 @@ public abstract class PolicyDefinitionStoreTestBase {
     @Test
     @EnabledIfSystemProperty(named = "policydefinitionstore.supports.sortorder", matches = "true", disabledReason = "This test only runs if sorting is supported")
     void findAll_sorting_nonExistentProperty() {
-
         IntStream.range(0, 10).mapToObj(i -> createPolicy(getRandomId())).forEach((d) -> getPolicyDefinitionStore().create(d));
-
 
         var query = QuerySpec.Builder.newInstance().sortField("notexist").sortOrder(SortOrder.DESC).build();
 
         var all = getPolicyDefinitionStore().findAll(query).collect(Collectors.toList());
-        Assertions.assertThat(all).isEmpty();
+        assertThat(all).isEmpty();
     }
 
     @Test
@@ -641,12 +642,11 @@ public abstract class PolicyDefinitionStoreTestBase {
         var store = getPolicyDefinitionStore();
 
         store.create(policy);
-        Assertions.assertThat(store.findAll(QuerySpec.none())).usingRecursiveFieldByFieldElementComparator().containsExactly(policy);
+        assertThat(store.findAll(QuerySpec.none())).usingRecursiveFieldByFieldElementComparator().containsExactly(policy);
 
         // modify the object
         var modifiedPolicy = PolicyDefinition.Builder.newInstance()
                 .policy(Policy.Builder.newInstance()
-
                         .permission(Permission.Builder.newInstance()
                                 .target("test-asset-id")
                                 .action(Action.Builder.newInstance()
@@ -659,9 +659,11 @@ public abstract class PolicyDefinitionStoreTestBase {
 
         store.update(modifiedPolicy);
 
-        // re-read
-        var all = store.findAll(QuerySpec.Builder.newInstance().filter("policy.permissions[0].target=test-asset-id").build()).collect(Collectors.toList());
-        Assertions.assertThat(all).hasSize(1).usingRecursiveFieldByFieldElementComparator().containsExactly(modifiedPolicy);
+        var querySpec = QuerySpec.Builder.newInstance().filter(Criterion.criterion("policy.permissions[0].target", "=", "test-asset-id")).build();
+
+        var result = store.findAll(querySpec);
+
+        assertThat(result).hasSize(1).usingRecursiveFieldByFieldElementComparator().containsExactly(modifiedPolicy);
     }
 
     protected abstract PolicyDefinitionStore getPolicyDefinitionStore();
@@ -676,14 +678,11 @@ public abstract class PolicyDefinitionStoreTestBase {
         return UUID.randomUUID().toString();
     }
 
-    private PolicyDefinition createPolicyDef(String id) {
-        return PolicyDefinition.Builder.newInstance()
-                .id(id)
-                .policy(Policy.Builder.newInstance().build())
-                .build();
-    }
-
     private PolicyDefinition createPolicyDef(String id, String target) {
         return PolicyDefinition.Builder.newInstance().id(id).policy(Policy.Builder.newInstance().target(target).build()).build();
+    }
+
+    private QuerySpec createQuery(Criterion criterion) {
+        return QuerySpec.Builder.newInstance().filter(criterion).build();
     }
 }

--- a/spi/control-plane/transfer-spi/src/testFixtures/java/org/eclipse/edc/connector/transfer/spi/testfixtures/store/TransferProcessStoreTestBase.java
+++ b/spi/control-plane/transfer-spi/src/testFixtures/java/org/eclipse/edc/connector/transfer/spi/testfixtures/store/TransferProcessStoreTestBase.java
@@ -697,7 +697,7 @@ public abstract class TransferProcessStoreTestBase {
         getTransferProcessStore().updateOrCreate(process2);
 
         var query = QuerySpec.Builder.newInstance()
-                .filter("deprovisionedResources.inProcess=true")
+                .filter(Criterion.criterion("deprovisionedResources.inProcess", "=", "true"))
                 .build();
 
         var result = getTransferProcessStore().findAll(query).collect(Collectors.toList());
@@ -774,7 +774,7 @@ public abstract class TransferProcessStoreTestBase {
         getTransferProcessStore().updateOrCreate(process2);
 
         var query = QuerySpec.Builder.newInstance()
-                .filter("deprovisionedResources.inProcess=false")
+                .filter(Criterion.criterion("deprovisionedResources.inProcess", "=", "false"))
                 .build();
 
         var result = getTransferProcessStore().findAll(query).collect(Collectors.toList());
@@ -802,7 +802,7 @@ public abstract class TransferProcessStoreTestBase {
         getTransferProcessStore().updateOrCreate(process1);
 
         var query = QuerySpec.Builder.newInstance()
-                .filter("deprovisionedResources.foobar=barbaz")
+                .filter(Criterion.criterion("deprovisionedResources.foobar", "=", "barbaz"))
                 .build();
 
         assertThat(getTransferProcessStore().findAll(query)).isEmpty();
@@ -828,7 +828,7 @@ public abstract class TransferProcessStoreTestBase {
         getTransferProcessStore().updateOrCreate(process1);
 
         var query = QuerySpec.Builder.newInstance()
-                .filter("deprovisionedResources.errorMessage=notexist")
+                .filter(Criterion.criterion("deprovisionedResources.errorMessage", "=", "notexist"))
                 .build();
 
         var result = getTransferProcessStore().findAll(query).collect(Collectors.toList());
@@ -958,13 +958,19 @@ public abstract class TransferProcessStoreTestBase {
     @Test
     void findAll_verifyFiltering() {
         IntStream.range(0, 10).forEach(i -> getTransferProcessStore().updateOrCreate(createTransferProcess("test-neg-" + i)));
-        assertThat(getTransferProcessStore().findAll(QuerySpec.Builder.newInstance().equalsAsContains(false).filter("id=test-neg-3").build())).extracting(TransferProcess::getId).containsOnly("test-neg-3");
+        var querySpec = QuerySpec.Builder.newInstance().filter(Criterion.criterion("id", "=", "test-neg-3")).build();
+
+        var result = getTransferProcessStore().findAll(querySpec);
+
+        assertThat(result).extracting(TransferProcess::getId).containsOnly("test-neg-3");
     }
 
     @Test
     void findAll_verifyFiltering_invalidFilterExpression() {
         IntStream.range(0, 10).forEach(i -> getTransferProcessStore().updateOrCreate(createTransferProcess("test-neg-" + i)));
-        assertThatThrownBy(() -> getTransferProcessStore().findAll(QuerySpec.Builder.newInstance().filter("something foobar other").build())).isInstanceOfAny(IllegalArgumentException.class);
+        var querySpec = QuerySpec.Builder.newInstance().filter(Criterion.criterion("something", "foobar", "other")).build();
+
+        assertThatThrownBy(() -> getTransferProcessStore().findAll(querySpec)).isInstanceOfAny(IllegalArgumentException.class);
     }
 
     @Test


### PR DESCRIPTION
## What this PR changes/adds

Removed `QuerySpec.Builder.filter` deprecated method

## Why it does that

cleanup

## Further notes



## Linked Issue(s)

Closes #3056 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md)._
