### PR TITLE
fix: Add missing `participantId` in Catalog response

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/ControlPlaneServicesExtension.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/ControlPlaneServicesExtension.java
@@ -62,6 +62,7 @@ import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.telemetry.Telemetry;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 
@@ -149,8 +150,8 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     }
 
     @Provider
-    public CatalogProtocolService catalogProtocolService() {
-        return new CatalogProtocolServiceImpl(datasetResolver, participantAgentService, dataServiceRegistry);
+    public CatalogProtocolService catalogProtocolService(ServiceExtensionContext context) {
+        return new CatalogProtocolServiceImpl(datasetResolver, participantAgentService, dataServiceRegistry, context.getParticipantId());
     }
 
     @Provider

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/catalog/CatalogProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/catalog/CatalogProtocolServiceImpl.java
@@ -25,19 +25,24 @@ import org.eclipse.edc.spi.iam.ClaimToken;
 import org.jetbrains.annotations.NotNull;
 
 import static java.util.stream.Collectors.toList;
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 
 public class CatalogProtocolServiceImpl implements CatalogProtocolService {
+
+    private static final String PARTICIPANT_ID_PROPERTY_KEY = "participantId";
 
     private final DatasetResolver datasetResolver;
     private final ParticipantAgentService participantAgentService;
     private final DataServiceRegistry dataServiceRegistry;
+    private final String participantId;
 
     public CatalogProtocolServiceImpl(DatasetResolver datasetResolver,
                                       ParticipantAgentService participantAgentService,
-                                      DataServiceRegistry dataServiceRegistry) {
+                                      DataServiceRegistry dataServiceRegistry, String participantId) {
         this.datasetResolver = datasetResolver;
         this.participantAgentService = participantAgentService;
         this.dataServiceRegistry = dataServiceRegistry;
+        this.participantId = participantId;
     }
 
     @Override
@@ -51,6 +56,7 @@ public class CatalogProtocolServiceImpl implements CatalogProtocolService {
             var catalog = Catalog.Builder.newInstance()
                     .dataServices(dataServices)
                     .datasets(datasets.collect(toList()))
+                    .property(EDC_NAMESPACE + PARTICIPANT_ID_PROPERTY_KEY, participantId)
                     .build();
 
             return ServiceResult.success(catalog);

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/catalog/CatalogProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/catalog/CatalogProtocolServiceImplTest.java
@@ -46,7 +46,7 @@ class CatalogProtocolServiceImplTest {
     private final ParticipantAgentService participantAgentService = mock(ParticipantAgentService.class);
     private final DataServiceRegistry dataServiceRegistry = mock(DataServiceRegistry.class);
 
-    private final CatalogProtocolServiceImpl service = new CatalogProtocolServiceImpl(datasetResolver, participantAgentService, dataServiceRegistry);
+    private final CatalogProtocolServiceImpl service = new CatalogProtocolServiceImpl(datasetResolver, participantAgentService, dataServiceRegistry, "participantId");
 
     @Test
     void getCatalog_shouldReturnCatalogWithConnectorDataServiceAndItsDataset() {


### PR DESCRIPTION
## What this PR changes/adds

Add `participantId` in Catalog response.

## Why it does that

`participantId` is required by the consumer in order to initiate the contract negotiation with the provider.
