### PR TITLE
fix: break lease for STARTED processes

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -140,7 +140,7 @@ maven/mavencentral/io.swagger.core.v3/swagger-core/2.2.8, Apache-2.0, approved, 
 maven/mavencentral/io.swagger.core.v3/swagger-integration-jakarta/2.2.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.core.v3/swagger-integration/2.2.10, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.core.v3/swagger-jaxrs2-jakarta/2.2.2, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.swagger.core.v3/swagger-jaxrs2/2.2.10, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.swagger.core.v3/swagger-jaxrs2/2.2.10, Apache-2.0, approved, #9814
 maven/mavencentral/io.swagger.core.v3/swagger-models-jakarta/2.2.2, Apache-2.0, approved, #5919
 maven/mavencentral/io.swagger.core.v3/swagger-models/2.2.10, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.core.v3/swagger-models/2.2.8, Apache-2.0, approved, clearlydefined

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
@@ -416,6 +416,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager {
     @WithSpan
     private boolean processStarted(TransferProcess transferProcess) {
         if (transferProcess.getType() != CONSUMER) {
+            breakLease(transferProcess);
             return false;
         }
 
@@ -526,7 +527,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager {
     }
 
     private Processor processTransfersInState(TransferProcessStates state, Function<TransferProcess, Boolean> function) {
-        var filter = new Criterion[] { hasState(state.code()), isNotPending() };
+        var filter = new Criterion[]{ hasState(state.code()), isNotPending() };
         return ProcessorImpl.Builder.newInstance(() -> transferProcessStore.nextNotLeased(batchSize, filter))
                 .process(telemetry.contextPropagationMiddleware(function))
                 .guard(pendingGuard, this::setPending)


### PR DESCRIPTION
## What this PR changes/adds

Breaks the lease for `STARTED` transfer processes on the provider side.

## Why it does that

Avoids zombie leases that never get broken.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #3335


_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
