### PR TITLE
fix: avoid sending messages on failing not-yet-requested consumer transfers

### DIFF
--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/process/DispatchFailure.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/process/DispatchFailure.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.connector.transfer.transfer;
+package org.eclipse.edc.connector.transfer.process;
 
 import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.connector.transfer.spi.types.TransferProcessStates;

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImplIntegrationTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImplIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -9,18 +9,15 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
- *       Fraunhofer Institute for Software and Systems Engineering
- *       Microsoft Corporation
  *
  */
 
-package org.eclipse.edc.connector.transfer.transfer;
+package org.eclipse.edc.connector.transfer.process;
 
 import org.eclipse.edc.connector.defaults.storage.transferprocess.InMemoryTransferProcessStore;
 import org.eclipse.edc.connector.policy.spi.store.PolicyArchive;
 import org.eclipse.edc.connector.transfer.TestProvisionedDataDestinationResource;
 import org.eclipse.edc.connector.transfer.TestResourceDefinition;
-import org.eclipse.edc.connector.transfer.process.TransferProcessManagerImpl;
 import org.eclipse.edc.connector.transfer.spi.flow.DataFlowManager;
 import org.eclipse.edc.connector.transfer.spi.observe.TransferProcessObservable;
 import org.eclipse.edc.connector.transfer.spi.provision.ProvisionManager;


### PR DESCRIPTION
## What this PR changes/adds

Avoid sending `TranferRequestMessage`s on failing `CONSUMER` `TransferProcess`es that have not been notified to the `PROVIDER` yet.

## Why it does that

bugfix

## Further notes

- moved the test classes from `package org.eclipse.edc.connector.transfer.transfer;` to `package org.eclipse.edc.connector.transfer.process;`

## Linked Issue(s)

Closes #3247 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md)._
