### PR TITLE
chore: remove blank-issue option

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,9 +1,6 @@
 ---
 blank_issues_enabled: false
 contact_links:
-  - name: Open up a blank issue
-    url: https://github.com/eclipse-edc/Connector/issues/new
-    about: Don’t see your issue here? Open up a blank one
   - name: Ask a question or get support
     url: https://github.com/eclipse-edc/Connector/discussions/categories/q-a
     about: Ask a question or request support for using the Eclipse Dataspace Connector


### PR DESCRIPTION
## What this PR changes/adds

removes the option to submit a blank issue.

## Why it does that

all issues should either be feature requests or bug reports. or they should really be a discussion.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md)._
