### PR TITLE
feat: make http client timeouts configurable

### DIFF
--- a/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/CoreDefaultServicesExtension.java
+++ b/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/CoreDefaultServicesExtension.java
@@ -48,8 +48,7 @@ import java.util.concurrent.Executors;
 public class CoreDefaultServicesExtension implements ServiceExtension {
 
     public static final String NAME = "Core Default Services";
-    public static final String SECRET_SEPARATOR = ";";
-    public static final String SECRET_KEY_VAULE_SEPARATOR = ":";
+
     /**
      * An optional OkHttp {@link EventListener} that can be used to instrument OkHttp client for collecting metrics.
      */

--- a/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/base/OkHttpClientFactory.java
+++ b/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/base/OkHttpClientFactory.java
@@ -66,7 +66,7 @@ public class OkHttpClientFactory {
 
         ofNullable(okHttpEventListener).ifPresent(builder::eventListener);
 
-        if (context.getSetting(EDC_HTTP_ENFORCE_HTTPS, null) == null) {
+        if (context.getSetting(EDC_HTTP_ENFORCE_HTTPS, null) != null) {
             context.getMonitor().warning(format("Configuration setting %s has been deprecated, please use %s instead", EDC_HTTP_ENFORCE_HTTPS, EDC_HTTP_CLIENT_HTTPS_ENFORCE));
         }
 

--- a/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/base/OkHttpClientFactory.java
+++ b/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/base/OkHttpClientFactory.java
@@ -24,15 +24,29 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
 
+import static java.lang.Integer.parseInt;
 import static java.lang.String.format;
 import static java.util.Optional.ofNullable;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class OkHttpClientFactory {
 
-    @Setting(value = "If true, enable HTTPS call enforcement. Default value is 'false'", type = "boolean")
+    private static final String DEFAULT_TIMEOUT = "30";
+    private static final String DEFAULT_HTTPS_ENFORCE = "false";
+
+    @Setting(value = "DEPRECATED. If true, enable HTTPS call enforcement. Default value is 'false'", type = "boolean")
+    @Deprecated(since = "0.1.3")
     public static final String EDC_HTTP_ENFORCE_HTTPS = "edc.http.enforce-https";
+
+    @Setting(value = "If true, enable HTTPS call enforcement.", defaultValue = DEFAULT_HTTPS_ENFORCE, type = "boolean")
+    public static final String EDC_HTTP_CLIENT_HTTPS_ENFORCE = "edc.http.client.https.enforce";
+
+    @Setting(value = "HTTP Client connect timeout, in seconds", defaultValue = DEFAULT_TIMEOUT, type = "int")
+    public static final String EDC_HTTP_CLIENT_TIMEOUT_CONNECT = "edc.http.client.timeout.connect";
+
+    @Setting(value = "HTTP Client read timeout, in seconds", defaultValue = DEFAULT_TIMEOUT, type = "int")
+    public static final String EDC_HTTP_CLIENT_TIMEOUT_READ = "edc.http.client.timeout.read";
 
     /**
      * Create an OkHttpClient instance
@@ -43,13 +57,20 @@ public class OkHttpClientFactory {
      */
     @NotNull
     public static OkHttpClient create(ServiceExtensionContext context, EventListener okHttpEventListener) {
+        var connectTimeout = context.getSetting(EDC_HTTP_CLIENT_TIMEOUT_CONNECT, parseInt(DEFAULT_TIMEOUT));
+        var readTimeout = context.getSetting(EDC_HTTP_CLIENT_TIMEOUT_READ, parseInt(DEFAULT_TIMEOUT));
+
         var builder = new OkHttpClient.Builder()
-                .connectTimeout(30, TimeUnit.SECONDS)
-                .readTimeout(30, TimeUnit.SECONDS);
+                .connectTimeout(connectTimeout, SECONDS)
+                .readTimeout(readTimeout, SECONDS);
 
         ofNullable(okHttpEventListener).ifPresent(builder::eventListener);
 
-        var enforceHttps = context.getSetting(EDC_HTTP_ENFORCE_HTTPS, false);
+        if (context.getSetting(EDC_HTTP_ENFORCE_HTTPS, null) == null) {
+            context.getMonitor().warning(format("Configuration setting %s has been deprecated, please use %s instead", EDC_HTTP_ENFORCE_HTTPS, EDC_HTTP_CLIENT_HTTPS_ENFORCE));
+        }
+
+        var enforceHttps = context.getSetting(EDC_HTTP_CLIENT_HTTPS_ENFORCE, context.getSetting(EDC_HTTP_ENFORCE_HTTPS, Boolean.parseBoolean(DEFAULT_HTTPS_ENFORCE)));
         if (enforceHttps) {
             builder.addInterceptor(new EnforceHttps());
         } else {

--- a/core/common/connector-core/src/test/java/org/eclipse/edc/connector/core/base/OkHttpClientFactoryTest.java
+++ b/core/common/connector-core/src/test/java/org/eclipse/edc/connector/core/base/OkHttpClientFactoryTest.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.eclipse.edc.connector.core.base.OkHttpClientFactory.EDC_HTTP_CLIENT_HTTPS_ENFORCE;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -46,8 +47,8 @@ class OkHttpClientFactoryTest {
 
     private static final String HTTP_URL = "http://localhost:11111";
     private static final String HTTPS_URL = "https://localhost:11111";
-    private final Monitor monitor = mock(Monitor.class);
-    private final EventListener eventListener = mock(EventListener.class);
+    private final Monitor monitor = mock();
+    private final EventListener eventListener = mock();
 
     @Test
     void shouldPrintLogIfHttpsNotEnforced() {
@@ -64,7 +65,7 @@ class OkHttpClientFactoryTest {
 
     @Test
     void shouldEnforceHttpsCalls() {
-        var config = Map.of("edc.http.enforce-https", "true");
+        var config = Map.of(EDC_HTTP_CLIENT_HTTPS_ENFORCE, "true");
         var context = createContextWithConfig(config);
 
         var okHttpClient = OkHttpClientFactory.create(context, eventListener)


### PR DESCRIPTION
## What this PR changes/adds

Make connect and read timeout configurable

## Why it does that

Configurability

## Further notes

- added the `client` part in the setting path to make it more self-descripting, deprecated the old "https enforcement" config value and add a new one replacing it 

## Linked Issue(s)

Closes #3273 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md)._
