### PR TITLE
chore(SqlTransferProcessStore): renames transfer_properties column to private_properties

### DIFF
--- a/extensions/control-plane/store/sql/transfer-process-store-sql/docs/schema.sql
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/docs/schema.sql
@@ -31,7 +31,7 @@ CREATE TABLE IF NOT EXISTS edc_transfer_process
     provisioned_resource_set   JSON,
     content_data_address       JSON,
     deprovisioned_resources    JSON,
-    transferprocess_properties JSON,
+    private_properties JSON,
     callback_addresses         JSON,
     lease_id                   VARCHAR
         CONSTRAINT transfer_process_lease_lease_id_fk

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/SqlTransferProcessStore.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/SqlTransferProcessStore.java
@@ -302,7 +302,7 @@ public class SqlTransferProcessStore extends AbstractSqlStore implements Transfe
                 }))
                 .callbackAddresses(fromJson(resultSet.getString(statements.getCallbackAddressesColumn()), new TypeReference<>() {
                 }))
-                .privateProperties(fromJson(resultSet.getString(statements.getPropertiesColumn()), getTypeRef()))
+                .privateProperties(fromJson(resultSet.getString(statements.getPrivatePropertiesColumn()), getTypeRef()))
                 .build();
     }
 

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/BaseSqlDialectStatements.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/BaseSqlDialectStatements.java
@@ -57,7 +57,7 @@ public abstract class BaseSqlDialectStatements implements TransferProcessStoreSt
                 getCreatedAtColumn(), getUpdatedAtColumn(),
                 getTraceContextColumn(), getErrorDetailColumn(), getResourceManifestColumn(),
                 getProvisionedResourcesetColumn(), getContentDataAddressColumn(), getTypeColumn(), getDeprovisionedResourcesColumn(),
-                getPropertiesColumn(), getCallbackAddressesColumn(),
+                getPrivatePropertiesColumn(), getCallbackAddressesColumn(),
                 // values
                 getFormatAsJsonOperator(), getFormatAsJsonOperator(), getFormatAsJsonOperator(), getFormatAsJsonOperator(),
                 getFormatAsJsonOperator(), getFormatAsJsonOperator(), getFormatAsJsonOperator());

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/TransferProcessStoreStatements.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/TransferProcessStoreStatements.java
@@ -116,8 +116,8 @@ public interface TransferProcessStoreStatements extends LeaseStatements {
         return "process_id";
     }
 
-    default String getPropertiesColumn() {
-        return "transferprocess_properties";
+    default String getPrivatePropertiesColumn() {
+        return "private_properties";
     }
 
     default String getDataRequestPropertiesColumn() {
@@ -151,7 +151,7 @@ public interface TransferProcessStoreStatements extends LeaseStatements {
     default String getCallbackAddressesColumn() {
         return "callback_addresses";
     }
-    
+
     default String getFormatAsJsonOperator() {
         return BaseSqlDialect.getJsonCastOperator();
     }

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/postgres/TransferProcessMapping.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/postgres/TransferProcessMapping.java
@@ -39,7 +39,7 @@ public class TransferProcessMapping extends TranslationMapping {
     private static final String FIELD_PROVISIONED_RESOURCE_SET = "provisionedResourceSet";
     private static final String FIELD_DEPROVISIONED_RESOURCES = "deprovisionedResources";
 
-    private static final String FIELD_PROPERTIES = "properties";
+    private static final String FIELD_PRIVATE_PROPERTIES = "privateProperties";
 
 
     public TransferProcessMapping(TransferProcessStoreStatements statements) {
@@ -53,7 +53,7 @@ public class TransferProcessMapping extends TranslationMapping {
         add(FIELD_DATAADDRESS, new JsonFieldMapping(statements.getContentDataAddressColumn()));
         add(FIELD_CONTENTDATAADDRESS, new JsonFieldMapping(statements.getContentDataAddressColumn()));
         add(FIELD_RESOURCE_MANIFEST, new ResourceManifestMapping());
-        add(FIELD_PROPERTIES, new JsonFieldMapping(statements.getPropertiesColumn()));
+        add(FIELD_PRIVATE_PROPERTIES, new JsonFieldMapping(statements.getPrivatePropertiesColumn()));
         add(FIELD_PROVISIONED_RESOURCE_SET, new ProvisionedResourceSetMapping());
         // using the alias instead of the actual column name to avoid name clashes.
         add(FIELD_DEPROVISIONED_RESOURCES, new JsonFieldMapping(PostgresDialectStatements.DEPROVISIONED_RESOURCES_ALIAS));


### PR DESCRIPTION
 ## What this PR changes/adds

Renames transfer_properties column to private_properties

## Why it does that

Consistency after #3063

## Linked Issue(s)

Closes #3093 
