### PR TITLE
chore: improve version bump job

### DIFF
--- a/.github/actions/bump-version/action.yml
+++ b/.github/actions/bump-version/action.yml
@@ -31,12 +31,12 @@ runs:
         newVersion="$RELEASE_VERSION_MAJOR.$RELEASE_VERSION_MINOR.$((RELEASE_VERSION_PATCH+1))"-SNAPSHOT
 
         # replace every occurrence of =$oldVersion with =$newVersion
-        sed -i "s/=${oldVersion}/=${newVersion}/g" gradle.properties
+        grep -rlz "$oldVersion" . --exclude=\*.{sh,bin} | xargs sed -i 's/$oldVersion/$newVersion/g'
 
         echo "Bumped the version from $oldVersion to $newVersion"
 
         # Commit and push to the desired branch, defaults to 'main'
-        git add gradle.properties
+        git add .
         git commit --message "Bump version from $oldVersion to $newVersion [skip ci]"
 
         git push origin ${{ inputs.target_branch }}

--- a/.github/workflows/release-edc.yml
+++ b/.github/workflows/release-edc.yml
@@ -65,8 +65,7 @@ jobs:
     name: 'Update release version'
     # cannot use the workflow-level env yet as it does not yet exist, must take output from previous job
     if: ${{ !endsWith( needs.Prepare-Release.outputs.edc-version, '-SNAPSHOT') }}
-    needs:
-      - Prepare-Release
+    needs: [ Prepare-Release, Github-Release ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/docs/developer/releases.md
+++ b/docs/developer/releases.md
@@ -93,7 +93,7 @@ execute the standard *dependencies* task:
 - First, the dependencies of this module are calculated with gradle and passed to the Dash tool:
 
 ```
-gradle dependencies | grep -Poh "(?<=\s)[\w.-]+:[\w.-]+:[^:\s]+" | sort | uniq | java -jar /path/org.eclipse.dash.licenses-0.0.1-SNAPSHOT.jar - -summary NOTICES
+gradle dependencies | grep -Poh "(?<=\s)[\w.-]+:[\w.-]+:[^:\s]+" | sort | uniq | java -jar /path/org.eclipse.dash.licenses-<VERSION>.jar - -summary NOTICES
 ```
 
 - Second, the resulting report is used as input for the shell script:


### PR DESCRIPTION
## What this PR changes/adds

This PR improves the version-bump action slightly, in that it recursively greps for the OLDVERSION in all files, and replaces it with the NEWVERSION using sed.

## Why it does that

more consistent version

## Further notes

I adapted the `releases.md` document so that it doesn't get picked up by that job 

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md)._
