### PR TITLE
feat(TokenParameters): add field for additional information

### DIFF
--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/iam/TokenParameters.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/iam/TokenParameters.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.edc.spi.iam;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -22,6 +24,8 @@ import java.util.Objects;
 public class TokenParameters {
     private String scope;
     private String audience;
+
+    private Map<String, Object> additional = new HashMap<>();
 
     private TokenParameters() {
     }
@@ -32,6 +36,10 @@ public class TokenParameters {
 
     public String getAudience() {
         return audience;
+    }
+
+    public Map<String, Object> getAdditional() {
+        return additional;
     }
 
     public static class Builder {
@@ -52,6 +60,11 @@ public class TokenParameters {
 
         public Builder audience(String audience) {
             result.audience = audience;
+            return this;
+        }
+
+        public Builder additional(Map<String, Object> additional) {
+            result.additional = additional;
             return this;
         }
 


### PR DESCRIPTION
## What this PR changes/adds

Adds an additional map field in `TokenParameters`

## Why it does that

Be able to provide additional information when evaluating a policy in the dispatcher

## Linked Issue(s)

Closes #3168 


