### PR TITLE
feat: logging http requests and responses handled by rest-assured

### DIFF
--- a/core/common/junit/build.gradle.kts
+++ b/core/common/junit/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
 
     implementation(libs.junit.pioneer)
     implementation(libs.testcontainers.junit)
+    implementation(libs.restAssured)
 }
 
 

--- a/core/common/junit/src/main/java/org/eclipse/edc/junit/testfixtures/TestUtils.java
+++ b/core/common/junit/src/main/java/org/eclipse/edc/junit/testfixtures/TestUtils.java
@@ -15,6 +15,9 @@
 package org.eclipse.edc.junit.testfixtures;
 
 import dev.failsafe.RetryPolicy;
+import io.restassured.RestAssured;
+import io.restassured.filter.log.RequestLoggingFilter;
+import io.restassured.filter.log.ResponseLoggingFilter;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import org.eclipse.edc.connector.core.base.EdcHttpClientImpl;
@@ -211,4 +214,10 @@ public class TestUtils {
         return null;
     }
 
+    /**
+     * Utility method to add filters to log http requests and respoinses handled by rest-assured.
+     */
+    public static void addRestAssuredLoggingFilters() {
+        RestAssured.filters(new RequestLoggingFilter(), new ResponseLoggingFilter());
+    }
 }

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/AbstractEndToEndTransfer.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/AbstractEndToEndTransfer.java
@@ -16,8 +16,10 @@ package org.eclipse.edc.test.e2e;
 
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
+import org.eclipse.edc.junit.testfixtures.TestUtils;
 import org.eclipse.edc.test.e2e.participant.EndToEndTransferParticipant;
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -55,6 +57,11 @@ public abstract class AbstractEndToEndTransfer {
             .name("provider")
             .id("urn:connector:provider")
             .build();
+
+    @BeforeAll
+    static void init() {
+        TestUtils.addRestAssuredLoggingFilters();
+    }
 
     @Test
     void httpPull_dataTransfer() {


### PR DESCRIPTION
## What this PR changes/adds

add utility method to enable log HTTP requests and responses handled by rest-assured in tests. 

## Why it does that

Logging HTTP requests and responses is useful for debugging and analysing the interaction between components.

## Further notes

This PR enabled the logging in e2e-transfer-test as a first place to poc. The logging can be shown by running the integration test like:

```
$ ./gradlew clean test -p system-tests/e2e-transfer-test/runner -PverboseTest -DincludeTags="EndToEndTest" --tests "*EndToEndTransferInMemoryTest.httpPushDataTransfer"
```

## Linked Issue(s)

This is addressing the part of #3398. I would like to address logging of okhttp in another PR.
