### PR TITLE
feat(build): use release version in bump-job

### DIFF
--- a/.github/actions/bump-version/action.yml
+++ b/.github/actions/bump-version/action.yml
@@ -5,7 +5,7 @@ inputs:
     default: 'main'
     description: "Branch on which the version bump is to be done."
     required: false
-  from_version:
+  base_version:
     description: "The current version, which is to be bumped to the next snapshot"
     required: false
 
@@ -25,10 +25,10 @@ runs:
         git checkout ${{ inputs.target_branch }}
 
         # use current version from input
-        oldVersion=${{ inputs.from_version }}
+        oldVersion=${{ inputs.base_version }}
         if [ -z $oldVersion ]; then
           #... or read it from gradle.properties
-          echo "No from_version input was given, will read base version from gradle.properties"
+          echo "No base_version input was given, will read base version from gradle.properties"
           oldVersion=$(grep "version" gradle.properties  | awk -F= '{print $2}')
         fi      
         

--- a/.github/actions/bump-version/action.yml
+++ b/.github/actions/bump-version/action.yml
@@ -5,6 +5,9 @@ inputs:
     default: 'main'
     description: "Branch on which the version bump is to be done."
     required: false
+  from_version:
+    description: "The current version, which is to be bumped to the next snapshot"
+    required: false
 
 runs:
   using: "composite"
@@ -21,14 +24,27 @@ runs:
         git fetch origin
         git checkout ${{ inputs.target_branch }}
 
-        # determine current version
-        oldVersion=$(grep "version" gradle.properties  | awk -F= '{print $2}')
-
+        # use current version from input
+        oldVersion=${{ inputs.from_version }}
+        if [ -z $oldVersion ]; then
+          #... or read it from gradle.properties
+          echo "No from_version input was given, will read base version from gradle.properties"
+          oldVersion=$(grep "version" gradle.properties  | awk -F= '{print $2}')
+        fi      
+        
         # read the major, minor, and patch components, consume -SNAPSHOT
         IFS=.- read -r RELEASE_VERSION_MAJOR RELEASE_VERSION_MINOR RELEASE_VERSION_PATCH SNAPSHOT<<<"$oldVersion"
+        INC=0
+        # Compute new snapshot version, do not increment snapshot on non-final releases, e.g. -rc1
+        if [ -z $SNAPSHOT ]; then
+          echo "$oldVersion is a final release version, increase patch for next snapshot"
+          INC=1
+        else
+          echo "$oldVersion is not a final release version (contains \"$SNAPSHOT\"), will not increase patch"
+        fi
 
         # construct the new version
-        newVersion="$RELEASE_VERSION_MAJOR.$RELEASE_VERSION_MINOR.$((RELEASE_VERSION_PATCH+1))"-SNAPSHOT
+        newVersion="$RELEASE_VERSION_MAJOR.$RELEASE_VERSION_MINOR.$((RELEASE_VERSION_PATCH+$INC))"-SNAPSHOT
 
         # replace every occurrence of =$oldVersion with =$newVersion
         grep -rlz "$oldVersion" . --exclude=\*.{sh,bin} | xargs sed -i "s/$oldVersion/$newVersion/g"

--- a/.github/workflows/release-edc.yml
+++ b/.github/workflows/release-edc.yml
@@ -72,4 +72,4 @@ jobs:
       - uses: ./.github/actions/bump-version
         with:
           target_branch: "main"
-          from_version: ${{ needs.Prepare-Release.outputs.edc-version }}
+          base_version: ${{ needs.Prepare-Release.outputs.edc-version }}

--- a/.github/workflows/release-edc.yml
+++ b/.github/workflows/release-edc.yml
@@ -72,3 +72,4 @@ jobs:
       - uses: ./.github/actions/bump-version
         with:
           target_branch: "main"
+          from_version: needs.Prepare-Release.outputs.edc-version

--- a/.github/workflows/release-edc.yml
+++ b/.github/workflows/release-edc.yml
@@ -72,4 +72,4 @@ jobs:
       - uses: ./.github/actions/bump-version
         with:
           target_branch: "main"
-          from_version: needs.Prepare-Release.outputs.edc-version
+          from_version: ${{ needs.Prepare-Release.outputs.edc-version }}


### PR DESCRIPTION
## What this PR changes/adds

This PR modifies the `bump-version` action and takes the release version (base version) from an action input and only falls back to the `gradle.properties` if that input was `null`.

## Why it does that

when releasing e.g. `0.2.0`, the next snapshot is supposed to be `0.2.1-SNAPSHOT`.

## Further notes

- I also improved the snapshot patch version increment, so that when releasing versions with metadata, e.g. `0.3.6-rc2`, the next snapshot version will still be `0.3.6-SNAPSHOT`.
- once this PR is approved, i'll do the same thing in all other repos as well.

## Linked Issue(s)

Closes #3198 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md)._
