### PR TITLE
feat(test): convert all postgres tests to use testcontainers

### DIFF
--- a/core/common/junit/build.gradle.kts
+++ b/core/common/junit/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     runtimeOnly(libs.junit.jupiter.engine)
 
     implementation(libs.junit.pioneer)
+    implementation(libs.testcontainers.junit)
 }
 
 

--- a/core/common/junit/src/main/java/org/eclipse/edc/junit/annotations/PostgresqlDbIntegrationTest.java
+++ b/core/common/junit/src/main/java/org/eclipse/edc/junit/annotations/PostgresqlDbIntegrationTest.java
@@ -16,6 +16,7 @@
 package org.eclipse.edc.junit.annotations;
 
 import org.junit.jupiter.api.Tag;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -28,6 +29,7 @@ import java.lang.annotation.Target;
 @Target({ ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @IntegrationTest
+@Testcontainers
 @Tag("PostgresqlIntegrationTest")
 public @interface PostgresqlDbIntegrationTest {
 }

--- a/extensions/common/sql/sql-core/build.gradle.kts
+++ b/extensions/common/sql/sql-core/build.gradle.kts
@@ -32,6 +32,9 @@ dependencies {
     testFixturesImplementation(project(":spi:common:transaction-datasource-spi"))
     testFixturesImplementation(libs.mockito.core)
 
+    testFixturesImplementation(libs.testcontainers.junit)
+    testFixturesImplementation(libs.testcontainers.postgres)
+
 }
 
 

--- a/extensions/common/sql/sql-core/src/test/java/org/eclipse/edc/sql/SqlQueryExecutorIntegrationTest.java
+++ b/extensions/common/sql/sql-core/src/test/java/org/eclipse/edc/sql/SqlQueryExecutorIntegrationTest.java
@@ -15,7 +15,7 @@
 
 package org.eclipse.edc.sql;
 
-import org.eclipse.edc.junit.annotations.PostgresqlDbIntegrationTest;
+import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.spi.persistence.EdcPersistenceException;
 import org.eclipse.edc.sql.testfixtures.PostgresqlStoreSetupExtension;
 import org.jetbrains.annotations.NotNull;
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-@PostgresqlDbIntegrationTest
+@ComponentTest
 @ExtendWith(PostgresqlStoreSetupExtension.class)
 public class SqlQueryExecutorIntegrationTest {
 
@@ -114,5 +114,6 @@ public class SqlQueryExecutorIntegrationTest {
         return keyValue;
     }
 
-    private record KeyValue(String key, String value) { }
+    private record KeyValue(String key, String value) {
+    }
 }

--- a/extensions/common/sql/sql-lease/src/test/java/org/eclipse/edc/sql/lease/PostgresLeaseContextTest.java
+++ b/extensions/common/sql/sql-lease/src/test/java/org/eclipse/edc/sql/lease/PostgresLeaseContextTest.java
@@ -15,7 +15,7 @@
 
 package org.eclipse.edc.sql.lease;
 
-import org.eclipse.edc.junit.annotations.PostgresqlDbIntegrationTest;
+import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.sql.ResultSetMapper;
 import org.eclipse.edc.sql.SqlQueryExecutor;
 import org.eclipse.edc.sql.testfixtures.PostgresqlLocalInstance;
@@ -48,7 +48,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@PostgresqlDbIntegrationTest
+@ComponentTest
 @ExtendWith(PostgresqlStoreSetupExtension.class)
 class PostgresLeaseContextTest {
 
@@ -57,13 +57,13 @@ class PostgresLeaseContextTest {
 
     private final TransactionContext transactionContext = new NoopTransactionContext();
     private final TestEntityLeaseStatements dialect = new TestEntityLeaseStatements();
+    private final SqlQueryExecutor queryExecutor = new SqlQueryExecutor();
     private SqlLeaseContextBuilder builder;
     private SqlLeaseContext leaseContext;
-    private final SqlQueryExecutor queryExecutor = new SqlQueryExecutor();
 
     @BeforeAll
-    static void prepare() {
-        PostgresqlLocalInstance.createTestDatabase();
+    static void prepare(PostgresqlLocalInstance postgres) {
+        postgres.createDatabase();
     }
 
     @BeforeEach

--- a/extensions/common/vault/vault-hashicorp/src/test/java/org/eclipse/edc/vault/hashicorp/HashicorpVaultTest.java
+++ b/extensions/common/vault/vault-hashicorp/src/test/java/org/eclipse/edc/vault/hashicorp/HashicorpVaultTest.java
@@ -16,15 +16,16 @@ package org.eclipse.edc.vault.hashicorp;
 
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class HashicorpVaultTest {
     private static final String KEY = "key";
@@ -35,34 +36,34 @@ class HashicorpVaultTest {
 
     @BeforeEach
     void setup() {
-        vaultClient = Mockito.mock(HashicorpVaultClient.class);
-        var monitor = Mockito.mock(Monitor.class);
+        vaultClient = mock();
+        var monitor = mock(Monitor.class);
         vault = new HashicorpVault(vaultClient, monitor);
     }
 
     @Test
     void getSecretSuccess() {
         // prepare
-        Mockito.when(vaultClient.getSecretValue(KEY)).thenReturn(Result.success("test-secret"));
+        when(vaultClient.getSecretValue(KEY)).thenReturn(Result.success("test-secret"));
 
         // invoke
         var returnValue = vault.resolveSecret(KEY);
 
         // verify
-        verify(vaultClient, Mockito.times(1)).getSecretValue(KEY);
+        verify(vaultClient, times(1)).getSecretValue(KEY);
         assertThat(returnValue).isEqualTo("test-secret");
     }
 
     @Test
     void getSecretFailure() {
         // prepare
-        Mockito.when(vaultClient.getSecretValue(KEY)).thenReturn(Result.failure("test-failure"));
+        when(vaultClient.getSecretValue(KEY)).thenReturn(Result.failure("test-failure"));
 
         // invoke
         var returnValue = vault.resolveSecret(KEY);
 
         // verify
-        verify(vaultClient, Mockito.times(1)).getSecretValue(KEY);
+        verify(vaultClient, times(1)).getSecretValue(KEY);
         assertThat(returnValue).isNull();
     }
 
@@ -70,53 +71,53 @@ class HashicorpVaultTest {
     void setSecretSuccess() {
         // prepare
         var value = UUID.randomUUID().toString();
-        Mockito.when(vaultClient.setSecret(KEY, value)).thenReturn(Result.success(null));
+        when(vaultClient.setSecret(KEY, value)).thenReturn(Result.success(null));
 
         // invoke
         var returnValue = vault.storeSecret(KEY, value);
 
         // verify
-        verify(vaultClient, Mockito.times(1)).setSecret(KEY, value);
-        Assertions.assertTrue(returnValue.succeeded());
+        verify(vaultClient, times(1)).setSecret(KEY, value);
+        assertThat(returnValue.succeeded()).isTrue();
     }
 
     @Test
     void setSecretFailure() {
         // prepare
         var value = UUID.randomUUID().toString();
-        Mockito.when(vaultClient.setSecret(KEY, value)).thenReturn(Result.failure("test-failure"));
+        when(vaultClient.setSecret(KEY, value)).thenReturn(Result.failure("test-failure"));
 
         // invoke
         var returnValue = vault.storeSecret(KEY, value);
 
         // verify
-        verify(vaultClient, Mockito.times(1)).setSecret(KEY, value);
-        Assertions.assertTrue(returnValue.failed());
+        verify(vaultClient, times(1)).setSecret(KEY, value);
+        assertThat(returnValue.failed()).isTrue();
     }
 
     @Test
     void destroySecretSuccess() {
         // prepare
-        Mockito.when(vaultClient.destroySecret(KEY)).thenReturn(Result.success());
+        when(vaultClient.destroySecret(KEY)).thenReturn(Result.success());
 
         // invoke
         var returnValue = vault.deleteSecret(KEY);
 
         // verify
-        verify(vaultClient, Mockito.times(1)).destroySecret(KEY);
-        Assertions.assertTrue(returnValue.succeeded());
+        verify(vaultClient, times(1)).destroySecret(KEY);
+        assertThat(returnValue.succeeded()).isTrue();
     }
 
     @Test
     void destroySecretFailure() {
         // prepare
-        Mockito.when(vaultClient.destroySecret(KEY)).thenReturn(Result.failure("test-failure"));
+        when(vaultClient.destroySecret(KEY)).thenReturn(Result.failure("test-failure"));
 
         // invoke
         var returnValue = vault.deleteSecret(KEY);
 
         // verify
-        verify(vaultClient, Mockito.times(1)).destroySecret(KEY);
-        Assertions.assertTrue(returnValue.failed());
+        verify(vaultClient, times(1)).destroySecret(KEY);
+        assertThat(returnValue.failed()).isTrue();
     }
 }

--- a/extensions/common/vault/vault-hashicorp/src/test/java/org/eclipse/edc/vault/hashicorp/PathUtilTest.java
+++ b/extensions/common/vault/vault-hashicorp/src/test/java/org/eclipse/edc/vault/hashicorp/PathUtilTest.java
@@ -14,28 +14,35 @@
 
 package org.eclipse.edc.vault.hashicorp;
 
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import java.util.stream.Stream;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 class PathUtilTest {
 
-    private static Stream<Arguments> provideStringsForTrimsPathsCorrect() {
-        return Stream.of(
-                Arguments.of("v1/secret/data", "v1/secret/data"),
-                Arguments.of("/v1/secret/data", "v1/secret/data"),
-                Arguments.of("/v1/secret/data/", "v1/secret/data"),
-                Arguments.of("v1/secret/data/", "v1/secret/data"));
-    }
 
     @ParameterizedTest
-    @MethodSource("provideStringsForTrimsPathsCorrect")
+    @ArgumentsSource(CorrectPathsProvider.class)
     void trimsPathsCorrect(String path, String expected) {
         final String result = PathUtil.trimLeadingOrEndingSlash(path);
 
-        Assertions.assertEquals(expected, result);
+        assertThat(expected).isEqualTo(result);
+    }
+
+    private static class CorrectPathsProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                    Arguments.of("v1/secret/data", "v1/secret/data"),
+                    Arguments.of("/v1/secret/data", "v1/secret/data"),
+                    Arguments.of("/v1/secret/data/", "v1/secret/data"),
+                    Arguments.of("v1/secret/data/", "v1/secret/data"));
+        }
     }
 }

--- a/extensions/control-plane/store/sql/asset-index-sql/build.gradle.kts
+++ b/extensions/control-plane/store/sql/asset-index-sql/build.gradle.kts
@@ -31,6 +31,8 @@ dependencies {
     testImplementation(testFixtures(project(":extensions:common:sql:sql-core")))
     testImplementation(libs.postgres)
 
+    testImplementation(libs.testcontainers.junit)
+    testImplementation(libs.testcontainers.postgres)
 }
 
 

--- a/extensions/control-plane/store/sql/asset-index-sql/src/test/java/org/eclipse/edc/connector/store/sql/assetindex/PostgresAssetIndexTest.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/test/java/org/eclipse/edc/connector/store/sql/assetindex/PostgresAssetIndexTest.java
@@ -18,7 +18,7 @@ package org.eclipse.edc.connector.store.sql.assetindex;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.edc.connector.store.sql.assetindex.schema.BaseSqlDialectStatements;
 import org.eclipse.edc.connector.store.sql.assetindex.schema.postgres.PostgresDialectStatements;
-import org.eclipse.edc.junit.annotations.PostgresqlDbIntegrationTest;
+import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.policy.model.PolicyRegistrationTypes;
 import org.eclipse.edc.spi.testfixtures.asset.AssetIndexTestBase;
 import org.eclipse.edc.spi.types.TypeManager;
@@ -32,7 +32,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
-@PostgresqlDbIntegrationTest
+@ComponentTest
 @ExtendWith(PostgresqlStoreSetupExtension.class)
 class PostgresAssetIndexTest extends AssetIndexTestBase {
 

--- a/extensions/control-plane/store/sql/contract-definition-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/contractdefinition/PostgresContractDefinitionStoreTest.java
+++ b/extensions/control-plane/store/sql/contract-definition-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/contractdefinition/PostgresContractDefinitionStoreTest.java
@@ -20,7 +20,7 @@ import org.eclipse.edc.connector.contract.spi.testfixtures.offer.store.ContractD
 import org.eclipse.edc.connector.contract.spi.testfixtures.offer.store.TestFunctions;
 import org.eclipse.edc.connector.store.sql.contractdefinition.schema.BaseSqlDialectStatements;
 import org.eclipse.edc.connector.store.sql.contractdefinition.schema.postgres.PostgresDialectStatements;
-import org.eclipse.edc.junit.annotations.PostgresqlDbIntegrationTest;
+import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.policy.model.PolicyRegistrationTypes;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
@@ -42,7 +42,7 @@ import java.util.List;
 import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@PostgresqlDbIntegrationTest
+@ComponentTest
 @ExtendWith(PostgresqlStoreSetupExtension.class)
 class PostgresContractDefinitionStoreTest extends ContractDefinitionStoreTestBase {
 

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/PostgresContractNegotiationStoreTest.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/PostgresContractNegotiationStoreTest.java
@@ -17,7 +17,7 @@ package org.eclipse.edc.connector.store.sql.contractnegotiation.store;
 import org.eclipse.edc.connector.contract.spi.ContractId;
 import org.eclipse.edc.connector.contract.spi.testfixtures.negotiation.store.ContractNegotiationStoreTestBase;
 import org.eclipse.edc.connector.store.sql.contractnegotiation.store.schema.postgres.PostgresDialectStatements;
-import org.eclipse.edc.junit.annotations.PostgresqlDbIntegrationTest;
+import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.policy.model.Action;
 import org.eclipse.edc.policy.model.AtomicConstraint;
 import org.eclipse.edc.policy.model.LiteralExpression;
@@ -62,14 +62,14 @@ import static org.eclipse.edc.spi.query.Criterion.criterion;
  * This test aims to verify those parts of the contract negotiation store, that are specific to Postgres, e.g. JSON
  * query operators.
  */
-@PostgresqlDbIntegrationTest
+@ComponentTest
 @ExtendWith(PostgresqlStoreSetupExtension.class)
 class PostgresContractNegotiationStoreTest extends ContractNegotiationStoreTestBase {
 
     private static final String TEST_ASSET_ID = "test-asset-id";
+    private final Clock clock = Clock.systemUTC();
     private SqlContractNegotiationStore store;
     private LeaseUtil leaseUtil;
-    private final Clock clock = Clock.systemUTC();
 
     @BeforeEach
     void setUp(PostgresqlStoreSetupExtension extension, QueryExecutor queryExecutor) throws IOException {
@@ -257,7 +257,7 @@ class PostgresContractNegotiationStoreTest extends ContractNegotiationStoreTestB
                 .state(REQUESTED.code())
                 .type(CONSUMER)
                 .build()).forEach(store::save);
-        var criteria = new Criterion[]{hasState(REQUESTED.code()), new Criterion("type", "=", "CONSUMER")};
+        var criteria = new Criterion[]{ hasState(REQUESTED.code()), new Criterion("type", "=", "CONSUMER") };
 
         var result = store.nextNotLeased(10, criteria);
 

--- a/extensions/control-plane/store/sql/policy-definition-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/policydefinition/PostgresPolicyDefinitionStoreTest.java
+++ b/extensions/control-plane/store/sql/policy-definition-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/policydefinition/PostgresPolicyDefinitionStoreTest.java
@@ -18,7 +18,7 @@ import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
 import org.eclipse.edc.connector.policy.spi.testfixtures.store.PolicyDefinitionStoreTestBase;
 import org.eclipse.edc.connector.store.sql.policydefinition.store.SqlPolicyDefinitionStore;
 import org.eclipse.edc.connector.store.sql.policydefinition.store.schema.postgres.PostgresDialectStatements;
-import org.eclipse.edc.junit.annotations.PostgresqlDbIntegrationTest;
+import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.policy.model.PolicyRegistrationTypes;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.query.SortOrder;
@@ -44,7 +44,7 @@ import static org.eclipse.edc.spi.query.Criterion.criterion;
  * This test aims to verify those parts of the policy definition store, that are specific to Postgres, e.g. JSON query
  * operators.
  */
-@PostgresqlDbIntegrationTest
+@ComponentTest
 @ExtendWith(PostgresqlStoreSetupExtension.class)
 class PostgresPolicyDefinitionStoreTest extends PolicyDefinitionStoreTestBase {
 

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/transferprocess/PostgresTransferProcessStoreTest.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/transferprocess/PostgresTransferProcessStoreTest.java
@@ -20,7 +20,7 @@ import org.eclipse.edc.connector.transfer.spi.testfixtures.store.TestFunctions;
 import org.eclipse.edc.connector.transfer.spi.testfixtures.store.TransferProcessStoreTestBase;
 import org.eclipse.edc.connector.transfer.spi.types.ProvisionedResourceSet;
 import org.eclipse.edc.connector.transfer.spi.types.ResourceManifest;
-import org.eclipse.edc.junit.annotations.PostgresqlDbIntegrationTest;
+import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.policy.model.PolicyRegistrationTypes;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
@@ -49,7 +49,7 @@ import static org.eclipse.edc.connector.transfer.spi.testfixtures.store.TestFunc
 import static org.eclipse.edc.connector.transfer.spi.testfixtures.store.TestFunctions.createTransferProcess;
 import static org.eclipse.edc.connector.transfer.spi.testfixtures.store.TestFunctions.createTransferProcessBuilder;
 
-@PostgresqlDbIntegrationTest
+@ComponentTest
 @ExtendWith(PostgresqlStoreSetupExtension.class)
 class PostgresTransferProcessStoreTest extends TransferProcessStoreTestBase {
 

--- a/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/src/test/java/org/eclipse/edc/connector/dataplane/selector/store/sql/PostgresDataPlaneInstanceStoreTest.java
+++ b/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/src/test/java/org/eclipse/edc/connector/dataplane/selector/store/sql/PostgresDataPlaneInstanceStoreTest.java
@@ -19,7 +19,7 @@ import org.eclipse.edc.connector.dataplane.selector.spi.store.DataPlaneInstanceS
 import org.eclipse.edc.connector.dataplane.selector.spi.testfixtures.store.DataPlaneInstanceStoreTestBase;
 import org.eclipse.edc.connector.dataplane.selector.store.sql.schema.DataPlaneInstanceStatements;
 import org.eclipse.edc.connector.dataplane.selector.store.sql.schema.postgres.PostgresDataPlaneInstanceStatements;
-import org.eclipse.edc.junit.annotations.PostgresqlDbIntegrationTest;
+import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.sql.QueryExecutor;
 import org.eclipse.edc.sql.testfixtures.PostgresqlLocalInstance;
@@ -35,7 +35,7 @@ import java.nio.file.Paths;
 import java.sql.SQLException;
 
 
-@PostgresqlDbIntegrationTest
+@ComponentTest
 @ExtendWith(PostgresqlStoreSetupExtension.class)
 public class PostgresDataPlaneInstanceStoreTest extends DataPlaneInstanceStoreTestBase {
 
@@ -45,8 +45,8 @@ public class PostgresDataPlaneInstanceStoreTest extends DataPlaneInstanceStoreTe
     SqlDataPlaneInstanceStore store;
 
     @BeforeAll
-    static void prepare() {
-        PostgresqlLocalInstance.createTestDatabase();
+    static void prepare(PostgresqlLocalInstance postgres) {
+        postgres.createDatabase();
     }
 
     @BeforeEach

--- a/extensions/data-plane/store/sql/data-plane-store-sql/src/test/java/org/eclipse/edc/connector/dataplane/store/sql/PostgresDataPlaneStoreTest.java
+++ b/extensions/data-plane/store/sql/data-plane-store-sql/src/test/java/org/eclipse/edc/connector/dataplane/store/sql/PostgresDataPlaneStoreTest.java
@@ -18,7 +18,7 @@ import org.eclipse.edc.connector.dataplane.spi.store.DataPlaneStore;
 import org.eclipse.edc.connector.dataplane.spi.testfixtures.store.DataPlaneStoreTestBase;
 import org.eclipse.edc.connector.dataplane.store.sql.schema.DataPlaneStatements;
 import org.eclipse.edc.connector.dataplane.store.sql.schema.postgres.PostgresDataPlaneStatements;
-import org.eclipse.edc.junit.annotations.PostgresqlDbIntegrationTest;
+import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.sql.QueryExecutor;
 import org.eclipse.edc.sql.testfixtures.PostgresqlStoreSetupExtension;
@@ -32,7 +32,7 @@ import java.nio.file.Paths;
 import java.time.Clock;
 
 
-@PostgresqlDbIntegrationTest
+@ComponentTest
 @ExtendWith(PostgresqlStoreSetupExtension.class)
 public class PostgresDataPlaneStoreTest extends DataPlaneStoreTestBase {
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -90,6 +90,7 @@ swagger-annotations-jakarta = { module = "io.swagger.core.v3:swagger-annotations
 titaniumJsonLd = { module = "com.apicatalog:titanium-json-ld", version.ref = "titanium" }
 testcontainers-vault = { module = "org.testcontainers:vault", version.ref = "testcontainers" }
 testcontainers-junit = { module = "org.testcontainers:junit-jupiter", version.ref = "testcontainers" }
+testcontainers-postgres = { module = "org.testcontainers:postgresql", version.ref = "testcontainers" }
 
 # other technology extensions
 apache-commons-pool = { module = "org.apache.commons:commons-pool2", version.ref = "apacheCommonsPool2" }

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/EndToEndTransferPostgresqlTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/EndToEndTransferPostgresqlTest.java
@@ -29,8 +29,9 @@ import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.stream.Stream;
 
-import static org.eclipse.edc.sql.testfixtures.PostgresqlLocalInstance.PASSWORD;
-import static org.eclipse.edc.sql.testfixtures.PostgresqlLocalInstance.USER;
+import static org.eclipse.edc.test.e2e.PostgresConstants.JDBC_URL_PREFIX;
+import static org.eclipse.edc.test.e2e.PostgresConstants.PASSWORD;
+import static org.eclipse.edc.test.e2e.PostgresConstants.USER;
 
 @PostgresqlDbIntegrationTest
 class EndToEndTransferPostgresqlTest extends AbstractEndToEndTransfer {
@@ -94,7 +95,8 @@ class EndToEndTransferPostgresqlTest extends AbstractEndToEndTransfer {
     private static void createDatabase(Participant consumer) throws ClassNotFoundException, SQLException, IOException {
         Class.forName("org.postgresql.Driver");
 
-        PostgresqlLocalInstance.createDatabase(consumer.getName());
+        var helper = new PostgresqlLocalInstance(USER, PASSWORD, JDBC_URL_PREFIX, consumer.getName());
+        helper.createDatabase(consumer.getName());
 
         var scripts = Stream.of(
                         "asset-index-sql",

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/Participant.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/Participant.java
@@ -27,7 +27,6 @@ import org.eclipse.edc.jsonld.util.JacksonJsonLd;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.ConsoleMonitor;
 import org.eclipse.edc.spi.types.domain.edr.EndpointDataReference;
-import org.eclipse.edc.sql.testfixtures.PostgresqlLocalInstance;
 import org.hamcrest.Matcher;
 import org.jetbrains.annotations.NotNull;
 
@@ -425,24 +424,24 @@ public class Participant {
             {
                 put("edc.datasource.asset.name", "asset");
                 put("edc.datasource.asset.url", jdbcUrl());
-                put("edc.datasource.asset.user", PostgresqlLocalInstance.USER);
-                put("edc.datasource.asset.password", PostgresqlLocalInstance.PASSWORD);
+                put("edc.datasource.asset.user", PostgresConstants.USER);
+                put("edc.datasource.asset.password", PostgresConstants.PASSWORD);
                 put("edc.datasource.contractdefinition.name", "contractdefinition");
                 put("edc.datasource.contractdefinition.url", jdbcUrl());
-                put("edc.datasource.contractdefinition.user", PostgresqlLocalInstance.USER);
-                put("edc.datasource.contractdefinition.password", PostgresqlLocalInstance.PASSWORD);
+                put("edc.datasource.contractdefinition.user", PostgresConstants.USER);
+                put("edc.datasource.contractdefinition.password", PostgresConstants.PASSWORD);
                 put("edc.datasource.contractnegotiation.name", "contractnegotiation");
                 put("edc.datasource.contractnegotiation.url", jdbcUrl());
-                put("edc.datasource.contractnegotiation.user", PostgresqlLocalInstance.USER);
-                put("edc.datasource.contractnegotiation.password", PostgresqlLocalInstance.PASSWORD);
+                put("edc.datasource.contractnegotiation.user", PostgresConstants.USER);
+                put("edc.datasource.contractnegotiation.password", PostgresConstants.PASSWORD);
                 put("edc.datasource.policy.name", "policy");
                 put("edc.datasource.policy.url", jdbcUrl());
-                put("edc.datasource.policy.user", PostgresqlLocalInstance.USER);
-                put("edc.datasource.policy.password", PostgresqlLocalInstance.PASSWORD);
+                put("edc.datasource.policy.user", PostgresConstants.USER);
+                put("edc.datasource.policy.password", PostgresConstants.PASSWORD);
                 put("edc.datasource.transferprocess.name", "transferprocess");
                 put("edc.datasource.transferprocess.url", jdbcUrl());
-                put("edc.datasource.transferprocess.user", PostgresqlLocalInstance.USER);
-                put("edc.datasource.transferprocess.password", PostgresqlLocalInstance.PASSWORD);
+                put("edc.datasource.transferprocess.user", PostgresConstants.USER);
+                put("edc.datasource.transferprocess.password", PostgresConstants.PASSWORD);
             }
         };
         baseConfiguration.putAll(postgresConfiguration);
@@ -452,7 +451,7 @@ public class Participant {
 
     @NotNull
     public String jdbcUrl() {
-        return PostgresqlLocalInstance.JDBC_URL_PREFIX + name;
+        return PostgresConstants.JDBC_URL_PREFIX + name;
     }
 
     public Map<String, String> dataPlaneConfiguration() {

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/PostgresConstants.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/PostgresConstants.java
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.e2e;
+
+public interface PostgresConstants {
+    String USER = "postgres";
+    String PASSWORD = "password";
+    String JDBC_URL_PREFIX = "jdbc:postgresql://localhost:5432/";
+}


### PR DESCRIPTION
## What this PR changes/adds

This PR converts all `@PostgresqlDbIntegrationTest` instances to `@ComponentTests` using Testcontainers. All tests - **except E2e**, that is. 

Converting the E2E tests over seemed to be quite a large undertaking, given how we are using test extensions and all the static initialization stuff etc. If needed, we can do it in a subsequent PR. 

Consequently, the `@PostgresqlDbIntegrationTest` annotation is only used for E2E tests anymore.

## Why it does that

Decision to use test containers.

## Further notes

- .
 
## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md)._
