### PR TITLE
feat: fix dataset case according to DSP specs

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -280,7 +280,7 @@ maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.10.0, EPL-2.0, appro
 maven/mavencentral/org.junit.platform/junit-platform-commons/1.10.0, EPL-2.0, approved, #9715
 maven/mavencentral/org.junit.platform/junit-platform-engine/1.10.0, EPL-2.0, approved, #9709
 maven/mavencentral/org.junit.platform/junit-platform-launcher/1.10.0, EPL-2.0, approved, #9704
-maven/mavencentral/org.junit/junit-bom/5.10.0, , restricted, clearlydefined
+maven/mavencentral/org.junit/junit-bom/5.10.0, EPL-2.0, approved, #9844
 maven/mavencentral/org.junit/junit-bom/5.9.2, EPL-2.0, approved, #4711
 maven/mavencentral/org.jvnet.mimepull/mimepull/1.9.15, CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, CQ21484
 maven/mavencentral/org.latencyutils/LatencyUtils/2.0.3, BSD-2-Clause, approved, CQ17408

--- a/core/common/transform-core/src/test/java/org/eclipse/edc/core/transform/transformer/to/JsonObjectToCatalogTransformerTest.java
+++ b/core/common/transform-core/src/test/java/org/eclipse/edc/core/transform/transformer/to/JsonObjectToCatalogTransformerTest.java
@@ -100,7 +100,7 @@ class JsonObjectToCatalogTransformerTest {
 
     @Test
     void transform_filledCatalog_returnCatalog() {
-        var dataSetJson = getJsonObject("dataset");
+        var datasetJson = getJsonObject("dataset");
         var dataServiceJson = getJsonObject("dataService");
 
         var dataset = Dataset.Builder.newInstance()
@@ -120,7 +120,7 @@ class JsonObjectToCatalogTransformerTest {
         var catalog = jsonFactory.createObjectBuilder()
                 .add(ID, CATALOG_ID)
                 .add(TYPE, DCAT_CATALOG_TYPE)
-                .add(DCAT_DATASET_ATTRIBUTE, dataSetJson)
+                .add(DCAT_DATASET_ATTRIBUTE, datasetJson)
                 .add(DCAT_DATA_SERVICE_ATTRIBUTE, dataServiceJson)
                 .build();
 

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/api/controller/DspNegotiationApiControllerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/api/controller/DspNegotiationApiControllerTest.java
@@ -124,7 +124,7 @@ class DspNegotiationApiControllerTest extends RestControllerTestBase {
                 .processId("testId")
                 .counterPartyAddress("http://connector")
                 .callbackAddress("http://connector")
-                .dataSet("dataSet")
+                .dataset("dataset")
                 .contractOffer(contractOffer())
                 .build();
     }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractRequestMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractRequestMessageTransformer.java
@@ -25,7 +25,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
-import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_DATA_SET;
+import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_DATASET;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER_ID;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE;
@@ -58,7 +58,7 @@ public class JsonObjectFromContractRequestMessageTransformer extends AbstractJso
         }
 
         if (requestMessage.getContractOffer() != null) {
-            builder.add(DSPACE_PROPERTY_DATA_SET, requestMessage.getContractOffer().getAssetId());
+            builder.add(DSPACE_PROPERTY_DATASET, requestMessage.getContractOffer().getAssetId());
             var policy = context.transform(requestMessage.getContractOffer().getPolicy(), JsonObject.class);
             if (policy == null) {
                 context.problem()
@@ -76,8 +76,8 @@ public class JsonObjectFromContractRequestMessageTransformer extends AbstractJso
 
         } else {
             builder.add(DSPACE_PROPERTY_OFFER_ID, requestMessage.getContractOfferId());
-            if (requestMessage.getDataSet() != null) {
-                builder.add(DSPACE_PROPERTY_DATA_SET, requestMessage.getDataSet());
+            if (requestMessage.getDataset() != null) {
+                builder.add(DSPACE_PROPERTY_DATASET, requestMessage.getDataset());
             }
         }
 

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractRequestMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractRequestMessageTransformer.java
@@ -23,7 +23,10 @@ import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Optional;
+
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_DATASET;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_DATA_SET;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER_ID;
@@ -57,9 +60,12 @@ public class JsonObjectToContractRequestMessageTransformer extends AbstractJsonL
             builder.callbackAddress(transformString(callback, context));
         }
 
-        var dataset = requestObject.get(DSPACE_PROPERTY_DATA_SET);
+        var dataset = Optional.of(requestObject)
+                .map(it -> it.get(DSPACE_PROPERTY_DATASET))
+                .orElseGet(() -> requestObject.get(DSPACE_PROPERTY_DATA_SET));
+
         if (dataset != null) {
-            builder.dataSet(transformString(dataset, context));
+            builder.dataset(transformString(dataset, context));
         }
 
         var contractOffer = returnJsonObject(requestObject.get(DSPACE_PROPERTY_OFFER), context, DSPACE_PROPERTY_OFFER, false);

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractRequestMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractRequestMessageTransformerTest.java
@@ -30,7 +30,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_DATA_SET;
+import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_DATASET;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER_ID;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE;
@@ -76,7 +76,7 @@ class JsonObjectFromContractRequestMessageTransformerTest {
         assertThat(result.getJsonString(ID).getString()).isNotEmpty();
         assertThat(result.getJsonString(TYPE).getString()).isEqualTo(DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE);
         assertThat(result.getJsonString(DSPACE_PROPERTY_PROCESS_ID).getString()).isEqualTo(PROCESS_ID);
-        assertThat(result.getJsonString(DSPACE_PROPERTY_DATA_SET).getString()).isEqualTo(DATASET_ID);
+        assertThat(result.getJsonString(DSPACE_PROPERTY_DATASET).getString()).isEqualTo(DATASET_ID);
         assertThat(result.getJsonString(DSPACE_PROPERTY_CALLBACK_ADDRESS).getString()).isEqualTo(CALLBACK_ADDRESS);
         assertThat(result.getJsonObject(DSPACE_PROPERTY_OFFER)).isNotNull();
         assertThat(result.getJsonObject(DSPACE_PROPERTY_OFFER).getString(ID)).isEqualTo(CONTRACT_OFFER_ID);
@@ -90,7 +90,7 @@ class JsonObjectFromContractRequestMessageTransformerTest {
                 .protocol(PROTOCOL)
                 .processId(PROCESS_ID)
                 .callbackAddress(CALLBACK_ADDRESS)
-                .dataSet(DATASET_ID)
+                .dataset(DATASET_ID)
                 .contractOfferId(CONTRACT_OFFER_ID)
                 .build();
 
@@ -100,7 +100,7 @@ class JsonObjectFromContractRequestMessageTransformerTest {
         assertThat(result.getJsonString(ID).getString()).isNotEmpty();
         assertThat(result.getJsonString(TYPE).getString()).isEqualTo(DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE);
         assertThat(result.getJsonString(DSPACE_PROPERTY_PROCESS_ID).getString()).isEqualTo(PROCESS_ID);
-        assertThat(result.getJsonString(DSPACE_PROPERTY_DATA_SET).getString()).isEqualTo(DATASET_ID);
+        assertThat(result.getJsonString(DSPACE_PROPERTY_DATASET).getString()).isEqualTo(DATASET_ID);
         assertThat(result.getJsonString(DSPACE_PROPERTY_CALLBACK_ADDRESS).getString()).isEqualTo(CALLBACK_ADDRESS);
         assertThat(result.getJsonString(DSPACE_PROPERTY_OFFER_ID)).isNotNull();
 
@@ -123,7 +123,7 @@ class JsonObjectFromContractRequestMessageTransformerTest {
                 .protocol(PROTOCOL)
                 .processId(PROCESS_ID)
                 .callbackAddress(CALLBACK_ADDRESS)
-                .dataSet(DATASET_ID)
+                .dataset(DATASET_ID)
                 .contractOffer(contractOffer())
                 .build();
     }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractRequestMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractRequestMessageTransformerTest.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_OFFER;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.to.TestInput.getExpanded;
+import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_DATASET;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_DATA_SET;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER_ID;
@@ -56,7 +57,7 @@ class JsonObjectToContractRequestMessageTransformerTest {
     private static final String CONTRACT_OFFER_ID = "contractOfferId";
 
     private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
-    private final TransformerContext context = mock(TransformerContext.class);
+    private final TransformerContext context = mock();
 
     private JsonObjectToContractRequestMessageTransformer transformer;
 
@@ -72,7 +73,7 @@ class JsonObjectToContractRequestMessageTransformerTest {
                 .add(JsonLdKeywords.ID, OBJECT_ID)
                 .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE)
                 .add(DSPACE_PROPERTY_PROCESS_ID, PROCESS_ID)
-                .add(DSPACE_PROPERTY_DATA_SET, DATASET_ID)
+                .add(DSPACE_PROPERTY_DATASET, DATASET_ID)
                 .add(DSPACE_PROPERTY_CALLBACK_ADDRESS, CALLBACK)
                 .add(DSPACE_PROPERTY_OFFER, contractOffer())
                 .build();
@@ -85,7 +86,7 @@ class JsonObjectToContractRequestMessageTransformerTest {
         assertThat(result.getProtocol()).isNotEmpty();
         assertThat(result.getProcessId()).isEqualTo(PROCESS_ID);
         assertThat(result.getCallbackAddress()).isEqualTo(CALLBACK);
-        assertThat(result.getDataSet()).isEqualTo(DATASET_ID);
+        assertThat(result.getDataset()).isEqualTo(DATASET_ID);
 
         var contractOffer = result.getContractOffer();
         assertThat(contractOffer).isNotNull();
@@ -97,12 +98,31 @@ class JsonObjectToContractRequestMessageTransformerTest {
     }
 
     @Test
-    void verify_usingOfferId() {
+    void shouldDeserialize_whenDatasetIsWrittenWithTheWrongCase_deprecated() {
         var message = jsonFactory.createObjectBuilder()
                 .add(JsonLdKeywords.ID, OBJECT_ID)
                 .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE)
                 .add(DSPACE_PROPERTY_PROCESS_ID, PROCESS_ID)
                 .add(DSPACE_PROPERTY_DATA_SET, DATASET_ID)
+                .add(DSPACE_PROPERTY_CALLBACK_ADDRESS, CALLBACK)
+                .add(DSPACE_PROPERTY_OFFER, contractOffer())
+                .build();
+
+        when(context.transform(any(JsonObject.class), eq(Policy.class))).thenReturn(policy());
+
+        var result = transformer.transform(getExpanded(message), context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getDataset()).isEqualTo(DATASET_ID);
+    }
+
+    @Test
+    void verify_usingOfferId() {
+        var message = jsonFactory.createObjectBuilder()
+                .add(JsonLdKeywords.ID, OBJECT_ID)
+                .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE)
+                .add(DSPACE_PROPERTY_PROCESS_ID, PROCESS_ID)
+                .add(DSPACE_PROPERTY_DATASET, DATASET_ID)
                 .add(DSPACE_PROPERTY_CALLBACK_ADDRESS, CALLBACK)
                 .add(DSPACE_PROPERTY_OFFER_ID, CONTRACT_OFFER_ID)
                 .build();
@@ -113,7 +133,7 @@ class JsonObjectToContractRequestMessageTransformerTest {
         assertThat(result.getProtocol()).isNotEmpty();
         assertThat(result.getProcessId()).isEqualTo(PROCESS_ID);
         assertThat(result.getCallbackAddress()).isEqualTo(CALLBACK);
-        assertThat(result.getDataSet()).isEqualTo(DATASET_ID);
+        assertThat(result.getDataset()).isEqualTo(DATASET_ID);
 
         assertThat(result.getContractOfferId()).isNotNull();
 
@@ -165,7 +185,7 @@ class JsonObjectToContractRequestMessageTransformerTest {
                 .add(JsonLdKeywords.ID, OBJECT_ID)
                 .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE)
                 .add(DSPACE_PROPERTY_PROCESS_ID, PROCESS_ID)
-                .add(DSPACE_PROPERTY_DATA_SET, DATASET_ID)
+                .add(DSPACE_PROPERTY_DATASET, DATASET_ID)
                 .add(DSPACE_PROPERTY_CALLBACK_ADDRESS, CALLBACK)
                 .add(DSPACE_PROPERTY_OFFER, contractOffer())
                 .build();

--- a/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/type/DspNegotiationPropertyAndTypeNames.java
+++ b/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/type/DspNegotiationPropertyAndTypeNames.java
@@ -38,6 +38,8 @@ public interface DspNegotiationPropertyAndTypeNames {
     String DSPACE_PROPERTY_AGREEMENT = DSPACE_SCHEMA + "agreement";
     String DSPACE_PROPERTY_OFFER = DSPACE_SCHEMA + "offer";
     String DSPACE_PROPERTY_OFFER_ID = DSPACE_SCHEMA + "offerId";
+    String DSPACE_PROPERTY_DATASET = DSPACE_SCHEMA + "dataset";
+    @Deprecated(since = "0.2.0")
     String DSPACE_PROPERTY_DATA_SET = DSPACE_SCHEMA + "dataSet";
     String DSPACE_PROPERTY_TIMESTAMP = DSPACE_SCHEMA + "timestamp";
     String DSPACE_PROPERTY_CONSUMER_ID = DSPACE_SCHEMA + "consumerId";

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessage.java
@@ -39,7 +39,7 @@ public class ContractRequestMessage implements ContractRemoteMessage {
     private String processId;
     private ContractOffer contractOffer;
     private String contractOfferId;
-    private String dataSet;
+    private String dataset;
 
     @NotNull
     @Override
@@ -83,8 +83,8 @@ public class ContractRequestMessage implements ContractRemoteMessage {
         return contractOfferId;
     }
 
-    public String getDataSet() {
-        return dataSet;
+    public String getDataset() {
+        return dataset;
     }
 
     public String getCallbackAddress() {
@@ -102,10 +102,10 @@ public class ContractRequestMessage implements ContractRemoteMessage {
     }
 
     public static class Builder {
-        private final ContractRequestMessage contractRequestMessage;
+        private final ContractRequestMessage message;
 
         private Builder() {
-            contractRequestMessage = new ContractRequestMessage();
+            message = new ContractRequestMessage();
         }
 
         public static Builder newInstance() {
@@ -113,61 +113,61 @@ public class ContractRequestMessage implements ContractRemoteMessage {
         }
 
         public Builder id(String id) {
-            this.contractRequestMessage.id = id;
+            this.message.id = id;
             return this;
         }
 
         public Builder protocol(String protocol) {
-            contractRequestMessage.protocol = protocol;
+            message.protocol = protocol;
             return this;
         }
 
         public Builder callbackAddress(String callbackAddress) {
-            contractRequestMessage.callbackAddress = callbackAddress;
+            message.callbackAddress = callbackAddress;
             return this;
         }
 
         public Builder counterPartyAddress(String counterPartyAddress) {
-            contractRequestMessage.counterPartyAddress = counterPartyAddress;
+            message.counterPartyAddress = counterPartyAddress;
             return this;
         }
 
         public Builder processId(String processId) {
-            contractRequestMessage.processId = processId;
+            message.processId = processId;
             return this;
         }
 
         public Builder contractOffer(ContractOffer contractOffer) {
-            contractRequestMessage.contractOffer = contractOffer;
+            message.contractOffer = contractOffer;
             return this;
         }
 
         public Builder contractOfferId(String id) {
-            contractRequestMessage.contractOfferId = id;
+            message.contractOfferId = id;
             return this;
         }
 
         public Builder type(Type type) {
-            contractRequestMessage.type = type;
+            message.type = type;
             return this;
         }
 
-        public Builder dataSet(String dataSet) {
-            contractRequestMessage.dataSet = dataSet;
+        public Builder dataset(String dataset) {
+            message.dataset = dataset;
             return this;
         }
 
         public ContractRequestMessage build() {
-            if (contractRequestMessage.id == null) {
-                contractRequestMessage.id = randomUUID().toString();
+            if (message.id == null) {
+                message.id = randomUUID().toString();
             }
-            requireNonNull(contractRequestMessage.processId, "processId");
-            if (contractRequestMessage.contractOfferId == null) {
-                requireNonNull(contractRequestMessage.contractOffer, "contractOffer");
+            requireNonNull(message.processId, "processId");
+            if (message.contractOfferId == null) {
+                requireNonNull(message.contractOffer, "contractOffer");
             } else {
-                requireNonNull(contractRequestMessage.contractOfferId, "contractOfferId");
+                requireNonNull(message.contractOfferId, "contractOfferId");
             }
-            return contractRequestMessage;
+            return message;
         }
     }
 }

--- a/spi/control-plane/contract-spi/src/test/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessageTest.java
+++ b/spi/control-plane/contract-spi/src/test/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessageTest.java
@@ -26,7 +26,7 @@ class ContractRequestMessageTest {
     public static final String CALLBACK_ADDRESS = "http://test.com";
     public static final String OFFER_ID = "offerId";
     public static final String PROCESS_ID = "123";
-    public static final String DATA_SET = "dataset1";
+    public static final String DATASET = "dataset1";
     public static final String ID = "id1";
     public static final String ASSET_ID = "asset1";
     public static final String PROTOCOL = "DPS";
@@ -38,7 +38,7 @@ class ContractRequestMessageTest {
                 .processId(PROCESS_ID)
                 .protocol(PROTOCOL)
                 .contractOfferId(OFFER_ID)
-                .dataSet(DATA_SET)
+                .dataset(DATASET)
                 .build();
     }
 
@@ -47,7 +47,7 @@ class ContractRequestMessageTest {
         assertThatThrownBy(() -> ContractRequestMessage.Builder.newInstance()
                 .type(INITIAL)
                 .protocol(PROTOCOL)
-                .dataSet(DATA_SET)
+                .dataset(DATASET)
                 .counterPartyAddress(CALLBACK_ADDRESS)
                 .build()).isInstanceOf(NullPointerException.class).hasMessageContaining("processId");
 
@@ -56,7 +56,7 @@ class ContractRequestMessageTest {
                 .type(COUNTER_OFFER)
                 .protocol(PROTOCOL)
                 .contractOfferId(OFFER_ID)
-                .dataSet(DATA_SET)
+                .dataset(DATASET)
                 .counterPartyAddress(CALLBACK_ADDRESS)
                 .build()).isInstanceOf(NullPointerException.class).hasMessageContaining("processId");
     }
@@ -68,7 +68,7 @@ class ContractRequestMessageTest {
                 .processId(PROCESS_ID)
                 .protocol(PROTOCOL)
                 .contractOfferId(OFFER_ID)
-                .dataSet(DATA_SET)
+                .dataset(DATASET)
                 .counterPartyAddress(CALLBACK_ADDRESS)
                 .build();
 
@@ -81,7 +81,7 @@ class ContractRequestMessageTest {
                         .assetId(ASSET_ID)
                         .policy(Policy.Builder.newInstance().build())
                         .build())
-                .dataSet(DATA_SET)
+                .dataset(DATASET)
                 .counterPartyAddress(CALLBACK_ADDRESS)
                 .build();
 
@@ -90,7 +90,7 @@ class ContractRequestMessageTest {
                 .type(INITIAL)
                 .processId(PROCESS_ID)
                 .protocol(PROTOCOL)
-                .dataSet(DATA_SET)
+                .dataset(DATASET)
                 .counterPartyAddress(CALLBACK_ADDRESS)
                 .build()).isInstanceOf(NullPointerException.class).hasMessageContaining("contractOffer");
 


### PR DESCRIPTION
## What this PR changes/adds

Change `dataSet` to `dataset` in `ContractRequestMessage`

## Why it does that

compliancy

## Further notes

- I made the deserialization transformer work also with the old value, this to avoid breaking changes in wire communication between older versions and newer ones.

## Linked Issue(s)

Closes #3237 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
