### PR TITLE
refactor: purge ids-multipart occurrences

### DIFF
--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -200,18 +200,12 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
     }
 
     /**
-     * Processes {@link ContractNegotiation} in state AGREED. For the deprecated ids-protocol, it's transitioned
-     * to FINALIZED, otherwise to VERIFYING to make the verification process start.
+     * Processes {@link ContractNegotiation} in state AGREED. It transitions to VERIFYING to make the verification process start.
      *
      * @return true if processed, false otherwise
      */
     @WithSpan
     private boolean processAgreed(ContractNegotiation negotiation) {
-        if ("ids-multipart".equals(negotiation.getProtocol())) {
-            transitionToFinalized(negotiation);
-            return true;
-        }
-
         transitionToVerifying(negotiation);
         return true;
     }

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -215,8 +215,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
     }
 
     /**
-     * Processes {@link ContractNegotiation} in state AGREED. For the deprecated ids-protocol, it's transitioned
-     * to FINALIZED, otherwise to VERIFYING to make the verification process start.
+     * Processes {@link ContractNegotiation} in state VERIFIED. It transitions to FINALIZING to make the finalization process start.
      *
      * @return true if processed, false otherwise
      */

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
@@ -61,7 +61,6 @@ import static org.awaitility.Awaitility.await;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.ACCEPTED;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.ACCEPTING;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.AGREED;
-import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.FINALIZED;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.INITIAL;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.REQUESTED;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.REQUESTING;
@@ -209,21 +208,6 @@ class ConsumerContractNegotiationManagerImplTest {
 
         await().untilAsserted(() -> {
             verify(store).save(argThat(p -> p.getState() == VERIFYING.code()));
-            verifyNoInteractions(dispatcherRegistry);
-        });
-    }
-
-    @Deprecated(since = "milestone9")
-    @Test
-    void agreed_shouldTransitionToFinalized_whenProtocolIsIdsMultipart() {
-        var negotiation = contractNegotiationBuilder().state(AGREED.code()).protocol("ids-multipart").build();
-        when(store.nextNotLeased(anyInt(), stateIs(AGREED.code()))).thenReturn(List.of(negotiation)).thenReturn(emptyList());
-        when(store.findById(negotiation.getId())).thenReturn(negotiation);
-
-        negotiationManager.start();
-
-        await().untilAsserted(() -> {
-            verify(store).save(argThat(p -> p.getState() == FINALIZED.code()));
             verifyNoInteractions(dispatcherRegistry);
         });
     }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/catalog/CatalogServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/catalog/CatalogServiceImpl.java
@@ -15,7 +15,6 @@
 
 package org.eclipse.edc.connector.service.catalog;
 
-import org.eclipse.edc.catalog.spi.Catalog;
 import org.eclipse.edc.catalog.spi.CatalogRequestMessage;
 import org.eclipse.edc.connector.spi.catalog.CatalogService;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
@@ -29,18 +28,6 @@ public class CatalogServiceImpl implements CatalogService {
 
     public CatalogServiceImpl(RemoteMessageDispatcherRegistry dispatcher) {
         this.dispatcher = dispatcher;
-    }
-
-    @Override
-    public CompletableFuture<Catalog> getByProviderUrl(String providerUrl, QuerySpec spec) {
-        var request = CatalogRequestMessage.Builder.newInstance()
-                .protocol("ids-multipart")
-                .connectorId(providerUrl)
-                .counterPartyAddress(providerUrl)
-                .querySpec(spec)
-                .build();
-
-        return dispatcher.send(Catalog.class, request);
     }
 
     @Override

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/catalog/CatalogServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/catalog/CatalogServiceImplTest.java
@@ -14,17 +14,11 @@
 
 package org.eclipse.edc.connector.service.catalog;
 
-import org.assertj.core.api.InstanceOfAssertFactories;
-import org.eclipse.edc.catalog.spi.Catalog;
 import org.eclipse.edc.catalog.spi.CatalogRequestMessage;
-import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
-import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.connector.spi.catalog.CatalogService;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
-import java.util.UUID;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -33,31 +27,13 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class CatalogServiceImplTest {
 
     private final RemoteMessageDispatcherRegistry dispatcher = mock(RemoteMessageDispatcherRegistry.class);
-    private final CatalogServiceImpl service = new CatalogServiceImpl(dispatcher);
-
-    @Test
-    void getByProviderId_shouldSendCatalogRequestToDispatcher() {
-        var contractOffer = ContractOffer.Builder.newInstance()
-                .id(UUID.randomUUID().toString())
-                .policy(Policy.Builder.newInstance().build())
-                .assetId(UUID.randomUUID().toString())
-                .build();
-        var catalog = Catalog.Builder.newInstance().id("id").contractOffers(List.of(contractOffer)).build();
-        when(dispatcher.send(any(), any())).thenReturn(completedFuture(catalog))
-                .thenReturn(completedFuture(Catalog.Builder.newInstance().id("id2").contractOffers(List.of()).build()));
-
-        var future = service.getByProviderUrl("test.provider.url", new QuerySpec());
-
-        assertThat(future).succeedsWithin(1, SECONDS).extracting(Catalog::getContractOffers, InstanceOfAssertFactories.list(ContractOffer.class)).hasSize(1);
-        verify(dispatcher, times(1)).send(eq(Catalog.class), isA(CatalogRequestMessage.class));
-    }
+    private final CatalogService service = new CatalogServiceImpl(dispatcher);
 
     @Test
     void request_shouldDispatchRequestAndReturnResult() {

--- a/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/contractnegotiation/InMemoryContractNegotiationStoreTest.java
+++ b/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/contractnegotiation/InMemoryContractNegotiationStoreTest.java
@@ -369,7 +369,7 @@ class InMemoryContractNegotiationStoreTest extends ContractNegotiationStoreTestB
                 .state(ContractNegotiationStates.REQUESTED.code())
                 .counterPartyAddress("consumer")
                 .counterPartyId("consumerId")
-                .protocol("ids-multipart")
+                .protocol("protocol")
                 .build();
 
         store.save(negotiation);

--- a/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/contractnegotiation/TestFunctions.java
+++ b/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/contractnegotiation/TestFunctions.java
@@ -42,7 +42,7 @@ public class TestFunctions {
                         .build()))
                 .counterPartyAddress("consumer")
                 .counterPartyId("consumerId")
-                .protocol("ids-multipart")
+                .protocol("protocol")
                 .correlationId("correlationId");
     }
 

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/transfer/TransferProcessManagerImplTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/transfer/TransferProcessManagerImplTest.java
@@ -965,7 +965,7 @@ class TransferProcessManagerImplTest {
         var processId = UUID.randomUUID().toString();
         var dataRequest = createDataRequestBuilder()
                 .processId(processId)
-                .protocol("ids-protocol")
+                .protocol("protocol")
                 .connectorAddress("http://an/address")
                 .managedResources(managed)
                 .build();

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/model/ContractNegotiationDto.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/model/ContractNegotiationDto.java
@@ -42,7 +42,7 @@ public class ContractNegotiationDto extends MutableDto {
     private String counterPartyAddress;
     private String errorDetail;
 
-    private String protocol = "ids-multipart";
+    private String protocol;
     private String state;
     private Type type = Type.CONSUMER;
 

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/model/NegotiationInitiateRequestDto.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/model/NegotiationInitiateRequestDto.java
@@ -40,7 +40,7 @@ public class NegotiationInitiateRequestDto extends BaseDto {
     @NotBlank(message = "connectorAddress is mandatory")
     private String connectorAddress; // TODO change to callbackAddress
     @NotBlank(message = "protocol is mandatory")
-    private String protocol = "ids-multipart";
+    private String protocol;
     @NotBlank(message = "connectorId is mandatory")
     private String connectorId;
     @NotNull(message = "offer cannot be null")

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/model/NegotiationInitiateRequestDtoValidationTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/model/NegotiationInitiateRequestDtoValidationTest.java
@@ -81,10 +81,10 @@ class NegotiationInitiateRequestDtoValidationTest {
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
             return Stream.of(
-                    Arguments.of("", "ids-multipart", "connector-id", validOffer()),
+                    Arguments.of("", "protocol", "connector-id", validOffer()),
                     Arguments.of("https://connector.com", "", "connector-id", validOffer()),
-                    Arguments.of("https://connector.com", "ids-multipart", "connector-id", null),
-                    Arguments.of("https://connector.com", "ids-multipart", "", validOffer())
+                    Arguments.of("https://connector.com", "protocol", "connector-id", null),
+                    Arguments.of("https://connector.com", "protocol", "", validOffer())
             );
         }
     }

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/model/TransferRequestDto.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/model/TransferRequestDto.java
@@ -57,7 +57,7 @@ public class TransferRequestDto {
     private Map<String, String> privateProperties = new HashMap<>();
 
     @NotNull(message = "protocol cannot be null")
-    private String protocol = "ids-multipart";
+    private String protocol;
     @NotNull(message = "connectorId cannot be null")
     private String connectorId;
     @NotNull(message = "assetId cannot be null")

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/api/management/transferprocess/model/TransferRequestDtoValidationTest.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/api/management/transferprocess/model/TransferRequestDtoValidationTest.java
@@ -63,12 +63,12 @@ class TransferRequestDtoValidationTest {
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
             return Stream.of(
-                    Arguments.of("id", null, "contractId", destination(), "ids-multipart", "connectorId", "assetId"),
-                    Arguments.of("id", "connectorAddress", null, destination(), "ids-multipart", "connectorId", "assetId"),
-                    Arguments.of("id", "connectorAddress", "contractId", null, "ids-multipart", "connectorId", "assetId"),
+                    Arguments.of("id", null, "contractId", destination(), "protocol", "connectorId", "assetId"),
+                    Arguments.of("id", "connectorAddress", null, destination(), "protocol", "connectorId", "assetId"),
+                    Arguments.of("id", "connectorAddress", "contractId", null, "protocol", "connectorId", "assetId"),
                     Arguments.of("id", "connectorAddress", "contractId", destination(), null, "connectorId", "assetId"),
-                    Arguments.of("id", "connectorAddress", "contractId", destination(), "ids-multipart", null, "assetId"),
-                    Arguments.of("id", "connectorAddress", "contractId", destination(), "ids-multipart", "connectorId", null)
+                    Arguments.of("id", "connectorAddress", "contractId", destination(), "protocol", null, "assetId"),
+                    Arguments.of("id", "connectorAddress", "contractId", destination(), "protocol", "connectorId", null)
             );
         }
     }

--- a/extensions/control-plane/store/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/contractnegotiation/CosmosContractNegotiationStoreIntegrationTest.java
+++ b/extensions/control-plane/store/cosmos/contract-negotiation-store-cosmos/src/test/java/org/eclipse/edc/connector/store/azure/cosmos/contractnegotiation/CosmosContractNegotiationStoreIntegrationTest.java
@@ -560,7 +560,7 @@ class CosmosContractNegotiationStoreIntegrationTest extends ContractNegotiationS
                 .state(REQUESTED.code())
                 .counterPartyAddress("consumer")
                 .counterPartyId("consumerId")
-                .protocol("ids-multipart")
+                .protocol("protocol")
                 .build();
 
         store.save(negotiation);

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/docs/schema.sql
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/docs/schema.sql
@@ -45,7 +45,7 @@ CREATE TABLE IF NOT EXISTS edc_contract_negotiation
     correlation_id       VARCHAR,
     counterparty_id      VARCHAR                                            NOT NULL,
     counterparty_address VARCHAR                                            NOT NULL,
-    protocol             VARCHAR DEFAULT 'ids-multipart'::CHARACTER VARYING NOT NULL,
+    protocol             VARCHAR                                            NOT NULL,
     type                 VARCHAR                                            NOT NULL,
     state                INTEGER DEFAULT 0                                  NOT NULL,
     state_count          INTEGER DEFAULT 0,

--- a/extensions/control-plane/transfer/transfer-data-plane/src/main/java/org/eclipse/edc/connector/transfer/dataplane/TransferDataPlaneCoreExtension.java
+++ b/extensions/control-plane/transfer/transfer-data-plane/src/main/java/org/eclipse/edc/connector/transfer/dataplane/TransferDataPlaneCoreExtension.java
@@ -38,7 +38,6 @@ import org.eclipse.edc.jwt.TokenValidationServiceImpl;
 import org.eclipse.edc.jwt.spi.TokenValidationService;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
-import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.configuration.Config;
@@ -58,9 +57,6 @@ public class TransferDataPlaneCoreExtension implements ServiceExtension {
 
     @Inject
     private ContractNegotiationStore contractNegotiationStore;
-
-    @Inject
-    private RemoteMessageDispatcherRegistry dispatcherRegistry;
 
     @Inject
     private WebService webService;
@@ -106,7 +102,7 @@ public class TransferDataPlaneCoreExtension implements ServiceExtension {
         webService.registerResource(controlApiConfiguration.getContextAlias(), new ConsumerPullTransferTokenValidationApiController(tokenValidationService, dataEncrypter, typeManager));
 
         var proxyReferenceService = createDataProxyReferenceService(context.getConfig(), typeManager);
-        dataFlowManager.register(new ConsumerPullTransferDataFlowController(context.getConnectorId(), proxyResolver, proxyReferenceService, dispatcherRegistry));
+        dataFlowManager.register(new ConsumerPullTransferDataFlowController(proxyResolver, proxyReferenceService));
         dataFlowManager.register(new ProviderPushTransferDataFlowController(callbackUrl, dataPlaneClient));
 
         var consumerProxyTransformer = new ConsumerPullTransferProxyTransformer(proxyResolver, proxyReferenceService);

--- a/extensions/control-plane/transfer/transfer-data-plane/src/test/java/org/eclipse/edc/connector/transfer/dataplane/flow/ConsumerPullTransferDataFlowControllerTest.java
+++ b/extensions/control-plane/transfer/transfer-data-plane/src/test/java/org/eclipse/edc/connector/transfer/dataplane/flow/ConsumerPullTransferDataFlowControllerTest.java
@@ -19,65 +19,33 @@ import org.eclipse.edc.connector.transfer.dataplane.spi.proxy.ConsumerPullTransf
 import org.eclipse.edc.connector.transfer.dataplane.spi.proxy.ConsumerPullTransferEndpointDataReferenceService;
 import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
 import org.eclipse.edc.policy.model.Policy;
-import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.edr.EndpointDataReference;
-import org.eclipse.edc.spi.types.domain.edr.EndpointDataReferenceMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.transfer.dataplane.spi.TransferDataPlaneConstants.HTTP_PROXY;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class ConsumerPullTransferDataFlowControllerTest {
 
-    private String connectorId;
     private ConsumerPullTransferProxyResolver proxyResolverMock;
-    private RemoteMessageDispatcherRegistry dispatcherRegistryMock;
     private ConsumerPullTransferEndpointDataReferenceService proxyReferenceServiceMock;
     private ConsumerPullTransferDataFlowController flowController;
 
-    private static EndpointDataReference createEndpointDataReference() {
-        return EndpointDataReference.Builder.newInstance()
-                .id(UUID.randomUUID().toString())
-                .endpoint("test.endpoint.url")
-                .build();
-    }
-
-    private static DataAddress testDataAddress() {
-        return DataAddress.Builder.newInstance().type("test-type").build();
-    }
-
-    private static DataRequest createDataRequest() {
-        return DataRequest.Builder.newInstance()
-                .id(UUID.randomUUID().toString())
-                .protocol("ids-multipart")
-                .contractId(UUID.randomUUID().toString())
-                .assetId(UUID.randomUUID().toString())
-                .connectorAddress("test.connector.address")
-                .processId(UUID.randomUUID().toString())
-                .destinationType(HTTP_PROXY)
-                .build();
-    }
-
     @BeforeEach
     void setUp() {
-        connectorId = "test";
         proxyResolverMock = mock(ConsumerPullTransferProxyResolver.class);
-        dispatcherRegistryMock = mock(RemoteMessageDispatcherRegistry.class);
         proxyReferenceServiceMock = mock(ConsumerPullTransferEndpointDataReferenceService.class);
-        flowController = new ConsumerPullTransferDataFlowController(connectorId, proxyResolverMock, proxyReferenceServiceMock, dispatcherRegistryMock);
+        flowController = new ConsumerPullTransferDataFlowController(proxyResolverMock, proxyReferenceServiceMock);
     }
 
     @Test
@@ -87,23 +55,20 @@ class ConsumerPullTransferDataFlowControllerTest {
     }
 
     @Test
-    void verifySuccessfulProxyReferenceCreationAndDispatch() {
+    void verifySuccessfulProxyReferenceCreation() {
         var request = createDataRequest();
         var dataAddress = testDataAddress();
         var edr = createEndpointDataReference();
         var proxyUrl = "proxy.test.url";
 
-        var edrRequestCaptor = ArgumentCaptor.forClass(EndpointDataReferenceMessage.class);
         var proxyCreationRequestCaptor = ArgumentCaptor.forClass(ConsumerPullTransferEndpointDataReferenceCreationRequest.class);
 
-        when(dispatcherRegistryMock.send(any(), any())).thenReturn(CompletableFuture.completedFuture(null));
         when(proxyReferenceServiceMock.createProxyReference(any())).thenReturn(Result.success(edr));
         when(proxyResolverMock.resolveProxyUrl(dataAddress)).thenReturn(Result.success(proxyUrl));
 
         var result = flowController.initiateFlow(request, dataAddress, Policy.Builder.newInstance().build());
 
         verify(proxyReferenceServiceMock).createProxyReference(proxyCreationRequestCaptor.capture());
-        verify(dispatcherRegistryMock).send(eq(Object.class), edrRequestCaptor.capture());
         verify(proxyResolverMock).resolveProxyUrl(any());
 
         assertThat(result.succeeded()).isTrue();
@@ -117,12 +82,6 @@ class ConsumerPullTransferDataFlowControllerTest {
             assertThat(address.getProperty(EndpointDataReference.AUTH_CODE)).isEqualTo(edr.getAuthCode());
             assertThat(address.getProperties()).containsAllEntriesOf(edr.getProperties());
         });
-
-        var edrRequest = edrRequestCaptor.getValue();
-        assertThat(edrRequest.getConnectorId()).isEqualTo(connectorId);
-        assertThat(edrRequest.getProtocol()).isEqualTo(request.getProtocol());
-        assertThat(edrRequest.getCounterPartyAddress()).isEqualTo(request.getConnectorAddress());
-        assertThat(edrRequest.getEndpointDataReference()).isEqualTo(edr);
 
         var proxyCreationRequest = proxyCreationRequestCaptor.getValue();
         assertThat(proxyCreationRequest.getId()).isEqualTo(request.getId());
@@ -142,7 +101,6 @@ class ConsumerPullTransferDataFlowControllerTest {
 
         var result = flowController.initiateFlow(request, dataAddress, Policy.Builder.newInstance().build());
 
-        verify(dispatcherRegistryMock, never()).send(any(), any());
         verify(proxyResolverMock).resolveProxyUrl(any());
 
         assertThat(result.failed()).isTrue();
@@ -166,4 +124,28 @@ class ConsumerPullTransferDataFlowControllerTest {
         assertThat(result.failed()).isTrue();
         assertThat(result.getFailureMessages()).allSatisfy(s -> assertThat(s).contains(errorMsg));
     }
+
+    private DataAddress testDataAddress() {
+        return DataAddress.Builder.newInstance().type("test-type").build();
+    }
+
+    private DataRequest createDataRequest() {
+        return DataRequest.Builder.newInstance()
+                .id(UUID.randomUUID().toString())
+                .protocol("protocol")
+                .contractId(UUID.randomUUID().toString())
+                .assetId(UUID.randomUUID().toString())
+                .connectorAddress("test.connector.address")
+                .processId(UUID.randomUUID().toString())
+                .destinationType(HTTP_PROXY)
+                .build();
+    }
+
+    private EndpointDataReference createEndpointDataReference() {
+        return EndpointDataReference.Builder.newInstance()
+                .id(UUID.randomUUID().toString())
+                .endpoint("test.endpoint.url")
+                .build();
+    }
+
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/AbstractResult.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/AbstractResult.java
@@ -95,13 +95,6 @@ public abstract class AbstractResult<T, F extends Failure, R extends AbstractRes
     }
 
     /**
-     * Alias for {@link AbstractResult#onFailure(Consumer)} to make code a bit more easily readable.
-     */
-    public R orElse(Consumer<F> failureAction) {
-        return onFailure(failureAction);
-    }
-
-    /**
      * Execute an action if this {@link Result} is not successful.
      *
      * @param failureAction The function that maps a {@link Failure} into the content.

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/system/ServiceExtensionContext.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/system/ServiceExtensionContext.java
@@ -17,10 +17,6 @@ package org.eclipse.edc.spi.system;
 
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.monitor.Monitor;
-import org.eclipse.edc.spi.telemetry.Telemetry;
-import org.eclipse.edc.spi.types.TypeManager;
-
-import java.time.Clock;
 
 /**
  * Context provided to extensions when they are initialized.
@@ -58,36 +54,6 @@ public interface ServiceExtensionContext extends SettingResolver {
      */
     default Monitor getMonitor() {
         return getService(Monitor.class);
-    }
-
-    /**
-     * Returns the system telemetry object.
-     *
-     * @deprecated please, @Inject the Telemetry service instead of using this method, that will be removed in the next releases.
-     */
-    @Deprecated(since = "milestone8")
-    default Telemetry getTelemetry() {
-        return getService(Telemetry.class);
-    }
-
-    /**
-     * Returns the type manager.
-     *
-     * @deprecated please, @Inject the TypeManager service instead of using this method, that will be removed in the next releases.
-     */
-    @Deprecated(since = "milestone8")
-    default TypeManager getTypeManager() {
-        return getService(TypeManager.class);
-    }
-
-    /**
-     * Returns the {@link Clock} to retrieve the current time, which can be mocked in unit tests.
-     *
-     * @deprecated please, @Inject the Clock service instead of using this method, that will be removed in the next releases.
-     */
-    @Deprecated(since = "milestone8")
-    default Clock getClock() {
-        return getService(Clock.class);
     }
 
     /**

--- a/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/negotiation/store/ContractNegotiationStoreTestBase.java
+++ b/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/negotiation/store/ContractNegotiationStoreTestBase.java
@@ -183,7 +183,7 @@ public abstract class ContractNegotiationStoreTestBase {
                 .correlationId("corr-test-id1")
                 .counterPartyAddress("consumer")
                 .counterPartyId("consumerId")
-                .protocol("ids-multipart")
+                .protocol("protocol")
                 .build();
 
         getContractNegotiationStore().save(newNegotiation);
@@ -237,7 +237,7 @@ public abstract class ContractNegotiationStoreTestBase {
                 .correlationId("corr-test-id1")
                 .counterPartyAddress("consumer")
                 .counterPartyId("consumerId")
-                .protocol("ids-multipart")
+                .protocol("protocol")
                 .build();
 
         // update should break lease

--- a/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/negotiation/store/TestFunctions.java
+++ b/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/negotiation/store/TestFunctions.java
@@ -75,7 +75,7 @@ public class TestFunctions {
                         .uri("local://test")
                         .events(Set.of("contract.negotiation.initiated"))
                         .build()))
-                .protocol("ids-multipart");
+                .protocol("protocol");
     }
 
     public static Policy createPolicy() {

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/catalog/CatalogService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/catalog/CatalogService.java
@@ -14,21 +14,11 @@
 
 package org.eclipse.edc.connector.spi.catalog;
 
-import org.eclipse.edc.catalog.spi.Catalog;
 import org.eclipse.edc.spi.query.QuerySpec;
 
 import java.util.concurrent.CompletableFuture;
 
 public interface CatalogService {
-    /**
-     * Return the catalog of the passed provider url
-     *
-     * @param providerUrl the url of the provider
-     * @return the provider's catalog
-     * @deprecated please use {@link #request(String, String, QuerySpec)}
-     */
-    @Deprecated(since = "milestone9")
-    CompletableFuture<Catalog> getByProviderUrl(String providerUrl, QuerySpec spec);
 
     /**
      * Return the catalog of the passed provider url.

--- a/spi/control-plane/transfer-spi/src/testFixtures/java/org/eclipse/edc/connector/transfer/spi/testfixtures/store/TestFunctions.java
+++ b/spi/control-plane/transfer-spi/src/testFixtures/java/org/eclipse/edc/connector/transfer/spi/testfixtures/store/TestFunctions.java
@@ -51,7 +51,7 @@ public class TestFunctions {
                         .keyName("Test Key Name")
                         .build())
                 .connectorAddress("http://some-connector.com")
-                .protocol("ids-multipart")
+                .protocol("protocol")
                 .connectorId("some-connector")
                 .contractId("some-contract")
                 .managedResources(false)


### PR DESCRIPTION
## What this PR changes/adds

Remove all the "ids-multipart" occurrences and related code

## Why it does that

cleanup

## Further notes

- removed some `@Deprecated` methods in the `ServiceExtensionContext`

## Linked Issue(s)

Closes #2442

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md)._
