### PR TITLE
fix: handle iterable Criterion operandRight

### DIFF
--- a/extensions/common/api/api-core/src/main/java/org/eclipse/edc/api/transformer/JsonObjectToCriterionDtoTransformer.java
+++ b/extensions/common/api/api-core/src/main/java/org/eclipse/edc/api/transformer/JsonObjectToCriterionDtoTransformer.java
@@ -21,6 +21,7 @@ import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import static java.util.stream.Collectors.toList;
 import static org.eclipse.edc.api.model.CriterionDto.CRITERION_OPERAND_LEFT;
 import static org.eclipse.edc.api.model.CriterionDto.CRITERION_OPERAND_RIGHT;
 import static org.eclipse.edc.api.model.CriterionDto.CRITERION_OPERATOR;
@@ -35,18 +36,17 @@ public class JsonObjectToCriterionDtoTransformer extends AbstractJsonLdTransform
     public @Nullable CriterionDto transform(@NotNull JsonObject object, @NotNull TransformerContext context) {
         var builder = CriterionDto.Builder.newInstance();
 
-        visitProperties(object, k -> {
-            switch (k) {
-                case CRITERION_OPERAND_LEFT:
-                    return v -> builder.operandLeft(transformString(v, context));
-                case CRITERION_OPERAND_RIGHT:
-                    return v -> builder.operandRight(transformString(v, context));
-                case CRITERION_OPERATOR:
-                    return v -> builder.operator(transformString(v, context));
-                default:
-                    return doNothing();
-            }
-        });
+        builder.operandLeft(transformString(object.get(CRITERION_OPERAND_LEFT), context));
+
+        var operator = transformString(object.get(CRITERION_OPERATOR), context);
+        builder.operator(operator);
+
+        var operandRight = object.get(CRITERION_OPERAND_RIGHT);
+        if ("in".equals(operator)) {
+            builder.operandRight(operandRight.asJsonArray().stream().map(this::nodeValue).collect(toList()));
+        } else {
+            builder.operandRight(transformString(operandRight, context));
+        }
 
         return builder.build();
     }

--- a/extensions/common/api/api-core/src/test/java/org/eclipse/edc/api/transformer/JsonObjectToCriterionDtoTransformerTest.java
+++ b/extensions/common/api/api-core/src/test/java/org/eclipse/edc/api/transformer/JsonObjectToCriterionDtoTransformerTest.java
@@ -14,18 +14,21 @@
 
 package org.eclipse.edc.api.transformer;
 
-import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonValue;
 import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
 import org.eclipse.edc.jsonld.transformer.to.JsonValueToGenericTypeTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.junit.jupiter.api.Test;
 
+import static jakarta.json.Json.createArrayBuilder;
+import static jakarta.json.Json.createObjectBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.api.model.CriterionDto.CRITERION_OPERAND_LEFT;
 import static org.eclipse.edc.api.model.CriterionDto.CRITERION_OPERAND_RIGHT;
 import static org.eclipse.edc.api.model.CriterionDto.CRITERION_OPERATOR;
 import static org.eclipse.edc.api.model.CriterionDto.CRITERION_TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
 import static org.eclipse.edc.jsonld.util.JacksonJsonLd.createObjectMapper;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -36,22 +39,49 @@ class JsonObjectToCriterionDtoTransformerTest {
 
     private final JsonObjectToCriterionDtoTransformer transformer = new JsonObjectToCriterionDtoTransformer();
     private final JsonValueToGenericTypeTransformer genericTypeTransformer = new JsonValueToGenericTypeTransformer(createObjectMapper());
+    private final TransformerContext context = mock(TransformerContext.class);
 
     @Test
     void transform() {
-        var context = mock(TransformerContext.class);
         when(context.transform(any(JsonValue.class), eq(Object.class))).thenAnswer(a -> genericTypeTransformer.transform(a.getArgument(0), context));
-        var json = Json.createObjectBuilder()
+        var json = createObjectBuilder()
                 .add(JsonLdKeywords.TYPE, CRITERION_TYPE)
-                .add(CRITERION_OPERAND_LEFT, "foo")
-                .add(CRITERION_OPERAND_RIGHT, "bar")
-                .add(CRITERION_OPERATOR, "=")
+                .add(CRITERION_OPERAND_LEFT, value("foo"))
+                .add(CRITERION_OPERAND_RIGHT, value("bar"))
+                .add(CRITERION_OPERATOR, value("="))
                 .build();
 
-        var crit = transformer.transform(json, context);
-        assertThat(crit).isNotNull();
-        assertThat(crit.getOperator()).isEqualTo("=");
-        assertThat(crit.getOperandLeft()).isEqualTo("foo");
-        assertThat(crit.getOperandRight()).isEqualTo("bar");
+        var result = transformer.transform(json, context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getOperator()).isEqualTo("=");
+        assertThat(result.getOperandLeft()).isEqualTo("foo");
+        assertThat(result.getOperandRight()).isEqualTo("bar");
+    }
+
+    @Test
+    void transforms_shouldTransformRightOperandAsList_whenOperatorIsIn() {
+        var context = mock(TransformerContext.class);
+        when(context.transform(any(JsonValue.class), eq(Object.class))).thenAnswer(a -> genericTypeTransformer.transform(a.getArgument(0), context));
+        var json = createObjectBuilder()
+                .add(JsonLdKeywords.TYPE, CRITERION_TYPE)
+                .add(CRITERION_OPERAND_LEFT, value("foo"))
+                .add(CRITERION_OPERATOR, "in")
+                .add(CRITERION_OPERAND_RIGHT, createArrayBuilder()
+                        .add(createObjectBuilder().add(VALUE, "bar"))
+                        .add(createObjectBuilder().add(VALUE, "baz"))
+                )
+                .build();
+
+        var result = transformer.transform(json, context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getOperator()).isEqualTo("in");
+        assertThat(result.getOperandLeft()).isEqualTo("foo");
+        assertThat(result.getOperandRight()).asList().containsExactly("bar", "baz");
+    }
+
+    private JsonArrayBuilder value(String value) {
+        return createArrayBuilder().add(createObjectBuilder().add(VALUE, value));
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/Criterion.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/Criterion.java
@@ -87,7 +87,7 @@ public class Criterion {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        Criterion criterion = (Criterion) o;
+        var criterion = (Criterion) o;
         return Objects.equals(operandLeft, criterion.operandLeft) && Objects.equals(operator, criterion.operator) && Objects.equals(operandRight, criterion.operandRight);
     }
 


### PR DESCRIPTION
## What this PR changes/adds

Make `JsonObjectToCriterionDtoTransformer` handle `in` operator correctly

## Why it does that

support "in" operator

## Further notes

- cleaned up some unused methods

## Linked Issue(s)

Fix #3216

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md)._
