### PR TITLE
fix: create openapi only on pushes to main

### DIFF
--- a/.github/workflows/apidoc.yaml
+++ b/.github/workflows/apidoc.yaml
@@ -9,6 +9,8 @@ on:
         type: string
 
   push:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## What this PR changes/adds

Only publishes OpenAPI specs when pushing to `main`

## Why it does that

no reason to create openapi publications on feature branches, e.g. dependabot branches


## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
