### PR TITLE
build: add workflow to bump the snapshot version

### DIFF
--- a/.github/actions/bump-version/action.yml
+++ b/.github/actions/bump-version/action.yml
@@ -1,0 +1,42 @@
+name: "Bump version in gradle.properties"
+description: "Increments the patch version of the version found in gradle.properties, appends -SNAPSHOT"
+inputs:
+  target_branch:
+    default: 'main'
+    description: "Branch on which the version bump is to be done."
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v3
+    - name: read version from gradle.properties
+      shell: bash
+      run: |
+        # Prepare git env
+        git config user.name "eclipse-edc-bot"
+        git config user.email "edc-bot@eclipse.org"
+
+        # checkout target
+        git fetch origin
+        git checkout ${{ inputs.target_branch }}
+
+        # determine current version
+        oldVersion=$(grep "version" gradle.properties  | awk -F= '{print $2}')
+
+        # read the major, minor, and patch components, consume -SNAPSHOT
+        IFS=.- read -r RELEASE_VERSION_MAJOR RELEASE_VERSION_MINOR RELEASE_VERSION_PATCH SNAPSHOT<<<"$oldVersion"
+
+        # construct the new version
+        newVersion="$RELEASE_VERSION_MAJOR.$RELEASE_VERSION_MINOR.$((RELEASE_VERSION_PATCH+1))"-SNAPSHOT
+
+        # replace every occurrence of =$oldVersion with =$newVersion
+        sed -i "s/=${oldVersion}/=${newVersion}/g" gradle.properties
+
+        echo "Bumped the version from $oldVersion to $newVersion"
+
+        # Commit and push to the desired branch, defaults to 'main'
+        git add gradle.properties
+        git commit --message "Bump version from $oldVersion to $newVersion [skip ci]"
+
+        git push origin ${{ inputs.target_branch }}

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -1,0 +1,23 @@
+---
+name: "Bump version (manually)"
+
+on:
+  # can be called manually from GH webpage
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        default: 'main'
+        description: "Branch on which the version bump is to be done."
+        required: false
+
+
+jobs:
+  Bump-Version:
+    name: 'Update snapshot version'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/bump-version
+        name: Bump version
+        with:
+          target_branch: ${{ inputs.target_branch }}

--- a/.github/workflows/release-edc.yml
+++ b/.github/workflows/release-edc.yml
@@ -43,7 +43,7 @@ jobs:
 
   Github-Release:
     # cannot use the workflow-level env yet as it does not yet exist, must take output from previous job
-    if:  ${{ !endsWith( needs.Prepare-Release.outputs.edc-version, '-SNAPSHOT') }}
+    if: ${{ !endsWith( needs.Prepare-Release.outputs.edc-version, '-SNAPSHOT') }}
     needs:
       - Prepare-Release
     runs-on: ubuntu-latest
@@ -60,3 +60,16 @@ jobs:
           tag: "v${{ env.EDC_VERSION }}"
           token: ${{ secrets.GITHUB_TOKEN }}
           removeArtifacts: true
+
+  Bump-Version:
+    name: 'Update release version'
+    # cannot use the workflow-level env yet as it does not yet exist, must take output from previous job
+    if: ${{ !endsWith( needs.Prepare-Release.outputs.edc-version, '-SNAPSHOT') }}
+    needs:
+      - Prepare-Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/bump-version
+        with:
+          target_branch: "main"


### PR DESCRIPTION
## What this PR changes/adds

Creates a workflow, that  bumps the (patch) version found in gradle.properties and commits it back into git.

## Why it does that

Preliminary work needed for #3084

## Further notes

The commit is made "as" the `eclipse-edc-bot` to avoid potential ECA check failures

## Linked Issue(s)

Contributes #3084

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md)._
