### PR TITLE
fix: handle fatal errors in dsp http dispatcher delegate

### DIFF
--- a/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/base/RemoteMessageDispatcherRegistryImpl.java
+++ b/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/base/RemoteMessageDispatcherRegistryImpl.java
@@ -18,8 +18,8 @@ package org.eclipse.edc.connector.core.base;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcher;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
+import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -38,22 +38,14 @@ public class RemoteMessageDispatcherRegistryImpl implements RemoteMessageDispatc
     }
 
     @Override
-    public <T> CompletableFuture<T> send(Class<T> responseType, RemoteMessage message) {
+    public <T> CompletableFuture<StatusResult<T>> dispatch(Class<T> responseType, RemoteMessage message) {
         Objects.requireNonNull(message, "Message was null");
         var protocol = message.getProtocol();
-        var dispatcher = getDispatcher(protocol);
+        var dispatcher = dispatchers.get(protocol);
         if (dispatcher == null) {
             return failedFuture(new EdcException("No provider dispatcher registered for protocol: " + protocol));
         }
-        return dispatcher.send(responseType, message);
+        return dispatcher.dispatch(responseType, message);
     }
 
-    @Nullable
-    private RemoteMessageDispatcher getDispatcher(@Nullable String protocol) {
-        if (protocol == null) {
-            return dispatchers.values().stream().findFirst()
-                    .orElse(null);
-        }
-        return dispatchers.get(protocol);
-    }
 }

--- a/core/common/state-machine/src/main/java/org/eclipse/edc/statemachine/retry/AsyncStatusResultRetryProcess.java
+++ b/core/common/state-machine/src/main/java/org/eclipse/edc/statemachine/retry/AsyncStatusResultRetryProcess.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.statemachine.retry;
+
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.entity.StatefulEntity;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.response.ResponseFailure;
+import org.eclipse.edc.spi.response.StatusResult;
+
+import java.time.Clock;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+
+/**
+ * Provides retry capabilities to an asynchronous process that returns a {@link CompletableFuture} with a {@link StatusResult} content
+ */
+public class AsyncStatusResultRetryProcess<E extends StatefulEntity<E>, C, SELF extends AsyncStatusResultRetryProcess<E, C, SELF>>
+        extends CompletableFutureRetryProcess<E, StatusResult<C>, SELF> {
+    private final Monitor monitor;
+    private BiConsumer<E, ResponseFailure> onFatalError;
+
+    public AsyncStatusResultRetryProcess(E entity, Supplier<CompletableFuture<StatusResult<C>>> process, Monitor monitor, Clock clock, EntityRetryProcessConfiguration configuration) {
+        super(entity, process, monitor, clock, configuration);
+        this.monitor = monitor;
+    }
+
+    @Override
+    public SELF onSuccess(BiConsumer<E, StatusResult<C>> onSuccessHandler) {
+        this.onSuccessHandler = (entity, result) -> {
+            new StatusResultRetryProcess<>(entity, () -> result, monitor, clock, configuration)
+                    .onSuccess((e, c) -> onSuccessHandler.accept(e, StatusResult.success(c)))
+                    .onFatalError(onFatalError)
+                    .onRetryExhausted((e, failure) -> onRetryExhausted.accept(e, new EdcException(failure.getFailureDetail())))
+                    .onFailure((e, failure) -> onFailureHandler.accept(e, new EdcException(failure.getFailureDetail())))
+                    .process(entity, description);
+        };
+        return (SELF) this;
+    }
+
+    public SELF onFatalError(BiConsumer<E, ResponseFailure> onFatalError) {
+        this.onFatalError = onFatalError;
+        return (SELF) this;
+    }
+}

--- a/core/common/state-machine/src/main/java/org/eclipse/edc/statemachine/retry/CompletableFutureRetryProcess.java
+++ b/core/common/state-machine/src/main/java/org/eclipse/edc/statemachine/retry/CompletableFutureRetryProcess.java
@@ -28,13 +28,14 @@ import static java.lang.String.format;
 /**
  * Provides retry capabilities to an asynchronous process that returns a {@link CompletableFuture} object
  */
-public class CompletableFutureRetryProcess<E extends StatefulEntity<E>, C> extends RetryProcess<E, CompletableFutureRetryProcess<E, C>> {
+public class CompletableFutureRetryProcess<E extends StatefulEntity<E>, C, SELF extends CompletableFutureRetryProcess<E, C, SELF>>
+        extends RetryProcess<E, CompletableFutureRetryProcess<E, C, SELF>> {
     private final Supplier<CompletableFuture<C>> process;
     private final Monitor monitor;
     private Function<String, E> entityRetrieve;
-    private BiConsumer<E, C> onSuccessHandler;
-    private BiConsumer<E, Throwable> onFailureHandler;
-    private BiConsumer<E, Throwable> onRetryExhausted;
+    protected BiConsumer<E, C> onSuccessHandler;
+    protected BiConsumer<E, Throwable> onFailureHandler;
+    protected BiConsumer<E, Throwable> onRetryExhausted;
 
     public CompletableFutureRetryProcess(E entity, Supplier<CompletableFuture<C>> process, Monitor monitor, Clock clock, EntityRetryProcessConfiguration configuration) {
         super(entity, configuration, monitor, clock);
@@ -79,23 +80,23 @@ public class CompletableFutureRetryProcess<E extends StatefulEntity<E>, C> exten
         return true;
     }
 
-    public CompletableFutureRetryProcess<E, C> onSuccess(BiConsumer<E, C> onSuccessHandler) {
+    public SELF onSuccess(BiConsumer<E, C> onSuccessHandler) {
         this.onSuccessHandler = onSuccessHandler;
-        return this;
+        return (SELF) this;
     }
 
-    public CompletableFutureRetryProcess<E, C> onFailure(BiConsumer<E, Throwable> onFailureHandler) {
+    public SELF onFailure(BiConsumer<E, Throwable> onFailureHandler) {
         this.onFailureHandler = onFailureHandler;
-        return this;
+        return (SELF) this;
     }
 
-    public CompletableFutureRetryProcess<E, C> entityRetrieve(Function<String, E> entityRetrieve) {
+    public SELF entityRetrieve(Function<String, E> entityRetrieve) {
         this.entityRetrieve = entityRetrieve;
-        return this;
+        return (SELF) this;
     }
 
-    public CompletableFutureRetryProcess<E, C> onRetryExhausted(BiConsumer<E, Throwable> onRetryExhausted) {
+    public SELF onRetryExhausted(BiConsumer<E, Throwable> onRetryExhausted) {
         this.onRetryExhausted = onRetryExhausted;
-        return this;
+        return (SELF) this;
     }
 }

--- a/core/common/state-machine/src/main/java/org/eclipse/edc/statemachine/retry/EntityRetryProcessFactory.java
+++ b/core/common/state-machine/src/main/java/org/eclipse/edc/statemachine/retry/EntityRetryProcessFactory.java
@@ -54,8 +54,15 @@ public class EntityRetryProcessFactory {
     /**
      * Initialize an asynchronous process that needs to be retried if it does not succeed
      */
-    public <T extends StatefulEntity<T>, C> CompletableFutureRetryProcess<T, C> doAsyncProcess(T entity, Supplier<CompletableFuture<C>> process) {
-        return new CompletableFutureRetryProcess<>(entity, process, monitor, clock, configuration);
+    public <T extends StatefulEntity<T>, C, SELF extends CompletableFutureRetryProcess<T, C, SELF>> SELF doAsyncProcess(T entity, Supplier<CompletableFuture<C>> process) {
+        return (SELF) new CompletableFutureRetryProcess<T, C, SELF>(entity, process, monitor, clock, configuration);
+    }
+
+    /**
+     * Initialize an asynchronous process that will return a {@link StatusResult} and it will need to be handled
+     */
+    public <T extends StatefulEntity<T>, C, SELF extends AsyncStatusResultRetryProcess<T, C, SELF>> SELF doAsyncStatusResultProcess(T entity, Supplier<CompletableFuture<StatusResult<C>>> process) {
+        return (SELF) new AsyncStatusResultRetryProcess<T, C, SELF>(entity, process, monitor, clock, configuration);
     }
 
 }

--- a/core/common/state-machine/src/main/java/org/eclipse/edc/statemachine/retry/StatusResultRetryProcess.java
+++ b/core/common/state-machine/src/main/java/org/eclipse/edc/statemachine/retry/StatusResultRetryProcess.java
@@ -47,6 +47,12 @@ public class StatusResultRetryProcess<E extends StatefulEntity<E>, C> extends Re
         monitor.debug(format("%s: ID %s. %s", entity.getClass().getSimpleName(), entity.getId(), description));
         var result = process.get();
 
+        handleResult(entity, description, result);
+
+        return true;
+    }
+
+    public void handleResult(E entity, String description, StatusResult<C> result) {
         if (result.succeeded()) {
             if (onSuccessHandler != null) {
                 onSuccessHandler.accept(entity, result.getContent());
@@ -86,8 +92,6 @@ public class StatusResultRetryProcess<E extends StatefulEntity<E>, C> extends Re
                 }
             }
         }
-
-        return true;
     }
 
     public StatusResultRetryProcess<E, C> onSuccess(BiConsumer<E, C> onSuccessHandler) {

--- a/core/common/state-machine/src/test/java/org/eclipse/edc/statemachine/retry/AsyncStatusResultRetryProcessTest.java
+++ b/core/common/state-machine/src/test/java/org/eclipse/edc/statemachine/retry/AsyncStatusResultRetryProcessTest.java
@@ -1,0 +1,114 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.statemachine.retry;
+
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.response.ResponseFailure;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+
+import static java.time.ZoneOffset.UTC;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.spi.response.ResponseStatus.FATAL_ERROR;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AsyncStatusResultRetryProcessTest {
+
+    private final BiConsumer<TestEntity, StatusResult<String>> onSuccess = mock();
+    private final BiConsumer<TestEntity, Throwable> onRetryExhausted = mock();
+    private final BiConsumer<TestEntity, ResponseFailure> onFatalError = mock();
+    private final BiConsumer<TestEntity, Throwable> onFailure = mock();
+    private final int retryLimit = 2;
+    private final int millis = 123;
+    private final Clock clock = Clock.fixed(Instant.ofEpochMilli(millis), UTC);
+    private final EntityRetryProcessConfiguration configuration = new EntityRetryProcessConfiguration(retryLimit, () -> () -> 1L);
+    private final Supplier<CompletableFuture<StatusResult<String>>> process = mock();
+
+    @Test
+    void shouldExecuteOnSuccess() {
+        when(process.get()).thenReturn(CompletableFuture.completedFuture(StatusResult.success("content")));
+        var entity = TestEntity.Builder.newInstance().id(UUID.randomUUID().toString()).clock(clock).build();
+        var retryProcess = new AsyncStatusResultRetryProcess<>(entity, process, mock(Monitor.class), clock, configuration);
+
+        var result = retryProcess.onSuccess(onSuccess).execute("any");
+
+        assertThat(result).isTrue();
+        verify(process).get();
+        verify(onSuccess).accept(eq(entity), argThat(it -> it.succeeded() && it.getContent().equals("content")));
+    }
+
+    @Test
+    void shouldReloadEntityIfConfigured() {
+        when(process.get()).thenReturn(CompletableFuture.completedFuture(StatusResult.success("content")));
+        var entity = TestEntity.Builder.newInstance().id(UUID.randomUUID().toString()).clock(clock).build();
+        var retryProcess = new AsyncStatusResultRetryProcess<>(entity, process, mock(Monitor.class), clock, configuration);
+        var reloadedEntity = TestEntity.Builder.newInstance().id(entity.getId()).clock(clock).state(10).build();
+
+        var result = retryProcess.onSuccess(onSuccess).entityRetrieve(id -> reloadedEntity).execute("any");
+
+        assertThat(result).isTrue();
+        verify(process).get();
+        verify(onSuccess).accept(eq(reloadedEntity), argThat(it -> it.succeeded() && it.getContent().equals("content")));
+    }
+
+    @Test
+    void shouldExecuteOnFatalError() {
+        CompletableFuture<StatusResult<String>> statusResult = CompletableFuture.completedFuture(StatusResult.failure(FATAL_ERROR));
+        when(process.get()).thenReturn(statusResult);
+        var entity = TestEntity.Builder.newInstance().id(UUID.randomUUID().toString()).clock(clock).stateCount(retryLimit + 1).stateTimestamp(millis - 2L).build();
+        var retryProcess = new AsyncStatusResultRetryProcess<>(entity, process, mock(Monitor.class), clock, configuration);
+
+        retryProcess.onSuccess((e, r) -> {}).onFatalError(onFatalError).execute("any");
+
+        verify(onFatalError).accept(entity, statusResult.join().getFailure());
+    }
+
+    @Test
+    void shouldExecuteOnRetryExhausted_whenFailureAndRetriesHaveBeenExhausted() {
+        CompletableFuture<StatusResult<String>> statusResult = CompletableFuture.failedFuture(new EdcException("error"));
+        when(process.get()).thenReturn(statusResult);
+        var entity = TestEntity.Builder.newInstance().id(UUID.randomUUID().toString()).clock(clock).stateCount(retryLimit + 1).stateTimestamp(millis - 2L).build();
+        var retryProcess = new AsyncStatusResultRetryProcess<>(entity, process, mock(Monitor.class), clock, configuration);
+
+        retryProcess.onSuccess((e, r) -> {}).onRetryExhausted(onRetryExhausted).execute("any");
+
+        verify(onRetryExhausted).accept(eq(entity), isA(EdcException.class));
+    }
+
+    @Test
+    void shouldExecuteOnRetry_whenFailureAndRetriesHaveNotBeenExhausted() {
+        CompletableFuture<StatusResult<String>> statusResult = CompletableFuture.failedFuture(new EdcException("error"));
+        when(process.get()).thenReturn(statusResult);
+        var entity = TestEntity.Builder.newInstance().id(UUID.randomUUID().toString()).clock(clock).stateCount(retryLimit).stateTimestamp(millis - 2L).build();
+        var retryProcess = new AsyncStatusResultRetryProcess<>(entity, process, mock(Monitor.class), clock, configuration);
+
+        retryProcess.onSuccess((e, r) -> {}).onFailure(onFailure).execute("any");
+
+        verify(onFailure).accept(eq(entity), isA(EdcException.class));
+    }
+}

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/DispatchFailure.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/DispatchFailure.java
@@ -16,10 +16,13 @@ package org.eclipse.edc.connector.contract.negotiation;
 
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates;
+import org.eclipse.edc.spi.response.StatusResult;
 import org.junit.jupiter.params.provider.Arguments;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.function.UnaryOperator;
 
+import static java.util.concurrent.CompletableFuture.failedFuture;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.INITIAL;
 
 public class DispatchFailure implements Arguments {
@@ -27,19 +30,21 @@ public class DispatchFailure implements Arguments {
     private final ContractNegotiationStates starting;
     private final ContractNegotiationStates ending;
     private final UnaryOperator<ContractNegotiation.Builder> builderEnricher;
+    private final CompletableFuture<StatusResult<Object>> result;
 
     public DispatchFailure() {
-        this(INITIAL, INITIAL, it -> it);
+        this(INITIAL, INITIAL, failedFuture(new RuntimeException("any")), it -> it);
     }
 
-    public DispatchFailure(ContractNegotiationStates starting, ContractNegotiationStates ending, UnaryOperator<ContractNegotiation.Builder> builderEnricher) {
+    public DispatchFailure(ContractNegotiationStates starting, ContractNegotiationStates ending, CompletableFuture<StatusResult<Object>> result, UnaryOperator<ContractNegotiation.Builder> builderEnricher) {
         this.starting = starting;
         this.ending = ending;
+        this.result = result;
         this.builderEnricher = builderEnricher;
     }
 
     @Override
     public Object[] get() {
-        return new Object[]{ starting, ending, builderEnricher };
+        return new Object[]{ starting, ending, result, builderEnricher };
     }
 }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/catalog/CatalogServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/catalog/CatalogServiceImpl.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.catalog.spi.CatalogRequestMessage;
 import org.eclipse.edc.connector.spi.catalog.CatalogService;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.response.StatusResult;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -31,7 +32,7 @@ public class CatalogServiceImpl implements CatalogService {
     }
 
     @Override
-    public CompletableFuture<byte[]> request(String providerUrl, String protocol, QuerySpec querySpec) {
+    public CompletableFuture<StatusResult<byte[]>> request(String providerUrl, String protocol, QuerySpec querySpec) {
         var request = CatalogRequestMessage.Builder.newInstance()
                 .protocol(protocol)
                 .connectorId(providerUrl)
@@ -39,6 +40,6 @@ public class CatalogServiceImpl implements CatalogService {
                 .querySpec(querySpec)
                 .build();
 
-        return dispatcher.send(byte[].class, request);
+        return dispatcher.dispatch(byte[].class, request);
     }
 }

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
@@ -36,6 +36,7 @@ import org.eclipse.edc.spi.iam.ClaimToken;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcher;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.protocol.ProtocolWebhook;
+import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.jetbrains.annotations.NotNull;
@@ -45,7 +46,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
 import static java.util.Collections.emptyList;
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -62,7 +62,6 @@ import static org.mockito.Mockito.when;
 class ContractNegotiationEventDispatchTest {
     private static final String CONSUMER = "consumer";
     private static final String PROVIDER = "provider";
-    private static final long CONTRACT_VALIDITY = TimeUnit.HOURS.toSeconds(1);
 
     private final EventSubscriber eventSubscriber = mock(EventSubscriber.class);
     private final ClaimToken token = ClaimToken.Builder.newInstance().claim(ParticipantAgentService.DEFAULT_IDENTITY_CLAIM_KEY, CONSUMER).build();
@@ -131,7 +130,7 @@ class ContractNegotiationEventDispatchTest {
     private RemoteMessageDispatcher succeedingDispatcher() {
         var testDispatcher = mock(RemoteMessageDispatcher.class);
         when(testDispatcher.protocol()).thenReturn("test");
-        when(testDispatcher.send(any(), any())).thenReturn(completedFuture("any"));
+        when(testDispatcher.dispatch(any(), any())).thenReturn(completedFuture(StatusResult.success("any")));
         return testDispatcher;
     }
 

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/transfer/DispatchFailure.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/transfer/DispatchFailure.java
@@ -16,8 +16,10 @@ package org.eclipse.edc.connector.transfer.transfer;
 
 import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.connector.transfer.spi.types.TransferProcessStates;
+import org.eclipse.edc.spi.response.StatusResult;
 import org.junit.jupiter.params.provider.Arguments;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.function.UnaryOperator;
 
 import static org.eclipse.edc.connector.transfer.spi.types.TransferProcessStates.INITIAL;
@@ -27,20 +29,22 @@ public class DispatchFailure implements Arguments {
 
     private final TransferProcessStates starting;
     private final TransferProcessStates ending;
+    private final CompletableFuture<StatusResult<Object>> result;
     private final UnaryOperator<TransferProcess.Builder> builderEnricher;
 
     public DispatchFailure() {
-        this(INITIAL, INITIAL, it -> it);
+        this(INITIAL, INITIAL, CompletableFuture.failedFuture(new RuntimeException("any")), it -> it);
     }
 
-    public DispatchFailure(TransferProcessStates starting, TransferProcessStates ending, UnaryOperator<TransferProcess.Builder> builderEnricher) {
+    public DispatchFailure(TransferProcessStates starting, TransferProcessStates ending, CompletableFuture<StatusResult<Object>> result, UnaryOperator<TransferProcess.Builder> builderEnricher) {
         this.starting = starting;
         this.ending = ending;
+        this.result = result;
         this.builderEnricher = builderEnricher;
     }
 
     @Override
     public Object[] get() {
-        return new Object[]{ starting, ending, builderEnricher };
+        return new Object[]{ starting, ending, result, builderEnricher };
     }
 }

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/src/test/java/org/eclipse/edc/protocol/dsp/catalog/dispatcher/delegate/CatalogRequestHttpRawDelegateTest.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/src/test/java/org/eclipse/edc/protocol/dsp/catalog/dispatcher/delegate/CatalogRequestHttpRawDelegateTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.protocol.dsp.catalog.dispatcher.delegate;
 
-import okhttp3.Response;
 import okhttp3.ResponseBody;
 import org.eclipse.edc.catalog.spi.CatalogRequestMessage;
 import org.eclipse.edc.protocol.dsp.spi.dispatcher.DspHttpDispatcherDelegate;
@@ -58,11 +57,10 @@ class CatalogRequestHttpRawDelegateTest extends DspHttpDispatcherDelegateTestBas
 
     @Test
     void parseResponse_returnCatalog() throws IOException {
-        var response = mock(Response.class);
         var responseBody = mock(ResponseBody.class);
+        var response = dummyResponseBuilder(200).body(responseBody).build();
         var bytes = "test".getBytes();
 
-        when(response.body()).thenReturn(responseBody);
         when(responseBody.bytes()).thenReturn(bytes);
         when(responseBody.byteStream()).thenReturn(new ByteArrayInputStream(bytes));
 

--- a/data-protocols/dsp/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/DspHttpCoreExtensionTest.java
+++ b/data-protocols/dsp/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/DspHttpCoreExtensionTest.java
@@ -61,7 +61,7 @@ class DspHttpCoreExtensionTest {
         extension = factory.constructInstance(DspHttpCoreExtension.class);
         var dispatcher = extension.dspHttpRemoteMessageDispatcher(context);
         dispatcher.registerDelegate(new TestMessageDelegate());
-        dispatcher.send(String.class, new TestMessage());
+        dispatcher.dispatch(String.class, new TestMessage());
 
         verify(isMock).obtainClientCredentials(argThat(tokenParams -> tokenParams.getScope() == null));
     }
@@ -78,7 +78,7 @@ class DspHttpCoreExtensionTest {
         extension = factory.constructInstance(DspHttpCoreExtension.class);
         var dispatcher = extension.dspHttpRemoteMessageDispatcher(context);
         dispatcher.registerDelegate(new TestMessageDelegate());
-        dispatcher.send(String.class, new TestMessage());
+        dispatcher.dispatch(String.class, new TestMessage());
 
         verify(isMock).obtainClientCredentials(argThat(tokenParams -> tokenParams.getScope().equals("test-scope")));
     }

--- a/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/spi/dispatcher/DspHttpDispatcherDelegate.java
+++ b/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/spi/dispatcher/DspHttpDispatcherDelegate.java
@@ -19,10 +19,17 @@ import okhttp3.MediaType;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+import okhttp3.ResponseBody;
 import org.eclipse.edc.protocol.dsp.spi.serialization.JsonLdRemoteMessageSerializer;
+import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
 
+import java.io.IOException;
+import java.util.Optional;
 import java.util.function.Function;
+
+import static org.eclipse.edc.spi.response.ResponseStatus.ERROR_RETRY;
+import static org.eclipse.edc.spi.response.ResponseStatus.FATAL_ERROR;
 
 /**
  * Delegate for sending a specific type of {@link RemoteMessage} using the dataspace protocol.
@@ -57,11 +64,34 @@ public abstract class DspHttpDispatcherDelegate<M extends RemoteMessage, R> {
     public abstract Request buildRequest(M message);
 
     /**
+     * Handles the response and returns a {@link StatusResult} containing the response object
+     *
+     * @return the {@link StatusResult}
+     */
+    public Function<Response, StatusResult<R>> handleResponse() {
+        return response -> {
+            if (response.isSuccessful()) {
+                var responsePayload = parseResponse().apply(response);
+                return StatusResult.success(responsePayload);
+            } else {
+                var responseBody = Optional.ofNullable(response.body())
+                        .map(this::asString)
+                        .orElse("Response body is null");
+
+                var status = response.code() >= 400 && response.code() < 500
+                        ? FATAL_ERROR : ERROR_RETRY;
+
+                return StatusResult.failure(status, responseBody);
+            }
+        };
+    }
+
+    /**
      * Parses the response to return an instance of the expected response type.
      *
      * @return the parsed response
      */
-    public abstract Function<Response, R> parseResponse();
+    protected abstract Function<Response, R> parseResponse();
 
     protected Request buildRequest(M message, String path) {
         var body = serializer.serialize(message);
@@ -74,6 +104,14 @@ public abstract class DspHttpDispatcherDelegate<M extends RemoteMessage, R> {
                 .header("Content-Type", APPLICATION_JSON)
                 .post(requestBody)
                 .build();
+    }
+
+    private String asString(ResponseBody it) {
+        try {
+            return it.string();
+        } catch (IOException e) {
+            return "Cannot read response body: " + e.getMessage();
+        }
     }
 
 }

--- a/data-protocols/dsp/dsp-http-spi/src/test/java/org/eclipse/edc/protocol/dsp/spi/dispatcher/DspHttpDispatcherDelegateTest.java
+++ b/data-protocols/dsp/dsp-http-spi/src/test/java/org/eclipse/edc/protocol/dsp/spi/dispatcher/DspHttpDispatcherDelegateTest.java
@@ -1,0 +1,128 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.spi.dispatcher;
+
+import okhttp3.MediaType;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.eclipse.edc.protocol.dsp.spi.serialization.JsonLdRemoteMessageSerializer;
+import org.eclipse.edc.spi.response.ResponseFailure;
+import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.spi.response.ResponseStatus.ERROR_RETRY;
+import static org.eclipse.edc.spi.response.ResponseStatus.FATAL_ERROR;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+class DspHttpDispatcherDelegateTest {
+
+    private final JsonLdRemoteMessageSerializer serializer = mock();
+    private final Function<Response, Object> parser = mock();
+    private final TestDspHttpDispatcherDelegate delegate = new TestDspHttpDispatcherDelegate();
+
+    @Test
+    void handleResponse_shouldShouldReturnSuccess_whenResponseIsSuccessful() {
+        var response = dummyResponse(200);
+
+        var result = delegate.handleResponse().apply(response);
+
+        assertThat(result).isSucceeded();
+        verify(parser).apply(response);
+    }
+
+    @Test
+    void handleResponse_shouldReturnFatalError_whenResponseIsClientError() {
+        var responseBody = "{\"any\": \"value\"}";
+        var response = dummyResponseBuilder(400).body(ResponseBody.create(responseBody, MediaType.get("application/json"))).build();
+
+        var result = delegate.handleResponse().apply(response);
+
+        assertThat(result).isFailed().satisfies(failure -> {
+            assertThat(failure.status()).isEqualTo(FATAL_ERROR);
+            assertThat(failure.getMessages()).containsOnly(responseBody);
+        });
+        verifyNoInteractions(parser);
+    }
+
+    @Test
+    void handleResponse_shouldReturnFatalError_whenResponseIsClientErrorAndBodyIsNull() {
+        var response = dummyResponseBuilder(400).body(null).build();
+
+        var result = delegate.handleResponse().apply(response);
+
+        assertThat(result).isFailed().satisfies(failure -> {
+            assertThat(failure.status()).isEqualTo(FATAL_ERROR);
+            assertThat(failure.getMessages()).allMatch(it -> it.contains("is null"));
+        });
+        verifyNoInteractions(parser);
+    }
+
+    @Test
+    void handleResponse_shouldReturnRetryError_whenResponseIsServerError() {
+        var response = dummyResponse(500);
+
+        var result = delegate.handleResponse().apply(response);
+
+        assertThat(result).isFailed().extracting(ResponseFailure::status).isEqualTo(ERROR_RETRY);
+        verifyNoInteractions(parser);
+    }
+
+    private class TestDspHttpDispatcherDelegate extends DspHttpDispatcherDelegate<RemoteMessage, Object> {
+
+        TestDspHttpDispatcherDelegate() {
+            super(DspHttpDispatcherDelegateTest.this.serializer);
+        }
+
+        @Override
+        public Class<RemoteMessage> getMessageType() {
+            return null;
+        }
+
+        @Override
+        public Request buildRequest(RemoteMessage message) {
+            return null;
+        }
+
+        @Override
+        public Function<Response, Object> parseResponse() {
+            return parser;
+        }
+    }
+
+    private static Response dummyResponse(int code) {
+        return dummyResponseBuilder(code)
+                .build();
+    }
+
+    @NotNull
+    private static Response.Builder dummyResponseBuilder(int code) {
+        return new Response.Builder()
+                .code(code)
+                .message("any")
+                .body(ResponseBody.create("", MediaType.get("application/json")))
+                .protocol(Protocol.HTTP_1_1)
+                .request(new Request.Builder().url("http://any").build());
+    }
+
+}

--- a/extensions/common/iam/oauth2/oauth2-client/src/main/java/org/eclipse/edc/iam/oauth2/client/Oauth2ClientImpl.java
+++ b/extensions/common/iam/oauth2/oauth2-client/src/main/java/org/eclipse/edc/iam/oauth2/client/Oauth2ClientImpl.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import static org.eclipse.edc.spi.http.FallbackFactories.statusMustBe;
+import static org.eclipse.edc.spi.http.FallbackFactories.retryWhenStatusIsNot;
 
 public class Oauth2ClientImpl implements Oauth2Client {
 
@@ -49,7 +49,7 @@ public class Oauth2ClientImpl implements Oauth2Client {
 
     @Override
     public Result<TokenRepresentation> requestToken(Oauth2CredentialsRequest request) {
-        return httpClient.execute(toRequest(request), List.of(statusMustBe(200)), this::handleResponse);
+        return httpClient.execute(toRequest(request), List.of(retryWhenStatusIsNot(200)), this::handleResponse);
     }
 
     private Result<TokenRepresentation> handleResponse(Response response) {

--- a/extensions/control-plane/api/control-plane-api-client/src/test/java/org/eclipse/edc/connector/api/client/transferprocess/TransferProcessHttpClientIntegrationTest.java
+++ b/extensions/control-plane/api/control-plane-api-client/src/test/java/org/eclipse/edc/connector/api/client/transferprocess/TransferProcessHttpClientIntegrationTest.java
@@ -30,6 +30,7 @@ import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.entity.StatefulEntity;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.protocol.ProtocolWebhook;
+import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.domain.DataAddress;
@@ -74,7 +75,7 @@ public class TransferProcessHttpClientIntegrationTest {
         extension.registerSystemExtension(ServiceExtension.class, new TransferServiceMockExtension(service));
         extension.registerServiceMock(ProtocolWebhook.class, mock(ProtocolWebhook.class));
         var registry = mock(RemoteMessageDispatcherRegistry.class);
-        when(registry.send(any(), any())).thenReturn(completedFuture("any"));
+        when(registry.dispatch(any(), any())).thenReturn(completedFuture(StatusResult.success("any")));
         extension.registerServiceMock(RemoteMessageDispatcherRegistry.class, registry);
     }
 

--- a/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/api/management/catalog/CatalogApiController.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/api/management/catalog/CatalogApiController.java
@@ -53,9 +53,13 @@ public class CatalogApiController implements CatalogApi {
                 .orElseThrow(InvalidRequestException::new);
 
         service.request(request.getProviderUrl(), request.getProtocol(), request.getQuerySpec())
-                .whenComplete((content, throwable) -> {
+                .whenComplete((result, throwable) -> {
                     if (throwable == null) {
-                        response.resume(content);
+                        if (result.succeeded()) {
+                            response.resume(result.getContent());
+                        } else {
+                            response.resume(new BadGatewayException(result.getFailureDetail()));
+                        }
                     } else {
                         if (throwable instanceof EdcException || throwable.getCause() instanceof EdcException) {
                             response.resume(new BadGatewayException(throwable.getMessage()));

--- a/extensions/control-plane/api/management-api/catalog-api/src/test/java/org/eclipse/edc/connector/api/management/catalog/CatalogApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/test/java/org/eclipse/edc/connector/api/management/catalog/CatalogApiControllerTest.java
@@ -21,6 +21,7 @@ import org.eclipse.edc.connector.spi.catalog.CatalogService;
 import org.eclipse.edc.junit.annotations.ApiTest;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.query.SortOrder;
+import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
@@ -32,6 +33,7 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.CompletableFuture.failedFuture;
+import static org.eclipse.edc.spi.response.ResponseStatus.FATAL_ERROR;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -56,7 +58,7 @@ class CatalogApiControllerTest extends RestControllerTestBase {
         var request = CatalogRequest.Builder.newInstance().providerUrl("http://url").build();
         when(transformerRegistry.transform(any(), eq(CatalogRequestDto.class))).thenReturn(Result.success(dto));
         when(transformerRegistry.transform(any(), eq(CatalogRequest.class))).thenReturn(Result.success(request));
-        when(service.request(any(), any(), any())).thenReturn(completedFuture("{}".getBytes()));
+        when(service.request(any(), any(), any())).thenReturn(completedFuture(StatusResult.success("{}".getBytes())));
 
         var requestDto = CatalogRequestDto.Builder.newInstance()
                 .protocol("protocol")
@@ -120,6 +122,35 @@ class CatalogApiControllerTest extends RestControllerTestBase {
 
     @Test
     void requestCatalog_shouldReturnBadGateway_whenServiceFails() {
+        var dto = CatalogRequestDto.Builder.newInstance().providerUrl("http://url").build();
+        var request = CatalogRequest.Builder.newInstance().providerUrl("http://url").build();
+        when(transformerRegistry.transform(any(), eq(CatalogRequestDto.class))).thenReturn(Result.success(dto));
+        when(transformerRegistry.transform(any(), eq(CatalogRequest.class))).thenReturn(Result.success(request));
+        when(service.request(any(), any(), any())).thenReturn(completedFuture(StatusResult.failure(FATAL_ERROR, "error")));
+
+        var requestDto = CatalogRequestDto.Builder.newInstance()
+                .protocol("protocol")
+                .querySpec(QuerySpecDto.Builder.newInstance()
+                        .limit(29)
+                        .offset(13)
+                        .filterExpression(List.of(TestFunctions.createCriterionDto("fooProp", "", "bar"), TestFunctions.createCriterionDto("bazProp", "in", List.of("blip", "blup", "blop"))))
+                        .sortField("someField")
+                        .sortOrder(SortOrder.DESC).build())
+                .providerUrl("some.provider.url")
+
+                .build();
+
+        given()
+                .port(port)
+                .contentType(JSON)
+                .body(requestDto)
+                .post("/v2/catalog/request")
+                .then()
+                .statusCode(502);
+    }
+
+    @Test
+    void requestCatalog_shouldReturnBadGateway_whenServiceThrowsException() {
         var dto = CatalogRequestDto.Builder.newInstance().providerUrl("http://url").build();
         var request = CatalogRequest.Builder.newInstance().providerUrl("http://url").build();
         when(transformerRegistry.transform(any(), eq(CatalogRequestDto.class))).thenReturn(Result.success(dto));

--- a/extensions/control-plane/callback/callback-event-dispatcher/src/main/java/org/eclipse/edc/connector/callback/dispatcher/CallbackEventDispatcher.java
+++ b/extensions/control-plane/callback/callback-event-dispatcher/src/main/java/org/eclipse/edc/connector/callback/dispatcher/CallbackEventDispatcher.java
@@ -62,7 +62,7 @@ public class CallbackEventDispatcher implements EventSubscriber {
                 try {
                     var protocol = resolverRegistry.resolve(URI.create(callback.getUri()).getScheme());
                     if (protocol != null) {
-                        dispatcher.send(Object.class, new CallbackEventRemoteMessage<>(callback, eventEnvelope, protocol)).get();
+                        dispatcher.dispatch(Object.class, new CallbackEventRemoteMessage<>(callback, eventEnvelope, protocol)).get();
                     } else {
                         monitor.warning(format("Failed to resolve protocol for URI %s", callback.getUri()));
                     }

--- a/extensions/control-plane/callback/callback-http-dispatcher/src/test/java/org/eclipse/edc/connector/callback/dispatcher/http/GenericHttpRemoteDispatcherWrapperTest.java
+++ b/extensions/control-plane/callback/callback-http-dispatcher/src/test/java/org/eclipse/edc/connector/callback/dispatcher/http/GenericHttpRemoteDispatcherWrapperTest.java
@@ -60,19 +60,16 @@ public class GenericHttpRemoteDispatcherWrapperTest {
     private static ClientAndServer receiverEndpointServer;
     private final TypeManager typeManager = new TypeManager();
     private EdcHttpClient httpClient;
-
-    private Vault vault;
+    private final Vault vault = mock();
 
     @BeforeEach
     void setup() {
         receiverEndpointServer = startClientAndServer(CALLBACK_PORT);
         httpClient = spy(testHttpClient());
-        vault = mock(Vault.class);
     }
 
     @AfterEach
     void tearDown() {
-
         stopQuietly(receiverEndpointServer);
     }
 
@@ -96,7 +93,7 @@ public class GenericHttpRemoteDispatcherWrapperTest {
         receiverEndpointServer.when(request).respond(successfulResponse());
 
 
-        dispatcher.send(Object.class, new CallbackEventRemoteMessage<>(callback, event, CALLBACK_EVENT_HTTP)).get();
+        dispatcher.dispatch(Object.class, new CallbackEventRemoteMessage<>(callback, event, CALLBACK_EVENT_HTTP)).get();
 
         verify(httpClient, atMostOnce()).execute(any());
 
@@ -132,12 +129,9 @@ public class GenericHttpRemoteDispatcherWrapperTest {
 
         receiverEndpointServer.when(request).respond(successfulResponse());
 
-
-        dispatcher.send(Object.class, new CallbackEventRemoteMessage<>(callback, event, CALLBACK_EVENT_HTTP)).get();
+        dispatcher.dispatch(Object.class, new CallbackEventRemoteMessage<>(callback, event, CALLBACK_EVENT_HTTP)).get();
 
         verify(httpClient, atMostOnce()).execute(any());
-
-
     }
 
     @Test
@@ -160,7 +154,7 @@ public class GenericHttpRemoteDispatcherWrapperTest {
         receiverEndpointServer.when(request).respond(failedResponse());
 
 
-        assertThatThrownBy(() -> dispatcher.send(Object.class, new CallbackEventRemoteMessage<>(callback, event, CALLBACK_EVENT_HTTP)).get())
+        assertThatThrownBy(() -> dispatcher.dispatch(Object.class, new CallbackEventRemoteMessage<>(callback, event, CALLBACK_EVENT_HTTP)).get())
                 .cause()
                 .isInstanceOf(EdcException.class);
 

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/message/RemoteMessageDispatcher.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/message/RemoteMessageDispatcher.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.spi.message;
 
+import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
 
 import java.util.concurrent.CompletableFuture;
@@ -34,7 +35,20 @@ public interface RemoteMessageDispatcher {
      * @param responseType the expected response type
      * @param message      the message
      * @return a future that can be used to retrieve the response when the operation has completed
+     * @deprecated please use {@link #dispatch(Class, RemoteMessage)}
      */
-    <T, M extends RemoteMessage> CompletableFuture<T> send(Class<T> responseType, M message);
+    @Deprecated(since = "0.1.1")
+    default <T, M extends RemoteMessage> CompletableFuture<T> send(Class<T> responseType, M message) {
+        return dispatch(responseType, message).thenApply(StatusResult::getContent);
+    }
+
+    /**
+     * Binds and sends the message.
+     *
+     * @param responseType the expected response type
+     * @param message      the message
+     * @return a future that can be used to retrieve the response when the operation has completed
+     */
+    <T, M extends RemoteMessage> CompletableFuture<StatusResult<T>> dispatch(Class<T> responseType, M message);
 
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/message/RemoteMessageDispatcherRegistry.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/message/RemoteMessageDispatcherRegistry.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.spi.message;
 
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
+import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
 
 import java.util.concurrent.CompletableFuture;
@@ -38,7 +39,20 @@ public interface RemoteMessageDispatcherRegistry {
      * @param responseType the expected response type
      * @param message      the message
      * @return a future that can be used to retrieve the response when the operation has completed
+     * @deprecated please use {@link #dispatch(Class, RemoteMessage)}
      */
-    <T> CompletableFuture<T> send(Class<T> responseType, RemoteMessage message);
+    @Deprecated(since = "0.1.1")
+    default <T> CompletableFuture<T> send(Class<T> responseType, RemoteMessage message) {
+        return dispatch(responseType, message).thenApply(StatusResult::getContent);
+    }
+
+    /**
+     * Sends the message.
+     *
+     * @param responseType the expected response type
+     * @param message      the message
+     * @return a future that can be used to retrieve the response when the operation has completed, it contains a {@link StatusResult}
+     */
+    <T> CompletableFuture<StatusResult<T>> dispatch(Class<T> responseType, RemoteMessage message);
 
 }

--- a/spi/common/http-spi/src/main/java/org/eclipse/edc/spi/http/FallbackFactories.java
+++ b/spi/common/http-spi/src/main/java/org/eclipse/edc/spi/http/FallbackFactories.java
@@ -27,11 +27,11 @@ import static java.lang.String.format;
 public interface FallbackFactories {
 
     /**
-     * Verifies that the response is successful, otherwise it should be retried
+     * Verifies that the response code is between 400 and 499, otherwise it should be retried
      *
      * @return the {@link FallbackFactory}
      */
-    static FallbackFactory statusMustBeSuccessful() {
+    static FallbackFactory retryWhenStatusNot2xxOr4xx() {
         return request -> {
             CheckedFunction<ExecutionAttemptedEvent<? extends Response>, Exception> exceptionSupplier = event -> {
                 var response = event.getLastResult();
@@ -42,7 +42,7 @@ public interface FallbackFactories {
                 }
             };
             return Fallback.builderOfException(exceptionSupplier)
-                    .handleResultIf(r -> !r.isSuccessful())
+                    .handleResultIf(r -> !(r.isSuccessful() || r.code() >= 400 && r.code() < 500))
                     .build();
         };
     }
@@ -52,7 +52,7 @@ public interface FallbackFactories {
      *
      * @return the {@link FallbackFactory}
      */
-    static FallbackFactory statusMustBe(int status) {
+    static FallbackFactory retryWhenStatusIsNot(int status) {
         return request -> {
             CheckedFunction<ExecutionAttemptedEvent<? extends Response>, Exception> exceptionSupplier = event -> {
                 var response = event.getLastResult();

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractNegotiation.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractNegotiation.java
@@ -313,7 +313,7 @@ public class ContractNegotiation extends StatefulEntity<ContractNegotiation> {
      * Transition to state TERMINATED.
      */
     public void transitionTerminated() {
-        transition(TERMINATED, TERMINATED, TERMINATING, VERIFIED, OFFERED, AGREEING, AGREED, REQUESTED);
+        transition(TERMINATED, state -> canBeTerminated());
     }
 
     /**

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/catalog/CatalogService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/catalog/CatalogService.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.connector.spi.catalog;
 
 import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.response.StatusResult;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -28,5 +29,5 @@ public interface CatalogService {
      * @param querySpec the {@link QuerySpec} object.
      * @return the provider's catalog
      */
-    CompletableFuture<byte[]> request(String providerUrl, String protocol, QuerySpec querySpec);
+    CompletableFuture<StatusResult<byte[]>> request(String providerUrl, String protocol, QuerySpec querySpec);
 }


### PR DESCRIPTION
## What this PR changes/adds

Add a new `dispatch` method on both `RemoteMessageDispatcher` and `RemoteMessageDispatcherRegistry` that return `StatusResult`, doing this it has been possible catch `FATAL_ERROR`s and avoid retry

## Why it does that

avoid network pollution, improve error messaging

## Further notes
From bottom to top:
- changed the fallback used to call the http client, now it enable retry mechanism only if the status is not 2xx or 4xx (because client errors usually cannot be fixed by retry)
- add the `handleResponse` method in `DspHttpDispatcherDelegate` that takes the place of `parseResponse`. It takes care to look at the status code and create the `StatusResult` accordingly, if response is successful, call `parseResponse` (that became protected)
- on the state machine level, added the `AsyncStatusResultRetryProcess` class, that extends `CompletableFutureRetryProcess` and uses `StatusResultRetryProcess` to handle the `StatusResult` when the future succeeds.
- the managers on fatal error will terminate the negotiation/transfer without sending anything to the counter-part.
- the deprecated `send` methods on `RemoteMessageDispatcher` and `RemoteMessageDispatcherRegistry` are now unused, but I left them there to avoid compilation errors on downstream projects.

## Linked Issue(s)

Closes #3202

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md)._
