### PR TITLE
fix: feed `TransferProcess#properties` from the new field 

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImpl.java
@@ -143,7 +143,6 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
                 .dataRequest(dataRequest)
                 .type(PROVIDER)
                 .clock(clock)
-                .properties(dataRequest.getProperties())
                 .traceContext(telemetry.getCurrentTraceContext())
                 .build();
 

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
@@ -184,7 +184,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
                 .dataRequest(dataRequest)
                 .type(CONSUMER)
                 .clock(clock)
-                .properties(dataRequest.getProperties())
+                .properties(transferRequest.getPrivateProperties())
                 .callbackAddresses(transferRequest.getCallbackAddresses())
                 .traceContext(telemetry.getCurrentTraceContext())
                 .build();
@@ -588,12 +588,12 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
         var resourcesToDeprovision = process.getResourcesToDeprovision();
 
         return entityRetryProcessFactory.doAsyncProcess(process, () -> provisionManager.deprovision(resourcesToDeprovision, policy))
-                        .entityRetrieve(transferProcessStore::findById)
-                        .onDelay(this::breakLease)
-                        .onSuccess(this::handleDeprovisionResult)
-                        .onFailure((t, throwable) -> transitionToDeprovisioning(t))
-                        .onRetryExhausted((t, throwable) -> transitionToDeprovisioningError(t, throwable.getMessage()))
-                        .execute("deprovisioning");
+                .entityRetrieve(transferProcessStore::findById)
+                .onDelay(this::breakLease)
+                .onSuccess(this::handleDeprovisionResult)
+                .onFailure((t, throwable) -> transitionToDeprovisioning(t))
+                .onRetryExhausted((t, throwable) -> transitionToDeprovisioningError(t, throwable.getMessage()))
+                .execute("deprovisioning");
     }
 
     private void handleProvisionResponses(TransferProcess transferProcess, List<ProvisionResponse> responses) {

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
@@ -184,7 +184,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
                 .dataRequest(dataRequest)
                 .type(CONSUMER)
                 .clock(clock)
-                .properties(transferRequest.getPrivateProperties())
+                .privateProperties(transferRequest.getPrivateProperties())
                 .callbackAddresses(transferRequest.getCallbackAddresses())
                 .traceContext(telemetry.getCurrentTraceContext())
                 .build();

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/model/TransferRequestDto.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/model/TransferRequestDto.java
@@ -37,6 +37,9 @@ public class TransferRequestDto {
     public static final String EDC_TRANSFER_REQUEST_DTO_DATA_DESTINATION = EDC_NAMESPACE + "dataDestination";
     public static final String EDC_TRANSFER_REQUEST_DTO_MANAGED_RESOURCES = EDC_NAMESPACE + "managedResources";
     public static final String EDC_TRANSFER_REQUEST_DTO_PROPERTIES = EDC_NAMESPACE + "properties";
+
+    public static final String EDC_TRANSFER_REQUEST_DTO_PRIVATE_PROPERTIES = EDC_NAMESPACE + "privateProperties";
+
     public static final String EDC_TRANSFER_REQUEST_DTO_PROTOCOL = EDC_NAMESPACE + "protocol";
     public static final String EDC_TRANSFER_REQUEST_DTO_CONNECTOR_ID = EDC_NAMESPACE + "connectorId";
     public static final String EDC_TRANSFER_REQUEST_DTO_ASSET_ID = EDC_NAMESPACE + "assetId";
@@ -50,6 +53,9 @@ public class TransferRequestDto {
     private DataAddress dataDestination;
     private boolean managedResources = true;
     private Map<String, String> properties = new HashMap<>();
+
+    private Map<String, String> privateProperties = new HashMap<>();
+
     @NotNull(message = "protocol cannot be null")
     private String protocol = "ids-multipart";
     @NotNull(message = "connectorId cannot be null")
@@ -82,6 +88,10 @@ public class TransferRequestDto {
 
     public Map<String, String> getProperties() {
         return properties;
+    }
+
+    public Map<String, String> getPrivateProperties() {
+        return privateProperties;
     }
 
     public String getProtocol() {
@@ -140,6 +150,11 @@ public class TransferRequestDto {
 
         public Builder properties(Map<String, String> properties) {
             request.properties = properties;
+            return this;
+        }
+
+        public Builder privateProperties(Map<String, String> privateProperties) {
+            request.privateProperties = privateProperties;
             return this;
         }
 

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/transform/JsonObjectToTransferRequestDtoTransformer.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/transform/JsonObjectToTransferRequestDtoTransformer.java
@@ -14,7 +14,9 @@
 
 package org.eclipse.edc.connector.api.management.transferprocess.transform;
 
+import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
 import org.eclipse.edc.connector.api.management.transferprocess.model.TransferRequestDto;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
 import org.eclipse.edc.spi.types.domain.DataAddress;
@@ -22,14 +24,19 @@ import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Consumer;
 
+import static jakarta.json.JsonValue.ValueType.ARRAY;
+import static jakarta.json.JsonValue.ValueType.OBJECT;
 import static org.eclipse.edc.connector.api.management.transferprocess.model.TransferRequestDto.EDC_TRANSFER_REQUEST_DTO_ASSET_ID;
 import static org.eclipse.edc.connector.api.management.transferprocess.model.TransferRequestDto.EDC_TRANSFER_REQUEST_DTO_CONNECTOR_ADDRESS;
 import static org.eclipse.edc.connector.api.management.transferprocess.model.TransferRequestDto.EDC_TRANSFER_REQUEST_DTO_CONNECTOR_ID;
 import static org.eclipse.edc.connector.api.management.transferprocess.model.TransferRequestDto.EDC_TRANSFER_REQUEST_DTO_CONTRACT_ID;
 import static org.eclipse.edc.connector.api.management.transferprocess.model.TransferRequestDto.EDC_TRANSFER_REQUEST_DTO_DATA_DESTINATION;
 import static org.eclipse.edc.connector.api.management.transferprocess.model.TransferRequestDto.EDC_TRANSFER_REQUEST_DTO_MANAGED_RESOURCES;
+import static org.eclipse.edc.connector.api.management.transferprocess.model.TransferRequestDto.EDC_TRANSFER_REQUEST_DTO_PRIVATE_PROPERTIES;
 import static org.eclipse.edc.connector.api.management.transferprocess.model.TransferRequestDto.EDC_TRANSFER_REQUEST_DTO_PROPERTIES;
 import static org.eclipse.edc.connector.api.management.transferprocess.model.TransferRequestDto.EDC_TRANSFER_REQUEST_DTO_PROTOCOL;
 
@@ -55,7 +62,9 @@ public class JsonObjectToTransferRequestDtoTransformer extends AbstractJsonLdTra
                 case EDC_TRANSFER_REQUEST_DTO_MANAGED_RESOURCES:
                     return (v) -> builder.managedResources(transformBoolean(v, context));
                 case EDC_TRANSFER_REQUEST_DTO_PROPERTIES:
-                    return (v) -> builder.properties(context.transform(v, Map.class));
+                    return (v) -> transformProperties(v, builder::properties, context);
+                case EDC_TRANSFER_REQUEST_DTO_PRIVATE_PROPERTIES:
+                    return (v) -> transformProperties(v, builder::privateProperties, context);
                 case EDC_TRANSFER_REQUEST_DTO_PROTOCOL:
                     return (v) -> builder.protocol(transformString(v, context));
                 case EDC_TRANSFER_REQUEST_DTO_CONNECTOR_ID:
@@ -68,5 +77,27 @@ public class JsonObjectToTransferRequestDtoTransformer extends AbstractJsonLdTra
         });
 
         return builder.build();
+    }
+
+    private void transformProperties(JsonValue jsonValue, Consumer<Map<String, String>> consumer, TransformerContext context) {
+        JsonObject jsonObject;
+        if (jsonValue instanceof JsonArray) {
+            jsonObject = jsonValue.asJsonArray().getJsonObject(0);
+        } else if (jsonValue instanceof JsonObject) {
+            jsonObject = (JsonObject) jsonValue;
+        } else {
+            context.problem()
+                    .unexpectedType()
+                    .actual(jsonValue.getValueType())
+                    .expected(OBJECT)
+                    .expected(ARRAY)
+                    .report();
+            return;
+        }
+        var properties = new HashMap<String, String>();
+        visitProperties(jsonObject, (k, v) -> {
+            properties.put(k, transformString(v, context));
+        });
+        consumer.accept(properties);
     }
 }

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/transform/TransferProcessToTransferProcessDtoTransformer.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/transform/TransferProcessToTransferProcessDtoTransformer.java
@@ -57,7 +57,7 @@ public class TransferProcessToTransferProcessDtoTransformer implements DtoTransf
                 .createdAt(object.getCreatedAt())
                 .updatedAt(object.getUpdatedAt())
                 .dataRequest(context.transform(dataRequest, DataRequestDto.class))
-                .properties(object.getProperties())
+                .properties(object.getPrivateProperties())
                 .callbackAddresses(object.getCallbackAddresses().stream().map(it -> context.transform(it, CallbackAddressDto.class)).collect(toList()))
                 .dataDestination(
                         DataAddressDto.Builder.newInstance()

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/transform/TransferRequestDtoToTransferRequestTransformer.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/transform/TransferRequestDtoToTransferRequestTransformer.java
@@ -63,6 +63,7 @@ public class TransferRequestDtoToTransferRequestTransformer implements DtoTransf
         return TransferRequest.Builder.newInstance()
                 .dataRequest(dataRequest)
                 .callbackAddresses(callbacks)
+                .privateProperties(object.getPrivateProperties())
                 .build();
     }
 }

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/api/management/transferprocess/transform/TransferRequestDtoToTransferRequestTransformerTest.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/api/management/transferprocess/transform/TransferRequestDtoToTransferRequestTransformerTest.java
@@ -74,6 +74,8 @@ class TransferRequestDtoToTransferRequestTransformerTest {
         assertThat(dataRequest.isManagedResources()).isEqualTo(transferReq.isManagedResources());
 
         assertThat(transferRequest.getCallbackAddresses()).hasSize(transferReq.getCallbackAddresses().size());
+        assertThat(transferRequest.getPrivateProperties()).isEqualTo(transferReq.getPrivateProperties());
+
     }
 
     @NotNull
@@ -86,7 +88,8 @@ class TransferRequestDtoToTransferRequestTransformerTest {
                 .dataDestination(DataAddress.Builder.newInstance().type("test-type").build())
                 .connectorId(UUID.randomUUID().toString())
                 .callbackAddresses(List.of(CallbackAddressDto.Builder.newInstance().uri("local://test").build()))
-                .properties(Map.of("key1", "value1"));
+                .properties(Map.of("key1", "value1"))
+                .privateProperties(Map.of("privateKey", "privateValue"));
     }
 
 }

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/SqlTransferProcessStore.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/SqlTransferProcessStore.java
@@ -257,7 +257,7 @@ public class SqlTransferProcessStore extends AbstractSqlStore implements Transfe
                 toJson(process.getContentDataAddress()),
                 process.getType().toString(),
                 toJson(process.getDeprovisionedResources()),
-                toJson(process.getProperties()),
+                toJson(process.getPrivateProperties()),
                 toJson(process.getCallbackAddresses()));
 
         //insert DataRequest
@@ -302,7 +302,7 @@ public class SqlTransferProcessStore extends AbstractSqlStore implements Transfe
                 }))
                 .callbackAddresses(fromJson(resultSet.getString(statements.getCallbackAddressesColumn()), new TypeReference<>() {
                 }))
-                .properties(fromJson(resultSet.getString(statements.getPropertiesColumn()), getTypeRef()))
+                .privateProperties(fromJson(resultSet.getString(statements.getPropertiesColumn()), getTypeRef()))
                 .build();
     }
 

--- a/extensions/control-plane/transfer/transfer-pull-http-dynamic-receiver/README.md
+++ b/extensions/control-plane/transfer/transfer-pull-http-dynamic-receiver/README.md
@@ -7,18 +7,22 @@ and will be used by the consumer connector to dispatch the EDR
 
 ```json
 {
-  "edctype": "dataspaceconnector:datarequest",
-  "protocol": "ids-multipart",
+  "@context": {
+    "edc": "https://w3id.org/edc/v0.0.1/ns/"
+  },
+  "@type": "TransferRequestDto",
+  "protocol": "dataspace-protocol-http",
   "assetId": "test-document",
   "contractId": "1:8147d6d6-9734-4821-b93d-2832ea7892e4",
   "dataDestination": {
+    "@type": "DataAddress",
     "type": "HttpProxy"
   },
   "managedResources": false,
   "connectorAddress": "http://localhost:8282/api/v1/ids/data",
   "connectorId": "consumer",
-  "properties": {
-    "receiver.http.endpoint" : "http://localhost:9999"
+  "privateProperties": {
+    "receiverHttpEndpoint" : "http://localhost:9999"
   }
 }
 ```

--- a/extensions/control-plane/transfer/transfer-pull-http-dynamic-receiver/src/main/java/org/eclipse/edc/connector/receiver/http/dynamic/HttpDynamicEndpointDataReferenceReceiver.java
+++ b/extensions/control-plane/transfer/transfer-pull-http-dynamic-receiver/src/main/java/org/eclipse/edc/connector/receiver/http/dynamic/HttpDynamicEndpointDataReferenceReceiver.java
@@ -74,7 +74,7 @@ public class HttpDynamicEndpointDataReferenceReceiver implements EndpointDataRef
             return CompletableFuture.completedFuture(Result.failure(format("Failed to found transfer process for id %s", processId)));
         }
 
-        var endpoint = transferProcess.getProperties().get(HTTP_RECEIVER_ENDPOINT);
+        var endpoint = transferProcess.getPrivateProperties().get(HTTP_RECEIVER_ENDPOINT);
 
         if (endpoint == null) {
             endpoint = fallbackEndpoint;

--- a/extensions/control-plane/transfer/transfer-pull-http-dynamic-receiver/src/main/java/org/eclipse/edc/connector/receiver/http/dynamic/HttpDynamicEndpointDataReferenceReceiver.java
+++ b/extensions/control-plane/transfer/transfer-pull-http-dynamic-receiver/src/main/java/org/eclipse/edc/connector/receiver/http/dynamic/HttpDynamicEndpointDataReferenceReceiver.java
@@ -32,6 +32,7 @@ import java.util.concurrent.CompletableFuture;
 
 import static dev.failsafe.Failsafe.with;
 import static java.lang.String.format;
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 import static org.eclipse.edc.util.string.StringUtils.isNullOrBlank;
 
 /**
@@ -41,7 +42,7 @@ import static org.eclipse.edc.util.string.StringUtils.isNullOrBlank;
 public class HttpDynamicEndpointDataReferenceReceiver implements EndpointDataReferenceReceiver {
 
 
-    public static final String HTTP_RECEIVER_ENDPOINT = "receiver.http.endpoint";
+    public static final String HTTP_RECEIVER_ENDPOINT = EDC_NAMESPACE + "receiverHttpEndpoint";
 
     private static final MediaType JSON = MediaType.get("application/json");
 

--- a/extensions/control-plane/transfer/transfer-pull-http-dynamic-receiver/src/test/java/org/eclipse/edc/connector/receiver/http/dynamic/TestFunctions.java
+++ b/extensions/control-plane/transfer/transfer-pull-http-dynamic-receiver/src/test/java/org/eclipse/edc/connector/receiver/http/dynamic/TestFunctions.java
@@ -37,7 +37,7 @@ public class TestFunctions {
                 .dataRequest(DataRequest.Builder.newInstance()
                         .destinationType("HttpProxy")
                         .build())
-                .properties(properties)
+                .privateProperties(properties)
                 .build();
     }
 

--- a/resources/openapi/yaml/management-api/transfer-process-api.yaml
+++ b/resources/openapi/yaml/management-api/transfer-process-api.yaml
@@ -524,6 +524,12 @@ components:
         managedResources:
           type: boolean
           example: null
+        privateProperties:
+          type: object
+          additionalProperties:
+            type: string
+            example: null
+          example: null
         properties:
           type: object
           additionalProperties:

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/TransferProcess.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/TransferProcess.java
@@ -109,7 +109,7 @@ public class TransferProcess extends StatefulEntity<TransferProcess> {
     private ResourceManifest resourceManifest;
     private ProvisionedResourceSet provisionedResourceSet;
     private List<DeprovisionedResource> deprovisionedResources = new ArrayList<>();
-    private Map<String, String> properties = new HashMap<>();
+    private Map<String, String> privateProperties = new HashMap<>();
     private List<CallbackAddress> callbackAddresses = new ArrayList<>();
 
     private TransferProcess() {
@@ -209,8 +209,8 @@ public class TransferProcess extends StatefulEntity<TransferProcess> {
         return provisionedResourceSet.getResources().stream().filter(r -> !deprovisionedResources.contains(r.getId())).collect(toList());
     }
 
-    public Map<String, String> getProperties() {
-        return Collections.unmodifiableMap(properties);
+    public Map<String, String> getPrivateProperties() {
+        return Collections.unmodifiableMap(privateProperties);
     }
 
     public List<CallbackAddress> getCallbackAddresses() {
@@ -332,7 +332,7 @@ public class TransferProcess extends StatefulEntity<TransferProcess> {
                 .provisionedResourceSet(provisionedResourceSet)
                 .contentDataAddress(contentDataAddress)
                 .deprovisionedResources(deprovisionedResources)
-                .properties(properties)
+                .privateProperties(privateProperties)
                 .callbackAddresses(callbackAddresses)
                 .type(type);
         return copy(builder);
@@ -432,8 +432,8 @@ public class TransferProcess extends StatefulEntity<TransferProcess> {
             return this;
         }
 
-        public Builder properties(Map<String, String> properties) {
-            entity.properties = properties;
+        public Builder privateProperties(Map<String, String> privateProperties) {
+            entity.privateProperties = privateProperties;
             return this;
         }
 

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/TransferRequest.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/TransferRequest.java
@@ -18,7 +18,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -30,6 +32,8 @@ public class TransferRequest {
 
     private List<CallbackAddress> callbackAddresses = new ArrayList<>();
 
+    private Map<String, String> privateProperties = new HashMap<>();
+    
     private DataRequest dataRequest;
 
     private TransferRequest() {
@@ -54,6 +58,13 @@ public class TransferRequest {
         return callbackAddresses;
     }
 
+    /**
+     * Custom private properties that are associated with this transfer request.
+     */
+    public Map<String, String> getPrivateProperties() {
+        return privateProperties;
+    }
+
     public static class Builder {
         private final TransferRequest request;
 
@@ -73,6 +84,11 @@ public class TransferRequest {
 
         public Builder callbackAddresses(List<CallbackAddress> callbackAddresses) {
             request.callbackAddresses = callbackAddresses;
+            return this;
+        }
+
+        public Builder privateProperties(Map<String, String> privateProperties) {
+            request.privateProperties = privateProperties;
             return this;
         }
 

--- a/spi/control-plane/transfer-spi/src/test/java/org/eclipse/edc/connector/transfer/spi/types/TransferProcessTest.java
+++ b/spi/control-plane/transfer-spi/src/test/java/org/eclipse/edc/connector/transfer/spi/types/TransferProcessTest.java
@@ -66,7 +66,7 @@ class TransferProcessTest {
                 .contentDataAddress(DataAddress.Builder.newInstance().type("test").build())
                 .stateCount(1)
                 .stateTimestamp(1)
-                .properties(Map.of("k", "v"))
+                .privateProperties(Map.of("k", "v"))
                 .build();
 
         var copy = process.copy();
@@ -76,7 +76,7 @@ class TransferProcessTest {
         assertEquals(process.getCreatedAt(), copy.getCreatedAt());
         assertEquals(process.getStateCount(), copy.getStateCount());
         assertEquals(process.getStateTimestamp(), copy.getStateTimestamp());
-        assertEquals(process.getProperties(), copy.getProperties());
+        assertEquals(process.getPrivateProperties(), copy.getPrivateProperties());
         assertNotNull(process.getContentDataAddress());
 
         assertThat(process).usingRecursiveComparison().isEqualTo(copy);

--- a/spi/control-plane/transfer-spi/src/testFixtures/java/org/eclipse/edc/connector/transfer/spi/testfixtures/store/TransferProcessStoreTestBase.java
+++ b/spi/control-plane/transfer-spi/src/testFixtures/java/org/eclipse/edc/connector/transfer/spi/testfixtures/store/TransferProcessStoreTestBase.java
@@ -69,7 +69,7 @@ public abstract class TransferProcessStoreTestBase {
 
     @Test
     void create() {
-        var t = TestFunctions.createTransferProcessBuilder("test-id").properties(Map.of("key", "value")).build();
+        var t = TestFunctions.createTransferProcessBuilder("test-id").privateProperties(Map.of("key", "value")).build();
         getTransferProcessStore().updateOrCreate(t);
 
         var all = getTransferProcessStore().findAll(QuerySpec.none()).collect(Collectors.toList());
@@ -83,7 +83,7 @@ public abstract class TransferProcessStoreTestBase {
 
         var callbacks = List.of(CallbackAddress.Builder.newInstance().uri("test").events(Set.of("event")).build());
 
-        var t = TestFunctions.createTransferProcessBuilder("test-id").properties(Map.of("key", "value")).callbackAddresses(callbacks).build();
+        var t = TestFunctions.createTransferProcessBuilder("test-id").privateProperties(Map.of("key", "value")).callbackAddresses(callbacks).build();
         getTransferProcessStore().updateOrCreate(t);
 
         var all = getTransferProcessStore().findAll(QuerySpec.none()).collect(Collectors.toList());

--- a/system-tests/e2e-transfer-test/control-plane/build.gradle.kts
+++ b/system-tests/e2e-transfer-test/control-plane/build.gradle.kts
@@ -33,6 +33,8 @@ dependencies {
 
     implementation(project(":extensions:control-plane:provision:provision-http"))
     implementation(project(":extensions:control-plane:transfer:transfer-pull-http-receiver"))
+    implementation(project(":extensions:control-plane:transfer:transfer-pull-http-dynamic-receiver"))
+
 }
 
 edcBuild {

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/AbstractEndToEndTransfer.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/AbstractEndToEndTransfer.java
@@ -62,7 +62,7 @@ public abstract class AbstractEndToEndTransfer {
         var policy = dataset.getJsonArray(ODRL_POLICY_ATTRIBUTE).get(0).asJsonObject();
 
         var contractAgreementId = CONSUMER.negotiateContract(PROVIDER, contractId.toString(), contractId.assetIdPart(), policy);
-        var transferProcessId = CONSUMER.initiateTransfer(contractAgreementId, assetId, PROVIDER, syncDataAddress());
+        var transferProcessId = CONSUMER.initiateTransferWithDynamicReceiver(contractAgreementId, assetId, PROVIDER, syncDataAddress());
 
         await().atMost(timeout).untilAsserted(() -> {
             var state = CONSUMER.getTransferProcessState(transferProcessId);
@@ -78,6 +78,11 @@ public abstract class AbstractEndToEndTransfer {
         // pull the data with additional query parameter
         var msg = UUID.randomUUID().toString();
         await().atMost(timeout).untilAsserted(() -> CONSUMER.pullData(edr, Map.of("message", msg), equalTo(msg)));
+
+        var edrList = CONSUMER.getAllDataReferences(transferProcessId);
+
+        assertThat(edrList).hasSize(2);
+
     }
 
     @Test


### PR DESCRIPTION
## What this PR changes/adds

Adds a new field `TransferProcessRequestDto#privateProperties` that will be stored in the `TransferProcess#properties` field

## Why it does that

Consistency

## Further notes

Also in this PR the `HttpDynamicEndpointDataReferenceReceiver` has been fixed

To make the change more consistent `TransferProcess#properties` has been renamed to `TransferProcess#privateProperties`

## Linked Issue(s)

Closes #3063 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md)._
