### PR TITLE
feat: add get negotiation by agreement id endpoint

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractagreement/ContractAgreementServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractagreement/ContractAgreementServiceImpl.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.service.contractagreement;
 
 import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.service.query.QueryValidator;
 import org.eclipse.edc.connector.spi.contractagreement.ContractAgreementService;
 import org.eclipse.edc.service.spi.result.ServiceResult;
@@ -25,6 +26,7 @@ import org.eclipse.edc.transaction.spi.TransactionContext;
 import java.util.stream.Stream;
 
 import static java.lang.String.format;
+import static org.eclipse.edc.spi.query.Criterion.criterion;
 
 public class ContractAgreementServiceImpl implements ContractAgreementService {
     private final ContractNegotiationStore store;
@@ -51,5 +53,12 @@ public class ContractAgreementServiceImpl implements ContractAgreementService {
         }
 
         return ServiceResult.success(transactionContext.execute(() -> store.queryAgreements(query)));
+    }
+
+    @Override
+    public ContractNegotiation findNegotiation(String contractAgreementId) {
+        var criterion = criterion("contractAgreement.id", "=", contractAgreementId);
+        var query = QuerySpec.Builder.newInstance().filter(criterion).build();
+        return transactionContext.execute(() -> store.queryNegotiations(query).findFirst().orElse(null));
     }
 }

--- a/extensions/common/api/management-api-configuration/src/main/java/org/eclipse/edc/connector/api/management/configuration/ManagementApiSchema.java
+++ b/extensions/common/api/management-api-configuration/src/main/java/org/eclipse/edc/connector/api/management/configuration/ManagementApiSchema.java
@@ -16,11 +16,14 @@ package org.eclipse.edc.connector.api.management.configuration;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 
+import java.util.List;
 import java.util.Set;
 
+import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 
@@ -76,13 +79,21 @@ public interface ManagementApiSchema {
 
     }
 
-    @Schema(name = "DataAddress")
+    @Schema(name = "DataAddress", additionalProperties = Schema.AdditionalPropertiesValue.TRUE)
     record DataAddressSchema(
             @Schema(name = TYPE, example = DataAddress.EDC_DATA_ADDRESS_TYPE)
             String type,
             @Schema(name = "type")
             String typeProperty
     ) {
+        public static final String DATA_ADDRESS_EXAMPLE = """
+                {
+                    "@context": { "edc": "https://w3id.org/edc/v0.0.1/ns/" },
+                    "@type": "https://w3id.org/edc/v0.0.1/ns/DataAddress",
+                    "type": "HttpData",
+                    "baseUrl": "http://example.com"
+                }
+                """;
     }
 
     @Schema(name = "Policy", description = "ODRL policy", example = PolicySchema.POLICY_EXAMPLE)
@@ -105,6 +116,45 @@ public interface ManagementApiSchema {
                     },
                     "prohibition": [],
                     "obligation": []
+                }
+                """;
+    }
+
+    @Schema(name = "ContractNegotiation", example = ContractNegotiationSchema.CONTRACT_NEGOTIATION_EXAMPLE)
+    record ContractNegotiationSchema(
+            @Schema(name = TYPE, example = CONTRACT_NEGOTIATION_TYPE)
+            String ldType,
+            @Schema(name = ID)
+            String id,
+            ContractNegotiation.Type type,
+            String protocol,
+            String counterPartyId,
+            String counterPartyAddress,
+            String state,
+            String contractAgreementId,
+            String errorDetail,
+            List<CallbackAddressSchema> callbackAddresses
+    ) {
+        public static final String CONTRACT_NEGOTIATION_EXAMPLE = """
+                {
+                    "@context": { "edc": "https://w3id.org/edc/v0.0.1/ns/" },
+                    "@type": "https://w3id.org/edc/v0.0.1/ns/ContractNegotiation",
+                    "@id": "negotiation-id",
+                    "type": "PROVIDER",
+                    "protocol": "dataspace-protocol-http",
+                    "counterPartyId": "counter-party-id",
+                    "counterPartyAddress": "http://counter/party/address",
+                    "state": "VERIFIED",
+                    "contractAgreementId": "contract:agreement:id",
+                    "errorDetail": "eventual-error-detail",
+                    "createdAt": 1688465655,
+                    "callbackAddresses": [{
+                        "transactional": false,
+                        "uri": "http://callback/url",
+                        "events": ["contract.negotiation", "transfer.process"],
+                        "authKey": "auth-key",
+                        "authCodeId": "auth-code-id"
+                    }]
                 }
                 """;
     }

--- a/extensions/common/api/management-api-configuration/src/test/java/org/eclipse/edc/connector/api/management/configuration/ManagementApiSchemaTest.java
+++ b/extensions/common/api/management-api-configuration/src/test/java/org/eclipse/edc/connector/api/management/configuration/ManagementApiSchemaTest.java
@@ -17,13 +17,23 @@ package org.eclipse.edc.connector.api.management.configuration;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.json.JsonObject;
+import org.eclipse.edc.api.validation.DataAddressValidator;
+import org.eclipse.edc.core.transform.TypeTransformerRegistryImpl;
+import org.eclipse.edc.core.transform.transformer.to.JsonObjectToDataAddressTransformer;
+import org.eclipse.edc.core.transform.transformer.to.JsonValueToGenericTypeTransformer;
 import org.eclipse.edc.jsonld.JsonLdExtension;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.jsonld.util.JacksonJsonLd;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.map;
 import static org.eclipse.edc.connector.api.management.configuration.ManagementApiSchema.ContractAgreementSchema.CONTRACT_AGREEMENT_EXAMPLE;
+import static org.eclipse.edc.connector.api.management.configuration.ManagementApiSchema.ContractNegotiationSchema.CONTRACT_NEGOTIATION_EXAMPLE;
+import static org.eclipse.edc.connector.api.management.configuration.ManagementApiSchema.DataAddressSchema.DATA_ADDRESS_EXAMPLE;
 import static org.eclipse.edc.connector.api.management.configuration.ManagementApiSchema.PolicySchema.POLICY_EXAMPLE;
 import static org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement.CONTRACT_AGREEMENT_ASSET_ID;
 import static org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement.CONTRACT_AGREEMENT_CONSUMER_ID;
@@ -31,6 +41,16 @@ import static org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgr
 import static org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement.CONTRACT_AGREEMENT_PROVIDER_ID;
 import static org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement.CONTRACT_AGREEMENT_SIGNING_DATE;
 import static org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement.CONTRACT_AGREEMENT_TYPE;
+import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_AGREEMENT_ID;
+import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_CALLBACK_ADDR;
+import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_COUNTERPARTY_ADDR;
+import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_COUNTERPARTY_ID;
+import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_CREATED_AT;
+import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_ERRORDETAIL;
+import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_NEG_TYPE;
+import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_PROTOCOL;
+import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_STATE;
+import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
@@ -42,6 +62,13 @@ class ManagementApiSchemaTest {
 
     private final ObjectMapper objectMapper = JacksonJsonLd.createObjectMapper();
     private final JsonLd jsonLd = new JsonLdExtension().createJsonLdService(testServiceExtensionContext());
+    private final TypeTransformerRegistry transformer = new TypeTransformerRegistryImpl();
+
+    @BeforeEach
+    void setUp() {
+        transformer.register(new JsonObjectToDataAddressTransformer());
+        transformer.register(new JsonValueToGenericTypeTransformer(objectMapper));
+    }
 
     @Test
     void contractAgreementExample() throws JsonProcessingException {
@@ -57,6 +84,44 @@ class ManagementApiSchemaTest {
             assertThat(content.getJsonArray(CONTRACT_AGREEMENT_SIGNING_DATE).getJsonObject(0).getJsonNumber(VALUE).longValue()).isGreaterThan(0);
             assertThat(content.getJsonArray(CONTRACT_AGREEMENT_POLICY).getJsonObject(0)).isNotNull();
         });
+    }
+
+    @Test
+    void contractNegotiationExample() throws JsonProcessingException {
+        var jsonObject = objectMapper.readValue(CONTRACT_NEGOTIATION_EXAMPLE, JsonObject.class);
+        var expanded = jsonLd.expand(jsonObject);
+
+        assertThat(expanded).isSucceeded().satisfies(content -> {
+            assertThat(content.getString(ID)).isNotBlank();
+            assertThat(content.getJsonArray(TYPE).getString(0)).isEqualTo(CONTRACT_NEGOTIATION_TYPE);
+            assertThat(content.getJsonArray(CONTRACT_NEGOTIATION_CREATED_AT).getJsonObject(0).getJsonNumber(VALUE).longValue()).isGreaterThan(0);
+            assertThat(content.getJsonArray(CONTRACT_NEGOTIATION_NEG_TYPE).getJsonObject(0).getString(VALUE)).isNotBlank();
+            assertThat(content.getJsonArray(CONTRACT_NEGOTIATION_PROTOCOL).getJsonObject(0).getString(VALUE)).isNotBlank();
+            assertThat(content.getJsonArray(CONTRACT_NEGOTIATION_COUNTERPARTY_ID).getJsonObject(0).getString(VALUE)).isNotBlank();
+            assertThat(content.getJsonArray(CONTRACT_NEGOTIATION_COUNTERPARTY_ADDR).getJsonObject(0).getString(VALUE)).isNotBlank();
+            assertThat(content.getJsonArray(CONTRACT_NEGOTIATION_STATE).getJsonObject(0).getString(VALUE)).isNotBlank();
+            assertThat(content.getJsonArray(CONTRACT_NEGOTIATION_AGREEMENT_ID).getJsonObject(0).getString(VALUE)).isNotBlank();
+            assertThat(content.getJsonArray(CONTRACT_NEGOTIATION_ERRORDETAIL).getJsonObject(0).getString(VALUE)).isNotBlank();
+            assertThat(content.getJsonArray(CONTRACT_NEGOTIATION_CALLBACK_ADDR)).asList().isNotEmpty();
+        });
+    }
+
+    @Test
+    void dataAddressExample() throws JsonProcessingException {
+        var validator = DataAddressValidator.instance();
+
+        var jsonObject = objectMapper.readValue(DATA_ADDRESS_EXAMPLE, JsonObject.class);
+        assertThat(jsonObject).isNotNull();
+
+        var expanded = jsonLd.expand(jsonObject);
+        assertThat(expanded).isSucceeded()
+                .satisfies(exp -> assertThat(validator.validate(exp)).isSucceeded())
+                .extracting(e -> transformer.transform(e, DataAddress.class).getContent())
+                .isNotNull()
+                .satisfies(transformed -> {
+                    assertThat(transformed.getType()).isNotBlank();
+                    assertThat(transformed.getProperties()).asInstanceOf(map(String.class, Object.class)).isNotEmpty();
+                });
     }
 
     @Test

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/v3/AssetApi.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/v3/AssetApi.java
@@ -112,7 +112,7 @@ public interface AssetApi {
         public static final String ASSET_INPUT_EXAMPLE = """
                 {
                     "@context": { "edc": "https://w3id.org/edc/v0.0.1/ns/" },
-                    "@id": "definition-id",
+                    "@id": "asset-id",
                     "properties": {
                         "key": "value"
                     },
@@ -140,7 +140,7 @@ public interface AssetApi {
         public static final String ASSET_OUTPUT_EXAMPLE = """
                 {
                     "@context": { "edc": "https://w3id.org/edc/v0.0.1/ns/" },
-                    "@id": "definition-id",
+                    "@id": "asset-id",
                     "edc:properties": {
                         "edc:key": "value"
                     },

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/v3/AssetApiTest.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/v3/AssetApiTest.java
@@ -46,7 +46,6 @@ class AssetApiTest {
     private final JsonLd jsonLd = new TitaniumJsonLd(mock());
     private final TypeTransformerRegistry transformer = new TypeTransformerRegistryImpl();
 
-
     @BeforeEach
     void setUp() {
         transformer.register(new JsonObjectToAssetTransformer());

--- a/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/api/management/contractagreement/ContractAgreementApi.java
+++ b/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/api/management/contractagreement/ContractAgreementApi.java
@@ -55,4 +55,17 @@ public interface ContractAgreementApi {
     )
     JsonObject getAgreementById(String id);
 
+
+    @Operation(description = "Gets a contract negotiation with the given contract agreement ID",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The contract negotiation",
+                            content = @Content(schema = @Schema(implementation = ManagementApiSchema.ContractNegotiationSchema.class))),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))),
+                    @ApiResponse(responseCode = "404", description = "An contract agreement with the given ID does not exist",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
+            }
+    )
+    JsonObject getNegotiationByAgreementId(String id);
+
 }

--- a/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/api/management/contractagreement/ContractAgreementApiController.java
+++ b/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/api/management/contractagreement/ContractAgreementApiController.java
@@ -92,5 +92,15 @@ public class ContractAgreementApiController implements ContractAgreementApi {
                 .orElseThrow(() -> new ObjectNotFoundException(ContractAgreement.class, id));
     }
 
+    @GET
+    @Path("{id}/negotiation")
+    @Override
+    public JsonObject getNegotiationByAgreementId(@PathParam("id") String id) {
+        return Optional.of(id)
+                .map(service::findNegotiation)
+                .map(it -> transformerRegistry.transform(it, JsonObject.class)
+                        .orElseThrow(failure -> new EdcException(failure.getFailureDetail())))
+                .orElseThrow(() -> new ObjectNotFoundException(ContractAgreement.class, id));
+    }
 
 }

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApi.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApi.java
@@ -30,13 +30,11 @@ import org.eclipse.edc.api.model.ApiCoreSchema;
 import org.eclipse.edc.connector.api.management.configuration.ManagementApiSchema;
 import org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractOfferDescription;
 import org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationState;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.web.spi.ApiErrorDetail;
 
 import java.util.List;
 
 import static org.eclipse.edc.connector.contract.spi.types.command.TerminateNegotiationCommand.TERMINATE_NEGOTIATION_TYPE;
-import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_TYPE;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.CONTRACT_REQUEST_TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
@@ -49,7 +47,7 @@ public interface ContractNegotiationApi {
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ApiCoreSchema.QuerySpecSchema.class))),
             responses = {
                     @ApiResponse(responseCode = "200", description = "The contract negotiations that match the query",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ContractNegotiationSchema.class)))),
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ManagementApiSchema.ContractNegotiationSchema.class)))),
                     @ApiResponse(responseCode = "400", description = "Request was malformed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))) }
     )
@@ -58,7 +56,7 @@ public interface ContractNegotiationApi {
     @Operation(description = "Gets a contract negotiation with the given ID",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The contract negotiation",
-                            content = @Content(schema = @Schema(implementation = ContractNegotiationSchema.class))),
+                            content = @Content(schema = @Schema(implementation = ManagementApiSchema.ContractNegotiationSchema.class))),
                     @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))),
                     @ApiResponse(responseCode = "404", description = "An contract negotiation with the given ID does not exist",
@@ -184,45 +182,6 @@ public interface ContractNegotiationApi {
                             }]
                         }
                     },
-                    "callbackAddresses": [{
-                        "transactional": false,
-                        "uri": "http://callback/url",
-                        "events": ["contract.negotiation", "transfer.process"],
-                        "authKey": "auth-key",
-                        "authCodeId": "auth-code-id"
-                    }]
-                }
-                """;
-    }
-
-    @Schema(name = "ContractNegotiation", example = ContractNegotiationSchema.CONTRACT_NEGOTIATION_EXAMPLE)
-    record ContractNegotiationSchema(
-            @Schema(name = TYPE, example = CONTRACT_NEGOTIATION_TYPE)
-            String ldType,
-            @Schema(name = ID)
-            String id,
-            ContractNegotiation.Type type,
-            String protocol,
-            String counterPartyId,
-            String counterPartyAddress,
-            String state,
-            String contractAgreementId,
-            String errorDetail,
-            List<ManagementApiSchema.CallbackAddressSchema> callbackAddresses
-    ) {
-        public static final String CONTRACT_NEGOTIATION_EXAMPLE = """
-                {
-                    "@context": { "edc": "https://w3id.org/edc/v0.0.1/ns/" },
-                    "@type": "https://w3id.org/edc/v0.0.1/ns/ContractNegotiation",
-                    "@id": "negotiation-id",
-                    "type": "PROVIDER",
-                    "protocol": "dataspace-protocol-http",
-                    "counterPartyId": "counter-party-id",
-                    "counterPartyAddress": "http://counter/party/address",
-                    "state": "VERIFIED",
-                    "contractAgreementId": "contract:agreement:id",
-                    "errorDetail": "eventual-error-detail",
-                    "createdAt": 1688465655,
                     "callbackAddresses": [{
                         "transactional": false,
                         "uri": "http://callback/url",

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiTest.java
@@ -35,23 +35,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.eclipse.edc.connector.api.management.contractnegotiation.ContractNegotiationApi.ContractNegotiationSchema.CONTRACT_NEGOTIATION_EXAMPLE;
 import static org.eclipse.edc.connector.api.management.contractnegotiation.ContractNegotiationApi.ContractRequestSchema.CONTRACT_REQUEST_EXAMPLE;
 import static org.eclipse.edc.connector.api.management.contractnegotiation.ContractNegotiationApi.NegotiationStateSchema.NEGOTIATION_STATE_EXAMPLE;
 import static org.eclipse.edc.connector.api.management.contractnegotiation.ContractNegotiationApi.TerminateNegotiationSchema.TERMINATE_NEGOTIATION_EXAMPLE;
 import static org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationState.NEGOTIATION_STATE_STATE;
 import static org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationState.NEGOTIATION_STATE_TYPE;
-import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_AGREEMENT_ID;
-import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_CALLBACK_ADDR;
-import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_COUNTERPARTY_ADDR;
-import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_COUNTERPARTY_ID;
-import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_CREATED_AT;
-import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_ERRORDETAIL;
-import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_NEG_TYPE;
-import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_PROTOCOL;
-import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_STATE;
-import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_TYPE;
-import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
@@ -87,26 +75,6 @@ class ContractNegotiationApiTest {
                         .satisfies(transformed -> {
                             assertThat(transformed.getProviderId()).isNotBlank();
                         }));
-    }
-
-    @Test
-    void contractNegotiationExample() throws JsonProcessingException {
-        var jsonObject = objectMapper.readValue(CONTRACT_NEGOTIATION_EXAMPLE, JsonObject.class);
-        var expanded = jsonLd.expand(jsonObject);
-
-        assertThat(expanded).isSucceeded().satisfies(content -> {
-            assertThat(content.getString(ID)).isNotBlank();
-            assertThat(content.getJsonArray(TYPE).getString(0)).isEqualTo(CONTRACT_NEGOTIATION_TYPE);
-            assertThat(content.getJsonArray(CONTRACT_NEGOTIATION_CREATED_AT).getJsonObject(0).getJsonNumber(VALUE).longValue()).isGreaterThan(0);
-            assertThat(content.getJsonArray(CONTRACT_NEGOTIATION_NEG_TYPE).getJsonObject(0).getString(VALUE)).isNotBlank();
-            assertThat(content.getJsonArray(CONTRACT_NEGOTIATION_PROTOCOL).getJsonObject(0).getString(VALUE)).isNotBlank();
-            assertThat(content.getJsonArray(CONTRACT_NEGOTIATION_COUNTERPARTY_ID).getJsonObject(0).getString(VALUE)).isNotBlank();
-            assertThat(content.getJsonArray(CONTRACT_NEGOTIATION_COUNTERPARTY_ADDR).getJsonObject(0).getString(VALUE)).isNotBlank();
-            assertThat(content.getJsonArray(CONTRACT_NEGOTIATION_STATE).getJsonObject(0).getString(VALUE)).isNotBlank();
-            assertThat(content.getJsonArray(CONTRACT_NEGOTIATION_AGREEMENT_ID).getJsonObject(0).getString(VALUE)).isNotBlank();
-            assertThat(content.getJsonArray(CONTRACT_NEGOTIATION_ERRORDETAIL).getJsonObject(0).getString(VALUE)).isNotBlank();
-            assertThat(content.getJsonArray(CONTRACT_NEGOTIATION_CALLBACK_ADDR)).asList().isNotEmpty();
-        });
     }
 
     @Test

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/contractagreement/ContractAgreementService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/contractagreement/ContractAgreementService.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.connector.spi.contractagreement;
 
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.service.spi.result.ServiceResult;
 import org.eclipse.edc.spi.query.QuerySpec;
 
@@ -40,5 +41,13 @@ public interface ContractAgreementService {
      * @return the collection of contract agreements that match the query
      */
     ServiceResult<Stream<ContractAgreement>> query(QuerySpec query);
+
+    /**
+     * Returns a contract negotiation by the agreement id.
+     *
+     * @param contractAgreementId the contract agreement id.
+     * @return the contract negotiation, null if it's not found.
+     */
+    ContractNegotiation findNegotiation(String contractAgreementId);
 
 }

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractAgreementApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractAgreementApiEndToEndTest.java
@@ -74,6 +74,24 @@ public class ContractAgreementApiEndToEndTest extends BaseManagementApiEndToEndT
         assertThat(json.getString("'edc:assetId'")).isNotNull();
     }
 
+    @Test
+    void getNegotiationByAgreementId() {
+        var store = controlPlane.getContext().getService(ContractNegotiationStore.class);
+        store.save(createContractNegotiationBuilder("negotiation-id")
+                .contractAgreement(createContractAgreement("agreement-id"))
+                .build());
+
+        var json = baseRequest()
+                .contentType(JSON)
+                .get("/v2/contractagreements/agreement-id/negotiation")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .extract().jsonPath();
+
+        assertThat(json.getString("@id")).isEqualTo("negotiation-id");
+    }
+
     private ContractNegotiation.Builder createContractNegotiationBuilder(String negotiationId) {
         return ContractNegotiation.Builder.newInstance()
                 .id(negotiationId)


### PR DESCRIPTION
## What this PR changes/adds

Adds an additional endpoint `GET /v2/contractagreements/{id}/negotiation` to obtain a negotiation given a contract agreement id

## Why it does that

Seems to be a pretty needed functionality

## Further notes

- improved some api documentation

## Linked Issue(s)

Closes #2316

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
