### PR TITLE
feat: handle ContractNegotiationEventMessage.ACCEPTED message

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -201,7 +201,7 @@ maven/mavencentral/org.apache.commons/commons-pool2/2.11.1, Apache-2.0, approved
 maven/mavencentral/org.apache.commons/commons-text/1.10.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.groovy/groovy-bom/4.0.11, Apache-2.0, approved, #9266
 maven/mavencentral/org.apache.groovy/groovy-json/4.0.11, Apache-2.0, approved, #7411
-maven/mavencentral/org.apache.groovy/groovy-xml/4.0.11, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.groovy/groovy-xml/4.0.11, Apache-2.0, approved, #10179
 maven/mavencentral/org.apache.groovy/groovy/4.0.11, Apache-2.0 AND BSD-3-Clause AND MIT, approved, #1742
 maven/mavencentral/org.apache.httpcomponents/httpclient/4.5.13, Apache-2.0 AND LicenseRef-Public-Domain, approved, CQ23527
 maven/mavencentral/org.apache.httpcomponents/httpcore/4.4.13, Apache-2.0, approved, CQ23528

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -31,6 +31,7 @@ import org.eclipse.edc.statemachine.StateMachineManager;
 
 import static java.lang.String.format;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation.Type.PROVIDER;
+import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.ACCEPTED;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.AGREEING;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.FINALIZING;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.OFFERING;
@@ -51,6 +52,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
         stateMachineManager = StateMachineManager.Builder.newInstance("provider-contract-negotiation", monitor, executorInstrumentation, waitStrategy)
                 .processor(processNegotiationsInState(OFFERING, this::processOffering))
                 .processor(processNegotiationsInState(REQUESTED, this::processRequested))
+                .processor(processNegotiationsInState(ACCEPTED, this::processAccepted))
                 .processor(processNegotiationsInState(AGREEING, this::processAgreeing))
                 .processor(processNegotiationsInState(VERIFIED, this::processVerified))
                 .processor(processNegotiationsInState(FINALIZING, this::processFinalizing))
@@ -133,6 +135,17 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
      */
     @WithSpan
     private boolean processRequested(ContractNegotiation negotiation) {
+        transitionToAgreeing(negotiation);
+        return true;
+    }
+
+    /**
+     * Processes {@link ContractNegotiation} in state ACCEPTED. It transitions to AGREEING.
+     *
+     * @return true if processed, false otherwise
+     */
+    @WithSpan
+    private boolean processAccepted(ContractNegotiation negotiation) {
         transitionToAgreeing(negotiation);
         return true;
     }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
@@ -22,7 +22,6 @@ import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementM
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementVerificationMessage;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractNegotiationEventMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
-import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationTerminationMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
@@ -40,7 +39,6 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Optional;
 import java.util.UUID;
 
-import static java.lang.String.format;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation.Type.PROVIDER;
 
 public class ContractNegotiationProtocolServiceImpl implements ContractNegotiationProtocolService {
@@ -71,7 +69,6 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
         return transactionContext.execute(() -> validateOffer(message, claimToken)
                     .compose(validatedOffer -> createNegotiation(message, validatedOffer))
                     .onSuccess(negotiation -> {
-                        monitor.debug(() -> "[Provider] Contract offer received.");
                         negotiation.transitionRequested();
                         update(negotiation);
                         observable.invokeForEach(l -> l.requested(negotiation));
@@ -85,7 +82,6 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
         return transactionContext.execute(() -> getNegotiation(message)
                 .compose(negotiation -> validateRequest(claimToken, negotiation))
                 .onSuccess(negotiation -> {
-                    monitor.debug(() -> "[Consumer] Contract offer received.");
                     negotiation.addContractOffer(message.getContractOffer());
                     negotiation.transitionOffered();
                     update(negotiation);
@@ -97,7 +93,13 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
     @WithSpan
     @NotNull
     public ServiceResult<ContractNegotiation> notifyAccepted(ContractNegotiationEventMessage message, ClaimToken claimToken) {
-        throw new UnsupportedOperationException("not implemented");
+        return transactionContext.execute(() -> getNegotiation(message)
+                .compose(negotiation -> validateRequest(claimToken, negotiation))
+                .onSuccess(negotiation -> {
+                    negotiation.transitionAccepted();
+                    update(negotiation);
+                    observable.invokeForEach(l -> l.accepted(negotiation));
+                }));
     }
 
     @Override
@@ -107,7 +109,6 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
         return transactionContext.execute(() -> getNegotiation(message)
                 .compose(negotiation -> validateAgreed(message, claimToken, negotiation))
                 .onSuccess(negotiation -> {
-                    monitor.debug("[Consumer] Contract agreement received. Validation successful.");
                     negotiation.setContractAgreement(message.getContractAgreement());
                     negotiation.transitionAgreed();
                     update(negotiation);
@@ -160,7 +161,7 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
     public ServiceResult<ContractNegotiation> findById(String id, ClaimToken claimToken) {
         return transactionContext.execute(() -> Optional.ofNullable(store.findById(id))
                 .map(negotiation -> validateRequest(claimToken, negotiation))
-                .orElse(ServiceResult.notFound(format("No negotiation with id %s found", id))));
+                .orElse(ServiceResult.notFound("No negotiation with id %s found".formatted(id))));
     }
 
     @NotNull
@@ -221,8 +222,8 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
 
     private void update(ContractNegotiation negotiation) {
         store.save(negotiation);
-        monitor.debug(String.format("[%s] ContractNegotiation %s is now in state %s.",
-                negotiation.getType(), negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
+        monitor.debug(() -> "[%s] ContractNegotiation %s is now in state %s."
+                .formatted(negotiation.getType(), negotiation.getId(), negotiation.stateAsString()));
     }
 
 }


### PR DESCRIPTION
## What this PR changes/adds

Handle `Accepted` message

## Why it does that

dsp completion

## Further notes

- refactored the service protocol tests
- removed some debug logs as they are duplicated (on every update there's a debug log printed already)

## Linked Issue(s)

Closes #3374 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
