### PR TITLE
refactor: switch properties to Map<String, Object>

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -71,6 +71,206 @@ maven/mavencentral/com.google.guava/guava/31.1-jre, Apache-2.0, approved, clearl
 maven/mavencentral/com.google.guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava, Apache-2.0, approved, CQ22657
 maven/mavencentral/com.google.j2objc/j2objc-annotations/1.3, Apache-2.0, approved, CQ21195
 maven/mavencentral/com.google.protobuf/protobuf-java/3.19.6, BSD-3-Clause, approved, clearlydefined
+maven/mavencentral/com.google.protobuf/protobuf-java/3.23.4, BSD-3-Clause, approved, #8634
+maven/mavencentral/com.googlecode.libphonenumber/libphonenumber/8.11.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.h2database/h2/2.2.220, (EPL-1.0 OR MPL-2.0) AND (LGPL-3.0-or-later OR EPL-1.0 OR MPL-2.0), approved, #9322
+maven/mavencentral/com.jayway.jsonpath/json-path/2.7.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.jcraft/jzlib/1.1.3, BSD-2-Clause, approved, CQ6218
+maven/mavencentral/com.lmax/disruptor/3.4.4, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.networknt/json-schema-validator/1.0.76, Apache-2.0, approved, CQ22638
+maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.28, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.31, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.puppycrawl.tools/checkstyle/10.0, LGPL-2.1-or-later, approved, #7936
+maven/mavencentral/com.samskivert/jmustache/1.15, BSD-2-Clause, approved, clearlydefined
+maven/mavencentral/com.squareup.okhttp3/okhttp-dnsoverhttps/4.11.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.squareup.okhttp3/okhttp/4.11.0, Apache-2.0, approved, #9240
+maven/mavencentral/com.squareup.okhttp3/okhttp/4.9.3, Apache-2.0 AND MPL-2.0, approved, #3225
+maven/mavencentral/com.squareup.okio/okio-jvm/3.2.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.squareup.okio/okio/3.2.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.sun.activation/jakarta.activation/2.0.0, EPL-2.0 OR BSD-3-Clause OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jaf
+maven/mavencentral/com.sun.activation/jakarta.activation/2.0.1, EPL-2.0 OR BSD-3-Clause OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jaf
+maven/mavencentral/com.sun.mail/mailapi/1.6.2, CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, clearlydefined
+maven/mavencentral/com.sun.xml.bind/jaxb-core/4.0.1, BSD-3-Clause, approved, ee4j.jaxb-impl
+maven/mavencentral/com.sun.xml.bind/jaxb-impl/4.0.1, BSD-3-Clause, approved, ee4j.jaxb-impl
+maven/mavencentral/commons-beanutils/commons-beanutils/1.8.3, Apache-2.0, approved, CQ4968
+maven/mavencentral/commons-beanutils/commons-beanutils/1.9.4, Apache-2.0, approved, CQ12654
+maven/mavencentral/commons-codec/commons-codec/1.11, Apache-2.0 AND BSD-3-Clause, approved, CQ15971
+maven/mavencentral/commons-codec/commons-codec/1.15, Apache-2.0 AND BSD-3-Clause AND LicenseRef-Public-Domain, approved, CQ22641
+maven/mavencentral/commons-collections/commons-collections/3.2.2, Apache-2.0, approved, CQ10385
+maven/mavencentral/commons-io/commons-io/2.11.0, Apache-2.0, approved, CQ23745
+maven/mavencentral/commons-logging/commons-logging/1.1.1, Apache-2.0, approved, CQ1907
+maven/mavencentral/commons-logging/commons-logging/1.2, Apache-2.0, approved, CQ10162
+maven/mavencentral/dev.failsafe/failsafe-okhttp/3.3.2, Apache-2.0, approved, #9178
+maven/mavencentral/dev.failsafe/failsafe/3.3.2, Apache-2.0, approved, #9268
+maven/mavencentral/info.picocli/picocli/4.6.3, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.cloudevents/cloudevents-api/2.5.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.cloudevents/cloudevents-core/2.5.0, Apache-2.0, approved, #9328
+maven/mavencentral/io.cloudevents/cloudevents-http-basic/2.5.0, Apache-2.0, approved, #9329
+maven/mavencentral/io.github.classgraph/classgraph/4.8.138, MIT, approved, CQ22530
+maven/mavencentral/io.github.classgraph/classgraph/4.8.154, MIT, approved, CQ22530
+maven/mavencentral/io.micrometer/micrometer-commons/1.11.2, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #9243
+maven/mavencentral/io.micrometer/micrometer-core/1.11.2, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #9238
+maven/mavencentral/io.micrometer/micrometer-observation/1.11.2, Apache-2.0, approved, #9242
+maven/mavencentral/io.netty/netty-buffer/4.1.86.Final, Apache-2.0, approved, CQ21842
+maven/mavencentral/io.netty/netty-codec-http/4.1.86.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-codec-http2/4.1.86.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-codec-socks/4.1.86.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-codec/4.1.86.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-common/4.1.86.Final, Apache-2.0 AND MIT AND CC0-1.0, approved, CQ21843
+maven/mavencentral/io.netty/netty-handler-proxy/4.1.86.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-handler/4.1.86.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-resolver/4.1.86.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-tcnative-boringssl-static/2.0.56.Final, Apache-2.0 OR LicenseRef-Public-Domain OR BSD-2-Clause OR MIT, approved, CQ15280
+maven/mavencentral/io.netty/netty-tcnative-classes/2.0.56.Final, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.netty/netty-transport-native-unix-common/4.1.86.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-transport/4.1.86.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations/1.28.0, Apache-2.0, approved, #9662
+maven/mavencentral/io.opentelemetry.proto/opentelemetry-proto/1.0.0-alpha, Apache-2.0, approved, #10044
+maven/mavencentral/io.opentelemetry/opentelemetry-api/1.28.0, Apache-2.0, approved, #9661
+maven/mavencentral/io.opentelemetry/opentelemetry-context/1.28.0, Apache-2.0, approved, #9663
+maven/mavencentral/io.prometheus/simpleclient/0.16.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.prometheus/simpleclient_common/0.16.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.prometheus/simpleclient_httpserver/0.16.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.prometheus/simpleclient_tracer_common/0.16.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.prometheus/simpleclient_tracer_otel/0.16.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.prometheus/simpleclient_tracer_otel_agent/0.16.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.rest-assured/json-path/5.3.1, Apache-2.0, approved, #9261
+maven/mavencentral/io.rest-assured/rest-assured-common/5.3.1, Apache-2.0, approved, #9264
+maven/mavencentral/io.rest-assured/rest-assured/5.3.1, Apache-2.0, approved, #9262
+maven/mavencentral/io.rest-assured/xml-path/5.3.1, Apache-2.0, approved, #9267
+maven/mavencentral/io.setl/rdf-urdna/1.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.15, Apache-2.0, approved, #5947
+maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.2, Apache-2.0, approved, #5947
+maven/mavencentral/io.swagger.core.v3/swagger-annotations/2.2.10, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.swagger.core.v3/swagger-annotations/2.2.8, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.swagger.core.v3/swagger-core-jakarta/2.2.2, Apache-2.0, approved, #5929
+maven/mavencentral/io.swagger.core.v3/swagger-core/2.2.10, Apache-2.0, approved, #9265
+maven/mavencentral/io.swagger.core.v3/swagger-core/2.2.8, Apache-2.0, approved, #9265
+maven/mavencentral/io.swagger.core.v3/swagger-integration-jakarta/2.2.2, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.swagger.core.v3/swagger-integration/2.2.10, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.swagger.core.v3/swagger-jaxrs2-jakarta/2.2.2, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.swagger.core.v3/swagger-jaxrs2/2.2.10, Apache-2.0, approved, #9814
+maven/mavencentral/io.swagger.core.v3/swagger-models-jakarta/2.2.2, Apache-2.0, approved, #5919
+maven/mavencentral/io.swagger.core.v3/swagger-models/2.2.10, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.swagger.core.v3/swagger-models/2.2.8, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.swagger.parser.v3/swagger-parser-core/2.1.10, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.swagger.parser.v3/swagger-parser-v2-converter/2.1.10, Apache-2.0, approved, #9330
+maven/mavencentral/io.swagger.parser.v3/swagger-parser-v3/2.1.10, Apache-2.0, approved, #9323
+maven/mavencentral/io.swagger.parser.v3/swagger-parser/2.1.10, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.swagger/swagger-annotations/1.6.9, Apache-2.0, approved, #3792
+maven/mavencentral/io.swagger/swagger-compat-spec-parser/1.0.64, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.swagger/swagger-core/1.6.9, Apache-2.0, approved, #4358
+maven/mavencentral/io.swagger/swagger-models/1.6.9, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.swagger/swagger-parser/1.0.64, Apache-2.0, approved, #4359
+maven/mavencentral/jakarta.activation/jakarta.activation-api/1.2.1, EPL-2.0 OR BSD-3-Clause OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jaf
+maven/mavencentral/jakarta.activation/jakarta.activation-api/2.1.0, EPL-2.0 OR BSD-3-Clause OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jaf
+maven/mavencentral/jakarta.annotation/jakarta.annotation-api/2.1.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.ca
+maven/mavencentral/jakarta.inject/jakarta.inject-api/2.0.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/jakarta.json/jakarta.json-api/2.1.1, EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, #7907
+maven/mavencentral/jakarta.transaction/jakarta.transaction-api/2.0.0, EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, #7697
+maven/mavencentral/jakarta.transaction/jakarta.transaction-api/2.0.1, EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, #7697
+maven/mavencentral/jakarta.validation/jakarta.validation-api/2.0.2, Apache-2.0, approved, clearlydefined
+maven/mavencentral/jakarta.validation/jakarta.validation-api/3.0.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/jakarta.validation/jakarta.validation-api/3.0.2, Apache-2.0, approved, clearlydefined
+maven/mavencentral/jakarta.ws.rs/jakarta.ws.rs-api/3.1.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.rest
+maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/2.3.2, BSD-3-Clause, approved, ee4j.jaxb
+maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/3.0.0, BSD-3-Clause, approved, ee4j.jaxb
+maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/3.0.1, BSD-3-Clause, approved, ee4j.jaxb
+maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0, BSD-3-Clause, approved, ee4j.jaxb
+maven/mavencentral/javax.servlet/javax.servlet-api/3.1.0, (CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0) AND Apache-2.0, approved, CQ7248
+maven/mavencentral/javax.servlet/javax.servlet-api/4.0.1, (CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0) AND Apache-2.0, approved, CQ16125
+maven/mavencentral/javax.ws.rs/javax.ws.rs-api/2.1, (CDDL-1.1 OR GPL-2.0 WITH Classpath-exception-2.0) AND Apache-2.0, approved, CQ18121
+maven/mavencentral/joda-time/joda-time/2.10.5, Apache-2.0, approved, clearlydefined
+maven/mavencentral/junit/junit/4.13.2, EPL-2.0, approved, CQ23636
+maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.1, Apache-2.0, approved, #7164
+maven/mavencentral/net.bytebuddy/byte-buddy/1.12.21, Apache-2.0 AND BSD-3-Clause, approved, #1811
+maven/mavencentral/net.bytebuddy/byte-buddy/1.14.1, Apache-2.0 AND BSD-3-Clause, approved, #7163
+maven/mavencentral/net.java.dev.jna/jna/5.12.1, Apache-2.0 OR LGPL-2.1-or-later, approved, #3217
+maven/mavencentral/net.javacrumbs.json-unit/json-unit-core/2.36.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/net.minidev/accessors-smart/2.4.7, Apache-2.0, approved, #7515
+maven/mavencentral/net.minidev/json-smart/2.4.7, Apache-2.0, approved, #3288
+maven/mavencentral/net.sf.jopt-simple/jopt-simple/5.0.4, MIT, approved, CQ13174
+maven/mavencentral/net.sf.saxon/Saxon-HE/10.6, MPL-2.0 AND W3C, approved, #7945
+maven/mavencentral/org.antlr/antlr4-runtime/4.9.3, BSD-3-Clause, approved, #322
+maven/mavencentral/org.apache.commons/commons-compress/1.23.0, Apache-2.0 AND BSD-3-Clause, approved, #7506
+maven/mavencentral/org.apache.commons/commons-digester3/3.2, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.commons/commons-lang3/3.10, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.commons/commons-lang3/3.11, Apache-2.0, approved, CQ22642
+maven/mavencentral/org.apache.commons/commons-lang3/3.12.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.commons/commons-pool2/2.11.1, Apache-2.0, approved, CQ23795
+maven/mavencentral/org.apache.commons/commons-text/1.10.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.groovy/groovy-bom/4.0.11, Apache-2.0, approved, #9266
+maven/mavencentral/org.apache.groovy/groovy-json/4.0.11, Apache-2.0, approved, #7411
+maven/mavencentral/org.apache.groovy/groovy-xml/4.0.11, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.groovy/groovy/4.0.11, Apache-2.0 AND BSD-3-Clause AND MIT, approved, #1742
+maven/mavencentral/org.apache.httpcomponents/httpclient/4.5.13, Apache-2.0 AND LicenseRef-Public-Domain, approved, CQ23527
+maven/mavencentral/org.apache.httpcomponents/httpcore/4.4.13, Apache-2.0, approved, CQ23528
+maven/mavencentral/org.apache.httpcomponents/httpmime/4.5.13, Apache-2.0, approved, CQ11718
+maven/mavencentral/org.apache.kafka/kafka-clients/3.5.1, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #9325
+maven/mavencentral/org.apache.velocity.tools/velocity-tools-generic/3.1, Apache-2.0, approved, #9331
+maven/mavencentral/org.apache.velocity/velocity-engine-core/2.3, Apache-2.0, approved, #2478
+maven/mavencentral/org.apache.velocity/velocity-engine-scripting/2.3, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.assertj/assertj-core/3.24.2, Apache-2.0, approved, #6161
+maven/mavencentral/org.awaitility/awaitility/4.2.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.72, MIT, approved, #3789
+maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.76, MIT, approved, #9825
+maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.72, MIT AND CC0-1.0, approved, #3538
+maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.76, MIT AND CC0-1.0, approved, #9827
+maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.72, MIT, approved, #3790
+maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.76, MIT, approved, #9828
+maven/mavencentral/org.ccil.cowan.tagsoup/tagsoup/1.2.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.checkerframework/checker-qual/3.12.0, MIT, approved, clearlydefined
+maven/mavencentral/org.checkerframework/checker-qual/3.31.0, MIT, approved, clearlydefined
+maven/mavencentral/org.eclipse.angus/angus-activation/1.0.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.angus
+maven/mavencentral/org.eclipse.edc/autodoc-processor/0.2.1-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/runtime-metamodel/0.2.1-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.jetty.toolchain/jetty-jakarta-servlet-api/5.0.2, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty.toolchain/jetty-jakarta-websocket-api/2.0.0, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty.websocket/websocket-core-client/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty.websocket/websocket-core-common/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty.websocket/websocket-core-server/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty.websocket/websocket-jakarta-client/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty.websocket/websocket-jakarta-common/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty.websocket/websocket-jakarta-server/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty.websocket/websocket-servlet/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty/jetty-alpn-client/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty/jetty-annotations/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty/jetty-client/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty/jetty-http/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty/jetty-io/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty/jetty-jndi/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty/jetty-plus/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty/jetty-security/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty/jetty-server/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty/jetty-servlet/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty/jetty-util/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty/jetty-webapp/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty/jetty-xml/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.glassfish.hk2.external/aopalliance-repackaged/3.0.4, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
+maven/mavencentral/org.glassfish.hk2/hk2-api/3.0.4, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
+maven/mavencentral/org.glassfish.hk2/hk2-locator/3.0.4, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
+maven/mavencentral/org.glassfish.hk2/hk2-utils/3.0.4, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
+maven/mavencentral/org.glassfish.hk2/osgi-resource-locator/1.0.3, CDDL-1.0, approved, CQ10889
+maven/mavencentral/org.glassfish.jersey.containers/jersey-container-servlet-core/3.1.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.containers/jersey-container-servlet/3.1.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.core/jersey-client/3.1.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.core/jersey-common/3.1.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.core/jersey-server/3.1.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.ext/jersey-entity-filtering/3.1.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.inject/jersey-hk2/3.1.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.media/jersey-media-json-jackson/3.1.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.media/jersey-media-multipart/3.1.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish/jakarta.json/2.0.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jsonp
+maven/mavencentral/org.hamcrest/hamcrest-core/1.3, BSD-2-Clause, approved, CQ11429
+maven/mavencentral/org.hamcrest/hamcrest-core/2.2, BSD-3-Clause, approved, clearlydefined
+maven/mavencentral/org.hamcrest/hamcrest/2.1, BSD-3-Clause, approved, clearlydefined
+maven/mavencentral/org.hamcrest/hamcrest/2.2, BSD-3-Clause, approved, clearlydefined
+maven/mavencentral/org.hdrhistogram/HdrHistogram/2.1.12, BSD-2-Clause OR LicenseRef-Public-Domain, approved, CQ13192
+maven/mavencentral/org.jacoco/org.jacoco.agent/0.8.8, EPL-2.0, approved, CQ23285
+maven/mavencentral/org.jacoco/org.jacoco.ant/0.8.8, EPL-2.0, approved, #1068
+maven/mavencentral/org.jacoco/org.jacoco.core/0.8.8, EPL-2.0, approved, CQ23283
+maven/mavencentral/org.jacoco/org.jacoco.report/0.8.8, EPL-2.0 AND Apache-2.0, approved, CQ23284
 maven/mavencentral/org.javassist/javassist/3.25.0-GA, MPL-1.1 OR LGPL-2.1-or-later OR Apache-2.0, approved, CQ19885
 maven/mavencentral/org.javassist/javassist/3.28.0-GA, Apache-2.0 OR LGPL-2.1-or-later OR MPL-1.1, approved, #327
 maven/mavencentral/org.javassist/javassist/3.29.2-GA, Apache-2.0 AND LGPL-2.1-or-later AND MPL-1.1, approved, #6023

--- a/core/common/transform-core/src/main/java/org/eclipse/edc/core/transform/transformer/from/JsonObjectFromDataAddressTransformer.java
+++ b/core/common/transform-core/src/main/java/org/eclipse/edc/core/transform/transformer/from/JsonObjectFromDataAddressTransformer.java
@@ -40,7 +40,7 @@ public class JsonObjectFromDataAddressTransformer extends AbstractJsonLdTransfor
 
         builder.add(TYPE, EDC_NAMESPACE + "DataAddress");
 
-        dataAddress.getProperties().forEach(builder::add);
+        dataAddress.getProperties().forEach((key, value) -> builder.add(key, (String) value)); // TODO: handle different types
 
         return builder.build();
     }

--- a/core/common/transform-core/src/test/java/org/eclipse/edc/core/transform/transformer/to/JsonObjectToDataAddressTransformerTest.java
+++ b/core/common/transform-core/src/test/java/org/eclipse/edc/core/transform/transformer/to/JsonObjectToDataAddressTransformerTest.java
@@ -84,7 +84,7 @@ class JsonObjectToDataAddressTransformerTest {
         var dataAddress = transformer.transform(json, transformerContext);
         assertThat(dataAddress).isNotNull();
         assertThat(dataAddress.getType()).isEqualTo(TEST_TYPE);
-        assertThat(dataAddress.getProperty(EDC_NAMESPACE + "my-test-prop")).isEqualTo("some-test-value");
+        assertThat(dataAddress.getStringProperty(EDC_NAMESPACE + "my-test-prop")).isEqualTo("some-test-value");
     }
 
     @Test

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/edr/DataAddressToEndpointDataReferenceTransformer.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/edr/DataAddressToEndpointDataReferenceTransformer.java
@@ -63,10 +63,10 @@ public class DataAddressToEndpointDataReferenceTransformer implements TypeTransf
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
         return EndpointDataReference.Builder.newInstance()
-                .id(address.getProperty(ID))
-                .authCode(address.getProperty(AUTH_CODE))
-                .authKey(address.getProperty(AUTH_KEY))
-                .endpoint(address.getProperty(ENDPOINT))
+                .id(address.getStringProperty(ID))
+                .authCode(address.getStringProperty(AUTH_CODE))
+                .authKey(address.getStringProperty(AUTH_KEY))
+                .endpoint(address.getStringProperty(ENDPOINT))
                 .properties(properties)
                 .build();
     }

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
@@ -255,7 +255,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager {
             process.setContentDataAddress(dataAddress);
 
             var dataDestination = process.getDataDestination();
-            var secret = dataDestination.getProperty(EDC_DATA_ADDRESS_SECRET);
+            var secret = dataDestination.getStringProperty(EDC_DATA_ADDRESS_SECRET);
             if (secret != null) {
                 vault.storeSecret(dataDestination.getKeyName(), secret);
             }

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/edr/DataAddressToEndpointDataReferenceTransformerTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/edr/DataAddressToEndpointDataReferenceTransformerTest.java
@@ -48,10 +48,10 @@ class DataAddressToEndpointDataReferenceTransformerTest {
                 .isNotNull()
                 .usingRecursiveComparison()
                 .isEqualTo(EndpointDataReference.Builder.newInstance()
-                        .endpoint(address.getProperty(EndpointDataReference.ENDPOINT))
-                        .authKey(address.getProperty(EndpointDataReference.AUTH_KEY))
-                        .authCode(address.getProperty(EndpointDataReference.AUTH_CODE))
-                        .id(address.getProperty(EndpointDataReference.ID))
+                        .endpoint(address.getStringProperty(EndpointDataReference.ENDPOINT))
+                        .authKey(address.getStringProperty(EndpointDataReference.AUTH_KEY))
+                        .authCode(address.getStringProperty(EndpointDataReference.AUTH_CODE))
+                        .id(address.getStringProperty(EndpointDataReference.ID))
                         .build());
     }
 

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImplTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImplTest.java
@@ -454,7 +454,7 @@ class TransferProcessManagerImplTest {
             verify(listener).requested(process);
             var requestMessage = captor.getValue();
             assertThat(requestMessage.getCallbackAddress()).isEqualTo(protocolWebhookUrl);
-            assertThat(requestMessage.getDataDestination().getProperty(EDC_DATA_ADDRESS_SECRET)).isNull();
+            assertThat(requestMessage.getDataDestination().getStringProperty(EDC_DATA_ADDRESS_SECRET)).isNull();
         });
     }
 
@@ -476,7 +476,7 @@ class TransferProcessManagerImplTest {
             verify(listener).requested(process);
             verify(vault).resolveSecret("keyName");
             var requestMessage = captor.getValue();
-            assertThat(requestMessage.getDataDestination().getProperty(EDC_DATA_ADDRESS_SECRET)).isEqualTo("secret");
+            assertThat(requestMessage.getDataDestination().getStringProperty(EDC_DATA_ADDRESS_SECRET)).isEqualTo("secret");
         });
     }
 

--- a/core/data-plane/data-plane-util/src/main/java/org/eclipse/edc/connector/dataplane/util/validation/EmptyValueValidationRule.java
+++ b/core/data-plane/data-plane-util/src/main/java/org/eclipse/edc/connector/dataplane/util/validation/EmptyValueValidationRule.java
@@ -15,13 +15,10 @@
 package org.eclipse.edc.connector.dataplane.util.validation;
 
 import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.util.string.StringUtils;
 
-import java.util.Map;
-
-import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
-
-public class EmptyValueValidationRule implements ValidationRule<Map<String, String>> {
+public class EmptyValueValidationRule implements ValidationRule<DataAddress> {
 
     private final String keyName;
 
@@ -30,9 +27,8 @@ public class EmptyValueValidationRule implements ValidationRule<Map<String, Stri
     }
 
     @Override
-    public Result<Void> apply(Map<String, String> map) {
-        // TODO applied quick fix to handle json-ld edc namespace. to be fixed with https://github.com/eclipse-edc/Connector/issues/3005
-        return StringUtils.isNullOrBlank(map.getOrDefault(keyName, map.get(EDC_NAMESPACE + keyName)))
+    public Result<Void> apply(DataAddress dataAddress) {
+        return StringUtils.isNullOrBlank(dataAddress.getStringProperty(keyName))
                 ? Result.failure("Missing or invalid value for key " + keyName)
                 : Result.success();
     }

--- a/core/data-plane/data-plane-util/src/main/java/org/eclipse/edc/connector/dataplane/util/validation/ValidationRule.java
+++ b/core/data-plane/data-plane-util/src/main/java/org/eclipse/edc/connector/dataplane/util/validation/ValidationRule.java
@@ -28,8 +28,8 @@ public interface ValidationRule<T> extends Function<T, Result<Void>> {
 
     default ValidationRule<T> and(ValidationRule<T> other) {
         return t -> {
-            Result<Void> thisResult = this.apply(t);
-            Result<Void> otherResult = other.apply(t);
+            var thisResult = this.apply(t);
+            var otherResult = other.apply(t);
 
             var thisFailureMessages = thisResult.failed() ? thisResult.getFailureMessages().stream() : Stream.<String>empty();
             var otherFailureMessages = otherResult.failed() ? otherResult.getFailureMessages().stream() : Stream.<String>empty();

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/to/JsonObjectToTransferRequestMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/to/JsonObjectToTransferRequestMessageTransformerTest.java
@@ -90,8 +90,8 @@ class JsonObjectToTransferRequestMessageTransformerTest {
         assertThat(result.getContractId()).isEqualTo(contractId);
         assertThat(result.getDataDestination().getType()).isEqualTo(destinationType);
         assertThat(result.getCallbackAddress()).isEqualTo(callbackAddress);
-        assertThat(result.getDataDestination().getProperty("accessKeyId")).isEqualTo("TESTID");
-        assertThat(result.getDataDestination().getProperty("region")).isEqualTo("eu-central-1");
+        assertThat(result.getDataDestination().getStringProperty("accessKeyId")).isEqualTo("TESTID");
+        assertThat(result.getDataDestination().getStringProperty("region")).isEqualTo("eu-central-1");
 
         verify(context, never()).reportProblem(anyString());
     }

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/TransferProcessApi.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/TransferProcessApi.java
@@ -130,6 +130,7 @@ public interface TransferProcessApi {
             String contractId,
             String assetId,
             ManagementApiSchema.DataAddressSchema dataDestination,
+            @Schema(deprecated = true, description = "Deprecated as this field is not used anymore, please use privateProperties instead")
             Map<String, String> properties,
             Map<String, String> privateProperties,
             List<ManagementApiSchema.CallbackAddressSchema> callbackAddresses) {
@@ -145,9 +146,6 @@ public interface TransferProcessApi {
                     "assetId": "asset-id",
                     "dataDestination": {
                         "type": "data-destination-type"
-                    },
-                    "properties": {
-                        "key": "value"
                     },
                     "privateProperties": {
                         "private-key": "private-value"
@@ -176,6 +174,10 @@ public interface TransferProcessApi {
             String state,
             String contractAgreementId,
             String errorDetail,
+            @Deprecated(since = "0.2.0")
+            @Schema(deprecated = true)
+            Map<String, String> properties,
+            Map<String, Object> privateProperties,
             List<ManagementApiSchema.CallbackAddressSchema> callbackAddresses
     ) {
         public static final String TRANSFER_PROCESS_EXAMPLE = """
@@ -192,9 +194,6 @@ public interface TransferProcessApi {
                     "contractId": "contractId",
                     "dataDestination": {
                         "type": "data-destination-type"
-                    },
-                    "properties": {
-                        "key": "value"
                     },
                     "privateProperties": {
                         "private-key": "private-value"

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/api/management/transferprocess/TransferProcessApiTest.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/api/management/transferprocess/TransferProcessApiTest.java
@@ -51,7 +51,6 @@ import static org.eclipse.edc.connector.transfer.spi.types.TransferProcess.TRANS
 import static org.eclipse.edc.connector.transfer.spi.types.TransferProcess.TRANSFER_PROCESS_DATA_DESTINATION;
 import static org.eclipse.edc.connector.transfer.spi.types.TransferProcess.TRANSFER_PROCESS_ERROR_DETAIL;
 import static org.eclipse.edc.connector.transfer.spi.types.TransferProcess.TRANSFER_PROCESS_PRIVATE_PROPERTIES;
-import static org.eclipse.edc.connector.transfer.spi.types.TransferProcess.TRANSFER_PROCESS_PROPERTIES;
 import static org.eclipse.edc.connector.transfer.spi.types.TransferProcess.TRANSFER_PROCESS_STATE;
 import static org.eclipse.edc.connector.transfer.spi.types.TransferProcess.TRANSFER_PROCESS_STATE_TIMESTAMP;
 import static org.eclipse.edc.connector.transfer.spi.types.TransferProcess.TRANSFER_PROCESS_TYPE;
@@ -96,7 +95,6 @@ class TransferProcessApiTest {
                             assertThat(transformed.getConnectorId()).isNotBlank();
                             assertThat(transformed.getAssetId()).isNotBlank();
                             assertThat(transformed.getDataDestination()).isNotNull();
-                            assertThat(transformed.getProperties()).asInstanceOf(map(String.class, Object.class)).isNotEmpty();
                             assertThat(transformed.getPrivateProperties()).asInstanceOf(map(String.class, Object.class)).isNotEmpty();
                             assertThat(transformed.getCallbackAddresses()).asList().isNotEmpty();
                         }));
@@ -134,7 +132,6 @@ class TransferProcessApiTest {
             assertThat(content.getJsonArray(TRANSFER_PROCESS_ASSET_ID).getJsonObject(0).getString(VALUE)).isNotBlank();
             assertThat(content.getJsonArray(TRANSFER_PROCESS_CONNECTOR_ID).getJsonObject(0).getString(VALUE)).isNotBlank();
             assertThat(content.getJsonArray(TRANSFER_PROCESS_CONTRACT_ID).getJsonObject(0).getString(VALUE)).isNotBlank();
-            assertThat(content.getJsonArray(TRANSFER_PROCESS_PROPERTIES).getJsonObject(0)).asInstanceOf(map(String.class, Object.class)).isNotEmpty();
             assertThat(content.getJsonArray(TRANSFER_PROCESS_PRIVATE_PROPERTIES).getJsonObject(0)).asInstanceOf(map(String.class, Object.class)).isNotEmpty();
             assertThat(content.getJsonArray(TRANSFER_PROCESS_TYPE_TYPE).getJsonObject(0).getString(VALUE)).isNotBlank();
             assertThat(content.getJsonArray(TRANSFER_PROCESS_ERROR_DETAIL).getJsonObject(0).getString(VALUE)).isNotBlank();

--- a/extensions/control-plane/transfer/transfer-pull-http-dynamic-receiver/src/main/java/org/eclipse/edc/connector/receiver/http/dynamic/HttpDynamicEndpointDataReferenceReceiver.java
+++ b/extensions/control-plane/transfer/transfer-pull-http-dynamic-receiver/src/main/java/org/eclipse/edc/connector/receiver/http/dynamic/HttpDynamicEndpointDataReferenceReceiver.java
@@ -70,7 +70,7 @@ public class HttpDynamicEndpointDataReferenceReceiver implements EndpointDataRef
 
         if (endpoint != null) {
             monitor.debug(format("Sending EDR to %s", endpoint));
-            return completedFuture(sendEdr(edr, endpoint));
+            return completedFuture(sendEdr(edr, endpoint.toString()));
         } else {
             monitor.debug(format("Missing %s property in the transfer process properties or fallback endpoint in configuration", HTTP_RECEIVER_ENDPOINT));
             return completedFuture(Result.success());

--- a/extensions/control-plane/transfer/transfer-pull-http-dynamic-receiver/src/test/java/org/eclipse/edc/connector/receiver/http/dynamic/HttpDynamicEndpointDataReferenceReceiverTest.java
+++ b/extensions/control-plane/transfer/transfer-pull-http-dynamic-receiver/src/test/java/org/eclipse/edc/connector/receiver/http/dynamic/HttpDynamicEndpointDataReferenceReceiverTest.java
@@ -40,7 +40,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.receiver.http.dynamic.HttpDynamicEndpointDataReferenceReceiver.HTTP_RECEIVER_ENDPOINT;
 import static org.eclipse.edc.connector.receiver.http.dynamic.TestFunctions.createTransferProcess;
 import static org.eclipse.edc.connector.receiver.http.dynamic.TestFunctions.transferProperties;
-import static org.eclipse.edc.connector.receiver.http.dynamic.TestFunctions.transferPropertiesWithAuth;
 import static org.eclipse.edc.junit.testfixtures.TestUtils.getFreePort;
 import static org.eclipse.edc.junit.testfixtures.TestUtils.testOkHttpClient;
 import static org.mockito.ArgumentMatchers.any;
@@ -120,8 +119,9 @@ public class HttpDynamicEndpointDataReferenceReceiverTest {
                 .monitor(monitor)
                 .build();
 
+        String url = receiverUrl();
         when(transferProcessStore.findForCorrelationId(any()))
-                .thenReturn(createTransferProcess(TRANSFER_ID, transferPropertiesWithAuth(receiverUrl(), authKey, authToken)));
+                .thenReturn(createTransferProcess(TRANSFER_ID, transferProperties(url)));
 
         var edr = createEndpointDataReferenceBuilder().build();
 

--- a/extensions/control-plane/transfer/transfer-pull-http-dynamic-receiver/src/test/java/org/eclipse/edc/connector/receiver/http/dynamic/TestFunctions.java
+++ b/extensions/control-plane/transfer/transfer-pull-http-dynamic-receiver/src/test/java/org/eclipse/edc/connector/receiver/http/dynamic/TestFunctions.java
@@ -26,7 +26,7 @@ import static org.eclipse.edc.connector.receiver.http.dynamic.HttpDynamicEndpoin
 
 public class TestFunctions {
 
-    public static TransferProcess createTransferProcess(String id, Map<String, String> properties) {
+    public static TransferProcess createTransferProcess(String id, Map<String, Object> properties) {
         return TransferProcess.Builder.newInstance()
                 .id(id)
                 .state(TransferProcessStates.STARTED.code())
@@ -45,12 +45,8 @@ public class TestFunctions {
         return createTransferProcess(id, new HashMap<>());
     }
 
-
-    public static Map<String, String> transferProperties(String url) {
+    public static Map<String, Object> transferProperties(String url) {
         return new HashMap<>(Map.of(HTTP_RECEIVER_ENDPOINT, url));
     }
 
-    public static Map<String, String> transferPropertiesWithAuth(String url, String key, String token) {
-        return new HashMap<>(Map.of(HTTP_RECEIVER_ENDPOINT, url));
-    }
 }

--- a/extensions/data-plane/data-plane-http-oauth2-core/src/test/java/org/eclipse/edc/connector/dataplane/http/oauth2/Oauth2CredentialsRequestFactoryTest.java
+++ b/extensions/data-plane/data-plane-http-oauth2-core/src/test/java/org/eclipse/edc/connector/dataplane/http/oauth2/Oauth2CredentialsRequestFactoryTest.java
@@ -122,7 +122,7 @@ class Oauth2CredentialsRequestFactoryTest {
                     assertThat(assertionToken.getJWTClaimsSet().getClaims())
                             .hasFieldOrPropertyWithValue("sub", "clientId")
                             .hasFieldOrPropertyWithValue("iss", "clientId")
-                            .hasFieldOrPropertyWithValue("aud", List.of(address.getProperty(TOKEN_URL)))
+                            .hasFieldOrPropertyWithValue("aud", List.of(address.getStringProperty(TOKEN_URL)))
                             .hasFieldOrProperty("jti")
                             .hasFieldOrPropertyWithValue("iat", Date.from(now))
                             .hasFieldOrPropertyWithValue("exp", Date.from(now.plusSeconds(600)));

--- a/extensions/data-plane/data-plane-http/src/testFixtures/java/org/eclipse/edc/connector/dataplane/http/testfixtures/HttpTestFixtures.java
+++ b/extensions/data-plane/data-plane-http/src/testFixtures/java/org/eclipse/edc/connector/dataplane/http/testfixtures/HttpTestFixtures.java
@@ -26,10 +26,10 @@ import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 
+import static java.util.Collections.emptyMap;
 import static okhttp3.Protocol.HTTP_2;
 
 public class HttpTestFixtures {
@@ -41,8 +41,8 @@ public class HttpTestFixtures {
     public static DataFlowRequest.Builder createRequest(String type) {
         return createRequest(
                 Map.of(DataFlowRequestSchema.METHOD, "GET"),
-                createDataAddress(type, Collections.emptyMap()).build(),
-                createDataAddress(type, Collections.emptyMap()).build()
+                createDataAddress(type, emptyMap()).build(),
+                createDataAddress(type, emptyMap()).build()
         );
     }
 
@@ -56,7 +56,7 @@ public class HttpTestFixtures {
                 .trackable(true);
     }
 
-    public static DataAddress.Builder createDataAddress(String type, Map<String, String> properties) {
+    public static DataAddress.Builder createDataAddress(String type, Map<String, Object> properties) {
         return DataAddress.Builder.newInstance()
                 .type(type)
                 .properties(properties);

--- a/extensions/data-plane/data-plane-kafka/src/main/java/org/eclipse/edc/dataplane/kafka/config/KafkaPropertiesFactory.java
+++ b/extensions/data-plane/data-plane-kafka/src/main/java/org/eclipse/edc/dataplane/kafka/config/KafkaPropertiesFactory.java
@@ -35,7 +35,7 @@ public class KafkaPropertiesFactory {
 
     private static final String BOOTSTRAP_SERVERS_CONFIG = "bootstrap.servers";
 
-    public Result<Properties> getConsumerProperties(Map<String, String> properties) {
+    public Result<Properties> getConsumerProperties(Map<String, Object> properties) {
         return getCommonProperties(properties)
                 .map(props -> {
                     props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
@@ -44,7 +44,7 @@ public class KafkaPropertiesFactory {
                 });
     }
 
-    public Result<Properties> getProducerProperties(Map<String, String> properties) {
+    public Result<Properties> getProducerProperties(Map<String, Object> properties) {
         return getCommonProperties(properties)
                 .map(props -> {
                     props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
@@ -53,7 +53,7 @@ public class KafkaPropertiesFactory {
                 });
     }
 
-    private Result<Properties> getCommonProperties(Map<String, String> properties) {
+    private Result<Properties> getCommonProperties(Map<String, Object> properties) {
         // TODO applied quick fix to handle json-ld edc namespace. to be fixed with https://github.com/eclipse-edc/Connector/issues/3005
         var props = new Properties();
         properties.entrySet().stream()

--- a/extensions/data-plane/data-plane-kafka/src/main/java/org/eclipse/edc/dataplane/kafka/pipeline/KafkaDataSinkFactory.java
+++ b/extensions/data-plane/data-plane-kafka/src/main/java/org/eclipse/edc/dataplane/kafka/pipeline/KafkaDataSinkFactory.java
@@ -67,7 +67,7 @@ public class KafkaDataSinkFactory implements DataSinkFactory {
         var producerProps = propertiesFactory.getProducerProperties(destination.getProperties())
                 .orElseThrow(failure -> new IllegalArgumentException(failure.getFailureDetail()));
 
-        var topic = Optional.ofNullable(destination.getProperty(TOPIC))
+        var topic = Optional.ofNullable(destination.getStringProperty(TOPIC))
                 .orElseThrow(() -> new IllegalArgumentException(format("Missing `%s` config", TOPIC)));
 
         return KafkaDataSink.Builder.newInstance()

--- a/extensions/data-plane/data-plane-kafka/src/main/java/org/eclipse/edc/dataplane/kafka/pipeline/KafkaDataSourceFactory.java
+++ b/extensions/data-plane/data-plane-kafka/src/main/java/org/eclipse/edc/dataplane/kafka/pipeline/KafkaDataSourceFactory.java
@@ -19,7 +19,7 @@ import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSource;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSourceFactory;
 import org.eclipse.edc.connector.dataplane.util.validation.ValidationRule;
 import org.eclipse.edc.dataplane.kafka.config.KafkaPropertiesFactory;
-import org.eclipse.edc.dataplane.kafka.pipeline.validation.KafkaSourceDataAddressValidationRule;
+import org.eclipse.edc.dataplane.kafka.pipeline.validation.KafkaSourceDataAddressValidation;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
@@ -50,7 +50,7 @@ public class KafkaDataSourceFactory implements DataSourceFactory {
     public KafkaDataSourceFactory(Monitor monitor, KafkaPropertiesFactory propertiesFactory, Clock clock) {
         this.monitor = monitor;
         this.propertiesFactory = propertiesFactory;
-        this.validation = new KafkaSourceDataAddressValidationRule(propertiesFactory);
+        this.validation = new KafkaSourceDataAddressValidation(propertiesFactory);
         this.clock = clock;
     }
 
@@ -79,16 +79,16 @@ public class KafkaDataSourceFactory implements DataSourceFactory {
                 .orElseThrow(failure -> new IllegalArgumentException(failure.getFailureDetail()));
         consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
 
-        var topic = Optional.ofNullable(source.getProperty(TOPIC))
+        var topic = Optional.ofNullable(source.getStringProperty(TOPIC))
                 .orElseThrow(() -> new IllegalArgumentException(format("Missing `%s` config", TOPIC)));
 
-        var name = source.getProperties().get(NAME);
+        var name = source.getStringProperty(NAME);
 
-        var maxDuration = Optional.ofNullable(source.getProperty(MAX_DURATION))
+        var maxDuration = Optional.ofNullable(source.getStringProperty(MAX_DURATION))
                 .map(Duration::parse)
                 .orElse(null);
 
-        var pollDuration = Optional.ofNullable(source.getProperty(POLL_DURATION))
+        var pollDuration = Optional.ofNullable(source.getStringProperty(POLL_DURATION))
                 .map(Duration::parse)
                 .orElse(DEFAULT_POLL_DURATION);
 

--- a/extensions/data-plane/data-plane-kafka/src/main/java/org/eclipse/edc/dataplane/kafka/pipeline/validation/KafkaSinkDataAddressValidation.java
+++ b/extensions/data-plane/data-plane-kafka/src/main/java/org/eclipse/edc/dataplane/kafka/pipeline/validation/KafkaSinkDataAddressValidation.java
@@ -22,13 +22,12 @@ import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 
 import java.util.List;
-import java.util.Map;
 
 import static org.eclipse.edc.dataplane.kafka.schema.KafkaDataAddressSchema.TOPIC;
 
 public class KafkaSinkDataAddressValidation implements ValidationRule<DataAddress> {
 
-    private final CompositeValidationRule<Map<String, String>> validationRule;
+    private final CompositeValidationRule<DataAddress> validationRule;
 
     public KafkaSinkDataAddressValidation(KafkaPropertiesFactory propertiesFactory) {
         this.validationRule = new CompositeValidationRule<>(
@@ -41,20 +40,15 @@ public class KafkaSinkDataAddressValidation implements ValidationRule<DataAddres
 
     @Override
     public Result<Void> apply(DataAddress dataAddress) {
-        return validationRule.apply(dataAddress.getProperties());
+        return validationRule.apply(dataAddress);
     }
 
-    private static final class ProducerPropertiesValidationRule implements ValidationRule<Map<String, String>> {
-
-        private final KafkaPropertiesFactory propertiesFactory;
-
-        private ProducerPropertiesValidationRule(KafkaPropertiesFactory propertiesFactory) {
-            this.propertiesFactory = propertiesFactory;
-        }
+    private record ProducerPropertiesValidationRule(
+            KafkaPropertiesFactory propertiesFactory) implements ValidationRule<DataAddress> {
 
         @Override
-        public Result<Void> apply(Map<String, String> properties) {
-            return propertiesFactory.getProducerProperties(properties)
+        public Result<Void> apply(DataAddress dataAddress) {
+            return propertiesFactory.getProducerProperties(dataAddress.getProperties())
                     .compose(p -> Result.success());
         }
     }

--- a/extensions/data-plane/data-plane-kafka/src/main/java/org/eclipse/edc/dataplane/kafka/pipeline/validation/KafkaSourceDataAddressValidation.java
+++ b/extensions/data-plane/data-plane-kafka/src/main/java/org/eclipse/edc/dataplane/kafka/pipeline/validation/KafkaSourceDataAddressValidation.java
@@ -22,15 +22,14 @@ import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 
 import java.util.List;
-import java.util.Map;
 
 import static org.eclipse.edc.dataplane.kafka.schema.KafkaDataAddressSchema.TOPIC;
 
-public class KafkaSourceDataAddressValidationRule implements ValidationRule<DataAddress> {
+public class KafkaSourceDataAddressValidation implements ValidationRule<DataAddress> {
 
-    private final CompositeValidationRule<Map<String, String>> validationRule;
+    private final CompositeValidationRule<DataAddress> validationRule;
 
-    public KafkaSourceDataAddressValidationRule(KafkaPropertiesFactory propertiesFactory) {
+    public KafkaSourceDataAddressValidation(KafkaPropertiesFactory propertiesFactory) {
         this.validationRule = new CompositeValidationRule<>(
                 List.of(
                         new EmptyValueValidationRule(TOPIC),
@@ -41,21 +40,15 @@ public class KafkaSourceDataAddressValidationRule implements ValidationRule<Data
 
     @Override
     public Result<Void> apply(DataAddress dataAddress) {
-        return validationRule.apply(dataAddress.getProperties());
+        return validationRule.apply(dataAddress);
     }
 
-    private static final class ConsumerPropertiesValidationRule implements ValidationRule<Map<String, String>> {
-
-        private final KafkaPropertiesFactory propertiesFactory;
-
-        private ConsumerPropertiesValidationRule(KafkaPropertiesFactory propertiesFactory) {
-            this.propertiesFactory = propertiesFactory;
-        }
+    private record ConsumerPropertiesValidationRule(
+            KafkaPropertiesFactory propertiesFactory) implements ValidationRule<DataAddress> {
 
         @Override
-        public Result<Void> apply(Map<String, String> properties) {
-            return propertiesFactory.getConsumerProperties(properties)
-                    .compose(p -> Result.success());
+        public Result<Void> apply(DataAddress dataAddress) {
+            return propertiesFactory.getConsumerProperties(dataAddress.getProperties()).compose(p -> Result.success());
         }
     }
 }

--- a/extensions/data-plane/data-plane-kafka/src/test/java/org/eclipse/edc/dataplane/kafka/pipeline/KafkaDataSinkFactoryTest.java
+++ b/extensions/data-plane/data-plane-kafka/src/test/java/org/eclipse/edc/dataplane/kafka/pipeline/KafkaDataSinkFactoryTest.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ExecutorService;
 
+import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
@@ -46,9 +47,9 @@ class KafkaDataSinkFactoryTest {
 
     @Test
     void verifyCanHandle() {
-        assertThat(factory.canHandle(createRequest("kafka", Map.of()))).isTrue();
-        assertThat(factory.canHandle(createRequest("KaFka", Map.of()))).isTrue();
-        assertThat(factory.canHandle(createRequest("kafkax", Map.of()))).isFalse();
+        assertThat(factory.canHandle(createRequest("kafka", emptyMap()))).isTrue();
+        assertThat(factory.canHandle(createRequest("KaFka", emptyMap()))).isTrue();
+        assertThat(factory.canHandle(createRequest("kafkax", emptyMap()))).isFalse();
     }
 
     @Test
@@ -65,7 +66,7 @@ class KafkaDataSinkFactoryTest {
 
     @Test
     void verifyValidateReturnsFailedResult_ifMissingTopicProperty() {
-        var request = createRequest(KafkaDataAddressSchema.KAFKA_TYPE, Map.of());
+        var request = createRequest(KafkaDataAddressSchema.KAFKA_TYPE, emptyMap());
 
         when(propertiesFactory.getProducerProperties(request.getDestinationDataAddress().getProperties()))
                 .thenReturn(Result.success(mock(Properties.class)));
@@ -92,7 +93,7 @@ class KafkaDataSinkFactoryTest {
 
     @Test
     void verifyCreateSinkThrows_ifMissingTopicProperty() {
-        var request = createRequest(KafkaDataAddressSchema.KAFKA_TYPE, Map.of());
+        var request = createRequest(KafkaDataAddressSchema.KAFKA_TYPE, emptyMap());
 
         when(propertiesFactory.getProducerProperties(request.getDestinationDataAddress().getProperties()))
                 .thenReturn(Result.success(mock(Properties.class)));
@@ -111,7 +112,7 @@ class KafkaDataSinkFactoryTest {
         assertThatExceptionOfType(EdcException.class).isThrownBy(() -> factory.createSink(request));
     }
 
-    private static DataFlowRequest createRequest(String destinationType, Map<String, String> destinationProperties) {
+    private DataFlowRequest createRequest(String destinationType, Map<String, Object> destinationProperties) {
         return DataFlowRequest.Builder.newInstance()
                 .id("id")
                 .processId("processId")

--- a/extensions/data-plane/data-plane-kafka/src/test/java/org/eclipse/edc/dataplane/kafka/pipeline/KafkaDataSourceFactoryTest.java
+++ b/extensions/data-plane/data-plane-kafka/src/test/java/org/eclipse/edc/dataplane/kafka/pipeline/KafkaDataSourceFactoryTest.java
@@ -28,6 +28,7 @@ import java.time.Clock;
 import java.util.Map;
 import java.util.Properties;
 
+import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
@@ -46,9 +47,9 @@ class KafkaDataSourceFactoryTest {
 
     @Test
     void verifyCanHandle() {
-        assertThat(factory.canHandle(createRequest("kafka", Map.of()))).isTrue();
-        assertThat(factory.canHandle(createRequest("KaFka", Map.of()))).isTrue();
-        assertThat(factory.canHandle(createRequest("kafkax", Map.of()))).isFalse();
+        assertThat(factory.canHandle(createRequest("kafka", emptyMap()))).isTrue();
+        assertThat(factory.canHandle(createRequest("KaFka", emptyMap()))).isTrue();
+        assertThat(factory.canHandle(createRequest("kafkax", emptyMap()))).isFalse();
     }
 
     @Test
@@ -64,7 +65,7 @@ class KafkaDataSourceFactoryTest {
 
     @Test
     void verifyValidateReturnsFailedResult_ifMissingTopicProperty() {
-        var request = createRequest(KafkaDataAddressSchema.KAFKA_TYPE, Map.of());
+        var request = createRequest(KafkaDataAddressSchema.KAFKA_TYPE, emptyMap());
 
         when(propertiesFactory.getConsumerProperties(request.getSourceDataAddress().getProperties()))
                 .thenReturn(Result.success(mock(Properties.class)));
@@ -89,7 +90,7 @@ class KafkaDataSourceFactoryTest {
 
     @Test
     void verifyCreateSourceThrows_ifMissingTopicProperty() {
-        var request = createRequest(KafkaDataAddressSchema.KAFKA_TYPE, Map.of());
+        var request = createRequest(KafkaDataAddressSchema.KAFKA_TYPE, emptyMap());
 
         when(propertiesFactory.getConsumerProperties(request.getSourceDataAddress().getProperties()))
                 .thenReturn(Result.success(mock(Properties.class)));
@@ -108,7 +109,7 @@ class KafkaDataSourceFactoryTest {
         assertThatExceptionOfType(EdcException.class).isThrownBy(() -> factory.createSource(request));
     }
 
-    private static DataFlowRequest createRequest(String sourceType, Map<String, String> sourceProperties) {
+    private DataFlowRequest createRequest(String sourceType, Map<String, Object> sourceProperties) {
         return DataFlowRequest.Builder.newInstance()
                 .id("id")
                 .processId("processId")

--- a/extensions/data-plane/data-plane-kafka/src/test/java/org/eclipse/edc/dataplane/kafka/pipeline/KafkaPropertiesFactoryTest.java
+++ b/extensions/data-plane/data-plane-kafka/src/test/java/org/eclipse/edc/dataplane/kafka/pipeline/KafkaPropertiesFactoryTest.java
@@ -27,7 +27,7 @@ class KafkaPropertiesFactoryTest {
 
     @Test
     void verifyGetConsumerProperties() {
-        var properties = Map.of(
+        var properties = Map.<String, Object>of(
                 "kafka.bootstrap.servers", "kafka:9092",
                 "kafka.foo.bar", "value1",
                 "kafka.hello.world", "value2",
@@ -48,7 +48,7 @@ class KafkaPropertiesFactoryTest {
 
     @Test
     void verifyGetProducerProperties() {
-        var properties = Map.of(
+        var properties = Map.<String, Object>of(
                 "kafka.bootstrap.servers", "kafka:9092",
                 "kafka.foo.bar", "value1",
                 "kafka.hello.world", "value2",
@@ -69,7 +69,7 @@ class KafkaPropertiesFactoryTest {
 
     @Test
     void verifyFromFailsIfMissingBootstrapServers() {
-        var properties = Map.of(
+        var properties = Map.<String, Object>of(
                 "kafka.foo.bar", "value1",
                 "kafka.hello.world", "value2"
         );

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/DataAddress.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/DataAddress.java
@@ -47,14 +47,14 @@ public class DataAddress {
     public static final String EDC_DATA_ADDRESS_KEY_NAME = EDC_NAMESPACE + "keyName";
     public static final String EDC_DATA_ADDRESS_SECRET = EDC_NAMESPACE + "secret";
 
-    protected final Map<String, String> properties = new HashMap<>();
+    protected final Map<String, Object> properties = new HashMap<>();
 
     protected DataAddress() {
     }
 
     @NotNull
     public String getType() {
-        return getProperty(EDC_DATA_ADDRESS_TYPE_PROPERTY);
+        return getStringProperty(EDC_DATA_ADDRESS_TYPE_PROPERTY);
     }
 
     @JsonIgnore
@@ -64,25 +64,25 @@ public class DataAddress {
     }
 
     @Nullable
-    public String getProperty(String key) {
-        return getProperty(key, null);
+    public String getStringProperty(String key) {
+        return getStringProperty(key, null);
     }
 
     @Nullable
-    public String getProperty(String key, String defaultValue) {
+    public String getStringProperty(String key, String defaultValue) {
         var value = Optional.ofNullable(properties.get(EDC_NAMESPACE + key)).orElseGet(() -> properties.get(key));
         if (value != null) {
-            return value;
+            return (String) value;
         }
         return defaultValue;
     }
 
-    public Map<String, String> getProperties() {
+    public Map<String, Object> getProperties() {
         return properties;
     }
 
     public String getKeyName() {
-        return getProperty(EDC_DATA_ADDRESS_KEY_NAME);
+        return getStringProperty(EDC_DATA_ADDRESS_KEY_NAME);
     }
 
     @JsonIgnore
@@ -99,7 +99,7 @@ public class DataAddress {
      */
     @JsonIgnore
     public boolean hasProperty(String key) {
-        return getProperty(key) != null;
+        return getStringProperty(key) != null;
     }
 
     @JsonPOJOBuilder(withPrefix = "")
@@ -120,18 +120,17 @@ public class DataAddress {
             return self();
         }
 
-        public B property(String key, String value) {
+        public B property(String key, Object value) {
             Objects.requireNonNull(key, "Property key null.");
-            if (SIMPLE_TYPE.equals(key)) {
-                key = EDC_DATA_ADDRESS_TYPE_PROPERTY;
-            } else if (SIMPLE_KEY_NAME.equals(key)) {
-                key = EDC_DATA_ADDRESS_KEY_NAME;
+            switch (key) {
+                case SIMPLE_TYPE -> address.properties.put(EDC_DATA_ADDRESS_TYPE_PROPERTY, value);
+                case SIMPLE_KEY_NAME -> address.properties.put(EDC_DATA_ADDRESS_KEY_NAME, value);
+                default -> address.properties.put(key, value);
             }
-            address.properties.put(key, value);
             return self();
         }
 
-        public B properties(Map<String, String> properties) {
+        public B properties(Map<String, Object> properties) {
             properties.forEach(this::property);
             return self();
         }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/HttpDataAddress.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/HttpDataAddress.java
@@ -25,9 +25,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyMap;
+import static java.util.stream.Collectors.toMap;
 
 /**
  * This is a wrapper class for the {@link DataAddress} object, which has typed accessors for properties specific to
@@ -64,81 +64,81 @@ public class HttpDataAddress extends DataAddress {
 
     @JsonIgnore
     public String getName() {
-        return getProperty(NAME);
+        return getStringProperty(NAME);
     }
 
     @JsonIgnore
     public String getBaseUrl() {
-        return getProperty(BASE_URL);
+        return getStringProperty(BASE_URL);
     }
 
     @JsonIgnore
     public String getPath() {
-        return getProperty(PATH);
+        return getStringProperty(PATH);
     }
 
     @JsonIgnore
     public String getQueryParams() {
-        return getProperty(QUERY_PARAMS);
+        return getStringProperty(QUERY_PARAMS);
     }
 
     @JsonIgnore
     public String getMethod() {
-        return getProperty(METHOD);
+        return getStringProperty(METHOD);
     }
 
     @JsonIgnore
     public String getAuthKey() {
-        return getProperty(AUTH_KEY);
+        return getStringProperty(AUTH_KEY);
     }
 
     @JsonIgnore
     public String getAuthCode() {
-        return getProperty(AUTH_CODE);
+        return getStringProperty(AUTH_CODE);
     }
 
     @JsonIgnore
     public String getSecretName() {
-        return getProperty(SECRET_NAME);
+        return getStringProperty(SECRET_NAME);
     }
 
     @JsonIgnore
     public String getProxyBody() {
-        return getProperty(PROXY_BODY);
+        return getStringProperty(PROXY_BODY);
     }
 
     @JsonIgnore
     public String getProxyPath() {
-        return getProperty(PROXY_PATH);
+        return getStringProperty(PROXY_PATH);
     }
 
     @JsonIgnore
     public String getProxyQueryParams() {
-        return getProperty(PROXY_QUERY_PARAMS);
+        return getStringProperty(PROXY_QUERY_PARAMS);
     }
 
     @JsonIgnore
     public String getProxyMethod() {
-        return getProperty(PROXY_METHOD);
+        return getStringProperty(PROXY_METHOD);
     }
 
     @JsonIgnore
     public String getContentType() {
-        return getProperty(CONTENT_TYPE, OCTET_STREAM);
+        return getStringProperty(CONTENT_TYPE, OCTET_STREAM);
     }
 
     @JsonIgnore
     public Map<String, String> getAdditionalHeaders() {
         return getProperties().entrySet().stream()
                 .filter(entry -> entry.getKey().startsWith(ADDITIONAL_HEADER))
-                .collect(Collectors.toMap(entry -> entry.getKey().replace(ADDITIONAL_HEADER, ""), Map.Entry::getValue));
+                .collect(toMap(entry -> entry.getKey().replace(ADDITIONAL_HEADER, ""), it -> (String) it.getValue()));
 
     }
 
     @JsonIgnore
     public boolean getNonChunkedTransfer() {
         return Optional.of(NON_CHUNKED_TRANSFER)
-                .map(this::getProperty)
+                .map(this::getStringProperty)
                 .map(Boolean::parseBoolean)
                 .orElse(false);
     }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/edr/EndpointDataReference.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/edr/EndpointDataReference.java
@@ -36,8 +36,7 @@ import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 public class EndpointDataReference {
 
     public static final String EDR_SIMPLE_TYPE = "EDR";
-    public static final String EDR_TYPE = EDC_NAMESPACE + EDR_SIMPLE_TYPE;
-    
+
     public static final String ID = EDC_NAMESPACE + "id";
     public static final String AUTH_CODE = EDC_NAMESPACE + "authCode";
     public static final String AUTH_KEY = EDC_NAMESPACE + "authKey";
@@ -46,9 +45,9 @@ public class EndpointDataReference {
     private final String endpoint;
     private final String authKey;
     private final String authCode;
-    private final Map<String, String> properties;
+    private final Map<String, Object> properties;
 
-    private EndpointDataReference(String id, String endpoint, String authKey, String authCode, Map<String, String> properties) {
+    private EndpointDataReference(String id, String endpoint, String authKey, String authCode, Map<String, Object> properties) {
         this.id = id;
         this.endpoint = endpoint;
         this.authKey = authKey;
@@ -77,13 +76,13 @@ public class EndpointDataReference {
     }
 
     @NotNull
-    public Map<String, String> getProperties() {
+    public Map<String, Object> getProperties() {
         return properties;
     }
 
     @JsonPOJOBuilder(withPrefix = "")
     public static class Builder {
-        private final Map<String, String> properties = new HashMap<>();
+        private final Map<String, Object> properties = new HashMap<>();
         private String id = UUID.randomUUID().toString();
         private String endpoint;
         private String authKey;
@@ -117,7 +116,7 @@ public class EndpointDataReference {
             return this;
         }
 
-        public EndpointDataReference.Builder properties(Map<String, String> properties) {
+        public EndpointDataReference.Builder properties(Map<String, Object> properties) {
             this.properties.putAll(properties);
             return this;
         }

--- a/spi/common/core-spi/src/test/java/org/eclipse/edc/spi/types/domain/DataAddressTest.java
+++ b/spi/common/core-spi/src/test/java/org/eclipse/edc/spi/types/domain/DataAddressTest.java
@@ -43,7 +43,7 @@ class DataAddressTest {
         assertThat(deserialized).isNotNull();
 
         assertThat(deserialized.getType()).isEqualTo("test");
-        assertThat(deserialized.getProperty("foo")).isEqualTo("bar");
+        assertThat(deserialized.getStringProperty("foo")).isEqualTo("bar");
     }
 
     @Test
@@ -72,7 +72,7 @@ class DataAddressTest {
 
     @Test
     void verifyGetDefaultPropertyValue() {
-        assertThat(DataAddress.Builder.newInstance().type("sometype").build().getProperty("missing", "defaultValue"))
+        assertThat(DataAddress.Builder.newInstance().type("sometype").build().getStringProperty("missing", "defaultValue"))
                 .isEqualTo("defaultValue");
     }
 
@@ -84,8 +84,8 @@ class DataAddressTest {
                 .property(EDC_NAMESPACE + "anotherExisting", "anotherValue")
                 .build();
 
-        assertThat(address.getProperty("existing", "defaultValue")).isEqualTo("aValue");
-        assertThat(address.getProperty("anotherExisting", "defaultValue")).isEqualTo("anotherValue");
+        assertThat(address.getStringProperty("existing", "defaultValue")).isEqualTo("aValue");
+        assertThat(address.getStringProperty("anotherExisting", "defaultValue")).isEqualTo("anotherValue");
     }
 
     @Test

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/TransferProcess.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/TransferProcess.java
@@ -125,7 +125,7 @@ public class TransferProcess extends StatefulEntity<TransferProcess> {
     private ResourceManifest resourceManifest;
     private ProvisionedResourceSet provisionedResourceSet = ProvisionedResourceSet.Builder.newInstance().build();
     private List<DeprovisionedResource> deprovisionedResources = new ArrayList<>();
-    private Map<String, String> privateProperties = new HashMap<>();
+    private Map<String, Object> privateProperties = new HashMap<>();
     private List<CallbackAddress> callbackAddresses = new ArrayList<>();
 
     private TransferProcess() {
@@ -219,7 +219,7 @@ public class TransferProcess extends StatefulEntity<TransferProcess> {
         return provisionedResourceSet.getResources().stream().filter(r -> !deprovisionedResources.contains(r.getId())).collect(toList());
     }
 
-    public Map<String, String> getPrivateProperties() {
+    public Map<String, Object> getPrivateProperties() {
         return Collections.unmodifiableMap(privateProperties);
     }
 
@@ -492,7 +492,7 @@ public class TransferProcess extends StatefulEntity<TransferProcess> {
             return this;
         }
 
-        public Builder privateProperties(Map<String, String> privateProperties) {
+        public Builder privateProperties(Map<String, Object> privateProperties) {
             entity.privateProperties = privateProperties;
             return this;
         }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/TransferRequest.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/TransferRequest.java
@@ -30,6 +30,7 @@ public class TransferRequest {
     public static final String TRANSFER_REQUEST_CONNECTOR_ADDRESS = EDC_NAMESPACE + "connectorAddress";
     public static final String TRANSFER_REQUEST_CONTRACT_ID = EDC_NAMESPACE + "contractId";
     public static final String TRANSFER_REQUEST_DATA_DESTINATION = EDC_NAMESPACE + "dataDestination";
+    @Deprecated(since = "0.2.0")
     public static final String TRANSFER_REQUEST_PROPERTIES = EDC_NAMESPACE + "properties";
     public static final String TRANSFER_REQUEST_PRIVATE_PROPERTIES = EDC_NAMESPACE + "privateProperties";
     public static final String TRANSFER_REQUEST_PROTOCOL = EDC_NAMESPACE + "protocol";
@@ -44,8 +45,9 @@ public class TransferRequest {
     private String contractId;
     private String assetId;
     private DataAddress dataDestination;
+    @Deprecated(since = "0.2.0")
     private Map<String, String> properties = new HashMap<>();
-    private Map<String, String> privateProperties = new HashMap<>();
+    private Map<String, Object> privateProperties = new HashMap<>();
     private List<CallbackAddress> callbackAddresses = new ArrayList<>();
 
     public String getConnectorAddress() {
@@ -64,11 +66,12 @@ public class TransferRequest {
         return dataDestination;
     }
 
+    @Deprecated(since = "0.2.0")
     public Map<String, String> getProperties() {
         return properties;
     }
 
-    public Map<String, String> getPrivateProperties() {
+    public Map<String, Object> getPrivateProperties() {
         return privateProperties;
     }
 
@@ -119,12 +122,13 @@ public class TransferRequest {
             return this;
         }
 
+        @Deprecated(since = "0.2.0")
         public Builder properties(Map<String, String> properties) {
             request.properties = properties;
             return this;
         }
 
-        public Builder privateProperties(Map<String, String> privateProperties) {
+        public Builder privateProperties(Map<String, Object> privateProperties) {
             request.privateProperties = privateProperties;
             return this;
         }


### PR DESCRIPTION
## What this PR changes/adds

Switch properties fields from `Map<String, String` to `Map<String, Object>`

## Why it does that

being more generic

## Further notes

- deprecated `TransferRequest.properties` as they are not really used anymore.

## Linked Issue(s)

Closes #3357 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
