### PR TITLE
fix(EndpointDataReferenceTransformerRegistry): adds transform call 

### DIFF
--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/TransferCoreExtension.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/TransferCoreExtension.java
@@ -159,12 +159,14 @@ public class TransferCoreExtension implements ServiceExtension {
         var iterationWaitMillis = context.getSetting(TRANSFER_STATE_MACHINE_ITERATION_WAIT_MILLIS, DEFAULT_ITERATION_WAIT);
         var waitStrategy = context.hasService(TransferWaitStrategy.class) ? context.getService(TransferWaitStrategy.class) : new ExponentialWaitStrategy(iterationWaitMillis);
 
-        var endpointDataReferenceReceiverRegistry = new EndpointDataReferenceReceiverRegistryImpl();
-        context.registerService(EndpointDataReferenceReceiverRegistry.class, endpointDataReferenceReceiverRegistry);
-
         // Register a default EndpointDataReferenceTransformer that can be overridden in extensions.
         var endpointDataReferenceTransformerRegistry = new EndpointDataReferenceTransformerRegistryImpl();
         context.registerService(EndpointDataReferenceTransformerRegistry.class, endpointDataReferenceTransformerRegistry);
+
+        var endpointDataReferenceReceiverRegistry = new EndpointDataReferenceReceiverRegistryImpl(endpointDataReferenceTransformerRegistry);
+        context.registerService(EndpointDataReferenceReceiverRegistry.class, endpointDataReferenceReceiverRegistry);
+
+
         // Integration with the new DSP protocol
         eventRouter.register(TransferProcessStarted.class, endpointDataReferenceReceiverRegistry);
 

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/edr/EndpointDataReferenceReceiverRegistryImpl.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/edr/EndpointDataReferenceReceiverRegistryImpl.java
@@ -64,7 +64,7 @@ public class EndpointDataReferenceReceiverRegistryImpl implements EndpointDataRe
             if (msg.getDataAddress() != null) {
                 var edr = EndpointDataAddressConstants.to(msg.getDataAddress())
                         .compose(transformerRegistry::transform)
-                        .orElseThrow(failure -> new EdcException(format("Failed to send EDR for transfer process :%s with error %s", msg.getTransferProcessId(), failure.getFailureDetail())));
+                        .orElseThrow(failure -> new EdcException(format("Failed to send EDR for transfer process %s with error %s", msg.getTransferProcessId(), failure.getFailureDetail())));
 
 
                 sendEdr(edr).join().orElseThrow(failure -> new EdcException(failure.getFailureDetail()));

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/edr/EndpointDataReferenceReceiverRegistryImpl.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/edr/EndpointDataReferenceReceiverRegistryImpl.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.transfer.edr;
 
 import org.eclipse.edc.connector.transfer.spi.edr.EndpointDataReferenceReceiver;
 import org.eclipse.edc.connector.transfer.spi.edr.EndpointDataReferenceReceiverRegistry;
+import org.eclipse.edc.connector.transfer.spi.edr.EndpointDataReferenceTransformerRegistry;
 import org.eclipse.edc.connector.transfer.spi.event.TransferProcessStarted;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.event.Event;
@@ -40,6 +41,12 @@ public class EndpointDataReferenceReceiverRegistryImpl implements EndpointDataRe
 
     private final List<EndpointDataReferenceReceiver> receivers = new ArrayList<>();
 
+    private final EndpointDataReferenceTransformerRegistry transformerRegistry;
+
+    public EndpointDataReferenceReceiverRegistryImpl(EndpointDataReferenceTransformerRegistry transformerRegistry) {
+        this.transformerRegistry = transformerRegistry;
+    }
+
     @Override
     public void registerReceiver(@NotNull EndpointDataReferenceReceiver receiver) {
         receivers.add(receiver);
@@ -56,8 +63,10 @@ public class EndpointDataReferenceReceiverRegistryImpl implements EndpointDataRe
             var msg = (TransferProcessStarted) event.getPayload();
             if (msg.getDataAddress() != null) {
                 var edr = EndpointDataAddressConstants.to(msg.getDataAddress())
+                        .compose(transformerRegistry::transform)
                         .orElseThrow(failure -> new EdcException(format("Failed to send EDR for transfer process :%s with error %s", msg.getTransferProcessId(), failure.getFailureDetail())));
-                
+
+
                 sendEdr(edr).join().orElseThrow(failure -> new EdcException(failure.getFailureDetail()));
             }
         }

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/edr/EndpointDataReferenceReceiverRegistryImplTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/edr/EndpointDataReferenceReceiverRegistryImplTest.java
@@ -41,6 +41,7 @@ import static org.mockito.Mockito.when;
 class EndpointDataReferenceReceiverRegistryImplTest {
 
 
+    private final EndpointDataReferenceTransformerRegistryImpl transformerRegistry = new EndpointDataReferenceTransformerRegistryImpl();
     private EndpointDataReferenceReceiver receiver1;
     private EndpointDataReferenceReceiver receiver2;
     private EndpointDataReferenceReceiverRegistryImpl registry;
@@ -49,7 +50,7 @@ class EndpointDataReferenceReceiverRegistryImplTest {
     public void setUp() {
         receiver1 = mock(EndpointDataReferenceReceiver.class);
         receiver2 = mock(EndpointDataReferenceReceiver.class);
-        registry = new EndpointDataReferenceReceiverRegistryImpl();
+        registry = new EndpointDataReferenceReceiverRegistryImpl(transformerRegistry);
 
     }
 
@@ -175,7 +176,7 @@ class EndpointDataReferenceReceiverRegistryImplTest {
 
         verify(receiver1, times(1)).send(any());
         verify(receiver2, times(1)).send(any());
-        
+
     }
 
     private TransferProcessStarted startedEvent(EndpointDataReference edr) {

--- a/extensions/control-plane/transfer/transfer-data-plane/src/main/java/org/eclipse/edc/connector/transfer/dataplane/proxy/ConsumerPullTransferEndpointDataReferenceServiceImpl.java
+++ b/extensions/control-plane/transfer/transfer-data-plane/src/main/java/org/eclipse/edc/connector/transfer/dataplane/proxy/ConsumerPullTransferEndpointDataReferenceServiceImpl.java
@@ -28,7 +28,7 @@ import java.time.Clock;
 import java.util.Date;
 import java.util.HashMap;
 
-import static org.eclipse.edc.connector.transfer.dataplane.spi.TransferDataPlaneConstants.CONTRACT_ID;
+import static org.eclipse.edc.connector.transfer.dataplane.spi.TransferDataPlaneConstants.EDC_CONTRACT_ID;
 
 public class ConsumerPullTransferEndpointDataReferenceServiceImpl implements ConsumerPullTransferEndpointDataReferenceService {
 
@@ -60,7 +60,7 @@ public class ConsumerPullTransferEndpointDataReferenceServiceImpl implements Con
         }
 
         var props = new HashMap<>(request.getProperties());
-        props.put(CONTRACT_ID, request.getContractId());
+        props.put(EDC_CONTRACT_ID, request.getContractId());
 
         var builder = EndpointDataReference.Builder.newInstance()
                 .id(request.getId())

--- a/extensions/control-plane/transfer/transfer-data-plane/src/main/java/org/eclipse/edc/connector/transfer/dataplane/proxy/ConsumerPullTransferProxyTransformer.java
+++ b/extensions/control-plane/transfer/transfer-data-plane/src/main/java/org/eclipse/edc/connector/transfer/dataplane/proxy/ConsumerPullTransferProxyTransformer.java
@@ -24,7 +24,7 @@ import org.eclipse.edc.spi.types.domain.edr.EndpointDataReference;
 import org.jetbrains.annotations.NotNull;
 
 import static java.lang.String.format;
-import static org.eclipse.edc.connector.transfer.dataplane.spi.TransferDataPlaneConstants.CONTRACT_ID;
+import static org.eclipse.edc.connector.transfer.dataplane.spi.TransferDataPlaneConstants.EDC_CONTRACT_ID;
 
 /**
  * Transforms {@link EndpointDataReference} returned by the provider Control Plane so that
@@ -42,6 +42,18 @@ public class ConsumerPullTransferProxyTransformer implements EndpointDataReferen
         this.proxyReferenceCreator = proxyCreator;
     }
 
+    private static DataAddress toHttpDataAddress(EndpointDataReference edr) {
+        return HttpDataAddress.Builder.newInstance()
+                .baseUrl(edr.getEndpoint())
+                .authKey(edr.getAuthKey())
+                .authCode(edr.getAuthCode())
+                .proxyBody(Boolean.TRUE.toString())
+                .proxyPath(Boolean.TRUE.toString())
+                .proxyMethod(Boolean.TRUE.toString())
+                .proxyQueryParams(Boolean.TRUE.toString())
+                .build();
+    }
+
     @Override
     public boolean canHandle(@NotNull EndpointDataReference edr) {
         return true;
@@ -56,7 +68,7 @@ public class ConsumerPullTransferProxyTransformer implements EndpointDataReferen
     @Override
     public Result<EndpointDataReference> transform(@NotNull EndpointDataReference edr) {
         var address = toHttpDataAddress(edr);
-        var contractId = edr.getProperties().get(CONTRACT_ID);
+        var contractId = edr.getProperties().get(EDC_CONTRACT_ID);
         if (contractId == null) {
             return Result.failure(format("Cannot transform endpoint data reference with id %s as contract id is missing", edr.getId()));
         }
@@ -73,17 +85,5 @@ public class ConsumerPullTransferProxyTransformer implements EndpointDataReferen
                 .contractId(contractId);
         edr.getProperties().forEach(builder::property);
         return proxyReferenceCreator.createProxyReference(builder.build());
-    }
-
-    private static DataAddress toHttpDataAddress(EndpointDataReference edr) {
-        return HttpDataAddress.Builder.newInstance()
-                .baseUrl(edr.getEndpoint())
-                .authKey(edr.getAuthKey())
-                .authCode(edr.getAuthCode())
-                .proxyBody(Boolean.TRUE.toString())
-                .proxyPath(Boolean.TRUE.toString())
-                .proxyMethod(Boolean.TRUE.toString())
-                .proxyQueryParams(Boolean.TRUE.toString())
-                .build();
     }
 }

--- a/extensions/control-plane/transfer/transfer-data-plane/src/test/java/org/eclipse/edc/connector/transfer/dataplane/proxy/ConsumerPullTransferEndpointDataReferenceServiceImplTest.java
+++ b/extensions/control-plane/transfer/transfer-data-plane/src/test/java/org/eclipse/edc/connector/transfer/dataplane/proxy/ConsumerPullTransferEndpointDataReferenceServiceImplTest.java
@@ -38,6 +38,7 @@ import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.transfer.dataplane.spi.TransferDataPlaneConstants.CONTRACT_ID;
 import static org.eclipse.edc.connector.transfer.dataplane.spi.TransferDataPlaneConstants.DATA_ADDRESS;
+import static org.eclipse.edc.connector.transfer.dataplane.spi.TransferDataPlaneConstants.EDC_CONTRACT_ID;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.EXPIRATION_TIME;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -110,7 +111,7 @@ class ConsumerPullTransferEndpointDataReferenceServiceImplTest {
         assertThat(edr.getAuthKey()).isEqualTo(HttpHeaders.AUTHORIZATION);
         assertThat(edr.getAuthCode()).isEqualTo(generatedToken.getToken());
         var expectedProperties = new HashMap<>(proxyCreationRequest.getProperties());
-        expectedProperties.put(CONTRACT_ID, contractId);
+        expectedProperties.put(EDC_CONTRACT_ID, contractId);
         assertThat(edr.getProperties()).containsExactlyInAnyOrderEntriesOf(expectedProperties);
     }
 

--- a/extensions/control-plane/transfer/transfer-data-plane/src/test/java/org/eclipse/edc/connector/transfer/dataplane/proxy/ConsumerPullTransferProxyTransformerTest.java
+++ b/extensions/control-plane/transfer/transfer-data-plane/src/test/java/org/eclipse/edc/connector/transfer/dataplane/proxy/ConsumerPullTransferProxyTransformerTest.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.connector.transfer.dataplane.spi.TransferDataPlaneConstants.CONTRACT_ID;
+import static org.eclipse.edc.connector.transfer.dataplane.spi.TransferDataPlaneConstants.EDC_CONTRACT_ID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -50,7 +50,7 @@ class ConsumerPullTransferProxyTransformerTest {
                 .id(UUID.randomUUID().toString())
                 .properties(Map.of(
                         "key1", "value1",
-                        CONTRACT_ID, UUID.randomUUID().toString())
+                        EDC_CONTRACT_ID, UUID.randomUUID().toString())
                 )
                 .build();
     }
@@ -84,7 +84,7 @@ class ConsumerPullTransferProxyTransformerTest {
 
         var proxyCreationRequest = proxyCreationRequestCapture.getValue();
         assertThat(proxyCreationRequest.getId()).isEqualTo(inputEdr.getId());
-        assertThat(proxyCreationRequest.getContractId()).isEqualTo(inputEdr.getProperties().get(CONTRACT_ID));
+        assertThat(proxyCreationRequest.getContractId()).isEqualTo(inputEdr.getProperties().get(EDC_CONTRACT_ID));
         assertThat(proxyCreationRequest.getProxyEndpoint()).isEqualTo(proxyUrl);
         assertThat(proxyCreationRequest.getProperties()).containsExactlyInAnyOrderEntriesOf(inputEdr.getProperties());
         assertThat(proxyCreationRequest.getContentAddress()).satisfies(address -> {

--- a/spi/control-plane/transfer-data-plane-spi/src/main/java/org/eclipse/edc/connector/transfer/dataplane/spi/TransferDataPlaneConstants.java
+++ b/spi/control-plane/transfer-data-plane-spi/src/main/java/org/eclipse/edc/connector/transfer/dataplane/spi/TransferDataPlaneConstants.java
@@ -16,6 +16,8 @@ package org.eclipse.edc.connector.transfer.dataplane.spi;
 
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
 
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
+
 /**
  * Type of Data Plane transfer.
  */
@@ -35,4 +37,9 @@ public interface TransferDataPlaneConstants {
      * Claim of the token used in input of Data Plane public API containing the contract id.
      */
     String CONTRACT_ID = "cid";
+
+    /**
+     * Claim of the token used in input of Data Plane public API containing the contract id with namespace.
+     */
+    String EDC_CONTRACT_ID = EDC_NAMESPACE + "cid";
 }


### PR DESCRIPTION

## What this PR changes/adds

Adds `EndpointDataReferenceTransformerRegistry#transform` call upon receiving the `TransferProcessStarted` 

## Why it does that

backward compatibility

## Linked Issue(s)

Closes #3079 

