### PR TITLE
feat: validate contract agreement controller

### DIFF
--- a/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/api/management/contractagreement/ContractAgreementApiExtension.java
+++ b/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/api/management/contractagreement/ContractAgreementApiExtension.java
@@ -25,6 +25,7 @@ import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 import org.eclipse.edc.web.spi.WebService;
 
 import java.util.Map;
@@ -45,6 +46,9 @@ public class ContractAgreementApiExtension implements ServiceExtension {
     @Inject
     private ContractAgreementService service;
 
+    @Inject
+    private JsonObjectValidatorRegistry validatorRegistry;
+
     @Override
     public String name() {
         return NAME;
@@ -56,6 +60,7 @@ public class ContractAgreementApiExtension implements ServiceExtension {
         transformerRegistry.register(new JsonObjectFromContractAgreementDtoTransformer(Json.createBuilderFactory(Map.of())));
         var monitor = context.getMonitor();
 
-        webService.registerResource(config.getContextAlias(), new ContractAgreementApiController(service, transformerRegistry, monitor));
+        var controller = new ContractAgreementApiController(service, transformerRegistry, monitor, validatorRegistry);
+        webService.registerResource(config.getContextAlias(), controller);
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

In fact this only adds the validation for the `QuerySpecDto` object, as `ContractAgreement` doesn't have any input dto to be validated

## Why it does that

validation

## Linked Issue(s)

Part of #3011

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md)._
