### PR TITLE
fix: specialize `ContractId` only for offers, not agreements

### DIFF
--- a/core/control-plane/catalog-core/src/main/java/org/eclipse/edc/connector/catalog/DatasetResolverImpl.java
+++ b/core/control-plane/catalog-core/src/main/java/org/eclipse/edc/connector/catalog/DatasetResolverImpl.java
@@ -17,7 +17,7 @@ package org.eclipse.edc.connector.catalog;
 import org.eclipse.edc.catalog.spi.Dataset;
 import org.eclipse.edc.catalog.spi.DatasetResolver;
 import org.eclipse.edc.catalog.spi.DistributionResolver;
-import org.eclipse.edc.connector.contract.spi.ContractId;
+import org.eclipse.edc.connector.contract.spi.ContractOfferId;
 import org.eclipse.edc.connector.contract.spi.offer.ContractDefinitionResolver;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractDefinition;
 import org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore;
@@ -91,7 +91,7 @@ public class DatasetResolverImpl implements DatasetResolver {
                 .forEach(contractDefinition -> {
                     var policyDefinition = policyDefinitionStore.findById(contractDefinition.getContractPolicyId());
                     if (policyDefinition != null) {
-                        var contractId = ContractId.create(contractDefinition.getId(), asset.getId());
+                        var contractId = ContractOfferId.create(contractDefinition.getId(), asset.getId());
                         datasetBuilder.offer(contractId.toString(), policyDefinition.getPolicy().withTarget(asset.getId()));
                     }
                 });

--- a/core/control-plane/catalog-core/src/test/java/org/eclipse/edc/connector/catalog/DatasetResolverImplTest.java
+++ b/core/control-plane/catalog-core/src/test/java/org/eclipse/edc/connector/catalog/DatasetResolverImplTest.java
@@ -22,7 +22,7 @@ import org.eclipse.edc.catalog.spi.DatasetResolver;
 import org.eclipse.edc.catalog.spi.Distribution;
 import org.eclipse.edc.catalog.spi.DistributionResolver;
 import org.eclipse.edc.connector.asset.CriterionToAssetPredicateConverterImpl;
-import org.eclipse.edc.connector.contract.spi.ContractId;
+import org.eclipse.edc.connector.contract.spi.ContractOfferId;
 import org.eclipse.edc.connector.contract.spi.offer.ContractDefinitionResolver;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractDefinition;
 import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
@@ -89,7 +89,7 @@ class DatasetResolverImplTest {
             assertThat(dataset.getId()).isEqualTo("assetId");
             assertThat(dataset.getDistributions()).hasSize(1).first().isEqualTo(distribution);
             assertThat(dataset.getOffers()).hasSize(1).allSatisfy((id, policy) -> {
-                assertThat(ContractId.parseId(id)).isSucceeded().extracting(ContractId::definitionPart).asString().isEqualTo("definitionId");
+                assertThat(ContractOfferId.parseId(id)).isSucceeded().extracting(ContractOfferId::definitionPart).asString().isEqualTo("definitionId");
                 assertThat(policy.getTarget()).isEqualTo("assetId");
             });
             assertThat(dataset.getProperties()).contains(entry("key", "value"));
@@ -126,11 +126,11 @@ class DatasetResolverImplTest {
             assertThat(dataset.getId()).isEqualTo("assetId");
             assertThat(dataset.getOffers()).hasSize(2)
                     .anySatisfy((id, policy) -> {
-                        assertThat(ContractId.parseId(id)).isSucceeded().extracting(ContractId::definitionPart).asString().isEqualTo("definition1");
+                        assertThat(ContractOfferId.parseId(id)).isSucceeded().extracting(ContractOfferId::definitionPart).asString().isEqualTo("definition1");
                         assertThat(policy.getType()).isEqualTo(SET);
                     })
                     .anySatisfy((id, policy) -> {
-                        assertThat(ContractId.parseId(id)).isSucceeded().extracting(ContractId::definitionPart).asString().isEqualTo("definition2");
+                        assertThat(ContractOfferId.parseId(id)).isSucceeded().extracting(ContractOfferId::definitionPart).asString().isEqualTo("definition2");
                         assertThat(policy.getType()).isEqualTo(OFFER);
                     });
         });
@@ -238,11 +238,11 @@ class DatasetResolverImplTest {
         assertThat(dataset.getId()).isEqualTo("datasetId");
         assertThat(dataset.getOffers()).hasSize(2)
                 .anySatisfy((id, policy) -> {
-                    assertThat(ContractId.parseId(id)).isSucceeded().extracting(ContractId::definitionPart).isEqualTo("definition1");
+                    assertThat(ContractOfferId.parseId(id)).isSucceeded().extracting(ContractOfferId::definitionPart).isEqualTo("definition1");
                     assertThat(policy.getType()).isEqualTo(SET);
                 })
                 .anySatisfy((id, policy) -> {
-                    assertThat(ContractId.parseId(id)).isSucceeded().extracting(ContractId::definitionPart).isEqualTo("definition2");
+                    assertThat(ContractOfferId.parseId(id)).isSucceeded().extracting(ContractOfferId::definitionPart).isEqualTo("definition2");
                     assertThat(policy.getType()).isEqualTo(OFFER);
                 });
         verify(assetIndex).findById("datasetId");

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -19,7 +19,6 @@
 package org.eclipse.edc.connector.contract.negotiation;
 
 import io.opentelemetry.instrumentation.annotations.WithSpan;
-import org.eclipse.edc.connector.contract.spi.ContractId;
 import org.eclipse.edc.connector.contract.spi.negotiation.ConsumerContractNegotiationManager;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementMessage;
@@ -155,16 +154,8 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
     private boolean processAccepting(ContractNegotiation negotiation) {
         var lastOffer = negotiation.getLastContractOffer();
 
-        var contractIdResult = ContractId.parseId(lastOffer.getId());
-        if (contractIdResult.failed()) {
-            monitor.severe("ConsumerContractNegotiationManagerImpl.approveContractOffers(): Offer Id not correctly formatted: " + contractIdResult.getFailureDetail());
-            return false;
-        }
-        var contractId = contractIdResult.getContent();
-
         var policy = lastOffer.getPolicy();
         var agreement = ContractAgreement.Builder.newInstance()
-                .id(contractId.derive().toString())
                 .contractSigningDate(clock.instant().getEpochSecond())
                 .providerId(negotiation.getCounterPartyId())
                 .consumerId(participantId)

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -19,7 +19,6 @@
 package org.eclipse.edc.connector.contract.negotiation;
 
 import io.opentelemetry.instrumentation.annotations.WithSpan;
-import org.eclipse.edc.connector.contract.spi.ContractId;
 import org.eclipse.edc.connector.contract.spi.negotiation.ProviderContractNegotiationManager;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementMessage;
@@ -163,16 +162,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
         if (retrievedAgreement == null) {
             var lastOffer = negotiation.getLastContractOffer();
 
-            var contractIdResult = ContractId.parseId(lastOffer.getId());
-            if (contractIdResult.failed()) {
-                monitor.severe("ProviderContractNegotiationManagerImpl.checkConfirming(): Offer Id not correctly formatted: " + contractIdResult.getFailureDetail());
-                return false;
-            }
-
-            var contractId = contractIdResult.getContent();
-
             agreement = ContractAgreement.Builder.newInstance()
-                    .id(contractId.derive().toString())
                     .contractSigningDate(clock.instant().getEpochSecond())
                     .providerId(participantId)
                     .consumerId(negotiation.getCounterPartyId())

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -16,7 +16,7 @@
 package org.eclipse.edc.connector.contract.negotiation;
 
 import org.eclipse.edc.connector.contract.observe.ContractNegotiationObservableImpl;
-import org.eclipse.edc.connector.contract.spi.ContractId;
+import org.eclipse.edc.connector.contract.spi.ContractOfferId;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementMessage;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementVerificationMessage;
@@ -325,7 +325,7 @@ class ContractNegotiationIntegrationTest {
      */
     private ContractOffer getContractOffer() {
         return ContractOffer.Builder.newInstance()
-                .id(ContractId.create("1", "test-asset-id").toString())
+                .id(ContractOfferId.create("1", "test-asset-id").toString())
                 .assetId(randomUUID().toString())
                 .policy(Policy.Builder.newInstance()
                         .type(PolicyType.CONTRACT)

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
@@ -16,7 +16,7 @@
 package org.eclipse.edc.connector.contract.negotiation;
 
 import org.eclipse.edc.connector.contract.observe.ContractNegotiationObservableImpl;
-import org.eclipse.edc.connector.contract.spi.ContractId;
+import org.eclipse.edc.connector.contract.spi.ContractOfferId;
 import org.eclipse.edc.connector.contract.spi.negotiation.ContractNegotiationPendingGuard;
 import org.eclipse.edc.connector.contract.spi.negotiation.observe.ContractNegotiationListener;
 import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
@@ -274,7 +274,7 @@ class ProviderContractNegotiationManagerImplTest {
 
     private ContractAgreement.Builder contractAgreementBuilder() {
         return ContractAgreement.Builder.newInstance()
-                .id(ContractId.create(UUID.randomUUID().toString(), "test-asset-id").toString())
+                .id(ContractOfferId.create(UUID.randomUUID().toString(), "test-asset-id").toString())
                 .providerId("any")
                 .consumerId("any")
                 .assetId("default")
@@ -283,7 +283,7 @@ class ProviderContractNegotiationManagerImplTest {
 
     private ContractOffer contractOffer() {
         return ContractOffer.Builder.newInstance()
-                .id(ContractId.create("1", "test-asset-id").toString())
+                .id(ContractOfferId.create("1", "test-asset-id").toString())
                 .policy(Policy.Builder.newInstance().build())
                 .assetId("assetId")
                 .build();

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImplTest.java
@@ -18,7 +18,7 @@
 package org.eclipse.edc.connector.contract.validation;
 
 import org.eclipse.edc.connector.contract.policy.PolicyEquality;
-import org.eclipse.edc.connector.contract.spi.ContractId;
+import org.eclipse.edc.connector.contract.spi.ContractOfferId;
 import org.eclipse.edc.connector.contract.spi.offer.ContractDefinitionResolver;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
@@ -66,7 +66,6 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -290,18 +289,6 @@ class ContractValidationServiceImplTest {
     }
 
     @Test
-    void validateAgreement_failsIfIdIsNotValid() {
-        var token = ClaimToken.Builder.newInstance().build();
-        var agreement = createContractAgreement().id("not a valid ID").build();
-
-        var result = validationService.validateAgreement(token, agreement);
-
-        assertThat(result.failed()).isTrue();
-
-        verify(agentService, times(0)).createFor(eq(token));
-    }
-
-    @Test
     void validateConfirmed_succeed() {
         var agreement = createContractAgreement().id("any").build();
         var offer = createContractOffer();
@@ -473,7 +460,7 @@ class ContractValidationServiceImplTest {
 
         var claimToken = ClaimToken.Builder.newInstance().build();
         var agreement = createContractAgreement()
-                .id(ContractId.create("1", "2").toString())
+                .id(ContractOfferId.create("1", "2").toString())
                 .contractSigningDate(Instant.now().toEpochMilli())
                 .build();
 
@@ -488,7 +475,7 @@ class ContractValidationServiceImplTest {
 
         var claimToken = ClaimToken.Builder.newInstance().build();
         var agreement = createContractAgreement()
-                .id(ContractId.create("1", "2").toString())
+                .id(ContractOfferId.create("1", "2").toString())
                 .contractSigningDate(signingDate)
                 .build();
 
@@ -497,7 +484,7 @@ class ContractValidationServiceImplTest {
 
     private ContractOffer createContractOffer(Asset asset, Policy policy) {
         return ContractOffer.Builder.newInstance()
-                .id(ContractId.create("1", asset.getId()).toString())
+                .id(ContractOfferId.create("1", asset.getId()).toString())
                 .assetId(asset.getId())
                 .policy(policy)
                 .build();
@@ -514,7 +501,7 @@ class ContractValidationServiceImplTest {
     }
 
     private ContractAgreement.Builder createContractAgreement() {
-        return ContractAgreement.Builder.newInstance().id(ContractId.create("1", "2").toString())
+        return ContractAgreement.Builder.newInstance()
                 .providerId(PROVIDER_ID)
                 .consumerId(CONSUMER_ID)
                 .policy(Policy.Builder.newInstance().build())

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.edc.connector.service.contractnegotiation;
 
-import org.eclipse.edc.connector.contract.spi.ContractId;
+import org.eclipse.edc.connector.contract.spi.ContractOfferId;
 import org.eclipse.edc.connector.contract.spi.event.contractnegotiation.ContractNegotiationAgreed;
 import org.eclipse.edc.connector.contract.spi.event.contractnegotiation.ContractNegotiationEvent;
 import org.eclipse.edc.connector.contract.spi.event.contractnegotiation.ContractNegotiationRequested;
@@ -110,7 +110,7 @@ class ContractNegotiationEventDispatchTest {
 
     private ContractRequestMessage createContractOfferRequest(Policy policy, String assetId) {
         var contractOffer = ContractOffer.Builder.newInstance()
-                .id(ContractId.create("contractDefinitionId", assetId).toString())
+                .id(ContractOfferId.create("contractDefinitionId", assetId).toString())
                 .assetId("assetId")
                 .policy(policy)
                 .build();

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
@@ -15,7 +15,7 @@
 package org.eclipse.edc.connector.service.contractnegotiation;
 
 import org.eclipse.edc.connector.contract.observe.ContractNegotiationObservableImpl;
-import org.eclipse.edc.connector.contract.spi.ContractId;
+import org.eclipse.edc.connector.contract.spi.ContractOfferId;
 import org.eclipse.edc.connector.contract.spi.negotiation.observe.ContractNegotiationListener;
 import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
@@ -476,7 +476,7 @@ class ContractNegotiationProtocolServiceImplTest {
     interface TestFunctions {
         static ContractOffer contractOffer() {
             return ContractOffer.Builder.newInstance()
-                    .id(ContractId.create("1", "test-asset-id").toString())
+                    .id(ContractOfferId.create("1", "test-asset-id").toString())
                     .policy(createPolicy())
                     .assetId("assetId")
                     .build();

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImplTest.java
@@ -15,7 +15,6 @@
 
 package org.eclipse.edc.connector.service.transferprocess;
 
-import org.eclipse.edc.connector.contract.spi.ContractId;
 import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.contract.spi.validation.ContractValidationService;
@@ -99,7 +98,7 @@ class TransferProcessProtocolServiceImplTest {
     void notifyRequested_validAgreement_shouldInitiateTransfer() {
         var message = TransferRequestMessage.Builder.newInstance()
                 .processId("transferProcessId")
-                .contractId(ContractId.create("definitionId", "assetId").toString())
+                .contractId("agreementId")
                 .protocol("protocol")
                 .callbackAddress("http://any")
                 .dataDestination(DataAddress.Builder.newInstance().type("any").build())
@@ -125,7 +124,7 @@ class TransferProcessProtocolServiceImplTest {
     void notifyRequested_doNothingIfProcessAlreadyExist() {
         var message = TransferRequestMessage.Builder.newInstance()
                 .processId("correlationId")
-                .contractId(ContractId.create("definitionId", "assetId").toString())
+                .contractId("agreementId")
                 .protocol("protocol")
                 .callbackAddress("http://any")
                 .dataDestination(DataAddress.Builder.newInstance().type("any").build())
@@ -143,28 +142,11 @@ class TransferProcessProtocolServiceImplTest {
     }
 
     @Test
-    void notifyRequested_invalidContractId_shouldNotInitiateTransfer() {
-        var message = TransferRequestMessage.Builder.newInstance()
-                .protocol("protocol")
-                .contractId("notvalidcontractid")
-                .callbackAddress("http://any")
-                .dataDestination(DataAddress.Builder.newInstance().type("any").build())
-                .build();
-        when(dataAddressValidator.validate(any())).thenReturn(Result.success());
-
-        var result = service.notifyRequested(message, claimToken());
-
-        assertThat(result).isFailed().extracting(ServiceFailure::getReason).isEqualTo(BAD_REQUEST);
-        verify(store, never()).save(any());
-        verifyNoInteractions(listener, store, negotiationStore, validationService);
-    }
-
-    @Test
     void notifyRequested_invalidAgreement_shouldNotInitiateTransfer() {
         var message = TransferRequestMessage.Builder.newInstance()
                 .protocol("protocol")
                 .callbackAddress("http://any")
-                .contractId(ContractId.create("definitionId", "assetId").toString())
+                .contractId("agreementId")
                 .dataDestination(DataAddress.Builder.newInstance().type("any").build())
                 .build();
         when(negotiationStore.findContractAgreement(any())).thenReturn(contractAgreement());
@@ -183,7 +165,7 @@ class TransferProcessProtocolServiceImplTest {
         when(dataAddressValidator.validate(any())).thenReturn(Result.failure("invalid data address"));
         var message = TransferRequestMessage.Builder.newInstance()
                 .protocol("protocol")
-                .contractId(ContractId.create("definitionId", "assetId").toString())
+                .contractId("agreementId")
                 .callbackAddress("http://any")
                 .dataDestination(DataAddress.Builder.newInstance().type("any").build())
                 .build();
@@ -200,7 +182,7 @@ class TransferProcessProtocolServiceImplTest {
         var message = TransferRequestMessage.Builder.newInstance()
                 .processId("transferProcessId")
                 .protocol("protocol")
-                .contractId(ContractId.create("definitionId", "assetId").toString())
+                .contractId("agreementId")
                 .callbackAddress("http://any")
                 .build();
         when(negotiationStore.findContractAgreement(any())).thenReturn(contractAgreement());
@@ -534,7 +516,7 @@ class TransferProcessProtocolServiceImplTest {
                 .id("agreementId")
                 .providerId("provider")
                 .consumerId("consumer")
-                .assetId("asset")
+                .assetId("assetId")
                 .policy(Policy.Builder.newInstance().build())
                 .build();
     }

--- a/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
+++ b/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
@@ -15,7 +15,6 @@
 package org.eclipse.edc.connector.provision.http.impl;
 
 import okhttp3.Interceptor;
-import org.eclipse.edc.connector.contract.spi.ContractId;
 import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
@@ -51,6 +50,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Map;
+import java.util.UUID;
 
 import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -71,7 +71,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(EdcExtension.class)
 public class HttpProvisionerExtensionEndToEndTest {
     private static final String ASSET_ID = "assetId";
-    private static final String CONTRACT_ID = ContractId.create("definitionId", ASSET_ID).toString();
+    private static final String CONTRACT_ID = UUID.randomUUID().toString();
     private static final String POLICY_ID = "3";
     private final int dataPort = getFreePort();
     private final Interceptor delegate = mock(Interceptor.class);

--- a/spi/common/policy-model/src/main/java/org/eclipse/edc/policy/model/PolicyRegistrationTypes.java
+++ b/spi/common/policy-model/src/main/java/org/eclipse/edc/policy/model/PolicyRegistrationTypes.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.policy.model;
 
-import java.security.Policy;
 import java.util.List;
 
 /**

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/ContractOfferId.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/ContractOfferId.java
@@ -15,7 +15,6 @@
 package org.eclipse.edc.connector.contract.spi;
 
 import org.eclipse.edc.spi.result.Result;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.Base64;
 import java.util.UUID;
@@ -23,14 +22,11 @@ import java.util.UUID;
 import static java.lang.String.format;
 
 /**
- * Handles contract ID generation for contract offers and agreement originating in an EDC runtime.
+ * Handles contract ID generation for contract offers originating in an EDC runtime.
  * Ids are architected to allow the contract definition which generated the contract to be de-referenced.
  * The id format follows the following scheme: <code>[definition-id]:[asset-id]:[UUID]</code>
- *
- * @deprecated please use {@link ContractOfferId}.
  */
-@Deprecated(since = "0.2.1", forRemoval = true)
-public final class ContractId {
+public final class ContractOfferId {
 
     private static final String DELIMITER = ":";
     private static final int DEFINITION_ID_PART = 0;
@@ -40,38 +36,24 @@ public final class ContractId {
     private final String assetId;
     private final String uuid;
 
-    private ContractId(String definitionId, String assetId, String uuid) {
+    private ContractOfferId(String definitionId, String assetId, String uuid) {
         this.definitionId = definitionId;
         this.assetId = assetId;
         this.uuid = uuid;
     }
 
-    public static ContractId create(String definitionId, String assetId) {
-        return new ContractId(definitionId, assetId, UUID.randomUUID().toString());
+    public static ContractOfferId create(String definitionId, String assetId) {
+        return new ContractOfferId(definitionId, assetId, UUID.randomUUID().toString());
     }
 
     /**
-     * Returns a new id given the definition part
-     *
-     * @param definitionPart the part that will be used as prefix of the id
-     * @param assetId        The ID of the asset that is contained in the offer
-     * @return a {@link String} that represent the contract id
-     * @deprecated please use {@link #create(String, String)}
-     */
-    @NotNull
-    @Deprecated(since = "0.1.2", forRemoval = true)
-    public static String createContractId(String definitionPart, String assetId) {
-        return create(definitionPart, assetId).toString();
-    }
-
-    /**
-     * Return a {@link ContractId} instance parsed from the passed string, that should be in the
+     * Return a {@link ContractOfferId} instance parsed from the passed string, that should be in the
      * <code>[definition-id]:[asset-id]:[UUID]</code> format
      *
      * @param id the string representation of the id
-     * @return the {@link ContractId} instance that represent the id
+     * @return the {@link ContractOfferId} instance that represent the id
      */
-    public static Result<ContractId> parseId(String id) {
+    public static Result<ContractOfferId> parseId(String id) {
         if (id == null) {
             return Result.failure("id cannot be null");
         }
@@ -90,23 +72,10 @@ public final class ContractId {
         var uuid = decodeSafely(uuidPart);
 
         var contractId = (definitionId == null || assetId == null || uuid == null)
-                ? new ContractId(definitionIdPart, assetIdPart, uuidPart)
-                : new ContractId(definitionId, assetId, uuid);
+                ? new ContractOfferId(definitionIdPart, assetIdPart, uuidPart)
+                : new ContractOfferId(definitionId, assetId, uuid);
 
         return Result.success(contractId);
-    }
-
-    /**
-     * Return a {@link ContractId} instance parsed from the passed string, that should be in the
-     * <code>[definition-id]:UUID</code> format
-     *
-     * @param id the string representation of the id
-     * @return the {@link ContractId} instance that represent the id
-     * @deprecated please use {@link #parseId(String)}
-     */
-    @Deprecated(since = "0.1.2", forRemoval = true)
-    public static ContractId parse(String id) {
-        return parseId(id).getContent();
     }
 
     private static String decodeSafely(String base64string) {
@@ -115,17 +84,6 @@ public final class ContractId {
         } catch (IllegalArgumentException exception) {
             return null;
         }
-    }
-
-    /**
-     * The id is valid if it follows the following scheme: [definition-id]:UUID
-     *
-     * @return true if it is valid, false otherwise
-     * @deprecated an instantiated {@link ContractId} object is always valid
-     */
-    @Deprecated(since = "0.1.2", forRemoval = true)
-    public boolean isValid() {
-        return true;
     }
 
     /**
@@ -154,15 +112,6 @@ public final class ContractId {
                 encoder.encodeToString(assetId.getBytes()) +
                 DELIMITER +
                 encoder.encodeToString(uuid.getBytes());
-    }
-
-    /**
-     * Create a new {@link ContractId} with the same definitionId and assetId but a new random UUID part.
-     *
-     * @return new {@link ContractId} instance.
-     */
-    public ContractId derive() {
-        return create(definitionId, assetId);
     }
 
 }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractAgreement.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractAgreement.java
@@ -23,6 +23,7 @@ import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
+import java.util.UUID;
 
 import static java.util.Objects.requireNonNull;
 import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
@@ -176,7 +177,9 @@ public class ContractAgreement {
         }
 
         public ContractAgreement build() {
-            requireNonNull(instance.id, "id cannot be null");
+            if (instance.id == null) {
+                instance.id = UUID.randomUUID().toString();
+            }
             requireNonNull(instance.providerId, "providerId cannot be null");
             requireNonNull(instance.consumerId, "consumerId cannot be null");
             requireNonNull(instance.assetId, "assetId cannot be null");

--- a/spi/control-plane/contract-spi/src/test/java/org/eclipse/edc/connector/contract/spi/types/ContractOfferIdTest.java
+++ b/spi/control-plane/contract-spi/src/test/java/org/eclipse/edc/connector/contract/spi/types/ContractOfferIdTest.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.edc.connector.contract.spi.types;
 
-import org.eclipse.edc.connector.contract.spi.ContractId;
+import org.eclipse.edc.connector.contract.spi.ContractOfferId;
 import org.junit.jupiter.api.Test;
 
 import java.util.Base64;
@@ -24,7 +24,7 @@ import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 
-class ContractIdTest {
+class ContractOfferIdTest {
 
     private final Base64.Encoder base64encoder = Base64.getEncoder();
 
@@ -32,7 +32,7 @@ class ContractIdTest {
     void parseId_shouldSucceedWhenItsValid() {
         var base64representation = encodedContractId("definitionId", "assetId", "uuid");
 
-        var result = ContractId.parseId(base64representation);
+        var result = ContractOfferId.parseId(base64representation);
 
         assertThat(result).isSucceeded().satisfies(it -> {
             assertThat(it.definitionPart()).isEqualTo("definitionId");
@@ -43,7 +43,7 @@ class ContractIdTest {
 
     @Test
     void parseId_shouldNotDecodePartsIfTheyArentBase64() {
-        var result = ContractId.parseId("not:base64:" + UUID.randomUUID());
+        var result = ContractOfferId.parseId("not:base64:" + UUID.randomUUID());
 
         assertThat(result).isSucceeded().satisfies(it -> {
             assertThat(it.definitionPart()).isEqualTo("not");
@@ -53,36 +53,23 @@ class ContractIdTest {
 
     @Test
     void shouldNotParse_whenInputIsNull() {
-        var result = ContractId.parseId(null);
+        var result = ContractOfferId.parseId(null);
 
         assertThat(result).isFailed();
     }
 
     @Test
     void shouldNotParse_whenTooFewParts() {
-        var result = ContractId.parseId("this:isinvalid");
+        var result = ContractOfferId.parseId("this:isinvalid");
 
         assertThat(result).isFailed();
     }
 
     @Test
     void shouldNotParse_whenTooManyParts() {
-        var result = ContractId.parseId("this:is:not:valid");
+        var result = ContractOfferId.parseId("this:is:not:valid");
 
         assertThat(result).isFailed();
-    }
-
-    @Test
-    void derive_shouldCreateNewContractWithSameDefinitionAndAssetPartsAndDifferentUuid() {
-        var base64representation = encodedContractId("definitionId", "assetId", "uuid");
-
-        var first = ContractId.parseId(base64representation).getContent();
-
-        var result = first.derive();
-
-        assertThat(result.definitionPart()).isEqualTo("definitionId");
-        assertThat(result.assetIdPart()).isEqualTo("assetId");
-        assertThat(result.toString()).isNotEqualTo(first.toString());
     }
 
     private String encodedContractId(String definitionId, String assetId, String uuid) {

--- a/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/negotiation/store/ContractNegotiationStoreTestBase.java
+++ b/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/negotiation/store/ContractNegotiationStoreTestBase.java
@@ -15,7 +15,7 @@
 
 package org.eclipse.edc.connector.contract.spi.testfixtures.negotiation.store;
 
-import org.eclipse.edc.connector.contract.spi.ContractId;
+import org.eclipse.edc.connector.contract.spi.ContractOfferId;
 import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
@@ -130,7 +130,7 @@ public abstract class ContractNegotiationStoreTestBase {
         @Test
         @DisplayName("Find ContractAgreement by contract ID")
         void findContractAgreement() {
-            var agreement = createContract(ContractId.create("test-cd1", "test-as1"));
+            var agreement = createContract(ContractOfferId.create("test-cd1", "test-as1"));
             var negotiation = createNegotiation("test-cn1", agreement);
             getContractNegotiationStore().save(negotiation);
 
@@ -186,7 +186,7 @@ public abstract class ContractNegotiationStoreTestBase {
         @Test
         @DisplayName("Verify that entity and related entities are stored")
         void withContract() {
-            var agreement = createContract(ContractId.create("definition", "asset"));
+            var agreement = createContract(ContractOfferId.create("definition", "asset"));
             var negotiation = createNegotiation("test-negotiation", agreement);
             getContractNegotiationStore().save(negotiation);
 
@@ -286,7 +286,7 @@ public abstract class ContractNegotiationStoreTestBase {
             getContractNegotiationStore().save(negotiation);
 
             // now add the agreement
-            var agreement = createContract(ContractId.create("definition", "asset"));
+            var agreement = createContract(ContractOfferId.create("definition", "asset"));
             var updatedNegotiation = createNegotiation(negotiationId, agreement);
 
             getContractNegotiationStore().save(updatedNegotiation); //should perform an update + insert
@@ -324,7 +324,7 @@ public abstract class ContractNegotiationStoreTestBase {
             getContractNegotiationStore().save(negotiation);
 
             // now add the agreement
-            var agreement = createContract(ContractId.create("definition", "asset"));
+            var agreement = createContract(ContractOfferId.create("definition", "asset"));
             var updatedNegotiation = createNegotiation(negotiationId, agreement);
 
             getContractNegotiationStore().save(updatedNegotiation);
@@ -342,7 +342,7 @@ public abstract class ContractNegotiationStoreTestBase {
         @DisplayName("Should update the agreement when a negotiation is updated")
         void whenAgreementExists_shouldUpdate() {
             var negotiationId = "test-cn1";
-            var agreement = createContract(ContractId.create("definition", "asset"));
+            var agreement = createContract(ContractOfferId.create("definition", "asset"));
             var negotiation = createNegotiation(negotiationId, null);
             getContractNegotiationStore().save(negotiation);
             var dbNegotiation = getContractNegotiationStore().findById(negotiationId);
@@ -402,7 +402,7 @@ public abstract class ContractNegotiationStoreTestBase {
         @DisplayName("Verify that attempting to delete a negotiation with a contract raises an exception")
         void contractExists() {
             var id = UUID.randomUUID().toString();
-            var contract = createContract(ContractId.create("definition", "asset"));
+            var contract = createContract(ContractOfferId.create("definition", "asset"));
             var n = createNegotiation(id, contract);
             getContractNegotiationStore().save(n);
 
@@ -458,7 +458,7 @@ public abstract class ContractNegotiationStoreTestBase {
 
         @Test
         void withAgreementOnAsset_negotiationWithAgreement() {
-            var agreement = createContract(ContractId.create("definition", "asset"));
+            var agreement = createContract(ContractOfferId.create("definition", "asset"));
             var negotiation = createNegotiation("negotiation1", agreement);
             var assetId = agreement.getAssetId();
 
@@ -515,7 +515,7 @@ public abstract class ContractNegotiationStoreTestBase {
 
             range(0, 100)
                     .mapToObj(i -> {
-                        var agreement = createContract(ContractId.create("definition" + 1, "asset"));
+                        var agreement = createContract(ContractOfferId.create("definition" + 1, "asset"));
                         return createNegotiation(String.valueOf(i), agreement);
                     })
                     .forEach(cn -> getContractNegotiationStore().save(cn));
@@ -541,8 +541,8 @@ public abstract class ContractNegotiationStoreTestBase {
 
         @Test
         void byAgreementId() {
-            var contractId1 = ContractId.create("def1", "asset");
-            var contractId2 = ContractId.create("def2", "asset");
+            var contractId1 = ContractOfferId.create("def1", "asset");
+            var contractId2 = ContractOfferId.create("def2", "asset");
             var negotiation1 = createNegotiation("neg1", createContract(contractId1));
             var negotiation2 = createNegotiation("neg2", createContract(contractId2));
             getContractNegotiationStore().save(negotiation1);
@@ -589,7 +589,7 @@ public abstract class ContractNegotiationStoreTestBase {
 
         @Test
         void shouldReturnEmpty_whenCriteriaLeftOperandIsInvalid() {
-            var contractId = ContractId.create("definition", "asset");
+            var contractId = ContractOfferId.create("definition", "asset");
             var agreement1 = createContract(contractId);
             var negotiation1 = createNegotiation("neg1", agreement1);
             getContractNegotiationStore().save(negotiation1);
@@ -616,7 +616,7 @@ public abstract class ContractNegotiationStoreTestBase {
         @Test
         void shouldReturnAllItems_whenQuerySpecHasNoFilter() {
             range(0, 10).forEach(i -> {
-                var contractAgreement = createContract(ContractId.create(UUID.randomUUID().toString(), ASSET_ID));
+                var contractAgreement = createContract(ContractOfferId.create(UUID.randomUUID().toString(), ASSET_ID));
                 var negotiation = createNegotiation(UUID.randomUUID().toString(), contractAgreement);
                 getContractNegotiationStore().save(negotiation);
             });
@@ -629,7 +629,7 @@ public abstract class ContractNegotiationStoreTestBase {
         @Test
         void withQuerySpec() {
             range(0, 10).mapToObj(i -> "asset-" + i).forEach(assetId -> {
-                var contractId = ContractId.create(UUID.randomUUID().toString(), assetId).toString();
+                var contractId = ContractOfferId.create(UUID.randomUUID().toString(), assetId).toString();
                 var contractAgreement = createContractBuilder(contractId).assetId(assetId).build();
                 var negotiation = createNegotiation(UUID.randomUUID().toString(), contractAgreement);
                 getContractNegotiationStore().save(negotiation);
@@ -644,7 +644,7 @@ public abstract class ContractNegotiationStoreTestBase {
         @Test
         void verifyPaging() {
             range(0, 10).forEach(i -> {
-                var contractAgreement = createContract(ContractId.create(UUID.randomUUID().toString(), ASSET_ID));
+                var contractAgreement = createContract(ContractOfferId.create(UUID.randomUUID().toString(), ASSET_ID));
                 var negotiation = createNegotiation(UUID.randomUUID().toString(), contractAgreement);
                 getContractNegotiationStore().save(negotiation);
             });
@@ -659,7 +659,7 @@ public abstract class ContractNegotiationStoreTestBase {
         @Test
         void verifySorting() {
             range(0, 9).forEach(i -> {
-                var contractId = ContractId.create(UUID.randomUUID().toString(), UUID.randomUUID().toString()).toString();
+                var contractId = ContractOfferId.create(UUID.randomUUID().toString(), UUID.randomUUID().toString()).toString();
                 var contractAgreement = createContractBuilder(contractId).consumerId(String.valueOf(i)).build();
                 var negotiation = createNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
                 getContractNegotiationStore().save(negotiation);
@@ -675,7 +675,7 @@ public abstract class ContractNegotiationStoreTestBase {
         @Test
         void shouldReturnEmpty_whenCriterionLeftOperandIsInvalid() {
             range(0, 10).mapToObj(i -> "asset-" + i).forEach(assetId -> {
-                var contractAgreement = createContractBuilder(ContractId.create(UUID.randomUUID().toString(), assetId).toString())
+                var contractAgreement = createContractBuilder(ContractOfferId.create(UUID.randomUUID().toString(), assetId).toString())
                         .assetId(assetId)
                         .build();
                 var negotiation = createNegotiation(UUID.randomUUID().toString(), contractAgreement);
@@ -773,7 +773,7 @@ public abstract class ContractNegotiationStoreTestBase {
         @Test
         @DisplayName("Verify that nextNotLeased returns the agreement")
         void withAgreement() {
-            var contractAgreement = createContract(ContractId.create(UUID.randomUUID().toString(), ASSET_ID));
+            var contractAgreement = createContract(ContractOfferId.create(UUID.randomUUID().toString(), ASSET_ID));
             var negotiation = createNegotiationBuilder(UUID.randomUUID().toString())
                     .contractAgreement(contractAgreement)
                     .state(ContractNegotiationStates.AGREED.code())

--- a/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/negotiation/store/TestFunctions.java
+++ b/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/negotiation/store/TestFunctions.java
@@ -15,7 +15,7 @@
 
 package org.eclipse.edc.connector.contract.spi.testfixtures.negotiation.store;
 
-import org.eclipse.edc.connector.contract.spi.ContractId;
+import org.eclipse.edc.connector.contract.spi.ContractOfferId;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates;
@@ -48,8 +48,8 @@ public class TestFunctions {
                 .build();
     }
 
-    public static ContractAgreement createContract(ContractId contractId) {
-        return createContractBuilder(contractId.toString())
+    public static ContractAgreement createContract(ContractOfferId contractOfferId) {
+        return createContractBuilder(contractOfferId.toString())
                 .build();
     }
 

--- a/system-tests/e2e-test-fixtures/src/testFixtures/java/org/eclipse/edc/test/system/utils/Participant.java
+++ b/system-tests/e2e-test-fixtures/src/testFixtures/java/org/eclipse/edc/test/system/utils/Participant.java
@@ -19,7 +19,7 @@ import io.restassured.specification.RequestSpecification;
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
-import org.eclipse.edc.connector.contract.spi.ContractId;
+import org.eclipse.edc.connector.contract.spi.ContractOfferId;
 import org.eclipse.edc.jsonld.TitaniumJsonLd;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.jsonld.util.JacksonJsonLd;
@@ -322,7 +322,7 @@ public class Participant {
     public String requestAsset(Participant provider, String assetId, JsonObject privateProperties, JsonObject destination) {
         var dataset = getDatasetForAsset(provider, assetId);
         var policy = dataset.getJsonArray(ODRL_POLICY_ATTRIBUTE).get(0).asJsonObject();
-        var contractDefinitionId = ContractId.parseId(policy.getString(ID))
+        var contractDefinitionId = ContractOfferId.parseId(policy.getString(ID))
                 .orElseThrow(failure -> new RuntimeException(failure.getFailureDetail()));
         var contractAgreementId = negotiateContract(provider, contractDefinitionId.toString(), assetId, policy);
         var transferProcessId = initiateTransfer(provider, contractAgreementId, assetId, privateProperties, destination);
@@ -346,9 +346,9 @@ public class Participant {
                 .extract().body().jsonPath().getString("'edc:state'");
     }
 
-    private ContractId extractContractDefinitionId(JsonObject dataset) {
+    private ContractOfferId extractContractDefinitionId(JsonObject dataset) {
         var contractId = dataset.getJsonArray(ODRL_POLICY_ATTRIBUTE).get(0).asJsonObject().getString(ID);
-        return ContractId.parseId(contractId).orElseThrow(f -> new RuntimeException(f.getFailureDetail()));
+        return ContractOfferId.parseId(contractId).orElseThrow(f -> new RuntimeException(f.getFailureDetail()));
     }
 
     private String getContractNegotiationState(String id) {


### PR DESCRIPTION
## What this PR changes/adds

Renamed `ContractId` to `ContractOfferId` and used it only for building/parsing contract offer ids, avoiding the use on `ContractAgreement`

## Why it does that

Interoperability, furthermore contract agreement id does not need to contain information about the contract definition and asset id (the agreement itself already contains asset id and the whole policy)

## Further notes

- deprecated the old one

## Linked Issue(s)

Closes #3403 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
