### PR TITLE
feat: add a policy scope for outgoing Catalog requests

### DIFF
--- a/data-protocols/dsp/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/DspHttpCoreExtension.java
+++ b/data-protocols/dsp/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/DspHttpCoreExtension.java
@@ -73,7 +73,7 @@ public class DspHttpCoreExtension implements ServiceExtension {
      * Policy scope evaluated when an outgoing catalog request is made
      */
     @PolicyScope
-    private static final String CATALOGING_REQUEST_SCOPE = "contract.cataloging.request";
+    private static final String CATALOGING_REQUEST_SCOPE = "catalog.request";
 
     @Inject
     private RemoteMessageDispatcherRegistry dispatcherRegistry;

--- a/data-protocols/dsp/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/DspHttpCoreExtension.java
+++ b/data-protocols/dsp/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/DspHttpCoreExtension.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.protocol.dsp;
 
+import org.eclipse.edc.catalog.spi.CatalogRequestMessage;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementMessage;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementVerificationMessage;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractNegotiationEventMessage;
@@ -68,6 +69,12 @@ public class DspHttpCoreExtension implements ServiceExtension {
     @PolicyScope
     private static final String TRANSFER_PROCESS_REQUEST_SCOPE = "transfer.process.request";
 
+    /**
+     * Policy scope evaluated when an outgoing catalog request is made
+     */
+    @PolicyScope
+    private static final String CATALOGING_REQUEST_SCOPE = "contract.cataloging.request";
+
     @Inject
     private RemoteMessageDispatcherRegistry dispatcherRegistry;
     @Inject
@@ -103,8 +110,14 @@ public class DspHttpCoreExtension implements ServiceExtension {
         var dispatcher = new DspHttpRemoteMessageDispatcherImpl(httpClient, identityService, td, policyEngine);
         registerNegotiationPolicyScopes(dispatcher);
         registerTransferProcessPolicyScopes(dispatcher);
+        registerCatalogPolicyScopes(dispatcher);
         dispatcherRegistry.register(dispatcher);
         return dispatcher;
+    }
+
+    @Provider
+    public JsonLdRemoteMessageSerializer jsonLdRemoteMessageSerializer() {
+        return new JsonLdRemoteMessageSerializerImpl(transformerRegistry, typeManager.getMapper(JSON_LD), jsonLdService);
     }
 
     private void registerNegotiationPolicyScopes(DspHttpRemoteMessageDispatcher dispatcher) {
@@ -122,9 +135,8 @@ public class DspHttpCoreExtension implements ServiceExtension {
         dispatcher.registerPolicyScope(TransferRequestMessage.class, TRANSFER_PROCESS_REQUEST_SCOPE, TransferRemoteMessage::getPolicy);
     }
 
-    @Provider
-    public JsonLdRemoteMessageSerializer jsonLdRemoteMessageSerializer() {
-        return new JsonLdRemoteMessageSerializerImpl(transformerRegistry, typeManager.getMapper(JSON_LD), jsonLdService);
+    private void registerCatalogPolicyScopes(DspHttpRemoteMessageDispatcher dispatcher) {
+        dispatcher.registerPolicyScope(CatalogRequestMessage.class, CATALOGING_REQUEST_SCOPE, CatalogRequestMessage::getPolicy);
     }
 
 }

--- a/spi/common/catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/CatalogRequestMessage.java
+++ b/spi/common/catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/CatalogRequestMessage.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.catalog.spi;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
 import org.jetbrains.annotations.NotNull;
@@ -28,11 +29,17 @@ import java.util.Objects;
 @JsonDeserialize(builder = CatalogRequestMessage.Builder.class)
 public class CatalogRequestMessage implements RemoteMessage {
 
+    private final Policy policy;
     private String protocol = "unknown";
     @Deprecated(forRemoval = true)
     private String connectorId;
     private String counterPartyAddress;
     private QuerySpec querySpec;
+
+    private CatalogRequestMessage() {
+        // at this time, this is just a placeholder.
+        policy = Policy.Builder.newInstance().build();
+    }
 
     @NotNull
     @Override
@@ -60,11 +67,21 @@ public class CatalogRequestMessage implements RemoteMessage {
         return querySpec;
     }
 
-    private CatalogRequestMessage() {
+    /**
+     * Returns the {@link Policy} associated with the Catalog Request. Currently, this is an empty policy and serves as placeholder.
+     *
+     * @return the stub {@link Policy}.
+     */
+    public Policy getPolicy() {
+        return policy;
     }
 
     public static class Builder {
-        private CatalogRequestMessage message;
+        private final CatalogRequestMessage message;
+
+        private Builder() {
+            message = new CatalogRequestMessage();
+        }
 
         @JsonCreator
         public static CatalogRequestMessage.Builder newInstance() {
@@ -100,10 +117,6 @@ public class CatalogRequestMessage implements RemoteMessage {
             }
 
             return message;
-        }
-
-        private Builder() {
-            message = new CatalogRequestMessage();
         }
 
     }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/offer/ContractDefinitionResolver.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/offer/ContractDefinitionResolver.java
@@ -32,7 +32,7 @@ import java.util.stream.Stream;
 public interface ContractDefinitionResolver {
 
     @PolicyScope
-    String CATALOGING_SCOPE = "contract.cataloging";
+    String CATALOGING_SCOPE = "catalog";
 
     /**
      * Returns the definitions for the given participant agent.


### PR DESCRIPTION
## What this PR changes/adds

This PR adds a policy scope `"contract.cataloging.request"`, so that we can invoke policy evaluation functions on outgoing catalog requests.

For now, the corresponding policy is an empty stub, because we don't (yet) have a way to supply one, but that may change in the future, e.g. by another extension.

## Why it does that

We need a way to invoke policy functions on all outgoing requests to attach credentials to the request. At this time, this is a requirement from Catena-X, but it is not limited to it.

## Further notes

- at this time, the type of credential that gets attached is determined by the function, but in future iterations we could have a policy (or policies) that determine(s), which credentials need to be attached for which request.

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md)._
