### PR TITLE
feat(policy): Support complex literal operand types

### DIFF
--- a/core/common/policy-evaluator/src/main/java/org/eclipse/edc/policy/evaluator/PolicyEvaluator.java
+++ b/core/common/policy-evaluator/src/main/java/org/eclipse/edc/policy/evaluator/PolicyEvaluator.java
@@ -72,7 +72,7 @@ public class PolicyEvaluator implements Policy.Visitor<Boolean>, Rule.Visitor<Bo
 
     @Override
     public Boolean visitPermission(Permission permission) {
-        for (RuleFunction<Permission> function : permissionRuleFunctions) {
+        for (var function : permissionRuleFunctions) {
             if (!function.evaluate(permission)) {
                 ruleProblems.add(RuleProblem.Builder.newInstance().rule(permission).description("Evalution failed for: " + permission.toString()).build());
                 return false;
@@ -96,7 +96,7 @@ public class PolicyEvaluator implements Policy.Visitor<Boolean>, Rule.Visitor<Bo
 
     @Override
     public Boolean visitProhibition(Prohibition prohibition) {
-        for (RuleFunction<Prohibition> function : prohibitionRuleFunctions) {
+        for (var function : prohibitionRuleFunctions) {
             if (function.evaluate(prohibition)) {
                 ruleProblems.add(RuleProblem.Builder.newInstance().rule(prohibition).description("Evalution failed for: " + prohibition.toString()).build());
                 return false;
@@ -112,7 +112,7 @@ public class PolicyEvaluator implements Policy.Visitor<Boolean>, Rule.Visitor<Bo
 
     @Override
     public Boolean visitDuty(Duty duty) {
-        for (RuleFunction<Duty> function : dutyRuleFunctions) {
+        for (var function : dutyRuleFunctions) {
             if (!function.evaluate(duty)) {
                 ruleProblems.add(RuleProblem.Builder.newInstance().rule(duty).description("Evalution failed for: " + duty.toString()).build());
                 return false;
@@ -139,7 +139,7 @@ public class PolicyEvaluator implements Policy.Visitor<Boolean>, Rule.Visitor<Bo
     @Override
     public Boolean visitXoneConstraint(XoneConstraint xoneConstraint) {
         int count = 0;
-        for (Constraint constraint : xoneConstraint.getConstraints()) {
+        for (var constraint : xoneConstraint.getConstraints()) {
             if (constraint.accept(this)) {
                 count++;
                 if (count > 1) {
@@ -153,7 +153,7 @@ public class PolicyEvaluator implements Policy.Visitor<Boolean>, Rule.Visitor<Bo
     @Override
     public Boolean visitAtomicConstraint(AtomicConstraint constraint) {
         var rightValue = constraint.getRightExpression().accept(this);
-        Object leftRawValue = constraint.getLeftExpression().accept(this);
+        var leftRawValue = constraint.getLeftExpression().accept(this);
         if (leftRawValue instanceof String) {
             AtomicConstraintFunction<Object, Rule, Boolean> function;
             if (ruleContext instanceof Permission) {
@@ -198,7 +198,7 @@ public class PolicyEvaluator implements Policy.Visitor<Boolean>, Rule.Visitor<Bo
     private Boolean visitRule(Rule rule) {
         var valid = true;
         RuleProblem.Builder problemBuilder = null;
-        for (Constraint constraint : rule.getConstraints()) {
+        for (var constraint : rule.getConstraints()) {
             var result = constraint.accept(this);
             if ((!result && !(ruleContext instanceof Prohibition) || (result && ruleContext instanceof Prohibition))) {
                 if (problemBuilder == null) {

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToAtomicConstraintComplexTypeTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToAtomicConstraintComplexTypeTest.java
@@ -1,0 +1,210 @@
+/*
+ *  Copyright (c) 2023 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.jsonld.transformer.to;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonString;
+import jakarta.json.JsonValue;
+import org.eclipse.edc.policy.model.AtomicConstraint;
+import org.eclipse.edc.policy.model.LiteralExpression;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_LEFT_OPERAND_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_OPERATOR_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_RIGHT_OPERAND_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.transformer.to.TestInput.getExpanded;
+import static org.eclipse.edc.policy.model.Operator.EQ;
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
+import static org.eclipse.edc.spi.CoreConstants.EDC_PREFIX;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+class JsonObjectToAtomicConstraintComplexTypeTest {
+
+    private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
+    private final TransformerContext context = mock(TransformerContext.class);
+
+    private JsonObjectToConstraintTransformer transformer;
+    private JsonObject left;
+
+    @BeforeEach
+    void setUp() {
+        transformer = new JsonObjectToConstraintTransformer();
+        left = jsonFactory.createObjectBuilder().add(VALUE, "left").build();
+    }
+
+    @Test
+    void verify_array_of_strings() {
+        var right = jsonFactory.createArrayBuilder().add("value1").add("value2").build();
+
+        var constraint = createConstraint(right);
+
+        var result = transformer.transform(constraint, context);
+
+        assertThat(result).isNotNull().asInstanceOf(type(AtomicConstraint.class))
+                .extracting(AtomicConstraint::getRightExpression)
+                .asInstanceOf(type(LiteralExpression.class))
+                .extracting(LiteralExpression::getValue)
+                .asInstanceOf(type(JsonArray.class))
+                .satisfies(array -> {
+                    assertThat(array.size()).isEqualTo(2);
+                    assertThat(array.get(0)).asInstanceOf(type(JsonObject.class)).extracting(v -> v.getJsonString(VALUE).getString()).isEqualTo("value1");
+                    assertThat(array.get(1)).asInstanceOf(type(JsonObject.class)).extracting(v -> v.getJsonString(VALUE).getString()).isEqualTo("value2");
+                });
+
+        verifyNoInteractions(context);
+    }
+
+    @Test
+    void verify_array_of_single_complex_type() {
+        var right = jsonFactory.createArrayBuilder().add(jsonFactory.createObjectBuilder(Map.of("edc:foo", "bar"))).build();
+
+        var constraint = createConstraint(right);
+
+        var result = transformer.transform(constraint, context);
+
+        assertThat(result).isNotNull().asInstanceOf(type(AtomicConstraint.class))
+                .extracting(AtomicConstraint::getRightExpression)
+                .asInstanceOf(type(LiteralExpression.class))
+                .extracting(LiteralExpression::getValue)
+                .asInstanceOf(type(JsonObject.class))
+                .extracting(o -> o.getJsonArray(EDC_NAMESPACE + "foo"))
+                .satisfies(array -> {
+                    assertThat(array.size()).isEqualTo(1);
+                    assertThat(array.get(0)).asInstanceOf(type(JsonObject.class)).extracting(v -> v.getJsonString(VALUE).getString()).isEqualTo("bar");
+                });
+
+        verifyNoInteractions(context);
+    }
+
+    @Test
+    void verify_object_no_value() {
+        var right = jsonFactory.createObjectBuilder(Map.of("edc:foo", "bar")).build();
+
+        var constraint = createConstraint(right);
+
+        var result = transformer.transform(constraint, context);
+
+        assertThat(result).isNotNull().asInstanceOf(type(AtomicConstraint.class))
+                .extracting(AtomicConstraint::getRightExpression)
+                .asInstanceOf(type(LiteralExpression.class))
+                .extracting(LiteralExpression::getValue)
+                .asInstanceOf(type(Map.class))
+                .extracting(m -> m.get(EDC_NAMESPACE + "foo"))
+                .asInstanceOf(type(JsonArray.class))
+                .extracting(a -> a.get(0))
+                .asInstanceOf(type(JsonObject.class))
+                .extracting(VALUE).asInstanceOf(type(JsonString.class))
+                .extracting(JsonString::getString)
+                .isEqualTo("bar");
+
+        verifyNoInteractions(context);
+    }
+
+    @Test
+    void verify_object_with_value() {
+        var right = jsonFactory.createObjectBuilder(Map.of(VALUE, "bar")).build();
+
+        var constraint = createConstraint(right);
+
+        var result = transformer.transform(constraint, context);
+
+        assertThat(result).isNotNull().asInstanceOf(type(AtomicConstraint.class))
+                .extracting(AtomicConstraint::getRightExpression)
+                .asInstanceOf(type(LiteralExpression.class))
+                .extracting(LiteralExpression::getValue)
+                .isEqualTo("bar");
+
+        verifyNoInteractions(context);
+    }
+
+    @Test
+    void verify_expanded_string() {
+        var constraint = createConstraint("bar");
+
+        var result = transformer.transform(constraint, context);
+
+        assertThat(result).isNotNull().asInstanceOf(type(AtomicConstraint.class))
+                .extracting(AtomicConstraint::getRightExpression)
+                .asInstanceOf(type(LiteralExpression.class))
+                .extracting(LiteralExpression::getValue)
+                .isEqualTo("bar");
+
+        verifyNoInteractions(context);
+    }
+
+    @Test
+    void verify_expanded_int() {
+        var constraint = createConstraint(1);
+
+        var result = transformer.transform(constraint, context);
+
+        assertThat(result).isNotNull().asInstanceOf(type(AtomicConstraint.class))
+                .extracting(AtomicConstraint::getRightExpression)
+                .asInstanceOf(type(LiteralExpression.class))
+                .extracting(LiteralExpression::getValue)
+                .isEqualTo(1);
+
+        verifyNoInteractions(context);
+    }
+
+    @Test
+    void verify_expanded_decimal() {
+        var constraint = createConstraint(1.1d);
+
+        var result = transformer.transform(constraint, context);
+
+        assertThat(result).isNotNull().asInstanceOf(type(AtomicConstraint.class))
+                .extracting(AtomicConstraint::getRightExpression)
+                .asInstanceOf(type(LiteralExpression.class))
+                .extracting(expr -> (BigDecimal) expr.getValue())
+                .usingComparator(BigDecimal::compareTo)
+                .isEqualTo(BigDecimal.valueOf(1.1d));
+
+        verifyNoInteractions(context);
+    }
+
+    private JsonObject createConstraint(Object value) {
+        var constraint = jsonFactory.createObjectBuilder()
+                .add(CONTEXT, jsonFactory.createObjectBuilder(Map.of(EDC_PREFIX, EDC_NAMESPACE)))
+                .add(ODRL_LEFT_OPERAND_ATTRIBUTE, left)
+                .add(ODRL_OPERATOR_ATTRIBUTE, EQ.toString());
+
+        if (value instanceof String right) {
+            constraint.add(ODRL_RIGHT_OPERAND_ATTRIBUTE, right);
+        } else if (value instanceof Integer right) {
+            constraint.add(ODRL_RIGHT_OPERAND_ATTRIBUTE, right);
+        } else if (value instanceof Double right) {
+            constraint.add(ODRL_RIGHT_OPERAND_ATTRIBUTE, right);
+        } else if (value instanceof JsonValue right) {
+            constraint.add(ODRL_RIGHT_OPERAND_ATTRIBUTE, right);
+        }
+
+        return getExpanded(constraint.build());
+    }
+
+}

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToAtomicConstraintComplexTypeTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToAtomicConstraintComplexTypeTest.java
@@ -57,6 +57,9 @@ class JsonObjectToAtomicConstraintComplexTypeTest {
         left = jsonFactory.createObjectBuilder().add(VALUE, "left").build();
     }
 
+    /**
+     * Verifies a Json-ld expanded array containing two strings as-is.
+     */
     @Test
     void verify_array_of_strings() {
         var right = jsonFactory.createArrayBuilder().add("value1").add("value2").build();
@@ -79,6 +82,9 @@ class JsonObjectToAtomicConstraintComplexTypeTest {
         verifyNoInteractions(context);
     }
 
+    /**
+     * Verifies a Json-Ld array containing a single element of a complex type has the complex type extracted and returned.
+     */
     @Test
     void verify_array_of_single_complex_type() {
         var right = jsonFactory.createArrayBuilder().add(jsonFactory.createObjectBuilder(Map.of("edc:foo", "bar"))).build();
@@ -101,6 +107,9 @@ class JsonObjectToAtomicConstraintComplexTypeTest {
         verifyNoInteractions(context);
     }
 
+    /**
+     * Verifies a Json-Ld object with no {@code value} property is returned as-is.
+     */
     @Test
     void verify_object_no_value() {
         var right = jsonFactory.createObjectBuilder(Map.of("edc:foo", "bar")).build();
@@ -125,6 +134,9 @@ class JsonObjectToAtomicConstraintComplexTypeTest {
         verifyNoInteractions(context);
     }
 
+    /**
+     * Verifies a Json-Ld object with a {@code value} property has the property extracted and transformed.
+     */
     @Test
     void verify_object_with_value() {
         var right = jsonFactory.createObjectBuilder(Map.of(VALUE, "bar")).build();
@@ -142,6 +154,9 @@ class JsonObjectToAtomicConstraintComplexTypeTest {
         verifyNoInteractions(context);
     }
 
+    /**
+     * Verifies string values are returned correctly.
+     */
     @Test
     void verify_expanded_string() {
         var constraint = createConstraint("bar");
@@ -157,6 +172,9 @@ class JsonObjectToAtomicConstraintComplexTypeTest {
         verifyNoInteractions(context);
     }
 
+    /**
+     * Verifies int values are returned correctly.
+     */
     @Test
     void verify_expanded_int() {
         var constraint = createConstraint(1);
@@ -172,6 +190,9 @@ class JsonObjectToAtomicConstraintComplexTypeTest {
         verifyNoInteractions(context);
     }
 
+    /**
+     * Verifies decimal values are returned correctly.
+     */
     @Test
     void verify_expanded_decimal() {
         var constraint = createConstraint(1.1d);

--- a/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/transformer/AbstractJsonLdTransformer.java
+++ b/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/transformer/AbstractJsonLdTransformer.java
@@ -52,6 +52,9 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
  * Base JSON-LD transformer implementation.
  */
 public abstract class AbstractJsonLdTransformer<INPUT, OUTPUT> implements JsonLdTransformer<INPUT, OUTPUT> {
+    private static final Consumer<JsonValue> NOOP_CONSUMER = v -> {
+    };
+
     private final Class<INPUT> input;
     private final Class<OUTPUT> output;
 
@@ -62,8 +65,7 @@ public abstract class AbstractJsonLdTransformer<INPUT, OUTPUT> implements JsonLd
 
     @NotNull
     protected static Consumer<JsonValue> doNothing() {
-        return v -> {
-        };
+        return NOOP_CONSUMER;
     }
 
     @Override
@@ -191,7 +193,8 @@ public abstract class AbstractJsonLdTransformer<INPUT, OUTPUT> implements JsonLd
      */
     protected void visitArray(JsonValue value, Consumer<JsonValue> resultFunction, TransformerContext context) {
         if (value instanceof JsonArray) {
-            visitArray(value.asJsonArray(), resultFunction);
+            var jsonArray = value.asJsonArray();
+            jsonArray.forEach(resultFunction);
         } else {
             context.problem()
                     .unexpectedType()
@@ -199,16 +202,6 @@ public abstract class AbstractJsonLdTransformer<INPUT, OUTPUT> implements JsonLd
                     .expected(ARRAY)
                     .report();
         }
-    }
-
-    /**
-     * Visit all the elements of the value and apply the result function.
-     *
-     * @param array          The input array
-     * @param resultFunction The function to apply to each element
-     */
-    protected void visitArray(JsonArray array, Consumer<JsonValue> resultFunction) {
-        array.forEach(resultFunction);
     }
 
     @Nullable
@@ -274,7 +267,7 @@ public abstract class AbstractJsonLdTransformer<INPUT, OUTPUT> implements JsonLd
                     .filter(Objects::nonNull)
                     .findFirst().map(it -> transformString(it, context))
                     .orElseGet(() -> {
-                        // no need to report problem as it will have been donne above with call to transformString()
+                        // no need to report problem as it will have been done above with call to transformString()
                         return null;
                     });
         } else if (value instanceof JsonArray) {


### PR DESCRIPTION
## What this PR changes/adds

Adds support for processing complex types (in addition to scalars) for right policy operands. Also performs some minor code cleanup in related classes.

The `PolicyEvaluator` remains type system agnostic (e.g., it does not have knowledge about Json-Ld or other type systems). `JsonObjectToConstraintTransformer` is enhanced to handle extraction of scalars and Json-Ld types according to the following rules:

 - Json-Ld expanded scalar types are extracted from their enclosing array and passed directly to the constraint evaluator.
 - Json-Ld arrays that contain a single element (Json-Ld scalar or complex type) will return the extracted element. 
 - Json-Ld arrays that contain multiple elements will be returned as-is.
 - Json-Ld objects that contain an `@value` property will have that property extracted and returned.
 - All other Json-Ld forms are returned as-is.

These rules preserve existing behavior where String values are passed directly to policy functions. In addition, extracted types will now be passed, if present.

## Linked Issue(s)

Closes #3037


