### PR TITLE
fix(jersey): bind controllers to the correct context

### DIFF
--- a/extensions/common/http/jersey-core/src/main/java/org/eclipse/edc/web/jersey/JerseyRestService.java
+++ b/extensions/common/http/jersey-core/src/main/java/org/eclipse/edc/web/jersey/JerseyRestService.java
@@ -88,7 +88,7 @@ public class JerseyRestService implements WebService {
         // Register controller (JAX-RS resources) with Jersey. Instances instead of classes are used so extensions may inject them with dependencies and manage their lifecycle.
         // In order to use instances with Jersey, the controller types must be registered along with an {@link AbstractBinder} that maps those types to the instances.
         resourceConfig.registerClasses(controllers.stream().map(Object::getClass).collect(toSet()));
-        resourceConfig.registerInstances(new Binder());
+        resourceConfig.registerInstances(new Binder(controllers));
         resourceConfig.registerInstances(new ObjectMapperProvider(typeManager.getMapper()));
         resourceConfig.registerInstances(new EdcApiExceptionMapper());
         resourceConfig.registerInstances(new UnexpectedExceptionMapper(monitor));
@@ -109,11 +109,17 @@ public class JerseyRestService implements WebService {
     /**
      * Maps (JAX-RS resource) instances to types.
      */
-    private class Binder extends AbstractBinder {
+    private static class Binder extends AbstractBinder {
+
+        private final List<Object> controllers;
+
+        Binder(List<Object> controllers) {
+            this.controllers = controllers;
+        }
 
         @Override
         protected void configure() {
-            controllers.forEach((key, value) -> value.forEach(c -> bind(c).to((Class<? super Object>) c.getClass())));
+            controllers.forEach(c -> bind(c).to((Class<? super Object>) c.getClass()));
         }
     }
 


### PR DESCRIPTION
## What this PR changes/adds

Bind controllers only on the specific context

## Why it does that

bugfix

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #3312

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
