### PR TITLE
refactor: add onNotProcessed handler on Processor

### DIFF
--- a/core/common/state-machine/src/test/java/org/eclipse/edc/statemachine/ProcessorImplTest.java
+++ b/core/common/state-machine/src/test/java/org/eclipse/edc/statemachine/ProcessorImplTest.java
@@ -18,6 +18,7 @@ import org.eclipse.edc.statemachine.retry.TestEntity;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -87,5 +88,33 @@ class ProcessorImplTest {
         assertThat(count).isEqualTo(1);
         verify(process).apply(entity);
         verifyNoInteractions(guardProcess);
+    }
+
+    @Test
+    void shouldExecuteOnNotProcessed_whenEntityProcessed() {
+        var entity = TestEntity.Builder.newInstance().id("id").build();
+        Consumer<TestEntity> onNotProcessed = mock();
+        var processor = ProcessorImpl.Builder.newInstance(() -> List.of(entity))
+                .process(e -> false)
+                .onNotProcessed(onNotProcessed)
+                .build();
+
+        processor.process();
+
+        verify(onNotProcessed).accept(entity);
+    }
+
+    @Test
+    void shouldNotExecuteOnNotProcessed_whenEntityProcessed() {
+        var entity = TestEntity.Builder.newInstance().id("id").build();
+        Consumer<TestEntity> onNotProcessed = mock();
+        var processor = ProcessorImpl.Builder.newInstance(() -> List.of(entity))
+                .process(e -> true)
+                .onNotProcessed(onNotProcessed)
+                .build();
+
+        processor.process();
+
+        verifyNoInteractions(onNotProcessed);
     }
 }

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/AbstractContractNegotiationManager.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/AbstractContractNegotiationManager.java
@@ -70,6 +70,7 @@ public abstract class AbstractContractNegotiationManager {
         return ProcessorImpl.Builder.newInstance(() -> negotiationStore.nextNotLeased(batchSize, filter))
                 .process(telemetry.contextPropagationMiddleware(function))
                 .guard(pendingGuard, this::setPending)
+                .onNotProcessed(this::breakLease)
                 .build();
     }
 

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -136,7 +136,6 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
 
         return entityRetryProcessFactory.doAsyncStatusResultProcess(negotiation, () -> dispatcherRegistry.dispatch(Object.class, request))
                 .entityRetrieve(negotiationStore::findById)
-                .onDelay(this::breakLease)
                 .onSuccess((n, result) -> transitionToRequested(n))
                 .onFailure((n, throwable) -> transitionToRequesting(n))
                 .onFatalError((n, failure) -> transitionToTerminated(n, failure.getFailureDetail()))
@@ -182,7 +181,6 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
 
         return entityRetryProcessFactory.doAsyncStatusResultProcess(negotiation, () -> dispatcherRegistry.dispatch(Object.class, request))
                 .entityRetrieve(negotiationStore::findById)
-                .onDelay(this::breakLease)
                 .onSuccess((n, result) -> transitionToAccepted(n))
                 .onFailure((n, throwable) -> transitionToAccepting(n))
                 .onFatalError((n, failure) -> transitionToTerminated(n, failure.getFailureDetail()))
@@ -219,7 +217,6 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
 
         return entityRetryProcessFactory.doAsyncStatusResultProcess(negotiation, () -> dispatcherRegistry.dispatch(Object.class, message))
                 .entityRetrieve(negotiationStore::findById)
-                .onDelay(this::breakLease)
                 .onSuccess((n, result) -> transitionToVerified(n))
                 .onFailure((n, throwable) -> transitionToVerifying(n))
                 .onFatalError((n, failure) -> transitionToTerminated(n, failure.getFailureDetail()))
@@ -246,7 +243,6 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
 
         return entityRetryProcessFactory.doAsyncStatusResultProcess(negotiation, () -> dispatcherRegistry.dispatch(Object.class, rejection))
                 .entityRetrieve(negotiationStore::findById)
-                .onDelay(this::breakLease)
                 .onSuccess((n, result) -> transitionToTerminated(n))
                 .onFailure((n, throwable) -> transitionToTerminating(n))
                 .onFatalError((n, failure) -> transitionToTerminated(n, failure.getFailureDetail()))

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -93,7 +93,6 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
 
         return entityRetryProcessFactory.doAsyncStatusResultProcess(negotiation, () -> dispatcherRegistry.dispatch(Object.class, contractOfferMessage))
                 .entityRetrieve(negotiationStore::findById)
-                .onDelay(this::breakLease)
                 .onSuccess((n, result) -> transitionToOffered(n))
                 .onFailure((n, throwable) -> transitionToOffering(n))
                 .onFatalError((n, failure) -> transitionToTerminated(n, failure.getFailureDetail()))
@@ -120,7 +119,6 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
 
         return entityRetryProcessFactory.doAsyncStatusResultProcess(negotiation, () -> dispatcherRegistry.dispatch(Object.class, rejection))
                 .entityRetrieve(negotiationStore::findById)
-                .onDelay(this::breakLease)
                 .onSuccess((n, result) -> transitionToTerminated(n))
                 .onFailure((n, throwable) -> transitionToTerminating(n))
                 .onFatalError((n, failure) -> transitionToTerminated(n, failure.getFailureDetail()))
@@ -194,7 +192,6 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
 
         return entityRetryProcessFactory.doAsyncStatusResultProcess(negotiation, () -> dispatcherRegistry.dispatch(Object.class, request))
                 .entityRetrieve(negotiationStore::findById)
-                .onDelay(this::breakLease)
                 .onSuccess((n, result) -> transitionToAgreed(n, agreement))
                 .onFailure((n, throwable) -> transitionToAgreeing(n))
                 .onFatalError((n, failure) -> transitionToTerminated(n, failure.getFailureDetail()))
@@ -232,7 +229,6 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
 
         return entityRetryProcessFactory.doAsyncStatusResultProcess(negotiation, () -> dispatcherRegistry.dispatch(Object.class, message))
                 .entityRetrieve(negotiationStore::findById)
-                .onDelay(this::breakLease)
                 .onSuccess((n, result) -> transitionToFinalized(n))
                 .onFailure((n, throwable) -> transitionToFinalizing(n))
                 .onFatalError((n, failure) -> transitionToTerminated(n, failure.getFailureDetail()))


### PR DESCRIPTION
## What this PR changes/adds

Add a `onNotProcessed` listener on `Processor`, this will permit to define a unique post not-processed entity behavior, that is always a break lease, because there shouldn't be any leased entity after a state machine iteration.
This refactor will permit to centralize this behavior in a single place instead of having it spread over multiple methods/classes.

## Why it does that

refactoring

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Pre-refactoring for issue #3401 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
