### PR TITLE
fix: avoid contract id validation on consumer side

### DIFF
--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImpl.java
@@ -39,6 +39,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Objects;
 import java.util.Optional;
 
 import static java.lang.String.format;
@@ -144,20 +145,16 @@ public class ContractValidationServiceImpl implements ContractValidationService 
             return failure("No offer found");
         }
 
-        return ContractId.parseId(agreement.getId())
-                .compose(contractId -> {
-                    var agent = agentService.createFor(token);
-                    var providerIdentity = agent.getIdentity();
-                    if (providerIdentity == null || !providerIdentity.equals(agreement.getProviderId())) {
-                        return failure("Invalid provider credentials");
-                    }
+        var agent = agentService.createFor(token);
+        if (!Objects.equals(agent.getIdentity(), agreement.getProviderId())) {
+            return failure("Invalid provider credentials");
+        }
 
-                    if (!policyEquality.test(agreement.getPolicy().withTarget(latestOffer.getAssetId()), latestOffer.getPolicy())) {
-                        return failure("Policy in the contract agreement is not equal to the one in the contract offer");
-                    }
+        if (!policyEquality.test(agreement.getPolicy().withTarget(latestOffer.getAssetId()), latestOffer.getPolicy())) {
+            return failure("Policy in the contract agreement is not equal to the one in the contract offer");
+        }
 
-                    return success();
-                });
+        return success();
     }
 
     /**


### PR DESCRIPTION
## What this PR changes/adds

Remove contract id validation on `ContractAgreementMessage` received on consumer side

## Why it does that

To permit the connector to interact with a non-EDC counter-party connector

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #3240 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md)._
