### PR TITLE
feat(protocol): add ContractOfferMessage

### DIFF
--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -28,7 +28,7 @@ import org.eclipse.edc.connector.contract.spi.types.command.ContractNegotiationC
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationTerminationMessage;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferMessage;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.statemachine.StateMachineManager;
 import org.eclipse.edc.statemachine.StateProcessorImpl;
@@ -102,22 +102,21 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
     @WithSpan
     private boolean processOffering(ContractNegotiation negotiation) {
         var currentOffer = negotiation.getLastContractOffer();
-
-        var contractOfferRequest = ContractRequestMessage.Builder.newInstance()
+        
+        var contractOfferMessage = ContractOfferMessage.Builder.newInstance()
                 .protocol(negotiation.getProtocol())
-                .connectorId(negotiation.getCounterPartyId())
                 .counterPartyAddress(negotiation.getCounterPartyAddress())
                 .contractOffer(currentOffer)
                 .processId(negotiation.getCorrelationId())
                 .build();
 
-        return entityRetryProcessFactory.doAsyncStatusResultProcess(negotiation, () -> dispatcherRegistry.dispatch(Object.class, contractOfferRequest))
+        return entityRetryProcessFactory.doAsyncStatusResultProcess(negotiation, () -> dispatcherRegistry.dispatch(Object.class, contractOfferMessage))
                 .entityRetrieve(negotiationStore::findById)
                 .onDelay(this::breakLease)
                 .onSuccess((n, result) -> transitionToOffered(n))
                 .onFailure((n, throwable) -> transitionToOffering(n))
                 .onFatalError((n, failure) -> transitionToTerminated(n, failure.getFailureDetail()))
-                .onRetryExhausted((n, throwable) -> transitionToTerminating(n, format("Failed to send %s to consumer: %s", contractOfferRequest.getClass().getSimpleName(), throwable.getMessage())))
+                .onRetryExhausted((n, throwable) -> transitionToTerminating(n, format("Failed to send %s to consumer: %s", contractOfferMessage.getClass().getSimpleName(), throwable.getMessage())))
                 .execute("[Provider] send counter offer");
     }
 

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
@@ -25,7 +25,7 @@ import org.eclipse.edc.connector.contract.spi.types.agreement.ContractNegotiatio
 import org.eclipse.edc.connector.contract.spi.types.command.ContractNegotiationCommand;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferMessage;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
 import org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore;
@@ -128,7 +128,7 @@ class ProviderContractNegotiationManagerImplTest {
 
         await().untilAsserted(() -> {
             verify(store).save(argThat(p -> p.getState() == OFFERED.code()));
-            verify(dispatcherRegistry, only()).dispatch(any(), isA(ContractRequestMessage.class));
+            verify(dispatcherRegistry, only()).dispatch(any(), isA(ContractOfferMessage.class));
             verify(listener).offered(any());
         });
     }

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
@@ -24,6 +24,7 @@ import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementV
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractNegotiationEventMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationTerminationMessage;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.contract.spi.validation.ContractValidationService;
@@ -143,6 +144,74 @@ class ContractNegotiationProtocolServiceImplTest {
 
         assertThat(result).isFailed().extracting(ServiceFailure::getReason).isEqualTo(BAD_REQUEST);
         verify(validationService).validateInitialOffer(token, contractOffer);
+    }
+    
+    @Test
+    void notifyOffered_shouldTransitionToOffered_whenNegotiationFound() {
+        var processId = "processId";
+        var token = ClaimToken.Builder.newInstance().build();
+        var contractOffer = contractOffer();
+        var message = ContractOfferMessage.Builder.newInstance()
+                .callbackAddress("callbackAddress")
+                .protocol("protocol")
+                .contractOffer(contractOffer)
+                .processId(processId)
+                .build();
+        var negotiation = createContractNegotiationRequested();
+        
+        when(store.findForCorrelationId(processId)).thenReturn(negotiation);
+        when(validationService.validateRequest(token, negotiation)).thenReturn(Result.success());
+        
+        var result = service.notifyOffered(message, token);
+        
+        assertThat(result).isSucceeded();
+        var updatedNegotiation = result.getContent();
+        assertThat(updatedNegotiation.getContractOffers()).hasSize(2);
+        assertThat(updatedNegotiation.getLastContractOffer()).isEqualTo(contractOffer);
+        
+        verify(listener).offered(any());
+        verify(transactionContext, atLeastOnce()).execute(any(TransactionContext.ResultTransactionBlock.class));
+    }
+    
+    @Test
+    void notifyOffered_shouldReturnFailure_whenNegotiationNotFound() {
+        var token = ClaimToken.Builder.newInstance().build();
+        var contractOffer = contractOffer();
+        var message = ContractOfferMessage.Builder.newInstance()
+                .callbackAddress("callbackAddress")
+                .protocol("protocol")
+                .contractOffer(contractOffer)
+                .processId("processId")
+                .build();
+    
+        when(store.findForCorrelationId(any())).thenReturn(null);
+        
+        var result = service.notifyOffered(message, token);
+        
+        assertThat(result).isFailed().extracting(ServiceFailure::getReason).isEqualTo(NOT_FOUND);
+        verify(listener, never()).offered(any());
+    }
+    
+    @Test
+    void notifyOffered_shouldReturnFailure_whenCounterPartyValidationFails() {
+        var processId = "processId";
+        var token = ClaimToken.Builder.newInstance().build();
+        var contractOffer = contractOffer();
+        var message = ContractOfferMessage.Builder.newInstance()
+                .callbackAddress("callbackAddress")
+                .protocol("protocol")
+                .contractOffer(contractOffer)
+                .processId(processId)
+                .build();
+        var negotiation = createContractNegotiationRequested();
+    
+        when(store.findForCorrelationId(processId)).thenReturn(negotiation);
+        when(validationService.validateRequest(token, negotiation)).thenReturn(Result.failure("error"));
+        
+        var result = service.notifyOffered(message, token);
+        
+        assertThat(result).isFailed().extracting(ServiceFailure::getReason).isEqualTo(BAD_REQUEST);
+        verify(listener, never()).offered(any());
     }
 
     @Test

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/api/controller/DspNegotiationApiController.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/api/controller/DspNegotiationApiController.java
@@ -29,6 +29,7 @@ import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementV
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractNegotiationEventMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationTerminationMessage;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
 import org.eclipse.edc.connector.contract.spi.types.protocol.ContractRemoteMessage;
 import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationProtocolService;
@@ -66,6 +67,7 @@ import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNam
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_ERROR;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_TERMINATION_MESSAGE;
+import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_OFFER_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS;
 
@@ -254,7 +256,15 @@ public class DspNegotiationApiController {
     public Response providerOffer(@PathParam("id") String id,
                                   JsonObject body,
                                   @HeaderParam(AUTHORIZATION) String token) {
-        return error().processId(id).notImplemented();
+        return handleMessage(MessageSpec.Builder.newInstance(ContractOfferMessage.class)
+                .expectedMessageType(DSPACE_TYPE_CONTRACT_OFFER_MESSAGE)
+                .processId(id)
+                .message(body)
+                .token(token)
+                .serviceCall(protocolService::notifyOffered)
+                .build())
+                .map(cn -> Response.ok().build())
+                .orElse(createErrorResponse(id));
     }
 
     /**

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-dispatcher/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/dispatcher/DspNegotiationHttpDispatcherExtension.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-dispatcher/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/dispatcher/DspNegotiationHttpDispatcherExtension.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.protocol.dsp.negotiation.dispatcher.delegate.ContractAgre
 import org.eclipse.edc.protocol.dsp.negotiation.dispatcher.delegate.ContractAgreementVerificationMessageHttpDelegate;
 import org.eclipse.edc.protocol.dsp.negotiation.dispatcher.delegate.ContractNegotiationEventMessageHttpDelegate;
 import org.eclipse.edc.protocol.dsp.negotiation.dispatcher.delegate.ContractNegotiationTerminationMessageHttpDelegate;
+import org.eclipse.edc.protocol.dsp.negotiation.dispatcher.delegate.ContractOfferMessageHttpDelegate;
 import org.eclipse.edc.protocol.dsp.negotiation.dispatcher.delegate.ContractRequestMessageHttpDelegate;
 import org.eclipse.edc.protocol.dsp.spi.dispatcher.DspHttpRemoteMessageDispatcher;
 import org.eclipse.edc.protocol.dsp.spi.serialization.JsonLdRemoteMessageSerializer;
@@ -56,5 +57,6 @@ public class DspNegotiationHttpDispatcherExtension implements ServiceExtension {
         messageDispatcher.registerDelegate(new ContractNegotiationEventMessageHttpDelegate(remoteMessageSerializer));
         messageDispatcher.registerDelegate(new ContractNegotiationTerminationMessageHttpDelegate(remoteMessageSerializer));
         messageDispatcher.registerDelegate(new ContractRequestMessageHttpDelegate(remoteMessageSerializer, typeManager.getMapper(JSON_LD), jsonLdService));
+        messageDispatcher.registerDelegate(new ContractOfferMessageHttpDelegate(remoteMessageSerializer));
     }
 }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-dispatcher/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/dispatcher/delegate/ContractOfferMessageHttpDelegate.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-dispatcher/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/dispatcher/delegate/ContractOfferMessageHttpDelegate.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2023 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.negotiation.dispatcher.delegate;
+
+import okhttp3.Request;
+import okhttp3.Response;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferMessage;
+import org.eclipse.edc.protocol.dsp.spi.dispatcher.DspHttpDispatcherDelegate;
+import org.eclipse.edc.protocol.dsp.spi.serialization.JsonLdRemoteMessageSerializer;
+
+import java.util.function.Function;
+
+import static org.eclipse.edc.protocol.dsp.negotiation.dispatcher.NegotiationApiPaths.BASE_PATH;
+import static org.eclipse.edc.protocol.dsp.negotiation.dispatcher.NegotiationApiPaths.CONTRACT_OFFER;
+
+/**
+ * Delegate for dispatching contract offer message as defined in the dataspace protocol specification.
+ */
+public class ContractOfferMessageHttpDelegate extends DspHttpDispatcherDelegate<ContractOfferMessage, Object> {
+    
+    public ContractOfferMessageHttpDelegate(JsonLdRemoteMessageSerializer serializer) {
+        super(serializer);
+    }
+    
+    @Override
+    public Class<ContractOfferMessage> getMessageType() {
+        return ContractOfferMessage.class;
+    }
+    
+    @Override
+    public Request buildRequest(ContractOfferMessage message) {
+        return buildRequest(message, BASE_PATH + message.getProcessId() + CONTRACT_OFFER);
+    }
+    
+    @Override
+    protected Function<Response, Object> parseResponse() {
+        return response -> null;
+    }
+}

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-dispatcher/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/dispatcher/delegate/ContractOfferMessageHttpDelegateTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-dispatcher/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/dispatcher/delegate/ContractOfferMessageHttpDelegateTest.java
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (c) 2023 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.negotiation.dispatcher.delegate;
+
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferMessage;
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.protocol.dsp.spi.dispatcher.DspHttpDispatcherDelegate;
+import org.eclipse.edc.protocol.dsp.spi.testfixtures.dispatcher.DspHttpDispatcherDelegateTestBase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static java.util.UUID.randomUUID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.protocol.dsp.negotiation.dispatcher.NegotiationApiPaths.BASE_PATH;
+import static org.eclipse.edc.protocol.dsp.negotiation.dispatcher.NegotiationApiPaths.CONTRACT_OFFER;
+
+class ContractOfferMessageHttpDelegateTest extends DspHttpDispatcherDelegateTestBase<ContractOfferMessage> {
+    
+    private ContractOfferMessageHttpDelegate delegate;
+    
+    @BeforeEach
+    void setUp() {
+        delegate = new ContractOfferMessageHttpDelegate(serializer);
+    }
+    
+    @Test
+    void getMessageType() {
+        assertThat(delegate.getMessageType()).isEqualTo(ContractOfferMessage.class);
+    }
+
+    @Test
+    void buildRequest() throws IOException {
+        var message = message();
+        testBuildRequest_shouldReturnRequest(message, BASE_PATH + message.getProcessId() + CONTRACT_OFFER);
+    }
+    
+    @Test
+    void buildRequest_serializationFails_throwException() {
+        testBuildRequest_shouldThrowException_whenSerializationFails(message());
+    }
+    
+    @Test
+    void parseResponse_shouldReturnNullFunction() {
+        testParseResponse_shouldReturnNullFunction_whenResponseBodyNotProcessed();
+    }
+    
+    @Override
+    protected DspHttpDispatcherDelegate<ContractOfferMessage, ?> delegate() {
+        return delegate;
+    }
+    
+    private ContractOfferMessage message() {
+        return ContractOfferMessage.Builder.newInstance()
+                .protocol("dsp")
+                .processId("processId")
+                .counterPartyAddress("http://connector")
+                .contractOffer(contractOffer())
+                .callbackAddress("http://callback")
+                .build();
+    }
+    
+    private ContractOffer contractOffer() {
+        return ContractOffer.Builder.newInstance()
+                .id(randomUUID().toString())
+                .assetId("assetId")
+                .policy(Policy.Builder.newInstance().build())
+                .build();
+    }
+}

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/DspNegotiationTransformExtension.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/DspNegotiationTransformExtension.java
@@ -20,11 +20,13 @@ import org.eclipse.edc.protocol.dsp.negotiation.transform.from.JsonObjectFromCon
 import org.eclipse.edc.protocol.dsp.negotiation.transform.from.JsonObjectFromContractNegotiationEventMessageTransformer;
 import org.eclipse.edc.protocol.dsp.negotiation.transform.from.JsonObjectFromContractNegotiationTerminationMessageTransformer;
 import org.eclipse.edc.protocol.dsp.negotiation.transform.from.JsonObjectFromContractNegotiationTransformer;
+import org.eclipse.edc.protocol.dsp.negotiation.transform.from.JsonObjectFromContractOfferMessageTransformer;
 import org.eclipse.edc.protocol.dsp.negotiation.transform.from.JsonObjectFromContractRequestMessageTransformer;
 import org.eclipse.edc.protocol.dsp.negotiation.transform.to.JsonObjectToContractAgreementMessageTransformer;
 import org.eclipse.edc.protocol.dsp.negotiation.transform.to.JsonObjectToContractAgreementVerificationMessageTransformer;
 import org.eclipse.edc.protocol.dsp.negotiation.transform.to.JsonObjectToContractNegotiationEventMessageTransformer;
 import org.eclipse.edc.protocol.dsp.negotiation.transform.to.JsonObjectToContractNegotiationTerminationMessageTransformer;
+import org.eclipse.edc.protocol.dsp.negotiation.transform.to.JsonObjectToContractOfferMessageTransformer;
 import org.eclipse.edc.protocol.dsp.negotiation.transform.to.JsonObjectToContractRequestMessageTransformer;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
@@ -60,11 +62,13 @@ public class DspNegotiationTransformExtension implements ServiceExtension {
         registry.register(new JsonObjectFromContractNegotiationTerminationMessageTransformer(builderFactory));
         registry.register(new JsonObjectFromContractNegotiationTransformer(builderFactory));
         registry.register(new JsonObjectFromContractRequestMessageTransformer(builderFactory));
+        registry.register(new JsonObjectFromContractOfferMessageTransformer(builderFactory));
 
         registry.register(new JsonObjectToContractAgreementMessageTransformer());
         registry.register(new JsonObjectToContractAgreementVerificationMessageTransformer());
         registry.register(new JsonObjectToContractNegotiationEventMessageTransformer());
         registry.register(new JsonObjectToContractRequestMessageTransformer());
         registry.register(new JsonObjectToContractNegotiationTerminationMessageTransformer());
+        registry.register(new JsonObjectToContractOfferMessageTransformer());
     }
 }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractOfferMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractOfferMessageTransformer.java
@@ -1,0 +1,73 @@
+/*
+ *  Copyright (c) 2023 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.negotiation.transform.from;
+
+import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferMessage;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER;
+import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_OFFER_MESSAGE;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
+
+/**
+ * Creates a {@link JsonObject} from a {@link ContractOfferMessage}.
+ */
+public class JsonObjectFromContractOfferMessageTransformer extends AbstractJsonLdTransformer<ContractOfferMessage, JsonObject> {
+    
+    private final JsonBuilderFactory jsonFactory;
+    
+    public JsonObjectFromContractOfferMessageTransformer(JsonBuilderFactory jsonFactory) {
+        super(ContractOfferMessage.class, JsonObject.class);
+        this.jsonFactory = jsonFactory;
+    }
+    
+    @Override
+    public @Nullable JsonObject transform(@NotNull ContractOfferMessage message, @NotNull TransformerContext context) {
+        var builder = jsonFactory.createObjectBuilder();
+        builder.add(ID, message.getId());
+        builder.add(TYPE, DSPACE_TYPE_CONTRACT_OFFER_MESSAGE);
+        builder.add(DSPACE_PROPERTY_PROCESS_ID, message.getProcessId());
+    
+        if (message.getCallbackAddress() != null) {
+            builder.add(DSPACE_PROPERTY_CALLBACK_ADDRESS, message.getCallbackAddress());
+        }
+        
+        var offer = message.getContractOffer();
+        var policy = context.transform(offer.getPolicy(), JsonObject.class);
+        if (policy == null) {
+            context.problem()
+                    .nullProperty()
+                    .type(ContractOfferMessage.class)
+                    .property("contractOffer")
+                    .report();
+            return null;
+        }
+        var enrichedPolicy = Json.createObjectBuilder(policy)
+                .add(ID, offer.getId())
+                .build();
+        builder.add(DSPACE_PROPERTY_OFFER, enrichedPolicy);
+        
+        return builder.build();
+    }
+}

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractOfferMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractOfferMessageTransformer.java
@@ -1,0 +1,87 @@
+/*
+ *  Copyright (c) 2023 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.negotiation.transform.to;
+
+import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferMessage;
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER;
+import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
+
+/**
+ * Creates a {@link ContractOfferMessage} from a {@link JsonObject}.
+ */
+public class JsonObjectToContractOfferMessageTransformer extends AbstractJsonLdTransformer<JsonObject, ContractOfferMessage> {
+    
+    public JsonObjectToContractOfferMessageTransformer() {
+        super(JsonObject.class, ContractOfferMessage.class);
+    }
+    
+    @Override
+    public @Nullable ContractOfferMessage transform(@NotNull JsonObject jsonObject, @NotNull TransformerContext context) {
+        var builder = ContractOfferMessage.Builder.newInstance();
+        if (!transformMandatoryString(jsonObject.get(DSPACE_PROPERTY_PROCESS_ID), builder::processId, context)) {
+            reportMissingProperty(DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE, DSPACE_PROPERTY_PROCESS_ID, context);
+            return null;
+        }
+    
+        var callback = jsonObject.get(DSPACE_PROPERTY_CALLBACK_ADDRESS);
+        if (callback != null) {
+            builder.callbackAddress(transformString(callback, context));
+        }
+    
+        var contractOffer = returnJsonObject(jsonObject.get(DSPACE_PROPERTY_OFFER), context, DSPACE_PROPERTY_OFFER, false);
+        if (contractOffer != null) {
+            var policy = transformObject(contractOffer, Policy.class, context);
+            if (policy == null) {
+                reportMissingProperty(DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE, DSPACE_PROPERTY_OFFER, context);
+                return null;
+            }
+            var id = nodeId(contractOffer);
+            if (id == null) {
+                reportMissingProperty(DSPACE_PROPERTY_OFFER, ID, context);
+                return null;
+            }
+            var offer = ContractOffer.Builder.newInstance()
+                    .id(id)
+                    .assetId(policy.getTarget())
+                    .policy(policy)
+                    .build();
+            builder.contractOffer(offer);
+        } else {
+            reportMissingProperty(DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE, DSPACE_PROPERTY_OFFER, context);
+            return null;
+        }
+        
+        return builder.build();
+    }
+    
+    private void reportMissingProperty(String type, String property, TransformerContext context) {
+        context.problem()
+                .missingProperty()
+                .type(type)
+                .property(property)
+                .report();
+    }
+}

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractOfferMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractOfferMessageTransformer.java
@@ -25,7 +25,7 @@ import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER;
-import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE;
+import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_OFFER_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
 
@@ -42,7 +42,7 @@ public class JsonObjectToContractOfferMessageTransformer extends AbstractJsonLdT
     public @Nullable ContractOfferMessage transform(@NotNull JsonObject jsonObject, @NotNull TransformerContext context) {
         var builder = ContractOfferMessage.Builder.newInstance();
         if (!transformMandatoryString(jsonObject.get(DSPACE_PROPERTY_PROCESS_ID), builder::processId, context)) {
-            reportMissingProperty(DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE, DSPACE_PROPERTY_PROCESS_ID, context);
+            reportMissingProperty(DSPACE_TYPE_CONTRACT_OFFER_MESSAGE, DSPACE_PROPERTY_PROCESS_ID, context);
             return null;
         }
     
@@ -55,7 +55,7 @@ public class JsonObjectToContractOfferMessageTransformer extends AbstractJsonLdT
         if (contractOffer != null) {
             var policy = transformObject(contractOffer, Policy.class, context);
             if (policy == null) {
-                reportMissingProperty(DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE, DSPACE_PROPERTY_OFFER, context);
+                reportMissingProperty(DSPACE_TYPE_CONTRACT_OFFER_MESSAGE, DSPACE_PROPERTY_OFFER, context);
                 return null;
             }
             var id = nodeId(contractOffer);
@@ -70,7 +70,7 @@ public class JsonObjectToContractOfferMessageTransformer extends AbstractJsonLdT
                     .build();
             builder.contractOffer(offer);
         } else {
-            reportMissingProperty(DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE, DSPACE_PROPERTY_OFFER, context);
+            reportMissingProperty(DSPACE_TYPE_CONTRACT_OFFER_MESSAGE, DSPACE_PROPERTY_OFFER, context);
             return null;
         }
         

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractOfferMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractOfferMessageTransformerTest.java
@@ -1,0 +1,116 @@
+/*
+ *  Copyright (c) 2023 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.negotiation.transform.from;
+
+import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferMessage;
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.transform.spi.ProblemBuilder;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER;
+import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_OFFER_MESSAGE;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class JsonObjectFromContractOfferMessageTransformerTest {
+    
+    private static final String MESSAGE_ID = "messageId";
+    private static final String CALLBACK_ADDRESS = "https://test.com";
+    private static final String PROCESS_ID = "processId";
+    private static final String PROTOCOL = "DSP";
+    private static final String CONTRACT_OFFER_ID = "contractId";
+    
+    private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
+    private final TransformerContext context = mock(TransformerContext.class);
+    
+    private JsonObjectFromContractOfferMessageTransformer transformer;
+    
+    @BeforeEach
+    void setUp() {
+        transformer = new JsonObjectFromContractOfferMessageTransformer(jsonFactory);
+    }
+    
+    @Test
+    void transform_shouldReturnJsonObject_whenValidMessage() {
+        var message = message();
+        var policyJson = jsonFactory.createObjectBuilder().build();
+        
+        when(context.transform(any(Policy.class), eq(JsonObject.class))).thenReturn(policyJson);
+        
+        var result = transformer.transform(message, context);
+        
+        assertThat(result).isNotNull();
+        assertThat(result.getJsonString(ID).getString()).isNotEmpty();
+        assertThat(result.getJsonString(TYPE).getString()).isEqualTo(DSPACE_TYPE_CONTRACT_OFFER_MESSAGE);
+        assertThat(result.getJsonString(DSPACE_PROPERTY_PROCESS_ID).getString()).isEqualTo(PROCESS_ID);
+        assertThat(result.getJsonString(DSPACE_PROPERTY_CALLBACK_ADDRESS).getString()).isEqualTo(CALLBACK_ADDRESS);
+        assertThat(result.getJsonObject(DSPACE_PROPERTY_OFFER)).isNotNull();
+        assertThat(result.getJsonObject(DSPACE_PROPERTY_OFFER)).isNotNull();
+        assertThat(result.getJsonObject(DSPACE_PROPERTY_OFFER).getJsonString(ID).getString()).isEqualTo(CONTRACT_OFFER_ID);
+    
+        verify(context, never()).reportProblem(anyString());
+    }
+    
+    @Test
+    void transform_shouldReportProblem_whenPolicyTransformationFails() {
+        var message = message();
+    
+        when(context.transform(any(Policy.class), eq(JsonObject.class))).thenReturn(null);
+        when(context.problem()).thenReturn(new ProblemBuilder(context));
+    
+        var result = transformer.transform(message, context);
+        
+        assertThat(result).isNull();
+        verify(context, times(1)).reportProblem(any());
+    }
+    
+    private ContractOfferMessage message() {
+        return ContractOfferMessage.Builder.newInstance()
+                .id(MESSAGE_ID)
+                .callbackAddress(CALLBACK_ADDRESS)
+                .processId(PROCESS_ID)
+                .protocol(PROTOCOL)
+                .contractOffer(contractOffer())
+                .build();
+    }
+    
+    private ContractOffer contractOffer() {
+        return ContractOffer.Builder.newInstance()
+                .id(CONTRACT_OFFER_ID)
+                .assetId("assetId")
+                .policy(Policy.Builder.newInstance().build())
+                .build();
+    }
+    
+}

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractOfferMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractOfferMessageTransformerTest.java
@@ -1,0 +1,186 @@
+/*
+ *  Copyright (c) 2023 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.negotiation.transform.to;
+
+import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.transform.spi.ProblemBuilder;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER;
+import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_OFFER_MESSAGE;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class JsonObjectToContractOfferMessageTransformerTest {
+    
+    private static final String PROCESS_ID = "processId";
+    private static final String CALLBACK_ADDRESS = "https://test.com";
+    private static final String MESSAGE_ID = "messageId";
+    private static final String ASSET_ID = "assetId";
+    private static final String CONTRACT_OFFER_ID = "assetId";
+    
+    private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
+    private final TransformerContext context = mock(TransformerContext.class);
+    
+    private JsonObjectToContractOfferMessageTransformer transformer;
+    
+    @BeforeEach
+    void setUp() {
+        transformer = new JsonObjectToContractOfferMessageTransformer();
+        when(context.problem()).thenReturn(new ProblemBuilder(context));
+    }
+    
+    @Test
+    void transform_shouldReturnMessage_whenValidJsonObject() {
+        var message = jsonFactory.createObjectBuilder()
+                .add(ID, MESSAGE_ID)
+                .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_OFFER_MESSAGE)
+                .add(DSPACE_PROPERTY_PROCESS_ID, PROCESS_ID)
+                .add(DSPACE_PROPERTY_CALLBACK_ADDRESS, CALLBACK_ADDRESS)
+                .add(DSPACE_PROPERTY_OFFER, jsonFactory.createObjectBuilder()
+                        .add(ID, CONTRACT_OFFER_ID)
+                        .build())
+                .build();
+        var policy = policy();
+        
+        when(context.transform(any(JsonObject.class), eq(Policy.class))).thenReturn(policy);
+        
+        var result = transformer.transform(message, context);
+        
+        assertThat(result).isNotNull();
+        assertThat(result.getProtocol()).isNotEmpty();
+        assertThat(result.getProcessId()).isEqualTo(PROCESS_ID);
+        assertThat(result.getCallbackAddress()).isEqualTo(CALLBACK_ADDRESS);
+    
+        var contractOffer = result.getContractOffer();
+        assertThat(contractOffer).isNotNull();
+        assertThat(contractOffer.getId()).isEqualTo(CONTRACT_OFFER_ID);
+        assertThat(contractOffer.getPolicy()).isEqualTo(policy);
+        assertThat(contractOffer.getAssetId()).isEqualTo(ASSET_ID);
+    
+        verify(context, never()).reportProblem(anyString());
+    }
+    
+    @Test
+    void transform_shouldReportProblem_whenMissingProcessId() {
+        var message = jsonFactory.createObjectBuilder()
+                .add(ID, MESSAGE_ID)
+                .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_OFFER_MESSAGE)
+                .add(DSPACE_PROPERTY_CALLBACK_ADDRESS, CALLBACK_ADDRESS)
+                .add(DSPACE_PROPERTY_OFFER, jsonFactory.createObjectBuilder()
+                        .add(ID, CONTRACT_OFFER_ID)
+                        .build())
+                .build();
+    
+        var result = transformer.transform(message, context);
+        
+        assertThat(result).isNull();
+        verify(context, times(1)).reportProblem(any());
+    }
+    
+    @Test
+    void transform_shouldReportProblem_whenMissingCallbackAddress() {
+        var message = jsonFactory.createObjectBuilder()
+                .add(ID, MESSAGE_ID)
+                .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_OFFER_MESSAGE)
+                .add(DSPACE_PROPERTY_PROCESS_ID, PROCESS_ID)
+                .add(DSPACE_PROPERTY_OFFER, jsonFactory.createObjectBuilder()
+                        .add(ID, CONTRACT_OFFER_ID)
+                        .build())
+                .build();
+    
+        var result = transformer.transform(message, context);
+    
+        assertThat(result).isNull();
+        verify(context, times(1)).reportProblem(any());
+    }
+    
+    @Test
+    void transform_shouldReportProblem_whenMissingContractOffer() {
+        var message = jsonFactory.createObjectBuilder()
+                .add(ID, MESSAGE_ID)
+                .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_OFFER_MESSAGE)
+                .add(DSPACE_PROPERTY_PROCESS_ID, PROCESS_ID)
+                .add(DSPACE_PROPERTY_CALLBACK_ADDRESS, CALLBACK_ADDRESS)
+                .build();
+        
+        var result = transformer.transform(message, context);
+    
+        assertThat(result).isNull();
+        verify(context, times(1)).reportProblem(any());
+    }
+    
+    @Test
+    void transform_shouldReportProblem_whenMissingContractOfferId() {
+        var message = jsonFactory.createObjectBuilder()
+                .add(ID, MESSAGE_ID)
+                .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_OFFER_MESSAGE)
+                .add(DSPACE_PROPERTY_PROCESS_ID, PROCESS_ID)
+                .add(DSPACE_PROPERTY_CALLBACK_ADDRESS, CALLBACK_ADDRESS)
+                .add(DSPACE_PROPERTY_OFFER, jsonFactory.createObjectBuilder().build())
+                .build();
+        var policy = policy();
+    
+        when(context.transform(any(JsonObject.class), eq(Policy.class))).thenReturn(policy);
+    
+        var result = transformer.transform(message, context);
+    
+        assertThat(result).isNull();
+        verify(context, times(1)).reportProblem(any());
+    }
+    
+    @Test
+    void transform_shouldReportProblem_whenPolicyTransformationFails() {
+        var message = jsonFactory.createObjectBuilder()
+                .add(ID, MESSAGE_ID)
+                .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_OFFER_MESSAGE)
+                .add(DSPACE_PROPERTY_PROCESS_ID, PROCESS_ID)
+                .add(DSPACE_PROPERTY_CALLBACK_ADDRESS, CALLBACK_ADDRESS)
+                .add(DSPACE_PROPERTY_OFFER, jsonFactory.createObjectBuilder()
+                        .add(ID, CONTRACT_OFFER_ID)
+                        .build())
+                .build();
+    
+        when(context.transform(any(JsonObject.class), eq(Policy.class))).thenReturn(null);
+    
+        var result = transformer.transform(message, context);
+    
+        assertThat(result).isNull();
+        verify(context, times(1)).reportProblem(any());
+    }
+    
+    private Policy policy() {
+        return Policy.Builder.newInstance().target(ASSET_ID).build();
+    }
+
+}

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractOfferMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractOfferMessageTransformerTest.java
@@ -109,23 +109,6 @@ class JsonObjectToContractOfferMessageTransformerTest {
     }
     
     @Test
-    void transform_shouldReportProblem_whenMissingCallbackAddress() {
-        var message = jsonFactory.createObjectBuilder()
-                .add(ID, MESSAGE_ID)
-                .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_OFFER_MESSAGE)
-                .add(DSPACE_PROPERTY_PROCESS_ID, PROCESS_ID)
-                .add(DSPACE_PROPERTY_OFFER, jsonFactory.createObjectBuilder()
-                        .add(ID, CONTRACT_OFFER_ID)
-                        .build())
-                .build();
-    
-        var result = transformer.transform(message, context);
-    
-        assertThat(result).isNull();
-        verify(context, times(1)).reportProblem(any());
-    }
-    
-    @Test
     void transform_shouldReportProblem_whenMissingContractOffer() {
         var message = jsonFactory.createObjectBuilder()
                 .add(ID, MESSAGE_ID)

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractOfferMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractOfferMessage.java
@@ -1,0 +1,129 @@
+/*
+ *  Copyright (c) 2023 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.contract.spi.types.negotiation;
+
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
+import org.eclipse.edc.connector.contract.spi.types.protocol.ContractRemoteMessage;
+import org.eclipse.edc.policy.model.Policy;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.UUID.randomUUID;
+
+/**
+ * Object that wraps the contract offer and provides additional information about e.g. protocol and recipient.
+ * Sent by the provider.
+ */
+public class ContractOfferMessage implements ContractRemoteMessage {
+    
+    private String id;
+    private String protocol = "unknown";
+    private String counterPartyAddress;
+    private String callbackAddress;
+    private String processId;
+    private ContractOffer contractOffer;
+    
+    @Override
+    public @NotNull String getId() {
+        return id;
+    }
+    
+    @Override
+    public @NotNull String getProcessId() {
+        return processId;
+    }
+    
+    @Override
+    public void setProtocol(String protocol) {
+        Objects.requireNonNull(protocol);
+        this.protocol = protocol;
+    }
+    
+    @Override
+    public String getProtocol() {
+        return protocol;
+    }
+    
+    public String getCallbackAddress() {
+        return callbackAddress;
+    }
+    
+    @Override
+    public String getCounterPartyAddress() {
+        return counterPartyAddress;
+    }
+    
+    public ContractOffer getContractOffer() {
+        return contractOffer;
+    }
+    
+    @Override
+    public Policy getPolicy() {
+        return contractOffer.getPolicy();
+    }
+    
+    public static class Builder {
+        private final ContractOfferMessage message;
+        
+        private Builder() {
+            message = new ContractOfferMessage();
+        }
+        
+        public static Builder newInstance() {
+            return new Builder();
+        }
+        
+        public Builder id(String id) {
+            message.id = id;
+            return this;
+        }
+    
+        public Builder protocol(String protocol) {
+            message.protocol = protocol;
+            return this;
+        }
+    
+        public Builder callbackAddress(String callbackAddress) {
+            message.callbackAddress = callbackAddress;
+            return this;
+        }
+    
+        public Builder counterPartyAddress(String counterPartyAddress) {
+            message.counterPartyAddress = counterPartyAddress;
+            return this;
+        }
+    
+        public Builder processId(String processId) {
+            message.processId = processId;
+            return this;
+        }
+    
+        public Builder contractOffer(ContractOffer contractOffer) {
+            message.contractOffer = contractOffer;
+            return this;
+        }
+        
+        public ContractOfferMessage build() {
+            if (message.id == null) {
+                message.id = randomUUID().toString();
+            }
+            requireNonNull(message.processId, "processId");
+            requireNonNull(message.contractOffer, "contractOffer");
+            return message;
+        }
+    }
+}

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessage.java
@@ -27,6 +27,7 @@ import static java.util.UUID.randomUUID;
 
 /**
  * Object that wraps the contract offer and provides additional information about e.g. protocol and recipient.
+ * Sent by the consumer.
  */
 public class ContractRequestMessage implements ContractRemoteMessage {
 

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/contractnegotiation/ContractNegotiationProtocolService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/contractnegotiation/ContractNegotiationProtocolService.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementV
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractNegotiationEventMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationTerminationMessage;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
 import org.eclipse.edc.service.spi.result.ServiceResult;
 import org.eclipse.edc.spi.iam.ClaimToken;
@@ -49,7 +50,7 @@ public interface ContractNegotiationProtocolService {
      * @return a succeeded result if the operation was successful, a failed one otherwise
      */
     @NotNull
-    ServiceResult<ContractNegotiation> notifyOffered(ContractRequestMessage message, ClaimToken claimToken);
+    ServiceResult<ContractNegotiation> notifyOffered(ContractOfferMessage message, ClaimToken claimToken);
 
     /**
      * Notifies the ContractNegotiation that it has been agreed by the accepted.


### PR DESCRIPTION
## What this PR changes/adds

Adds the type `ContractOfferMessage` including transformers and a dispatcher. Using this message, implements the `notifyOffered` method in `ContractNegotiationProtocolService` as well as the `providerOffer` method in `DspNegotiationApiController`.

## Why it does that

To support the protocol specification

## Linked Issue(s)

Closes #2750 
