### PR TITLE
fix(workflow): correct `only-labels` in stale bot

### DIFF
--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -23,7 +23,7 @@ jobs:
           days-before-pr-close: -1 # ignore PRs (overwrite default days-before-close)
           remove-issue-stale-when-updated: true
           exempt-all-issue-milestones: false # issues with assigned milestones will be ignored
-          only-label: 'triage'
+          only-labels: 'triage'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
   close-issues-with-assignee:


### PR DESCRIPTION
## What this PR changes/adds

Change `only-labels` according to [the GH action's guide](https://github.com/actions/stale#list-of-input-options).

## Why it does that

A typo currently leads to issues being marked as `stale` although they are assigned to milestones.

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md)._
