### PR TITLE
chore: handle missing destination in transfer protocol service

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImpl.java
@@ -89,7 +89,7 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
         }
 
         var destination = message.getDataDestination();
-        if (destination != null) { // NOTE: optional property according to protocol spec
+        if (destination != null) {
             var validDestination = dataAddressValidator.validate(destination);
             if (validDestination.failed()) {
                 return ServiceResult.badRequest(validDestination.getFailureMessages());
@@ -138,7 +138,6 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
     private ServiceResult<TransferProcess> requestedAction(TransferRequestMessage message, ContractId contractId) {
         var assetId = contractId.assetIdPart();
         
-        // NOTE: if destination is missing a pull transfer is requested
         var destination = message.getDataDestination() != null ? message.getDataDestination() :
                 DataAddress.Builder.newInstance().type(HTTP_PROXY).build();
         var dataRequest = DataRequest.Builder.newInstance()


### PR DESCRIPTION
## What this PR changes/adds

Adds a null check on the data destination to `TransferProcessProtocolServiceImpl::notifyRequested` before validating the destination. In `requestedAction` creates a destination `DataAddress` of type `HTTP_PROXY` (= pull) for the `DataRequest`, if no destination was specified.

## Why it does that

The destination is optional according to the protocol spec, as it is only required for push transfers.

## Linked Issue(s)

Closes #2728 
