### PR TITLE
fix: send correlation id as process id in the transfer messages

### DIFF
--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
@@ -455,7 +455,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager {
         var message = TransferCompletionMessage.Builder.newInstance()
                 .protocol(process.getProtocol())
                 .counterPartyAddress(process.getConnectorAddress())
-                .processId(process.getId())
+                .processId(process.getCorrelationId())
                 .policy(policyArchive.findPolicyForContract(process.getContractId()))
                 .build();
 
@@ -487,7 +487,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager {
         var message = TransferTerminationMessage.Builder.newInstance()
                 .counterPartyAddress(process.getConnectorAddress())
                 .protocol(process.getProtocol())
-                .processId(process.getId())
+                .processId(process.getCorrelationId())
                 .policy(policyArchive.findPolicyForContract(process.getContractId()))
                 .build();
 

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
@@ -430,6 +430,7 @@ public class TransferProcessManagerImpl implements TransferProcessManager {
         var checker = statusCheckerRegistry.resolve(transferProcess.getDataDestination().getType());
         if (checker == null) {
             monitor.warning(format("No checker found for process %s. The process will not advance to the COMPLETED state.", transferProcess.getId()));
+            breakLease(transferProcess);
             return false;
         } else {
             var resources = transferProcess.getProvisionedResources();

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImplTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImplTest.java
@@ -606,7 +606,9 @@ class TransferProcessManagerImplTest {
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferProcessStore, never()).save(any());
+            var captor = ArgumentCaptor.forClass(TransferProcess.class);
+            verify(transferProcessStore).save(captor.capture());
+            assertThat(captor.getValue().getState()).isEqualTo(STARTED.code());
         });
     }
 

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImplTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImplTest.java
@@ -622,7 +622,7 @@ class TransferProcessManagerImplTest {
 
     @Test
     void completing_shouldTransitionToCompleted_whenSendingMessageSucceed() {
-        var process = createTransferProcess(COMPLETING);
+        var process = createTransferProcessBuilder(COMPLETING).dataRequest(createDataRequestBuilder().id("correlationId").build()).build();
         when(transferProcessStore.nextNotLeased(anyInt(), stateIs(COMPLETING.code()))).thenReturn(List.of(process)).thenReturn(emptyList());
         when(transferProcessStore.findById(process.getId())).thenReturn(process, process.toBuilder().state(COMPLETING.code()).build());
         when(dispatcherRegistry.dispatch(any(), isA(TransferCompletionMessage.class))).thenReturn(completedFuture(StatusResult.success("any")));
@@ -630,7 +630,10 @@ class TransferProcessManagerImplTest {
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(dispatcherRegistry).dispatch(any(), isA(TransferCompletionMessage.class));
+            var captor = ArgumentCaptor.forClass(TransferCompletionMessage.class);
+            verify(dispatcherRegistry).dispatch(eq(Object.class), captor.capture());
+            var message = captor.getValue();
+            assertThat(message.getProcessId()).isEqualTo("correlationId");
             verify(transferProcessStore, times(RETRY_LIMIT)).save(argThat(p -> p.getState() == COMPLETED.code()));
             verify(listener).completed(process);
         });
@@ -638,7 +641,8 @@ class TransferProcessManagerImplTest {
 
     @Test
     void terminating_shouldTransitionToTerminated_whenMessageSentCorrectly() {
-        var process = createTransferProcessBuilder(TERMINATING).type(PROVIDER).build();
+        var process = createTransferProcessBuilder(TERMINATING).type(PROVIDER)
+                .dataRequest(createDataRequestBuilder().id("correlationId").build()).build();
         when(transferProcessStore.nextNotLeased(anyInt(), stateIs(TERMINATING.code()))).thenReturn(List.of(process)).thenReturn(emptyList());
         when(transferProcessStore.findById(process.getId())).thenReturn(process, process.toBuilder().state(TERMINATING.code()).build());
         when(dispatcherRegistry.dispatch(any(), isA(TransferTerminationMessage.class))).thenReturn(completedFuture(StatusResult.success("any")));
@@ -646,7 +650,10 @@ class TransferProcessManagerImplTest {
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(dispatcherRegistry).dispatch(any(), isA(TransferTerminationMessage.class));
+            var captor = ArgumentCaptor.forClass(TransferTerminationMessage.class);
+            verify(dispatcherRegistry).dispatch(eq(Object.class), captor.capture());
+            var message = captor.getValue();
+            assertThat(message.getProcessId()).isEqualTo("correlationId");
             verify(transferProcessStore, times(RETRY_LIMIT)).save(argThat(p -> p.getState() == TERMINATED.code()));
             verify(listener).terminated(process);
         });
@@ -785,7 +792,6 @@ class TransferProcessManagerImplTest {
         var processId = UUID.randomUUID().toString();
         var dataRequest = createDataRequestBuilder()
                 .processId(processId)
-                .protocol("protocol")
                 .connectorAddress("http://an/address")
                 .build();
 
@@ -802,7 +808,8 @@ class TransferProcessManagerImplTest {
                 .id(UUID.randomUUID().toString())
                 .contractId(UUID.randomUUID().toString())
                 .assetId(UUID.randomUUID().toString())
-                .destinationType(DESTINATION_TYPE);
+                .destinationType(DESTINATION_TYPE)
+                .protocol("protocol");
     }
 
     private ProvisionedDataDestinationResource provisionedDataDestinationResource() {

--- a/system-tests/e2e-transfer-test/control-plane/build.gradle.kts
+++ b/system-tests/e2e-transfer-test/control-plane/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     implementation(project(":extensions:common:vault:vault-filesystem"))
     implementation(project(":extensions:common:http"))
     implementation(project(":extensions:common:iam:iam-mock"))
+    implementation(project(":extensions:control-plane:api:control-plane-api"))
     implementation(project(":extensions:control-plane:api:management-api"))
     implementation(project(":extensions:control-plane:transfer:transfer-data-plane"))
     implementation(project(":extensions:data-plane:data-plane-client"))

--- a/system-tests/e2e-transfer-test/data-plane/build.gradle.kts
+++ b/system-tests/e2e-transfer-test/data-plane/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
 
 dependencies {
     implementation(project(":core:data-plane:data-plane-core"))
+    implementation(project(":extensions:control-plane:api:control-plane-api-client"))
     implementation(project(":extensions:data-plane:data-plane-http"))
     implementation(project(":extensions:data-plane:data-plane-kafka"))
     implementation(project(":extensions:data-plane:data-plane-http-oauth2"))

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/AbstractEndToEndTransfer.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/AbstractEndToEndTransfer.java
@@ -32,6 +32,7 @@ import static jakarta.json.Json.createObjectBuilder;
 import static java.time.Duration.ofDays;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.eclipse.edc.connector.transfer.spi.types.TransferProcessStates.COMPLETED;
 import static org.eclipse.edc.connector.transfer.spi.types.TransferProcessStates.STARTED;
 import static org.eclipse.edc.connector.transfer.spi.types.TransferProcessStates.TERMINATED;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
@@ -147,7 +148,7 @@ public abstract class AbstractEndToEndTransfer {
         var transferProcessId = CONSUMER.requestAsset(PROVIDER, assetId, noPrivateProperty(), destination);
         await().atMost(timeout).untilAsserted(() -> {
             var state = CONSUMER.getTransferProcessState(transferProcessId);
-            assertThat(state).isEqualTo(STARTED.name());
+            assertThat(state).isEqualTo(COMPLETED.name());
 
             given()
                     .baseUri(CONSUMER.backendService().toString())
@@ -170,7 +171,7 @@ public abstract class AbstractEndToEndTransfer {
         var transferProcessId = CONSUMER.requestAsset(PROVIDER, assetId, noPrivateProperty(), destination);
         await().atMost(timeout).untilAsserted(() -> {
             var state = CONSUMER.getTransferProcessState(transferProcessId);
-            assertThat(state).isEqualTo(STARTED.name());
+            assertThat(state).isEqualTo(COMPLETED.name());
 
             given()
                     .baseUri(CONSUMER.backendService().toString())


### PR DESCRIPTION
## What this PR changes/adds

Send correlationId and not transfer process id in the protocol messages

## Why it does that

fix bug

## Further notes

- I enhanced the e2e transfer tests by making the TP going to COMPLETED, this was done adding the `control-plane-api` and `control-plane-api-client` to the runtimes
- **question 1**: given that we have this control-plane to data-plane communication I wonder if we need the `statusChecker` at all. From an hi level perspective it is correct that the data plane has the knowledge about the transfer completion, this will download some responsibilities from the control-plane
- **question 2** Currently as specified in #3334 not everyone is aware that there's this communication layer between CP and DP so I was wondering if it would be better to get rid of the `NoopTransferProcessClient` to clearly state that a DP needs to communicate with the CP, otherwise it should not start.

thoughts on these 2? 

## Linked Issue(s)

Closes #3377 
Closes #3334 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
