### PR TITLE
refactor: improve `PolicyEngine` interface

### DIFF
--- a/core/common/policy-engine/build.gradle.kts
+++ b/core/common/policy-engine/build.gradle.kts
@@ -21,6 +21,8 @@ dependencies {
     api(project(":spi:common:policy-engine-spi"))
     api(project(":spi:common:policy-model"))
     implementation(project(":core:common:policy-evaluator"))
+
+    testImplementation(project(":core:common:junit"))
 }
 
 

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/offer/ContractDefinitionResolverImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/offer/ContractDefinitionResolverImpl.java
@@ -21,6 +21,7 @@ import org.eclipse.edc.connector.contract.spi.offer.store.ContractDefinitionStor
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractDefinition;
 import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
 import org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore;
+import org.eclipse.edc.policy.engine.spi.PolicyContextImpl;
 import org.eclipse.edc.policy.engine.spi.PolicyEngine;
 import org.eclipse.edc.spi.agent.ParticipantAgent;
 import org.eclipse.edc.spi.monitor.Monitor;
@@ -72,10 +73,11 @@ public class ContractDefinitionResolverImpl implements ContractDefinitionResolve
      * Determines the applicability of a definition to an agent by evaluating its access policy.
      */
     private boolean evaluateAccessPolicy(ContractDefinition definition, ParticipantAgent agent) {
+        var policyContext = PolicyContextImpl.Builder.newInstance().additional(ParticipantAgent.class, agent).build();
         var accessResult = Optional.of(definition.getAccessPolicyId())
                 .map(policyStore::findById)
                 .map(PolicyDefinition::getPolicy)
-                .map(policy -> policyEngine.evaluate(CATALOGING_SCOPE, policy, agent))
+                .map(policy -> policyEngine.evaluate(CATALOGING_SCOPE, policy, policyContext))
                 .orElse(Result.failure(format("Policy %s not found", definition.getAccessPolicyId())));
 
         if (accessResult.failed()) {

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/validation/ContractExpiryCheckFunction.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/validation/ContractExpiryCheckFunction.java
@@ -127,40 +127,27 @@ public class ContractExpiryCheckFunction implements AtomicConstraintFunction<Per
      * @throws EdcException if the string was not recognized
      */
     private TemporalUnit asChrono(String unit) {
-        switch (unit) {
-            case "s":
-                return ChronoUnit.SECONDS;
-            case "m":
-                return ChronoUnit.MINUTES;
-            case "h":
-                return ChronoUnit.HOURS;
-            case "d":
-                return ChronoUnit.DAYS;
-            default:
-                throw new EdcException(format("Cannot parse '%s' into a ChronoUnit", unit));
-        }
+        return switch (unit) {
+            case "s" -> ChronoUnit.SECONDS;
+            case "m" -> ChronoUnit.MINUTES;
+            case "h" -> ChronoUnit.HOURS;
+            case "d" -> ChronoUnit.DAYS;
+            default -> throw new EdcException(format("Cannot parse '%s' into a ChronoUnit", unit));
+        };
     }
 
     private boolean checkFixedPeriod(Instant now, Operator operator, Instant bound) {
         var comparison = now.compareTo(bound);
 
-        switch (operator) {
-            case EQ:
-                return comparison == 0;
-            case NEQ:
-                return comparison != 0;
-            case GT:
-                return comparison > 0;
-            case GEQ:
-                return comparison >= 0;
-            case LT:
-                return comparison < 0;
-            case LEQ:
-                return comparison <= 0;
-            case IN:
-            default:
-                throw new IllegalStateException("Unexpected value: " + operator);
-        }
+        return switch (operator) {
+            case EQ -> comparison == 0;
+            case NEQ -> comparison != 0;
+            case GT -> comparison > 0;
+            case GEQ -> comparison >= 0;
+            case LT -> comparison < 0;
+            case LEQ -> comparison <= 0;
+            default -> throw new IllegalStateException("Unexpected value: " + operator);
+        };
     }
 
     private Instant asInstant(String isoString) {

--- a/data-protocols/dsp/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/dispatcher/DspHttpRemoteMessageDispatcherImpl.java
+++ b/data-protocols/dsp/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/dispatcher/DspHttpRemoteMessageDispatcherImpl.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.protocol.dsp.dispatcher;
 
+import org.eclipse.edc.policy.engine.spi.PolicyContextImpl;
 import org.eclipse.edc.policy.engine.spi.PolicyEngine;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.protocol.dsp.spi.dispatcher.DspHttpDispatcherDelegate;
@@ -87,10 +88,11 @@ public class DspHttpRemoteMessageDispatcherImpl implements DspHttpRemoteMessageD
 
         var policyScope = policyScopes.get(message.getClass());
         if (policyScope != null) {
-            var policyContext = new HashMap<Class<?>, Object>();
-            policyContext.put(TokenParameters.Builder.class, tokenParametersBuilder);
+            var context = PolicyContextImpl.Builder.newInstance()
+                    .additional(TokenParameters.Builder.class, tokenParametersBuilder)
+                    .build();
             var policyProvider = (Function<M, Policy>) policyScope.policyProvider;
-            policyEngine.evaluate(policyScope.scope, policyProvider.apply(message), null, policyContext);
+            policyEngine.evaluate(policyScope.scope, policyProvider.apply(message), context);
         }
 
         var tokenParameters = tokenParametersBuilder

--- a/data-protocols/dsp/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/dispatcher/DspHttpRemoteMessageDispatcherImplTest.java
+++ b/data-protocols/dsp/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/dispatcher/DspHttpRemoteMessageDispatcherImplTest.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.protocol.dsp.dispatcher;
 
 import okhttp3.Request;
 import okhttp3.Response;
+import org.eclipse.edc.policy.engine.spi.PolicyContext;
 import org.eclipse.edc.policy.engine.spi.PolicyEngine;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.protocol.dsp.spi.dispatcher.DspHttpDispatcherDelegate;
@@ -40,10 +41,11 @@ import static java.time.temporal.ChronoUnit.SECONDS;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.protocol.dsp.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP;
+import static org.mockito.AdditionalMatchers.and;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -182,7 +184,7 @@ class DspHttpRemoteMessageDispatcherImplTest {
         var result = dispatcher.send(String.class, new TestMessage());
 
         assertThat(result).succeedsWithin(timeout);
-        verify(policyEngine).evaluate(any(), eq(policy), isNull(), argThat(map -> map.containsKey(TokenParameters.Builder.class)));
+        verify(policyEngine).evaluate(eq("test.message"), eq(policy), and(isA(PolicyContext.class), argThat(c -> c.getContextData(TokenParameters.Builder.class) != null)));
     }
 
     static class TestMessage implements RemoteMessage {

--- a/spi/common/policy-engine-spi/src/main/java/org/eclipse/edc/policy/engine/spi/PolicyContext.java
+++ b/spi/common/policy-engine-spi/src/main/java/org/eclipse/edc/policy/engine/spi/PolicyContext.java
@@ -43,7 +43,10 @@ public interface PolicyContext {
 
     /**
      * Returns the participant agent to evaluate the policy against.
+     *
+     * @deprecated please use {@link #getContextData(Class)}.
      */
+    @Deprecated(since = "0.1.1")
     ParticipantAgent getParticipantAgent();
 
     /**

--- a/spi/common/policy-engine-spi/src/main/java/org/eclipse/edc/policy/engine/spi/PolicyEngine.java
+++ b/spi/common/policy-engine-spi/src/main/java/org/eclipse/edc/policy/engine/spi/PolicyEngine.java
@@ -56,14 +56,25 @@ public interface PolicyEngine {
     Policy filter(Policy policy, String scope);
 
     /**
-     * Evaluates the given policy for an agent for the given scope.
+     * Evaluates the given policy with a context for the given scope.
      */
+    Result<Void> evaluate(String scope, Policy policy, PolicyContext context);
+
+    /**
+     * Evaluates the given policy for an agent for the given scope.
+     *
+     * @deprecated please use {@link #evaluate(String, Policy, PolicyContext)}.
+     */
+    @Deprecated(since = "0.1.1")
     Result<Policy> evaluate(String scope, Policy policy, ParticipantAgent agent);
 
     /**
      * Evaluates the given policy for an agent for the given scope using additional context information.
      * Values in the map need to be of the same type defined by the key.
+     *
+     * @deprecated please use {@link #evaluate(String, Policy, PolicyContext)}.
      */
+    @Deprecated(since = "0.1.1")
     Result<Policy> evaluate(String scope, Policy policy, ParticipantAgent agent, Map<Class<?>, Object> contextInformation);
 
     /**


### PR DESCRIPTION
## What this PR changes/adds

Add a new method that accepts a `PolicyContext` object, deprecating the others 

## Why it does that

improve interface

## Further notes

- went using `PolicyContext` also if in the issue I stated that it should not be done, has been shown to be the best approach

## Linked Issue(s)

Closes #3162 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md)._
