### PR TITLE
feat: handle ContractRequestMessage on an already existing negotiation

### DIFF
--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/ContractCoreExtension.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/ContractCoreExtension.java
@@ -185,7 +185,7 @@ public class ContractCoreExtension implements ServiceExtension {
         var participantId = context.getParticipantId();
 
         var policyEquality = new PolicyEquality(typeManager);
-        var validationService = new ContractValidationServiceImpl(participantId, agentService, contractDefinitionResolver, assetIndex, policyStore, policyEngine, policyEquality);
+        var validationService = new ContractValidationServiceImpl(agentService, contractDefinitionResolver, assetIndex, policyStore, policyEngine, policyEquality);
         context.registerService(ContractValidationService.class, validationService);
 
         // bind/register rule to evaluate contract expiry

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImpl.java
@@ -51,7 +51,6 @@ import static org.eclipse.edc.spi.result.Result.success;
  */
 public class ContractValidationServiceImpl implements ContractValidationService {
 
-    private final String participantId;
     private final ParticipantAgentService agentService;
     private final ContractDefinitionResolver contractDefinitionResolver;
     private final AssetIndex assetIndex;
@@ -59,14 +58,12 @@ public class ContractValidationServiceImpl implements ContractValidationService 
     private final PolicyEngine policyEngine;
     private final PolicyEquality policyEquality;
 
-    public ContractValidationServiceImpl(String participantId,
-                                         ParticipantAgentService agentService,
+    public ContractValidationServiceImpl(ParticipantAgentService agentService,
                                          ContractDefinitionResolver contractDefinitionResolver,
                                          AssetIndex assetIndex,
                                          PolicyDefinitionStore policyStore,
                                          PolicyEngine policyEngine,
                                          PolicyEquality policyEquality) {
-        this.participantId = participantId;
         this.agentService = agentService;
         this.contractDefinitionResolver = contractDefinitionResolver;
         this.assetIndex = assetIndex;

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImplTest.java
@@ -95,7 +95,7 @@ class ContractValidationServiceImplTest {
 
     @BeforeEach
     void setUp() {
-        validationService = new ContractValidationServiceImpl(PROVIDER_ID, agentService, definitionResolver, assetIndex, policyStore, policyEngine, policyEquality);
+        validationService = new ContractValidationServiceImpl(agentService, definitionResolver, assetIndex, policyStore, policyEngine, policyEquality);
         when(assetIndex.countAssets(anyList())).thenReturn(1L);
     }
 

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/AbstractResult.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/AbstractResult.java
@@ -173,10 +173,23 @@ public abstract class AbstractResult<T, F extends Failure, R extends AbstractRes
     }
 
     /**
+     * If the result is failed maps the content into a result applying the mapping function, otherwise do nothing.
+     *
+     * @param mappingFunction a function converting this result into another when it's failed.
+     * @return the result of the mapping function
+     */
+    public R recover(Function<F, R> mappingFunction) {
+        if (succeeded()) {
+            return newInstance(getContent(), null);
+        } else {
+            return mappingFunction.apply(getFailure());
+        }
+    }
+
+    /**
      * Returns a new result instance.
      * This default implementation exists only to avoid breaking changes, in a future this should become an abstract
      * method.
-     * If this {@link UnsupportedOperationException} was thrown, please override this method with a proper behavior.
      *
      * @param content the content.
      * @param failure the failure.

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractNegotiation.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractNegotiation.java
@@ -191,7 +191,7 @@ public class ContractNegotiation extends StatefulEntity<ContractNegotiation> {
      */
     public void transitionRequested() {
         if (Type.PROVIDER == type) {
-            transition(REQUESTED, INITIAL);
+            transition(REQUESTED, OFFERED, INITIAL);
         } else {
             transition(REQUESTED, REQUESTED, REQUESTING);
         }
@@ -367,7 +367,7 @@ public class ContractNegotiation extends StatefulEntity<ContractNegotiation> {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        ContractNegotiation that = (ContractNegotiation) o;
+        var that = (ContractNegotiation) o;
         return state == that.state && stateCount == that.stateCount && stateTimestamp == that.stateTimestamp && Objects.equals(id, that.id) &&
                 Objects.equals(correlationId, that.correlationId) && Objects.equals(counterPartyId, that.counterPartyId) &&
                 Objects.equals(clock, that.clock) &&


### PR DESCRIPTION
## What this PR changes/adds

Handles the `ContractRequestMessage` on an already existing negotiation.

## Why it does that

dsp completion

## Further notes

- added a `recover` method on `AbstractResult` that will execute the mapping function when the result is failed, otherwise will do nothing. [Inspired by vertx Future.recover function](https://vertx.io/docs/apidocs/io/vertx/core/Future.html#recover-java.util.function.Function-)

## Linked Issue(s)

Closes #3380 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
