### PR TITLE
fix: Add PathParam

### DIFF
--- a/extensions/data-plane/data-plane-api/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlanePublicApi.java
+++ b/extensions/data-plane/data-plane-api/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlanePublicApi.java
@@ -42,7 +42,7 @@ public interface DataPlanePublicApi {
                     @ApiResponse(responseCode = "500", description = "Failed to transfer data")
             }
     )
-    void get(ContainerRequestContext context, AsyncResponse response);
+    void get(ContainerRequestContext context, AsyncResponse response, String pathExtension);
 
     @Operation(description = "Send `POST` data query to the Data Plane.",
             responses = {
@@ -51,7 +51,7 @@ public interface DataPlanePublicApi {
                     @ApiResponse(responseCode = "500", description = "Failed to transfer data")
             }
     )
-    void post(ContainerRequestContext context, AsyncResponse response);
+    void post(ContainerRequestContext context, AsyncResponse response, String pathExtension);
 
     @Operation(description = "Send `PUT` data query to the Data Plane.",
             responses = {
@@ -60,7 +60,7 @@ public interface DataPlanePublicApi {
                     @ApiResponse(responseCode = "500", description = "Failed to transfer data")
             }
     )
-    void put(ContainerRequestContext context, AsyncResponse response);
+    void put(ContainerRequestContext context, AsyncResponse response, String pathExtension);
 
     @Operation(description = "Send `DELETE` data query to the Data Plane.",
             responses = {
@@ -69,7 +69,7 @@ public interface DataPlanePublicApi {
                     @ApiResponse(responseCode = "500", description = "Failed to transfer data")
             }
     )
-    void delete(ContainerRequestContext context, AsyncResponse response);
+    void delete(ContainerRequestContext context, AsyncResponse response,String pathExtension);
 
     @Operation(description = "Send `PATCH` data query to the Data Plane.",
             responses = {
@@ -78,5 +78,5 @@ public interface DataPlanePublicApi {
                     @ApiResponse(responseCode = "500", description = "Failed to transfer data")
             }
     )
-    void patch(ContainerRequestContext context, AsyncResponse response);
+    void patch(ContainerRequestContext context, AsyncResponse response, String pathExtension);
 }

--- a/extensions/data-plane/data-plane-api/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlanePublicApiController.java
+++ b/extensions/data-plane/data-plane-api/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlanePublicApiController.java
@@ -15,13 +15,7 @@
 
 package org.eclipse.edc.connector.dataplane.api.controller;
 
-import jakarta.ws.rs.DELETE;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.PATCH;
-import jakarta.ws.rs.POST;
-import jakarta.ws.rs.PUT;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.*;
 import jakarta.ws.rs.container.AsyncResponse;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.Suspended;
@@ -68,7 +62,7 @@ public class DataPlanePublicApiController implements DataPlanePublicApi {
 
     @GET
     @Override
-    public void get(@Context ContainerRequestContext requestContext, @Suspended AsyncResponse response) {
+    public void get(@Context ContainerRequestContext requestContext, @Suspended AsyncResponse response, @PathParam("any") String pathExtension) {
         handle(requestContext, response);
     }
 
@@ -80,7 +74,7 @@ public class DataPlanePublicApiController implements DataPlanePublicApi {
      */
     @DELETE
     @Override
-    public void delete(@Context ContainerRequestContext requestContext, @Suspended AsyncResponse response) {
+    public void delete(@Context ContainerRequestContext requestContext, @Suspended AsyncResponse response, @PathParam("any") String pathExtension) {
         handle(requestContext, response);
     }
 
@@ -92,7 +86,7 @@ public class DataPlanePublicApiController implements DataPlanePublicApi {
      */
     @PATCH
     @Override
-    public void patch(@Context ContainerRequestContext requestContext, @Suspended AsyncResponse response) {
+    public void patch(@Context ContainerRequestContext requestContext, @Suspended AsyncResponse response, @PathParam("any") String pathExtension) {
         handle(requestContext, response);
     }
 
@@ -104,7 +98,7 @@ public class DataPlanePublicApiController implements DataPlanePublicApi {
      */
     @PUT
     @Override
-    public void put(@Context ContainerRequestContext requestContext, @Suspended AsyncResponse response) {
+    public void put(@Context ContainerRequestContext requestContext, @Suspended AsyncResponse response, @PathParam("any") String pathExtension) {
         handle(requestContext, response);
     }
 
@@ -116,7 +110,7 @@ public class DataPlanePublicApiController implements DataPlanePublicApi {
      */
     @POST
     @Override
-    public void post(@Context ContainerRequestContext requestContext, @Suspended AsyncResponse response) {
+    public void post(@Context ContainerRequestContext requestContext, @Suspended AsyncResponse response, @PathParam("any") String pathExtension) {
         handle(requestContext, response);
     }
 


### PR DESCRIPTION
## What this PR changes/adds

Adds the parameter specified in the path to the methods under said path.

## Why it does that

OpenAPI considers this an error otherwise.

## Further notes

There's a few ways we could go about this and I'd like some input:
1) Remove the path parameter, as it is used only to forward a call to any path to this API. This would be my preferred approach.
2) Use the path parameter to resolve the source data address if this cannot be done via the token (not sure if this makes sense though).
3) Leave the parameter, but don't use it. (Current state of this PR).

Ref. #3371