### PR TITLE
docs: dataplanes api docs fix 

### DIFF
--- a/core/common/validator-core/src/main/java/org/eclipse/edc/validator/jsonobject/validators/MandatoryArray.java
+++ b/core/common/validator-core/src/main/java/org/eclipse/edc/validator/jsonobject/validators/MandatoryArray.java
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.validator.jsonobject.validators;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.validator.jsonobject.JsonLdPath;
+import org.eclipse.edc.validator.spi.ValidationResult;
+import org.eclipse.edc.validator.spi.Validator;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import static java.lang.String.format;
+import static org.eclipse.edc.validator.spi.Violation.violation;
+
+/**
+ * Verifies that an array is present with optional constraint on min size.
+ */
+public class MandatoryArray implements Validator<JsonObject> {
+    private final JsonLdPath path;
+    private final Integer min;
+
+    public MandatoryArray(JsonLdPath path) {
+        this(path, null);
+    }
+
+    public MandatoryArray(JsonLdPath path, Integer min) {
+        this.path = path;
+        this.min = min;
+    }
+
+    public static Function<JsonLdPath, Validator<JsonObject>> min(Integer min) {
+        return path -> new MandatoryArray(path, min);
+    }
+
+    @Override
+    public ValidationResult validate(JsonObject input) {
+        return Optional.ofNullable(input.getJsonArray(path.last()))
+                .map(this::validateMin)
+                .orElseGet(() -> ValidationResult.failure(violation(format("mandatory array '%s' is missing", path), path.toString())));
+    }
+
+    private ValidationResult validateMin(JsonArray array) {
+        if (min == null || (array.size() >= min)) {
+            return ValidationResult.success();
+        }
+        return ValidationResult.failure(violation(format("array '%s' should at least contains '%s' elements", path, min), path.toString()));
+    }
+
+}

--- a/core/common/validator-core/src/test/java/org/eclipse/edc/validator/jsonobject/JsonObjectValidatorTest.java
+++ b/core/common/validator-core/src/test/java/org/eclipse/edc/validator/jsonobject/JsonObjectValidatorTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.validator.jsonobject;
 
 import jakarta.json.JsonArrayBuilder;
+import org.eclipse.edc.validator.jsonobject.validators.MandatoryArray;
 import org.eclipse.edc.validator.jsonobject.validators.MandatoryObject;
 import org.eclipse.edc.validator.jsonobject.validators.MandatoryValue;
 import org.eclipse.edc.validator.jsonobject.validators.OptionalIdNotBlank;
@@ -76,7 +77,7 @@ class JsonObjectValidatorTest {
 
         assertThat(result).isFailed();
     }
-    
+
     @Test
     void shouldValidateNestedObject_whenMandatoryObject_success() {
         var input = createObjectBuilder()
@@ -163,6 +164,42 @@ class JsonObjectValidatorTest {
         assertThat(result).isFailed().satisfies(failure -> {
             assertThat(failure.getViolations()).anySatisfy(violation -> {
                 assertThat(violation.path()).contains("arrayProperty/subProperty");
+            });
+        });
+    }
+
+    @Test
+    void shouldValidateMandatoryArrayMinSize_failure() {
+        var input = createObjectBuilder()
+                .add("arrayProperty", createArrayBuilder()
+                        .add(createObjectBuilder().add("subProperty", value("value1")))
+                        .add(createObjectBuilder().add("subProperty", value(" ")))
+                );
+
+        var result = JsonObjectValidator.newValidator()
+                .verify("arrayProperty", MandatoryArray.min(3))
+                .build()
+                .validate(input.build());
+
+        assertThat(result).isFailed().satisfies(failure -> {
+            assertThat(failure.getViolations()).anySatisfy(violation -> {
+                assertThat(violation.path()).contains("arrayProperty");
+            });
+        });
+    }
+
+    @Test
+    void shouldValidateMandatoryArray_failure() {
+        var input = createObjectBuilder();
+
+        var result = JsonObjectValidator.newValidator()
+                .verify("arrayProperty", MandatoryArray::new)
+                .build()
+                .validate(input.build());
+
+        assertThat(result).isFailed().satisfies(failure -> {
+            assertThat(failure.getViolations()).anySatisfy(violation -> {
+                assertThat(violation.path()).contains("arrayProperty");
             });
         });
     }

--- a/extensions/data-plane-selector/data-plane-selector-api/build.gradle.kts
+++ b/extensions/data-plane-selector/data-plane-selector-api/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     implementation(project(":extensions:common:json-ld"))
     implementation(project(":extensions:common:api:management-api-configuration"))
     implementation(project(":extensions:common:api:api-core")) //for the exception mapper
+    implementation(project(":core:common:validator-core"))
     implementation(libs.jakarta.rsApi)
 
     testImplementation(project(":core:data-plane-selector:data-plane-selector-core"))

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/schemas/DataPlaneInstanceSchema.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/schemas/DataPlaneInstanceSchema.java
@@ -35,6 +35,9 @@ public record DataPlaneInstanceSchema(@Schema(name = TYPE, example = DATAPLANE_I
                                       URL url) {
     public static final String DATAPLANE_INSTANCE_EXAMPLE = """
             {
+                "@context": {
+                    "edc": "https://w3id.org/edc/v0.0.1/ns/"
+                },
                 "@id": "your-dataplane-id",
                 "url": "http://somewhere.com:1234/api/v1",
                 "allowedSourceTypes": [

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/schemas/SelectionRequestSchema.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/schemas/SelectionRequestSchema.java
@@ -30,6 +30,9 @@ public record SelectionRequestSchema(
 ) {
     public static final String SELECTION_REQUEST_INPUT_EXAMPLE = """
             {
+                "@context": {
+                    "edc": "https://w3id.org/edc/v0.0.1/ns/"
+                },
                 "source": {
                     "@type": "https://w3id.org/edc/v0.0.1/ns/DataAddress",
                     "type": "test-src1"

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/validation/DataPlaneInstanceValidator.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/validation/DataPlaneInstanceValidator.java
@@ -16,10 +16,13 @@ package org.eclipse.edc.connector.dataplane.selector.api.v2.validation;
 
 import jakarta.json.JsonObject;
 import org.eclipse.edc.validator.jsonobject.JsonObjectValidator;
+import org.eclipse.edc.validator.jsonobject.validators.MandatoryArray;
 import org.eclipse.edc.validator.jsonobject.validators.MandatoryValue;
 import org.eclipse.edc.validator.jsonobject.validators.OptionalIdNotBlank;
 import org.eclipse.edc.validator.spi.Validator;
 
+import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_DEST_TYPES;
+import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_SOURCE_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.URL;
 
 /**
@@ -31,6 +34,8 @@ public class DataPlaneInstanceValidator {
         return JsonObjectValidator.newValidator()
                 .verifyId(OptionalIdNotBlank::new)
                 .verify(URL, MandatoryValue::new)
+                .verify(ALLOWED_SOURCE_TYPES, MandatoryArray.min(1))
+                .verify(ALLOWED_DEST_TYPES, MandatoryArray.min(1))
                 .build();
     }
 

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/validation/DataPlaneInstanceValidator.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/validation/DataPlaneInstanceValidator.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.selector.api.v2.validation;
+
+import jakarta.json.JsonObject;
+import org.eclipse.edc.validator.jsonobject.JsonObjectValidator;
+import org.eclipse.edc.validator.jsonobject.validators.MandatoryValue;
+import org.eclipse.edc.validator.jsonobject.validators.OptionalIdNotBlank;
+import org.eclipse.edc.validator.spi.Validator;
+
+import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.URL;
+
+/**
+ * Contains the DataPlaneInstance validator definition
+ */
+public class DataPlaneInstanceValidator {
+
+    public static Validator<JsonObject> instance() {
+        return JsonObjectValidator.newValidator()
+                .verifyId(OptionalIdNotBlank::new)
+                .verify(URL, MandatoryValue::new)
+                .build();
+    }
+
+}

--- a/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/TestFunctions.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/TestFunctions.java
@@ -41,12 +41,16 @@ public class TestFunctions {
     }
 
     public static JsonObject createInstanceJson(String id) {
-        return Json.createObjectBuilder()
-                .add(ID, id)
+        return createInstanceJsonBuilder(id)
                 .add(URL, "http://somewhere.com:1234/api/v1")
                 .add(ALLOWED_SOURCE_TYPES, Json.createArrayBuilder(Set.of("source1", "source2")))
                 .add(ALLOWED_DEST_TYPES, Json.createArrayBuilder(Set.of("dest1", "dest2")))
                 .build();
+    }
+
+    public static JsonObjectBuilder createInstanceJsonBuilder(String id) {
+        return Json.createObjectBuilder()
+                .add(ID, id);
     }
 
     public static JsonObject createSelectionRequestJson(String srcType, String destType, String strategy) {

--- a/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/api/DataPlaneApiSelectorTest.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/api/DataPlaneApiSelectorTest.java
@@ -1,0 +1,89 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.selector.api;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.dataplane.selector.api.v2.model.SelectionRequest;
+import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
+import org.eclipse.edc.connector.dataplane.selector.transformer.JsonObjectToDataPlaneInstanceTransformer;
+import org.eclipse.edc.connector.dataplane.selector.transformer.JsonObjectToSelectionRequestTransformer;
+import org.eclipse.edc.core.transform.TypeTransformerRegistryImpl;
+import org.eclipse.edc.core.transform.transformer.to.JsonObjectToDataAddressTransformer;
+import org.eclipse.edc.core.transform.transformer.to.JsonValueToGenericTypeTransformer;
+import org.eclipse.edc.jsonld.TitaniumJsonLd;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.jsonld.util.JacksonJsonLd;
+import org.eclipse.edc.junit.assertions.AbstractResultAssert;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.connector.dataplane.selector.api.v2.schemas.DataPlaneInstanceSchema.DATAPLANE_INSTANCE_EXAMPLE;
+import static org.eclipse.edc.connector.dataplane.selector.api.v2.schemas.SelectionRequestSchema.SELECTION_REQUEST_INPUT_EXAMPLE;
+import static org.mockito.Mockito.mock;
+
+public class DataPlaneApiSelectorTest {
+
+    private final ObjectMapper objectMapper = JacksonJsonLd.createObjectMapper();
+    private final JsonLd jsonLd = new TitaniumJsonLd(mock());
+    private final TypeTransformerRegistry transformer = new TypeTransformerRegistryImpl();
+
+    @BeforeEach
+    void setUp() {
+        transformer.register(new JsonObjectToDataPlaneInstanceTransformer());
+        transformer.register(new JsonObjectToSelectionRequestTransformer());
+        transformer.register(new JsonObjectToDataAddressTransformer());
+        transformer.register(new JsonValueToGenericTypeTransformer(objectMapper));
+    }
+
+    @Test
+    void dataPlaneInstanceInputExample() throws JsonProcessingException {
+
+        var jsonObject = objectMapper.readValue(DATAPLANE_INSTANCE_EXAMPLE, JsonObject.class);
+        assertThat(jsonObject).isNotNull();
+
+        var expanded = jsonLd.expand(jsonObject);
+        AbstractResultAssert.assertThat(expanded).isSucceeded()
+                .extracting(e -> transformer.transform(e, DataPlaneInstance.class).getContent())
+                .isNotNull()
+                .satisfies(transformed -> {
+                    assertThat(transformed.getId()).isNotBlank();
+                    assertThat(transformed.getUrl().toString()).isEqualTo("http://somewhere.com:1234/api/v1");
+                    assertThat(transformed.getAllowedDestTypes()).containsExactlyInAnyOrder("your-dest-type");
+                    assertThat(transformed.getAllowedSourceTypes()).containsExactlyInAnyOrder("source-type1", "source-type2");
+                });
+    }
+
+    @Test
+    void selectionRequestInputExample() throws JsonProcessingException {
+
+        var jsonObject = objectMapper.readValue(SELECTION_REQUEST_INPUT_EXAMPLE, JsonObject.class);
+        assertThat(jsonObject).isNotNull();
+
+        var expanded = jsonLd.expand(jsonObject);
+        AbstractResultAssert.assertThat(expanded).isSucceeded()
+                .extracting(e -> transformer.transform(e, SelectionRequest.class).getContent())
+                .isNotNull()
+                .satisfies(transformed -> {
+                    assertThat(transformed.getStrategy()).isNotBlank();
+                    assertThat(transformed.getDestination()).isNotNull();
+                    assertThat(transformed.getSource()).isNotNull();
+                });
+    }
+
+}

--- a/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/api/DataPlaneSelectorApiControllerTest.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/api/DataPlaneSelectorApiControllerTest.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.dataplane.selector.TestFunctions.createInstance;
 import static org.eclipse.edc.connector.dataplane.selector.TestFunctions.createInstanceBuilder;
 import static org.eclipse.edc.connector.dataplane.selector.TestFunctions.createInstanceJson;
+import static org.eclipse.edc.connector.dataplane.selector.TestFunctions.createInstanceJsonBuilder;
 import static org.eclipse.edc.connector.dataplane.selector.TestFunctions.createSelectionRequestJson;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.hamcrest.Matchers.equalTo;
@@ -86,6 +87,19 @@ public class DataPlaneSelectorApiControllerTest {
 
         assertThat(store.getAll()).hasSize(1)
                 .allMatch(d -> d.getId().equals("test-id"));
+    }
+
+    @Test
+    void addEntry_fails_whenMissingUrl(DataPlaneInstanceStore store) {
+        var dpi = createInstanceJsonBuilder("test-id").build();
+
+        baseRequest()
+                .body(dpi)
+                .contentType(JSON)
+                .post()
+                .then()
+                .statusCode(400);
+        
     }
 
     @Test

--- a/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/api/v2/validation/DataPlaneInstanceValidatorTest.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/api/v2/validation/DataPlaneInstanceValidatorTest.java
@@ -1,0 +1,82 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.selector.api.v2.validation;
+
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
+import org.assertj.core.api.Assertions;
+import org.eclipse.edc.validator.spi.Validator;
+import org.junit.jupiter.api.Test;
+
+import static jakarta.json.Json.createArrayBuilder;
+import static jakarta.json.Json.createObjectBuilder;
+import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_DEST_TYPES;
+import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_SOURCE_TYPES;
+import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.URL;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+
+public class DataPlaneInstanceValidatorTest {
+    private final Validator<JsonObject> validator = DataPlaneInstanceValidator.instance();
+
+    @Test
+    void shouldSucceed_whenValidInput() {
+        var input = createObjectBuilder()
+                .add(URL, value("http://myurl"))
+                .add(ALLOWED_DEST_TYPES, createArrayBuilder().add("test"))
+                .add(ALLOWED_SOURCE_TYPES, createArrayBuilder().add("test"))
+                .build();
+
+        var result = validator.validate(input);
+
+        assertThat(result).isSucceeded();
+    }
+
+    @Test
+    void shouldFail_whenIdIsBlank() {
+        var input = createObjectBuilder()
+                .add(ID, " ")
+                .add(URL, value("http://myurl"))
+                .build();
+
+        var result = validator.validate(input);
+
+        assertThat(result).isFailed().satisfies(failure -> {
+            Assertions.assertThat(failure.getViolations()).hasSize(1).anySatisfy(v -> {
+                Assertions.assertThat(v.path()).isEqualTo(ID);
+            });
+        });
+    }
+
+    @Test
+    void shouldFail_whenUrlIsMissing() {
+        var input = createObjectBuilder()
+                .add(ID, "my_id")
+                .build();
+
+        var result = validator.validate(input);
+
+        assertThat(result).isFailed().satisfies(failure -> {
+            Assertions.assertThat(failure.getViolations()).hasSize(1).anySatisfy(v -> {
+                Assertions.assertThat(v.path()).isEqualTo(URL);
+            });
+        });
+    }
+
+    private JsonArrayBuilder value(String value) {
+        return createArrayBuilder().add(createObjectBuilder().add(VALUE, value));
+    }
+}

--- a/extensions/data-plane-selector/data-plane-selector-client/src/test/java/org/eclipse/edc/connector/dataplane/selector/client/RemoteDataPlaneSelectorClientTest.java
+++ b/extensions/data-plane-selector/data-plane-selector-client/src/test/java/org/eclipse/edc/connector/dataplane/selector/client/RemoteDataPlaneSelectorClientTest.java
@@ -31,6 +31,7 @@ import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 import org.eclipse.edc.web.jersey.jsonld.JerseyJsonLdInterceptor;
 import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
 import org.junit.jupiter.api.BeforeAll;
@@ -57,6 +58,7 @@ class RemoteDataPlaneSelectorClientTest extends RestControllerTestBase {
     private static final DataPlaneSelectorService SELECTOR_SERVICE_MOCK = mock();
     private static final TypeManager TYPE_MANAGER = new TypeManager();
     private final TypeTransformerRegistry typeTransformerRegistry = new TypeTransformerRegistryImpl();
+    private final JsonObjectValidatorRegistry validator = mock(JsonObjectValidatorRegistry.class);
     private RemoteDataPlaneSelectorClient client;
 
     @BeforeAll
@@ -105,7 +107,7 @@ class RemoteDataPlaneSelectorClientTest extends RestControllerTestBase {
 
     @Override
     protected Object controller() {
-        return new DataplaneSelectorApiController(SELECTOR_SERVICE_MOCK, typeTransformerRegistry);
+        return new DataplaneSelectorApiController(SELECTOR_SERVICE_MOCK, typeTransformerRegistry, validator);
     }
 
     @Override


### PR DESCRIPTION
## What this PR changes/adds

Adds the `@context` in the `addEntry` API example 

## Why it does that

docs

## Further notes

- Added tests + validation on `addEntry` API

## Linked Issue(s)

Closes #3421 

