### PR TITLE
feat: permit to configure fs vault with configuration file

### DIFF
--- a/core/common/util/src/main/java/org/eclipse/edc/util/configuration/ConfigurationFunctions.java
+++ b/core/common/util/src/main/java/org/eclipse/edc/util/configuration/ConfigurationFunctions.java
@@ -26,11 +26,11 @@ public class ConfigurationFunctions {
      * <p>Naming conventions for keys are '[qualifier].[value]' in lower case. When checking for env variables, keys will be converted to uppercase and '.' replaced by '_'.</p>
      */
     public static String propOrEnv(String key, String defaultValue) {
-        String value = System.getProperty(key);
+        var value = System.getProperty(key);
         if (!StringUtils.isNullOrBlank(value)) {
             return value;
         }
-        String upperKey = key.toUpperCase().replace('.', '_');
+        var upperKey = key.toUpperCase().replace('.', '_');
         value = System.getenv(upperKey);
         if (!StringUtils.isNullOrBlank(value)) {
             return value;

--- a/core/common/util/src/test/java/org/eclipse/edc/util/configuration/ConfigurationFunctionsTest.java
+++ b/core/common/util/src/test/java/org/eclipse/edc/util/configuration/ConfigurationFunctionsTest.java
@@ -57,13 +57,13 @@ class ConfigurationFunctionsTest {
     @SetSystemProperty(key = SYS_PROP_2, value = "")
     @SetSystemProperty(key = SYS_PROP_3, value = "    ")
     public void returnSystemProperty(String key, String expected) {
-        String resultValue = ConfigurationFunctions.propOrEnv(key, DEFAULT);
+        var resultValue = ConfigurationFunctions.propOrEnv(key, DEFAULT);
         assertThat(resultValue).isEqualTo(expected);
     }
 
     @Test
     public void returnDefaultEnv_NullValue() {
-        String resultValue = ConfigurationFunctions.propOrEnv("nonexistent", DEFAULT);
+        var resultValue = ConfigurationFunctions.propOrEnv("nonexistent", DEFAULT);
         assertThat(resultValue).isEqualTo(DEFAULT);
     }
 


### PR DESCRIPTION
## What this PR changes/adds

Uses `getSetting` where possible instead of `propOrEnv`

## Why it does that

permit vault to be configured via configuration (!)

## Further notes



## Linked Issue(s)

Closes #1106

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
