### PR TITLE
feat(ci): improve outputting dependencies if they are different

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -52,12 +52,20 @@ jobs:
             echo "::error file=DEPENDENCIES,title=Rejected Dependencies found::Some dependencies are marked 'rejected', they cannot be used"
             exit 1
           fi
-      - name: print expected DEPENDENCIES file
-        run: |
-          cat DEPENDENCIES-gen
       - name: Check for differences
         run: |
-          diff DEPENDENCIES DEPENDENCIES-gen
+          if diff DEPENDENCIES DEPENDENCIES-gen ; then
+            echo "DEPENDENCIES up-do-date"
+          else
+            diff DEPENDENCIES DEPENDENCIES-gen
+            echo "------------------------------------------------------------"
+            echo "Please copy the following content back to DEPENDENCIES" 
+            cat DEPENDENCIES-gen
+            echo "end of content"
+            echo "::error file=DEPENDENCIES,title=Dependencies outdated::The DEPENDENCIES file was outdated and must be regenerated. Check the output of this job for more information"
+            exit 1
+          fi
+  
 
   Dependency-Analysis:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What this PR changes/adds

If the `DEPENDENCIES` file is outdated or differs from the generated one in any way, an error is issued and the job fails.
Also, in that case, the contents of the regenerated file are echoed.

## Why it does that

improved convenience function

## Further notes

- after this is merged, we should move the `dependency-review.yaml` job up into the `.github` repository.

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
