### PR TITLE
feat: evaluate policy on message dispatch for CN and TP

### DIFF
--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -183,11 +183,9 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
 
         var request = ContractAgreementMessage.Builder.newInstance()
                 .protocol(negotiation.getProtocol())
-                .connectorId(negotiation.getCounterPartyId())
                 .counterPartyAddress(negotiation.getCounterPartyAddress())
                 .contractAgreement(agreement)
                 .processId(negotiation.getId())
-                .policy(policy)
                 .build();
 
         return entityRetryProcessFactory.doAsyncProcess(negotiation, () -> dispatcherRegistry.send(Object.class, request))
@@ -223,6 +221,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
                 .protocol(negotiation.getProtocol())
                 .counterPartyAddress(negotiation.getCounterPartyAddress())
                 .processId(negotiation.getId())
+                .policy(negotiation.getContractAgreement().getPolicy())
                 .build();
 
         return entityRetryProcessFactory.doAsyncProcess(negotiation, () -> dispatcherRegistry.send(Object.class, message))
@@ -245,10 +244,10 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
     private boolean processTerminating(ContractNegotiation negotiation) {
         var rejection = ContractNegotiationTerminationMessage.Builder.newInstance()
                 .protocol(negotiation.getProtocol())
-                .connectorId(negotiation.getCounterPartyId())
                 .counterPartyAddress(negotiation.getCounterPartyAddress())
                 .processId(negotiation.getId())
                 .rejectionReason(negotiation.getErrorDetail())
+                .policy(negotiation.getLastContractOffer().getPolicy())
                 .build();
 
         return entityRetryProcessFactory.doAsyncProcess(negotiation, () -> dispatcherRegistry.send(Object.class, rejection))

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
@@ -179,7 +179,7 @@ class ProviderContractNegotiationManagerImplTest {
 
     @Test
     void finalizing_shouldSendMessageAndTransitionToFinalized() {
-        var negotiation = contractNegotiationBuilder().state(FINALIZING.code()).build();
+        var negotiation = contractNegotiationBuilder().state(FINALIZING.code()).contractOffer(contractOffer()).contractAgreement(contractAgreementBuilder().build()).build();
         when(store.nextNotLeased(anyInt(), stateIs(FINALIZING.code()))).thenReturn(List.of(negotiation)).thenReturn(emptyList());
         when(store.findById(negotiation.getId())).thenReturn(negotiation);
         when(dispatcherRegistry.send(any(), any())).thenReturn(completedFuture("any"));
@@ -271,13 +271,13 @@ class ProviderContractNegotiationManagerImplTest {
                     // retries not exhausted
                     new DispatchFailure(OFFERING, OFFERING, b -> b.stateCount(RETRIES_NOT_EXHAUSTED).contractOffer(contractOffer())),
                     new DispatchFailure(AGREEING, AGREEING, b -> b.stateCount(RETRIES_NOT_EXHAUSTED).contractOffer(contractOffer())),
-                    new DispatchFailure(FINALIZING, FINALIZING, b -> b.stateCount(RETRIES_NOT_EXHAUSTED).contractOffer(contractOffer())),
-                    new DispatchFailure(TERMINATING, TERMINATING, b -> b.stateCount(RETRIES_NOT_EXHAUSTED).errorDetail("an error")),
+                    new DispatchFailure(FINALIZING, FINALIZING, b -> b.stateCount(RETRIES_NOT_EXHAUSTED).contractOffer(contractOffer()).contractAgreement(createContractAgreement())),
+                    new DispatchFailure(TERMINATING, TERMINATING, b -> b.stateCount(RETRIES_NOT_EXHAUSTED).errorDetail("an error").contractOffer(contractOffer())),
                     // retries exhausted
                     new DispatchFailure(OFFERING, TERMINATING, b -> b.stateCount(RETRIES_EXHAUSTED).contractOffer(contractOffer())),
                     new DispatchFailure(AGREEING, TERMINATING, b -> b.stateCount(RETRIES_EXHAUSTED).contractOffer(contractOffer())),
-                    new DispatchFailure(FINALIZING, TERMINATING, b -> b.stateCount(RETRIES_EXHAUSTED).contractOffer(contractOffer())),
-                    new DispatchFailure(TERMINATING, TERMINATED, b -> b.stateCount(RETRIES_EXHAUSTED).errorDetail("an error"))
+                    new DispatchFailure(FINALIZING, TERMINATING, b -> b.stateCount(RETRIES_EXHAUSTED).contractOffer(contractOffer()).contractAgreement(createContractAgreement())),
+                    new DispatchFailure(TERMINATING, TERMINATED, b -> b.stateCount(RETRIES_EXHAUSTED).errorDetail("an error").contractOffer(contractOffer()))
             );
         }
 
@@ -287,6 +287,17 @@ class ProviderContractNegotiationManagerImplTest {
                     .assetId("assetId")
                     .build();
         }
+
+        private ContractAgreement createContractAgreement() {
+            return ContractAgreement.Builder.newInstance()
+                    .id("contractId")
+                    .consumerId("consumerId")
+                    .providerId("providerId")
+                    .assetId("assetId")
+                    .policy(Policy.Builder.newInstance().build())
+                    .build();
+        }
+
     }
 
 }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImpl.java
@@ -126,7 +126,6 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
         var dataRequest = DataRequest.Builder.newInstance()
                 .id(message.getProcessId())
                 .protocol(message.getProtocol())
-                .connectorId(message.getConnectorId())
                 .connectorAddress(message.getCallbackAddress())
                 .dataDestination(message.getDataDestination())
                 .properties(message.getProperties())

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
@@ -153,11 +153,9 @@ class ContractNegotiationProtocolServiceImplTest {
         when(validationService.validateConfirmed(eq(token), eq(contractAgreement), any(ContractOffer.class))).thenReturn(Result.success());
         var message = ContractAgreementMessage.Builder.newInstance()
                 .protocol("protocol")
-                .connectorId("connectorId")
                 .counterPartyAddress("http://any")
                 .processId("processId")
                 .contractAgreement(contractAgreement)
-                .policy(createPolicy())
                 .build();
 
         var result = service.notifyAgreed(message, token);
@@ -181,11 +179,9 @@ class ContractNegotiationProtocolServiceImplTest {
         when(validationService.validateConfirmed(eq(token), eq(contractAgreement), any(ContractOffer.class))).thenReturn(Result.failure("failure"));
         var message = ContractAgreementMessage.Builder.newInstance()
                 .protocol("protocol")
-                .connectorId("connectorId")
                 .counterPartyAddress("http://any")
                 .processId("processId")
                 .contractAgreement(contractAgreement)
-                .policy(createPolicy())
                 .build();
 
         var result = service.notifyAgreed(message, token);
@@ -383,11 +379,9 @@ class ContractNegotiationProtocolServiceImplTest {
             return Stream.of(
                     Arguments.of(agreed, ContractAgreementMessage.Builder.newInstance()
                             .protocol("protocol")
-                            .connectorId("connectorId")
                             .counterPartyAddress("http://any")
                             .processId("processId")
                             .contractAgreement(mock(ContractAgreement.class))
-                            .policy(Policy.Builder.newInstance().build())
                             .build()),
                     Arguments.of(verified, ContractAgreementVerificationMessage.Builder.newInstance()
                             .protocol("protocol")

--- a/data-protocols/dsp/dsp-http-core/build.gradle.kts
+++ b/data-protocols/dsp/dsp-http-core/build.gradle.kts
@@ -19,6 +19,7 @@ plugins {
 dependencies {
     api(project(":spi:common:http-spi"))
     api(project(":spi:common:json-ld-spi"))
+    api(project(":spi:control-plane:transfer-spi"))
     api(project(":extensions:common:json-ld"))
     api(project(":data-protocols:dsp:dsp-http-spi"))
 

--- a/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/spi/dispatcher/DspHttpRemoteMessageDispatcher.java
+++ b/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/spi/dispatcher/DspHttpRemoteMessageDispatcher.java
@@ -14,8 +14,11 @@
 
 package org.eclipse.edc.protocol.dsp.spi.dispatcher;
 
+import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcher;
 import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
+
+import java.util.function.Function;
 
 /**
  * {@link RemoteMessageDispatcher} for sending dataspace protocol messages.
@@ -30,5 +33,14 @@ public interface DspHttpRemoteMessageDispatcher extends RemoteMessageDispatcher 
      * @param <R> the response type
      */
     <M extends RemoteMessage, R> void registerDelegate(DspHttpDispatcherDelegate<M, R> delegate);
-    
+
+    /**
+     * Registers a {@link Policy} scope to be evaluated for certain types of messages
+     *
+     * @param messageClass the message type for which evaluate the policy.
+     * @param scope the scope to be used.
+     * @param policyProvider function that extracts the Policy from the message.
+     * @param <M> the message type.
+     */
+    <M extends RemoteMessage> void registerPolicyScope(Class<M> messageClass, String scope, Function<M, Policy> policyProvider);
 }

--- a/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
+++ b/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
@@ -170,7 +170,6 @@ public class HttpProvisionerExtensionEndToEndTest {
                 .counterPartyAddress("http://any")
                 .callbackAddress("http://any")
                 .contractId(CONTRACT_ID)
-                .assetId(ASSET_ID)
                 .build();
     }
 

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/iam/TokenParameters.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/iam/TokenParameters.java
@@ -55,7 +55,6 @@ public class TokenParameters {
             return this;
         }
 
-
         public TokenParameters build() {
             Objects.requireNonNull(result.audience, "audience");
             return result;

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractAgreementMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractAgreementMessage.java
@@ -23,15 +23,12 @@ import java.util.Objects;
 import static java.util.UUID.randomUUID;
 
 public class ContractAgreementMessage implements ContractRemoteMessage {
+
     private String id;
     private String protocol = "unknown";
-    @Deprecated(forRemoval = true)
-    private String connectorId;
     private String counterPartyAddress;
     private String processId;
     private ContractAgreement contractAgreement;
-    @Deprecated(forRemoval = true)
-    private Policy policy;
 
     @Override
     @NotNull
@@ -55,11 +52,6 @@ public class ContractAgreementMessage implements ContractRemoteMessage {
         return counterPartyAddress;
     }
 
-    @Deprecated
-    public String getConnectorId() {
-        return connectorId;
-    }
-
     @Override
     public @NotNull String getProcessId() {
         return processId;
@@ -69,9 +61,8 @@ public class ContractAgreementMessage implements ContractRemoteMessage {
         return contractAgreement;
     }
 
-    @Deprecated
     public Policy getPolicy() {
-        return policy;
+        return contractAgreement.getPolicy();
     }
 
     public static class Builder {
@@ -95,12 +86,6 @@ public class ContractAgreementMessage implements ContractRemoteMessage {
             return this;
         }
 
-        @Deprecated
-        public Builder connectorId(String connectorId) {
-            this.contractAgreementMessage.connectorId = connectorId;
-            return this;
-        }
-
         public Builder counterPartyAddress(String counterPartyAddress) {
             this.contractAgreementMessage.counterPartyAddress = counterPartyAddress;
             return this;
@@ -113,12 +98,6 @@ public class ContractAgreementMessage implements ContractRemoteMessage {
 
         public Builder contractAgreement(ContractAgreement contractAgreement) {
             this.contractAgreementMessage.contractAgreement = contractAgreement;
-            return this;
-        }
-
-        @Deprecated
-        public Builder policy(Policy policy) {
-            this.contractAgreementMessage.policy = policy;
             return this;
         }
 

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractAgreementVerificationMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractAgreementVerificationMessage.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.connector.contract.spi.types.agreement;
 
 import org.eclipse.edc.connector.contract.spi.types.protocol.ContractRemoteMessage;
+import org.eclipse.edc.policy.model.Policy;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
@@ -27,6 +28,7 @@ public class ContractAgreementVerificationMessage implements ContractRemoteMessa
     private String protocol = "unknown";
     private String counterPartyAddress;
     private String processId;
+    private Policy policy;
 
     @NotNull
     @Override
@@ -56,11 +58,16 @@ public class ContractAgreementVerificationMessage implements ContractRemoteMessa
         return processId;
     }
 
+    @Override
+    public Policy getPolicy() {
+        return policy;
+    }
+
     public static class Builder {
         private final ContractAgreementVerificationMessage message;
 
         private Builder() {
-            this.message = new ContractAgreementVerificationMessage();
+            message = new ContractAgreementVerificationMessage();
         }
 
         public static Builder newInstance() {
@@ -68,22 +75,27 @@ public class ContractAgreementVerificationMessage implements ContractRemoteMessa
         }
 
         public Builder id(String id) {
-            this.message.id = id;
+            message.id = id;
             return this;
         }
 
         public Builder protocol(String protocol) {
-            this.message.protocol = protocol;
+            message.protocol = protocol;
             return this;
         }
 
         public Builder counterPartyAddress(String counterPartyAddress) {
-            this.message.counterPartyAddress = counterPartyAddress;
+            message.counterPartyAddress = counterPartyAddress;
             return this;
         }
 
         public Builder processId(String processId) {
-            this.message.processId = processId;
+            message.processId = processId;
+            return this;
+        }
+
+        public Builder policy(Policy policy) {
+            message.policy = policy;
             return this;
         }
 

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractNegotiationEventMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractNegotiationEventMessage.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.connector.contract.spi.types.agreement;
 
 import org.eclipse.edc.connector.contract.spi.types.protocol.ContractRemoteMessage;
+import org.eclipse.edc.policy.model.Policy;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
@@ -27,6 +28,7 @@ public class ContractNegotiationEventMessage implements ContractRemoteMessage {
     private String counterPartyAddress;
     private String processId;
     private Type type;
+    private Policy policy;
 
     @Override
     @NotNull
@@ -61,11 +63,16 @@ public class ContractNegotiationEventMessage implements ContractRemoteMessage {
         return type;
     }
 
+    @Override
+    public Policy getPolicy() {
+        return policy;
+    }
+
     public static class Builder {
         private final ContractNegotiationEventMessage message;
 
         private Builder() {
-            this.message = new ContractNegotiationEventMessage();
+            message = new ContractNegotiationEventMessage();
         }
 
         public static Builder newInstance() {
@@ -73,27 +80,32 @@ public class ContractNegotiationEventMessage implements ContractRemoteMessage {
         }
 
         public Builder id(String id) {
-            this.message.id = id;
+            message.id = id;
             return this;
         }
 
         public Builder protocol(String protocol) {
-            this.message.protocol = protocol;
+            message.protocol = protocol;
             return this;
         }
 
         public Builder counterPartyAddress(String counterPartyAddress) {
-            this.message.counterPartyAddress = counterPartyAddress;
+            message.counterPartyAddress = counterPartyAddress;
             return this;
         }
 
         public Builder processId(String processId) {
-            this.message.processId = processId;
+            message.processId = processId;
             return this;
         }
 
         public Builder type(Type type) {
-            this.message.type = type;
+            message.type = type;
+            return this;
+        }
+
+        public Builder policy(Policy policy) {
+            message.policy = policy;
             return this;
         }
 

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractNegotiationTerminationMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractNegotiationTerminationMessage.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.connector.contract.spi.types.negotiation;
 
 import org.eclipse.edc.connector.contract.spi.types.protocol.ContractRemoteMessage;
+import org.eclipse.edc.policy.model.Policy;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -26,12 +27,11 @@ public class ContractNegotiationTerminationMessage implements ContractRemoteMess
 
     private String id;
     private String protocol = "unknown";
-    @Deprecated(forRemoval = true)
-    private String connectorId;
     private String counterPartyAddress;
     private String processId;
     private String rejectionReason; // TODO change to list https://github.com/eclipse-edc/Connector/issues/2729
     private String code;
+    private Policy policy;
 
     @NotNull
     @Override
@@ -55,11 +55,6 @@ public class ContractNegotiationTerminationMessage implements ContractRemoteMess
         return counterPartyAddress;
     }
 
-    @Deprecated
-    public String getConnectorId() {
-        return connectorId;
-    }
-
     @Override
     @NotNull
     public String getProcessId() {
@@ -76,11 +71,16 @@ public class ContractNegotiationTerminationMessage implements ContractRemoteMess
         return code;
     }
 
+    @Override
+    public Policy getPolicy() {
+        return policy;
+    }
+
     public static class Builder {
-        private final ContractNegotiationTerminationMessage contractNegotiationTerminationMessage;
+        private final ContractNegotiationTerminationMessage message;
 
         private Builder() {
-            this.contractNegotiationTerminationMessage = new ContractNegotiationTerminationMessage();
+            message = new ContractNegotiationTerminationMessage();
         }
 
         public static Builder newInstance() {
@@ -88,48 +88,47 @@ public class ContractNegotiationTerminationMessage implements ContractRemoteMess
         }
 
         public Builder id(String id) {
-            this.contractNegotiationTerminationMessage.id = id;
+            message.id = id;
             return this;
         }
 
         public Builder protocol(String protocol) {
-            this.contractNegotiationTerminationMessage.protocol = protocol;
-            return this;
-        }
-
-        @Deprecated
-        public Builder connectorId(String connectorId) {
-            this.contractNegotiationTerminationMessage.connectorId = connectorId;
+            message.protocol = protocol;
             return this;
         }
 
         public Builder counterPartyAddress(String counterPartyAddress) {
-            this.contractNegotiationTerminationMessage.counterPartyAddress = counterPartyAddress;
+            message.counterPartyAddress = counterPartyAddress;
             return this;
         }
 
         public Builder processId(String processId) {
-            this.contractNegotiationTerminationMessage.processId = processId;
+            message.processId = processId;
             return this;
         }
 
         public Builder rejectionReason(String rejectionReason) {
-            this.contractNegotiationTerminationMessage.rejectionReason = rejectionReason;
+            message.rejectionReason = rejectionReason;
             return this;
         }
 
         public Builder code(String code) {
-            this.contractNegotiationTerminationMessage.code = code;
+            message.code = code;
+            return this;
+        }
+
+        public Builder policy(Policy policy) {
+            message.policy = policy;
             return this;
         }
 
         public ContractNegotiationTerminationMessage build() {
-            if (contractNegotiationTerminationMessage.id == null) {
-                contractNegotiationTerminationMessage.id = randomUUID().toString();
+            if (message.id == null) {
+                message.id = randomUUID().toString();
             }
 
-            Objects.requireNonNull(contractNegotiationTerminationMessage.processId, "processId");
-            return contractNegotiationTerminationMessage;
+            Objects.requireNonNull(message.processId, "processId");
+            return message;
         }
     }
 }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessage.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.contract.spi.types.negotiation;
 
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.contract.spi.types.protocol.ContractRemoteMessage;
+import org.eclipse.edc.policy.model.Policy;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -94,6 +95,11 @@ public class ContractRequestMessage implements ContractRemoteMessage {
 
     public String getCallbackAddress() {
         return callbackAddress;
+    }
+
+    @Override
+    public Policy getPolicy() {
+        return contractOffer.getPolicy();
     }
 
     public enum Type {

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/protocol/ContractRemoteMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/protocol/ContractRemoteMessage.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.connector.contract.spi.types.protocol;
 
+import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.types.domain.message.ProcessRemoteMessage;
 
 /**
@@ -21,5 +22,11 @@ import org.eclipse.edc.spi.types.domain.message.ProcessRemoteMessage;
  */
 public interface ContractRemoteMessage extends ProcessRemoteMessage {
 
+    /**
+     * Returns the {@link Policy} associated with the Contract.
+     *
+     * @return the contract {@link Policy}.
+     */
+    Policy getPolicy();
 
 }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferCompletionMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferCompletionMessage.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.transfer.spi.types.protocol;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.policy.model.Policy;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
@@ -32,6 +33,7 @@ public class TransferCompletionMessage implements TransferRemoteMessage {
     private String counterPartyAddress;
     private String protocol = "unknown";
     private String processId;
+    private Policy policy;
 
     @NotNull
     @Override
@@ -61,6 +63,11 @@ public class TransferCompletionMessage implements TransferRemoteMessage {
         return processId;
     }
 
+    @Override
+    public Policy getPolicy() {
+        return policy;
+    }
+
     @JsonPOJOBuilder(withPrefix = "")
     public static class Builder {
         private final TransferCompletionMessage message;
@@ -81,6 +88,11 @@ public class TransferCompletionMessage implements TransferRemoteMessage {
 
         public Builder counterPartyAddress(String address) {
             message.counterPartyAddress = address;
+            return this;
+        }
+
+        public Builder policy(Policy policy) {
+            message.policy = policy;
             return this;
         }
 

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferRemoteMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferRemoteMessage.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.connector.transfer.spi.types.protocol;
 
+import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.types.domain.message.ProcessRemoteMessage;
 import org.jetbrains.annotations.NotNull;
 
@@ -30,4 +31,11 @@ public interface TransferRemoteMessage extends ProcessRemoteMessage {
     @Override
     @NotNull
     String getProcessId();
+
+    /**
+     * Returns the {@link Policy} associated with the Transfer Process.
+     *
+     * @return the transfer process {@link Policy}.
+     */
+    Policy getPolicy();
 }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferRequestMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferRequestMessage.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.transfer.spi.types.protocol;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.jetbrains.annotations.NotNull;
 
@@ -35,13 +36,10 @@ public class TransferRequestMessage implements TransferRemoteMessage {
     private String protocol = "unknown";
     private String processId;
     private String contractId;
-    @Deprecated(forRemoval = true)
-    private String assetId;
     private DataAddress dataDestination;
-    @Deprecated(forRemoval = true)
-    private String connectorId;
     private String callbackAddress;
     private Map<String, String> properties = new HashMap<>();
+    private Policy policy;
 
     @NotNull
     @Override
@@ -71,18 +69,13 @@ public class TransferRequestMessage implements TransferRemoteMessage {
         return processId;
     }
 
-    @Deprecated
-    public String getAssetId() {
-        return assetId;
+    @Override
+    public Policy getPolicy() {
+        return policy;
     }
 
     public String getContractId() {
         return contractId;
-    }
-
-    @Deprecated
-    public String getConnectorId() {
-        return connectorId;
     }
 
     public Map<String, String> getProperties() {
@@ -111,7 +104,12 @@ public class TransferRequestMessage implements TransferRemoteMessage {
         }
 
         public Builder id(String id) {
-            this.message.id = id;
+            message.id = id;
+            return this;
+        }
+
+        public Builder policy(Policy policy) {
+            message.policy = policy;
             return this;
         }
 
@@ -140,20 +138,8 @@ public class TransferRequestMessage implements TransferRemoteMessage {
             return this;
         }
 
-        @Deprecated
-        public Builder assetId(String assetId) {
-            message.assetId = assetId;
-            return this;
-        }
-
         public Builder dataDestination(DataAddress dataDestination) {
             message.dataDestination = dataDestination;
-            return this;
-        }
-
-        @Deprecated
-        public Builder connectorId(String connectorId) {
-            message.connectorId = connectorId;
             return this;
         }
 

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferStartMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferStartMessage.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.transfer.spi.types.protocol;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.jetbrains.annotations.NotNull;
 
@@ -32,6 +33,7 @@ public class TransferStartMessage implements TransferRemoteMessage {
     private String counterPartyAddress;
     private String protocol = "unknown";
     private String processId;
+    private Policy policy;
 
     private DataAddress dataAddress;
 
@@ -63,6 +65,11 @@ public class TransferStartMessage implements TransferRemoteMessage {
         return processId;
     }
 
+    @Override
+    public Policy getPolicy() {
+        return policy;
+    }
+
     public DataAddress getDataAddress() {
         return dataAddress;
     }
@@ -87,6 +94,11 @@ public class TransferStartMessage implements TransferRemoteMessage {
 
         public Builder counterPartyAddress(String counterPartyAddress) {
             message.counterPartyAddress = counterPartyAddress;
+            return this;
+        }
+
+        public Builder policy(Policy policy) {
+            message.policy = policy;
             return this;
         }
 

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferTerminationMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferTerminationMessage.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.transfer.spi.types.protocol;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.policy.model.Policy;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
@@ -33,10 +34,9 @@ public class TransferTerminationMessage implements TransferRemoteMessage {
     private String counterPartyAddress;
     private String protocol = "unknown";
     private String processId;
-
     private String code;
-
     private String reason; //TODO change to List  https://github.com/eclipse-edc/Connector/issues/2729
+    private Policy policy;
 
     @NotNull
     @Override
@@ -64,6 +64,11 @@ public class TransferTerminationMessage implements TransferRemoteMessage {
     @NotNull
     public String getProcessId() {
         return processId;
+    }
+
+    @Override
+    public Policy getPolicy() {
+        return policy;
     }
 
     public String getCode() {
@@ -94,6 +99,11 @@ public class TransferTerminationMessage implements TransferRemoteMessage {
 
         public Builder counterPartyAddress(String counterPartyAddress) {
             message.counterPartyAddress = counterPartyAddress;
+            return this;
+        }
+
+        public Builder policy(Policy policy) {
+            message.policy = policy;
             return this;
         }
 


### PR DESCRIPTION
## What this PR changes/adds

evaluate policy on specific registered `RemoteMessage`

## Why it does that

_Briefly state why the change was necessary._

## Further notes

- removed some deprecated fields from the messages

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md)._
