### PR TITLE
refactor: get rid of `managedResource`

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -53,6 +53,7 @@ jobs:
             exit 1
           fi
       - name: print expected DEPENDENCIES file
+        run: |
           cat DEPENDENCIES-gen
       - name: Check for differences
         run: |

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -34,6 +34,7 @@ maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-prov
 maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.15.2, Apache-2.0, approved, #9236
 maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.14.1, Apache-2.0, approved, #5308
 maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.15.2, Apache-2.0, approved, #9241
+maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.14.2, Apache-2.0, approved, #7931
 maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.15.2, Apache-2.0, approved, #7929
 maven/mavencentral/com.fasterxml.uuid/java-uuid-generator/4.1.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.github.cliftonlabs/json-simple/3.0.2, Apache-2.0, approved, clearlydefined
@@ -274,18 +275,14 @@ maven/mavencentral/org.jetbrains/annotations/13.0, Apache-2.0, approved, clearly
 maven/mavencentral/org.jetbrains/annotations/17.0.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.jetbrains/annotations/24.0.1, Apache-2.0, approved, #7417
 maven/mavencentral/org.junit-pioneer/junit-pioneer/2.0.1, EPL-2.0, approved, clearlydefined
-maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.9.2, EPL-2.0, approved, #3133
 maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.9.3, EPL-2.0, approved, #3133
-maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.9.2, EPL-2.0, approved, #3125
 maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.9.3, EPL-2.0, approved, #3125
-maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.9.2, EPL-2.0, approved, #3134
 maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.9.3, EPL-2.0, approved, #3134
-maven/mavencentral/org.junit.platform/junit-platform-commons/1.9.2, EPL-2.0, approved, #3130
 maven/mavencentral/org.junit.platform/junit-platform-commons/1.9.3, EPL-2.0, approved, #3130
-maven/mavencentral/org.junit.platform/junit-platform-engine/1.9.2, EPL-2.0, approved, #3128
 maven/mavencentral/org.junit.platform/junit-platform-engine/1.9.3, EPL-2.0, approved, #3128
-maven/mavencentral/org.junit.platform/junit-platform-launcher/1.9.2, EPL-2.0, approved, #3132
+maven/mavencentral/org.junit.platform/junit-platform-launcher/1.9.3, EPL-2.0, approved, #3132
 maven/mavencentral/org.junit/junit-bom/5.9.2, EPL-2.0, approved, #4711
+maven/mavencentral/org.junit/junit-bom/5.9.3, EPL-2.0, approved, #4711
 maven/mavencentral/org.jvnet.mimepull/mimepull/1.9.15, CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, CQ21484
 maven/mavencentral/org.latencyutils/LatencyUtils/2.0.3, BSD-2-Clause, approved, CQ17408
 maven/mavencentral/org.lz4/lz4-java/1.8.0, Apache-2.0, approved, clearlydefined

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -34,7 +34,6 @@ maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-prov
 maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.15.2, Apache-2.0, approved, #9236
 maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.14.1, Apache-2.0, approved, #5308
 maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.15.2, Apache-2.0, approved, #9241
-maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.14.2, Apache-2.0, approved, #7931
 maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.15.2, Apache-2.0, approved, #7929
 maven/mavencentral/com.fasterxml.uuid/java-uuid-generator/4.1.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.github.cliftonlabs/json-simple/3.0.2, Apache-2.0, approved, clearlydefined
@@ -275,14 +274,18 @@ maven/mavencentral/org.jetbrains/annotations/13.0, Apache-2.0, approved, clearly
 maven/mavencentral/org.jetbrains/annotations/17.0.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.jetbrains/annotations/24.0.1, Apache-2.0, approved, #7417
 maven/mavencentral/org.junit-pioneer/junit-pioneer/2.0.1, EPL-2.0, approved, clearlydefined
+maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.9.2, EPL-2.0, approved, #3133
 maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.9.3, EPL-2.0, approved, #3133
+maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.9.2, EPL-2.0, approved, #3125
 maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.9.3, EPL-2.0, approved, #3125
+maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.9.2, EPL-2.0, approved, #3134
 maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.9.3, EPL-2.0, approved, #3134
+maven/mavencentral/org.junit.platform/junit-platform-commons/1.9.2, EPL-2.0, approved, #3130
 maven/mavencentral/org.junit.platform/junit-platform-commons/1.9.3, EPL-2.0, approved, #3130
+maven/mavencentral/org.junit.platform/junit-platform-engine/1.9.2, EPL-2.0, approved, #3128
 maven/mavencentral/org.junit.platform/junit-platform-engine/1.9.3, EPL-2.0, approved, #3128
-maven/mavencentral/org.junit.platform/junit-platform-launcher/1.9.3, EPL-2.0, approved, #3132
+maven/mavencentral/org.junit.platform/junit-platform-launcher/1.9.2, EPL-2.0, approved, #3132
 maven/mavencentral/org.junit/junit-bom/5.9.2, EPL-2.0, approved, #4711
-maven/mavencentral/org.junit/junit-bom/5.9.3, EPL-2.0, approved, #4711
 maven/mavencentral/org.jvnet.mimepull/mimepull/1.9.15, CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, CQ21484
 maven/mavencentral/org.latencyutils/LatencyUtils/2.0.3, BSD-2-Clause, approved, CQ17408
 maven/mavencentral/org.lz4/lz4-java/1.8.0, Apache-2.0, approved, clearlydefined

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessEventDispatchTest.java
@@ -111,7 +111,6 @@ public class TransferProcessEventDispatchTest {
                 .assetId("assetId")
                 .destinationType("any")
                 .protocol("test")
-                .managedResources(false)
                 .connectorAddress("http://an/address")
                 .contractId("contractId")
                 .build();
@@ -173,7 +172,6 @@ public class TransferProcessEventDispatchTest {
                 .assetId("assetId")
                 .destinationType("any")
                 .protocol("test")
-                .managedResources(false)
                 .connectorAddress("http://an/address")
                 .contractId("contractId")
                 .build();
@@ -200,7 +198,6 @@ public class TransferProcessEventDispatchTest {
                 .assetId("assetId")
                 .destinationType("any")
                 .protocol("test")
-                .managedResources(true)
                 .connectorAddress("http://an/address")
                 .build();
 
@@ -225,7 +222,6 @@ public class TransferProcessEventDispatchTest {
                 .assetId("assetId")
                 .destinationType("any")
                 .protocol("test")
-                .managedResources(false)
                 .connectorAddress("http://an/address")
                 .build();
 

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/provision/ResourceManifestGeneratorImpl.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/provision/ResourceManifestGeneratorImpl.java
@@ -57,9 +57,6 @@ public class ResourceManifestGeneratorImpl implements ResourceManifestGenerator 
 
     @Override
     public Result<ResourceManifest> generateConsumerResourceManifest(DataRequest dataRequest, Policy policy) {
-        if (!dataRequest.isManagedResources()) {
-            return Result.success(ResourceManifest.Builder.newInstance().build());
-        }
         var definitions = consumerGenerators.stream()
                 .filter(generator -> generator.canGenerate(dataRequest, policy))
                 .map(generator -> generator.generate(dataRequest, policy))

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImplIntegrationTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImplIntegrationTest.java
@@ -148,10 +148,9 @@ class TransferProcessManagerImplIntegrationTest {
     }
 
     private TransferProcess.Builder createInitialTransferProcess() {
-        String processId = UUID.randomUUID().toString();
+        var processId = UUID.randomUUID().toString();
         var dataRequest = DataRequest.Builder.newInstance()
                 .id(processId)
-                .managedResources(true)
                 .destinationType("test-type")
                 .contractId(UUID.randomUUID().toString())
                 .build();

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/provision/ResourceManifestGeneratorImplTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/provision/ResourceManifestGeneratorImplTest.java
@@ -55,7 +55,7 @@ class ResourceManifestGeneratorImplTest {
 
     @Test
     void shouldGenerateResourceManifestForConsumerManagedTransferProcess() {
-        var dataRequest = createDataRequest(true);
+        var dataRequest = createDataRequest();
         var resourceDefinition = TestResourceDefinition.Builder.newInstance().id(UUID.randomUUID().toString()).build();
         when(consumerGenerator.canGenerate(any(), any())).thenReturn(true);
         when(consumerGenerator.generate(any(), any())).thenReturn(resourceDefinition);
@@ -70,7 +70,7 @@ class ResourceManifestGeneratorImplTest {
 
     @Test
     void shouldGenerateEmptyResourceManifestForNotGeneratedFilter() {
-        var dataRequest = createDataRequest(true);
+        var dataRequest = createDataRequest();
         when(consumerGenerator.canGenerate(any(), any())).thenReturn(false);
         when(policyEngine.evaluate(any(), any(), isA(PolicyContext.class))).thenReturn(Result.success());
 
@@ -81,20 +81,8 @@ class ResourceManifestGeneratorImplTest {
     }
 
     @Test
-    void shouldGenerateEmptyResourceManifestForEmptyConsumerNotManagedTransferProcess() {
-        var dataRequest = createDataRequest(false);
-
-        var result = generator.generateConsumerResourceManifest(dataRequest, policy);
-
-        assertThat(result.succeeded()).isTrue();
-        assertThat(result.getContent().getDefinitions()).isEmpty();
-        verifyNoInteractions(consumerGenerator);
-        verifyNoInteractions(providerGenerator);
-    }
-
-    @Test
     void shouldReturnFailedResultForConsumerWhenPolicyEvaluationFailed() {
-        var dataRequest = createDataRequest(true);
+        var dataRequest = createDataRequest();
         var resourceDefinition = TestResourceDefinition.Builder.newInstance().id(UUID.randomUUID().toString()).build();
         when(consumerGenerator.generate(any(), any())).thenReturn(resourceDefinition);
         when(policyEngine.evaluate(any(), any(), isA(PolicyContext.class))).thenReturn(Result.failure("error"));
@@ -106,7 +94,7 @@ class ResourceManifestGeneratorImplTest {
 
     @Test
     void shouldGenerateResourceManifestForProviderTransferProcess() {
-        var process = createDataRequest(false);
+        var process = createDataRequest();
         var resourceDefinition = TestResourceDefinition.Builder.newInstance().id(UUID.randomUUID().toString()).build();
         when(providerGenerator.canGenerate(any(), any(), any())).thenReturn(true);
         when(providerGenerator.generate(any(), any(), any())).thenReturn(resourceDefinition);
@@ -119,7 +107,7 @@ class ResourceManifestGeneratorImplTest {
 
     @Test
     void shouldGenerateEmptyResourceManifestForProviderTransferProcess() {
-        var process = createDataRequest(false);
+        var process = createDataRequest();
         when(providerGenerator.canGenerate(any(), any(), any())).thenReturn(false);
 
         var resourceManifest = generator.generateProviderResourceManifest(process, dataAddress, policy);
@@ -128,9 +116,8 @@ class ResourceManifestGeneratorImplTest {
         verifyNoInteractions(consumerGenerator);
     }
 
-
-    private DataRequest createDataRequest(boolean managedResources) {
+    private DataRequest createDataRequest() {
         var destination = DataAddress.Builder.newInstance().type("any").build();
-        return DataRequest.Builder.newInstance().managedResources(managedResources).dataDestination(destination).build();
+        return DataRequest.Builder.newInstance().dataDestination(destination).build();
     }
 }

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/model/TransferRequestDto.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/model/TransferRequestDto.java
@@ -34,7 +34,6 @@ public class TransferRequestDto {
     public static final String EDC_TRANSFER_REQUEST_DTO_CONNECTOR_ADDRESS = EDC_NAMESPACE + "connectorAddress";
     public static final String EDC_TRANSFER_REQUEST_DTO_CONTRACT_ID = EDC_NAMESPACE + "contractId";
     public static final String EDC_TRANSFER_REQUEST_DTO_DATA_DESTINATION = EDC_NAMESPACE + "dataDestination";
-    public static final String EDC_TRANSFER_REQUEST_DTO_MANAGED_RESOURCES = EDC_NAMESPACE + "managedResources";
     public static final String EDC_TRANSFER_REQUEST_DTO_PROPERTIES = EDC_NAMESPACE + "properties";
 
     public static final String EDC_TRANSFER_REQUEST_DTO_PRIVATE_PROPERTIES = EDC_NAMESPACE + "privateProperties";
@@ -48,7 +47,6 @@ public class TransferRequestDto {
     private String connectorAddress; // TODO change to callbackAddress
     private String contractId;
     private DataAddress dataDestination;
-    private boolean managedResources = true;
     private Map<String, String> properties = new HashMap<>();
 
     private Map<String, String> privateProperties = new HashMap<>();
@@ -74,10 +72,6 @@ public class TransferRequestDto {
 
     public DataAddress getDataDestination() {
         return dataDestination;
-    }
-
-    public boolean isManagedResources() {
-        return managedResources;
     }
 
     public Map<String, String> getProperties() {
@@ -134,11 +128,6 @@ public class TransferRequestDto {
 
         public Builder dataDestination(DataAddress dataDestination) {
             request.dataDestination = dataDestination;
-            return this;
-        }
-
-        public Builder managedResources(boolean managedResources) {
-            request.managedResources = managedResources;
             return this;
         }
 

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/transform/JsonObjectToTransferRequestDtoTransformer.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/transform/JsonObjectToTransferRequestDtoTransformer.java
@@ -38,7 +38,6 @@ import static org.eclipse.edc.connector.api.management.transferprocess.model.Tra
 import static org.eclipse.edc.connector.api.management.transferprocess.model.TransferRequestDto.EDC_TRANSFER_REQUEST_DTO_CONNECTOR_ID;
 import static org.eclipse.edc.connector.api.management.transferprocess.model.TransferRequestDto.EDC_TRANSFER_REQUEST_DTO_CONTRACT_ID;
 import static org.eclipse.edc.connector.api.management.transferprocess.model.TransferRequestDto.EDC_TRANSFER_REQUEST_DTO_DATA_DESTINATION;
-import static org.eclipse.edc.connector.api.management.transferprocess.model.TransferRequestDto.EDC_TRANSFER_REQUEST_DTO_MANAGED_RESOURCES;
 import static org.eclipse.edc.connector.api.management.transferprocess.model.TransferRequestDto.EDC_TRANSFER_REQUEST_DTO_PRIVATE_PROPERTIES;
 import static org.eclipse.edc.connector.api.management.transferprocess.model.TransferRequestDto.EDC_TRANSFER_REQUEST_DTO_PROPERTIES;
 import static org.eclipse.edc.connector.api.management.transferprocess.model.TransferRequestDto.EDC_TRANSFER_REQUEST_DTO_PROTOCOL;
@@ -62,8 +61,6 @@ public class JsonObjectToTransferRequestDtoTransformer extends AbstractJsonLdTra
                     return (v) -> builder.contractId(transformString(v, context));
                 case EDC_TRANSFER_REQUEST_DTO_DATA_DESTINATION:
                     return (v) -> builder.dataDestination(transformObject(v, DataAddress.class, context));
-                case EDC_TRANSFER_REQUEST_DTO_MANAGED_RESOURCES:
-                    return (v) -> builder.managedResources(transformBoolean(v, context));
                 case EDC_TRANSFER_REQUEST_DTO_PROPERTIES:
                     return (v) -> transformProperties(v, builder::properties, context);
                 case EDC_TRANSFER_REQUEST_DTO_CALLBACK_ADDRESSES:

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/transform/TransferRequestDtoToTransferRequestTransformer.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/transform/TransferRequestDtoToTransferRequestTransformer.java
@@ -50,7 +50,6 @@ public class TransferRequestDtoToTransferRequestTransformer implements DtoTransf
                 .connectorAddress(object.getConnectorAddress())
                 .contractId(object.getContractId())
                 .destinationType(object.getDataDestination().getType())
-                .managedResources(object.isManagedResources())
                 .protocol(object.getProtocol())
                 .dataDestination(object.getDataDestination())
                 .build();

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/api/management/transferprocess/transform/JsonObjectToTransferRequestDtoTransformerTest.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/api/management/transferprocess/transform/JsonObjectToTransferRequestDtoTransformerTest.java
@@ -30,7 +30,6 @@ import static org.eclipse.edc.connector.api.management.transferprocess.model.Tra
 import static org.eclipse.edc.connector.api.management.transferprocess.model.TransferRequestDto.EDC_TRANSFER_REQUEST_DTO_CONNECTOR_ID;
 import static org.eclipse.edc.connector.api.management.transferprocess.model.TransferRequestDto.EDC_TRANSFER_REQUEST_DTO_CONTRACT_ID;
 import static org.eclipse.edc.connector.api.management.transferprocess.model.TransferRequestDto.EDC_TRANSFER_REQUEST_DTO_DATA_DESTINATION;
-import static org.eclipse.edc.connector.api.management.transferprocess.model.TransferRequestDto.EDC_TRANSFER_REQUEST_DTO_MANAGED_RESOURCES;
 import static org.eclipse.edc.connector.api.management.transferprocess.model.TransferRequestDto.EDC_TRANSFER_REQUEST_DTO_PRIVATE_PROPERTIES;
 import static org.eclipse.edc.connector.api.management.transferprocess.model.TransferRequestDto.EDC_TRANSFER_REQUEST_DTO_PROPERTIES;
 import static org.eclipse.edc.connector.api.management.transferprocess.model.TransferRequestDto.EDC_TRANSFER_REQUEST_DTO_PROTOCOL;
@@ -72,7 +71,6 @@ class JsonObjectToTransferRequestDtoTransformerTest {
                 .add(EDC_TRANSFER_REQUEST_DTO_CONNECTOR_ADDRESS, "address")
                 .add(EDC_TRANSFER_REQUEST_DTO_CONTRACT_ID, "contractId")
                 .add(EDC_TRANSFER_REQUEST_DTO_DATA_DESTINATION, dataDestinationJson)
-                .add(EDC_TRANSFER_REQUEST_DTO_MANAGED_RESOURCES, false)
                 .add(EDC_TRANSFER_REQUEST_DTO_PROPERTIES, propertiesJson)
                 .add(EDC_TRANSFER_REQUEST_DTO_PRIVATE_PROPERTIES, privatePropertiesJson)
                 .add(EDC_TRANSFER_REQUEST_DTO_PROTOCOL, "protocol")
@@ -87,7 +85,6 @@ class JsonObjectToTransferRequestDtoTransformerTest {
         assertThat(result.getConnectorAddress()).isEqualTo("address");
         assertThat(result.getContractId()).isEqualTo("contractId");
         assertThat(result.getDataDestination()).isSameAs(dataDestination);
-        assertThat(result.isManagedResources()).isFalse();
         assertThat(result.getProperties()).containsAllEntriesOf(properties);
         assertThat(result.getPrivateProperties()).containsAllEntriesOf(privateProperties);
         assertThat(result.getProtocol()).isEqualTo("protocol");

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/api/management/transferprocess/transform/TransferRequestDtoToTransferRequestTransformerTest.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/api/management/transferprocess/transform/TransferRequestDtoToTransferRequestTransformerTest.java
@@ -48,13 +48,14 @@ class TransferRequestDtoToTransferRequestTransformerTest {
 
     @Test
     void transform() {
-        String destinationType = "test-type";
+        var destinationType = "test-type";
         var context = mock(TransformerContext.class);
         var transferReq = transferRequestDto()
                 .id(UUID.randomUUID().toString())
                 .build();
 
         var transferRequest = transformer.transform(transferReq, context);
+
         assertThat(transferRequest.getDataRequest())
                 .isNotNull()
                 .extracting(DataRequest::getDestinationType)
@@ -70,7 +71,6 @@ class TransferRequestDtoToTransferRequestTransformerTest {
         assertThat(dataRequest.getDestinationType()).isEqualTo(transferReq.getDataDestination().getType());
         assertThat(dataRequest.getContractId()).isEqualTo(transferReq.getContractId());
         assertThat(dataRequest.getProtocol()).isEqualTo(transferReq.getProtocol());
-        assertThat(dataRequest.isManagedResources()).isEqualTo(transferReq.isManagedResources());
 
         assertThat(transferRequest.getCallbackAddresses()).hasSize(transferReq.getCallbackAddresses().size());
         assertThat(transferRequest.getPrivateProperties()).isEqualTo(transferReq.getPrivateProperties());

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/docs/schema.sql
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/docs/schema.sql
@@ -65,7 +65,6 @@ CREATE TABLE IF NOT EXISTS edc_data_request
     asset_id            VARCHAR NOT NULL,
     contract_id         VARCHAR NOT NULL,
     data_destination    JSON    NOT NULL,
-    managed_resources   BOOLEAN DEFAULT TRUE,
     transfer_process_id VARCHAR NOT NULL
         CONSTRAINT data_request_transfer_process_id_fk
             REFERENCES edc_transfer_process

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/SqlTransferProcessStore.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/SqlTransferProcessStore.java
@@ -173,7 +173,6 @@ public class SqlTransferProcessStore extends AbstractSqlStore implements Transfe
                 .connectorId(resultSet.getString(statements.getConnectorIdColumn()))
                 .connectorAddress(resultSet.getString(statements.getConnectorAddressColumn()))
                 .contractId(resultSet.getString(statements.getContractIdColumn()))
-                .managedResources(resultSet.getBoolean(statements.getManagedResourcesColumn()))
                 .processId(resultSet.getString(statements.getProcessIdColumn()))
                 .build();
     }
@@ -221,7 +220,6 @@ public class SqlTransferProcessStore extends AbstractSqlStore implements Transfe
                 dataRequest.getAssetId(),
                 dataRequest.getContractId(),
                 toJson(dataRequest.getDataDestination()),
-                dataRequest.isManagedResources(),
                 existingDataRequestId);
     }
 
@@ -278,8 +276,7 @@ public class SqlTransferProcessStore extends AbstractSqlStore implements Transfe
                 dr.getContractId(),
                 toJson(dr.getDataDestination()),
                 processId,
-                dr.getProtocol(),
-                dr.isManagedResources());
+                dr.getProtocol());
     }
 
     private TransferProcess mapTransferProcess(ResultSet resultSet) throws SQLException {

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/BaseSqlDialectStatements.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/BaseSqlDialectStatements.java
@@ -80,11 +80,10 @@ public abstract class BaseSqlDialectStatements implements TransferProcessStoreSt
 
     @Override
     public String getInsertDataRequestTemplate() {
-        return format("INSERT INTO %s (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s) VALUES (?, ?, ?, ?, ?, ?, ?%s, ?, ?, ?);",
+        return format("INSERT INTO %s (%s, %s, %s, %s, %s, %s, %s, %s, %s) VALUES (?, ?, ?, ?, ?, ?, ?%s, ?, ?);",
                 getDataRequestTable(), getDataRequestIdColumn(), getProcessIdColumn(), getConnectorAddressColumn(),
                 getConnectorIdColumn(), getAssetIdColumn(), getContractIdColumn(), getDataDestinationColumn(),
-                getTransferProcessIdFkColumn(), getProtocolColumn(), getManagedResourcesColumn(),
-                getFormatAsJsonOperator());
+                getTransferProcessIdFkColumn(), getProtocolColumn(), getFormatAsJsonOperator());
     }
 
     @Override
@@ -95,10 +94,10 @@ public abstract class BaseSqlDialectStatements implements TransferProcessStoreSt
 
     @Override
     public String getUpdateDataRequestTemplate() {
-        return format("UPDATE %s SET %s=?, %s=?, %s=?, %s=?, %s=?, %s=?, %s=?, %s=?%s, %s=? WHERE %s=?",
+        return format("UPDATE %s SET %s=?, %s=?, %s=?, %s=?, %s=?, %s=?, %s=?, %s=?%s WHERE %s=?",
                 getDataRequestTable(),
                 getDataRequestIdColumn(), getProcessIdColumn(), getConnectorAddressColumn(), getProtocolColumn(), getConnectorIdColumn(), getAssetIdColumn(), getContractIdColumn(),
-                getDataDestinationColumn(), getFormatAsJsonOperator(), getManagedResourcesColumn(), getDataRequestIdColumn());
+                getDataDestinationColumn(), getFormatAsJsonOperator(), getDataRequestIdColumn());
     }
 
     @Override

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/TransferProcessStoreStatements.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/TransferProcessStoreStatements.java
@@ -106,10 +106,6 @@ public interface TransferProcessStoreStatements extends LeaseStatements {
         return "contract_id";
     }
 
-    default String getManagedResourcesColumn() {
-        return "managed_resources";
-    }
-
     default String getProcessIdColumn() {
         return "process_id";
     }

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/postgres/DataRequestMapping.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/postgres/DataRequestMapping.java
@@ -33,7 +33,6 @@ class DataRequestMapping extends TranslationMapping {
     private static final String FIELD_ASSET_ID = "assetId";
     private static final String FIELD_CONTRACT_ID = "contractId";
     private static final String FIELD_DATA_DESTINATION = "dataDestination";
-    private static final String FIELD_MANAGED_RESOURCES = "managedResources";
     private static final String FIELD_TRANSFER_PROCESS_ID = "transferProcessId";
 
     DataRequestMapping(TransferProcessStoreStatements statements) {
@@ -45,7 +44,6 @@ class DataRequestMapping extends TranslationMapping {
         add(FIELD_ASSET_ID, statements.getAssetIdColumn());
         add(FIELD_CONTRACT_ID, statements.getContractIdColumn());
         add(FIELD_DATA_DESTINATION, new JsonFieldMapping(statements.getDataDestinationColumn()));
-        add(FIELD_MANAGED_RESOURCES, statements.getManagedResourcesColumn());
         add(FIELD_TRANSFER_PROCESS_ID, statements.getTransferProcessIdFkColumn());
     }
 }

--- a/extensions/control-plane/transfer/transfer-pull-http-dynamic-receiver/README.md
+++ b/extensions/control-plane/transfer/transfer-pull-http-dynamic-receiver/README.md
@@ -18,7 +18,6 @@ and will be used by the consumer connector to dispatch the EDR
     "@type": "DataAddress",
     "type": "HttpProxy"
   },
-  "managedResources": false,
   "connectorAddress": "http://localhost:8282/api/v1/ids/data",
   "connectorId": "consumer",
   "privateProperties": {

--- a/resources/openapi/openapi.yaml
+++ b/resources/openapi/openapi.yaml
@@ -3068,9 +3068,6 @@ components:
         id:
           type: string
           example: null
-        managedResources:
-          type: boolean
-          example: null
         privateProperties:
           type: object
           additionalProperties:

--- a/resources/openapi/yaml/management-api/transfer-process-api.yaml
+++ b/resources/openapi/yaml/management-api/transfer-process-api.yaml
@@ -526,9 +526,6 @@ components:
         id:
           type: string
           example: null
-        managedResources:
-          type: boolean
-          example: null
         privateProperties:
           type: object
           additionalProperties:

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/DataRequest.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/DataRequest.java
@@ -35,7 +35,6 @@ public class DataRequest implements Polymorphic {
     private String assetId;
     private String contractId;
     private DataAddress dataDestination;
-    private boolean managedResources = true;
 
     /**
      * The unique request id. Request ids are provided by the originating consumer and must be unique.
@@ -107,10 +106,6 @@ public class DataRequest implements Polymorphic {
         return dataDestination;
     }
 
-    public boolean isManagedResources() {
-        return managedResources;
-    }
-
     public void updateDestination(DataAddress dataAddress) {
         dataDestination = dataAddress;
     }
@@ -175,11 +170,6 @@ public class DataRequest implements Polymorphic {
 
         public Builder dataDestination(DataAddress destination) {
             request.dataDestination = destination;
-            return this;
-        }
-
-        public Builder managedResources(boolean value) {
-            request.managedResources = value;
             return this;
         }
 

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/ProvisionedResource.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/ProvisionedResource.java
@@ -42,10 +42,6 @@ public abstract class ProvisionedResource implements Polymorphic {
         return transferProcessId;
     }
 
-    void setTransferProcessId(String transferProcessId) {
-        this.transferProcessId = transferProcessId;
-    }
-
     @NotNull
     public String getResourceDefinitionId() {
         return resourceDefinitionId;

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/ProvisionedResourceSet.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/ProvisionedResourceSet.java
@@ -27,27 +27,13 @@ import java.util.List;
 @JsonTypeName("dataspaceconnector:provisionedresourceset")
 @JsonDeserialize(builder = ProvisionedResourceSet.Builder.class)
 public class ProvisionedResourceSet {
-    private String transferProcessId;
-
     private final List<ProvisionedResource> resources = new ArrayList<>();
-
-    public String getTransferProcessId() {
-        return transferProcessId;
-    }
-
-    void setTransferProcessId(String transferProcessId) {
-        this.transferProcessId = transferProcessId;
-        resources.forEach(r -> r.setTransferProcessId(transferProcessId));
-    }
 
     public List<ProvisionedResource> getResources() {
         return resources;
     }
 
     public void addResource(ProvisionedResource resource) {
-        if (transferProcessId != null) {
-            resource.setTransferProcessId(transferProcessId);
-        }
         resources.add(resource);
     }
 
@@ -69,11 +55,6 @@ public class ProvisionedResourceSet {
 
         public Builder resources(List<ProvisionedResource> resources) {
             resourceSet.resources.addAll(resources);
-            return this;
-        }
-
-        public Builder transferProcessId(String id) {
-            resourceSet.setTransferProcessId(id);
             return this;
         }
 

--- a/spi/control-plane/transfer-spi/src/testFixtures/java/org/eclipse/edc/connector/transfer/spi/testfixtures/store/TestFunctions.java
+++ b/spi/control-plane/transfer-spi/src/testFixtures/java/org/eclipse/edc/connector/transfer/spi/testfixtures/store/TestFunctions.java
@@ -54,7 +54,6 @@ public class TestFunctions {
                 .protocol("protocol")
                 .connectorId("some-connector")
                 .contractId("some-contract")
-                .managedResources(false)
                 .assetId(Asset.Builder.newInstance().id("asset-id").build().getId())
                 .processId("test-process-id");
     }


### PR DESCRIPTION
## What this PR changes/adds

removed the `managedResource` field on `DataRequest` and all the accessors because it had no more meaning in the current situation

## Why it does that

refactoring

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #3292 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md)._
