### PR TITLE
docs: decision record about contributor onboarding process

### DIFF
--- a/docs/developer/decision-records/2023-06-19-onboarding-contributors/README.md
+++ b/docs/developer/decision-records/2023-06-19-onboarding-contributors/README.md
@@ -1,0 +1,45 @@
+# Changes to onboarding contributors
+
+## Decision
+
+Becoming a _"contributor"_ in the project will now require a proven track record of continuous contributions. The list
+of _"contributors"_ will be checked regularly for active participation, and inactive members will get removed.
+
+NB: the term _"contributor"_ refers to a specific role in the GitHub org defined by Eclipse, not in the loosely defined
+GitHub sense "person who has contributed once".
+
+## Rationale
+
+Contributors have certain rights, like assigning issue labels, that can have a significant impact on the lifecycle of an
+issue. For example, a contributor could remove the `triage` label (
+see [this decision-record](../2023-06-19-new-issue-triage-process)) and thus schedule an issue for planning. At the very
+least that causes additional work for the technical committee.
+Combined with the fact that up until now there was no real process to become a committer, that could cause confusion and
+additional effort.
+
+So in order to become a committer, there now has to be a sustained stream of valuable contributions in the form of
+pull-requests and beyond that, the contributor-to-be has to show that they'll be a valuable addition to the group, e.g.
+by participating in discussions, answering questions etc. It is generally assumed that the project guidelines
+regarding [pull requests](../../../../pr_etiquette.md), [code style](../../../../styleguide.md), [coding
+principles](../../architecture/coding-principles.md) etc. are adhered to.
+
+The intention behind this is not to make it unduly hard for people to participate in the project ("gate-keeping"), but
+rather to groom an active community, that gains insight and knowledge about EDC, and where members can - and are willing
+to - contribute back into the community.
+
+While pull requests are certainly the most important and impactful way of contributing, there are others, like
+participating in discussions, creating meaningful and well-formulated issues, etc. that will be taken into
+consideration.
+
+If active participation of a contributor stagnates or ceases completely, that contributor may get removed again without
+prior notice. Both adding and removing happens at the discretion of the technical committee of EDC.
+
+> Being a contributor first is a precondition to becoming a committer!
+
+## Approach
+
+- Adding and removing contributors is done by the technical committee in one of its regular meetings
+- There is no hard minimum amount of contributions, approval happens at the discretion of the committee. There also is
+  no guaranteed time frame for a decision.
+- After this decision-record gets accepted, the technical committee will evaluate the current list of contributors, and
+  perform an initial clean-up

--- a/docs/developer/decision-records/README.md
+++ b/docs/developer/decision-records/README.md
@@ -64,3 +64,4 @@
 - [2023-06-02-separating_plugins_and_metamodel](2023-06-02-separating_plugins_and_metamodel)
 - [2023-06-05-validation-engine](2023-06-05-validation-engine)
 - [2023-06-19-change-of-github-labels](2023-06-19-new-issue-triage-process/)
+- [2023-06-19-onboarding-contributors](2023-06-19-onboarding-contributors/)


### PR DESCRIPTION
## What this PR changes/adds

Adds a decision record about the requirements to become a contributor.

## Why it does that

persist the decision from June 16 2023

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md)._
