### PR TITLE
feat: adds counter party validation on all DSP messages

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImpl.java
@@ -107,37 +107,36 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
     @WithSpan
     @NotNull
     public ServiceResult<TransferProcess> notifyStarted(TransferStartMessage message, ClaimToken claimToken) {
-        return onMessageDo(message, transferProcess -> startedAction(message, transferProcess));
+        return onMessageDo(message, claimToken, transferProcess -> startedAction(message, transferProcess));
     }
 
     @Override
     @WithSpan
     @NotNull
     public ServiceResult<TransferProcess> notifyCompleted(TransferCompletionMessage message, ClaimToken claimToken) {
-        return onMessageDo(message, transferProcess -> completedAction(message, transferProcess));
+        return onMessageDo(message, claimToken, transferProcess -> completedAction(message, transferProcess));
     }
 
     @Override
     @WithSpan
     @NotNull
     public ServiceResult<TransferProcess> notifyTerminated(TransferTerminationMessage message, ClaimToken claimToken) {
-        return onMessageDo(message, transferProcess -> terminatedAction(message, transferProcess));
+        return onMessageDo(message, claimToken, transferProcess -> terminatedAction(message, transferProcess));
     }
-    
+
     @Override
     @WithSpan
     @NotNull
     public ServiceResult<TransferProcess> findById(String id, ClaimToken claimToken) {
         return transactionContext.execute(() -> Optional.ofNullable(transferProcessStore.findById(id))
-                .filter(tp -> validateCounterParty(claimToken, tp))
-                .map(ServiceResult::success)
-                .orElse(ServiceResult.notFound(format("No negotiation with id %s found", id))));
+                .map(tp -> validateCounterParty(claimToken, tp))
+                .orElse(notFound(id)));
     }
-    
+
     @NotNull
     private ServiceResult<TransferProcess> requestedAction(TransferRequestMessage message, ContractId contractId) {
         var assetId = contractId.assetIdPart();
-        
+
         var destination = message.getDataDestination() != null ? message.getDataDestination() :
                 DataAddress.Builder.newInstance().type(HTTP_PROXY).build();
         var dataRequest = DataRequest.Builder.newInstance()
@@ -210,18 +209,25 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
         }
     }
 
-    private ServiceResult<TransferProcess> onMessageDo(TransferRemoteMessage message, Function<TransferProcess, ServiceResult<TransferProcess>> action) {
+    private ServiceResult<TransferProcess> onMessageDo(TransferRemoteMessage message, ClaimToken claimToken, Function<TransferProcess, ServiceResult<TransferProcess>> action) {
         return transactionContext.execute(() -> transferProcessStore
                 .findByCorrelationIdAndLease(message.getProcessId())
                 .flatMap(ServiceResult::from)
+                .compose(transferProcess -> validateCounterParty(claimToken, transferProcess))
                 .compose(action));
     }
-    
-    private boolean validateCounterParty(ClaimToken claimToken, TransferProcess transferProcess) {
+
+    private ServiceResult<TransferProcess> validateCounterParty(ClaimToken claimToken, TransferProcess transferProcess) {
         return Optional.ofNullable(negotiationStore.findContractAgreement(transferProcess.getContractId()))
                 .map(agreement -> contractValidationService.validateRequest(claimToken, agreement))
                 .filter(Result::succeeded)
-                .isPresent();
+                .map(e -> ServiceResult.success(transferProcess))
+                .orElse(notFound(transferProcess.getId()));
+
+    }
+
+    private ServiceResult<TransferProcess> notFound(String transferProcessId) {
+        return ServiceResult.notFound(format("No transfer process with id %s found", transferProcessId));
     }
 
     private void update(TransferProcess transferProcess) {

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImpl.java
@@ -214,8 +214,8 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
                 .findByCorrelationIdAndLease(message.getProcessId())
                 .flatMap(ServiceResult::from)
                 .compose(transferProcess -> validateCounterParty(claimToken, transferProcess)
-                        .onFailure(f -> breakLease(transferProcess)))
-                .compose(action));
+                        .compose(action)
+                        .onFailure(f -> breakLease(transferProcess))));
     }
 
     private ServiceResult<TransferProcess> validateCounterParty(ClaimToken claimToken, TransferProcess transferProcess) {

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImplTest.java
@@ -71,6 +71,7 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -293,6 +294,9 @@ class TransferProcessProtocolServiceImplTest {
                 .isFailed()
                 .extracting(ServiceFailure::getReason)
                 .isEqualTo(NOT_FOUND);
+
+        verify(store, times(1)).save(any());
+
     }
 
     @Test
@@ -363,6 +367,8 @@ class TransferProcessProtocolServiceImplTest {
                 .isFailed()
                 .extracting(ServiceFailure::getReason)
                 .isEqualTo(NOT_FOUND);
+
+        verify(store, times(1)).save(any());
 
     }
 
@@ -440,6 +446,9 @@ class TransferProcessProtocolServiceImplTest {
                 .isFailed()
                 .extracting(ServiceFailure::getReason)
                 .isEqualTo(NOT_FOUND);
+
+        verify(store, times(1)).save(any());
+
     }
 
     @Test

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImplTest.java
@@ -268,7 +268,8 @@ class TransferProcessProtocolServiceImplTest {
         var result = service.notifyStarted(message, token);
 
         assertThat(result).isFailed().extracting(ServiceFailure::getReason).isEqualTo(CONFLICT);
-        verify(store, never()).save(any());
+        // state didn't change
+        verify(store, times(1)).save(argThat(tp -> tp.getState() == COMPLETED.code()));
         verifyNoInteractions(listener);
     }
 
@@ -342,7 +343,8 @@ class TransferProcessProtocolServiceImplTest {
         var result = service.notifyCompleted(message, token);
 
         assertThat(result).isFailed().extracting(ServiceFailure::getReason).isEqualTo(CONFLICT);
-        verify(store, never()).save(any());
+        // state didn't change
+        verify(store, times(1)).save(argThat(tp -> tp.getState() == REQUESTED.code()));
         verifyNoInteractions(listener);
     }
 
@@ -418,7 +420,8 @@ class TransferProcessProtocolServiceImplTest {
         var result = service.notifyTerminated(message, token);
 
         assertThat(result).isFailed().extracting(ServiceFailure::getReason).isEqualTo(CONFLICT);
-        verify(store, never()).save(any());
+        // state didn't change
+        verify(store, times(1)).save(argThat(tp -> tp.getState() == TERMINATED.code()));
         verifyNoInteractions(listener);
     }
 


### PR DESCRIPTION
## What this PR changes/adds

Add counter party validation on all DSP messages

## Why it does that
consistency

## Further notes
Shouldn't we also break lease in case of conflict or other error case? e.g.

https://github.com/eclipse-edc/Connector/blob/73d53586a6bb82e083de3dbd6b469e006111b39a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImpl.java#L172-L184

## Linked Issue(s)

Closes #3397 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
