### PR TITLE
build: update release.yml file

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -4,15 +4,19 @@ changelog:
   exclude:
     labels:
       - no-changelog
-    authors:
-      - dependabot[bot]
   categories:
     - title: Bugfixes
       labels:
         - bug
     - title: New Features & Improvements
       labels:
-        - "*"
+        - enhancement
+    - title: Dependencies
+      labels:
+        - dependencies
     - title: Documentation
       labels:
         - documentation
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
## What this PR changes/adds

Updates release.yml file to add a `dependencies` category.
Also moved the `*` to the end, because it was avoiding the `documentation` group to be shown.
Removed the `dependabot` exclusion, firstly because it was not working (as dependabot PR are actually shown in the release notes), ans secondly because it's good to show them as dependency updates are important changes.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

- if this file works out for everybody, I will spread it to all the other repos.

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
