### PR TITLE
docs: add guidelines about committer retirements

### DIFF
--- a/COMMITTERS.md
+++ b/COMMITTERS.md
@@ -1,0 +1,23 @@
+## Committers
+Committers decide what code goes into the code base, they decide how a project builds, and they ultimately decide what gets delivered to the adopter community. With awesome power, comes awesome responsibility, and so the Open Source Rules of Engagement described by the Eclipse Foundation Development Process puts meritocracy on equal footing with transparency and openness: becoming a committer isn’t necessarily hard, but it does require a demonstration of merit:
+- Operate in an open, transparent, and meritocratic manner;
+- Write code (and other project content) and push it directly into the project’s source code repository;
+- Review contributions (merge and pull requests) from contributors;
+- Engage in the Intellectual Property Due Diligence Process;
+- Vote in committer and project lead elections;
+- Engage in the project planning process; and
+- Otherwise represent the interests of the open source project.
+
+For Eclipse projects (and the open source world in general), committers are the ones who hold the keys. Committers are either appointed at the time of project creation or elected by the existing project team.
+
+## Inactive Committers
+
+It's inevitable, but there are times when someone shifts focus, changes jobs, or retires from a particular area of the project (for a period of time). These people may be experts in certain areas of the codebase or reference persons for certain topics but can no longer devote the time necessary to take on the responsibilities of a committer role.  However, being a Committer within an Eclipse Foundation project comes with an elevated set of permissions. These capabilities should not be used by those that are not familiar with the current state of the EDC project.
+
+From time to time, it is necessary to prune inactive folks. A core principle in maintaining a healthy community is encouraging active participation. Those listed as a Committer of the project have a higher activity requirement, as they directly impact the ability of others to contribute. Therefore, members with an extended period away from the project with no activity will be retired from their role of Committer
+in the EDC and will be required to go through the meritocratic process again after re-familiarizing themselves with the current state. Committers, that can no longer devote the time are kindly asked to follow the retirement process of the Eclipse Foundation.
+
+According to the EF rules, before retiring a committer, the project’s community will be informed of the change and the Committer must be given a chance to defend retaining their status via the project’s dev-list.
+
+To honor the contributions, retired committers are listed as Historic Committers on a project’s Who’s Involved page. When a committer returns to being more active in that area, they may be promoted back on the decision of the committers' committee. However, after an extended period away from the project with no activity those would need demonstrably have to re-familiarize themselves with the current state before being able to contribute effectively.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,6 +176,35 @@ If an issue labeled with `Bug` and `FlakyTest` is assigned to you, please priori
 We are taking the quality of our code very serious and reporting on flaky tests is an important step toward improvement
 in that area.
 
+## Non-code Contributions
+
+The following list shows examples of non-code contributions which, however, are not limited to:
+
+- Strengthen the EDC brand
+  - Evangelizing the project
+  - Developing community
+- Community education
+  - Answering questions on Github, Discord, Youtube, etc.
+  - Onboarding new contributors
+  - Contribute to EDC docs
+  - Doing hands-on sessions and demos
+- Outward-facing community work
+  - Hosting meetups (Q&A) and general evangelism
+  - Presentation of work to meetups
+  - Social Media
+  - Non-Documentation writing (Blogs, Articles, Interviews)
+- Branding/Visual Communication
+  - Website management
+  - Visuals (diagrams, infographic design, icon design)
+- Management of communication tools (at the discretion of project maintainers)
+  - Mailing list moderation
+  - Discord management
+  - Calendar management
+- Event management
+  - Host community events
+  - Support summits and hackathons
+  - Staffing EDC booths at conferences
+
 ## Project and Milestone Planning
 
 We use milestones to set a common focus for a period of 6 to 8 weeks. 

--- a/docs/developer/decision-records/2023-07-06-committer-retirement-guidelines/README.md
+++ b/docs/developer/decision-records/2023-07-06-committer-retirement-guidelines/README.md
@@ -1,0 +1,22 @@
+# Adding guidelines for committers retirement
+
+## Decision
+[Committer of the EDC](https://projects.eclipse.org/projects/technology.edc/who) project have a higher activity requirement, as they directly impact the ability of others to contribute. Therefore, committers with an extended period away from the project with no activity will be retired from their role of _"committer"_ in the EDC and will be required to go through the meritocratic process again after re-familiarizing themselves with the current state.
+
+Inactive _"committers"_ are defined as members of the EDC Committers with no contributions across any repository within 6 months (according to EF’s suggestion), or recognizable non-code contributions to the project. _"Committers"_ are required to show up in Committer-Meetings.
+
+NB: The EF tool does not consider non-code contributions. If a non-code contributing member is accidentally removed this way, they may open an issue to quickly be re-instated.
+
+## Rationale
+
+According to the [Eclipse Foundation Project Handbook](https://www.eclipse.org/projects/handbook/#roles-cm), _"committers"_ are the ones who hold the keys. _"Committers"_ are either appointed at the time of project creation, or elected by the existing project team.  They decide what code goes into the code base, decide how a project builds, and they ultimately decide what gets delivered to the adopter community. With awesome power, comes awesome responsibility, and so the Open Source Rules of Engagement described by the Eclipse Foundation Development Process, puts meritocracy on equal footing with transparency and openness:
+
+> being a _"committers"_ does require a demonstration of merit.
+
+Some committers may not be able to continue contributing actively in the project for a variety of reasons. A statement on how a retirement of these _"committers"_ is handled in the EDC project is missing to the point.
+
+## Approach
+
+- Evaluation and initiating the retirement process of _"committers"_ is done by the EDC Committers' Roundtable on a regular basis
+- Evaluation criteria based on code and non-code contributions are described in [COMMITTERS.md](../../../../COMMITTERS.md) and [CONTRIBUTING.md](../../../../CONTRIBUTING.md)
+- The retirement process is started for identified inactive committers for an initial clean-up after the decision-record is accepted


### PR DESCRIPTION
## What this PR changes/adds

Add a decision-record about guidelines how the retirement of inactive committers is handled in the EDC project.

## Why it does that

No documentation of the retirement process and obligations of committers available.

## Further notes

As prior discussed and agreed within the Committers Roundtable
