### PR TITLE
feat: move observability api from `management` to `default` 

### DIFF
--- a/extensions/common/api/api-observability/build.gradle.kts
+++ b/extensions/common/api/api-observability/build.gradle.kts
@@ -21,10 +21,11 @@ dependencies {
     api(project(":spi:common:core-spi"))
     api(project(":spi:common:web-spi"))
     implementation(project(":core:common:util"))
-    implementation(project(":extensions:common:api:management-api-configuration"))
-
     implementation(libs.jakarta.rsApi)
+
     testImplementation(project(":core:common:junit"))
+    testImplementation(testFixtures(project(":extensions:common:http:jersey-core")))
+    testImplementation(libs.restAssured)
 }
 
 edcBuild {

--- a/extensions/common/api/api-observability/src/main/java/org/eclipse/edc/api/observability/ObservabilityApiController.java
+++ b/extensions/common/api/api-observability/src/main/java/org/eclipse/edc/api/observability/ObservabilityApiController.java
@@ -22,10 +22,8 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.system.health.HealthCheckService;
 import org.eclipse.edc.spi.system.health.HealthStatus;
-import org.jetbrains.annotations.NotNull;
 
 
 @Consumes({ MediaType.APPLICATION_JSON })
@@ -35,29 +33,14 @@ public class ObservabilityApiController implements ObservabilityApi {
 
     private final HealthCheckService healthCheckService;
 
-    /**
-     * This deprecation is used to permit a softer transition from the deprecated `web.http` (default) config group to the
-     * current `web.http.management`
-     *
-     * @deprecated "web.http.management" config should be used instead of "web.http" (default)
-     */
-    @Deprecated(since = "milestone8")
-    private final boolean deprecated;
-    private final Monitor monitor;
-
-    public ObservabilityApiController(HealthCheckService provider, boolean deprecated, Monitor monitor) {
+    public ObservabilityApiController(HealthCheckService provider) {
         healthCheckService = provider;
-        this.deprecated = deprecated;
-        this.monitor = monitor;
     }
 
     @GET
     @Path("health")
     @Override
     public Response checkHealth() {
-        if (deprecated) {
-            monitor.warning(deprecationMessage());
-        }
         var status = healthCheckService.getStartupStatus();
         return createResponse(status);
     }
@@ -66,9 +49,6 @@ public class ObservabilityApiController implements ObservabilityApi {
     @Path("liveness")
     @Override
     public Response getLiveness() {
-        if (deprecated) {
-            monitor.warning(deprecationMessage());
-        }
         var status = healthCheckService.isLive();
         return createResponse(status);
 
@@ -78,9 +58,6 @@ public class ObservabilityApiController implements ObservabilityApi {
     @Path("readiness")
     @Override
     public Response getReadiness() {
-        if (deprecated) {
-            monitor.warning(deprecationMessage());
-        }
         var status = healthCheckService.isReady();
         return createResponse(status);
     }
@@ -89,16 +66,8 @@ public class ObservabilityApiController implements ObservabilityApi {
     @Path("startup")
     @Override
     public Response getStartup() {
-        if (deprecated) {
-            monitor.warning(deprecationMessage());
-        }
         var status = healthCheckService.getStartupStatus();
         return createResponse(status);
-    }
-
-    @NotNull
-    private String deprecationMessage() {
-        return "The /check/* endpoint has been moved under the 'management' context, please update your url accordingly, because this endpoint will be deleted in the next releases";
     }
 
     private Response createResponse(HealthStatus status) {

--- a/extensions/common/api/api-observability/src/test/java/org/eclipse/edc/api/observability/ObservabilityApiControllerTest.java
+++ b/extensions/common/api/api-observability/src/test/java/org/eclipse/edc/api/observability/ObservabilityApiControllerTest.java
@@ -14,36 +14,36 @@
 
 package org.eclipse.edc.api.observability;
 
-import jakarta.ws.rs.core.Response;
-import org.eclipse.edc.spi.monitor.Monitor;
+import io.restassured.specification.RequestSpecification;
+import org.eclipse.edc.junit.annotations.ApiTest;
 import org.eclipse.edc.spi.system.health.HealthCheckResult;
 import org.eclipse.edc.spi.system.health.HealthCheckService;
 import org.eclipse.edc.spi.system.health.HealthStatus;
-import org.junit.jupiter.api.BeforeEach;
+import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-class ObservabilityApiControllerTest {
+@ApiTest
+class ObservabilityApiControllerTest extends RestControllerTestBase {
 
     private final HealthCheckService healthCheckService = mock(HealthCheckService.class);
-    private ObservabilityApiController controller;
-
-    @BeforeEach
-    void setUp() {
-        controller = new ObservabilityApiController(healthCheckService, false, mock(Monitor.class));
-    }
 
     @Test
     void checkHealth() {
         when(healthCheckService.getStartupStatus()).thenReturn(new HealthStatus(HealthCheckResult.success()));
 
-        assertThat(controller.checkHealth()).extracting(Response::getStatus).isEqualTo(200);
+        baseRequest()
+                .get("/health")
+                .then()
+                .statusCode(200)
+                .contentType(JSON);
 
         verify(healthCheckService, times(1)).getStartupStatus();
         verifyNoMoreInteractions(healthCheckService);
@@ -53,7 +53,11 @@ class ObservabilityApiControllerTest {
     void checkHealth_mixedResults() {
         when(healthCheckService.getStartupStatus()).thenReturn(new HealthStatus(HealthCheckResult.success(), HealthCheckResult.failed("test failure")));
 
-        assertThat(controller.checkHealth()).extracting(Response::getStatus).isEqualTo(503);
+        baseRequest()
+                .get("/health")
+                .then()
+                .statusCode(503)
+                .contentType(JSON);
 
         verify(healthCheckService, times(1)).getStartupStatus();
         verifyNoMoreInteractions(healthCheckService);
@@ -63,8 +67,11 @@ class ObservabilityApiControllerTest {
     void checkHealth_noProviders() {
         when(healthCheckService.getStartupStatus()).thenReturn(new HealthStatus());
 
-        // no provider = system not healthy
-        assertThat(controller.checkHealth()).extracting(Response::getStatus).isEqualTo(503);
+        baseRequest()
+                .get("/health")
+                .then()
+                .statusCode(503)
+                .contentType(JSON);
 
         verify(healthCheckService, times(1)).getStartupStatus();
         verifyNoMoreInteractions(healthCheckService);
@@ -74,7 +81,11 @@ class ObservabilityApiControllerTest {
     void getLiveness() {
         when(healthCheckService.isLive()).thenReturn(new HealthStatus(HealthCheckResult.success()));
 
-        assertThat(controller.getLiveness()).extracting(Response::getStatus).isEqualTo(200);
+        baseRequest()
+                .get("/liveness")
+                .then()
+                .statusCode(200)
+                .contentType(JSON);
 
         verify(healthCheckService, times(1)).isLive();
         verifyNoMoreInteractions(healthCheckService);
@@ -84,7 +95,11 @@ class ObservabilityApiControllerTest {
     void getLiveness_mixedResults() {
         when(healthCheckService.isLive()).thenReturn(new HealthStatus(HealthCheckResult.success(), HealthCheckResult.failed("test failure")));
 
-        assertThat(controller.getLiveness()).extracting(Response::getStatus).isEqualTo(503);
+        baseRequest()
+                .get("/liveness")
+                .then()
+                .statusCode(503)
+                .contentType(JSON);
 
         verify(healthCheckService, times(1)).isLive();
         verifyNoMoreInteractions(healthCheckService);
@@ -94,7 +109,11 @@ class ObservabilityApiControllerTest {
     void getLiveness_noProviders() {
         when(healthCheckService.isLive()).thenReturn(new HealthStatus());
 
-        assertThat(controller.getLiveness()).extracting(Response::getStatus).isEqualTo(503);
+        baseRequest()
+                .get("/liveness")
+                .then()
+                .statusCode(503)
+                .contentType(JSON);
 
         verify(healthCheckService, times(1)).isLive();
         verifyNoMoreInteractions(healthCheckService);
@@ -104,7 +123,11 @@ class ObservabilityApiControllerTest {
     void getReadiness() {
         when(healthCheckService.isReady()).thenReturn(new HealthStatus(HealthCheckResult.success()));
 
-        assertThat(controller.getReadiness()).extracting(Response::getStatus).isEqualTo(200);
+        baseRequest()
+                .get("/readiness")
+                .then()
+                .statusCode(200)
+                .contentType(JSON);
 
         verify(healthCheckService, times(1)).isReady();
         verifyNoMoreInteractions(healthCheckService);
@@ -114,7 +137,11 @@ class ObservabilityApiControllerTest {
     void getReadiness_mixedResults() {
         when(healthCheckService.isReady()).thenReturn(new HealthStatus(HealthCheckResult.success(), HealthCheckResult.failed("test failure")));
 
-        assertThat(controller.getReadiness()).extracting(Response::getStatus).isEqualTo(503);
+        baseRequest()
+                .get("/readiness")
+                .then()
+                .statusCode(503)
+                .contentType(JSON);
 
         verify(healthCheckService, times(1)).isReady();
         verifyNoMoreInteractions(healthCheckService);
@@ -124,7 +151,11 @@ class ObservabilityApiControllerTest {
     void getReadiness_noProvider() {
         when(healthCheckService.isReady()).thenReturn(new HealthStatus());
 
-        assertThat(controller.getReadiness()).extracting(Response::getStatus).isEqualTo(503);
+        baseRequest()
+                .get("/readiness")
+                .then()
+                .statusCode(503)
+                .contentType(JSON);
 
         verify(healthCheckService, times(1)).isReady();
         verifyNoMoreInteractions(healthCheckService);
@@ -134,7 +165,11 @@ class ObservabilityApiControllerTest {
     void getStartup() {
         when(healthCheckService.getStartupStatus()).thenReturn(new HealthStatus(HealthCheckResult.success()));
 
-        assertThat(controller.getStartup()).extracting(Response::getStatus).isEqualTo(200);
+        baseRequest()
+                .get("/startup")
+                .then()
+                .statusCode(200)
+                .contentType(JSON);
 
         verify(healthCheckService, times(1)).getStartupStatus();
         verifyNoMoreInteractions(healthCheckService);
@@ -144,7 +179,11 @@ class ObservabilityApiControllerTest {
     void getStartup_mixedResults() {
         when(healthCheckService.getStartupStatus()).thenReturn(new HealthStatus(HealthCheckResult.success(), HealthCheckResult.failed("test failure")));
 
-        assertThat(controller.getStartup()).extracting(Response::getStatus).isEqualTo(503);
+        baseRequest()
+                .get("/startup")
+                .then()
+                .statusCode(503)
+                .contentType(JSON);
 
         verify(healthCheckService, times(1)).getStartupStatus();
         verifyNoMoreInteractions(healthCheckService);
@@ -154,10 +193,24 @@ class ObservabilityApiControllerTest {
     void getStartup_noProviders() {
         when(healthCheckService.getStartupStatus()).thenReturn(new HealthStatus());
 
-        // no provider = system not healthy
-        assertThat(controller.checkHealth()).extracting(Response::getStatus).isEqualTo(503);
+        baseRequest()
+                .get("/startup")
+                .then()
+                .statusCode(503)
+                .contentType(JSON);
 
         verify(healthCheckService, times(1)).getStartupStatus();
         verifyNoMoreInteractions(healthCheckService);
+    }
+
+    @Override
+    protected Object controller() {
+        return new ObservabilityApiController(healthCheckService);
+    }
+
+    private RequestSpecification baseRequest() {
+        return given()
+                .baseUri("http://localhost:" + port + "/check")
+                .when();
     }
 }

--- a/extensions/common/api/api-observability/src/test/java/org/eclipse/edc/api/observability/ObservabilityApiExtensionTest.java
+++ b/extensions/common/api/api-observability/src/test/java/org/eclipse/edc/api/observability/ObservabilityApiExtensionTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.api.observability;
 
-import org.eclipse.edc.connector.api.management.configuration.ManagementApiConfiguration;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.health.HealthCheckService;
@@ -22,12 +21,10 @@ import org.eclipse.edc.spi.system.health.LivenessProvider;
 import org.eclipse.edc.spi.system.health.ReadinessProvider;
 import org.eclipse.edc.spi.system.injection.ObjectFactory;
 import org.eclipse.edc.web.spi.WebService;
-import org.eclipse.edc.web.spi.configuration.WebServiceConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -36,20 +33,14 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 @ExtendWith(DependencyInjectionExtension.class)
 class ObservabilityApiExtensionTest {
 
-    private final WebService webService = mock(WebService.class);
-    private final HealthCheckService healthService = mock(HealthCheckService.class);
+    private final WebService webService = mock();
+    private final HealthCheckService healthService = mock();
     private ObservabilityApiExtension extension;
 
     @BeforeEach
     void setup(ServiceExtensionContext context, ObjectFactory factory) {
-        var webServiceConfiguration = WebServiceConfiguration.Builder.newInstance()
-                .contextAlias("management")
-                .path("/management")
-                .port(8888)
-                .build();
         context.registerService(WebService.class, webService);
         context.registerService(HealthCheckService.class, healthService);
-        context.registerService(ManagementApiConfiguration.class, new ManagementApiConfiguration(webServiceConfiguration));
         extension = factory.constructInstance(ObservabilityApiExtension.class);
     }
 
@@ -60,7 +51,6 @@ class ObservabilityApiExtensionTest {
         extension.initialize(contextMock);
 
         verify(webService).registerResource(isA(ObservabilityApiController.class));
-        verify(webService).registerResource(eq("management"), isA(ObservabilityApiController.class));
         verify(healthService).addReadinessProvider(isA(ReadinessProvider.class));
         verify(healthService).addLivenessProvider(isA(LivenessProvider.class));
         verifyNoMoreInteractions(webService);


### PR DESCRIPTION
## What this PR changes/adds

Remove observability controller from management api and put on the default context as it was before the api context refactoring

## Why it does that

Untangling dependencies between an hi-level api as observability and the management api

## Further notes

-

## Linked Issue(s)

Closes #3165 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md)._
