### PR TITLE
fix: Align behavior of getProperty and hasProperty in DataAddress

### DIFF
--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/DataAddress.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/DataAddress.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -60,16 +61,17 @@ public class DataAddress {
         properties.put(TYPE, type);
     }
 
+    @Nullable
     public String getProperty(String key) {
         return getProperty(key, null);
     }
 
+    @Nullable
     public String getProperty(String key, String defaultValue) {
         var value = Optional.ofNullable(properties.get(EDC_NAMESPACE + key)).orElseGet(() -> properties.get(key));
         if (value != null) {
             return value;
         }
-
         return defaultValue;
     }
 
@@ -95,7 +97,7 @@ public class DataAddress {
      */
     @JsonIgnore
     public boolean hasProperty(String key) {
-        return properties.containsKey(key);
+        return getProperty(key) != null;
     }
 
     @JsonPOJOBuilder(withPrefix = "")


### PR DESCRIPTION
## What this PR changes/adds

Align behavior of `getProperty` and `hasProperty` methods in `DataAddress` (handling of the `EDC_NAMESPACE` prefix).

## Why it does that

`hasProperty` is not checking if property existing with the `EDC_NAMESPACE` prefix while `getProperty` does. This leads to inconsistent behaviors, for example in `Oauth2HttpRequestParamsDecorator`.
