### PR TITLE
chore(TokenParameters): make additional additive

### DIFF
--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/iam/TokenParameters.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/iam/TokenParameters.java
@@ -22,10 +22,9 @@ import java.util.Objects;
  * Parameter Object for {@link IdentityService#obtainClientCredentials(TokenParameters)}.
  */
 public class TokenParameters {
+    private final Map<String, Object> additional = new HashMap<>();
     private String scope;
     private String audience;
-
-    private Map<String, Object> additional = new HashMap<>();
 
     private TokenParameters() {
     }
@@ -64,7 +63,12 @@ public class TokenParameters {
         }
 
         public Builder additional(Map<String, Object> additional) {
-            result.additional = additional;
+            result.additional.putAll(additional);
+            return this;
+        }
+
+        public Builder additional(String key, Object value) {
+            result.additional.put(key, value);
             return this;
         }
 


### PR DESCRIPTION
## What this PR changes/adds

Make `TokenParameters.Builder#additional` additive

## Why it does that

When working with multiple policy functions that deals with `TokenParamenter.Builder` it's better to have an additive version of `additional` method in the builder.

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_


