### PR TITLE
feat(dsp): implement GET /id negotiation endpoint

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
@@ -149,7 +149,8 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
     @NotNull
     public ServiceResult<ContractNegotiation> findById(String id, ClaimToken claimToken) {
         return transactionContext.execute(() -> Optional.ofNullable(store.findById(id))
-                .map(negotiation -> validateGetRequest(claimToken, id, negotiation))
+                .map(negotiation -> validateGetRequest(claimToken, negotiation))
+                .map(ServiceResult::success)
                 .orElse(ServiceResult.notFound(format("No negotiation with id %s found", id))));
     }
 
@@ -205,14 +206,12 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
         }
     }
     
-    @NotNull
-    private ServiceResult<ContractNegotiation> validateGetRequest(ClaimToken claimToken, String id, ContractNegotiation negotiation) {
+    private ContractNegotiation validateGetRequest(ClaimToken claimToken, ContractNegotiation negotiation) {
         var result = validationService.validateRequest(claimToken, negotiation);
         if (result.failed()) {
-            // should return not found if counter-party not authorized
-            return ServiceResult.notFound(format("No negotiation with id %s found", id));
+            return null;
         } else {
-            return ServiceResult.success(negotiation);
+            return negotiation;
         }
     }
 

--- a/data-protocols/dsp/dsp-api-configuration/src/main/java/org/eclipse/edc/protocol/dsp/api/configuration/error/DspErrorResponse.java
+++ b/data-protocols/dsp/dsp-api-configuration/src/main/java/org/eclipse/edc/protocol/dsp/api/configuration/error/DspErrorResponse.java
@@ -99,6 +99,7 @@ public class DspErrorResponse {
         return switch (failure.getReason()) {
             case UNAUTHORIZED -> Response.Status.UNAUTHORIZED;
             case CONFLICT -> Response.Status.CONFLICT;
+            case NOT_FOUND -> Response.Status.NOT_FOUND;
             default -> Response.Status.BAD_REQUEST;
         };
     }

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/contractnegotiation/ContractNegotiationProtocolService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/contractnegotiation/ContractNegotiationProtocolService.java
@@ -104,4 +104,15 @@ public interface ContractNegotiationProtocolService {
      */
     @NotNull
     ServiceResult<ContractNegotiation> notifyTerminated(ContractNegotiationTerminationMessage message, ClaimToken claimToken);
+    
+    /**
+     * Finds a contract negotiation that has been requested by the counter-part. An existing
+     * negotiation, for which the counter-part is not authorized, is treated as non-existent.
+     *
+     * @param id id of the negotiation
+     * @param claimToken the counter-party claim token
+     * @return a succeeded result containing the negotiation if it was found, a failed one otherwise
+     */
+    @NotNull
+    ServiceResult<ContractNegotiation> findById(String id, ClaimToken claimToken);
 }


### PR DESCRIPTION
## What this PR changes/adds

Adds a method `findById` to the `ContractNegotiationProtocolService`, that takes a `ClaimToken` as parameter and returns a negotiation only if the requesting party is authorized. Using this method, implements the `GET /id` endpoint in the `DspNegotiationApiController`.

## Why it does that

To support the protocol specification

## Linked Issue(s)

Closes #2795 
