### PR TITLE
feat: implement get dataset dsp endpoint

### DIFF
--- a/core/control-plane/catalog-core/src/test/java/org/eclipse/edc/connector/catalog/DatasetResolverImplPerformanceTest.java
+++ b/core/control-plane/catalog-core/src/test/java/org/eclipse/edc/connector/catalog/DatasetResolverImplPerformanceTest.java
@@ -51,11 +51,6 @@ class DatasetResolverImplPerformanceTest {
 
     private final Clock clock = Clock.systemUTC();
 
-    @NotNull
-    private static PolicyDefinition.Builder createPolicyDefinition(String id) {
-        return PolicyDefinition.Builder.newInstance().id(id).policy(Policy.Builder.newInstance().build());
-    }
-
     @BeforeEach
     void setUp(EdcExtension extension) {
         extension.registerServiceMock(ProtocolWebhook.class, mock(ProtocolWebhook.class));
@@ -98,6 +93,11 @@ class DatasetResolverImplPerformanceTest {
         var lastPageDatasets = queryDatasetsIn(datasetResolver, lastPageQuery, ofSeconds(1));
 
         assertThat(lastPageDatasets).hasSize(100);
+    }
+
+    @NotNull
+    private PolicyDefinition.Builder createPolicyDefinition(String id) {
+        return PolicyDefinition.Builder.newInstance().id(id).policy(Policy.Builder.newInstance().build());
     }
 
     private Stream<Dataset> queryDatasetsIn(DatasetResolver datasetResolver, QuerySpec querySpec, Duration duration) {

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-api/src/main/java/org/eclipse/edc/protocol/dsp/catalog/api/CatalogApiPaths.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-api/src/main/java/org/eclipse/edc/protocol/dsp/catalog/api/CatalogApiPaths.java
@@ -21,6 +21,6 @@ public interface CatalogApiPaths {
     
     String BASE_PATH = "/catalog";
     String CATALOG_REQUEST = "/request";
-    String DATASET_REQUEST = "/catalog/datasets";
+    String DATASET_REQUEST = "/datasets";
 
 }

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-api/src/main/java/org/eclipse/edc/protocol/dsp/catalog/api/CatalogApiPaths.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-api/src/main/java/org/eclipse/edc/protocol/dsp/catalog/api/CatalogApiPaths.java
@@ -21,5 +21,6 @@ public interface CatalogApiPaths {
     
     String BASE_PATH = "/catalog";
     String CATALOG_REQUEST = "/request";
-    
+    String DATASET_REQUEST = "/catalog/datasets";
+
 }

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-api/src/test/java/org/eclipse/edc/protocol/dsp/catalog/api/controller/DspCatalogApiControllerTest.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-api/src/test/java/org/eclipse/edc/protocol/dsp/catalog/api/controller/DspCatalogApiControllerTest.java
@@ -15,14 +15,17 @@
 package org.eclipse.edc.protocol.dsp.catalog.api.controller;
 
 import io.restassured.specification.RequestSpecification;
-import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.ws.rs.core.HttpHeaders;
 import org.eclipse.edc.catalog.spi.Catalog;
 import org.eclipse.edc.catalog.spi.CatalogRequestMessage;
+import org.eclipse.edc.catalog.spi.DataService;
+import org.eclipse.edc.catalog.spi.Dataset;
+import org.eclipse.edc.catalog.spi.Distribution;
 import org.eclipse.edc.connector.spi.catalog.CatalogProtocolService;
 import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
 import org.eclipse.edc.junit.annotations.ApiTest;
+import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.service.spi.result.ServiceResult;
 import org.eclipse.edc.spi.iam.ClaimToken;
 import org.eclipse.edc.spi.iam.IdentityService;
@@ -35,11 +38,14 @@ import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
+import static jakarta.json.Json.createObjectBuilder;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DATASET_TYPE;
 import static org.eclipse.edc.protocol.dsp.catalog.api.CatalogApiPaths.BASE_PATH;
 import static org.eclipse.edc.protocol.dsp.catalog.api.CatalogApiPaths.CATALOG_REQUEST;
+import static org.eclipse.edc.protocol.dsp.catalog.api.CatalogApiPaths.DATASET_REQUEST;
 import static org.eclipse.edc.protocol.dsp.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP;
 import static org.eclipse.edc.protocol.dsp.type.DspCatalogPropertyAndTypeNames.DSPACE_TYPE_CATALOG_ERROR;
 import static org.eclipse.edc.protocol.dsp.type.DspCatalogPropertyAndTypeNames.DSPACE_TYPE_CATALOG_REQUEST_MESSAGE;
@@ -49,10 +55,12 @@ import static org.eclipse.edc.service.spi.result.ServiceResult.badRequest;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ApiTest
@@ -63,7 +71,7 @@ class DspCatalogApiControllerTest extends RestControllerTestBase {
     private final TypeTransformerRegistry transformerRegistry = mock(TypeTransformerRegistry.class);
     private final CatalogProtocolService service = mock(CatalogProtocolService.class);
     private final String callbackAddress = "http://callback";
-    private final JsonObject request = Json.createObjectBuilder()
+    private final JsonObject request = createObjectBuilder()
             .add(TYPE, DSPACE_TYPE_CATALOG_REQUEST_MESSAGE)
             .build();
     private final CatalogRequestMessage requestMessage = CatalogRequestMessage.Builder.newInstance()
@@ -71,8 +79,8 @@ class DspCatalogApiControllerTest extends RestControllerTestBase {
             .build();
 
     @Test
-    void getCatalog_returnCatalog() {
-        var catalog = Json.createObjectBuilder().add(JsonLdKeywords.TYPE, "catalog").build();
+    void requestCatalog_returnCatalog() {
+        var catalog = createObjectBuilder().add(JsonLdKeywords.TYPE, "catalog").build();
 
         var token = createToken();
         when(transformerRegistry.transform(isA(JsonObject.class), eq(CatalogRequestMessage.class))).thenReturn(Result.success(requestMessage));
@@ -96,11 +104,11 @@ class DspCatalogApiControllerTest extends RestControllerTestBase {
     }
 
     @Test
-    void getCatalog_invalidTypeInRequest_throwException() {
+    void requestCatalog_invalidTypeInRequest_throwException() {
         when(identityService.verifyJwtToken(any(TokenRepresentation.class), eq(callbackAddress)))
                 .thenReturn(Result.success(createToken()));
 
-        var invalidRequest = Json.createObjectBuilder()
+        var invalidRequest = createObjectBuilder()
                 .add(TYPE, "not-a-catalog-request")
                 .build();
 
@@ -117,7 +125,7 @@ class DspCatalogApiControllerTest extends RestControllerTestBase {
     }
 
     @Test
-    void getCatalog_transformingRequestFails_throwException() {
+    void requestCatalog_transformingRequestFails_throwException() {
         when(identityService.verifyJwtToken(any(TokenRepresentation.class), eq(callbackAddress)))
                 .thenReturn(Result.success(createToken()));
         when(transformerRegistry.transform(isA(JsonObject.class), eq(CatalogRequestMessage.class)))
@@ -136,7 +144,7 @@ class DspCatalogApiControllerTest extends RestControllerTestBase {
     }
 
     @Test
-    void getCatalog_authenticationFails_throwException() {
+    void requestCatalog_authenticationFails_throwException() {
         when(identityService.verifyJwtToken(any(TokenRepresentation.class), eq(callbackAddress)))
                 .thenReturn(Result.failure("error"));
 
@@ -153,7 +161,7 @@ class DspCatalogApiControllerTest extends RestControllerTestBase {
     }
 
     @Test
-    void getCatalog_shouldForwardServiceError_whenServiceCallFails() {
+    void requestCatalog_shouldForwardServiceError_whenServiceCallFails() {
         when(service.getCatalog(any(), any())).thenReturn(badRequest("error"));
         when(identityService.verifyJwtToken(any(TokenRepresentation.class), eq(callbackAddress)))
                 .thenReturn(Result.success(createToken()));
@@ -174,6 +182,81 @@ class DspCatalogApiControllerTest extends RestControllerTestBase {
         verify(service).getCatalog(any(), any());
     }
 
+    @Test
+    void getDataset_shouldGetDataset() {
+        var claimToken = createToken();
+        when(identityService.verifyJwtToken(any(TokenRepresentation.class), any()))
+                .thenReturn(Result.success(claimToken));
+        var dataset = createDataset();
+        when(service.getDataset(any(), any())).thenReturn(ServiceResult.success(dataset));
+        var responseBody = createObjectBuilder().add(TYPE, DCAT_DATASET_TYPE).build();
+        when(transformerRegistry.transform(any(), any())).thenReturn(Result.success(responseBody));
+
+        baseRequest()
+                .get(DATASET_REQUEST + "/datasetId")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .body(TYPE, is(DCAT_DATASET_TYPE));
+
+        verify(identityService).verifyJwtToken(argThat(it -> it.getToken().equals("auth")), eq(callbackAddress));
+        verify(service).getDataset("datasetId", claimToken);
+        verify(transformerRegistry).transform(dataset, JsonObject.class);
+    }
+
+    @Test
+    void getDataset_shouldReturnUnauthorized_whenAuthorizationFails() {
+        when(identityService.verifyJwtToken(any(TokenRepresentation.class), any())).thenReturn(Result.failure("unauthorized"));
+
+        baseRequest()
+                .get(DATASET_REQUEST + "/datasetId")
+                .then()
+                .statusCode(401)
+                .contentType(JSON)
+                .body(TYPE, is(DSPACE_TYPE_CATALOG_ERROR))
+                .body(format("'%s'", DSPACE_PROPERTY_CODE), is("401"))
+                .body(format("'%s'", DSPACE_PROPERTY_REASON), notNullValue());
+
+        verifyNoInteractions(service, transformerRegistry);
+    }
+
+    @Test
+    void getDataset_shouldReturnNotFound_whenServiceReturnsNotFound() {
+        when(identityService.verifyJwtToken(any(TokenRepresentation.class), any()))
+                .thenReturn(Result.success(createToken()));
+        when(service.getDataset(any(), any())).thenReturn(ServiceResult.notFound("not found"));
+
+        baseRequest()
+                .get(DATASET_REQUEST + "/datasetId")
+                .then()
+                .statusCode(404)
+                .contentType(JSON)
+                .body(TYPE, is(DSPACE_TYPE_CATALOG_ERROR))
+                .body(format("'%s'", DSPACE_PROPERTY_CODE), is("404"))
+                .body(format("'%s'", DSPACE_PROPERTY_REASON), notNullValue());
+
+        verifyNoInteractions(transformerRegistry);
+    }
+
+    @Test
+    void getDataset_shouldReturnInternalServerError_whenTransformationFails() {
+        var claimToken = createToken();
+        when(identityService.verifyJwtToken(any(TokenRepresentation.class), any()))
+                .thenReturn(Result.success(claimToken));
+        var dataset = createDataset();
+        when(service.getDataset(any(), any())).thenReturn(ServiceResult.success(dataset));
+        when(transformerRegistry.transform(any(), any())).thenReturn(Result.failure("error"));
+
+        baseRequest()
+                .get(DATASET_REQUEST + "/datasetId")
+                .then()
+                .statusCode(500)
+                .contentType(JSON)
+                .body(TYPE, is(DSPACE_TYPE_CATALOG_ERROR))
+                .body(format("'%s'", DSPACE_PROPERTY_CODE), is("500"))
+                .body(format("'%s'", DSPACE_PROPERTY_REASON), notNullValue());
+    }
+
     @Override
     protected Object controller() {
         return new DspCatalogApiController(monitor, identityService, transformerRegistry, callbackAddress, service);
@@ -185,6 +268,12 @@ class DspCatalogApiControllerTest extends RestControllerTestBase {
                 .basePath(BASE_PATH)
                 .header(HttpHeaders.AUTHORIZATION, "auth")
                 .when();
+    }
+
+    private Dataset createDataset() {
+        var dataService = DataService.Builder.newInstance().build();
+        var distribution = Distribution.Builder.newInstance().dataService(dataService).format("format").build();
+        return Dataset.Builder.newInstance().distribution(distribution).offer("offerId", Policy.Builder.newInstance().build()).build();
     }
 
     private ClaimToken createToken() {

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToDatasetTransformer.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToDatasetTransformer.java
@@ -51,23 +51,20 @@ public class JsonObjectToDatasetTransformer extends AbstractJsonLdTransformer<Js
     }
 
     private void transformProperties(String key, JsonValue value, Dataset.Builder builder, TransformerContext context) {
-        if (ODRL_POLICY_ATTRIBUTE.equals(key)) {
-            transformPolicies(value, builder, context);
-        } else if (DCAT_DISTRIBUTION_ATTRIBUTE.equals(key)) {
-            transformArrayOrObject(value, Distribution.class, builder::distribution, context);
-        } else {
-            builder.property(key, transformGenericProperty(value, context));
+        switch (key) {
+            case ODRL_POLICY_ATTRIBUTE -> transformPolicies(value, builder, context);
+            case DCAT_DISTRIBUTION_ATTRIBUTE ->
+                    transformArrayOrObject(value, Distribution.class, builder::distribution, context);
+            default -> builder.property(key, transformGenericProperty(value, context));
         }
     }
 
     private void transformPolicies(JsonValue value, Dataset.Builder builder, TransformerContext context) {
-        if (value instanceof JsonObject) {
-            var object = (JsonObject) value;
+        if (value instanceof JsonObject object) {
             var id = nodeId(object);
             var policy = context.transform(object, Policy.class);
             builder.offer(id, policy);
-        } else if (value instanceof JsonArray) {
-            var array = (JsonArray) value;
+        } else if (value instanceof JsonArray array) {
             array.forEach(entry -> transformPolicies(entry, builder, context));
         } else {
             context.problem()

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToDatasetTransformerTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToDatasetTransformerTest.java
@@ -48,8 +48,8 @@ class JsonObjectToDatasetTransformerTest {
 
     private static final String DATASET_ID = "datasetId";
 
-    private JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
-    private TransformerContext context = mock(TransformerContext.class);
+    private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
+    private final TransformerContext context = mock();
 
     private JsonObjectToDatasetTransformer transformer;
 
@@ -123,30 +123,6 @@ class JsonObjectToDatasetTransformerTest {
 
         verify(context, never()).reportProblem(anyString());
         verify(context, times(1)).transform(any(JsonValue.class), eq(Object.class));
-    }
-
-    @Test
-    void transform_invalidType_reportProblem() {
-        var dataset = jsonFactory.createObjectBuilder()
-                .add(TYPE, "not-a-dataset")
-                .build();
-
-        transformer.transform(getExpanded(dataset), context);
-
-        verify(context, times(1)).reportProblem(anyString());
-    }
-
-    @Test
-    void transform_requiredAttributesMissing_reportProblem() {
-        var dataset = jsonFactory.createObjectBuilder()
-                .add(ID, DATASET_ID)
-                .add(TYPE, DCAT_DATASET_TYPE)
-                .build();
-
-        var result = transformer.transform(getExpanded(dataset), context);
-
-        assertThat(result).isNull();
-        verify(context, times(1)).reportProblem(anyString());
     }
 
     private JsonObject getJsonObject(String id, String type) {

--- a/spi/common/aggregate-service-spi/src/main/java/org/eclipse/edc/service/spi/result/ServiceResult.java
+++ b/spi/common/aggregate-service-spi/src/main/java/org/eclipse/edc/service/spi/result/ServiceResult.java
@@ -60,28 +60,24 @@ public class ServiceResult<T> extends AbstractResult<T, ServiceFailure, ServiceR
         if (storeResult.succeeded()) {
             return success(storeResult.getContent());
         }
-        switch (storeResult.reason()) {
-            case NOT_FOUND:
-                return notFound(storeResult.getFailureDetail());
-            case ALREADY_EXISTS:
-                return conflict(storeResult.getFailureDetail());
-            default:
-                return badRequest(storeResult.getFailureDetail());
-        }
+
+        return switch (storeResult.reason()) {
+            case NOT_FOUND -> notFound(storeResult.getFailureDetail());
+            case ALREADY_EXISTS -> conflict(storeResult.getFailureDetail());
+            default -> badRequest(storeResult.getFailureDetail());
+        };
     }
 
     public static <T> ServiceResult<T> fromFailure(StoreResult<?> storeResult) {
         if (storeResult.succeeded()) {
             throw new IllegalArgumentException("Can only use this method when the argument is a failed result!");
         }
-        switch (storeResult.reason()) {
-            case NOT_FOUND:
-                return notFound(storeResult.getFailureDetail());
-            case ALREADY_EXISTS:
-                return conflict(storeResult.getFailureDetail());
-            default:
-                return badRequest(storeResult.getFailureDetail());
-        }
+
+        return switch (storeResult.reason()) {
+            case NOT_FOUND -> notFound(storeResult.getFailureDetail());
+            case ALREADY_EXISTS -> conflict(storeResult.getFailureDetail());
+            default -> badRequest(storeResult.getFailureDetail());
+        };
     }
 
     public static <T> ServiceResult<T> unauthorized(List<String> failureMessages) {

--- a/spi/common/catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/Dataset.java
+++ b/spi/common/catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/Dataset.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import static java.util.UUID.randomUUID;
 
@@ -41,7 +40,7 @@ public class Dataset {
     /**
      * Policies under which this Dataset is available.
      */
-    private Map<String, Policy> offers;
+    private final Map<String, Policy> offers = new HashMap<>();
 
     /**
      * Representations of this Dataset.
@@ -74,6 +73,10 @@ public class Dataset {
         return properties.get(key);
     }
 
+    public boolean hasOffers() {
+        return !offers.isEmpty();
+    }
+
     @JsonPOJOBuilder(withPrefix = "")
     public static class Builder {
         private final Dataset dataset;
@@ -92,15 +95,7 @@ public class Dataset {
             return this;
         }
 
-        public Builder offers(Map<String, Policy> offers) {
-            this.dataset.offers = offers;
-            return this;
-        }
-
         public Builder offer(String offerId, Policy policy) {
-            if (dataset.offers == null) {
-                dataset.offers = new HashMap<>();
-            }
             dataset.offers.put(offerId, policy);
             return this;
         }
@@ -135,9 +130,6 @@ public class Dataset {
             if (dataset.id == null) {
                 dataset.id = randomUUID().toString();
             }
-
-            Objects.requireNonNull(dataset.offers, "At least one offer required for Dataset.");
-            Objects.requireNonNull(dataset.distributions, "At least one Distribution required for Dataset.");
 
             return dataset;
         }

--- a/spi/common/catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/DatasetResolver.java
+++ b/spi/common/catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/DatasetResolver.java
@@ -26,7 +26,7 @@ import java.util.stream.Stream;
 public interface DatasetResolver {
 
     /**
-     * Resolves {@link Dataset}s given the {@link ParticipantAgent}, a {@link QuerySpec} and a {@link DataService}
+     * Resolves {@link Dataset}s given the {@link ParticipantAgent} and a {@link QuerySpec}
      *
      * @param agent the participant agent that requested the dataset.
      * @param querySpec the query spec for filtering and pagination.
@@ -34,4 +34,13 @@ public interface DatasetResolver {
      */
     @NotNull
     Stream<Dataset> query(ParticipantAgent agent, QuerySpec querySpec);
+
+    /**
+     * Resolves a {@link Dataset} given its id
+     *
+     * @param participantAgent the participant agent that requested the dataset.
+     * @param id the dataset id.
+     * @return the {@link Dataset} if found, null otherwise.
+     */
+    Dataset getById(ParticipantAgent participantAgent, String id);
 }

--- a/spi/common/catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/Distribution.java
+++ b/spi/common/catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/Distribution.java
@@ -44,7 +44,7 @@ public class Distribution {
 
     @JsonPOJOBuilder(withPrefix = "")
     public static class Builder {
-        private Distribution distribution;
+        private final Distribution distribution;
 
         private Builder() {
             distribution = new Distribution();

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/catalog/CatalogProtocolService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/catalog/CatalogProtocolService.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.spi.catalog;
 
 import org.eclipse.edc.catalog.spi.Catalog;
 import org.eclipse.edc.catalog.spi.CatalogRequestMessage;
+import org.eclipse.edc.catalog.spi.Dataset;
 import org.eclipse.edc.service.spi.result.ServiceResult;
 import org.eclipse.edc.spi.iam.ClaimToken;
 import org.jetbrains.annotations.NotNull;
@@ -34,4 +35,14 @@ public interface CatalogProtocolService {
      */
     @NotNull
     ServiceResult<Catalog> getCatalog(CatalogRequestMessage message, ClaimToken token);
+
+    /**
+     * Returns a dataset given its id and a {@link ClaimToken}
+     *
+     * @param datasetId the dataset id.
+     * @param claimToken the claim token.
+     * @return succeeded result with the {@link Dataset}, failed result otherwise.
+     */
+    @NotNull
+    ServiceResult<Dataset> getDataset(String datasetId, ClaimToken claimToken);
 }


### PR DESCRIPTION
## What this PR changes/adds

Implement DSP `/catalog/datasets/{id}` endpoint

## Why it does that

dsp compliance

## Further notes

- now the Dataset id is the same as the Asset id.

## Linked Issue(s)

Closes #3220 
Closes #3231 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md)._
