### PR TITLE
feat: encode `ContractId` parts

### DIFF
--- a/core/control-plane/catalog-core/src/main/java/org/eclipse/edc/connector/catalog/DatasetResolverImpl.java
+++ b/core/control-plane/catalog-core/src/main/java/org/eclipse/edc/connector/catalog/DatasetResolverImpl.java
@@ -92,8 +92,8 @@ public class DatasetResolverImpl implements DatasetResolver {
         if (policyDefinition == null) {
             return null;
         }
-        var contractId = ContractId.createContractId(definition.getId(), assetId);
-        return new Offer(contractId, policyDefinition.getPolicy());
+        var contractId = ContractId.create(definition.getId(), assetId);
+        return new Offer(contractId.toString(), policyDefinition.getPolicy());
     }
 
     private static class Offer {

--- a/core/control-plane/catalog-core/src/test/java/org/eclipse/edc/connector/catalog/DatasetResolverImplTest.java
+++ b/core/control-plane/catalog-core/src/test/java/org/eclipse/edc/connector/catalog/DatasetResolverImplTest.java
@@ -47,6 +47,7 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.policy.model.PolicyType.OFFER;
 import static org.eclipse.edc.policy.model.PolicyType.SET;
 import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
@@ -89,8 +90,7 @@ class DatasetResolverImplTest {
             assertThat(dataset.getId()).matches(isUuid());
             assertThat(dataset.getDistributions()).hasSize(1).first().isEqualTo(distribution);
             assertThat(dataset.getOffers()).hasSize(1).allSatisfy((id, policy) -> {
-                assertThat(id).startsWith("definitionId");
-                assertThat(ContractId.parse(id)).matches(ContractId::isValid);
+                assertThat(ContractId.parseId(id)).isSucceeded().extracting(ContractId::definitionPart).asString().isEqualTo("definitionId");
                 assertThat(policy.getTarget()).isEqualTo("assetId");
             });
             assertThat(dataset.getProperties()).contains(entry("key", "value"));
@@ -127,11 +127,11 @@ class DatasetResolverImplTest {
             assertThat(dataset.getId()).matches(isUuid());
             assertThat(dataset.getOffers()).hasSize(2)
                     .anySatisfy((id, policy) -> {
-                        assertThat(id).startsWith("definition1");
+                        assertThat(ContractId.parseId(id)).isSucceeded().extracting(ContractId::definitionPart).asString().isEqualTo("definition1");
                         assertThat(policy.getType()).isEqualTo(SET);
                     })
                     .anySatisfy((id, policy) -> {
-                        assertThat(id).startsWith("definition2");
+                        assertThat(ContractId.parseId(id)).isSucceeded().extracting(ContractId::definitionPart).asString().isEqualTo("definition2");
                         assertThat(policy.getType()).isEqualTo(OFFER);
                     });
         });

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -174,7 +174,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
 
         var policy = lastOffer.getPolicy();
         var agreement = ContractAgreement.Builder.newInstance()
-                .id(contractId.spawn().toString())
+                .id(contractId.derive().toString())
                 .contractSigningDate(clock.instant().getEpochSecond())
                 .providerId(negotiation.getCounterPartyId())
                 .consumerId(participantId)

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -165,16 +165,16 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
     private boolean processAccepting(ContractNegotiation negotiation) {
         var lastOffer = negotiation.getLastContractOffer();
 
-        var contractId = ContractId.parse(lastOffer.getId());
-        if (!contractId.isValid()) {
-            monitor.severe("ConsumerContractNegotiationManagerImpl.approveContractOffers(): Offer Id not correctly formatted.");
+        var contractIdResult = ContractId.parseId(lastOffer.getId());
+        if (contractIdResult.failed()) {
+            monitor.severe("ConsumerContractNegotiationManagerImpl.approveContractOffers(): Offer Id not correctly formatted: " + contractIdResult.getFailureDetail());
             return false;
         }
-        var definitionId = contractId.definitionPart();
+        var contractId = contractIdResult.getContent();
 
         var policy = lastOffer.getPolicy();
         var agreement = ContractAgreement.Builder.newInstance()
-                .id(ContractId.createContractId(definitionId, lastOffer.getAssetId()))
+                .id(contractId.spawn().toString())
                 .contractSigningDate(clock.instant().getEpochSecond())
                 .providerId(negotiation.getCounterPartyId())
                 .consumerId(participantId)

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -183,7 +183,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
             var contractId = contractIdResult.getContent();
 
             agreement = ContractAgreement.Builder.newInstance()
-                    .id(contractId.spawn().toString())
+                    .id(contractId.derive().toString())
                     .contractSigningDate(clock.instant().getEpochSecond())
                     .providerId(participantId)
                     .consumerId(negotiation.getCounterPartyId())

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -174,15 +174,16 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
         if (retrievedAgreement == null) {
             var lastOffer = negotiation.getLastContractOffer();
 
-            var contractId = ContractId.parse(lastOffer.getId());
-            if (!contractId.isValid()) {
-                monitor.severe("ProviderContractNegotiationManagerImpl.checkConfirming(): Offer Id not correctly formatted.");
+            var contractIdResult = ContractId.parseId(lastOffer.getId());
+            if (contractIdResult.failed()) {
+                monitor.severe("ProviderContractNegotiationManagerImpl.checkConfirming(): Offer Id not correctly formatted: " + contractIdResult.getFailureDetail());
                 return false;
             }
-            var definitionId = contractId.definitionPart();
+
+            var contractId = contractIdResult.getContent();
 
             agreement = ContractAgreement.Builder.newInstance()
-                    .id(ContractId.createContractId(definitionId, lastOffer.getAssetId()))
+                    .id(contractId.spawn().toString())
                     .contractSigningDate(clock.instant().getEpochSecond())
                     .providerId(participantId)
                     .consumerId(negotiation.getCounterPartyId())

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/offer/ContractOfferResolverImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/offer/ContractOfferResolverImpl.java
@@ -113,15 +113,16 @@ public class ContractOfferResolverImpl implements ContractOfferResolver {
         return Optional.of(definition.getContractPolicyId())
                 .map(policyStore::findById)
                 .map(policyDefinition -> assetIndex.queryAssets(assetQuerySpec)
-                        .map(asset -> createContractOffer(definition, policyDefinition.getPolicy(), asset.getId())))
+                        .map(asset -> ContractId.create(definition.getId(), asset.getId()))
+                        .map(contractId -> createContractOffer(policyDefinition.getPolicy(), contractId)))
                 .orElse(Stream.empty());
     }
 
     @NotNull
-    private ContractOffer.Builder createContractOffer(ContractDefinition definition, Policy policy, String assetId) {
+    private ContractOffer.Builder createContractOffer(Policy policy, ContractId contractId) {
         return ContractOffer.Builder.newInstance()
-                .id(ContractId.createContractId(definition.getId(), assetId))
-                .policy(policy.withTarget(assetId))
-                .assetId(assetId);
+                .id(contractId.toString())
+                .policy(policy.withTarget(contractId.assetIdPart()))
+                .assetId(contractId.assetIdPart());
     }
 }

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImpl.java
@@ -21,7 +21,6 @@ import org.eclipse.edc.connector.contract.spi.ContractId;
 import org.eclipse.edc.connector.contract.spi.offer.ContractDefinitionResolver;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
-import org.eclipse.edc.connector.contract.spi.types.offer.ContractDefinition;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.contract.spi.validation.ContractValidationService;
 import org.eclipse.edc.connector.contract.spi.validation.ValidatedConsumerOffer;
@@ -42,7 +41,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 
 import static java.lang.String.format;
-import static org.eclipse.edc.connector.contract.spi.ContractId.createContractId;
 import static org.eclipse.edc.spi.result.Result.failure;
 import static org.eclipse.edc.spi.result.Result.success;
 
@@ -78,68 +76,47 @@ public class ContractValidationServiceImpl implements ContractValidationService 
     @Override
     @NotNull
     public Result<ValidatedConsumerOffer> validateInitialOffer(ClaimToken token, ContractOffer offer) {
-        var contractId = ContractId.parse(offer.getId());
-        if (!contractId.isValid()) {
-            return failure("Invalid id: " + offer.getId());
-        }
-
-        var agent = agentService.createFor(token);
-
-        var result = validateInitialOffer(contractId, agent);
-
-        return result.map(r ->
-                new ValidatedConsumerOffer(agent.getIdentity(),
-                        ContractOffer.Builder.newInstance()
-                                .id(offer.getId())
-                                .assetId(contractId.assetIdPart())
-                                .providerId(participantId)
-                                .policy(r.getPolicy())
-                                .build())
-        );
+        return validateInitialOffer(token, offer.getId());
     }
 
     @Override
     public @NotNull Result<ValidatedConsumerOffer> validateInitialOffer(ClaimToken token, String offerId) {
-        var contractId = ContractId.parse(offerId);
-        if (!contractId.isValid()) {
-            return failure("Invalid id: " + offerId);
-        }
+        return ContractId.parseId(offerId)
+                .compose(contractId -> {
+                    var agent = agentService.createFor(token);
 
-        var agent = agentService.createFor(token);
-
-        var result = validateInitialOffer(contractId, agent);
-
-        return result.map(r -> {
-            var offer = createContractOffer(result.getContent().getDefinition(), result.getContent().getPolicy(), contractId.assetIdPart());
-            return new ValidatedConsumerOffer(agent.getIdentity(), offer);
-        });
+                    return validateInitialOffer(contractId, agent)
+                            .map(sanitizedPolicy -> {
+                                var offer = createContractOffer(sanitizedPolicy, contractId);
+                                return new ValidatedConsumerOffer(agent.getIdentity(), offer);
+                            });
+                });
 
     }
 
     @Override
     @NotNull
     public Result<ContractAgreement> validateAgreement(ClaimToken token, ContractAgreement agreement) {
-        var contractId = ContractId.parse(agreement.getId());
-        if (!contractId.isValid()) {
-            return failure(format("The contract id %s does not follow the expected scheme", agreement.getId()));
-        }
+        return ContractId.parseId(agreement.getId())
+                .compose(contractId -> {
+                    var agent = agentService.createFor(token);
+                    var consumerIdentity = agent.getIdentity();
+                    if (consumerIdentity == null || !consumerIdentity.equals(agreement.getConsumerId())) {
+                        return failure("Invalid provider credentials");
+                    }
 
-        var agent = agentService.createFor(token);
-        var consumerIdentity = agent.getIdentity();
-        if (consumerIdentity == null || !consumerIdentity.equals(agreement.getConsumerId())) {
-            return failure("Invalid provider credentials");
-        }
+                    var policyContext = PolicyContextImpl.Builder.newInstance()
+                            .additional(ParticipantAgent.class, agent)
+                            .additional(ContractAgreement.class, agreement)
+                            .additional(Instant.class, Instant.now())
+                            .build();
+                    var policyResult = policyEngine.evaluate(TRANSFER_SCOPE, agreement.getPolicy(), policyContext);
+                    if (!policyResult.succeeded()) {
+                        return failure(format("Policy does not fulfill the agreement %s, policy evaluation %s", agreement.getId(), policyResult.getFailureDetail()));
+                    }
+                    return success(agreement);
+                });
 
-        var policyContext = PolicyContextImpl.Builder.newInstance()
-                .additional(ParticipantAgent.class, agent)
-                .additional(ContractAgreement.class, agreement)
-                .additional(Instant.class, Instant.now())
-                .build();
-        var policyResult = policyEngine.evaluate(TRANSFER_SCOPE, agreement.getPolicy(), policyContext);
-        if (!policyResult.succeeded()) {
-            return failure(format("Policy does not fulfill the agreement %s, policy evaluation %s", agreement.getId(), policyResult.getFailureDetail()));
-        }
-        return success(agreement);
     }
 
     @Override
@@ -157,29 +134,27 @@ public class ContractValidationServiceImpl implements ContractValidationService 
             return failure("No offer found");
         }
 
-        var contractId = ContractId.parse(agreement.getId());
-        if (!contractId.isValid()) {
-            return failure(format("ContractId %s does not follow the expected schema.", agreement.getId()));
-        }
+        return ContractId.parseId(agreement.getId())
+                .compose(contractId -> {
+                    var agent = agentService.createFor(token);
+                    var providerIdentity = agent.getIdentity();
+                    if (providerIdentity == null || !providerIdentity.equals(agreement.getProviderId())) {
+                        return failure("Invalid provider credentials");
+                    }
 
-        var agent = agentService.createFor(token);
-        var providerIdentity = agent.getIdentity();
-        if (providerIdentity == null || !providerIdentity.equals(agreement.getProviderId())) {
-            return failure("Invalid provider credentials");
-        }
+                    if (!policyEquality.test(agreement.getPolicy().withTarget(latestOffer.getAssetId()), latestOffer.getPolicy())) {
+                        return failure("Policy in the contract agreement is not equal to the one in the contract offer");
+                    }
 
-        if (!policyEquality.test(agreement.getPolicy().withTarget(latestOffer.getAssetId()), latestOffer.getPolicy())) {
-            return failure("Policy in the contract agreement is not equal to the one in the contract offer");
-        }
-
-        return success();
+                    return success();
+                });
     }
 
     /**
      * Validates an initial contract offer, ensuring that the referenced asset exists, is selected by the corresponding policy definition and the agent fulfills the contract policy.
      * A sanitized policy definition is returned to avoid clients injecting manipulated policies.
      */
-    private Result<SanitizedResult> validateInitialOffer(ContractId contractId, ParticipantAgent agent) {
+    private Result<Policy> validateInitialOffer(ContractId contractId, ParticipantAgent agent) {
         var consumerIdentity = agent.getIdentity();
         if (consumerIdentity == null) {
             return failure("Invalid consumer identity");
@@ -214,36 +189,17 @@ public class ContractValidationServiceImpl implements ContractValidationService 
         if (policyResult.failed()) {
             return failure(format("Policy %s not fulfilled", policyDefinition.getUid()));
         }
-        return Result.success(new SanitizedResult(contractDefinition, policy));
+        return Result.success(policy);
     }
 
     @NotNull
-    private ContractOffer createContractOffer(ContractDefinition definition, Policy policy, String assetId) {
+    private ContractOffer createContractOffer(Policy policy, ContractId contractId) {
         return ContractOffer.Builder.newInstance()
-                .id(createContractId(definition.getId(), assetId))
+                .id(contractId.toString())
                 .providerId(participantId)
                 .policy(policy)
-                .assetId(assetId)
+                .assetId(contractId.assetIdPart())
                 .build();
     }
-
-    private static class SanitizedResult {
-        private final ContractDefinition definition;
-        private final Policy policy;
-
-        SanitizedResult(ContractDefinition definition, Policy policy) {
-            this.definition = definition;
-            this.policy = policy;
-        }
-
-        ContractDefinition getDefinition() {
-            return definition;
-        }
-
-        Policy getPolicy() {
-            return policy;
-        }
-    }
-
 
 }

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -326,7 +326,7 @@ class ContractNegotiationIntegrationTest {
      */
     private ContractOffer getContractOffer() {
         return ContractOffer.Builder.newInstance()
-                .id(ContractId.createContractId("1", "test-asset-id"))
+                .id(ContractId.create("1", "test-asset-id").toString())
                 .providerId("provider")
                 .assetId(randomUUID().toString())
                 .policy(Policy.Builder.newInstance()

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
@@ -248,7 +248,7 @@ class ProviderContractNegotiationManagerImplTest {
 
     private ContractAgreement.Builder contractAgreementBuilder() {
         return ContractAgreement.Builder.newInstance()
-                .id(ContractId.createContractId(UUID.randomUUID().toString(), "test-asset-id"))
+                .id(ContractId.create(UUID.randomUUID().toString(), "test-asset-id").toString())
                 .providerId("any")
                 .consumerId("any")
                 .assetId("default")
@@ -257,7 +257,7 @@ class ProviderContractNegotiationManagerImplTest {
 
     private ContractOffer contractOffer() {
         return ContractOffer.Builder.newInstance()
-                .id(ContractId.createContractId("1", "test-asset-id"))
+                .id(ContractId.create("1", "test-asset-id").toString())
                 .policy(Policy.Builder.newInstance().build())
                 .assetId("assetId")
                 .providerId(PROVIDER_ID)

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImplTest.java
@@ -18,6 +18,7 @@
 package org.eclipse.edc.connector.contract.validation;
 
 import org.eclipse.edc.connector.contract.policy.PolicyEquality;
+import org.eclipse.edc.connector.contract.spi.ContractId;
 import org.eclipse.edc.connector.contract.spi.offer.ContractDefinitionResolver;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
@@ -49,7 +50,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static java.lang.String.format;
 import static java.time.Instant.MIN;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -238,12 +238,10 @@ class ContractValidationServiceImplTest {
         var claimToken = ClaimToken.Builder.newInstance().build();
         var agreement = createContractAgreement()
                 .contractSigningDate(now.getEpochSecond())
-                .id("1:2:3")
                 .consumerId(CONSUMER_ID)
                 .build();
 
         var isValid = validationService.validateAgreement(claimToken, agreement);
-
 
         assertThat(isValid.succeeded()).isTrue();
 
@@ -269,7 +267,6 @@ class ContractValidationServiceImplTest {
         var claimToken = ClaimToken.Builder.newInstance().build();
         var agreement = createContractAgreement()
                 .contractSigningDate(now.getEpochSecond())
-                .id("1:2:3")
                 .consumerId(CONSUMER_ID)
                 .build();
 
@@ -307,7 +304,8 @@ class ContractValidationServiceImplTest {
 
     @Test
     void validateConfirmed_succeed() {
-        var agreement = createContractAgreement().id("1:2:3").build();
+        var id = ContractId.create("1", "2").toString();
+        var agreement = createContractAgreement().id(id).build();
         var offer = createContractOffer();
         var token = ClaimToken.Builder.newInstance().build();
 
@@ -324,7 +322,8 @@ class ContractValidationServiceImplTest {
 
     @Test
     void validateConfirmed_failsIfOfferIsNull() {
-        var agreement = createContractAgreement().id("1:2:3").build();
+        var id = ContractId.create("1", "2").toString();
+        var agreement = createContractAgreement().id(id).build();
         var token = ClaimToken.Builder.newInstance().build();
 
         var result = validationService.validateConfirmed(token, agreement, null);
@@ -337,7 +336,7 @@ class ContractValidationServiceImplTest {
     @ValueSource(strings = { CONSUMER_ID })
     @NullSource
     void validateConfirmed_failsIfInvalidClaims(String counterPartyId) {
-        var agreement = createContractAgreement().id("1:2:3").build();
+        var agreement = createContractAgreement().build();
         var offer = createContractOffer();
         var token = ClaimToken.Builder.newInstance().build();
 
@@ -366,7 +365,7 @@ class ContractValidationServiceImplTest {
 
     @Test
     void validateConfirmed_failsIfPoliciesAreNotEqual() {
-        var agreement = createContractAgreement().id("1:2:3").build();
+        var agreement = createContractAgreement().build();
         var offer = createContractOffer();
         var token = ClaimToken.Builder.newInstance().build();
 
@@ -454,7 +453,7 @@ class ContractValidationServiceImplTest {
 
         var claimToken = ClaimToken.Builder.newInstance().build();
         var agreement = createContractAgreement()
-                .id("1:2:3")
+                .id(ContractId.create("1", "2").toString())
                 .contractSigningDate(Instant.now().toEpochMilli())
                 .build();
 
@@ -469,7 +468,7 @@ class ContractValidationServiceImplTest {
 
         var claimToken = ClaimToken.Builder.newInstance().build();
         var agreement = createContractAgreement()
-                .id("1:2:3")
+                .id(ContractId.create("1", "2").toString())
                 .contractSigningDate(signingDate)
                 .build();
 
@@ -478,7 +477,7 @@ class ContractValidationServiceImplTest {
 
     private ContractOffer createContractOffer(Asset asset, Policy policy) {
         return ContractOffer.Builder.newInstance()
-                .id(format("1:%s:3", asset.getId()))
+                .id(ContractId.create("1", asset.getId()).toString())
                 .assetId(asset.getId())
                 .policy(policy)
                 .providerId(PROVIDER_ID)
@@ -496,7 +495,7 @@ class ContractValidationServiceImplTest {
     }
 
     private ContractAgreement.Builder createContractAgreement() {
-        return ContractAgreement.Builder.newInstance().id("1")
+        return ContractAgreement.Builder.newInstance().id(ContractId.create("1", "2").toString())
                 .providerId(PROVIDER_ID)
                 .consumerId(CONSUMER_ID)
                 .policy(Policy.Builder.newInstance().build())

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImpl.java
@@ -80,9 +80,9 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
     @WithSpan
     @NotNull
     public ServiceResult<TransferProcess> notifyRequested(TransferRequestMessage message, ClaimToken claimToken) {
-        var contractId = ContractId.parse(message.getContractId());
-        if (!contractId.isValid()) {
-            return ServiceResult.badRequest("ContractId is not valid");
+        var contractIdResult = ContractId.parseId(message.getContractId());
+        if (contractIdResult.failed()) {
+            return ServiceResult.badRequest("ContractId is not valid: " + contractIdResult.getFailureDetail());
         }
 
         var validDestination = dataAddressValidator.validate(message.getDataDestination());
@@ -93,7 +93,7 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
         return transactionContext.execute(() ->
                 Optional.ofNullable(negotiationStore.findContractAgreement(message.getContractId()))
                         .filter(agreement -> contractValidationService.validateAgreement(claimToken, agreement).succeeded())
-                        .map(agreement -> requestedAction(message))
+                        .map(agreement -> requestedAction(message, contractIdResult.getContent()))
                         .orElse(ServiceResult.conflict(format("Cannot process %s because %s", message.getClass().getSimpleName(), "agreement not found or not valid"))));
     }
 
@@ -119,8 +119,7 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
     }
 
     @NotNull
-    private ServiceResult<TransferProcess> requestedAction(TransferRequestMessage message) {
-        var contractId = ContractId.parse(message.getContractId());
+    private ServiceResult<TransferProcess> requestedAction(TransferRequestMessage message, ContractId contractId) {
         var assetId = contractId.assetIdPart();
 
         var dataRequest = DataRequest.Builder.newInstance()

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.connector.service.contractnegotiation;
 
+import org.eclipse.edc.connector.contract.spi.ContractId;
 import org.eclipse.edc.connector.contract.spi.event.contractnegotiation.ContractNegotiationAgreed;
 import org.eclipse.edc.connector.contract.spi.event.contractnegotiation.ContractNegotiationEvent;
 import org.eclipse.edc.connector.contract.spi.event.contractnegotiation.ContractNegotiationRequested;
@@ -45,7 +46,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Map;
-import java.util.UUID;
 
 import static java.util.Collections.emptyList;
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -110,7 +110,7 @@ class ContractNegotiationEventDispatchTest {
 
     private ContractRequestMessage createContractOfferRequest(Policy policy, String assetId) {
         var contractOffer = ContractOffer.Builder.newInstance()
-                .id("contractDefinitionId:" + assetId + ":" + UUID.randomUUID())
+                .id(ContractId.create("contractDefinitionId", assetId).toString())
                 .assetId("assetId")
                 .policy(policy)
                 .providerId(PROVIDER)

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
@@ -402,7 +402,7 @@ class ContractNegotiationProtocolServiceImplTest {
 
     private ContractOffer contractOffer() {
         return ContractOffer.Builder.newInstance()
-                .id(ContractId.createContractId("1", "test-asset-id"))
+                .id(ContractId.create("1", "test-asset-id").toString())
                 .policy(createPolicy())
                 .assetId("assetId")
                 .providerId(PROVIDER_ID)

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImplTest.java
@@ -97,7 +97,7 @@ class TransferProcessProtocolServiceImplTest {
     void notifyRequested_validAgreement_shouldInitiateTransfer() {
         var message = TransferRequestMessage.Builder.newInstance()
                 .processId("transferProcessId")
-                .contractId(ContractId.createContractId("definitionId", "assetId"))
+                .contractId(ContractId.create("definitionId", "assetId").toString())
                 .protocol("protocol")
                 .callbackAddress("http://any")
                 .dataDestination(DataAddress.Builder.newInstance().type("any").build())
@@ -123,7 +123,7 @@ class TransferProcessProtocolServiceImplTest {
     void notifyRequested_doNothingIfProcessAlreadyExist() {
         var message = TransferRequestMessage.Builder.newInstance()
                 .processId("correlationId")
-                .contractId(ContractId.createContractId("definitionId", "assetId"))
+                .contractId(ContractId.create("definitionId", "assetId").toString())
                 .protocol("protocol")
                 .callbackAddress("http://any")
                 .dataDestination(DataAddress.Builder.newInstance().type("any").build())
@@ -162,7 +162,7 @@ class TransferProcessProtocolServiceImplTest {
         var message = TransferRequestMessage.Builder.newInstance()
                 .protocol("protocol")
                 .callbackAddress("http://any")
-                .contractId(ContractId.createContractId("definitionId", "assetId"))
+                .contractId(ContractId.create("definitionId", "assetId").toString())
                 .dataDestination(DataAddress.Builder.newInstance().type("any").build())
                 .build();
         when(negotiationStore.findContractAgreement(any())).thenReturn(contractAgreement());
@@ -181,7 +181,7 @@ class TransferProcessProtocolServiceImplTest {
         when(dataAddressValidator.validate(any())).thenReturn(Result.failure("invalid data address"));
         var message = TransferRequestMessage.Builder.newInstance()
                 .protocol("protocol")
-                .contractId(ContractId.createContractId("definitionId", "assetId"))
+                .contractId(ContractId.create("definitionId", "assetId").toString())
                 .callbackAddress("http://any")
                 .dataDestination(DataAddress.Builder.newInstance().type("any").build())
                 .build();

--- a/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/contractnegotiation/InMemoryContractNegotiationStoreTest.java
+++ b/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/contractnegotiation/InMemoryContractNegotiationStoreTest.java
@@ -275,7 +275,7 @@ class InMemoryContractNegotiationStoreTest extends ContractNegotiationStoreTestB
     @Test
     void queryAgreements_noQuerySpec() {
         range(0, 10).forEach(i -> {
-            var contractAgreement = TestFunctions.createAgreementBuilder().id(ContractId.createContractId(UUID.randomUUID().toString(), TEST_ASSET_ID)).build();
+            var contractAgreement = TestFunctions.createAgreementBuilder().id(ContractId.create(UUID.randomUUID().toString(), TEST_ASSET_ID).toString()).build();
             var negotiation = TestFunctions.createNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
             store.save(negotiation);
         });
@@ -288,7 +288,7 @@ class InMemoryContractNegotiationStoreTest extends ContractNegotiationStoreTestB
     @Test
     void queryAgreements_verifyPaging() {
         range(0, 10).forEach(i -> {
-            var contractAgreement = TestFunctions.createAgreementBuilder().id(ContractId.createContractId(UUID.randomUUID().toString(), TEST_ASSET_ID)).build();
+            var contractAgreement = TestFunctions.createAgreementBuilder().id(ContractId.create(UUID.randomUUID().toString(), TEST_ASSET_ID).toString()).build();
             var negotiation = TestFunctions.createNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
             store.save(negotiation);
         });

--- a/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
+++ b/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
@@ -72,7 +72,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(EdcExtension.class)
 public class HttpProvisionerExtensionEndToEndTest {
     private static final String ASSET_ID = "assetId";
-    private static final String CONTRACT_ID = ContractId.createContractId("definitionId", ASSET_ID);
+    private static final String CONTRACT_ID = ContractId.create("definitionId", ASSET_ID).toString();
     private static final String POLICY_ID = "3";
     private final int dataPort = getFreePort();
     private final Interceptor delegate = mock(Interceptor.class);

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/PostgresContractNegotiationStoreTest.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/PostgresContractNegotiationStoreTest.java
@@ -95,15 +95,14 @@ class PostgresContractNegotiationStoreTest extends ContractNegotiationStoreTestB
 
     @Test
     void query_byAgreementId() {
-
-        var agreement1 = createContract("agr1");
-        var agreement2 = createContract("agr2");
-        var negotiation1 = createNegotiation("neg1", agreement1);
-        var negotiation2 = createNegotiation("neg2", agreement2);
+        var contractId1 = ContractId.create("def1", "asset");
+        var contractId2 = ContractId.create("def2", "asset");
+        var negotiation1 = createNegotiation("neg1", createContract(contractId1));
+        var negotiation2 = createNegotiation("neg2", createContract(contractId2));
         store.save(negotiation1);
         store.save(negotiation2);
 
-        var expression = criterion("contractAgreement.id", "=", "agr1");
+        var expression = criterion("contractAgreement.id", "=", contractId1.toString());
         var query = QuerySpec.Builder.newInstance().filter(expression).build();
         var result = store.queryNegotiations(query).collect(Collectors.toList());
 
@@ -145,11 +144,12 @@ class PostgresContractNegotiationStoreTest extends ContractNegotiationStoreTestB
 
     @Test
     void query_invalidKey_shouldThrowException() {
-        var agreement1 = createContract("agr1");
+        var contractId = ContractId.create("definition", "asset");
+        var agreement1 = createContract(contractId);
         var negotiation1 = createNegotiation("neg1", agreement1);
         store.save(negotiation1);
 
-        var expression = criterion("contractAgreement.notexist", "=", "agr1");
+        var expression = criterion("contractAgreement.notexist", "=", contractId.toString());
         var query = QuerySpec.Builder.newInstance().filter(expression).build();
         assertThatThrownBy(() -> store.queryNegotiations(query))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -158,7 +158,8 @@ class PostgresContractNegotiationStoreTest extends ContractNegotiationStoreTestB
 
     @Test
     void query_invalidKeyInJson() {
-        var agreement1 = createContract("agr1");
+        var contractId = ContractId.create("definition", "asset");
+        var agreement1 = createContract(contractId);
         var negotiation1 = createNegotiation("neg1", agreement1);
         store.save(negotiation1);
 
@@ -170,7 +171,7 @@ class PostgresContractNegotiationStoreTest extends ContractNegotiationStoreTestB
     @Test
     void queryAgreements_withQuerySpec() {
         IntStream.range(0, 10).forEach(i -> {
-            var contractAgreement = createContractBuilder(ContractId.createContractId(UUID.randomUUID().toString(), TEST_ASSET_ID))
+            var contractAgreement = createContractBuilder(ContractId.create(UUID.randomUUID().toString(), TEST_ASSET_ID).toString())
                     .assetId("asset-" + i)
                     .build();
             var negotiation = createNegotiation(UUID.randomUUID().toString(), contractAgreement);
@@ -186,7 +187,7 @@ class PostgresContractNegotiationStoreTest extends ContractNegotiationStoreTestB
     @Test
     void queryAgreements_withQuerySpec_invalidOperand() {
         IntStream.range(0, 10).forEach(i -> {
-            var contractAgreement = createContractBuilder(ContractId.createContractId(UUID.randomUUID().toString(), TEST_ASSET_ID))
+            var contractAgreement = createContractBuilder(ContractId.create(UUID.randomUUID().toString(), TEST_ASSET_ID).toString())
                     .assetId("asset-" + i)
                     .build();
             var negotiation = createNegotiation(UUID.randomUUID().toString(), contractAgreement);
@@ -200,7 +201,7 @@ class PostgresContractNegotiationStoreTest extends ContractNegotiationStoreTestB
     @Test
     void queryAgreements_withQuerySpec_noFilter() {
         IntStream.range(0, 10).forEach(i -> {
-            var contractAgreement = createContractBuilder(ContractId.createContractId(UUID.randomUUID().toString(), TEST_ASSET_ID))
+            var contractAgreement = createContractBuilder(ContractId.create(UUID.randomUUID().toString(), TEST_ASSET_ID).toString())
                     .assetId("asset-" + i)
                     .build();
             var negotiation = createNegotiation(UUID.randomUUID().toString(), contractAgreement);
@@ -214,7 +215,7 @@ class PostgresContractNegotiationStoreTest extends ContractNegotiationStoreTestB
     @Test
     void queryAgreements_withQuerySpec_invalidValue() {
         IntStream.range(0, 10).forEach(i -> {
-            var contractAgreement = createContractBuilder(ContractId.createContractId(UUID.randomUUID().toString(), TEST_ASSET_ID))
+            var contractAgreement = createContractBuilder(ContractId.create(UUID.randomUUID().toString(), TEST_ASSET_ID).toString())
                     .assetId("asset-" + i)
                     .build();
             var negotiation = createNegotiation(UUID.randomUUID().toString(), contractAgreement);
@@ -232,7 +233,7 @@ class PostgresContractNegotiationStoreTest extends ContractNegotiationStoreTestB
         store.save(negotiation);
 
         // now add the agreement
-        var agreement = createContract("test-ca1");
+        var agreement = createContract(ContractId.create("definition", "asset"));
         var updatedNegotiation = createNegotiation(negotiationId, agreement);
 
         store.save(updatedNegotiation);
@@ -256,7 +257,7 @@ class PostgresContractNegotiationStoreTest extends ContractNegotiationStoreTestB
                 .state(REQUESTED.code())
                 .type(CONSUMER)
                 .build()).forEach(store::save);
-        Criterion[] criteria = { hasState(REQUESTED.code()), new Criterion("type", "=", "CONSUMER") };
+        var criteria = new Criterion[]{hasState(REQUESTED.code()), new Criterion("type", "=", "CONSUMER")};
 
         var result = store.nextNotLeased(10, criteria);
 

--- a/spi/control-plane/contract-spi/build.gradle.kts
+++ b/spi/control-plane/contract-spi/build.gradle.kts
@@ -23,6 +23,8 @@ dependencies {
     api(project(":spi:common:policy-engine-spi"))
     api(project(":spi:control-plane:policy-spi"))
 
+    testImplementation(project(":core:common:junit"))
+
     // needed by the abstract test spec located in testFixtures
     testFixturesImplementation(libs.bundles.jupiter)
     testFixturesImplementation(libs.mockito.core)

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/ContractId.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/ContractId.java
@@ -56,7 +56,7 @@ public final class ContractId {
      * @deprecated please use {@link #create(String, String)}
      */
     @NotNull
-    @Deprecated(since = "0.1.2")
+    @Deprecated(since = "0.1.2", forRemoval = true)
     public static String createContractId(String definitionPart, String assetId) {
         return create(definitionPart, assetId).toString();
     }
@@ -100,7 +100,7 @@ public final class ContractId {
      * @return the {@link ContractId} instance that represent the id
      * @deprecated please use {@link #parseId(String)}
      */
-    @Deprecated(since = "0.1.2")
+    @Deprecated(since = "0.1.2", forRemoval = true)
     public static ContractId parse(String id) {
         return parseId(id).getContent();
     }
@@ -115,7 +115,7 @@ public final class ContractId {
      * @return true if it is valid, false otherwise
      * @deprecated an instantiated {@link ContractId} object is always valid
      */
-    @Deprecated(since = "0.1.2")
+    @Deprecated(since = "0.1.2", forRemoval = true)
     public boolean isValid() {
         return true;
     }
@@ -148,7 +148,12 @@ public final class ContractId {
                 encoder.encodeToString(uuid.getBytes());
     }
 
-    public ContractId spawn() {
+    /**
+     * Create a new {@link ContractId} with the same definitionId and assetId but a new random UUID part.
+     *
+     * @return new {@link ContractId} instance.
+     */
+    public ContractId derive() {
         return create(definitionId, assetId);
     }
 }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/ContractId.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/ContractId.java
@@ -14,24 +14,37 @@
 
 package org.eclipse.edc.connector.contract.spi;
 
+import org.eclipse.edc.spi.result.Result;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Base64;
 import java.util.UUID;
+
+import static java.lang.String.format;
 
 /**
  * Handles contract ID generation for contract offers and agreements originating in an EDC runtime.
  * Ids are architected to allow the contract definition which generated the contract to be de-referenced.
- * The id format follows the following scheme: <code>[definition-id]:[asset-id]:UUID</code>
+ * The id format follows the following scheme: <code>[definition-id]:[asset-id]:[UUID]</code>
  */
 public final class ContractId {
 
-    private static final int DEFINITION_PART = 0;
-    private static final int ASSET_ID_PART = 1;
     private static final String DELIMITER = ":";
-    private final String value;
+    private static final int DEFINITION_ID_PART = 0;
+    private static final int ASSET_ID_PART = 1;
+    private static final int UUID_PART = 2;
+    private final String definitionId;
+    private final String assetId;
+    private final String uuid;
 
-    private ContractId(String value) {
-        this.value = value;
+    private ContractId(String definitionId, String assetId, String uuid) {
+        this.definitionId = definitionId;
+        this.assetId = assetId;
+        this.uuid = uuid;
+    }
+
+    public static ContractId create(String definitionId, String assetId) {
+        return new ContractId(definitionId, assetId, UUID.randomUUID().toString());
     }
 
     /**
@@ -40,10 +53,43 @@ public final class ContractId {
      * @param definitionPart the part that will be used as prefix of the id
      * @param assetId        The ID of the asset that is contained in the offer
      * @return a {@link String} that represent the contract id
+     * @deprecated please use {@link #create(String, String)}
      */
     @NotNull
+    @Deprecated(since = "0.1.2")
     public static String createContractId(String definitionPart, String assetId) {
-        return definitionPart + DELIMITER + assetId + DELIMITER + UUID.randomUUID();
+        return create(definitionPart, assetId).toString();
+    }
+
+    /**
+     * Return a {@link ContractId} instance parsed from the passed string, that should be in the
+     * <code>[definition-id]:[asset-id]:[UUID]</code> format
+     *
+     * @param id the string representation of the id
+     * @return the {@link ContractId} instance that represent the id
+     */
+    public static Result<ContractId> parseId(String id) {
+        if (id == null) {
+            return Result.failure("id cannot be null");
+        }
+
+        var parts = id.split(":");
+        if (parts.length != 3) {
+            return Result.failure(format("contract id should be in the form [definition-id]:[asset-id]:[UUID] but it was %s", id));
+        }
+
+        var definitionIdPart = parts[DEFINITION_ID_PART];
+        var assetIdPart = parts[ASSET_ID_PART];
+        var uuidPart = parts[UUID_PART];
+        try {
+            var definitionId = decode(definitionIdPart);
+            var assetId = decode(assetIdPart);
+            var uuid = decode(uuidPart);
+
+            return Result.success(new ContractId(definitionId, assetId, uuid));
+        } catch (IllegalArgumentException e) {
+            return Result.failure(format("contract id parts should be encoded in base64 but they were: Definition ID: %s, Asset ID: %s, UUID: %s", definitionIdPart, assetIdPart, uuidPart));
+        }
     }
 
     /**
@@ -52,19 +98,26 @@ public final class ContractId {
      *
      * @param id the string representation of the id
      * @return the {@link ContractId} instance that represent the id
+     * @deprecated please use {@link #parseId(String)}
      */
+    @Deprecated(since = "0.1.2")
     public static ContractId parse(String id) {
-        return new ContractId(id);
+        return parseId(id).getContent();
+    }
+
+    private static String decode(String base64string) {
+        return new String(Base64.getDecoder().decode(base64string));
     }
 
     /**
      * The id is valid if it follows the following scheme: [definition-id]:UUID
      *
      * @return true if it is valid, false otherwise
+     * @deprecated an instantiated {@link ContractId} object is always valid
      */
+    @Deprecated(since = "0.1.2")
     public boolean isValid() {
-        var parts = parseContractId(value);
-        return parts.length == 3;
+        return true;
     }
 
     /**
@@ -73,8 +126,7 @@ public final class ContractId {
      * @return The definition part of the id
      */
     public String definitionPart() {
-        var parts = parseContractId(value);
-        return parts[DEFINITION_PART];
+        return definitionId;
     }
 
     /**
@@ -83,16 +135,20 @@ public final class ContractId {
      * @return The definition part of the id
      */
     public String assetIdPart() {
-        var parts = parseContractId(value);
-        return parts[ASSET_ID_PART];
-    }
-
-    private String[] parseContractId(@NotNull String id) {
-        return id.split(DELIMITER);
+        return assetId;
     }
 
     @Override
     public String toString() {
-        return value;
+        var encoder = Base64.getEncoder();
+        return encoder.encodeToString(definitionId.getBytes()) +
+                DELIMITER +
+                encoder.encodeToString(assetId.getBytes()) +
+                DELIMITER +
+                encoder.encodeToString(uuid.getBytes());
+    }
+
+    public ContractId spawn() {
+        return create(definitionId, assetId);
     }
 }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/ContractId.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/ContractId.java
@@ -81,15 +81,16 @@ public final class ContractId {
         var definitionIdPart = parts[DEFINITION_ID_PART];
         var assetIdPart = parts[ASSET_ID_PART];
         var uuidPart = parts[UUID_PART];
-        try {
-            var definitionId = decode(definitionIdPart);
-            var assetId = decode(assetIdPart);
-            var uuid = decode(uuidPart);
 
-            return Result.success(new ContractId(definitionId, assetId, uuid));
-        } catch (IllegalArgumentException e) {
-            return Result.failure(format("contract id parts should be encoded in base64 but they were: Definition ID: %s, Asset ID: %s, UUID: %s", definitionIdPart, assetIdPart, uuidPart));
-        }
+        var definitionId = decodeSafely(definitionIdPart);
+        var assetId = decodeSafely(assetIdPart);
+        var uuid = decodeSafely(uuidPart);
+
+        var contractId = (definitionId == null || assetId == null || uuid == null)
+                ? new ContractId(definitionIdPart, assetIdPart, uuidPart)
+                : new ContractId(definitionId, assetId, uuid);
+
+        return Result.success(contractId);
     }
 
     /**
@@ -105,8 +106,12 @@ public final class ContractId {
         return parseId(id).getContent();
     }
 
-    private static String decode(String base64string) {
-        return new String(Base64.getDecoder().decode(base64string));
+    private static String decodeSafely(String base64string) {
+        try {
+            return new String(Base64.getDecoder().decode(base64string));
+        } catch (IllegalArgumentException exception) {
+            return null;
+        }
     }
 
     /**

--- a/spi/control-plane/contract-spi/src/test/java/org/eclipse/edc/connector/contract/spi/types/ContractIdTest.java
+++ b/spi/control-plane/contract-spi/src/test/java/org/eclipse/edc/connector/contract/spi/types/ContractIdTest.java
@@ -16,51 +16,76 @@ package org.eclipse.edc.connector.contract.spi.types;
 
 import org.eclipse.edc.connector.contract.spi.ContractId;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.Base64;
+
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 
 class ContractIdTest {
 
-    @ParameterizedTest
-    @ValueSource(strings = { "this:is:valid", "this:is:valid:" })
-    void isValid(String idString) {
-        var id = ContractId.parse(idString);
+    private final Base64.Encoder base64encoder = Base64.getEncoder();
 
-        assertThat(id.isValid()).isTrue();
+    @Test
+    void parseId_shouldSucceedWhenItsValid() {
+        var result = ContractId.parseId(encodedContractId("this", "is", "valid"));
+
+        assertThat(result).isSucceeded();
     }
 
     @Test
-    void isValid_tooFewParts() {
-        assertThat(ContractId.parse("thisis:invalid").isValid()).isFalse();
+    void shouldNotParse_whenInputIsNull() {
+        var result = ContractId.parseId(null);
+
+        assertThat(result).isFailed();
     }
 
     @Test
-    void isValid_falseIfNoColonPresent() {
-        var id = ContractId.parse("thisisaninvalidid");
+    void shouldNotParse_whenTooFewParts() {
+        var result = ContractId.parseId("this:isinvalid");
 
-        assertThat(id.isValid()).isFalse();
+        assertThat(result).isFailed();
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = { "thisis:a:very:invalidid", ":this:is:invalid" })
-    void isValid_falseIfTooManyColonsPresent(String idString) {
-        var id = ContractId.parse(idString);
-        assertThat(id.isValid()).isFalse();
+    @Test
+    void shouldNotParse_whenTooManyParts() {
+        var result = ContractId.parseId("this:is:not:valid");
+
+        assertThat(result).isFailed();
     }
 
     @Test
     void definitionPart_returnsTheFirstPartOfTheId() {
-        var id = ContractId.parse("definitionPart:assetPart:agreementPart");
+        var base64representation = encodedContractId("definitionId", "assetId", "uuid");
 
-        assertThat(id.definitionPart()).isEqualTo("definitionPart");
+        var result = ContractId.parseId(base64representation);
+
+        assertThat(result).isSucceeded().satisfies(it -> {
+            assertThat(it.definitionPart()).isEqualTo("definitionId");
+            assertThat(it.assetIdPart()).isEqualTo("assetId");
+            assertThat(it.toString()).isEqualTo(base64representation);
+        });
     }
 
     @Test
-    void assetIdPart_returnsSecondPartOfTheId() {
-        var id = ContractId.parse("definitionPart:assetPart:agreementPart");
+    void spawn_shouldCreateNewContractWithSameDefinitionAndAssetPartsAndDifferentUuid() {
+        var base64representation = encodedContractId("definitionId", "assetId", "uuid");
 
-        assertThat(id.assetIdPart()).isEqualTo("assetPart");
+        var first = ContractId.parseId(base64representation).getContent();
+
+        var result = first.spawn();
+
+        assertThat(result.definitionPart()).isEqualTo("definitionId");
+        assertThat(result.assetIdPart()).isEqualTo("assetId");
+        assertThat(result.toString()).isNotEqualTo(first.toString());
+    }
+
+    private String encodedContractId(String definitionId, String assetId, String uuid) {
+        return format("%s:%s:%s",
+                base64encoder.encodeToString(definitionId.getBytes()),
+                base64encoder.encodeToString(assetId.getBytes()),
+                base64encoder.encodeToString(uuid.getBytes())
+        );
     }
 }

--- a/spi/control-plane/contract-spi/src/test/java/org/eclipse/edc/connector/contract/spi/types/ContractIdTest.java
+++ b/spi/control-plane/contract-spi/src/test/java/org/eclipse/edc/connector/contract/spi/types/ContractIdTest.java
@@ -74,7 +74,7 @@ class ContractIdTest {
 
         var first = ContractId.parseId(base64representation).getContent();
 
-        var result = first.spawn();
+        var result = first.derive();
 
         assertThat(result.definitionPart()).isEqualTo("definitionId");
         assertThat(result.assetIdPart()).isEqualTo("assetId");

--- a/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/negotiation/store/ContractNegotiationStoreTestBase.java
+++ b/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/negotiation/store/ContractNegotiationStoreTestBase.java
@@ -104,7 +104,7 @@ public abstract class ContractNegotiationStoreTestBase {
     @Test
     @DisplayName("Find ContractAgreement by contract ID")
     void findContractAgreement() {
-        var agreement = createContract("test-ca1");
+        var agreement = createContract(ContractId.create("test-cd1", "test-as1"));
         var negotiation = createNegotiation("test-cn1", agreement);
         getContractNegotiationStore().save(negotiation);
 
@@ -147,6 +147,7 @@ public abstract class ContractNegotiationStoreTestBase {
         var contract = getContractNegotiationStore().findById(negotiation.getId());
 
         assertThat(contract)
+                .isNotNull()
                 .usingRecursiveComparison()
                 .isEqualTo(negotiation);
 
@@ -156,7 +157,7 @@ public abstract class ContractNegotiationStoreTestBase {
     @Test
     @DisplayName("Verify that entity and related entities are stored")
     void save_withContract() {
-        var agreement = createContract("test-agreement");
+        var agreement = createContract(ContractId.create("definition", "asset"));
         var negotiation = createNegotiation("test-negotiation", agreement);
         getContractNegotiationStore().save(negotiation);
 
@@ -253,7 +254,7 @@ public abstract class ContractNegotiationStoreTestBase {
         getContractNegotiationStore().save(negotiation);
 
         // now add the agreement
-        var agreement = createContract("test-ca1");
+        var agreement = createContract(ContractId.create("definition", "asset"));
         var updatedNegotiation = createNegotiation(negotiationId, agreement);
 
         getContractNegotiationStore().save(updatedNegotiation); //should perform an update + insert
@@ -291,7 +292,7 @@ public abstract class ContractNegotiationStoreTestBase {
         getContractNegotiationStore().save(negotiation);
 
         // now add the agreement
-        var agreement = createContract("test-ca1");
+        var agreement = createContract(ContractId.create("definition", "asset"));
         var updatedNegotiation = createNegotiation(negotiationId, agreement);
 
         getContractNegotiationStore().save(updatedNegotiation);
@@ -309,7 +310,7 @@ public abstract class ContractNegotiationStoreTestBase {
     @DisplayName("Should update the agreement when a negotiation is updated")
     void update_whenAgreementExists_shouldUpdate() {
         var negotiationId = "test-cn1";
-        var agreement = createContract("test-ca1");
+        var agreement = createContract(ContractId.create("definition", "asset"));
         var negotiation = createNegotiation(negotiationId, null);
         getContractNegotiationStore().save(negotiation);
         var dbNegotiation = getContractNegotiationStore().findById(negotiationId);
@@ -377,7 +378,7 @@ public abstract class ContractNegotiationStoreTestBase {
     @DisplayName("Verify that attempting to delete a negotiation with a contract raises an exception")
     void delete_contractExists() {
         var id = UUID.randomUUID().toString();
-        var contract = createContract("test-agreement");
+        var contract = createContract(ContractId.create("definition", "asset"));
         var n = createNegotiation(id, contract);
         getContractNegotiationStore().save(n);
 
@@ -423,7 +424,7 @@ public abstract class ContractNegotiationStoreTestBase {
 
     @Test
     void getNegotiationsWithAgreementOnAsset_negotiationWithAgreement() {
-        var agreement = createContract("contract1");
+        var agreement = createContract(ContractId.create("definition", "asset"));
         var negotiation = createNegotiation("negotiation1", agreement);
         var assetId = agreement.getAssetId();
 
@@ -481,7 +482,7 @@ public abstract class ContractNegotiationStoreTestBase {
 
         IntStream.range(0, 100)
                 .mapToObj(i -> {
-                    var agreement = createContract("contract" + i);
+                    var agreement = createContract(ContractId.create("definition" + 1, "asset"));
                     return createNegotiation(String.valueOf(i), agreement);
                 })
                 .forEach(cn -> getContractNegotiationStore().save(cn));
@@ -567,7 +568,7 @@ public abstract class ContractNegotiationStoreTestBase {
     @Test
     @DisplayName("Verify that nextNotLeased returns the agreement")
     void nextNotLeased_withAgreement() {
-        var contractAgreement = createContract(ContractId.createContractId(UUID.randomUUID().toString(), ASSET_ID));
+        var contractAgreement = createContract(ContractId.create(UUID.randomUUID().toString(), ASSET_ID));
         var negotiation = createNegotiationBuilder(UUID.randomUUID().toString())
                 .contractAgreement(contractAgreement)
                 .state(ContractNegotiationStates.AGREED.code())
@@ -584,7 +585,7 @@ public abstract class ContractNegotiationStoreTestBase {
     @Test
     void queryAgreements_noQuerySpec() {
         IntStream.range(0, 10).forEach(i -> {
-            var contractAgreement = createContract(ContractId.createContractId(UUID.randomUUID().toString(), ASSET_ID));
+            var contractAgreement = createContract(ContractId.create(UUID.randomUUID().toString(), ASSET_ID));
             var negotiation = createNegotiation(UUID.randomUUID().toString(), contractAgreement);
             getContractNegotiationStore().save(negotiation);
         });
@@ -597,7 +598,7 @@ public abstract class ContractNegotiationStoreTestBase {
     @Test
     void queryAgreements_verifyPaging() {
         IntStream.range(0, 10).forEach(i -> {
-            var contractAgreement = createContract(ContractId.createContractId(UUID.randomUUID().toString(), ASSET_ID));
+            var contractAgreement = createContract(ContractId.create(UUID.randomUUID().toString(), ASSET_ID));
             var negotiation = createNegotiation(UUID.randomUUID().toString(), contractAgreement);
             getContractNegotiationStore().save(negotiation);
         });

--- a/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/negotiation/store/TestFunctions.java
+++ b/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/negotiation/store/TestFunctions.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.edc.connector.contract.spi.testfixtures.negotiation.store;
 
+import org.eclipse.edc.connector.contract.spi.ContractId;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates;
@@ -47,8 +48,8 @@ public class TestFunctions {
                 .build();
     }
 
-    public static ContractAgreement createContract(String id) {
-        return createContractBuilder(id)
+    public static ContractAgreement createContract(ContractId contractId) {
+        return createContractBuilder(contractId.toString())
                 .build();
     }
 

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/AbstractEndToEndTransfer.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/AbstractEndToEndTransfer.java
@@ -220,7 +220,7 @@ public abstract class AbstractEndToEndTransfer {
 
     private ContractId getContractId(JsonObject dataset) {
         var id = dataset.getJsonArray(ODRL_POLICY_ATTRIBUTE).get(0).asJsonObject().getString(ID);
-        return ContractId.parse(id);
+        return ContractId.parseId(id).getContent();
     }
 
     private JsonObject httpDataAddress(String baseUrl) {

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/KafkaTransferTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/KafkaTransferTest.java
@@ -211,7 +211,7 @@ class KafkaTransferTest {
 
     private ContractId getContractId(JsonObject dataset) {
         var id = dataset.getJsonArray(ODRL_POLICY_ATTRIBUTE).get(0).asJsonObject().getString(ID);
-        return ContractId.parse(id);
+        return ContractId.parseId(id).getContent();
     }
 
     private void createResourcesOnProvider(String assetId, Map<String, Object> dataAddressProperties) {

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/Participant.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/Participant.java
@@ -479,7 +479,7 @@ public class Participant {
 
     private ContractId getContractId(JsonObject dataset) {
         var id = dataset.getJsonArray(ODRL_POLICY_ATTRIBUTE).get(0).asJsonObject().getString(ID);
-        return ContractId.parse(id);
+        return ContractId.parseId(id).getContent();
     }
 
     private String getContractNegotiationField(String negotiationId, String fieldName) {

--- a/system-tests/tests/src/testFixtures/java/org/eclipse/edc/test/system/utils/TransferTestClient.java
+++ b/system-tests/tests/src/testFixtures/java/org/eclipse/edc/test/system/utils/TransferTestClient.java
@@ -192,7 +192,7 @@ public class TransferTestClient {
 
     static ContractId getContractId(JsonObject dataset) {
         var id = dataset.getJsonArray(ODRL_POLICY_ATTRIBUTE).get(0).asJsonObject().getString(ID);
-        return ContractId.parse(id);
+        return ContractId.parseId(id).getContent();
     }
 
     public Map<String, String> getTransferProcess(String transferProcessId) {


### PR DESCRIPTION
## What this PR changes/adds

Encodes the three parts of a `ContractId` with base64

## Why it does that

 avoid issues with id containing `:`.

## Further notes

- ~~this is a BREAKING CHANGE, so already stored ongoing contracts could stop working~~ it will work also with not encoded old ids
- refactored the `ContractId` class to adhere our convention, adding the `parseId` method returning a `Result<ContractId>` and adding a `create` that returns a `ContractId`
- deprecating old methods to avoid compilation errors in downstream projects. 

## Linked Issue(s)

Closes #3211 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md)._
