### PR TITLE
refactor: add `findForCorrelationId` method on `TransferProcessStore`

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImpl.java
@@ -134,9 +134,9 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
                 .contractId(message.getContractId())
                 .build();
 
-        var processId = transferProcessStore.processIdForDataRequestId(dataRequest.getId());
-        if (processId != null) {
-            return ServiceResult.success(transferProcessStore.findById(processId));
+        var existentTransferProcess = transferProcessStore.findForCorrelationId(dataRequest.getId());
+        if (existentTransferProcess != null) {
+            return ServiceResult.success(existentTransferProcess);
         }
         var process = TransferProcess.Builder.newInstance()
                 .id(randomUUID().toString())
@@ -197,8 +197,7 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
 
     private ServiceResult<TransferProcess> onMessageDo(TransferRemoteMessage message, Function<TransferProcess, ServiceResult<TransferProcess>> action) {
         return transactionContext.execute(() -> Optional.of(message.getProcessId())
-                .map(transferProcessStore::processIdForDataRequestId)
-                .map(transferProcessStore::findById)
+                .map(transferProcessStore::findForCorrelationId)
                 .map(action)
                 .orElse(ServiceResult.notFound(format("TransferProcess with DataRequest id %s not found", message.getProcessId()))));
     }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImpl.java
@@ -134,9 +134,9 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
                 .contractId(message.getContractId())
                 .build();
 
-        var existentTransferProcess = transferProcessStore.findForCorrelationId(dataRequest.getId());
-        if (existentTransferProcess != null) {
-            return ServiceResult.success(existentTransferProcess);
+        var existingTransferProcess = transferProcessStore.findForCorrelationId(dataRequest.getId());
+        if (existingTransferProcess != null) {
+            return ServiceResult.success(existingTransferProcess);
         }
         var process = TransferProcess.Builder.newInstance()
                 .id(randomUUID().toString())

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/InMemoryStatefulEntityStore.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/InMemoryStatefulEntityStore.java
@@ -89,7 +89,7 @@ public class InMemoryStatefulEntityStore<T extends StatefulEntity<T>> {
                     .filter(e -> !isLeased(e.getId()))
                     .sorted(comparingLong(StatefulEntity::getStateTimestamp)) //order by state timestamp, oldest first
                     .limit(max)
-                    .collect(toList());
+                    .toList();
             entities.forEach(i -> acquireLease(i.getId(), lockId));
             return entities.stream().map(StatefulEntity::copy).collect(toList());
         });

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/transferprocess/InMemoryTransferProcessStore.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/transferprocess/InMemoryTransferProcessStore.java
@@ -30,6 +30,8 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Stream;
 
+import static org.eclipse.edc.spi.query.Criterion.criterion;
+
 /**
  * An in-memory, threadsafe process store. This implementation is intended for testing purposes only.
  */
@@ -52,13 +54,10 @@ public class InMemoryTransferProcessStore implements TransferProcessStore {
     }
 
     @Override
-    @Nullable
-    public String processIdForDataRequestId(String id) {
-        return store.findAll()
-                .filter(p -> id.equals(p.getDataRequest().getId()))
-                .findFirst()
-                .map(TransferProcess::getId)
-                .orElse(null);
+    public @Nullable TransferProcess findForCorrelationId(String correlationId) {
+        var querySpec = QuerySpec.Builder.newInstance().filter(criterion("dataRequest.id", "=", correlationId)).build();
+
+        return store.findAll(querySpec).findFirst().orElse(null);
     }
 
     @Override
@@ -79,10 +78,6 @@ public class InMemoryTransferProcessStore implements TransferProcessStore {
     @Override
     public @NotNull List<TransferProcess> nextNotLeased(int max, Criterion... criteria) {
         return store.leaseAndGet(max, criteria);
-    }
-
-    public Stream<TransferProcess> findAll() {
-        return store.findAll();
     }
 
 }

--- a/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/transferprocess/InMemoryTransferProcessStoreTest.java
+++ b/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/transferprocess/InMemoryTransferProcessStoreTest.java
@@ -45,16 +45,6 @@ class InMemoryTransferProcessStoreTest extends TransferProcessStoreTestBase {
     }
 
     @Override
-    protected boolean supportsInOperator() {
-        return true;
-    }
-
-    @Override
-    protected boolean supportsSortOrder() {
-        return true;
-    }
-
-    @Override
     protected TransferProcessStore getTransferProcessStore() {
         return store;
     }

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
@@ -176,9 +176,9 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
     public StatusResult<TransferProcess> initiateConsumerRequest(TransferRequest transferRequest) {
         // make the request idempotent: if the process exists, return
         var dataRequest = transferRequest.getDataRequest();
-        var processId = transferProcessStore.processIdForDataRequestId(dataRequest.getId());
-        if (processId != null) {
-            return StatusResult.success(transferProcessStore.findById(processId));
+        var existentTransferProcess = transferProcessStore.findForCorrelationId(dataRequest.getId());
+        if (existentTransferProcess != null) {
+            return StatusResult.success(existentTransferProcess);
         }
         var process = TransferProcess.Builder.newInstance()
                 .id(dataRequest.getId())

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
@@ -176,9 +176,9 @@ public class TransferProcessManagerImpl implements TransferProcessManager, Provi
     public StatusResult<TransferProcess> initiateConsumerRequest(TransferRequest transferRequest) {
         // make the request idempotent: if the process exists, return
         var dataRequest = transferRequest.getDataRequest();
-        var existentTransferProcess = transferProcessStore.findForCorrelationId(dataRequest.getId());
-        if (existentTransferProcess != null) {
-            return StatusResult.success(existentTransferProcess);
+        var existingTransferProcess = transferProcessStore.findForCorrelationId(dataRequest.getId());
+        if (existingTransferProcess != null) {
+            return StatusResult.success(existingTransferProcess);
         }
         var process = TransferProcess.Builder.newInstance()
                 .id(dataRequest.getId())

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/transfer/TransferProcessManagerImplTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/transfer/TransferProcessManagerImplTest.java
@@ -182,7 +182,7 @@ class TransferProcessManagerImplTest {
 
     @Test
     void initiateConsumerRequest() {
-        when(transferProcessStore.processIdForDataRequestId("1")).thenReturn(null, "2");
+        when(transferProcessStore.findForCorrelationId("1")).thenReturn(null);
         var callback = CallbackAddress.Builder.newInstance().uri("local://test").events(Set.of("test")).build();
         var dataRequest = DataRequest.Builder.newInstance().id("1").destinationType("test").build();
 

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/transferprocess/PostgresTransferProcessStoreTest.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/transferprocess/PostgresTransferProcessStoreTest.java
@@ -191,16 +191,6 @@ class PostgresTransferProcessStoreTest extends TransferProcessStoreTestBase {
                 .hasMessageStartingWith("Translation failed for Model");
     }
 
-    @Test
-    void query_6000_items() {
-        range(0, 6000).forEach(i -> getTransferProcessStore().updateOrCreate(createTransferProcess("test-neg-" + i)));
-        var query = QuerySpec.Builder.newInstance().limit(6000).build();
-
-        var result = getTransferProcessStore().findAll(query);
-
-        assertThat(result).hasSize(6000);
-    }
-
     @Override
     protected boolean supportsCollectionQuery() {
         return true;
@@ -208,16 +198,6 @@ class PostgresTransferProcessStoreTest extends TransferProcessStoreTestBase {
 
     @Override
     protected boolean supportsLikeOperator() {
-        return true;
-    }
-
-    @Override
-    protected boolean supportsInOperator() {
-        return true;
-    }
-
-    @Override
-    protected boolean supportsSortOrder() {
         return true;
     }
 

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/store/TransferProcessStore.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/store/TransferProcessStore.java
@@ -35,10 +35,10 @@ public interface TransferProcessStore extends StateEntityStore<TransferProcess> 
     TransferProcess findById(String id);
 
     /**
-     * Returns the transfer process for the data request id or null if not found.
+     * Returns the transfer process for the correlation id or null if not found.
      */
     @Nullable
-    String processIdForDataRequestId(String id);
+    TransferProcess findForCorrelationId(String correlationId);
 
     /**
      * Persists a transfer process. This follows UPSERT semantics, so if the object didn't exit before, it's


### PR DESCRIPTION
## What this PR changes/adds

Add  `findForCorrelationId` method on `TransferProcessStore` to align with `ContractNegotiationStore`

## Why it does that

refactor

## Further notes

- removed the now unused `processIdForDataRequestId`
- cleaned up store tests a bit

## Linked Issue(s)

Closes #3062 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md)._
