### PR TITLE
chore: adapt issue labels and auto-stale

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug Report
 about: Create a report to help us improve
 title: ''
-labels: 'bug'
+labels: [ "bug_report", "triage" ]
 assignees: ''
 
 ---
@@ -10,22 +10,28 @@ assignees: ''
 # Bug Report
 
 ## Describe the Bug
+
 _A clear and concise description of the bug._
 
 ### Expected Behavior
+
 _A clear and concise description of what you expected to happen._
 
 ### Observed Behavior
+
 _A clear and concise description of what happened instead._
 
 ## Steps to Reproduce
+
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
 ## Context Information
+
 _Add any other context about the problem here._
 
 - Used version [e.g. EDC v1.0.0]
@@ -33,7 +39,9 @@ _Add any other context about the problem here._
 - ...
 
 ## Detailed Description
+
 _If applicable, add screenshots and logs to help explain your problem._
 
 ## Possible Implementation
+
 _You already know the root cause of the erroneous state and how to fix it? Feel free to share your thoughts._

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,20 +2,24 @@
 name: Feature Request
 about: Help us with new ideas
 title: ''
-labels: ''
+labels: [ "feature_request", "triage" ]
 assignees: ''
 
 ---
 
 # Feature Request
 
-_If you are missing a feature or have an idea how to improve this project that should first be discussed, please feel free to open up a [discussion](https://github.com/eclipse-edc/Connector/discussions/categories/ideas)._
+_If you are missing a feature or have an idea how to improve this project that should first be discussed, please feel
+free to open up a [discussion](https://github.com/eclipse-edc/Connector/discussions/categories/ideas)._
 
 ## Which Areas Would Be Affected?
+
 _e.g., DPF, CI, build, transfer, etc._
 
 ## Why Is the Feature Desired?
+
 _Are there any requirements?_
 
 ## Solution Proposal
+
 _If possible, provide a (brief!) solution proposal._

--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -5,6 +5,27 @@ on:
   workflow_dispatch: # allow manual trigger
 
 jobs:
+  close-issues-in-triage:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/stale@v8
+        with:
+          operations-per-run: 1000
+          days-before-issue-stale: 28
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 28 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          close-issue-reason: 'not_planned'
+          days-before-pr-stale: -1 # ignore PRs (overwrite default days-before-stale)
+          days-before-pr-close: -1 # ignore PRs (overwrite default days-before-close)
+          remove-issue-stale-when-updated: true
+          exempt-all-issue-milestones: false # issues with assigned milestones will be ignored
+          only-label: 'triage'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
   close-issues-with-assignee:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## What this PR changes/adds

- auto assigns labels `triage` and `bug_report`/`feature_request` respectively
- automatically sets `triage` issues to `stale` after 28 days, and closes them after another 14 days.

## Why it does that

decision record

## Further notes

- once this gets approved, I'll do the same thing in all other repos as well.

## Linked Issue(s)

Closes #3199 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md)._
