### PR TITLE
feat(ci): publish OpenAPI specs on releases

### DIFF
--- a/.github/workflows/apidoc.yaml
+++ b/.github/workflows/apidoc.yaml
@@ -2,6 +2,12 @@ name: Verify and Publish OpenAPI Specs
 
 on:
   workflow_call:
+    inputs:
+      version:
+        required: true
+        description: "The version under which the API should be published"
+        type: string
+
   push:
   pull_request:
     branches: [ main ]
@@ -68,6 +74,7 @@ jobs:
       rootDir: resources/openapi/yaml/${{ matrix.apiGroup }}
       SWAGGERHUB_API_KEY: ${{ secrets.SWAGGERHUB_TOKEN }}
       SWAGGERHUB_USER: ${{ secrets.SWAGGERHUB_USER }}
+      VERSION: ${{ github.event.inputs.version || inputs.version }}
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-build
@@ -76,7 +83,12 @@ jobs:
       # merge together all api groups
       - name: Generate API Specs
         run: |
-          ./gradlew -PapiTitle="${{ matrix.apiGroup }}" -PapiDescription="REST API documentation for the ${{ matrix.apiGroup }}" :mergeApiSpec --input=${{ env.rootDir }} --output=${{ matrix.apiGroup }}.yaml
+          # give option to override
+          cmd=""
+          if [ ! -z $VERSION ]; then
+            cmd="-Pversion=$VERSION"
+          fi
+          ./gradlew ${cmd} -PapiTitle="${{ matrix.apiGroup }}" -PapiDescription="REST API documentation for the ${{ matrix.apiGroup }}" :mergeApiSpec --input=${{ env.rootDir }} --output=${{ matrix.apiGroup }}.yaml
 
       # install swaggerhub CLI
       - name: Install SwaggerHub CLI
@@ -91,7 +103,10 @@ jobs:
       # Post snapshots of the API to SwaggerHub as "unpublished", because published APIs cannot be overwritten
       - name: Publish API Specs to SwaggerHub
         run: |
-          if [[ $(grep "version" gradle.properties  | awk -F= '{print $2}') != *-SNAPSHOT ]]; then
+          # coalesce $VERSION, or whatever's stored in gradle.properties
+          vers=${VERSION:-$(grep "version" gradle.properties  | awk -F= '{print $2}')}
+          
+          if [[ $vers != *-SNAPSHOT ]]; then
             echo "no snapshot, will set the API to 'published'";
             swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/${{ matrix.apiGroup}} -f ${{ matrix.apiGroup }}.yaml --visibility=public --published=publish
           else

--- a/.github/workflows/apidoc.yaml
+++ b/.github/workflows/apidoc.yaml
@@ -64,7 +64,7 @@ jobs:
 
   Publish-To-SwaggerHub:
     # do NOT run on forks or on PRs. The Org ("edc") is unique all across SwaggerHub
-    if: github.repository == 'eclipse-edc/Connector' && github.event_name == 'push' && github.ref_name == 'main'
+    #    if: github.repository == 'eclipse-edc/Connector' && github.event_name == 'push' && github.ref_name == 'main'
     runs-on: ubuntu-latest
     needs: [ Verify-OpenAPI-Definitions ]
     strategy:

--- a/.github/workflows/apidoc.yaml
+++ b/.github/workflows/apidoc.yaml
@@ -64,7 +64,7 @@ jobs:
 
   Publish-To-SwaggerHub:
     # do NOT run on forks or on PRs. The Org ("edc") is unique all across SwaggerHub
-    if: github.repository == 'eclipse-edc/Connector' && github.event_name == 'push' && github.ref_name == 'main'
+    if: github.repository == 'eclipse-edc/Connector' && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     needs: [ Verify-OpenAPI-Definitions ]
     strategy:

--- a/.github/workflows/apidoc.yaml
+++ b/.github/workflows/apidoc.yaml
@@ -64,7 +64,7 @@ jobs:
 
   Publish-To-SwaggerHub:
     # do NOT run on forks or on PRs. The Org ("edc") is unique all across SwaggerHub
-    #    if: github.repository == 'eclipse-edc/Connector' && github.event_name == 'push' && github.ref_name == 'main'
+    if: github.repository == 'eclipse-edc/Connector' && github.event_name == 'push' && github.ref_name == 'main'
     runs-on: ubuntu-latest
     needs: [ Verify-OpenAPI-Definitions ]
     strategy:

--- a/.github/workflows/apidoc.yaml
+++ b/.github/workflows/apidoc.yaml
@@ -1,6 +1,7 @@
 name: Verify and Publish OpenAPI Specs
 
 on:
+  workflow_call:
   push:
   pull_request:
     branches: [ main ]
@@ -87,7 +88,13 @@ jobs:
         run: |
           swaggerhub api:create ${{ env.SWAGGERHUB_USER }}/${{ matrix.apiGroup}} -f ${{ matrix.apiGroup }}.yaml --visibility=public --published=unpublish
 
-      # Post the API to SwaggerHub as "unpublished", because published APIs cannot be overwritten
+      # Post snapshots of the API to SwaggerHub as "unpublished", because published APIs cannot be overwritten
       - name: Publish API Specs to SwaggerHub
         run: |
-          swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/${{ matrix.apiGroup}} -f ${{ matrix.apiGroup }}.yaml --visibility=public --published=unpublish
+          if [[ $(grep "version" gradle.properties  | awk -F= '{print $2}') != *-SNAPSHOT ]]; then
+            echo "no snapshot, will set the API to 'published'";
+            swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/${{ matrix.apiGroup}} -f ${{ matrix.apiGroup }}.yaml --visibility=public --published=publish
+          else
+            echo "snapshot, will set the API to 'unpublished'";
+            swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/${{ matrix.apiGroup}} -f ${{ matrix.apiGroup }}.yaml --visibility=public --published=unpublish
+          fi

--- a/.github/workflows/release-edc.yml
+++ b/.github/workflows/release-edc.yml
@@ -48,6 +48,8 @@ jobs:
     if: ${{ !endsWith( needs.Prepare-Release.outputs.edc-version, '-SNAPSHOT') }}
     uses: ./.github/workflows/apidoc.yaml
     secrets: inherit
+    with:
+      version: ${{ env.EDC_VERSION }}
 
   Github-Release:
     # cannot use the workflow-level env yet as it does not yet exist, must take output from previous job

--- a/.github/workflows/release-edc.yml
+++ b/.github/workflows/release-edc.yml
@@ -41,6 +41,14 @@ jobs:
     outputs:
       edc-version: ${{ env.EDC_VERSION }}
 
+  # Calls the openapi workflow to publish the api spec
+  Publish-OpenApi:
+    needs:
+      - Prepare-Release
+    if: ${{ !endsWith( needs.Prepare-Release.outputs.edc-version, '-SNAPSHOT') }}
+    uses: ./.github/workflows/apidoc.yaml
+    secrets: inherit
+
   Github-Release:
     # cannot use the workflow-level env yet as it does not yet exist, must take output from previous job
     if: ${{ !endsWith( needs.Prepare-Release.outputs.edc-version, '-SNAPSHOT') }}

--- a/.github/workflows/release-edc.yml
+++ b/.github/workflows/release-edc.yml
@@ -49,7 +49,7 @@ jobs:
     uses: ./.github/workflows/apidoc.yaml
     secrets: inherit
     with:
-      version: ${{ env.EDC_VERSION }}
+      version: ${{ needs.Prepare-Release.outputs.edc-version }}
 
   Github-Release:
     # cannot use the workflow-level env yet as it does not yet exist, must take output from previous job


### PR DESCRIPTION
## What this PR changes/adds

This PR lets the `release-edc` workflow call the `apidoc` workflow, which publishes the OpenAPI specs to Swaggerhub.

If the `apidoc` workflow is invoked passing in a non-snapshot version, the API is set to `"published"` on SwaggerHub, which means it cannot be altered afterwards.

## Why it does that

We should publish immutable OpenAPI documents of our release versions.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #2834 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md)._
