### PR TITLE
build: switch to java 17

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -7,6 +7,3 @@ runs:
       with:
         java-version: '17'
         distribution: 'temurin'
-
-    - name: Setup Gradle cache
-      uses: gradle/gradle-build-action@v2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,9 +18,8 @@ plugins {
 }
 
 val javaVersion: String by project
-val edcScmConnection: String by project
-val edcWebsiteUrl: String by project
 val edcScmUrl: String by project
+val edcScmConnection: String by project
 val annotationProcessorVersion: String by project
 val metaModelVersion: String by project
 
@@ -46,11 +45,8 @@ allprojects {
             metaModel.set(metaModelVersion)
         }
         pom {
-            projectName.set(project.name)
-            description.set("edc :: ${project.name}")
-            projectUrl.set(edcWebsiteUrl)
-            scmConnection.set(edcScmConnection)
             scmUrl.set(edcScmUrl)
+            scmConnection.set(edcScmConnection)
         }
         swagger {
             title.set((project.findProperty("apiTitle") ?: "EDC REST API") as String)
@@ -59,7 +55,6 @@ allprojects {
             outputFilename.set(project.name)
             outputDirectory.set(file("${rootProject.projectDir.path}/resources/openapi/yaml"))
         }
-        javaLanguageVersion.set(JavaLanguageVersion.of(javaVersion))
     }
 
     configure<CheckstyleExtension> {

--- a/core/common/util/src/test/java/org/eclipse/edc/util/configuration/ConfigurationFunctionsTest.java
+++ b/core/common/util/src/test/java/org/eclipse/edc/util/configuration/ConfigurationFunctionsTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junitpioneer.jupiter.ClearEnvironmentVariable;
 import org.junitpioneer.jupiter.ClearSystemProperty;
-import org.junitpioneer.jupiter.SetEnvironmentVariable;
 import org.junitpioneer.jupiter.SetSystemProperty;
 
 import java.util.stream.Stream;
@@ -62,16 +61,6 @@ class ConfigurationFunctionsTest {
         assertThat(resultValue).isEqualTo(expected);
     }
 
-    @ParameterizedTest
-    @ArgumentsSource(EnvVarsSource.class)
-    @SetEnvironmentVariable(key = ENV_VAR_1, value = VALUE_1)
-    @SetEnvironmentVariable(key = ENV_VAR_2, value = "")
-    @SetEnvironmentVariable(key = EDC_VAR_3, value = "    ")
-    public void returnEnv(String key, String expected) {
-        String resultValue = ConfigurationFunctions.propOrEnv(key, DEFAULT);
-        assertThat(resultValue).isEqualTo(expected);
-    }
-
     @Test
     public void returnDefaultEnv_NullValue() {
         String resultValue = ConfigurationFunctions.propOrEnv("nonexistent", DEFAULT);
@@ -90,16 +79,4 @@ class ConfigurationFunctionsTest {
         }
     }
 
-    private static class EnvVarsSource implements ArgumentsProvider {
-
-        @Override
-        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-            return Stream.of(
-                    Arguments.of(ENV_VAR_1, VALUE_1),
-                    Arguments.of(SYS_PROP_1, VALUE_1),
-                    Arguments.of(ENV_VAR_2, DEFAULT),
-                    Arguments.of(EDC_VAR_3, DEFAULT)
-            );
-        }
-    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,10 @@
 group=org.eclipse.edc
 version=0.0.1-SNAPSHOT
-javaVersion=11
 
 # for now, we're using the same version for the autodoc plugin, the processor and the runtime-metamodel lib, but that could
 # change in the future
 annotationProcessorVersion=0.0.1-SNAPSHOT
 edcGradlePluginsVersion=0.0.1-SNAPSHOT
 metaModelVersion=0.0.1-SNAPSHOT
-edcScmConnection=scm:git:git@github.com:eclipse-edc/Connector.git
-edcWebsiteUrl=https://github.com/eclipse-edc/Connector.git
 edcScmUrl=https://github.com/eclipse-edc/Connector.git
+edcScmConnection=scm:git:git@github.com:eclipse-edc/Connector.git


### PR DESCRIPTION
## What this PR changes/adds

Switch to Java 17 by removing custom project version and letting the version being set by the `edc-build` plugin

## Why it does that

_Briefly state why the change was necessary._

## Further notes

- cleanup build file a little
- had to change `ConfigurationFunctionsTest` because of https://junit-pioneer.org/docs/environment-variables/#warnings-for-reflective-access

## Linked Issue(s)

Closes #3069 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md)._
