### PR TITLE
feat: implement newInstance everywhere

### DIFF
--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/command/CommandResult.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/command/CommandResult.java
@@ -15,10 +15,16 @@
 package org.eclipse.edc.spi.command;
 
 import org.eclipse.edc.spi.result.AbstractResult;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
 public class CommandResult extends AbstractResult<Void, CommandFailure, CommandResult> {
+
+    protected CommandResult(Void content, CommandFailure failure) {
+        super(content, failure);
+    }
 
     public static CommandResult success() {
         return new CommandResult(null, null);
@@ -36,11 +42,14 @@ public class CommandResult extends AbstractResult<Void, CommandFailure, CommandR
         return new CommandResult(null, new CommandFailure(List.of(message), CommandFailure.Reason.CONFLICT));
     }
 
-    protected CommandResult(Void content, CommandFailure failure) {
-        super(content, failure);
-    }
-
     public CommandFailure.Reason reason() {
         return getFailure().getReason();
+    }
+
+    @NotNull
+    @Override
+    @SuppressWarnings("unchecked")
+    protected <R1 extends AbstractResult<C1, CommandFailure, R1>, C1> R1 newInstance(@Nullable C1 content, @Nullable CommandFailure failure) {
+        return (R1) new CommandResult(null, failure);
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/response/StatusResult.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/response/StatusResult.java
@@ -15,6 +15,8 @@
 package org.eclipse.edc.spi.response;
 
 import org.eclipse.edc.spi.result.AbstractResult;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
 import java.util.List;
@@ -23,6 +25,10 @@ import static org.eclipse.edc.spi.response.ResponseStatus.FATAL_ERROR;
 
 
 public class StatusResult<T> extends AbstractResult<T, ResponseFailure, StatusResult<T>> {
+
+    private StatusResult(T content, ResponseFailure failure) {
+        super(content, failure);
+    }
 
     public static StatusResult<Void> success() {
         return new StatusResult<>(null, null);
@@ -40,11 +46,14 @@ public class StatusResult<T> extends AbstractResult<T, ResponseFailure, StatusRe
         return new StatusResult<>(null, new ResponseFailure(status, List.of(error)));
     }
 
-    private StatusResult(T content, ResponseFailure failure) {
-        super(content, failure);
-    }
-
     public boolean fatalError() {
         return failed() && getFailure().status() == FATAL_ERROR;
+    }
+
+    @NotNull
+    @SuppressWarnings("unchecked")
+    @Override
+    protected <R1 extends AbstractResult<C1, ResponseFailure, R1>, C1> R1 newInstance(@Nullable C1 content, @Nullable ResponseFailure failure) {
+        return (R1) new StatusResult<>(content, failure);
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/AbstractResult.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/AbstractResult.java
@@ -127,34 +127,17 @@ public abstract class AbstractResult<T, F extends Failure, R extends AbstractRes
      *
      * @return this instance.
      */
-    @SuppressWarnings({"unchecked"})
+    @SuppressWarnings({ "unchecked" })
     public R self() {
         return (R) this;
-    }
-
-    /**
-     * Returns a new result instance.
-     * This default implementation exists only to avoid breaking changes, in a future this should become an abstract
-     * method.
-     * If this {@link UnsupportedOperationException} was thrown, please override this method with a proper behavior.
-     *
-     * @param content the content.
-     * @param failure the failure.
-     * @param <R1> the new result type.
-     * @param <C1> the new content type.
-     * @return a new result instance
-     */
-    @NotNull
-    protected <R1 extends AbstractResult<C1, F, R1>, C1> R1 newInstance(@Nullable C1 content, @Nullable F failure) {
-        throw new UnsupportedOperationException("Not implemented for " + getClass());
     }
 
     /**
      * Map the content into another, applying the mapping function.
      *
      * @param mapFunction a function that converts the content into another.
-     * @param <T2> the new content type.
-     * @param <R2> the new result type.
+     * @param <T2>        the new content type.
+     * @param <R2>        the new result type.
      * @return a new result with a mapped content if succeeded, a new failed one otherwise.
      */
     public <T2, R2 extends AbstractResult<T2, F, R2>> R2 map(Function<T, T2> mapFunction) {
@@ -188,4 +171,19 @@ public abstract class AbstractResult<T, F extends Failure, R extends AbstractRes
             return newInstance(null, getFailure());
         }
     }
+
+    /**
+     * Returns a new result instance.
+     * This default implementation exists only to avoid breaking changes, in a future this should become an abstract
+     * method.
+     * If this {@link UnsupportedOperationException} was thrown, please override this method with a proper behavior.
+     *
+     * @param content the content.
+     * @param failure the failure.
+     * @param <R1>    the new result type.
+     * @param <C1>    the new content type.
+     * @return a new result instance
+     */
+    @NotNull
+    protected abstract <R1 extends AbstractResult<C1, F, R1>, C1> R1 newInstance(@Nullable C1 content, @Nullable F failure);
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/StoreResult.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/StoreResult.java
@@ -15,6 +15,9 @@
 
 package org.eclipse.edc.spi.result;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import java.util.List;
 
 import static org.eclipse.edc.spi.result.StoreFailure.Reason.ALREADY_EXISTS;
@@ -59,5 +62,12 @@ public class StoreResult<T> extends AbstractResult<T, StoreFailure, StoreResult<
 
     public StoreFailure.Reason reason() {
         return getFailure().getReason();
+    }
+
+    @NotNull
+    @Override
+    @SuppressWarnings("unchecked")
+    protected <R1 extends AbstractResult<C1, StoreFailure, R1>, C1> R1 newInstance(@Nullable C1 content, @Nullable StoreFailure failure) {
+        return (R1) new StoreResult<>(content, failure);
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/system/health/HealthCheckResult.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/system/health/HealthCheckResult.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.eclipse.edc.spi.result.AbstractResult;
 import org.eclipse.edc.spi.result.Failure;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -43,9 +44,17 @@ public class HealthCheckResult extends AbstractResult<Boolean, Failure, HealthCh
     }
 
     @JsonProperty("isHealthy")
+
     @Override
     public @NotNull Boolean getContent() {
         return super.getContent();
+    }
+
+    @NotNull
+    @SuppressWarnings("unchecked")
+    @Override
+    protected <R1 extends AbstractResult<C1, Failure, R1>, C1> R1 newInstance(@Nullable C1 content, @Nullable Failure failure) {
+        return (R1) new HealthCheckResult(failure == null, failure);
     }
 
     public String getComponent() {

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/pipeline/StreamResult.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/pipeline/StreamResult.java
@@ -16,6 +16,8 @@ package org.eclipse.edc.connector.dataplane.spi.pipeline;
 
 import org.eclipse.edc.spi.result.AbstractResult;
 import org.eclipse.edc.spi.result.Result;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
@@ -61,5 +63,12 @@ public class StreamResult<T> extends AbstractResult<T, StreamFailure, StreamResu
 
     public StreamFailure.Reason reason() {
         return getFailure().getReason();
+    }
+
+    @NotNull
+    @SuppressWarnings("unchecked")
+    @Override
+    protected <R1 extends AbstractResult<C1, StreamFailure, R1>, C1> R1 newInstance(@Nullable C1 content, @Nullable StreamFailure failure) {
+        return (R1) new StreamResult<>(content, failure);
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Makes the `AbstractREsult#newInstance` method abstract

## Why it does that

avoids `UnsupportedOperationException`s when calling e.g. the `map()` operator

## Further notes

.

## Linked Issue(s)

Closes #3353 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
