### PR TITLE
docs: add example to contract definition management api

### DIFF
--- a/extensions/common/api/api-core/build.gradle.kts
+++ b/extensions/common/api/api-core/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     implementation(project(":core:common:util"))
     implementation(project(":core:common:validator-core"))
     implementation(libs.jakarta.rsApi)
+    implementation(libs.swagger.annotations.jakarta)
 
     testImplementation(libs.jersey.common)
     testImplementation(libs.jersey.server)

--- a/extensions/common/api/api-core/src/main/java/org/eclipse/edc/api/ApiCoreExtension.java
+++ b/extensions/common/api/api-core/src/main/java/org/eclipse/edc/api/ApiCoreExtension.java
@@ -25,6 +25,7 @@ import org.eclipse.edc.api.transformer.JsonObjectFromDataAddressDtoTransformer;
 import org.eclipse.edc.api.transformer.JsonObjectFromIdResponseDtoTransformer;
 import org.eclipse.edc.api.transformer.JsonObjectToCallbackAddressTransformer;
 import org.eclipse.edc.api.transformer.JsonObjectToCriterionDtoTransformer;
+import org.eclipse.edc.api.transformer.JsonObjectToQuerySpecDtoTransformer;
 import org.eclipse.edc.api.transformer.QuerySpecDtoToQuerySpecTransformer;
 import org.eclipse.edc.api.validation.QuerySpecDtoValidator;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
@@ -77,6 +78,7 @@ public class ApiCoreExtension implements ServiceExtension {
 
         transformerRegistry.register(new JsonObjectToCallbackAddressTransformer());
         transformerRegistry.register(new JsonObjectToCriterionDtoTransformer());
+        transformerRegistry.register(new JsonObjectToQuerySpecDtoTransformer());
 
         validatorRegistry.register(EDC_QUERY_SPEC_TYPE, QuerySpecDtoValidator.instance());
     }

--- a/extensions/common/api/api-core/src/main/java/org/eclipse/edc/api/model/ApiCoreSchema.java
+++ b/extensions/common/api/api-core/src/main/java/org/eclipse/edc/api/model/ApiCoreSchema.java
@@ -1,0 +1,83 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.api.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.eclipse.edc.spi.query.SortOrder;
+
+import java.util.List;
+
+import static org.eclipse.edc.api.model.CriterionDto.CRITERION_TYPE;
+import static org.eclipse.edc.api.model.QuerySpecDto.EDC_QUERY_SPEC_TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+
+public interface ApiCoreSchema {
+
+    @Schema(example = CriterionSchema.CRITERION_EXAMPLE)
+    record CriterionSchema(
+            @Schema(name = TYPE, example = CRITERION_TYPE)
+            String type,
+            Object operandLeft,
+            String operator,
+            Object operandRight) {
+
+        public static final String CRITERION_EXAMPLE = """
+                {
+                    "@context": { "edc": "https://w3id.org/edc/v0.0.1/ns/" },
+                    "operandLeft": "fieldName",
+                    "operator": "=",
+                    "operandRight": "some value"
+                }
+                """;
+    }
+
+    @Schema(example = QuerySpecSchema.QUERY_SPEC_EXAMPLE)
+    record QuerySpecSchema(
+            @Schema(name = TYPE, example = EDC_QUERY_SPEC_TYPE)
+            String type,
+            int offset,
+            int limit,
+            SortOrder sortOrder,
+            String sortField,
+            List<CriterionSchema> filterExpression
+    ) {
+        public static final String QUERY_SPEC_EXAMPLE = """
+                {
+                    "@context": { "edc": "https://w3id.org/edc/v0.0.1/ns/" },
+                    "offset": 5,
+                    "limit": 10,
+                    "sortOrder": "DESC",
+                    "sortField": "fieldName",
+                    "criterion": []
+                }
+                """;
+    }
+
+    @Schema(example = IdResponseSchema.ID_RESPONSE_EXAMPLE)
+    record IdResponseSchema(
+            @Schema(name = ID)
+            String id,
+            long createdAt
+    ) {
+        public static final String ID_RESPONSE_EXAMPLE = """
+                {
+                    "@context": { "edc": "https://w3id.org/edc/v0.0.1/ns/" },
+                    "@id": "id-value",
+                    "createdAt": 1688465655
+                }
+                """;
+    }
+}

--- a/extensions/common/api/api-core/src/main/java/org/eclipse/edc/api/transformer/JsonObjectToQuerySpecDtoTransformer.java
+++ b/extensions/common/api/api-core/src/main/java/org/eclipse/edc/api/transformer/JsonObjectToQuerySpecDtoTransformer.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.connector.api.management.catalog.transform;
+package org.eclipse.edc.api.transformer;
 
 import jakarta.json.JsonObject;
 import org.eclipse.edc.api.model.CriterionDto;

--- a/extensions/common/api/api-core/src/test/java/org/eclipse/edc/api/model/ApiCoreSchemaTest.java
+++ b/extensions/common/api/api-core/src/test/java/org/eclipse/edc/api/model/ApiCoreSchemaTest.java
@@ -1,0 +1,91 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.api.model;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.api.transformer.JsonObjectToCriterionDtoTransformer;
+import org.eclipse.edc.api.transformer.JsonObjectToQuerySpecDtoTransformer;
+import org.eclipse.edc.api.validation.CriterionDtoValidator;
+import org.eclipse.edc.api.validation.QuerySpecDtoValidator;
+import org.eclipse.edc.jsonld.TitaniumJsonLd;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.jsonld.util.JacksonJsonLd;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.eclipse.edc.api.model.ApiCoreSchema.CriterionSchema.CRITERION_EXAMPLE;
+import static org.eclipse.edc.api.model.ApiCoreSchema.IdResponseSchema.ID_RESPONSE_EXAMPLE;
+import static org.eclipse.edc.api.model.ApiCoreSchema.QuerySpecSchema.QUERY_SPEC_EXAMPLE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.mockito.Mockito.mock;
+
+class ApiCoreSchemaTest {
+
+    private final ObjectMapper objectMapper = JacksonJsonLd.createObjectMapper();
+    private final JsonLd jsonLd = new TitaniumJsonLd(mock());
+
+    @Test
+    void criterionExample() throws JsonProcessingException {
+        var transformer = new JsonObjectToCriterionDtoTransformer();
+        var validator = CriterionDtoValidator.instance();
+
+        var jsonObject = objectMapper.readValue(CRITERION_EXAMPLE, JsonObject.class);
+        assertThat(jsonObject).isNotNull();
+
+        var expanded = jsonLd.expand(jsonObject);
+        assertThat(expanded).isSucceeded()
+                .satisfies(exp -> assertThat(validator.validate(exp)).isSucceeded())
+                .extracting(e -> transformer.transform(e, mock()))
+                .isNotNull()
+                .satisfies(transformed -> {
+                    assertThat(transformed.getOperandLeft()).isNotNull();
+                    assertThat(transformed.getOperator()).isNotBlank();
+                    assertThat(transformed.getOperandRight()).isNotNull();
+                });
+    }
+
+    @Test
+    void querySpecExample() throws JsonProcessingException {
+        var transformer = new JsonObjectToQuerySpecDtoTransformer();
+        var validator = QuerySpecDtoValidator.instance();
+
+        var jsonObject = objectMapper.readValue(QUERY_SPEC_EXAMPLE, JsonObject.class);
+        assertThat(jsonObject).isNotNull();
+
+        var expanded = jsonLd.expand(jsonObject);
+        assertThat(expanded).isSucceeded()
+                .satisfies(exp -> assertThat(validator.validate(exp)).isSucceeded())
+                .extracting(e -> transformer.transform(e, mock()))
+                .isNotNull()
+                .satisfies(transformed -> {
+                    assertThat(transformed.getOffset()).isGreaterThan(0);
+                    assertThat(transformed.getLimit()).isGreaterThan(1);
+                    assertThat(transformed.getSortOrder()).isNotNull();
+                    assertThat(transformed.getSortField()).isNotBlank();
+                });
+    }
+
+    @Test
+    void idResponseExample() throws JsonProcessingException {
+        var idResponse = objectMapper.readValue(ID_RESPONSE_EXAMPLE, JsonObject.class);
+
+        assertThat(idResponse).isNotNull();
+        assertThat(idResponse.getString(ID)).isNotBlank();
+        assertThat(idResponse.getJsonNumber("createdAt").longValue()).isGreaterThan(0);
+    }
+}

--- a/extensions/common/api/api-core/src/test/java/org/eclipse/edc/api/transformer/JsonObjectToQuerySpecDtoTransformerTest.java
+++ b/extensions/common/api/api-core/src/test/java/org/eclipse/edc/api/transformer/JsonObjectToQuerySpecDtoTransformerTest.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.connector.api.management.catalog.transform;
+package org.eclipse.edc.api.transformer;
 
 import jakarta.json.Json;
 import jakarta.json.JsonObject;

--- a/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/api/management/catalog/CatalogApiExtension.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/api/management/catalog/CatalogApiExtension.java
@@ -17,7 +17,6 @@ package org.eclipse.edc.connector.api.management.catalog;
 import org.eclipse.edc.catalog.spi.CatalogRequest;
 import org.eclipse.edc.connector.api.management.catalog.transform.CatalogRequestDtoToCatalogRequestTransformer;
 import org.eclipse.edc.connector.api.management.catalog.transform.JsonObjectToCatalogRequestDtoTransformer;
-import org.eclipse.edc.connector.api.management.catalog.transform.JsonObjectToQuerySpecDtoTransformer;
 import org.eclipse.edc.connector.api.management.catalog.validation.CatalogRequestValidator;
 import org.eclipse.edc.connector.api.management.configuration.ManagementApiConfiguration;
 import org.eclipse.edc.connector.spi.catalog.CatalogService;
@@ -58,7 +57,6 @@ public class CatalogApiExtension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
         transformerRegistry.register(new CatalogRequestDtoToCatalogRequestTransformer());
         transformerRegistry.register(new JsonObjectToCatalogRequestDtoTransformer());
-        transformerRegistry.register(new JsonObjectToQuerySpecDtoTransformer());
 
         webService.registerResource(config.getContextAlias(), new CatalogApiController(service, transformerRegistry, validatorRegistry));
 

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionApi.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionApi.java
@@ -24,21 +24,26 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
-import org.eclipse.edc.api.model.IdResponseDto;
-import org.eclipse.edc.api.model.QuerySpecDto;
-import org.eclipse.edc.connector.api.management.contractdefinition.model.ContractDefinitionRequestDto;
-import org.eclipse.edc.connector.api.management.contractdefinition.model.ContractDefinitionResponseDto;
+import org.eclipse.edc.api.model.ApiCoreSchema;
 import org.eclipse.edc.web.spi.ApiErrorDetail;
+
+import java.util.List;
+
+import static org.eclipse.edc.connector.api.management.contractdefinition.ContractDefinitionApi.ContractDefinitionInputSchema.CONTRACT_DEFINITION_INPUT_EXAMPLE;
+import static org.eclipse.edc.connector.api.management.contractdefinition.ContractDefinitionApi.ContractDefinitionOutputSchema.CONTRACT_DEFINITION_OUTPUT_EXAMPLE;
+import static org.eclipse.edc.connector.api.management.contractdefinition.model.ContractDefinitionRequestDto.CONTRACT_DEFINITION_TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 
 @OpenAPIDefinition
 @Tag(name = "Contract Definition")
 public interface ContractDefinitionApi {
 
     @Operation(description = "Returns all contract definitions according to a query",
-            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = QuerySpecDto.class))),
+            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ApiCoreSchema.QuerySpecSchema.class))),
             responses = {
                     @ApiResponse(responseCode = "200", description = "The contract definitions matching the query",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ContractDefinitionResponseDto.class)))),
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ContractDefinitionOutputSchema.class)))),
                     @ApiResponse(responseCode = "400", description = "Request was malformed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
             }
@@ -48,7 +53,7 @@ public interface ContractDefinitionApi {
     @Operation(description = "Gets an contract definition with the given ID",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The contract definition",
-                            content = @Content(schema = @Schema(implementation = ContractDefinitionResponseDto.class))),
+                            content = @Content(schema = @Schema(implementation = ContractDefinitionOutputSchema.class))),
                     @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))),
                     @ApiResponse(responseCode = "404", description = "An contract agreement with the given ID does not exist",
@@ -58,10 +63,10 @@ public interface ContractDefinitionApi {
     JsonObject getContractDefinition(String id);
 
     @Operation(description = "Creates a new contract definition",
-            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ContractDefinitionRequestDto.class))),
+            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ContractDefinitionInputSchema.class))),
             responses = {
                     @ApiResponse(responseCode = "200", description = "contract definition was created successfully. Returns the Contract Definition Id and created timestamp",
-                            content = @Content(schema = @Schema(implementation = IdResponseDto.class))),
+                            content = @Content(schema = @Schema(implementation = ApiCoreSchema.IdResponseSchema.class))),
                     @ApiResponse(responseCode = "400", description = "Request body was malformed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))),
                     @ApiResponse(responseCode = "409", description = "Could not create contract definition, because a contract definition with that ID already exists",
@@ -82,7 +87,7 @@ public interface ContractDefinitionApi {
     void deleteContractDefinition(String id);
 
     @Operation(description = "Updated a contract definition with the given ID. The supplied JSON structure must be a valid JSON-LD object",
-            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ContractDefinitionRequestDto.class))),
+            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ContractDefinitionInputSchema.class))),
             responses = {
                     @ApiResponse(responseCode = "204", description = "Contract definition was updated successfully"),
                     @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
@@ -93,4 +98,47 @@ public interface ContractDefinitionApi {
     )
     void updateContractDefinition(JsonObject updateObject);
 
+    @Schema(example = CONTRACT_DEFINITION_INPUT_EXAMPLE)
+    record ContractDefinitionInputSchema(
+            @Schema(name = ID)
+            String id,
+            @Schema(name = TYPE, example = CONTRACT_DEFINITION_TYPE)
+            String type,
+            String accessPolicyId,
+            String contractPolicyId,
+            List<ApiCoreSchema.CriterionSchema> assetsSelector) {
+
+        public static final String CONTRACT_DEFINITION_INPUT_EXAMPLE = """
+                {
+                    "@context": { "edc": "https://w3id.org/edc/v0.0.1/ns/" },
+                    "@id": "definition-id",
+                    "accessPolicyId": "asset-policy-id",
+                    "contractPolicyId": "contract-policy-id",
+                    "assetsSelector": []
+                }
+                """;
+    }
+
+    @Schema(example = CONTRACT_DEFINITION_OUTPUT_EXAMPLE)
+    record ContractDefinitionOutputSchema(
+            @Schema(name = ID)
+            String id,
+            @Schema(name = TYPE, example = CONTRACT_DEFINITION_TYPE)
+            String type,
+            String accessPolicyId,
+            String contractPolicyId,
+            List<ApiCoreSchema.CriterionSchema> assetsSelector,
+            long createdAt) {
+
+        public static final String CONTRACT_DEFINITION_OUTPUT_EXAMPLE = """
+                {
+                    "@context": { "edc": "https://w3id.org/edc/v0.0.1/ns/" },
+                    "@id": "definition-id",
+                    "accessPolicyId": "asset-policy-id",
+                    "contractPolicyId": "contract-policy-id",
+                    "assetsSelector": [],
+                    "createdAt": 1688465655
+                }
+                """;
+    }
 }

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionApiTest.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionApiTest.java
@@ -1,0 +1,71 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.contractdefinition;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.api.management.contractdefinition.transform.JsonObjectToContractDefinitionRequestDtoTransformer;
+import org.eclipse.edc.connector.api.management.contractdefinition.validation.ContractDefinitionRequestDtoValidator;
+import org.eclipse.edc.jsonld.TitaniumJsonLd;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.jsonld.util.JacksonJsonLd;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.eclipse.edc.connector.api.management.contractdefinition.ContractDefinitionApi.ContractDefinitionInputSchema.CONTRACT_DEFINITION_INPUT_EXAMPLE;
+import static org.eclipse.edc.connector.api.management.contractdefinition.ContractDefinitionApi.ContractDefinitionOutputSchema.CONTRACT_DEFINITION_OUTPUT_EXAMPLE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.mockito.Mockito.mock;
+
+class ContractDefinitionApiTest {
+
+    private final ObjectMapper objectMapper = JacksonJsonLd.createObjectMapper();
+    private final JsonLd jsonLd = new TitaniumJsonLd(mock());
+
+    @Test
+    void contractDefinitionInputExample() throws JsonProcessingException {
+        var transformer = new JsonObjectToContractDefinitionRequestDtoTransformer();
+        var validator = ContractDefinitionRequestDtoValidator.instance();
+
+        var jsonObject = objectMapper.readValue(CONTRACT_DEFINITION_INPUT_EXAMPLE, JsonObject.class);
+        assertThat(jsonObject).isNotNull();
+
+        var expanded = jsonLd.expand(jsonObject);
+        assertThat(expanded).isSucceeded()
+                .satisfies(exp -> assertThat(validator.validate(exp)).isSucceeded())
+                .extracting(e -> transformer.transform(e, mock()))
+                .isNotNull()
+                .satisfies(transformed -> {
+                    assertThat(transformed.getId()).isNotBlank();
+                    assertThat(transformed.getAccessPolicyId()).isNotBlank();
+                    assertThat(transformed.getContractPolicyId()).isNotBlank();
+                    assertThat(transformed.getAssetsSelector()).asList().isEmpty();
+                });
+    }
+
+    @Test
+    void contractDefinitionOutputExample() throws JsonProcessingException {
+        var jsonObject = objectMapper.readValue(CONTRACT_DEFINITION_OUTPUT_EXAMPLE, JsonObject.class);
+        assertThat(jsonObject).isNotNull();
+
+        assertThat(jsonObject.getString(ID)).isNotBlank();
+        assertThat(jsonObject.getString("accessPolicyId")).isNotBlank();
+        assertThat(jsonObject.getString("contractPolicyId")).isNotBlank();
+        assertThat(jsonObject.getJsonArray("assetsSelector")).asList().isEmpty();
+    }
+
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ postgres = "42.6.0"
 restAssured = "5.3.1"
 rsApi = "3.1.0"
 slf4j = "2.0.7"
+swagger-annotations-jakarta = "2.2.14"
 titanium = "1.3.2"
 kafkaClients = "3.5.0"
 
@@ -84,6 +85,7 @@ opentelemetry-instrumentation-annotations = { module = "io.opentelemetry.instrum
 opentelemetry-proto = { module = "io.opentelemetry.proto:opentelemetry-proto", version.ref = "opentelemetry-proto" }
 restAssured = { module = "io.rest-assured:rest-assured", version.ref = "restAssured" }
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
+swagger-annotations-jakarta = { module = "io.swagger.core.v3:swagger-annotations-jakarta", version.ref = "swagger-annotations-jakarta"}
 titaniumJsonLd = { module = "com.apicatalog:titanium-json-ld", version.ref = "titanium" }
 
 # other technology extensions

--- a/resources/openapi/openapi.yaml
+++ b/resources/openapi/openapi.yaml
@@ -653,7 +653,7 @@ paths:
         content:
           '*/*':
             schema:
-              $ref: '#/components/schemas/ContractDefinitionRequestDto'
+              $ref: '#/components/schemas/ContractDefinitionInputSchema'
       responses:
         "204":
           description: Contract definition was updated successfully
@@ -684,7 +684,7 @@ paths:
         content:
           '*/*':
             schema:
-              $ref: '#/components/schemas/ContractDefinitionRequestDto'
+              $ref: '#/components/schemas/ContractDefinitionInputSchema'
       responses:
         "200":
           description: contract definition was created successfully. Returns the Contract
@@ -692,7 +692,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IdResponseDto'
+                $ref: '#/components/schemas/IdResponseSchema'
         "400":
           description: Request body was malformed
           content:
@@ -722,7 +722,7 @@ paths:
         content:
           '*/*':
             schema:
-              $ref: '#/components/schemas/QuerySpecDto'
+              $ref: '#/components/schemas/QuerySpecSchema'
       responses:
         "200":
           description: The contract definitions matching the query
@@ -732,7 +732,7 @@ paths:
                 type: array
                 example: null
                 items:
-                  $ref: '#/components/schemas/ContractDefinitionResponseDto'
+                  $ref: '#/components/schemas/ContractDefinitionOutputSchema'
         "400":
           description: Request was malformed
           content:
@@ -763,7 +763,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ContractDefinitionResponseDto'
+                $ref: '#/components/schemas/ContractDefinitionOutputSchema'
         "400":
           description: "Request was malformed, e.g. id was null"
           content:
@@ -1818,18 +1818,15 @@ components:
           type: string
           example: null
       example: null
-    ContractDefinitionRequestDto:
+    ContractDefinitionInputSchema:
       type: object
       properties:
-        '@context':
-          type: object
-          example: null
         '@id':
           type: string
           example: null
         '@type':
           type: string
-          example: null
+          example: https://w3id.org/edc/v0.0.1/ns/ContractDefinition
         accessPolicyId:
           type: string
           example: null
@@ -1837,23 +1834,26 @@ components:
           type: array
           example: null
           items:
-            $ref: '#/components/schemas/CriterionDto'
+            $ref: '#/components/schemas/CriterionSchema'
         contractPolicyId:
           type: string
           example: null
-      example: null
-    ContractDefinitionResponseDto:
+      example:
+        '@context':
+          edc: https://w3id.org/edc/v0.0.1/ns/
+        '@id': definition-id
+        accessPolicyId: asset-policy-id
+        contractPolicyId: contract-policy-id
+        assetsSelector: []
+    ContractDefinitionOutputSchema:
       type: object
       properties:
-        '@context':
-          type: object
-          example: null
         '@id':
           type: string
           example: null
         '@type':
           type: string
-          example: null
+          example: https://w3id.org/edc/v0.0.1/ns/ContractDefinition
         accessPolicyId:
           type: string
           example: null
@@ -1861,7 +1861,7 @@ components:
           type: array
           example: null
           items:
-            $ref: '#/components/schemas/CriterionDto'
+            $ref: '#/components/schemas/CriterionSchema'
         contractPolicyId:
           type: string
           example: null
@@ -1869,7 +1869,14 @@ components:
           type: integer
           format: int64
           example: null
-      example: null
+      example:
+        '@context':
+          edc: https://w3id.org/edc/v0.0.1/ns/
+        '@id': definition-id
+        accessPolicyId: asset-policy-id
+        contractPolicyId: contract-policy-id
+        assetsSelector: []
+        createdAt: 1688465655
     ContractNegotiationDto:
       type: object
       properties:
@@ -1963,6 +1970,27 @@ components:
           type: string
           example: null
       example: null
+    CriterionSchema:
+      type: object
+      properties:
+        '@type':
+          type: string
+          example: https://w3id.org/edc/v0.0.1/ns/CriterionDto
+        operandLeft:
+          type: object
+          example: null
+        operandRight:
+          type: object
+          example: null
+        operator:
+          type: string
+          example: null
+      example:
+        '@context':
+          edc: https://w3id.org/edc/v0.0.1/ns/
+        operandLeft: fieldName
+        operator: =
+        operandRight: some value
     DataAddress:
       type: object
       properties:
@@ -2216,6 +2244,21 @@ components:
           format: int64
           example: null
       example: null
+    IdResponseSchema:
+      type: object
+      properties:
+        '@id':
+          type: string
+          example: null
+        createdAt:
+          type: integer
+          format: int64
+          example: null
+      example:
+        '@context':
+          edc: https://w3id.org/edc/v0.0.1/ns/
+        '@id': id-value
+        createdAt: 1688465655
     JsonArray:
       type: array
       properties:
@@ -2492,6 +2535,42 @@ components:
           - ASC
           - DESC
       example: null
+    QuerySpecSchema:
+      type: object
+      properties:
+        '@type':
+          type: string
+          example: https://w3id.org/edc/v0.0.1/ns/QuerySpecDto
+        filterExpression:
+          type: array
+          example: null
+          items:
+            $ref: '#/components/schemas/CriterionSchema'
+        limit:
+          type: integer
+          format: int32
+          example: null
+        offset:
+          type: integer
+          format: int32
+          example: null
+        sortField:
+          type: string
+          example: null
+        sortOrder:
+          type: string
+          example: null
+          enum:
+          - ASC
+          - DESC
+      example:
+        '@context':
+          edc: https://w3id.org/edc/v0.0.1/ns/
+        offset: 5
+        limit: 10
+        sortOrder: DESC
+        sortField: fieldName
+        criterion: []
     SelectionRequest:
       type: object
       properties:

--- a/resources/openapi/yaml/management-api/contract-definition-api.yaml
+++ b/resources/openapi/yaml/management-api/contract-definition-api.yaml
@@ -8,13 +8,13 @@ paths:
         content:
           '*/*':
             schema:
-              $ref: '#/components/schemas/ContractDefinitionRequestDto'
+              $ref: '#/components/schemas/ContractDefinitionInputSchema'
       responses:
         "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IdResponseDto'
+                $ref: '#/components/schemas/IdResponseSchema'
           description: contract definition was created successfully. Returns the Contract
             Definition Id and created timestamp
         "400":
@@ -46,7 +46,7 @@ paths:
         content:
           '*/*':
             schema:
-              $ref: '#/components/schemas/ContractDefinitionRequestDto'
+              $ref: '#/components/schemas/ContractDefinitionInputSchema'
       responses:
         "204":
           description: Contract definition was updated successfully
@@ -78,7 +78,7 @@ paths:
         content:
           '*/*':
             schema:
-              $ref: '#/components/schemas/QuerySpecDto'
+              $ref: '#/components/schemas/QuerySpecSchema'
       responses:
         "200":
           content:
@@ -87,7 +87,7 @@ paths:
                 type: array
                 example: null
                 items:
-                  $ref: '#/components/schemas/ContractDefinitionResponseDto'
+                  $ref: '#/components/schemas/ContractDefinitionOutputSchema'
           description: The contract definitions matching the query
         "400":
           content:
@@ -152,7 +152,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ContractDefinitionResponseDto'
+                $ref: '#/components/schemas/ContractDefinitionOutputSchema'
           description: The contract definition
         "400":
           content:
@@ -192,19 +192,22 @@ components:
         type:
           type: string
           example: null
-    ContractDefinitionRequestDto:
+    ContractDefinitionInputSchema:
       type: object
-      example: null
-      properties:
+      example:
         '@context':
-          type: object
-          example: null
+          edc: https://w3id.org/edc/v0.0.1/ns/
+        '@id': definition-id
+        accessPolicyId: asset-policy-id
+        contractPolicyId: contract-policy-id
+        assetsSelector: []
+      properties:
         '@id':
           type: string
           example: null
         '@type':
           type: string
-          example: null
+          example: https://w3id.org/edc/v0.0.1/ns/ContractDefinition
         accessPolicyId:
           type: string
           example: null
@@ -212,23 +215,27 @@ components:
           type: array
           example: null
           items:
-            $ref: '#/components/schemas/CriterionDto'
+            $ref: '#/components/schemas/CriterionSchema'
         contractPolicyId:
           type: string
           example: null
-    ContractDefinitionResponseDto:
+    ContractDefinitionOutputSchema:
       type: object
-      example: null
-      properties:
+      example:
         '@context':
-          type: object
-          example: null
+          edc: https://w3id.org/edc/v0.0.1/ns/
+        '@id': definition-id
+        accessPolicyId: asset-policy-id
+        contractPolicyId: contract-policy-id
+        assetsSelector: []
+        createdAt: 1688465655
+      properties:
         '@id':
           type: string
           example: null
         '@type':
           type: string
-          example: null
+          example: https://w3id.org/edc/v0.0.1/ns/ContractDefinition
         accessPolicyId:
           type: string
           example: null
@@ -236,7 +243,7 @@ components:
           type: array
           example: null
           items:
-            $ref: '#/components/schemas/CriterionDto'
+            $ref: '#/components/schemas/CriterionSchema'
         contractPolicyId:
           type: string
           example: null
@@ -244,16 +251,18 @@ components:
           type: integer
           format: int64
           example: null
-    CriterionDto:
+    CriterionSchema:
       type: object
-      example: null
-      properties:
+      example:
         '@context':
-          type: object
-          example: null
+          edc: https://w3id.org/edc/v0.0.1/ns/
+        operandLeft: fieldName
+        operator: =
+        operandRight: some value
+      properties:
         '@type':
           type: string
-          example: null
+          example: https://w3id.org/edc/v0.0.1/ns/CriterionDto
         operandLeft:
           type: object
           example: null
@@ -263,17 +272,15 @@ components:
         operator:
           type: string
           example: null
-    IdResponseDto:
+    IdResponseSchema:
       type: object
-      example: null
-      properties:
+      example:
         '@context':
-          type: object
-          example: null
+          edc: https://w3id.org/edc/v0.0.1/ns/
+        '@id': id-value
+        createdAt: 1688465655
+      properties:
         '@id':
-          type: string
-          example: null
-        '@type':
           type: string
           example: null
         createdAt:
@@ -335,21 +342,25 @@ components:
           - "FALSE"
           - "NULL"
           example: null
-    QuerySpecDto:
+    QuerySpecSchema:
       type: object
-      example: null
-      properties:
+      example:
         '@context':
-          type: object
-          example: null
+          edc: https://w3id.org/edc/v0.0.1/ns/
+        offset: 5
+        limit: 10
+        sortOrder: DESC
+        sortField: fieldName
+        criterion: []
+      properties:
         '@type':
           type: string
-          example: null
+          example: https://w3id.org/edc/v0.0.1/ns/QuerySpecDto
         filterExpression:
           type: array
           example: null
           items:
-            $ref: '#/components/schemas/CriterionDto'
+            $ref: '#/components/schemas/CriterionSchema'
         limit:
           type: integer
           format: int32


### PR DESCRIPTION
## What this PR changes/adds

Adds example to openapi specs for `ContractDefinition` api endpoints

## Why it does that

documentations

## Further notes

- introduced schema records that are used to create the specs
- doing this the `Dto` objects will become obsolete (and the related transformers too)
- the example json strings are tested doing deserialization / expansion / validation and transformation.

## Linked Issue(s)

Part of #3146

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md)._
