### PR TITLE
docs: Fix typo in Contract In Force Policy documentation

### DIFF
--- a/docs/developer/contract-duration/contract-validity-check.md
+++ b/docs/developer/contract-duration/contract-validity-check.md
@@ -27,7 +27,7 @@ The following values are supported for the time unit:
 | h     | hours        |
 | d     | days         |
 
-A duration is defined in a `ContractDefinition` using the following policy and lef-hand
+A duration is defined in a `ContractDefinition` using the following policy and left-hand
 operands `https://w3id.org/edc/v0.0.1/ns/inForceDate`:
 
 ```json


### PR DESCRIPTION
## What this PR changes/adds

Just a typo

## Why it does that

Typos are the evil