### PR TITLE
feat(dsp): implement GET /id transfer process endpoint

### DIFF
--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImpl.java
@@ -40,6 +40,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Optional;
 
 import static java.lang.String.format;
 import static org.eclipse.edc.connector.contract.spi.ContractId.createContractId;
@@ -141,7 +142,16 @@ public class ContractValidationServiceImpl implements ContractValidationService 
         }
         return success(agreement);
     }
-
+    
+    @Override
+    public @NotNull Result<Void> validateRequest(ClaimToken token, ContractAgreement agreement) {
+        var agent = agentService.createFor(token);
+        return Optional.ofNullable(agent.getIdentity())
+                .filter(id -> id.equals(agreement.getConsumerId()) || id.equals(agreement.getProviderId()))
+                .map(id -> Result.success())
+                .orElse(Result.failure("Invalid counter-party identity"));
+    }
+    
     @Override
     @NotNull
     public Result<Void> validateRequest(ClaimToken token, ContractNegotiation negotiation) {

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -150,7 +150,7 @@ class ContractNegotiationIntegrationTest {
         var offer = getContractOffer();
         when(validationService.validateInitialOffer(token, offer)).thenReturn(Result.success(new ValidatedConsumerOffer(CONSUMER_ID, offer)));
         when(validationService.validateConfirmed(eq(token), any(ContractAgreement.class), any(ContractOffer.class))).thenReturn(Result.success());
-        when(validationService.validateRequest(eq(token), any())).thenReturn(Result.success());
+        when(validationService.validateRequest(eq(token), any(ContractNegotiation.class))).thenReturn(Result.success());
 
         // Start provider and consumer negotiation managers
         providerManager.start();

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImplTest.java
@@ -380,6 +380,45 @@ class ContractValidationServiceImplTest {
 
         verify(agentService).createFor(eq(token));
     }
+    
+    @Test
+    void validateRequest_shouldReturnSuccess_whenRequestingPartyProvider() {
+        var token = ClaimToken.Builder.newInstance().build();
+        var agreement = createContractAgreement().build();
+        var participantAgent = new ParticipantAgent(Map.of(), Map.of(PARTICIPANT_IDENTITY, PROVIDER_ID));
+    
+        when(agentService.createFor(token)).thenReturn(participantAgent);
+        
+        var result = validationService.validateRequest(token, agreement);
+        
+        assertThat(result).isSucceeded();
+    }
+    
+    @Test
+    void validateRequest_shouldReturnSuccess_whenRequestingPartyConsumer() {
+        var token = ClaimToken.Builder.newInstance().build();
+        var agreement = createContractAgreement().build();
+        var participantAgent = new ParticipantAgent(Map.of(), Map.of(PARTICIPANT_IDENTITY, CONSUMER_ID));
+    
+        when(agentService.createFor(token)).thenReturn(participantAgent);
+    
+        var result = validationService.validateRequest(token, agreement);
+    
+        assertThat(result).isSucceeded();
+    }
+    
+    @Test
+    void validateRequest_shouldReturnFailure_whenRequestingPartyUnauthorized() {
+        var token = ClaimToken.Builder.newInstance().build();
+        var agreement = createContractAgreement().build();
+        var participantAgent = new ParticipantAgent(Map.of(), Map.of(PARTICIPANT_IDENTITY, "invalid"));
+    
+        when(agentService.createFor(token)).thenReturn(participantAgent);
+    
+        var result = validationService.validateRequest(token, agreement);
+    
+        assertThat(result).isFailed();
+    }
 
     @Test
     void validateConsumerRequest() {

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/ControlPlaneServicesExtension.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/ControlPlaneServicesExtension.java
@@ -194,6 +194,6 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     @Provider
     public TransferProcessProtocolService transferProcessProtocolService() {
         return new TransferProcessProtocolServiceImpl(transferProcessStore, transactionContext, contractNegotiationStore,
-                contractValidationService, dataAddressValidator, transferProcessObservable, clock, monitor, telemetry);
+                contractValidationService, dataAddressValidator, transferProcessObservable, participantAgentService, clock, monitor, telemetry);
     }
 }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/ControlPlaneServicesExtension.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/ControlPlaneServicesExtension.java
@@ -194,6 +194,6 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     @Provider
     public TransferProcessProtocolService transferProcessProtocolService() {
         return new TransferProcessProtocolServiceImpl(transferProcessStore, transactionContext, contractNegotiationStore,
-                contractValidationService, dataAddressValidator, transferProcessObservable, participantAgentService, clock, monitor, telemetry);
+                contractValidationService, dataAddressValidator, transferProcessObservable, clock, monitor, telemetry);
     }
 }

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
@@ -197,7 +197,7 @@ class ContractNegotiationProtocolServiceImplTest {
     void notifyVerified_shouldTransitionToVerified() {
         var negotiation = contractNegotiationBuilder().id("negotiationId").type(PROVIDER).state(AGREED.code()).build();
         when(store.findForCorrelationId("processId")).thenReturn(negotiation);
-        when(validationService.validateRequest(any(), any())).thenReturn(Result.success());
+        when(validationService.validateRequest(any(), any(ContractNegotiation.class))).thenReturn(Result.success());
         var message = ContractAgreementVerificationMessage.Builder.newInstance()
                 .protocol("protocol")
                 .counterPartyAddress("http://any")
@@ -209,7 +209,7 @@ class ContractNegotiationProtocolServiceImplTest {
         assertThat(result).isSucceeded();
         verify(store).save(argThat(n -> n.getState() == VERIFIED.code()));
         verify(listener).verified(negotiation);
-        verify(validationService).validateRequest(any(), any());
+        verify(validationService).validateRequest(any(), any(ContractNegotiation.class));
         verify(transactionContext, atLeastOnce()).execute(any(TransactionContext.ResultTransactionBlock.class));
     }
 
@@ -217,7 +217,7 @@ class ContractNegotiationProtocolServiceImplTest {
     void notifyVerified_shouldReturnBadRequest_whenValidationFails() {
         var negotiation = contractNegotiationBuilder().id("negotiationId").type(PROVIDER).state(AGREED.code()).build();
         when(store.findForCorrelationId("processId")).thenReturn(negotiation);
-        when(validationService.validateRequest(any(), any())).thenReturn(Result.failure("validation error"));
+        when(validationService.validateRequest(any(), any(ContractNegotiation.class))).thenReturn(Result.failure("validation error"));
         var message = ContractAgreementVerificationMessage.Builder.newInstance()
                 .protocol("protocol")
                 .counterPartyAddress("http://any")
@@ -235,7 +235,7 @@ class ContractNegotiationProtocolServiceImplTest {
     void notifyFinalized_shouldTransitionToFinalized() {
         var negotiation = contractNegotiationBuilder().id("negotiationId").type(PROVIDER).state(VERIFIED.code()).build();
         when(store.findForCorrelationId("processId")).thenReturn(negotiation);
-        when(validationService.validateRequest(any(), any())).thenReturn(Result.success());
+        when(validationService.validateRequest(any(), any(ContractNegotiation.class))).thenReturn(Result.success());
         var message = ContractNegotiationEventMessage.Builder.newInstance()
                 .type(ContractNegotiationEventMessage.Type.FINALIZED)
                 .protocol("protocol")
@@ -249,7 +249,7 @@ class ContractNegotiationProtocolServiceImplTest {
         assertThat(result).isSucceeded();
         verify(store).save(argThat(n -> n.getState() == FINALIZED.code()));
         verify(listener).finalized(negotiation);
-        verify(validationService).validateRequest(any(), any());
+        verify(validationService).validateRequest(any(), any(ContractNegotiation.class));
         verify(transactionContext, atLeastOnce()).execute(any(TransactionContext.ResultTransactionBlock.class));
     }
 
@@ -257,7 +257,7 @@ class ContractNegotiationProtocolServiceImplTest {
     void notifyFinalized_shouldReturnBadRequest_whenValidationFails() {
         var negotiation = contractNegotiationBuilder().id("negotiationId").type(PROVIDER).state(VERIFIED.code()).build();
         when(store.findForCorrelationId("processId")).thenReturn(negotiation);
-        when(validationService.validateRequest(any(), any())).thenReturn(Result.failure("validation error"));
+        when(validationService.validateRequest(any(), any(ContractNegotiation.class))).thenReturn(Result.failure("validation error"));
         var message = ContractNegotiationEventMessage.Builder.newInstance()
                 .type(ContractNegotiationEventMessage.Type.FINALIZED)
                 .protocol("protocol")
@@ -277,7 +277,7 @@ class ContractNegotiationProtocolServiceImplTest {
     void notifyTerminated_shouldTransitionToTerminated() {
         var negotiation = contractNegotiationBuilder().id("negotiationId").type(PROVIDER).state(VERIFIED.code()).build();
         when(store.findForCorrelationId("processId")).thenReturn(negotiation);
-        when(validationService.validateRequest(any(), any())).thenReturn(Result.success());
+        when(validationService.validateRequest(any(), any(ContractNegotiation.class))).thenReturn(Result.success());
         var message = ContractNegotiationTerminationMessage.Builder.newInstance()
                 .protocol("protocol")
                 .processId("processId")
@@ -291,7 +291,7 @@ class ContractNegotiationProtocolServiceImplTest {
         assertThat(result).isSucceeded();
         verify(store).save(argThat(n -> n.getState() == TERMINATED.code()));
         verify(listener).terminated(negotiation);
-        verify(validationService).validateRequest(any(), any());
+        verify(validationService).validateRequest(any(), any(ContractNegotiation.class));
         verify(transactionContext, atLeastOnce()).execute(any(TransactionContext.ResultTransactionBlock.class));
     }
 
@@ -299,7 +299,7 @@ class ContractNegotiationProtocolServiceImplTest {
     void notifyTerminated_shouldReturnBadRequest_whenValidationFails() {
         var negotiation = contractNegotiationBuilder().id("negotiationId").type(PROVIDER).state(VERIFIED.code()).build();
         when(store.findForCorrelationId("processId")).thenReturn(negotiation);
-        when(validationService.validateRequest(any(), any())).thenReturn(Result.failure("validation error"));
+        when(validationService.validateRequest(any(), any(ContractNegotiation.class))).thenReturn(Result.failure("validation error"));
         var message = ContractNegotiationTerminationMessage.Builder.newInstance()
                 .protocol("protocol")
                 .processId("processId")

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/validation/ContractValidationService.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/validation/ContractValidationService.java
@@ -70,6 +70,17 @@ public interface ContractValidationService {
      */
     @NotNull
     Result<ContractAgreement> validateAgreement(ClaimToken token, ContractAgreement agreement);
+    
+    /**
+     * Validates the request for a contract agreement. Verifies that the requesting party is involved
+     * in the contract agreement, but does not perform policy evaluation.
+     *
+     * @param token The {@link ClaimToken} of the counter-party
+     * @param agreement The agreement
+     * @return The result of the validation
+     */
+    @NotNull
+    Result<Void> validateRequest(ClaimToken token, ContractAgreement agreement);
 
     /**
      * Validates the request for a contract negotiation.

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/transferprocess/TransferProcessProtocolService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/transferprocess/TransferProcessProtocolService.java
@@ -67,5 +67,15 @@ public interface TransferProcessProtocolService {
      */
     @NotNull
     ServiceResult<TransferProcess> notifyTerminated(TransferTerminationMessage message, ClaimToken claimToken);
-
+    
+    /**
+     * Finds a transfer process that has been requested by the counter-part. An existing
+     * process, for which the counter-part is not authorized, is treated as non-existent.
+     *
+     * @param id id of the transfer process
+     * @param claimToken the counter-party claim token
+     * @return a succeeded result containing the transfer process if it was found, a failed one otherwise
+     */
+    @NotNull
+    ServiceResult<TransferProcess> findById(String id, ClaimToken claimToken);
 }


### PR DESCRIPTION
## What this PR changes/adds

Adds a method `findById` to the `TransferProcessProtocolService`, that takes a ClaimToken as parameter and returns a transfer process only if the requesting party is authorized. Using this method, implements the `GET /id` endpoint in the `DspTransferProcessApiController`.

## Why it does that

To support the protocol specification

## Further notes

Adds a second `validateRequest()` method to the `ContractValidationService`, that checks whether a requesting participant is authorized for a contract agreement, but does not perform policy evaluation.

## Linked Issue(s)

Closes #2761 