### PR TITLE
refactor: put DataAddress as Asset field

### DIFF
--- a/core/control-plane/catalog-core/src/test/java/org/eclipse/edc/connector/catalog/DatasetResolverImplIntegrationTest.java
+++ b/core/control-plane/catalog-core/src/test/java/org/eclipse/edc/connector/catalog/DatasetResolverImplIntegrationTest.java
@@ -29,7 +29,6 @@ import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
-import org.eclipse.edc.spi.types.domain.asset.AssetEntry;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -77,9 +76,9 @@ class DatasetResolverImplIntegrationTest {
         var assets2 = range(24, 113).mapToObj(i -> createAsset("asset" + i).build()).collect(Collectors.toList());
         var assets3 = range(113, 178).mapToObj(i -> createAsset("asset" + i).build()).collect(Collectors.toList());
 
-        store(assets1);
-        store(assets2);
-        store(assets3);
+        assets1.forEach(assetIndex::create);
+        assets2.forEach(assetIndex::create);
+        assets3.forEach(assetIndex::create);
 
         var def1 = getContractDefBuilder("def1").assetsSelector(selectorFrom(assets1)).build();
         var def2 = getContractDefBuilder("def2").assetsSelector(selectorFrom(assets2)).build();
@@ -104,8 +103,8 @@ class DatasetResolverImplIntegrationTest {
         var maximumRange = max(0, (assets1.size() + assets2.size()) - from);
         var requestedRange = to - from;
 
-        store(assets1);
-        store(assets2);
+        assets1.forEach(assetIndex::create);
+        assets2.forEach(assetIndex::create);
 
         var contractDefinition1 = getContractDefBuilder("contract-definition-")
                 .assetsSelector(selectorFrom(assets1)).build();
@@ -125,8 +124,8 @@ class DatasetResolverImplIntegrationTest {
         var assets1 = range(0, 12).mapToObj(i -> createAsset("asset" + i).build()).collect(Collectors.toList());
         var assets2 = range(12, 18).mapToObj(i -> createAsset("asset" + i).build()).collect(Collectors.toList());
 
-        store(assets1);
-        store(assets2);
+        assets1.forEach(assetIndex::create);
+        assets2.forEach(assetIndex::create);
 
         var def1 = getContractDefBuilder("def1").assetsSelector(selectorFrom(assets1)).build();
         var def2 = getContractDefBuilder("def2").assetsSelector(selectorFrom(assets2)).build();
@@ -162,11 +161,6 @@ class DatasetResolverImplIntegrationTest {
         return new ParticipantAgent(emptyMap(), emptyMap());
     }
 
-    private void store(Collection<Asset> assets) {
-        assets.stream().map(a -> new AssetEntry(a, DataAddress.Builder.newInstance().type("test-type").build()))
-                .forEach(assetIndex::create);
-    }
-
     private List<Criterion> selectorFrom(Collection<Asset> assets1) {
         var ids = assets1.stream().map(Asset::getId).collect(Collectors.toList());
         return List.of(new Criterion(Asset.PROPERTY_ID, "in", ids));
@@ -181,7 +175,10 @@ class DatasetResolverImplIntegrationTest {
     }
 
     private Asset.Builder createAsset(String id) {
-        return Asset.Builder.newInstance().id(id).name("test asset " + id);
+        return Asset.Builder.newInstance()
+                .id(id)
+                .name("test asset " + id)
+                .dataAddress(DataAddress.Builder.newInstance().type("test-type").build());
     }
 
     static class RangeProvider implements ArgumentsProvider {

--- a/core/control-plane/catalog-core/src/test/java/org/eclipse/edc/connector/catalog/DatasetResolverImplPerformanceTest.java
+++ b/core/control-plane/catalog-core/src/test/java/org/eclipse/edc/connector/catalog/DatasetResolverImplPerformanceTest.java
@@ -29,7 +29,6 @@ import org.eclipse.edc.spi.protocol.ProtocolWebhook;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
-import org.eclipse.edc.spi.types.domain.asset.AssetEntry;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -70,7 +69,7 @@ class DatasetResolverImplPerformanceTest {
                 .contractPolicyId("policy")
                 .assetsSelectorCriterion(criterion(Asset.PROPERTY_ID, "=", String.valueOf(i))).build()
                 ).forEach(contractDefinitionStore::save);
-        range(0, 10000).mapToObj(i -> createAsset(String.valueOf(i)).build()).map(this::createAssetEntry).forEach(assetIndex::create);
+        range(0, 10000).mapToObj(i -> createAsset(String.valueOf(i)).build()).forEach(assetIndex::create);
 
         var firstPageQuery = QuerySpec.Builder.newInstance().offset(0).limit(100).build();
         var firstPageDatasets = queryDatasetsIn(datasetResolver, firstPageQuery, ofSeconds(1));
@@ -87,7 +86,7 @@ class DatasetResolverImplPerformanceTest {
     void fewDefinitionsSelectAllAssets(DatasetResolver datasetResolver, ContractDefinitionStore contractDefinitionStore, AssetIndex assetIndex, PolicyDefinitionStore policyDefinitionStore) {
         policyDefinitionStore.create(createPolicyDefinition("policy").build());
         range(0, 10).mapToObj(i -> createContractDefinition(String.valueOf(i)).accessPolicyId("policy").contractPolicyId("policy").build()).forEach(contractDefinitionStore::save);
-        range(0, 10000).mapToObj(i -> createAsset(String.valueOf(i)).build()).map(this::createAssetEntry).forEach(assetIndex::create);
+        range(0, 10000).mapToObj(i -> createAsset(String.valueOf(i)).build()).forEach(assetIndex::create);
 
         var firstPageQuery = QuerySpec.Builder.newInstance().offset(0).limit(100).build();
         var firstPageDatasets = queryDatasetsIn(datasetResolver, firstPageQuery, ofSeconds(1));
@@ -116,12 +115,10 @@ class DatasetResolverImplPerformanceTest {
                 .contractPolicyId("contract");
     }
 
-    @NotNull
-    private AssetEntry createAssetEntry(Asset it) {
-        return new AssetEntry(it, DataAddress.Builder.newInstance().type("type").build());
-    }
-
     private Asset.Builder createAsset(String id) {
-        return Asset.Builder.newInstance().id(id).name("test asset " + id);
+        return Asset.Builder.newInstance()
+                .id(id)
+                .name("test asset " + id)
+                .dataAddress(DataAddress.Builder.newInstance().type("type").build());
     }
 }

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -35,6 +35,7 @@ import org.eclipse.edc.connector.defaults.storage.contractnegotiation.InMemoryCo
 import org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore;
 import org.eclipse.edc.connector.service.contractnegotiation.ContractNegotiationProtocolServiceImpl;
 import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationProtocolService;
+import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.policy.model.Action;
 import org.eclipse.edc.policy.model.Duty;
 import org.eclipse.edc.policy.model.Policy;
@@ -76,7 +77,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-//@ComponentTest
+@ComponentTest
 class ContractNegotiationIntegrationTest {
     private static final String CONSUMER_ID = "consumer";
     private static final String PROVIDER_ID = "provider";

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/offer/ContractOfferResolverImplIntegrationTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/offer/ContractOfferResolverImplIntegrationTest.java
@@ -32,7 +32,6 @@ import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
-import org.eclipse.edc.spi.types.domain.asset.AssetEntry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -90,9 +89,9 @@ class ContractOfferResolverImplIntegrationTest {
         var assets2 = range(24, 113).mapToObj(i -> createAsset("asset" + i).build()).collect(Collectors.toList());
         var assets3 = range(113, 178).mapToObj(i -> createAsset("asset" + i).build()).collect(Collectors.toList());
 
-        store(assets1);
-        store(assets2);
-        store(assets3);
+        assets1.forEach(assetIndex::create);
+        assets2.forEach(assetIndex::create);
+        assets3.forEach(assetIndex::create);
 
         var def1 = getContractDefBuilder("def1").assetsSelector(selectorFrom(assets1)).build();
         var def2 = getContractDefBuilder("def2").assetsSelector(selectorFrom(assets2)).build();
@@ -123,8 +122,8 @@ class ContractOfferResolverImplIntegrationTest {
         var maximumRange = max(0, (assets1.size() + assets2.size()) - from);
         var requestedRange = to - from;
 
-        store(assets1);
-        store(assets2);
+        assets1.forEach(assetIndex::create);
+        assets2.forEach(assetIndex::create);
 
         var contractDefinition1 = getContractDefBuilder("contract-definition-")
                 .assetsSelector(selectorFrom(assets1)).build();
@@ -144,8 +143,8 @@ class ContractOfferResolverImplIntegrationTest {
         var assets1 = range(0, 12).mapToObj(i -> createAsset("asset" + i).build()).collect(Collectors.toList());
         var assets2 = range(12, 18).mapToObj(i -> createAsset("asset" + i).build()).collect(Collectors.toList());
 
-        store(assets1);
-        store(assets2);
+        assets1.forEach(assetIndex::create);
+        assets2.forEach(assetIndex::create);
 
         var def1 = getContractDefBuilder("def1").assetsSelector(selectorFrom(assets1)).build();
         var def2 = getContractDefBuilder("def2").assetsSelector(selectorFrom(assets2)).build();
@@ -186,11 +185,6 @@ class ContractOfferResolverImplIntegrationTest {
         verify(policyStore, never()).findById("contract");
     }
 
-    private void store(Collection<Asset> assets) {
-        assets.stream().map(a -> new AssetEntry(a, DataAddress.Builder.newInstance().type("test-type").build()))
-                .forEach(assetIndex::create);
-    }
-
     private List<Criterion> selectorFrom(Collection<Asset> assets1) {
         var ids = assets1.stream().map(Asset::getId).toList();
         return List.of(new Criterion(Asset.PROPERTY_ID, "in", ids));
@@ -204,7 +198,10 @@ class ContractOfferResolverImplIntegrationTest {
     }
 
     private Asset.Builder createAsset(String id) {
-        return Asset.Builder.newInstance().id(id).name("test asset " + id);
+        return Asset.Builder.newInstance()
+                .id(id)
+                .name("test asset " + id)
+                .dataAddress(DataAddress.Builder.newInstance().type("test-type").build());
     }
 
     static class RangeProvider implements ArgumentsProvider {

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/asset/AssetServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/asset/AssetServiceImpl.java
@@ -70,13 +70,18 @@ public class AssetServiceImpl implements AssetService {
 
     @Override
     public ServiceResult<Asset> create(Asset asset, DataAddress dataAddress) {
-        var validDataAddress = dataAddressValidator.validate(dataAddress);
+        return create(asset.toBuilder().dataAddress(dataAddress).build());
+    }
+
+    @Override
+    public ServiceResult<Asset> create(Asset asset) {
+        var validDataAddress = dataAddressValidator.validate(asset.getDataAddress());
         if (validDataAddress.failed()) {
             return ServiceResult.badRequest(validDataAddress.getFailureMessages());
         }
 
         return transactionContext.execute(() -> {
-            var createResult = index.create(asset, dataAddress);
+            var createResult = index.create(asset);
             if (createResult.succeeded()) {
                 observable.invokeForEach(l -> l.created(asset));
                 return ServiceResult.success(asset);

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
@@ -98,7 +98,7 @@ class ContractNegotiationEventDispatchTest {
                 .build();
         contractDefinitionStore.save(contractDefinition);
         policyDefinitionStore.create(PolicyDefinition.Builder.newInstance().id("policyId").policy(policy).build());
-        assetIndex.create(Asset.Builder.newInstance().id("assetId").build(), DataAddress.Builder.newInstance().type("any").build());
+        assetIndex.create(Asset.Builder.newInstance().id("assetId").dataAddress(DataAddress.Builder.newInstance().type("any").build()).build());
 
         service.notifyRequested(createContractOfferRequest(policy, "assetId"), token);
 

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/assetindex/InMemoryAssetIndex.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/assetindex/InMemoryAssetIndex.java
@@ -22,9 +22,9 @@ import org.eclipse.edc.spi.query.SortOrder;
 import org.eclipse.edc.spi.result.StoreResult;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
-import org.eclipse.edc.spi.types.domain.asset.AssetEntry;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -54,31 +54,14 @@ public class InMemoryAssetIndex implements AssetIndex {
     public Stream<Asset> queryAssets(QuerySpec querySpec) {
         lock.readLock().lock();
         try {
-            // filter
-            var result = filterBy(querySpec.getFilterExpression());
+            var comparator = querySpec.getSortField() == null
+                    ? (Comparator<Asset>) (o1, o2) -> 0
+                    : new AssetComparator(querySpec.getSortField(), querySpec.getSortOrder());
 
-            // ... then sort
-            var sortField = querySpec.getSortField();
-            if (sortField != null) {
-                result = result.sorted((asset1, asset2) -> {
-                    var f1 = asComparable(asset1.getProperty(sortField));
-                    var f2 = asComparable(asset2.getProperty(sortField));
+            return filterBy(querySpec.getFilterExpression())
+                    .sorted(comparator)
+                    .skip(querySpec.getOffset()).limit(querySpec.getLimit());
 
-                    // try for private properties next
-                    if (f1 == null && f2 == null) {
-                        f1 = asComparable(asset1.getPrivateProperty(sortField));
-                        f2 = asComparable(asset2.getPrivateProperty(sortField));
-                    }
-
-                    if (f1 == null || f2 == null) {
-                        throw new IllegalArgumentException(format("Cannot sort by field %s, it does not exist on one or more Assets", sortField));
-                    }
-                    return querySpec.getSortOrder() == SortOrder.ASC ? f1.compareTo(f2) : f2.compareTo(f1);
-                });
-            }
-
-            // ... then limit
-            return result.skip(querySpec.getOffset()).limit(querySpec.getLimit());
         } finally {
             lock.readLock().unlock();
         }
@@ -98,14 +81,19 @@ public class InMemoryAssetIndex implements AssetIndex {
     }
 
     @Override
-    public StoreResult<Void> create(AssetEntry item) {
+    public StoreResult<Void> create(Asset asset) {
         lock.writeLock().lock();
         try {
-            var id = item.getAsset().getId();
+            if (asset.hasDuplicatePropertyKeys()) {
+                var msg = format(DUPLICATE_PROPERTY_KEYS_TEMPLATE);
+                return StoreResult.duplicateKeys(msg);
+            }
+
+            var id = asset.getId();
             if (cache.containsKey(id)) {
                 return StoreResult.alreadyExists(format(ASSET_EXISTS_TEMPLATE, id));
             }
-            add(item.getAsset(), item.getDataAddress());
+            add(asset, asset.getDataAddress());
         } finally {
             lock.writeLock().unlock();
         }
@@ -133,7 +121,7 @@ public class InMemoryAssetIndex implements AssetIndex {
     public StoreResult<Asset> updateAsset(Asset asset) {
         lock.writeLock().lock();
         try {
-            String id = asset.getId();
+            var id = asset.getId();
             Objects.requireNonNull(asset, "asset");
             Objects.requireNonNull(id, "assetId");
             if (cache.containsKey(id)) {
@@ -156,7 +144,7 @@ public class InMemoryAssetIndex implements AssetIndex {
                 dataAddresses.put(assetId, dataAddress);
                 return StoreResult.success(dataAddress);
             }
-            return StoreResult.notFound(format(DATAADDRESS_NOT_FOUND_TEMPLATE, assetId));
+            return StoreResult.notFound(format(DATA_ADDRESS_NOT_FOUND_TEMPLATE, assetId));
         } finally {
             lock.writeLock().unlock();
         }
@@ -182,10 +170,6 @@ public class InMemoryAssetIndex implements AssetIndex {
                 .filter(predicate);
     }
 
-    private @Nullable Comparable asComparable(Object property) {
-        return property instanceof Comparable ? (Comparable) property : null;
-    }
-
     private Asset delete(String assetId) {
         dataAddresses.remove(assetId);
         return cache.remove(assetId);
@@ -195,10 +179,28 @@ public class InMemoryAssetIndex implements AssetIndex {
      * this method is NOT secured with locks, any guarding must take place in the calling method!
      */
     private void add(Asset asset, DataAddress address) {
-        String id = asset.getId();
+        var id = asset.getId();
         Objects.requireNonNull(asset, "asset");
         Objects.requireNonNull(id, "asset.getId()");
         cache.put(id, asset);
         dataAddresses.put(id, address);
+    }
+
+    private record AssetComparator(String sortField, SortOrder sortOrder) implements Comparator<Asset> {
+
+        @Override
+        public int compare(Asset asset1, Asset asset2) {
+            var f1 = asComparable(asset1.getPropertyOrPrivate(sortField));
+            var f2 = asComparable(asset2.getPropertyOrPrivate(sortField));
+
+            if (f1 == null || f2 == null) {
+                throw new IllegalArgumentException(format("Cannot sort by field %s, it does not exist on one or more Assets", sortField));
+            }
+            return sortOrder == SortOrder.ASC ? f1.compareTo(f2) : f2.compareTo(f1);
+        }
+
+        private @Nullable Comparable<Object> asComparable(Object property) {
+            return property instanceof Comparable ? (Comparable<Object>) property : null;
+        }
     }
 }

--- a/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/assetindex/InMemoryAssetIndexTest.java
+++ b/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/assetindex/InMemoryAssetIndexTest.java
@@ -16,180 +16,19 @@ package org.eclipse.edc.connector.defaults.storage.assetindex;
 
 
 import org.eclipse.edc.spi.asset.AssetIndex;
-import org.eclipse.edc.spi.query.QuerySpec;
-import org.eclipse.edc.spi.query.SortOrder;
-import org.eclipse.edc.spi.result.StoreResult;
 import org.eclipse.edc.spi.testfixtures.asset.AssetIndexTestBase;
-import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.spi.query.Criterion.criterion;
-import static org.eclipse.edc.spi.result.StoreFailure.Reason.NOT_FOUND;
 
 class InMemoryAssetIndexTest extends AssetIndexTestBase {
+
     private InMemoryAssetIndex index;
 
     @BeforeEach
     void setUp() {
         index = new InMemoryAssetIndex();
-    }
-
-    @Test
-    void findById() {
-        String id = UUID.randomUUID().toString();
-        var testAsset = createAsset("barbaz", id);
-        index.create(testAsset, createDataAddress(testAsset));
-
-        var result = index.findById(id);
-
-        assertThat(result).isNotNull().isEqualTo(testAsset);
-    }
-
-    @Test
-    void findById_notfound() {
-        String id = UUID.randomUUID().toString();
-        var testAsset = createAsset("foobar", id);
-        index.create(testAsset, createDataAddress(testAsset));
-
-        var result = index.findById("not-exist");
-
-        assertThat(result).isNull();
-    }
-
-    @Test
-    void findAll_noQuerySpec() {
-        var assets = IntStream.range(0, 10).mapToObj(i -> createAsset("test-asset", "id" + i))
-                .peek(a -> index.create(a, createDataAddress(a))).collect(Collectors.toList());
-
-        assertThat(index.queryAssets(QuerySpec.Builder.newInstance().build())).containsAll(assets);
-    }
-
-    @Test
-    void findAll_withPaging_noSortOrderDesc() {
-        IntStream.range(0, 10)
-                .mapToObj(i -> createAsset("test-asset", "id" + i))
-                .forEach(a -> index.create(a, createDataAddress(a)));
-
-        var spec = QuerySpec.Builder.newInstance().sortOrder(SortOrder.DESC).offset(5).limit(2).build();
-
-        var all = index.queryAssets(spec);
-        assertThat(all).hasSize(2);
-    }
-
-    @Test
-    void findAll_withPaging_noSortOrderAsc() {
-        IntStream.range(0, 10)
-                .mapToObj(i -> createAsset("test-asset", "id" + i))
-                .forEach(a -> index.create(a, createDataAddress(a)));
-
-        var spec = QuerySpec.Builder.newInstance().sortOrder(SortOrder.ASC).offset(3).limit(3).build();
-
-        var all = index.queryAssets(spec);
-        assertThat(all).hasSize(3);
-    }
-
-    @Test
-    void findAll_withFiltering() {
-        var assets = IntStream.range(0, 10)
-                .mapToObj(i -> createAsset("test-asset", "id" + i))
-                .peek(a -> index.create(a, createDataAddress(a)))
-                .collect(Collectors.toList());
-
-        var spec = QuerySpec.Builder.newInstance().filter(criterion(Asset.PROPERTY_ID, "=", "id1")).build();
-        assertThat(index.queryAssets(spec)).hasSize(1).containsExactly(assets.get(1));
-    }
-
-    @Test
-    void findAll_withFiltering_limitExceedsResultSize() {
-        IntStream.range(0, 10)
-                .mapToObj(i -> createAsset("test-asset" + i))
-                .forEach(a -> index.create(a, createDataAddress(a)));
-
-        var spec = QuerySpec.Builder.newInstance()
-                .sortOrder(SortOrder.ASC)
-                .offset(15)
-                .limit(10)
-                .build();
-        assertThat(index.queryAssets(spec)).isEmpty();
-    }
-
-    @Test
-    void findAll_withSorting() {
-        var assets = IntStream.range(0, 10)
-                .mapToObj(i -> createAsset("test-asset", "id" + i))
-                .peek(a -> index.create(a, createDataAddress(a)))
-                .collect(Collectors.toList());
-
-        var spec = QuerySpec.Builder.newInstance().sortField(Asset.PROPERTY_ID).sortOrder(SortOrder.ASC).build();
-        assertThat(index.queryAssets(spec)).containsAll(assets);
-    }
-
-    @Test
-    void findAll_withPrivateSorting() {
-        var assets = IntStream.range(0, 10)
-                .mapToObj(i -> createAssetBuilder("" + i).privateProperty("pKey", "pValue").build())
-                .peek(a -> index.create(a, createDataAddress(a)))
-                .collect(Collectors.toList());
-
-        var spec = QuerySpec.Builder.newInstance().sortField("pKey").sortOrder(SortOrder.ASC).build();
-        assertThat(index.queryAssets(spec)).containsAll(assets);
-    }
-
-    @Test
-    void deleteById_whenMissing_returnsNull() {
-        assertThat(index.deleteById("not-exists")).isNotNull().extracting(StoreResult::reason).isEqualTo(NOT_FOUND);
-    }
-
-    @Test
-    void updateAsset_whenNotExists_returnsFailure() {
-        var id = UUID.randomUUID().toString();
-        var asset = createAsset("test-asset", id);
-        var result = index.updateAsset(asset);
-        assertThat(result.succeeded()).isFalse();
-    }
-
-    @Test
-    void updateAsset_whenExists_returnsUpdatedAsset() {
-        var id = UUID.randomUUID().toString();
-        var asset = createAsset("test-asset", id);
-        var dataAddress = createDataAddress(asset);
-
-        index.create(asset, dataAddress);
-
-        var newAsset = createAsset("new-name", id);
-        var result = index.updateAsset(newAsset);
-        assertThat(result).isNotNull().extracting(StoreResult::getContent).usingRecursiveComparison().isEqualTo(newAsset);
-    }
-
-    @Test
-    void updateDataAddress_whenNotExists_returnsFailure() {
-        var id = UUID.randomUUID().toString();
-        var address = createDataAddress(createAsset("test-asset", id));
-        var result = index.updateDataAddress(id, address);
-        assertThat(result.succeeded()).isFalse();
-    }
-
-    @Test
-    void updateDataAddress_whenExists_returnsUpdatedDataAddress() {
-        var id = UUID.randomUUID().toString();
-        var asset = createAsset("test-asset", id);
-        var dataAddress = createDataAddress(asset);
-
-        index.create(asset, dataAddress);
-
-        dataAddress.getProperties().put("new", "value");
-        var result = index.updateDataAddress(id, dataAddress);
-        assertThat(result.succeeded()).isTrue();
-        assertThat(result.getContent()).isNotNull().usingRecursiveComparison().isEqualTo(dataAddress);
-        assertThat(result.getContent().getProperties().get("new")).isEqualTo("value");
     }
 
     @Override
@@ -201,6 +40,5 @@ class InMemoryAssetIndexTest extends AssetIndexTestBase {
     protected AssetIndex getAssetIndex() {
         return index;
     }
-
 
 }

--- a/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/assetindex/InMemoryDataAddressResolverTest.java
+++ b/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/assetindex/InMemoryDataAddressResolverTest.java
@@ -35,9 +35,9 @@ class InMemoryDataAddressResolverTest {
     @Test
     void resolveForAsset() {
         var id = UUID.randomUUID().toString();
-        var testAsset = createAsset("foobar", id);
-        var address = createDataAddress(testAsset);
-        resolver.create(testAsset, address);
+        var address = createDataAddress();
+        var testAsset = createAssetBuilder("foobar", id).dataAddress(address).build();
+        resolver.create(testAsset);
 
         assertThat(resolver.resolveForAsset(testAsset.getId())).isEqualTo(address);
     }
@@ -45,31 +45,31 @@ class InMemoryDataAddressResolverTest {
     @Test
     void resolveForAsset_assetNull_raisesException() {
         var id = UUID.randomUUID().toString();
-        var testAsset = createAsset("foobar", id);
-        var address = createDataAddress(testAsset);
-        resolver.create(testAsset, address);
+        var address = createDataAddress();
+        var testAsset = createAssetBuilder("foobar", id).dataAddress(address).build();
+        resolver.create(testAsset);
 
         assertThatThrownBy(() -> resolver.resolveForAsset(null)).isInstanceOf(NullPointerException.class);
     }
 
     @Test
     void resolveForAsset_whenAssetDeleted_raisesException() {
-        var testAsset = createAsset("foobar", UUID.randomUUID().toString());
-        var address = createDataAddress(testAsset);
-        resolver.create(testAsset, address);
+        var address = createDataAddress();
+        var testAsset = createAssetBuilder("foobar", UUID.randomUUID().toString()).dataAddress(address).build();
+        resolver.create(testAsset);
         resolver.deleteById(testAsset.getId());
 
         assertThat(resolver.resolveForAsset(testAsset.getId())).isNull();
     }
 
-    private Asset createAsset(String name, String id) {
-        return Asset.Builder.newInstance().id(id).name(name).version("1").contentType("type").build();
+    private static Asset.Builder createAssetBuilder(String name, String id) {
+        return Asset.Builder.newInstance().id(id).name(name).version("1").contentType("type");
     }
 
-    private DataAddress createDataAddress(Asset asset) {
+    private DataAddress createDataAddress() {
         return DataAddress.Builder.newInstance()
                 .keyName("test-keyname")
-                .type(asset.getContentType())
+                .type("type")
                 .build();
     }
 }

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/from/JsonObjectFromAssetTransformer.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/from/JsonObjectFromAssetTransformer.java
@@ -38,21 +38,24 @@ public class JsonObjectFromAssetTransformer extends AbstractJsonLdTransformer<As
 
     @Override
     public @Nullable JsonObject transform(@NotNull Asset asset, @NotNull TransformerContext context) {
-        var builder = jsonFactory.createObjectBuilder();
-        builder.add(ID, asset.getId());
-        builder.add(TYPE, Asset.EDC_ASSET_TYPE);
-        //transform public properties
+        var builder = jsonFactory.createObjectBuilder()
+                .add(ID, asset.getId())
+                .add(TYPE, Asset.EDC_ASSET_TYPE);
+
         var propBuilder = jsonFactory.createObjectBuilder();
         transformProperties(asset.getProperties(), propBuilder, mapper, context);
         builder.add(Asset.EDC_ASSET_PROPERTIES, propBuilder);
 
-
-        //transform private properties
         if (asset.getPrivateProperties() != null && !asset.getPrivateProperties().isEmpty()) {
             var privatePropBuilder = jsonFactory.createObjectBuilder();
             transformProperties(asset.getPrivateProperties(), privatePropBuilder, mapper, context);
             builder.add(Asset.EDC_ASSET_PRIVATE_PROPERTIES, privatePropBuilder);
         }
+
+        if (asset.getDataAddress() != null) {
+            builder.add(Asset.EDC_ASSET_DATA_ADDRESS, context.transform(asset.getDataAddress(), JsonObject.class));
+        }
+
         return builder.build();
     }
 }

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToAssetTransformer.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/transformer/to/JsonObjectToAssetTransformer.java
@@ -18,11 +18,13 @@ import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonValue;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import static org.eclipse.edc.spi.types.domain.asset.Asset.EDC_ASSET_DATA_ADDRESS;
 import static org.eclipse.edc.spi.types.domain.asset.Asset.EDC_ASSET_PRIVATE_PROPERTIES;
 
 /**
@@ -49,6 +51,8 @@ public class JsonObjectToAssetTransformer extends AbstractJsonLdTransformer<Json
         } else if (EDC_ASSET_PRIVATE_PROPERTIES.equals(key) && jsonValue instanceof JsonArray) {
             var props = jsonValue.asJsonArray().getJsonObject(0);
             visitProperties(props, (k, val) -> transformProperties(k, val, builder, context, true));
+        } else if (EDC_ASSET_DATA_ADDRESS.equals(key) && jsonValue instanceof JsonArray) {
+            builder.dataAddress(transformObject(jsonValue, DataAddress.class, context));
         } else {
             if (isPrivate) {
                 builder.privateProperty(key, transformGenericProperty(jsonValue, context));

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApiExtension.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/AssetApiExtension.java
@@ -21,7 +21,9 @@ import org.eclipse.edc.connector.api.management.asset.transform.AssetRequestDtoT
 import org.eclipse.edc.connector.api.management.asset.transform.AssetToAssetResponseDtoTransformer;
 import org.eclipse.edc.connector.api.management.asset.transform.AssetUpdateRequestWrapperDtoToAssetTransformer;
 import org.eclipse.edc.connector.api.management.asset.transform.JsonObjectToAssetEntryNewDtoTransformer;
+import org.eclipse.edc.connector.api.management.asset.v3.AssetApiController;
 import org.eclipse.edc.connector.api.management.asset.validation.AssetEntryDtoValidator;
+import org.eclipse.edc.connector.api.management.asset.validation.AssetValidator;
 import org.eclipse.edc.connector.api.management.configuration.ManagementApiConfiguration;
 import org.eclipse.edc.connector.spi.asset.AssetService;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
@@ -75,9 +77,10 @@ public class AssetApiExtension implements ServiceExtension {
         transformerRegistry.register(new JsonObjectToAssetEntryNewDtoTransformer());
 
         validator.register(EDC_ASSET_ENTRY_DTO_TYPE, AssetEntryDtoValidator.assetEntryValidator());
-        validator.register(EDC_ASSET_TYPE, AssetEntryDtoValidator.assetValidator());
+        validator.register(EDC_ASSET_TYPE, AssetValidator.instance());
         validator.register(EDC_DATA_ADDRESS_TYPE, DataAddressDtoValidator.instance());
 
-        webService.registerResource(config.getContextAlias(), new AssetApiController(assetService, dataAddressResolver, transformerRegistry, monitor, validator));
+        webService.registerResource(config.getContextAlias(), new org.eclipse.edc.connector.api.management.asset.v2.AssetApiController(assetService, dataAddressResolver, transformerRegistry, monitor, validator));
+        webService.registerResource(config.getContextAlias(), new AssetApiController(assetService, transformerRegistry, monitor, validator));
     }
 }

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/v2/AssetApi.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/v2/AssetApi.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.connector.api.management.asset;
+package org.eclipse.edc.connector.api.management.asset.v2;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.Operation;
@@ -36,6 +36,7 @@ import org.eclipse.edc.web.spi.ApiErrorDetail;
 @OpenAPIDefinition(info = @Info(description = "This contains both the current and the new Asset API, which accepts JSON-LD and will become the standard API once the Dataspace Protocol is stable. " +
         "The new Asset API is prefixed with /v2, and the old endpoints have been deprecated. At that time of switching, the old API will be removed, and this API will be available without the /v2 prefix.", title = "Asset API"))
 @Tag(name = "Asset")
+@Deprecated
 public interface AssetApi {
 
     @Operation(description = "Creates a new asset together with a data address",

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/v2/AssetApiController.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/v2/AssetApiController.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.connector.api.management.asset;
+package org.eclipse.edc.connector.api.management.asset.v2;
 
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
@@ -47,12 +47,12 @@ import static java.util.Optional.of;
 import static org.eclipse.edc.api.model.QuerySpecDto.EDC_QUERY_SPEC_TYPE;
 import static org.eclipse.edc.connector.api.management.asset.model.AssetEntryNewDto.EDC_ASSET_ENTRY_DTO_TYPE;
 import static org.eclipse.edc.spi.types.domain.DataAddress.EDC_DATA_ADDRESS_TYPE;
-import static org.eclipse.edc.spi.types.domain.asset.Asset.EDC_ASSET_TYPE;
 import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMapper;
 
 @Consumes(APPLICATION_JSON)
 @Produces(APPLICATION_JSON)
 @Path("/v2/assets")
+@Deprecated
 public class AssetApiController implements AssetApi {
     private final TypeTransformerRegistry transformerRegistry;
     private final AssetService service;
@@ -136,7 +136,8 @@ public class AssetApiController implements AssetApi {
     @PUT
     @Override
     public void updateAsset(JsonObject assetJsonObject) {
-        validator.validate(EDC_ASSET_TYPE, assetJsonObject).orElseThrow(ValidationFailureException::new);
+        // validation removed because now the asset validation requires the dataAddress field
+        // validator.validate(EDC_ASSET_TYPE, assetJsonObject).orElseThrow(ValidationFailureException::new);
 
         var assetResult = transformerRegistry.transform(assetJsonObject, Asset.class)
                 .orElseThrow(InvalidRequestException::new);

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/v3/AssetApi.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/v3/AssetApi.java
@@ -1,0 +1,99 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.asset.v3;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.api.model.IdResponseDto;
+import org.eclipse.edc.api.model.QuerySpecDto;
+import org.eclipse.edc.connector.api.management.asset.model.AssetResponseDto;
+import org.eclipse.edc.connector.api.management.asset.model.AssetUpdateRequestDto;
+import org.eclipse.edc.spi.types.domain.asset.Asset;
+import org.eclipse.edc.web.spi.ApiErrorDetail;
+
+@OpenAPIDefinition(info = @Info(description = "This contains both the current and the new Asset API, which accepts JSON-LD and will become the standard API once the Dataspace Protocol is stable. " +
+        "The new Asset API is prefixed with /v2, and the old endpoints have been deprecated. At that time of switching, the old API will be removed, and this API will be available without the /v2 prefix.", title = "Asset API"))
+@Tag(name = "Asset")
+public interface AssetApi {
+
+    @Operation(description = "Creates a new asset together with a data address",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = Asset.class))),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Asset was created successfully. Returns the asset Id and created timestamp",
+                            content = @Content(schema = @Schema(implementation = IdResponseDto.class))),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))),
+                    @ApiResponse(responseCode = "409", description = "Could not create asset, because an asset with that ID already exists",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))) }
+    )
+    JsonObject createAsset(JsonObject asset);
+
+    @Operation(description = " all assets according to a particular query",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = QuerySpecDto.class))),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The assets matching the query",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = AssetResponseDto.class)))),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
+            })
+    JsonArray requestAssets(JsonObject querySpecDto);
+
+    @Operation(description = "Gets an asset with the given ID",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The asset",
+                            content = @Content(schema = @Schema(implementation = Asset.class))),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))),
+                    @ApiResponse(responseCode = "404", description = "An asset with the given ID does not exist",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
+            }
+    )
+    JsonObject getAsset(String id);
+
+    @Operation(description = "Removes an asset with the given ID if possible. Deleting an asset is only possible if that asset is not yet referenced " +
+            "by a contract agreement, in which case an error is returned. " +
+            "DANGER ZONE: Note that deleting assets can have unexpected results, especially for contract offers that have been sent out or ongoing or contract negotiations.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Asset was deleted successfully"),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))),
+                    @ApiResponse(responseCode = "404", description = "An asset with the given ID does not exist",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))),
+                    @ApiResponse(responseCode = "409", description = "The asset cannot be deleted, because it is referenced by a contract agreement",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
+            })
+    void removeAsset(String id);
+
+    @Operation(description = "Updates an asset with the given ID if it exists. If the asset is not found, no further action is taken. " +
+            "DANGER ZONE: Note that updating assets can have unexpected results, especially for contract offers that have been sent out or are ongoing in contract negotiations.",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = AssetUpdateRequestDto.class))),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Asset was updated successfully"),
+                    @ApiResponse(responseCode = "404", description = "Asset could not be updated, because it does not exist."),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))),
+            })
+    void updateAsset(JsonObject asset);
+
+}

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/v3/AssetApiController.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/v3/AssetApiController.java
@@ -1,0 +1,141 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.asset.v3;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import org.eclipse.edc.api.model.IdResponseDto;
+import org.eclipse.edc.api.model.QuerySpecDto;
+import org.eclipse.edc.connector.spi.asset.AssetService;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.types.domain.asset.Asset;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.web.spi.exception.InvalidRequestException;
+import org.eclipse.edc.web.spi.exception.ObjectNotFoundException;
+import org.eclipse.edc.web.spi.exception.ValidationFailureException;
+
+import static jakarta.json.stream.JsonCollectors.toJsonArray;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static java.util.Optional.of;
+import static org.eclipse.edc.api.model.QuerySpecDto.EDC_QUERY_SPEC_TYPE;
+import static org.eclipse.edc.spi.types.domain.asset.Asset.EDC_ASSET_TYPE;
+import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMapper;
+
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
+@Path("/v3/assets")
+public class AssetApiController implements AssetApi {
+    private final TypeTransformerRegistry transformerRegistry;
+    private final AssetService service;
+    private final Monitor monitor;
+    private final JsonObjectValidatorRegistry validator;
+
+    public AssetApiController(AssetService service, TypeTransformerRegistry transformerRegistry,
+                              Monitor monitor, JsonObjectValidatorRegistry validator) {
+        this.transformerRegistry = transformerRegistry;
+        this.service = service;
+        this.monitor = monitor;
+        this.validator = validator;
+    }
+
+    @POST
+    @Override
+    public JsonObject createAsset(JsonObject assetJson) {
+        validator.validate(EDC_ASSET_TYPE, assetJson).orElseThrow(ValidationFailureException::new);
+
+        var asset = transformerRegistry.transform(assetJson, Asset.class)
+                .orElseThrow(InvalidRequestException::new);
+
+        var dto = service.create(asset)
+                .map(a -> IdResponseDto.Builder.newInstance()
+                        .id(a.getId())
+                        .createdAt(a.getCreatedAt())
+                        .build())
+                .orElseThrow(exceptionMapper(Asset.class, asset.getId()));
+
+        return transformerRegistry.transform(dto, JsonObject.class)
+                .orElseThrow(f -> new EdcException(f.getFailureDetail()));
+    }
+
+    @POST
+    @Path("/request")
+    @Override
+    public JsonArray requestAssets(JsonObject querySpecDto) {
+        QuerySpec querySpec;
+        if (querySpecDto == null) {
+            querySpec = QuerySpec.Builder.newInstance().build();
+        } else {
+            validator.validate(EDC_QUERY_SPEC_TYPE, querySpecDto).orElseThrow(ValidationFailureException::new);
+
+            querySpec = transformerRegistry.transform(querySpecDto, QuerySpecDto.class)
+                    .compose(dto -> transformerRegistry.transform(dto, QuerySpec.class))
+                    .orElseThrow(InvalidRequestException::new);
+        }
+
+        try (var assets = service.query(querySpec).orElseThrow(exceptionMapper(QuerySpec.class, null))) {
+            return assets
+                    .map(it -> transformerRegistry.transform(it, JsonObject.class))
+                    .peek(r -> r.onFailure(f -> monitor.warning(f.getFailureDetail())))
+                    .filter(Result::succeeded)
+                    .map(Result::getContent)
+                    .collect(toJsonArray());
+        }
+    }
+
+    @GET
+    @Path("{id}")
+    @Override
+    public JsonObject getAsset(@PathParam("id") String id) {
+        var asset = of(id)
+                .map(it -> service.findById(id))
+                .orElseThrow(() -> new ObjectNotFoundException(Asset.class, id));
+
+        return transformerRegistry.transform(asset, JsonObject.class)
+                .orElseThrow(f -> new EdcException(f.getFailureDetail()));
+
+    }
+
+    @DELETE
+    @Path("{id}")
+    @Override
+    public void removeAsset(@PathParam("id") String id) {
+        service.delete(id).orElseThrow(exceptionMapper(Asset.class, id));
+    }
+
+    @PUT
+    @Override
+    public void updateAsset(JsonObject assetJson) {
+        validator.validate(EDC_ASSET_TYPE, assetJson).orElseThrow(ValidationFailureException::new);
+
+        var assetResult = transformerRegistry.transform(assetJson, Asset.class)
+                .orElseThrow(InvalidRequestException::new);
+
+        service.update(assetResult)
+                .orElseThrow(exceptionMapper(Asset.class, assetResult.getId()));
+    }
+
+}

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/validation/AssetValidator.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/validation/AssetValidator.java
@@ -22,38 +22,23 @@ import org.eclipse.edc.validator.jsonobject.validators.OptionalIdNotBlank;
 import org.eclipse.edc.validator.spi.ValidationResult;
 import org.eclipse.edc.validator.spi.Validator;
 
-import static org.eclipse.edc.connector.api.management.asset.model.AssetEntryNewDto.EDC_ASSET_ENTRY_DTO_ASSET;
-import static org.eclipse.edc.connector.api.management.asset.model.AssetEntryNewDto.EDC_ASSET_ENTRY_DTO_DATA_ADDRESS;
+import static org.eclipse.edc.spi.types.domain.asset.Asset.EDC_ASSET_DATA_ADDRESS;
 import static org.eclipse.edc.spi.types.domain.asset.Asset.EDC_ASSET_PRIVATE_PROPERTIES;
 import static org.eclipse.edc.spi.types.domain.asset.Asset.EDC_ASSET_PROPERTIES;
 import static org.eclipse.edc.validator.spi.Violation.violation;
 
 /**
  * Contains the AssetEntryDto validator definition
- *
- * @deprecated this will supersede by {@link AssetValidator}
  */
-@Deprecated(since = "0.1.2", forRemoval = true)
-public class AssetEntryDtoValidator {
+public class AssetValidator {
 
-    public static Validator<JsonObject> assetEntryValidator() {
-        return JsonObjectValidator.newValidator()
-                .verify(EDC_ASSET_ENTRY_DTO_ASSET, MandatoryObject::new)
-                .verifyObject(EDC_ASSET_ENTRY_DTO_ASSET, v -> v
-                        .verifyId(OptionalIdNotBlank::new)
-                        .verify(EDC_ASSET_PROPERTIES, MandatoryObject::new)
-                        .verify(path -> new AssetPropertiesUniqueness())
-                )
-                .verify(EDC_ASSET_ENTRY_DTO_DATA_ADDRESS, MandatoryObject::new)
-                .verifyObject(EDC_ASSET_ENTRY_DTO_DATA_ADDRESS, DataAddressDtoValidator::instance)
-                .build();
-    }
-
-    public static Validator<JsonObject> assetValidator() {
+    public static Validator<JsonObject> instance() {
         return JsonObjectValidator.newValidator()
                 .verifyId(OptionalIdNotBlank::new)
                 .verify(EDC_ASSET_PROPERTIES, MandatoryObject::new)
+                .verify(EDC_ASSET_DATA_ADDRESS, MandatoryObject::new)
                 .verify(path -> new AssetPropertiesUniqueness())
+                .verifyObject(EDC_ASSET_DATA_ADDRESS, DataAddressDtoValidator::instance)
                 .build();
     }
 
@@ -67,7 +52,7 @@ public class AssetEntryDtoValidator {
             var privateProperties = input.getJsonArray(EDC_ASSET_PRIVATE_PROPERTIES).getJsonObject(0);
 
             if (properties.keySet().stream().anyMatch(privateProperties::containsKey)) {
-                return ValidationResult.failure(violation("cannot exists duplicated keys between 'properties' and 'privateProperties'", EDC_ASSET_ENTRY_DTO_ASSET + "/" + EDC_ASSET_PROPERTIES));
+                return ValidationResult.failure(violation("cannot exists duplicated keys between 'properties' and 'privateProperties'", EDC_ASSET_PROPERTIES));
             }
             return ValidationResult.success();
         }

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/AssetApiExtensionTest.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/AssetApiExtensionTest.java
@@ -14,9 +14,11 @@
 
 package org.eclipse.edc.connector.api.management.asset;
 
+import org.eclipse.edc.connector.api.management.asset.v3.AssetApiController;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.web.spi.WebService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,6 +28,7 @@ import static org.eclipse.edc.spi.types.domain.DataAddress.EDC_DATA_ADDRESS_TYPE
 import static org.eclipse.edc.spi.types.domain.asset.Asset.EDC_ASSET_TYPE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -33,10 +36,20 @@ import static org.mockito.Mockito.verify;
 class AssetApiExtensionTest {
 
     private final JsonObjectValidatorRegistry validatorRegistry = mock();
+    private final WebService webService = mock();
 
     @BeforeEach
     void setUp(ServiceExtensionContext context) {
         context.registerService(JsonObjectValidatorRegistry.class, validatorRegistry);
+        context.registerService(WebService.class, webService);
+    }
+
+    @Test
+    void initialize_shouldRegisterControllers(AssetApiExtension extension, ServiceExtensionContext context) {
+        extension.initialize(context);
+
+        verify(webService).registerResource(any(), isA(org.eclipse.edc.connector.api.management.asset.v2.AssetApiController.class));
+        verify(webService).registerResource(any(), isA(AssetApiController.class));
     }
 
     @Test

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/v2/AssetApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/v2/AssetApiControllerTest.java
@@ -1,0 +1,581 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.asset.v2;
+
+import io.restassured.specification.RequestSpecification;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import org.eclipse.edc.api.model.DataAddressDto;
+import org.eclipse.edc.api.model.IdResponseDto;
+import org.eclipse.edc.api.model.QuerySpecDto;
+import org.eclipse.edc.connector.api.management.asset.model.AssetEntryNewDto;
+import org.eclipse.edc.connector.spi.asset.AssetService;
+import org.eclipse.edc.junit.annotations.ApiTest;
+import org.eclipse.edc.service.spi.result.ServiceResult;
+import org.eclipse.edc.spi.asset.DataAddressResolver;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.asset.Asset;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.validator.spi.ValidationResult;
+import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static jakarta.json.Json.createObjectBuilder;
+import static org.eclipse.edc.api.model.IdResponseDto.EDC_ID_RESPONSE_DTO_CREATED_AT;
+import static org.eclipse.edc.api.model.IdResponseDto.EDC_ID_RESPONSE_DTO_TYPE;
+import static org.eclipse.edc.connector.api.management.asset.model.AssetEntryNewDto.EDC_ASSET_ENTRY_DTO_TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
+import static org.eclipse.edc.spi.CoreConstants.EDC_PREFIX;
+import static org.eclipse.edc.spi.types.domain.DataAddress.EDC_DATA_ADDRESS_TYPE;
+import static org.eclipse.edc.spi.types.domain.asset.Asset.EDC_ASSET_TYPE;
+import static org.eclipse.edc.validator.spi.Violation.violation;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ApiTest
+@Deprecated
+class AssetApiControllerTest extends RestControllerTestBase {
+
+    private static final String TEST_ASSET_ID = "test-asset-id";
+    private static final String TEST_ASSET_CONTENTTYPE = "application/json";
+    private static final String TEST_ASSET_DESCRIPTION = "test description";
+    private static final String TEST_ASSET_VERSION = "0.4.2";
+    private static final String TEST_ASSET_NAME = "test-asset";
+    private final AssetService service = mock(AssetService.class);
+    private final DataAddressResolver dataAddressResolver = mock(DataAddressResolver.class);
+    private final TypeTransformerRegistry transformerRegistry = mock(TypeTransformerRegistry.class);
+    private final JsonObjectValidatorRegistry validator = mock(JsonObjectValidatorRegistry.class);
+
+    @BeforeEach
+    void setup() {
+        when(transformerRegistry.transform(isA(JsonObject.class), eq(DataAddress.class))).thenReturn(Result.success(DataAddress.Builder.newInstance().type("test-type").build()));
+        when(transformerRegistry.transform(isA(IdResponseDto.class), eq(JsonObject.class))).thenAnswer(a -> {
+            var dto = (IdResponseDto) a.getArgument(0);
+            return Result.success(createObjectBuilder()
+                    .add(TYPE, EDC_ID_RESPONSE_DTO_TYPE)
+                    .add(ID, dto.getId())
+                    .add(EDC_ID_RESPONSE_DTO_CREATED_AT, dto.getCreatedAt())
+                    .build()
+            );
+        });
+    }
+
+    @Test
+    void requestAsset() {
+        when(service.query(any()))
+                .thenReturn(ServiceResult.success(Stream.of(Asset.Builder.newInstance().build())));
+        when(transformerRegistry.transform(isA(Asset.class), eq(JsonObject.class)))
+                .thenReturn(Result.success(createAssetJson().build()));
+        when(transformerRegistry.transform(isA(JsonObject.class), eq(QuerySpecDto.class)))
+                .thenReturn(Result.success(QuerySpecDto.Builder.newInstance().offset(10).build()));
+        when(transformerRegistry.transform(isA(QuerySpecDto.class), eq(QuerySpec.class)))
+                .thenReturn(Result.success(QuerySpec.Builder.newInstance().offset(10).build()));
+        when(validator.validate(any(), any())).thenReturn(ValidationResult.success());
+
+        baseRequest()
+                .contentType(JSON)
+                .body("{}")
+                .post("/assets/request")
+                .then()
+                .log().ifError()
+                .statusCode(200)
+                .contentType(JSON)
+                .body("size()", is(1));
+        verify(service).query(argThat(s -> s.getOffset() == 10));
+        verify(transformerRegistry).transform(isA(Asset.class), eq(JsonObject.class));
+        verify(transformerRegistry).transform(isA(QuerySpecDto.class), eq(QuerySpec.class));
+    }
+
+    @Test
+    void requestAsset_filtersOutFailedTransforms() {
+        when(service.query(any()))
+                .thenReturn(ServiceResult.success(Stream.of(Asset.Builder.newInstance().build())));
+        when(transformerRegistry.transform(isA(QuerySpecDto.class), eq(QuerySpec.class)))
+                .thenReturn(Result.success(QuerySpec.Builder.newInstance().offset(10).build()));
+        when(transformerRegistry.transform(isA(Asset.class), eq(JsonObject.class)))
+                .thenReturn(Result.failure("failed to transform"));
+        when(validator.validate(any(), any())).thenReturn(ValidationResult.success());
+
+        baseRequest()
+                .contentType(JSON)
+                .post("/assets/request")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .body("size()", is(0));
+    }
+
+    @Test
+    void requestAsset_shouldReturnBadRequest_whenQueryIsInvalid() {
+        when(transformerRegistry.transform(any(JsonObject.class), eq(QuerySpecDto.class))).thenReturn(Result.success(QuerySpecDto.Builder.newInstance().build()));
+        when(transformerRegistry.transform(any(QuerySpecDto.class), eq(QuerySpec.class))).thenReturn(Result.success(QuerySpec.Builder.newInstance().build()));
+        when(service.query(any())).thenReturn(ServiceResult.badRequest("test-message"));
+        when(validator.validate(any(), any())).thenReturn(ValidationResult.success());
+
+        baseRequest()
+                .body(Map.of("offset", -1))
+                .contentType(JSON)
+                .post("/assets/request")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    void requestAsset_shouldReturnBadRequest_whenQueryTransformFails() {
+        when(transformerRegistry.transform(isA(JsonObject.class), eq(QuerySpecDto.class)))
+                .thenReturn(Result.success(QuerySpecDto.Builder.newInstance().build()));
+        when(transformerRegistry.transform(isA(QuerySpecDto.class), eq(QuerySpec.class)))
+                .thenReturn(Result.failure("error"));
+        when(service.query(any())).thenReturn(ServiceResult.success());
+        when(validator.validate(any(), any())).thenReturn(ValidationResult.success());
+
+        baseRequest()
+                .contentType(JSON)
+                .body("{}")
+                .post("/assets/request")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    void requestAsset_shouldReturnBadRequest_whenServiceReturnsBadRequest() {
+        when(transformerRegistry.transform(isA(QuerySpecDto.class), eq(QuerySpec.class)))
+                .thenReturn(Result.success(QuerySpec.Builder.newInstance().build()));
+        when(service.query(any())).thenReturn(ServiceResult.badRequest());
+        when(validator.validate(any(), any())).thenReturn(ValidationResult.success());
+
+        baseRequest()
+                .contentType(JSON)
+                .post("/assets/request")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    void requestAsset_shouldReturnBadRequest_whenValidationFails() {
+        when(transformerRegistry.transform(isA(QuerySpecDto.class), eq(QuerySpec.class)))
+                .thenReturn(Result.success(QuerySpec.Builder.newInstance().build()));
+        when(validator.validate(any(), any())).thenReturn(ValidationResult.failure(violation("validation failure", "a path")));
+
+        baseRequest()
+                .contentType(JSON)
+                .body("{}")
+                .post("/assets/request")
+                .then()
+                .statusCode(400);
+        verify(validator).validate(eq(QuerySpecDto.EDC_QUERY_SPEC_TYPE), isA(JsonObject.class));
+        verifyNoInteractions(service);
+    }
+
+    @Test
+    void getSingleAsset() {
+        var asset = Asset.Builder.newInstance().property("key", "value").build();
+        when(service.findById("id")).thenReturn(asset);
+        var jobj = createAssetJson().build();
+        when(transformerRegistry.transform(isA(Asset.class), eq(JsonObject.class))).thenReturn(Result.success(jobj));
+
+        baseRequest()
+                .get("/assets/id")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .body(ID, equalTo(TEST_ASSET_ID));
+
+        verify(transformerRegistry).transform(isA(Asset.class), eq(JsonObject.class));
+        verifyNoMoreInteractions(transformerRegistry);
+    }
+
+    @Test
+    void getSingleAsset_notFound() {
+        when(service.findById(any())).thenReturn(null);
+
+        baseRequest()
+                .get("/assets/not-existent-id")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    void getAssetById_shouldReturnNotFound_whenTransformFails() {
+        when(service.findById("id")).thenReturn(Asset.Builder.newInstance().build());
+        when(transformerRegistry.transform(isA(Asset.class), eq(JsonObject.class))).thenReturn(Result.failure("failure"));
+
+        baseRequest()
+                .get("/assets/id")
+                .then()
+                .statusCode(500);
+    }
+
+    @Test
+    void createAsset() {
+        var assetEntry = createAssetEntryDto();
+        var asset = createAssetBuilder().build();
+        var dataAddress = DataAddress.Builder.newInstance().type("any").build();
+        var assetEntryDto = AssetEntryNewDto.Builder.newInstance().asset(asset).dataAddress(dataAddress).build();
+        when(transformerRegistry.transform(any(JsonObject.class), eq(AssetEntryNewDto.class))).thenReturn(Result.success(assetEntryDto));
+        when(service.create(any(), any())).thenReturn(ServiceResult.success(asset));
+        when(validator.validate(any(), any())).thenReturn(ValidationResult.success());
+
+        baseRequest()
+                .contentType(JSON)
+                .body(assetEntry)
+                .post("/assets")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .body(ID, is(TEST_ASSET_ID))
+                .body("'" + EDC_NAMESPACE + "createdAt'", greaterThan(0L));
+
+        verify(transformerRegistry).transform(any(), eq(AssetEntryNewDto.class));
+        verify(transformerRegistry).transform(isA(IdResponseDto.class), eq(JsonObject.class));
+        verify(service).create(isA(Asset.class), isA(DataAddress.class));
+        verifyNoMoreInteractions(service, transformerRegistry);
+    }
+
+    @Test
+    void createAsset_shouldReturnBadRequest_whenValidationFails() {
+        var assetEntry = createAssetEntryDto();
+        when(validator.validate(any(), any())).thenReturn(ValidationResult.failure(violation("a failure", "a path")));
+
+        baseRequest()
+                .contentType(JSON)
+                .body(assetEntry)
+                .post("/assets")
+                .then()
+                .statusCode(400);
+
+        verify(validator).validate(eq(EDC_ASSET_ENTRY_DTO_TYPE), isA(JsonObject.class));
+        verifyNoInteractions(service, transformerRegistry);
+    }
+
+    @Test
+    void createAsset_shouldReturnBadRequest_whenTransformFails() {
+        when(transformerRegistry.transform(isA(JsonObject.class), eq(AssetEntryNewDto.class))).thenReturn(Result.failure("failed"));
+        when(validator.validate(any(), any())).thenReturn(ValidationResult.success());
+
+        baseRequest()
+                .body(createAssetEntryDto())
+                .contentType(JSON)
+                .post("/assets")
+                .then()
+                .statusCode(400);
+        verify(service, never()).create(any(), any());
+    }
+
+    @Test
+    void createAsset_alreadyExists() {
+        var asset = createAssetBuilder().build();
+        var dataAddress = DataAddress.Builder.newInstance().type("any").build();
+        var assetNewDto = AssetEntryNewDto.Builder.newInstance().asset(asset).dataAddress(dataAddress).build();
+        when(transformerRegistry.transform(any(JsonObject.class), eq(AssetEntryNewDto.class))).thenReturn(Result.success(assetNewDto));
+        when(service.create(any(), any())).thenReturn(ServiceResult.conflict("already exists"));
+        when(validator.validate(any(), any())).thenReturn(ValidationResult.success());
+
+        baseRequest()
+                .body(createAssetEntryDto())
+                .contentType(JSON)
+                .post("/assets")
+                .then()
+                .statusCode(409);
+    }
+
+    @Test
+    void createAsset_emptyAttributes() {
+        when(transformerRegistry.transform(isA(JsonObject.class), eq(AssetEntryNewDto.class))).thenReturn(Result.failure("Cannot be transformed"));
+        var assetEntryDto = createAssetEntryDto(createObjectBuilder().build(), createDataAddressJson());
+        when(validator.validate(any(), any())).thenReturn(ValidationResult.success());
+
+        baseRequest()
+                .body(assetEntryDto)
+                .contentType(JSON)
+                .post("/assets")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    void deleteAsset() {
+        when(service.delete("assetId"))
+                .thenReturn(ServiceResult.success(createAssetBuilder().build()));
+
+        baseRequest()
+                .contentType(JSON)
+                .delete("/assets/assetId")
+                .then()
+                .statusCode(204);
+        verify(service).delete("assetId");
+    }
+
+    @Test
+    void deleteAsset_notExists() {
+        when(service.delete(any())).thenReturn(ServiceResult.notFound("not found"));
+
+        baseRequest()
+                .contentType(JSON)
+                .delete("/assets/not-existent-id")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    void deleteAsset_conflicts() {
+        when(service.delete(any())).thenReturn(ServiceResult.conflict("conflict"));
+
+        baseRequest()
+                .contentType(JSON)
+                .delete("/assets/id")
+                .then()
+                .statusCode(409);
+    }
+
+    @Test
+    void getAssetAddress() {
+        when(dataAddressResolver.resolveForAsset("id"))
+                .thenReturn(DataAddress.Builder.newInstance().type("any").build());
+        when(transformerRegistry.transform(isA(DataAddress.class), eq(JsonObject.class)))
+                .thenReturn(Result.success(createObjectBuilder().build()));
+
+        baseRequest()
+                .get("/assets/id/dataaddress")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .body(notNullValue());
+        verify(transformerRegistry).transform(isA(DataAddress.class), eq(JsonObject.class));
+        verifyNoMoreInteractions(service, transformerRegistry);
+    }
+
+    @Test
+    void getAssetAddress_notFound() {
+        when(dataAddressResolver.resolveForAsset(any())).thenReturn(null);
+
+        baseRequest()
+                .get("/assets/not-existent-id/address")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    void updateAsset_whenExists() {
+        var asset = Asset.Builder.newInstance().property("key1", "value1").build();
+        when(transformerRegistry.transform(isA(JsonObject.class), eq(Asset.class))).thenReturn(Result.success(asset));
+        when(service.update(any(Asset.class))).thenReturn(ServiceResult.success());
+        when(validator.validate(any(), any())).thenReturn(ValidationResult.success());
+
+        baseRequest()
+                .body(createAssetJson().build())
+                .contentType(JSON)
+                .put("/assets")
+                .then()
+                .statusCode(204);
+        verify(service).update(eq(asset));
+    }
+
+    @Test
+    void updateAsset_shouldReturnNotFound_whenItDoesNotExists() {
+        var asset = Asset.Builder.newInstance().property("key1", "value1").build();
+        when(transformerRegistry.transform(isA(JsonObject.class), eq(Asset.class))).thenReturn(Result.success(asset));
+        when(service.update(any(Asset.class))).thenReturn(ServiceResult.notFound("not found"));
+        when(validator.validate(any(), any())).thenReturn(ValidationResult.success());
+
+        baseRequest()
+                .body(createAssetJson().build())
+                .contentType(JSON)
+                .put("/assets")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    void updateAsset_shouldReturnBadRequest_whenTransformFails() {
+        when(transformerRegistry.transform(isA(JsonObject.class), eq(Asset.class))).thenReturn(Result.failure("error"));
+        when(validator.validate(any(), any())).thenReturn(ValidationResult.success());
+
+        baseRequest()
+                .body(createAssetJson().build())
+                .contentType(JSON)
+                .put("/assets")
+                .then()
+                .statusCode(400);
+        verifyNoInteractions(service);
+    }
+
+    @Test
+    @Disabled
+    void updateAsset_shouldReturnBadRequest_whenValidationFails() {
+        when(transformerRegistry.transform(isA(JsonObject.class), eq(Asset.class))).thenReturn(Result.failure("error"));
+        when(validator.validate(any(), any())).thenReturn(ValidationResult.failure(violation("validation failure", "path")));
+
+        baseRequest()
+                .body(createAssetJson().build())
+                .contentType(JSON)
+                .put("/assets")
+                .then()
+                .statusCode(400);
+        verify(validator).validate(eq(EDC_ASSET_TYPE), isA(JsonObject.class));
+        verifyNoInteractions(service, transformerRegistry);
+    }
+
+    @Test
+    void updateDataAddress_whenAssetExists() {
+        var dataAddress = DataAddress.Builder.newInstance().type("test-type").property("key1", "value1").build();
+        when(transformerRegistry.transform(isA(JsonObject.class), eq(DataAddress.class)))
+                .thenReturn(Result.success(dataAddress));
+        when(service.update(any(), any(DataAddress.class))).thenReturn(ServiceResult.success());
+        when(validator.validate(any(), any())).thenReturn(ValidationResult.success());
+
+        baseRequest()
+                .body(createDataAddressJson())
+                .contentType(JSON)
+                .put("/assets/assetId/dataaddress")
+                .then()
+                .statusCode(204);
+        verify(service).update(eq("assetId"), eq(dataAddress));
+    }
+
+    @Test
+    void updateDataAddress_shouldReturnNotFound_whenItDoesNotExists() {
+        var dataAddressDto = createDataAddressJson();
+        var dataAddress = DataAddress.Builder.newInstance().type("test-type").property("key1", "value1").build();
+        when(transformerRegistry.transform(isA(DataAddressDto.class), eq(DataAddress.class))).thenReturn(Result.success(dataAddress));
+        when(service.update(any(), any(DataAddress.class))).thenReturn(ServiceResult.notFound("not found"));
+        when(validator.validate(any(), any())).thenReturn(ValidationResult.success());
+
+        baseRequest()
+                .body(dataAddressDto)
+                .contentType(JSON)
+                .put("/assets/assetId/dataaddress")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    void updateDataAddress_shouldReturnBadRequest_whenTransformationFails() {
+        when(transformerRegistry.transform(isA(JsonObject.class), eq(DataAddress.class)))
+                .thenReturn(Result.failure("error"));
+        when(validator.validate(any(), any())).thenReturn(ValidationResult.success());
+
+        baseRequest()
+                .body(createDataAddressJson())
+                .contentType(JSON)
+                .put("/assets/assetId/dataaddress")
+                .then()
+                .statusCode(400);
+        verifyNoInteractions(service);
+    }
+
+    @Test
+    void updateDataAddress_shouldReturnBadRequest_whenValidationFails() {
+        when(transformerRegistry.transform(isA(JsonObject.class), eq(DataAddress.class)))
+                .thenReturn(Result.failure("error"));
+        when(validator.validate(any(), any())).thenReturn(ValidationResult.failure(violation("validation error", "path")));
+
+        baseRequest()
+                .body(createDataAddressJson())
+                .contentType(JSON)
+                .put("/assets/assetId/dataaddress")
+                .then()
+                .statusCode(400);
+        verify(validator).validate(eq(EDC_DATA_ADDRESS_TYPE), isA(JsonObject.class));
+        verifyNoInteractions(service);
+    }
+
+    @Override
+    protected Object controller() {
+        return new AssetApiController(service, dataAddressResolver, transformerRegistry, monitor, validator);
+    }
+
+    private JsonObject createDataAddressJson() {
+        return createObjectBuilder()
+                .add(CONTEXT, createObjectBuilder().add(EDC_PREFIX, EDC_NAMESPACE))
+                .add(TYPE, "DataAddress")
+                .add("type", "test-type")
+                .build();
+    }
+
+    private JsonObject createAssetEntryDto() {
+        return createAssetEntryDto(createAssetJson().build(), createDataAddressJson());
+    }
+
+    private JsonObject createAssetEntryDto(JsonObject asset, JsonObject dataAddress) {
+        return createObjectBuilder()
+                .add("asset", asset)
+                .add("dataAddress", dataAddress)
+                .build();
+    }
+
+    private JsonObjectBuilder createAssetJson() {
+        return createObjectBuilder()
+                .add(CONTEXT, createContextBuilder().build())
+                .add(TYPE, EDC_ASSET_TYPE)
+                .add(ID, TEST_ASSET_ID)
+                .add("properties", createPropertiesBuilder().build());
+    }
+
+    private JsonObjectBuilder createPropertiesBuilder() {
+        return createObjectBuilder()
+                .add("name", TEST_ASSET_NAME)
+                .add("description", TEST_ASSET_DESCRIPTION)
+                .add("edc:version", TEST_ASSET_VERSION)
+                .add("contenttype", TEST_ASSET_CONTENTTYPE);
+    }
+
+    private JsonObjectBuilder createContextBuilder() {
+        return createObjectBuilder()
+                .add(VOCAB, EDC_NAMESPACE)
+                .add(EDC_PREFIX, EDC_NAMESPACE);
+    }
+
+    private RequestSpecification baseRequest() {
+        return given()
+                .baseUri("http://localhost:" + port + "/v2")
+                .when();
+    }
+
+    private Asset.Builder createAssetBuilder() {
+        return Asset.Builder.newInstance()
+                .name(TEST_ASSET_NAME)
+                .id(TEST_ASSET_ID)
+                .contentType(TEST_ASSET_CONTENTTYPE)
+                .description(TEST_ASSET_DESCRIPTION)
+                .version(TEST_ASSET_VERSION);
+    }
+}

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/validation/AssetValidatorTest.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/validation/AssetValidatorTest.java
@@ -1,0 +1,123 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.asset.validation;
+
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.validator.spi.Validator;
+import org.junit.jupiter.api.Test;
+
+import static jakarta.json.Json.createArrayBuilder;
+import static jakarta.json.Json.createObjectBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.spi.types.domain.DataAddress.EDC_DATA_ADDRESS_TYPE_PROPERTY;
+import static org.eclipse.edc.spi.types.domain.asset.Asset.EDC_ASSET_DATA_ADDRESS;
+import static org.eclipse.edc.spi.types.domain.asset.Asset.EDC_ASSET_PRIVATE_PROPERTIES;
+import static org.eclipse.edc.spi.types.domain.asset.Asset.EDC_ASSET_PROPERTIES;
+
+class AssetValidatorTest {
+
+    private final Validator<JsonObject> validator = AssetValidator.instance();
+
+    @Test
+    void shouldSucceed_whenValidInput() {
+        var input = createObjectBuilder()
+                .add(EDC_ASSET_PROPERTIES, createArrayBuilder().add(createObjectBuilder()))
+                .add(EDC_ASSET_DATA_ADDRESS, validDataAddress())
+                .build();
+
+        var result = validator.validate(input);
+
+        assertThat(result).isSucceeded();
+    }
+
+    @Test
+    void shouldFail_whenIdIsBlank() {
+        var input = createObjectBuilder()
+                .add(ID, " ")
+                .add(EDC_ASSET_PROPERTIES, createArrayBuilder().add(createObjectBuilder()))
+                .add(EDC_ASSET_DATA_ADDRESS, validDataAddress())
+                .build();
+
+        var result = validator.validate(input);
+
+        assertThat(result).isFailed().satisfies(failure -> {
+            assertThat(failure.getViolations()).hasSize(1).anySatisfy(v -> {
+                assertThat(v.path()).isEqualTo(ID);
+            });
+        });
+    }
+
+    @Test
+    void shouldFail_whenPropertiesAreMissing() {
+        var input = createObjectBuilder()
+                .add(EDC_ASSET_DATA_ADDRESS, validDataAddress())
+                .build();
+
+        var result = validator.validate(input);
+
+        assertThat(result).isFailed().satisfies(failure -> {
+            assertThat(failure.getViolations()).hasSize(1).anySatisfy(v ->
+                    assertThat(v.path()).isEqualTo(EDC_ASSET_PROPERTIES));
+        });
+    }
+
+    @Test
+    void shouldFail_whenPropertiesAndPrivatePropertiesHaveDuplicatedKeys() {
+        var input = createObjectBuilder()
+                .add(EDC_ASSET_PROPERTIES, createArrayBuilder().add(createObjectBuilder().add("key", createArrayBuilder())))
+                .add(EDC_ASSET_PRIVATE_PROPERTIES, createArrayBuilder().add(createObjectBuilder().add("key", createArrayBuilder())))
+                .add(EDC_ASSET_DATA_ADDRESS, validDataAddress())
+                .build();
+
+        var result = validator.validate(input);
+
+        assertThat(result).isFailed().satisfies(failure -> {
+            assertThat(failure.getViolations()).hasSize(1).anySatisfy(v ->
+                    assertThat(v.path()).isEqualTo(EDC_ASSET_PROPERTIES));
+        });
+    }
+
+    @Test
+    void shouldFail_whenDataAddressHasNoType() {
+        var input = createObjectBuilder()
+                .add(EDC_ASSET_PROPERTIES, createArrayBuilder().add(createObjectBuilder()))
+                .add(EDC_ASSET_DATA_ADDRESS, createArrayBuilder().add(createObjectBuilder()))
+                .build();
+
+        var result = validator.validate(input);
+
+        assertThat(result).isFailed().satisfies(failure -> {
+            assertThat(failure.getViolations()).hasSize(1).anySatisfy(v ->
+                    assertThat(v.path()).isEqualTo(EDC_ASSET_DATA_ADDRESS + "/" + EDC_DATA_ADDRESS_TYPE_PROPERTY));
+        });
+    }
+
+    private JsonArrayBuilder validDataAddress() {
+        return createArrayBuilder().add(createObjectBuilder()
+                .add(EDC_DATA_ADDRESS_TYPE_PROPERTY, createArrayBuilder().add(createObjectBuilder().add(VALUE, "AddressType")))
+        );
+    }
+
+    private JsonArrayBuilder validAsset() {
+        return createArrayBuilder()
+                .add(createObjectBuilder()
+                        .add(EDC_ASSET_PROPERTIES, createArrayBuilder().add(createObjectBuilder()))
+                );
+    }
+}

--- a/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
+++ b/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
@@ -43,7 +43,6 @@ import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
-import org.eclipse.edc.spi.types.domain.asset.AssetEntry;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -156,10 +155,11 @@ public class HttpProvisionerExtensionEndToEndTest {
     }
 
     @NotNull
-    private AssetEntry createAssetEntry() {
-        var asset = Asset.Builder.newInstance().id(ASSET_ID).build();
-        var dataAddress = DataAddress.Builder.newInstance().type(TEST_DATA_TYPE).build();
-        return new AssetEntry(asset, dataAddress);
+    private Asset createAssetEntry() {
+        return Asset.Builder.newInstance()
+                .id(ASSET_ID)
+                .dataAddress(DataAddress.Builder.newInstance().type(TEST_DATA_TYPE).build())
+                .build();
     }
 
     private TransferRequestMessage createTransferRequestMessage() {

--- a/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/assetindex/schema/BaseSqlDialectStatements.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/assetindex/schema/BaseSqlDialectStatements.java
@@ -123,8 +123,8 @@ public class BaseSqlDialectStatements implements AssetStatements {
     @Override
     public SqlQueryStatement createQuery(QuerySpec querySpec) {
         var criteria = querySpec.getFilterExpression();
-        var conditions = criteria.stream().map(SqlConditionExpression::new).collect(Collectors.toList());
-        var results = conditions.stream().map(SqlConditionExpression::isValidExpression).collect(Collectors.toList());
+        var conditions = criteria.stream().map(SqlConditionExpression::new).toList();
+        var results = conditions.stream().map(SqlConditionExpression::isValidExpression).toList();
 
         if (results.stream().anyMatch(Result::failed)) {
             var message = results.stream().flatMap(r -> r.getFailureMessages().stream()).collect(Collectors.joining(", "));

--- a/extensions/control-plane/store/sql/asset-index-sql/src/test/java/org/eclipse/edc/connector/store/sql/assetindex/PostgresAssetIndexTest.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/test/java/org/eclipse/edc/connector/store/sql/assetindex/PostgresAssetIndexTest.java
@@ -20,31 +20,17 @@ import org.eclipse.edc.connector.store.sql.assetindex.schema.BaseSqlDialectState
 import org.eclipse.edc.connector.store.sql.assetindex.schema.postgres.PostgresDialectStatements;
 import org.eclipse.edc.junit.annotations.PostgresqlDbIntegrationTest;
 import org.eclipse.edc.policy.model.PolicyRegistrationTypes;
-import org.eclipse.edc.spi.query.QuerySpec;
-import org.eclipse.edc.spi.result.StoreResult;
 import org.eclipse.edc.spi.testfixtures.asset.AssetIndexTestBase;
-import org.eclipse.edc.spi.testfixtures.asset.TestObject;
 import org.eclipse.edc.spi.types.TypeManager;
-import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.eclipse.edc.sql.QueryExecutor;
 import org.eclipse.edc.sql.testfixtures.PostgresqlStoreSetupExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.eclipse.edc.spi.query.Criterion.criterion;
-import static org.eclipse.edc.spi.result.StoreFailure.Reason.DUPLICATE_KEYS;
 
 @PostgresqlDbIntegrationTest
 @ExtendWith(PostgresqlStoreSetupExtension.class)
@@ -73,118 +59,9 @@ class PostgresAssetIndexTest extends AssetIndexTestBase {
         setupExtension.runQuery("DROP TABLE " + sqlStatements.getAssetPropertyTable() + " CASCADE");
     }
 
-
-    @Test
-    @DisplayName("Verify an asset query based on an Asset property")
-    void query_byAssetProperty() {
-        List<Asset> allAssets = createAssets(5);
-        var query = QuerySpec.Builder.newInstance().filter(criterion("test-key", "=", "test-value1")).build();
-
-        assertThat(sqlAssetIndex.queryAssets(query)).usingRecursiveFieldByFieldElementComparator().containsOnly(allAssets.get(1));
-
-    }
-
-    @Test
-    @DisplayName("Verify an asset query based on an Asset property")
-    void query_byAssetPrivateProperty() {
-        List<Asset> allAssets = createPrivateAssets(5);
-        var query = QuerySpec.Builder.newInstance().filter(criterion("test-pKey", "=", "test-pValue1")).build();
-
-        assertThat(sqlAssetIndex.queryAssets(query)).usingRecursiveFieldByFieldElementComparator().containsOnly(allAssets.get(1));
-
-    }
-
-    @Test
-    @DisplayName("Verify an asset query based on an Asset property, when the left operand does not exist")
-    void query_byAssetProperty_leftOperandNotExist() {
-        createAssets(5);
-        var query = QuerySpec.Builder.newInstance().filter(criterion("notexist-key", "=", "test-value1")).build();
-
-        assertThat(sqlAssetIndex.queryAssets(query)).isEmpty();
-    }
-
-    @Test
-    @DisplayName("Verify that the correct Postgres JSON operator is used")
-    void verifyCorrectJsonOperator() {
-        assertThat(sqlStatements.getFormatAsJsonOperator()).isEqualTo("::json");
-    }
-
-    @Test
-    @DisplayName("Verify an asset query based on an Asset property, where the property value is actually a complex object")
-    void query_assetPropertyAsObject() {
-        var asset = TestFunctions.createAsset("id1");
-        asset.getProperties().put("testobj", new TestObject("test123", 42, false));
-        sqlAssetIndex.create(asset, TestFunctions.createDataAddress("test-type"));
-
-        var assetsFound = sqlAssetIndex.queryAssets(QuerySpec.Builder.newInstance()
-                .filter(criterion("testobj", "like", "%test1%"))
-                .build());
-
-        assertThat(assetsFound).usingRecursiveFieldByFieldElementComparator().containsExactly(asset);
-        assertThat(asset.getProperty("testobj")).isInstanceOf(TestObject.class);
-    }
-
-    @Test
-    @DisplayName("Verify an asset query based on an Asset property, where the right operand does not exist")
-    void query_byAssetProperty_rightOperandNotExist() {
-        createAssets(5);
-        var query = QuerySpec.Builder.newInstance().filter(criterion("test-key", "=", "notexist")).build();
-
-        assertThat(sqlAssetIndex.queryAssets(query)).isEmpty();
-    }
-
-    @Test
-    @DisplayName("Verify an asset query where the operator is invalid (=not supported)")
-    void queryAgreements_withQuerySpec_invalidOperator() {
-        var asset = TestFunctions.createAssetBuilder("id1").property("testproperty", "testvalue").build();
-        sqlAssetIndex.create(asset, TestFunctions.createDataAddress("test-type"));
-
-        var query = QuerySpec.Builder.newInstance().filter(criterion("testproperty", "<>", "foobar")).build();
-        assertThatThrownBy(() -> sqlAssetIndex.queryAssets(query)).isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    @DisplayName("Verify that creating an asset that contains duplicate keys in properties and private properties fails")
-    void createAsset_withDuplicatePropertyKeys() {
-        var asset = TestFunctions.createAssetBuilder("id1")
-                .property("testproperty", "testvalue")
-                .privateProperty("testproperty", "testvalue")
-                .build();
-
-        var result = sqlAssetIndex.create(asset, TestFunctions.createDataAddress("test-type"));
-        assertThat(result).isNotNull().extracting(StoreResult::reason).isEqualTo(DUPLICATE_KEYS);
-    }
-
     @Override
     protected SqlAssetIndex getAssetIndex() {
         return sqlAssetIndex;
-    }
-
-    /**
-     * creates a configurable amount of assets with one property ("test-key" = "test-valueN") and a data address of type
-     * "test-type"
-     */
-    private List<Asset> createAssets(int amount) {
-        return IntStream.range(0, amount).mapToObj(i -> {
-            var asset = TestFunctions.createAssetBuilder("test-asset" + i)
-                    .property("test-key", "test-value" + i)
-                    .build();
-            var dataAddress = TestFunctions.createDataAddress("test-type");
-            sqlAssetIndex.create(asset, dataAddress);
-            return asset;
-        }).collect(Collectors.toList());
-    }
-
-    private List<Asset> createPrivateAssets(int amount) {
-        return IntStream.range(0, amount).mapToObj(i -> {
-            var asset = TestFunctions.createAssetBuilder("test-asset" + i)
-                    .property("test-key", "test-value" + i)
-                    .privateProperty("test-pKey", "test-pValue" + i)
-                    .build();
-            var dataAddress = TestFunctions.createDataAddress("test-type");
-            sqlAssetIndex.create(asset, dataAddress);
-            return asset;
-        }).collect(Collectors.toList());
     }
 
 }

--- a/resources/openapi/openapi.yaml
+++ b/resources/openapi/openapi.yaml
@@ -330,6 +330,7 @@ paths:
                   $ref: '#/components/schemas/ApiErrorDetail'
         "404":
           description: "Asset could not be updated, because it does not exist."
+      deprecated: true
     post:
       tags:
       - Asset
@@ -367,6 +368,7 @@ paths:
                 example: null
                 items:
                   $ref: '#/components/schemas/ApiErrorDetail'
+      deprecated: true
   /v2/assets/request:
     post:
       tags:
@@ -397,6 +399,7 @@ paths:
                 example: null
                 items:
                   $ref: '#/components/schemas/ApiErrorDetail'
+      deprecated: true
   /v2/assets/{assetId}/dataaddress:
     put:
       tags:
@@ -438,6 +441,7 @@ paths:
                 example: null
                 items:
                   $ref: '#/components/schemas/ApiErrorDetail'
+      deprecated: true
   /v2/assets/{id}:
     get:
       tags:
@@ -478,6 +482,7 @@ paths:
                 example: null
                 items:
                   $ref: '#/components/schemas/ApiErrorDetail'
+      deprecated: true
     delete:
       tags:
       - Asset
@@ -527,6 +532,7 @@ paths:
                 example: null
                 items:
                   $ref: '#/components/schemas/ApiErrorDetail'
+      deprecated: true
   /v2/assets/{id}/dataaddress:
     get:
       tags:
@@ -567,6 +573,7 @@ paths:
                 example: null
                 items:
                   $ref: '#/components/schemas/ApiErrorDetail'
+      deprecated: true
   /v2/catalog/request:
     post:
       tags:
@@ -1549,6 +1556,190 @@ paths:
                 example: null
                 items:
                   $ref: '#/components/schemas/ApiErrorDetail'
+  /v3/assets:
+    put:
+      tags:
+      - Asset
+      description: "Updates an asset with the given ID if it exists. If the asset\
+        \ is not found, no further action is taken. DANGER ZONE: Note that updating\
+        \ assets can have unexpected results, especially for contract offers that\
+        \ have been sent out or are ongoing in contract negotiations."
+      operationId: updateAsset_1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssetUpdateRequestDto'
+      responses:
+        "200":
+          description: Asset was updated successfully
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "404":
+          description: "Asset could not be updated, because it does not exist."
+    post:
+      tags:
+      - Asset
+      description: Creates a new asset together with a data address
+      operationId: createAsset_1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Asset'
+      responses:
+        "200":
+          description: Asset was created successfully. Returns the asset Id and created
+            timestamp
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdResponseDto'
+        "400":
+          description: Request body was malformed
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "409":
+          description: "Could not create asset, because an asset with that ID already\
+            \ exists"
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /v3/assets/request:
+    post:
+      tags:
+      - Asset
+      description: ' all assets according to a particular query'
+      operationId: requestAssets_1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QuerySpecDto'
+      responses:
+        "200":
+          description: The assets matching the query
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/AssetResponseDto'
+        "400":
+          description: Request body was malformed
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /v3/assets/{id}:
+    get:
+      tags:
+      - Asset
+      description: Gets an asset with the given ID
+      operationId: getAsset_1
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+          example: null
+      responses:
+        "200":
+          description: The asset
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Asset'
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "404":
+          description: An asset with the given ID does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+    delete:
+      tags:
+      - Asset
+      description: "Removes an asset with the given ID if possible. Deleting an asset\
+        \ is only possible if that asset is not yet referenced by a contract agreement,\
+        \ in which case an error is returned. DANGER ZONE: Note that deleting assets\
+        \ can have unexpected results, especially for contract offers that have been\
+        \ sent out or ongoing or contract negotiations."
+      operationId: removeAsset_1
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+          example: null
+      responses:
+        "200":
+          description: Asset was deleted successfully
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "404":
+          description: An asset with the given ID does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "409":
+          description: "The asset cannot be deleted, because it is referenced by a\
+            \ contract agreement"
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
   /{any}:
     get:
       tags:
@@ -1647,6 +1838,8 @@ components:
           type: integer
           format: int64
           example: null
+        dataAddress:
+          $ref: '#/components/schemas/DataAddress'
         id:
           type: string
           example: null

--- a/resources/openapi/yaml/management-api/asset-api.yaml
+++ b/resources/openapi/yaml/management-api/asset-api.yaml
@@ -9,6 +9,7 @@ info:
 paths:
   /v2/assets:
     post:
+      deprecated: true
       description: Creates a new asset together with a data address
       operationId: createAsset
       requestBody:
@@ -46,6 +47,7 @@ paths:
       tags:
       - Asset
     put:
+      deprecated: true
       description: "Updates an asset with the given ID if it exists. If the asset\
         \ is not found, no further action is taken. DANGER ZONE: Note that updating\
         \ assets can have unexpected results, especially for contract offers that\
@@ -74,6 +76,7 @@ paths:
       - Asset
   /v2/assets/request:
     post:
+      deprecated: true
       description: ' all assets according to a particular query'
       operationId: requestAssets
       requestBody:
@@ -104,6 +107,7 @@ paths:
       - Asset
   /v2/assets/{assetId}/dataaddress:
     put:
+      deprecated: true
       description: Updates a DataAddress for an asset with the given ID.
       operationId: updateDataAddress
       parameters:
@@ -143,6 +147,7 @@ paths:
       - Asset
   /v2/assets/{id}:
     delete:
+      deprecated: true
       description: "Removes an asset with the given ID if possible. Deleting an asset\
         \ is only possible if that asset is not yet referenced by a contract agreement,\
         \ in which case an error is returned. DANGER ZONE: Note that deleting assets\
@@ -190,6 +195,7 @@ paths:
       tags:
       - Asset
     get:
+      deprecated: true
       description: Gets an asset with the given ID
       operationId: getAsset
       parameters:
@@ -228,6 +234,7 @@ paths:
       - Asset
   /v2/assets/{id}/dataaddress:
     get:
+      deprecated: true
       description: Gets a data address of an asset with the given ID
       operationId: getAssetDataAddress
       parameters:
@@ -244,6 +251,186 @@ paths:
               schema:
                 $ref: '#/components/schemas/DataAddressDto'
           description: The data address
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: "Request was malformed, e.g. id was null"
+        "404":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: An asset with the given ID does not exist
+      tags:
+      - Asset
+  /v3/assets:
+    post:
+      description: Creates a new asset together with a data address
+      operationId: createAsset_1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Asset'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdResponseDto'
+          description: Asset was created successfully. Returns the asset Id and created
+            timestamp
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: Request body was malformed
+        "409":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: "Could not create asset, because an asset with that ID already\
+            \ exists"
+      tags:
+      - Asset
+    put:
+      description: "Updates an asset with the given ID if it exists. If the asset\
+        \ is not found, no further action is taken. DANGER ZONE: Note that updating\
+        \ assets can have unexpected results, especially for contract offers that\
+        \ have been sent out or are ongoing in contract negotiations."
+      operationId: updateAsset_1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssetUpdateRequestDto'
+      responses:
+        "200":
+          description: Asset was updated successfully
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: "Request was malformed, e.g. id was null"
+        "404":
+          description: "Asset could not be updated, because it does not exist."
+      tags:
+      - Asset
+  /v3/assets/request:
+    post:
+      description: ' all assets according to a particular query'
+      operationId: requestAssets_1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QuerySpecDto'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/AssetResponseDto'
+          description: The assets matching the query
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: Request body was malformed
+      tags:
+      - Asset
+  /v3/assets/{id}:
+    delete:
+      description: "Removes an asset with the given ID if possible. Deleting an asset\
+        \ is only possible if that asset is not yet referenced by a contract agreement,\
+        \ in which case an error is returned. DANGER ZONE: Note that deleting assets\
+        \ can have unexpected results, especially for contract offers that have been\
+        \ sent out or ongoing or contract negotiations."
+      operationId: removeAsset_1
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+          example: null
+      responses:
+        "200":
+          description: Asset was deleted successfully
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: "Request was malformed, e.g. id was null"
+        "404":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: An asset with the given ID does not exist
+        "409":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: "The asset cannot be deleted, because it is referenced by a\
+            \ contract agreement"
+      tags:
+      - Asset
+    get:
+      description: Gets an asset with the given ID
+      operationId: getAsset_1
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+          example: null
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Asset'
+          description: The asset
         "400":
           content:
             application/json:
@@ -290,6 +477,8 @@ components:
           type: integer
           format: int64
           example: null
+        dataAddress:
+          $ref: '#/components/schemas/DataAddress'
         id:
           type: string
           example: null

--- a/spi/common/core-spi/build.gradle.kts
+++ b/spi/common/core-spi/build.gradle.kts
@@ -29,10 +29,11 @@ dependencies {
     testImplementation(project(":core:common:junit"))
 
     // needed by the abstract test spec located in testFixtures
+    testFixturesImplementation(project(":core:common:junit"))
     testFixturesImplementation(libs.bundles.jupiter)
-    testFixturesRuntimeOnly(libs.junit.jupiter.engine)
     testFixturesImplementation(libs.mockito.core)
     testFixturesImplementation(libs.assertj)
+    testFixturesRuntimeOnly(libs.junit.jupiter.engine)
 }
 
 

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/asset/AssetIndex.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/asset/AssetIndex.java
@@ -39,7 +39,7 @@ public interface AssetIndex extends DataAddressResolver {
 
     String ASSET_EXISTS_TEMPLATE = "Asset with ID %s already exists";
     String ASSET_NOT_FOUND_TEMPLATE = "Asset with ID %s not found";
-    String DATAADDRESS_NOT_FOUND_TEMPLATE = "DataAddress with ID %s not found";
+    String DATA_ADDRESS_NOT_FOUND_TEMPLATE = "DataAddress with ID %s not found";
     String DUPLICATE_PROPERTY_KEYS_TEMPLATE = "Duplicate keys in properties and private properties are not allowed";
 
     /**
@@ -73,12 +73,39 @@ public interface AssetIndex extends DataAddressResolver {
      * @param asset       The {@link Asset} to store
      * @param dataAddress The {@link DataAddress} to store
      * @return {@link StoreResult#success()} if the objects were stored, {@link StoreResult#alreadyExists(String)} when an object with the same ID already exists.
+     * @deprecated please use {@link #create(Asset)}
      */
+    @Deprecated(since = "0.1.2", forRemoval = true)
     default StoreResult<Void> create(Asset asset, DataAddress dataAddress) {
         return create(new AssetEntry(asset, dataAddress));
     }
 
-    StoreResult<Void> create(AssetEntry item);
+    /**
+     * This method will be removed in favor of {@link #create(Asset)}
+     *
+     * @param item the asset entry.
+     * @return the result.
+     * @deprecated please use and override {@link #create(Asset)}
+     */
+    @Deprecated(since = "0.1.2")
+    default StoreResult<Void> create(AssetEntry item) {
+        var asset = item.getAsset();
+        var assetWithDataAddress = asset.toBuilder()
+                .dataAddress(item.getDataAddress())
+                .build();
+        return create(assetWithDataAddress);
+    }
+
+    /**
+     * Stores a {@link Asset} in the asset index, if no asset with the same ID already exists.
+     * Implementors must ensure that it's stored in a transactional way.
+     *
+     * @param asset       The {@link Asset} to store
+     * @return {@link StoreResult#success()} if the objects were stored, {@link StoreResult#alreadyExists(String)} when an object with the same ID already exists.
+     */
+    default StoreResult<Void> create(Asset asset) {
+        return create(new AssetEntry(asset, asset.getDataAddress()));
+    }
 
     /**
      * Deletes an asset if it exists.

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/asset/DataAddressResolver.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/asset/DataAddressResolver.java
@@ -28,8 +28,7 @@ public interface DataAddressResolver {
      * a storage system like a database or a document store.
      *
      * @param assetId The {@code assetId} for which the data pointer should be fetched.
-     * @return A DataAddress
-     * @throws IllegalArgumentException if no corresponding {@code DataAddress} was found for a certain asset
+     * @return A DataAddress, null if not found
      */
     DataAddress resolveForAsset(String assetId);
 }

--- a/spi/common/core-spi/src/test/java/org/eclipse/edc/spi/types/domain/asset/AssetTest.java
+++ b/spi/common/core-spi/src/test/java/org/eclipse/edc/spi/types/domain/asset/AssetTest.java
@@ -40,9 +40,8 @@ class AssetTest {
                 .build();
 
         var json = typeManager.writeValueAsString(asset);
-        assertThat(json).isNotNull();
 
-        assertThat(json).contains("abcd123")
+        assertThat(json).isNotNull().contains("abcd123")
                 .contains("application/json")
                 .contains("testasset")
                 .contains("some-critical.value")

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/asset/AssetService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/asset/AssetService.java
@@ -45,8 +45,18 @@ public interface AssetService {
      * @param asset       the asset
      * @param dataAddress the address of the asset
      * @return successful result if the asset is created correctly, failure otherwise
+     * @deprecated please use {@link #create(Asset)}
      */
+    @Deprecated(since = "0.1.2")
     ServiceResult<Asset> create(Asset asset, DataAddress dataAddress);
+
+    /**
+     * Create an asset
+     *
+     * @param asset       the asset
+     * @return successful result if the asset is created correctly, failure otherwise
+     */
+    ServiceResult<Asset> create(Asset asset);
 
     /**
      * Delete an asset

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/Participant.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/Participant.java
@@ -87,10 +87,9 @@ public class Participant {
     public void createAsset(String assetId, Map<String, Object> dataAddressProperties) {
         var requestBody = createObjectBuilder()
                 .add(CONTEXT, createObjectBuilder().add(EDC_PREFIX, EDC_NAMESPACE))
-                .add("asset", createObjectBuilder()
-                        .add(ID, assetId)
-                        .add("properties", createObjectBuilder()
-                                .add("description", "description")))
+                .add(ID, assetId)
+                .add("properties", createObjectBuilder()
+                        .add("description", "description"))
                 .add("dataAddress", createObjectBuilder(dataAddressProperties))
                 .build();
 
@@ -99,7 +98,7 @@ public class Participant {
                 .contentType(JSON)
                 .body(requestBody)
                 .when()
-                .post("/v2/assets")
+                .post("/v3/assets")
                 .then()
                 .statusCode(200)
                 .contentType(JSON);

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/CatalogApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/CatalogApiEndToEndTest.java
@@ -23,7 +23,6 @@ import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.asset.AssetIndex;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
-import org.eclipse.edc.spi.types.domain.asset.AssetEntry;
 import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
@@ -67,8 +66,8 @@ public class CatalogApiEndToEndTest extends BaseManagementApiEndToEndTest {
 
     @Test
     void shouldReturnCatalog_withQuerySpec() {
-        var asset = createAsset("id-1");
-        var asset1 = createAsset("id-2");
+        var asset = createAsset("id-1").dataAddress(createDataAddress().build());
+        var asset1 = createAsset("id-2").dataAddress(createDataAddress().build());
 
         var assetIndex = controlPlane.getContext().getService(AssetIndex.class);
         var policyDefinitionStore = controlPlane.getContext().getService(PolicyDefinitionStore.class);
@@ -88,8 +87,8 @@ public class CatalogApiEndToEndTest extends BaseManagementApiEndToEndTest {
         policyDefinitionStore.create(PolicyDefinition.Builder.newInstance().id(policyId).policy(policy).build());
         contractDefinitionStore.save(cd);
 
-        assetIndex.create(new AssetEntry(asset.build(), createDataAddress().build()));
-        assetIndex.create(new AssetEntry(asset1.build(), createDataAddress().build()));
+        assetIndex.create(asset.build());
+        assetIndex.create(asset1.build());
 
         var criteria = createArrayBuilder()
                 .add(createObjectBuilder()


### PR DESCRIPTION
## What this PR changes/adds

Put `DataAddress` as a field of `Asset`

## Why it does that

At first they were kept separated because `DataAddress` was like "private data for asset", but now we have also `privateProperties` in `Asset`, so there aren't good reasons to keep them split. Doing this we'll end up with a way more clean api. 

## Further notes

- added a `/v3/assets` api endpoint that would avoid breaking changes, though the advice is to switch to the new api as soon as possible.
- cleaned up AssetIndex tests on both in memory and postgresql, likely they could broke in the cosmosdb, eventually I will take care of fixing them

## Linked Issue(s)

Closes #3151 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md)._
