### PR TITLE
feat: make json-ld expansion fails if titanium returns empty result

### DIFF
--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/TitaniumJsonLd.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/TitaniumJsonLd.java
@@ -61,7 +61,6 @@ public class TitaniumJsonLd implements JsonLd {
     @Override
     public Result<JsonObject> expand(JsonObject json) {
         try {
-
             var document = JsonDocument.of(injectVocab(json));
             var expanded = com.apicatalog.jsonld.JsonLd.expand(document)
                     .options(new JsonLdOptions(documentLoader))
@@ -69,7 +68,7 @@ public class TitaniumJsonLd implements JsonLd {
             if (expanded.size() > 0) {
                 return Result.success(expanded.getJsonObject(0));
             }
-            return Result.success(createObjectBuilder().build());
+            return Result.failure("Error expanding JSON-LD structure: result was empty, it could be caused by missing '@context'");
         } catch (JsonLdError error) {
             monitor.warning("Error expanding JSON-LD structure", error);
             return Result.failure(error.getMessage());

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/TitaniumJsonLdTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/TitaniumJsonLdTest.java
@@ -63,8 +63,7 @@ class TitaniumJsonLdTest {
 
         var expanded = defaultService().expand(jsonObject);
 
-        assertThat(expanded.succeeded()).isTrue();
-        assertThat(expanded.getContent().toString())
+        assertThat(expanded).isSucceeded().extracting(Object::toString).asString()
                 .contains("test:item")
                 .contains("test:key1")
                 .contains("@value\":\"value1\"")
@@ -73,11 +72,12 @@ class TitaniumJsonLdTest {
     }
 
     @Test
-    void expand_withEmptyArray() {
-        var expanded = defaultService().expand(createObjectBuilder().build());
+    void expand_shouldFail_whenPropertiesWithoutNamespaceAndContextIsMissing() {
+        var emptyJson = createObjectBuilder().add("key", "value").build();
 
-        assertThat(expanded.succeeded()).isTrue();
-        assertThat(expanded.getContent()).isEmpty();
+        var expanded = defaultService().expand(emptyJson);
+
+        assertThat(expanded).isFailed();
     }
 
     @Test
@@ -93,8 +93,7 @@ class TitaniumJsonLdTest {
 
         var expanded = defaultService().expand(jsonObject);
 
-        assertThat(expanded.succeeded()).isTrue();
-        assertThat(expanded.getContent().toString())
+        assertThat(expanded).isSucceeded().extracting(Object::toString).asString()
                 .contains("test:item")
                 .contains("test:key1")
                 .contains("@value\":\"value1\"")
@@ -114,10 +113,11 @@ class TitaniumJsonLdTest {
 
         var compacted = defaultService().compact(expanded);
 
-        assertThat(compacted.succeeded()).isTrue();
-        assertThat(compacted.getContent().getJsonObject(ns + "item")).isNotNull();
-        assertThat(compacted.getContent().getJsonObject(ns + "item").getJsonString(ns + "key1").getString()).isEqualTo("value1");
-        assertThat(compacted.getContent().getJsonObject(ns + "item").getJsonString(ns + "key2").getString()).isEqualTo("value2");
+        assertThat(compacted).isSucceeded().satisfies(c -> {
+            assertThat(c.getJsonObject(ns + "item")).isNotNull();
+            assertThat(c.getJsonObject(ns + "item").getJsonString(ns + "key1").getString()).isEqualTo("value1");
+            assertThat(c.getJsonObject(ns + "item").getJsonString(ns + "key2").getString()).isEqualTo("value2");
+        });
     }
 
     @Test
@@ -135,10 +135,11 @@ class TitaniumJsonLdTest {
         service.registerNamespace(prefix, ns);
         var compacted = service.compact(expanded);
 
-        assertThat(compacted.succeeded()).isTrue();
-        assertThat(compacted.getContent().getJsonObject(prefix + ":item")).isNotNull();
-        assertThat(compacted.getContent().getJsonObject(prefix + ":item").getJsonString(prefix + ":key1").getString()).isEqualTo("value1");
-        assertThat(compacted.getContent().getJsonObject(prefix + ":item").getJsonString(prefix + ":key2").getString()).isEqualTo("value2");
+        assertThat(compacted).isSucceeded().satisfies(c -> {
+            assertThat(c.getJsonObject(prefix + ":item")).isNotNull();
+            assertThat(c.getJsonObject(prefix + ":item").getJsonString(prefix + ":key1").getString()).isEqualTo("value1");
+            assertThat(c.getJsonObject(prefix + ":item").getJsonString(prefix + ":key2").getString()).isEqualTo("value2");
+        });
     }
 
     @Test

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApiExtension.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApiExtension.java
@@ -33,6 +33,7 @@ import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 import org.eclipse.edc.web.spi.WebService;
 
 import static org.eclipse.edc.connector.api.management.asset.model.AssetEntryNewDto.EDC_ASSET_ENTRY_DTO_TYPE;
+import static org.eclipse.edc.spi.types.domain.asset.Asset.EDC_ASSET_TYPE;
 
 @Extension(value = AssetApiExtension.NAME)
 public class AssetApiExtension implements ServiceExtension {
@@ -71,8 +72,9 @@ public class AssetApiExtension implements ServiceExtension {
         transformerRegistry.register(new AssetToAssetResponseDtoTransformer());
         transformerRegistry.register(new JsonObjectToAssetEntryNewDtoTransformer());
 
-        validator.register(EDC_ASSET_ENTRY_DTO_TYPE, AssetEntryDtoValidator.instance());
-        
+        validator.register(EDC_ASSET_ENTRY_DTO_TYPE, AssetEntryDtoValidator.assetEntryValidator());
+        validator.register(EDC_ASSET_TYPE, AssetEntryDtoValidator.assetValidator());
+
         webService.registerResource(config.getContextAlias(), new AssetApiController(assetService, dataAddressResolver, transformerRegistry, monitor, validator));
     }
 }

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/validation/AssetEntryDtoValidator.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/validation/AssetEntryDtoValidator.java
@@ -34,7 +34,7 @@ import static org.eclipse.edc.validator.spi.Violation.violation;
  */
 public class AssetEntryDtoValidator {
 
-    public static Validator<JsonObject> instance() {
+    public static Validator<JsonObject> assetEntryValidator() {
         return JsonObjectValidator.newValidator()
                 .verify(EDC_ASSET_ENTRY_DTO_ASSET, MandatoryObject::new)
                 .verifyObject(EDC_ASSET_ENTRY_DTO_ASSET, v -> v
@@ -46,6 +46,14 @@ public class AssetEntryDtoValidator {
                 .verifyObject(EDC_ASSET_ENTRY_DTO_DATA_ADDRESS, v -> v
                         .verify(EDC_DATA_ADDRESS_TYPE_PROPERTY, MandatoryValue::new)
                 )
+                .build();
+    }
+
+    public static Validator<JsonObject> assetValidator() {
+        return JsonObjectValidator.newValidator()
+                .verifyId(OptionalIdNotBlank::new)
+                .verify(EDC_ASSET_PROPERTIES, MandatoryObject::new)
+                .verify(path -> new AssetPropertiesUniqueness())
                 .build();
     }
 

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/AssetApiExtensionTest.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/AssetApiExtensionTest.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.asset;
+
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.system.injection.ObjectFactory;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.eclipse.edc.connector.api.management.asset.model.AssetEntryNewDto.EDC_ASSET_ENTRY_DTO_TYPE;
+import static org.eclipse.edc.spi.types.domain.asset.Asset.EDC_ASSET_TYPE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(DependencyInjectionExtension.class)
+class AssetApiExtensionTest {
+
+    private final JsonObjectValidatorRegistry validatorRegistry = mock();
+    private AssetApiExtension extension;
+
+    @BeforeEach
+    void setUp(ObjectFactory factory, ServiceExtensionContext context) {
+        context.registerService(JsonObjectValidatorRegistry.class, validatorRegistry);
+        extension = factory.constructInstance(AssetApiExtension.class);
+    }
+
+    @Test
+    void initialize_shouldRegisterValidators(ServiceExtensionContext context) {
+        extension.initialize(context);
+
+        verify(validatorRegistry).register(eq(EDC_ASSET_TYPE), any());
+        verify(validatorRegistry).register(eq(EDC_ASSET_ENTRY_DTO_TYPE), any());
+    }
+}

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/validation/AssetEntryDtoValidatorTest.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/validation/AssetEntryDtoValidatorTest.java
@@ -33,7 +33,7 @@ import static org.eclipse.edc.spi.types.domain.asset.Asset.EDC_ASSET_PROPERTIES;
 
 class AssetEntryDtoValidatorTest {
 
-    private final Validator<JsonObject> validator = AssetEntryDtoValidator.instance();
+    private final Validator<JsonObject> validator = AssetEntryDtoValidator.assetEntryValidator();
 
     @Test
     void shouldSucceed_whenValidInput() {

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/AssetApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/AssetApiEndToEndTest.java
@@ -305,6 +305,7 @@ public class AssetApiEndToEndTest extends BaseManagementApiEndToEndTest {
                 .body(assetJson)
                 .put()
                 .then()
+                .log().all()
                 .statusCode(204)
                 .body(notNullValue());
 

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractDefinitionApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractDefinitionApiEndToEndTest.java
@@ -56,7 +56,6 @@ public class ContractDefinitionApiEndToEndTest extends BaseManagementApiEndToEnd
 
         var body = baseRequest()
                 .contentType(JSON)
-                .body("{}")
                 .post("/request")
                 .then()
                 .statusCode(200)

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/PolicyDefinitionApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/PolicyDefinitionApiEndToEndTest.java
@@ -94,7 +94,6 @@ public class PolicyDefinitionApiEndToEndTest extends BaseManagementApiEndToEndTe
                 .extract().jsonPath().getString(ID);
 
         var createdAt = baseRequest()
-                .body(createObjectBuilder().build())
                 .contentType(JSON)
                 .post("/request")
                 .then()

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TransferProcessApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TransferProcessApiEndToEndTest.java
@@ -37,6 +37,7 @@ import static org.eclipse.edc.connector.transfer.spi.types.TransferProcessStates
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
 import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 import static org.eclipse.edc.spi.CoreConstants.EDC_PREFIX;
 import static org.eclipse.edc.spi.types.domain.callback.CallbackAddress.EVENTS;
@@ -54,11 +55,9 @@ public class TransferProcessApiEndToEndTest extends BaseManagementApiEndToEndTes
     void getAll() {
         getStore().updateOrCreate(createTransferProcess("tp1"));
         getStore().updateOrCreate(createTransferProcess("tp2"));
-        var requestBody = createObjectBuilder().build();
 
         baseRequest()
                 .contentType(JSON)
-                .body(requestBody)
                 .post("/request")
                 .then()
                 .statusCode(200)
@@ -138,10 +137,14 @@ public class TransferProcessApiEndToEndTest extends BaseManagementApiEndToEndTes
     void terminate() {
         var id = UUID.randomUUID().toString();
         getStore().updateOrCreate(createTransferProcess(id));
+        var requestBody = createObjectBuilder()
+                .add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
+                .add("reason", "any")
+                .build();
 
         baseRequest()
                 .contentType(JSON)
-                .body(createObjectBuilder().build())
+                .body(requestBody)
                 .post("/" + id + "/terminate")
                 .then()
                 .statusCode(204);


### PR DESCRIPTION
## What this PR changes/adds

Make `TitaniumJsonLd` expansion fails if the result is empty (that usually happens when there are no expanded properties, e.g. when there are no namespaced properties withouth the `@context` property set).

It also fix a nit that avoided the validator to work correctly on the `update` method

## Why it does that

improve error messages

## Further notes

-

## Linked Issue(s)

Closes #3172 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md)._
