### PR TITLE
docs: Added missing Google Cloud Storage extension in extensions/README.md #3085

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -79,6 +79,7 @@
     - [API](data-plane/data-plane-api/)
     - [Azure Storage](data-plane/data-plane-azure-storage/)
     - [Data Factory](data-plane/data-plane-azure-data-factory/)
+    - [Google Cloud Storage](data-plane/data-plane-google-storage/)
     - [HTTP](data-plane/data-plane-http/)
     - [S3](data-plane/data-plane-aws-s3/)
     - [Tests](data-plane/data-plane-integration-tests/)


### PR DESCRIPTION
https://github.com/eclipse-edc/Connector/issues/3085

## What this PR changes/adds

The documentation was missing the Google Cloud Storage extension in the data pane section. This PR adds the missing extension.

## Why it does that
NA

## Further notes

NA

## Linked Issue(s)
https://github.com/eclipse-edc/Connector/issues/3085

Closes 1

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md)._
