### PR TITLE
feat: add priority on `DataFlowController` registration

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -4,13 +4,12 @@ maven/mavencentral/com.apicatalog/titanium-json-ld/1.0.0, Apache-2.0, approved, 
 maven/mavencentral/com.apicatalog/titanium-json-ld/1.3.1, Apache-2.0, approved, #8912
 maven/mavencentral/com.apicatalog/titanium-json-ld/1.3.2, Apache-2.0, approved, #8912
 maven/mavencentral/com.atomikos/atomikos-util/6.0.0, Apache-2.0, approved, #9326
-maven/mavencentral/com.atomikos/transactions-api/6.0.0, NOASSERTION, restricted, clearlydefined
+maven/mavencentral/com.atomikos/transactions-api/6.0.0, None, restricted, #10351
 maven/mavencentral/com.atomikos/transactions-jdbc/6.0.0, Apache-2.0, approved, #9273
 maven/mavencentral/com.atomikos/transactions-jta/6.0.0, Apache-2.0, approved, #9275
 maven/mavencentral/com.atomikos/transactions/6.0.0, Apache-2.0, approved, #9321
 maven/mavencentral/com.ethlo.time/itu/1.7.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.10.3, Apache-2.0, approved, CQ21280
-maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.13.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.14.0, Apache-2.0, approved, #5303
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.14.1, Apache-2.0, approved, #5303
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.15.1, Apache-2.0, approved, #7947
@@ -19,22 +18,19 @@ maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.14.1, Apache-2.0 AN
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.15.1, MIT AND Apache-2.0, approved, #7932
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.15.2, MIT AND Apache-2.0, approved, #7932
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.11.0, Apache-2.0, approved, CQ23093
-maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.13.3, Apache-2.0, approved, #2134
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.14.0, Apache-2.0, approved, #4105
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.14.1, Apache-2.0, approved, #4105
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.15.1, Apache-2.0, approved, #7934
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.15.2, Apache-2.0, approved, #7934
-maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.13.3, Apache-2.0, approved, #2566
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.14.0, Apache-2.0, approved, #5933
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.15.1, Apache-2.0, approved, #8802
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.15.2, Apache-2.0, approved, #8802
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jakarta-jsonp/2.15.2, Apache-2.0, approved, #9179
-maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.14.0, Apache-2.0, approved, #4699
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.15.1, Apache-2.0, approved, #7930
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.15.2, Apache-2.0, approved, #7930
 maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/2.15.2, Apache-2.0, approved, #9235
-maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.13.3, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.15.1, Apache-2.0, approved, #9236
 maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.15.2, Apache-2.0, approved, #9236
 maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.14.1, Apache-2.0, approved, #5308
 maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.15.2, Apache-2.0, approved, #9241
@@ -42,7 +38,7 @@ maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.15.1, Apache-2.0, approve
 maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.15.2, Apache-2.0, approved, #7929
 maven/mavencentral/com.fasterxml.uuid/java-uuid-generator/4.1.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.github.cliftonlabs/json-simple/3.0.2, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.github.docker-java/docker-java-api/3.3.3, , restricted, clearlydefined
+maven/mavencentral/com.github.docker-java/docker-java-api/3.3.3, Apache-2.0, approved, #10346
 maven/mavencentral/com.github.docker-java/docker-java-transport-zerodep/3.3.3, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #7946
 maven/mavencentral/com.github.docker-java/docker-java-transport/3.3.3, Apache-2.0, approved, #7942
 maven/mavencentral/com.github.java-json-tools/btf/1.3, Apache-2.0 OR LGPL-3.0-or-later, approved, #2721
@@ -106,7 +102,6 @@ maven/mavencentral/info.picocli/picocli/4.6.3, Apache-2.0, approved, clearlydefi
 maven/mavencentral/io.cloudevents/cloudevents-api/2.5.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.cloudevents/cloudevents-core/2.5.0, Apache-2.0, approved, #9328
 maven/mavencentral/io.cloudevents/cloudevents-http-basic/2.5.0, Apache-2.0, approved, #9329
-maven/mavencentral/io.github.classgraph/classgraph/4.8.138, MIT, approved, CQ22530
 maven/mavencentral/io.github.classgraph/classgraph/4.8.154, MIT, approved, CQ22530
 maven/mavencentral/io.micrometer/micrometer-commons/1.11.3, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #9243
 maven/mavencentral/io.micrometer/micrometer-core/1.11.3, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #9238
@@ -140,19 +135,18 @@ maven/mavencentral/io.rest-assured/rest-assured/5.3.1, Apache-2.0, approved, #92
 maven/mavencentral/io.rest-assured/xml-path/5.3.1, Apache-2.0, approved, #9267
 maven/mavencentral/io.setl/rdf-urdna/1.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.15, Apache-2.0, approved, #5947
-maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.2, Apache-2.0, approved, #5947
 maven/mavencentral/io.swagger.core.v3/swagger-annotations/2.2.15, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.core.v3/swagger-annotations/2.2.8, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.swagger.core.v3/swagger-core-jakarta/2.2.2, Apache-2.0, approved, #5929
+maven/mavencentral/io.swagger.core.v3/swagger-core-jakarta/2.2.15, Apache-2.0, approved, #5929
 maven/mavencentral/io.swagger.core.v3/swagger-core/2.2.15, Apache-2.0, approved, #9265
 maven/mavencentral/io.swagger.core.v3/swagger-core/2.2.8, Apache-2.0, approved, #9265
-maven/mavencentral/io.swagger.core.v3/swagger-integration-jakarta/2.2.2, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.swagger.core.v3/swagger-integration/2.2.15, , restricted, clearlydefined
-maven/mavencentral/io.swagger.core.v3/swagger-jaxrs2-jakarta/2.2.2, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.swagger.core.v3/swagger-integration-jakarta/2.2.15, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.swagger.core.v3/swagger-integration/2.2.15, Apache-2.0, approved, #10352
+maven/mavencentral/io.swagger.core.v3/swagger-jaxrs2-jakarta/2.2.15, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.core.v3/swagger-jaxrs2/2.2.15, Apache-2.0, approved, #9814
-maven/mavencentral/io.swagger.core.v3/swagger-models-jakarta/2.2.2, Apache-2.0, approved, #5919
-maven/mavencentral/io.swagger.core.v3/swagger-models/2.2.15, , restricted, clearlydefined
-maven/mavencentral/io.swagger.core.v3/swagger-models/2.2.8, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.swagger.core.v3/swagger-models-jakarta/2.2.15, Apache-2.0, approved, #5919
+maven/mavencentral/io.swagger.core.v3/swagger-models/2.2.15, LicenseRef-scancode-proprietary-license AND Apache-2.0, restricted, #10353
+maven/mavencentral/io.swagger.core.v3/swagger-models/2.2.8, LicenseRef-scancode-proprietary-license AND Apache-2.0, restricted, #10354
 maven/mavencentral/io.swagger.parser.v3/swagger-parser-core/2.1.10, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.parser.v3/swagger-parser-v2-converter/2.1.10, Apache-2.0, approved, #9330
 maven/mavencentral/io.swagger.parser.v3/swagger-parser-v3/2.1.10, Apache-2.0, approved, #9323
@@ -170,7 +164,6 @@ maven/mavencentral/jakarta.json/jakarta.json-api/2.1.1, EPL-2.0 OR GPL-2.0-only 
 maven/mavencentral/jakarta.transaction/jakarta.transaction-api/2.0.0, EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, #7697
 maven/mavencentral/jakarta.transaction/jakarta.transaction-api/2.0.1, EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, #7697
 maven/mavencentral/jakarta.validation/jakarta.validation-api/2.0.2, Apache-2.0, approved, clearlydefined
-maven/mavencentral/jakarta.validation/jakarta.validation-api/3.0.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/jakarta.validation/jakarta.validation-api/3.0.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/jakarta.ws.rs/jakarta.ws.rs-api/3.1.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.rest
 maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/2.3.2, BSD-3-Clause, approved, ee4j.jaxb
@@ -271,7 +264,6 @@ maven/mavencentral/org.jacoco/org.jacoco.agent/0.8.8, EPL-2.0, approved, CQ23285
 maven/mavencentral/org.jacoco/org.jacoco.ant/0.8.8, EPL-2.0, approved, #1068
 maven/mavencentral/org.jacoco/org.jacoco.core/0.8.8, EPL-2.0, approved, CQ23283
 maven/mavencentral/org.jacoco/org.jacoco.report/0.8.8, EPL-2.0 AND Apache-2.0, approved, CQ23284
-maven/mavencentral/org.javassist/javassist/3.25.0-GA, MPL-1.1 OR LGPL-2.1-or-later OR Apache-2.0, approved, CQ19885
 maven/mavencentral/org.javassist/javassist/3.28.0-GA, Apache-2.0 OR LGPL-2.1-or-later OR MPL-1.1, approved, #327
 maven/mavencentral/org.javassist/javassist/3.29.2-GA, Apache-2.0 AND LGPL-2.1-or-later AND MPL-1.1, approved, #6023
 maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-common/1.6.20, Apache-2.0, approved, clearlydefined
@@ -322,11 +314,11 @@ maven/mavencentral/org.slf4j/slf4j-api/1.7.36, MIT, approved, CQ13368
 maven/mavencentral/org.slf4j/slf4j-api/2.0.5, MIT, approved, #5915
 maven/mavencentral/org.slf4j/slf4j-api/2.0.6, MIT, approved, #5915
 maven/mavencentral/org.slf4j/slf4j-api/2.0.9, MIT, approved, #5915
-maven/mavencentral/org.testcontainers/database-commons/1.19.0, , restricted, clearlydefined
-maven/mavencentral/org.testcontainers/jdbc/1.19.0, , restricted, clearlydefined
-maven/mavencentral/org.testcontainers/junit-jupiter/1.19.0, , restricted, clearlydefined
-maven/mavencentral/org.testcontainers/postgresql/1.19.0, , restricted, clearlydefined
-maven/mavencentral/org.testcontainers/testcontainers/1.19.0, , restricted, clearlydefined
+maven/mavencentral/org.testcontainers/database-commons/1.19.0, Apache-2.0, approved, #10345
+maven/mavencentral/org.testcontainers/jdbc/1.19.0, Apache-2.0, approved, #10348
+maven/mavencentral/org.testcontainers/junit-jupiter/1.19.0, None, restricted, #10344
+maven/mavencentral/org.testcontainers/postgresql/1.19.0, None, restricted, #10350
+maven/mavencentral/org.testcontainers/testcontainers/1.19.0, None, restricted, #10347
 maven/mavencentral/org.testcontainers/vault/1.19.0, , restricted, clearlydefined
 maven/mavencentral/org.xerial.snappy/snappy-java/1.1.10.1, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #9098
 maven/mavencentral/org.xmlunit/xmlunit-core/2.9.1, Apache-2.0, approved, #6272

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/flow/DataFlowManagerImpl.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/flow/DataFlowManagerImpl.java
@@ -18,13 +18,13 @@ import io.opentelemetry.instrumentation.annotations.WithSpan;
 import org.eclipse.edc.connector.transfer.spi.flow.DataFlowController;
 import org.eclipse.edc.connector.transfer.spi.flow.DataFlowManager;
 import org.eclipse.edc.connector.transfer.spi.types.DataFlowResponse;
-import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
+import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.response.StatusResult;
-import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 import static java.lang.String.format;
@@ -34,33 +34,43 @@ import static org.eclipse.edc.spi.response.ResponseStatus.FATAL_ERROR;
  * The default data flow manager.
  */
 public class DataFlowManagerImpl implements DataFlowManager {
-    private final List<DataFlowController> controllers = new ArrayList<>();
+
+    private final List<PrioritizedDataFlowController> controllers = new ArrayList<>();
 
     @Override
     public void register(DataFlowController controller) {
-        controllers.add(controller);
+        controllers.add(new PrioritizedDataFlowController(0, controller));
+    }
+
+    @Override
+    public void register(int priority, DataFlowController controller) {
+        controllers.add(new PrioritizedDataFlowController(priority, controller));
     }
 
     @WithSpan
     @Override
-    public @NotNull StatusResult<DataFlowResponse> initiate(DataRequest dataRequest, DataAddress contentAddress, Policy policy) {
+    public @NotNull StatusResult<DataFlowResponse> initiate(TransferProcess transferProcess, Policy policy) {
         try {
             return controllers.stream()
-                    .filter(controller -> controller.canHandle(dataRequest, contentAddress))
+                    .sorted(Comparator.comparingInt(a -> -a.priority))
+                    .map(PrioritizedDataFlowController::controller)
+                    .filter(controller -> controller.canHandle(transferProcess))
                     .findFirst()
-                    .map(controller -> controller.initiateFlow(dataRequest, contentAddress, policy))
-                    .orElseGet(() -> StatusResult.failure(FATAL_ERROR, controllerNotFound(dataRequest.getId())));
+                    .map(controller -> controller.initiateFlow(transferProcess, policy))
+                    .orElseGet(() -> StatusResult.failure(FATAL_ERROR, controllerNotFound(transferProcess.getId())));
         } catch (Exception e) {
-            return StatusResult.failure(FATAL_ERROR, runtimeException(dataRequest.getId(), e.getLocalizedMessage()));
+            return StatusResult.failure(FATAL_ERROR, runtimeException(transferProcess.getId(), e.getLocalizedMessage()));
         }
     }
 
     private String runtimeException(String id, String message) {
-        return format("Unable to process data request %s. Data flow controller throws an exception: %s", id, message);
+        return format("Unable to process transfer %s. Data flow controller throws an exception: %s", id, message);
     }
 
     private String controllerNotFound(String id) {
-        return format("Unable to process data request %s. No data flow controller found", id);
+        return format("Unable to process transfer %s. No data flow controller found", id);
     }
+
+    record PrioritizedDataFlowController(int priority, DataFlowController controller) { }
 
 }

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
@@ -367,13 +367,11 @@ public class TransferProcessManagerImpl implements TransferProcessManager {
             return false;
         }
 
-        var contentAddress = process.getContentDataAddress();
-
         var policy = policyArchive.findPolicyForContract(process.getContractId());
 
         var description = "Initiate data flow";
 
-        return entityRetryProcessFactory.doSyncProcess(process, () -> dataFlowManager.initiate(process.getDataRequest(), contentAddress, policy))
+        return entityRetryProcessFactory.doSyncProcess(process, () -> dataFlowManager.initiate(process, policy))
                 .onSuccess((p, dataFlowResponse) -> sendTransferStartMessage(p, dataFlowResponse, policy))
                 .onFatalError((p, failure) -> transitionToTerminating(p, failure.getFailureDetail()))
                 .onFailure((t, failure) -> transitionToStarting(t))

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/flow/DataFlowManagerImplTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/flow/DataFlowManagerImplTest.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.connector.transfer.flow;
 import org.eclipse.edc.connector.transfer.spi.flow.DataFlowController;
 import org.eclipse.edc.connector.transfer.spi.types.DataFlowResponse;
 import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
+import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.response.StatusResult;
@@ -27,40 +28,43 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.spi.response.ResponseStatus.FATAL_ERROR;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class DataFlowManagerImplTest {
 
+    private final DataFlowManagerImpl manager = new DataFlowManagerImpl();
 
     @Test
     void should_initiate_flow_on_correct_controller() {
-        var manager = new DataFlowManagerImpl();
         var controller = mock(DataFlowController.class);
         var dataRequest = DataRequest.Builder.newInstance().destinationType("test-dest-type").build();
         var policy = Policy.Builder.newInstance().build();
         var dataAddress = DataAddress.Builder.newInstance().type("test-type").build();
+        var transferProcess = TransferProcess.Builder.newInstance().dataRequest(dataRequest).contentDataAddress(dataAddress).build();
 
-        when(controller.canHandle(any(), any())).thenReturn(true);
-        when(controller.initiateFlow(any(), any(), any())).thenReturn(StatusResult.success(DataFlowResponse.Builder.newInstance().build()));
+        when(controller.canHandle(any())).thenReturn(true);
+        when(controller.initiateFlow(any(), any())).thenReturn(StatusResult.success(DataFlowResponse.Builder.newInstance().build()));
         manager.register(controller);
 
-        var response = manager.initiate(dataRequest, dataAddress, policy);
+        var response = manager.initiate(transferProcess, policy);
 
         assertThat(response.succeeded()).isTrue();
     }
 
     @Test
     void should_return_fatal_error_if_no_controller_can_handle_the_request() {
-        var manager = new DataFlowManagerImpl();
         var controller = mock(DataFlowController.class);
         var dataRequest = DataRequest.Builder.newInstance().destinationType("test-dest-type").build();
         var dataAddress = DataAddress.Builder.newInstance().type("test-type").build();
         var policy = Policy.Builder.newInstance().build();
+        var transferProcess = TransferProcess.Builder.newInstance().dataRequest(dataRequest).contentDataAddress(dataAddress).build();
 
-        when(controller.canHandle(any(), any())).thenReturn(false);
+        when(controller.canHandle(any())).thenReturn(false);
         manager.register(controller);
 
-        var response = manager.initiate(dataRequest, dataAddress, policy);
+        var response = manager.initiate(transferProcess, policy);
 
         assertThat(response.succeeded()).isFalse();
         assertThat(response.getFailure().status()).isEqualTo(FATAL_ERROR);
@@ -68,21 +72,41 @@ class DataFlowManagerImplTest {
 
     @Test
     void should_catch_exceptions_and_return_fatal_error() {
-        var manager = new DataFlowManagerImpl();
         var controller = mock(DataFlowController.class);
         var dataRequest = DataRequest.Builder.newInstance().destinationType("test-dest-type").build();
         var dataAddress = DataAddress.Builder.newInstance().type("test-type").build();
         var policy = Policy.Builder.newInstance().build();
+        var transferProcess = TransferProcess.Builder.newInstance().dataRequest(dataRequest).contentDataAddress(dataAddress).build();
 
         var errorMsg = "Test Error Message";
-        when(controller.canHandle(any(), any())).thenReturn(true);
-        when(controller.initiateFlow(any(), any(), any())).thenThrow(new EdcException(errorMsg));
+        when(controller.canHandle(any())).thenReturn(true);
+        when(controller.initiateFlow(any(), any())).thenThrow(new EdcException(errorMsg));
         manager.register(controller);
 
-        var response = manager.initiate(dataRequest, dataAddress, policy);
+        var response = manager.initiate(transferProcess, policy);
 
         assertThat(response.succeeded()).isFalse();
         assertThat(response.getFailure().status()).isEqualTo(FATAL_ERROR);
         assertThat(response.getFailureMessages()).hasSize(1).first().matches(message -> message.contains(errorMsg));
+    }
+
+    @Test
+    void shouldChooseHighestPriorityController() {
+        var highPriority = createDataFlowController();
+        var lowPriority = createDataFlowController();
+        manager.register(1, lowPriority);
+        manager.register(2, highPriority);
+
+        manager.initiate(TransferProcess.Builder.newInstance().build(), Policy.Builder.newInstance().build());
+
+        verify(highPriority).initiateFlow(any(), any());
+        verifyNoInteractions(lowPriority);
+    }
+
+    private DataFlowController createDataFlowController() {
+        var dataFlowController = mock(DataFlowController.class);
+        when(dataFlowController.canHandle(any())).thenReturn(true);
+        when(dataFlowController.initiateFlow(any(), any())).thenReturn(StatusResult.success(DataFlowResponse.Builder.newInstance().build()));
+        return dataFlowController;
     }
 }

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImplTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImplTest.java
@@ -146,7 +146,7 @@ class TransferProcessManagerImplTest {
     @BeforeEach
     void setup() {
         when(protocolWebhook.url()).thenReturn(protocolWebhookUrl);
-        when(dataFlowManager.initiate(any(), any(), any())).thenReturn(StatusResult.success(createDataFlowResponse()));
+        when(dataFlowManager.initiate(any(), any())).thenReturn(StatusResult.success(createDataFlowResponse()));
         var observable = new TransferProcessObservableImpl();
         observable.registerListener(listener);
         var entityRetryProcessConfiguration = new EntityRetryProcessConfiguration(RETRY_LIMIT, () -> new ExponentialWaitStrategy(0L));
@@ -487,7 +487,7 @@ class TransferProcessManagerImplTest {
         when(policyArchive.findPolicyForContract(anyString())).thenReturn(Policy.Builder.newInstance().build());
         when(transferProcessStore.nextNotLeased(anyInt(), stateIs(STARTING.code()))).thenReturn(List.of(process)).thenReturn(emptyList());
         when(transferProcessStore.findById(process.getId())).thenReturn(process);
-        when(dataFlowManager.initiate(any(), any(), any())).thenReturn(StatusResult.success(dataFlowResponse));
+        when(dataFlowManager.initiate(any(), any())).thenReturn(StatusResult.success(dataFlowResponse));
         when(dispatcherRegistry.dispatch(any(), isA(TransferStartMessage.class))).thenReturn(completedFuture(StatusResult.success("any")));
 
         manager.start();
@@ -505,7 +505,7 @@ class TransferProcessManagerImplTest {
     @Test
     void starting_onFailureAndRetriesNotExhausted_updatesStateCountForRetry() {
         var process = createTransferProcess(STARTING).toBuilder().type(PROVIDER).build();
-        when(dataFlowManager.initiate(any(), any(), any())).thenReturn(StatusResult.failure(ResponseStatus.ERROR_RETRY));
+        when(dataFlowManager.initiate(any(), any())).thenReturn(StatusResult.failure(ResponseStatus.ERROR_RETRY));
         when(transferProcessStore.nextNotLeased(anyInt(), stateIs(STARTING.code()))).thenReturn(List.of(process)).thenReturn(emptyList());
         when(transferProcessStore.findById(process.getId())).thenReturn(process, process.toBuilder().state(STARTING.code()).build());
 
@@ -521,7 +521,7 @@ class TransferProcessManagerImplTest {
         var process = createTransferProcess(STARTING).toBuilder().type(PROVIDER).build();
         when(policyArchive.findPolicyForContract(anyString())).thenReturn(Policy.Builder.newInstance().build());
         when(transferProcessStore.nextNotLeased(anyInt(), stateIs(STARTING.code()))).thenReturn(List.of(process)).thenReturn(emptyList());
-        when(dataFlowManager.initiate(any(), any(), any())).thenReturn(StatusResult.failure(FATAL_ERROR));
+        when(dataFlowManager.initiate(any(), any())).thenReturn(StatusResult.failure(FATAL_ERROR));
 
         manager.start();
 
@@ -533,7 +533,7 @@ class TransferProcessManagerImplTest {
     @Test
     void starting_onFailureAndRetriesExhausted_transitToTerminating() {
         var process = createTransferProcessBuilder(STARTING).type(PROVIDER).stateCount(RETRY_EXHAUSTED).build();
-        when(dataFlowManager.initiate(any(), any(), any())).thenReturn(StatusResult.failure(ResponseStatus.ERROR_RETRY));
+        when(dataFlowManager.initiate(any(), any())).thenReturn(StatusResult.failure(ResponseStatus.ERROR_RETRY));
         when(transferProcessStore.nextNotLeased(anyInt(), stateIs(STARTING.code()))).thenReturn(List.of(process)).thenReturn(emptyList());
         when(transferProcessStore.findById(process.getId())).thenReturn(process);
 
@@ -547,7 +547,7 @@ class TransferProcessManagerImplTest {
     @Test
     void starting_whenShouldWait_updatesStateCount() {
         var process = createTransferProcessBuilder(STARTING).type(PROVIDER).stateCount(2).stateTimestamp(clock.millis() + 1000L).build();
-        when(dataFlowManager.initiate(any(), any(), any())).thenReturn(StatusResult.failure(ResponseStatus.ERROR_RETRY));
+        when(dataFlowManager.initiate(any(), any())).thenReturn(StatusResult.failure(ResponseStatus.ERROR_RETRY));
         when(transferProcessStore.nextNotLeased(anyInt(), stateIs(STARTING.code()))).thenReturn(List.of(process)).thenReturn(emptyList());
         when(transferProcessStore.findById(process.getId())).thenReturn(process, process.toBuilder().state(STARTING.code()).build());
 

--- a/extensions/control-plane/transfer/transfer-data-plane/src/main/java/org/eclipse/edc/connector/transfer/dataplane/flow/ConsumerPullTransferDataFlowController.java
+++ b/extensions/control-plane/transfer/transfer-data-plane/src/main/java/org/eclipse/edc/connector/transfer/dataplane/flow/ConsumerPullTransferDataFlowController.java
@@ -18,7 +18,7 @@ import org.eclipse.edc.connector.dataplane.selector.spi.client.DataPlaneSelector
 import org.eclipse.edc.connector.transfer.dataplane.proxy.ConsumerPullDataPlaneProxyResolver;
 import org.eclipse.edc.connector.transfer.spi.flow.DataFlowController;
 import org.eclipse.edc.connector.transfer.spi.types.DataFlowResponse;
-import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
+import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.types.domain.DataAddress;
@@ -42,12 +42,14 @@ public class ConsumerPullTransferDataFlowController implements DataFlowControlle
     }
 
     @Override
-    public boolean canHandle(DataRequest dataRequest, DataAddress contentAddress) {
-        return HTTP_PROXY.equals(dataRequest.getDestinationType());
+    public boolean canHandle(TransferProcess transferProcess) {
+        return HTTP_PROXY.equals(transferProcess.getDestinationType());
     }
 
     @Override
-    public @NotNull StatusResult<DataFlowResponse> initiateFlow(DataRequest dataRequest, DataAddress contentAddress, Policy policy) {
+    public @NotNull StatusResult<DataFlowResponse> initiateFlow(TransferProcess transferProcess, Policy policy) {
+        var contentAddress = transferProcess.getContentDataAddress();
+        var dataRequest = transferProcess.getDataRequest();
         return Optional.ofNullable(selectorClient.find(contentAddress, dataRequest.getDataDestination()))
                 .map(instance -> resolver.toDataAddress(dataRequest, contentAddress, instance)
                         .map(this::toResponse)

--- a/extensions/control-plane/transfer/transfer-data-plane/src/test/java/org/eclipse/edc/connector/transfer/dataplane/flow/ProviderPushTransferDataFlowControllerTest.java
+++ b/extensions/control-plane/transfer/transfer-data-plane/src/test/java/org/eclipse/edc/connector/transfer/dataplane/flow/ProviderPushTransferDataFlowControllerTest.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.connector.transfer.dataplane.flow;
 import org.eclipse.edc.connector.dataplane.spi.client.DataPlaneClient;
 import org.eclipse.edc.connector.transfer.spi.callback.ControlApiUrl;
 import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
+import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.response.ResponseStatus;
 import org.eclipse.edc.spi.response.StatusResult;
@@ -28,7 +29,6 @@ import org.mockito.ArgumentCaptor;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -40,7 +40,7 @@ import static org.mockito.Mockito.when;
 
 class ProviderPushTransferDataFlowControllerTest {
 
-    private DataPlaneClient dataPlaneClientMock;
+    private final DataPlaneClient dataPlaneClient = mock();
     private ProviderPushTransferDataFlowController flowController;
 
     @BeforeEach
@@ -48,26 +48,28 @@ class ProviderPushTransferDataFlowControllerTest {
         var callbackUrlMock = mock(ControlApiUrl.class);
         var url = new URL("http://localhost");
         when(callbackUrlMock.get()).thenReturn(url);
-        dataPlaneClientMock = mock(DataPlaneClient.class);
-        flowController = new ProviderPushTransferDataFlowController(callbackUrlMock, dataPlaneClientMock);
+        flowController = new ProviderPushTransferDataFlowController(callbackUrlMock, dataPlaneClient);
     }
 
     @Test
     void verifyCanHandle() {
-        assertThat(flowController.canHandle(DataRequest.Builder.newInstance().destinationType(HTTP_PROXY).build(), null)).isFalse();
-        assertThat(flowController.canHandle(DataRequest.Builder.newInstance().destinationType("not-http-proxy").build(), null)).isTrue();
+        assertThat(flowController.canHandle(transferProcess(HTTP_PROXY))).isFalse();
+        assertThat(flowController.canHandle(transferProcess("not-http-proxy"))).isTrue();
     }
 
     @Test
     void verifyReturnFailedResultIfTransferFails() {
         var errorMsg = "error";
-        var request = createDataRequest();
+        var transferProcess = TransferProcess.Builder.newInstance()
+                .dataRequest(createDataRequest())
+                .contentDataAddress(testDataAddress())
+                .build();
 
-        when(dataPlaneClientMock.transfer(any())).thenReturn(StatusResult.failure(ResponseStatus.FATAL_ERROR, errorMsg));
+        when(dataPlaneClient.transfer(any())).thenReturn(StatusResult.failure(ResponseStatus.FATAL_ERROR, errorMsg));
 
-        var result = flowController.initiateFlow(request, testDataAddress(), Policy.Builder.newInstance().build());
+        var result = flowController.initiateFlow(transferProcess, Policy.Builder.newInstance().build());
 
-        verify(dataPlaneClientMock).transfer(any());
+        verify(dataPlaneClient).transfer(any());
 
         assertThat(result.failed()).isTrue();
         assertThat(result.getFailureMessages()).allSatisfy(s -> assertThat(s).contains(errorMsg));
@@ -77,17 +79,21 @@ class ProviderPushTransferDataFlowControllerTest {
     void verifyTransferSuccess() {
         var request = createDataRequest();
         var source = testDataAddress();
+        var transferProcess = TransferProcess.Builder.newInstance()
+                .dataRequest(createDataRequest())
+                .contentDataAddress(testDataAddress())
+                .build();
 
-        when(dataPlaneClientMock.transfer(any(DataFlowRequest.class))).thenReturn(StatusResult.success());
+        when(dataPlaneClient.transfer(any(DataFlowRequest.class))).thenReturn(StatusResult.success());
 
-        var result = flowController.initiateFlow(request, source, Policy.Builder.newInstance().build());
+        var result = flowController.initiateFlow(transferProcess, Policy.Builder.newInstance().build());
 
         assertThat(result.succeeded()).isTrue();
         var captor = ArgumentCaptor.forClass(DataFlowRequest.class);
-        verify(dataPlaneClientMock).transfer(captor.capture());
+        verify(dataPlaneClient).transfer(captor.capture());
         var captured = captor.getValue();
         assertThat(captured.isTrackable()).isTrue();
-        assertThat(captured.getProcessId()).isEqualTo(request.getProcessId());
+        assertThat(captured.getProcessId()).isEqualTo(transferProcess.getId());
         assertThat(captured.getSourceDataAddress()).usingRecursiveComparison().isEqualTo(source);
         assertThat(captured.getDestinationDataAddress()).usingRecursiveComparison().isEqualTo(request.getDataDestination());
         assertThat(captured.getProperties()).isEmpty();
@@ -96,20 +102,23 @@ class ProviderPushTransferDataFlowControllerTest {
 
     @Test
     void verifyTransferSuccessWithAdditionalProperties() {
-        var properties = Map.of("foo", "bar", "hello", "world");
         var request = createDataRequest("test");
         var source = testDataAddress();
+        var transferProcess = TransferProcess.Builder.newInstance()
+                .dataRequest(createDataRequest())
+                .contentDataAddress(testDataAddress())
+                .build();
 
-        when(dataPlaneClientMock.transfer(any(DataFlowRequest.class))).thenReturn(StatusResult.success());
+        when(dataPlaneClient.transfer(any(DataFlowRequest.class))).thenReturn(StatusResult.success());
 
-        var result = flowController.initiateFlow(request, source, Policy.Builder.newInstance().build());
+        var result = flowController.initiateFlow(transferProcess, Policy.Builder.newInstance().build());
 
         assertThat(result.succeeded()).isTrue();
         var captor = ArgumentCaptor.forClass(DataFlowRequest.class);
-        verify(dataPlaneClientMock).transfer(captor.capture());
+        verify(dataPlaneClient).transfer(captor.capture());
         var captured = captor.getValue();
         assertThat(captured.isTrackable()).isTrue();
-        assertThat(captured.getProcessId()).isEqualTo(request.getProcessId());
+        assertThat(captured.getProcessId()).isEqualTo(transferProcess.getId());
         assertThat(captured.getSourceDataAddress()).usingRecursiveComparison().isEqualTo(source);
         assertThat(captured.getDestinationDataAddress()).usingRecursiveComparison().isEqualTo(request.getDataDestination());
         assertThat(captured.getCallbackAddress()).isNotNull();
@@ -132,6 +141,12 @@ class ProviderPushTransferDataFlowControllerTest {
                 .connectorAddress("test.connector.address")
                 .processId(UUID.randomUUID().toString())
                 .destinationType(destinationType)
+                .build();
+    }
+
+    private TransferProcess transferProcess(String destinationType) {
+        return TransferProcess.Builder.newInstance()
+                .dataRequest(DataRequest.Builder.newInstance().destinationType(destinationType).build())
                 .build();
     }
 }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/flow/DataFlowController.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/flow/DataFlowController.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.transfer.spi.flow;
 
 import org.eclipse.edc.connector.transfer.spi.types.DataFlowResponse;
 import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
+import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.response.ResponseStatus;
 import org.eclipse.edc.spi.response.StatusResult;
@@ -28,12 +29,36 @@ import org.jetbrains.annotations.NotNull;
 public interface DataFlowController {
 
     /**
+     * Returns true if the manager can handle the Transfer Process.
+     *
+     * @param transferProcess    the TransferProcess
+     * @return true if it can handle the TransferProcess, false otherwise.
+     */
+    boolean canHandle(TransferProcess transferProcess);
+
+    /**
+     * Initiate a data flow.
+     *
+     * <p>Implementations should not throw exceptions. If an unexpected exception occurs and the flow should be re-attempted, set {@link ResponseStatus#ERROR_RETRY} in the
+     * response. If an exception occurs and re-tries should not be re-attempted, set {@link ResponseStatus#FATAL_ERROR} in the response. </p>
+     *
+     * @param transferProcess    the transfer process
+     * @param policy             the contract agreement usage policy for the asset being transferred
+     */
+    @NotNull
+    StatusResult<DataFlowResponse> initiateFlow(TransferProcess transferProcess, Policy policy);
+
+    /**
      * Returns true if the manager can handle the data type.
      *
      * @param dataRequest    the request
      * @param contentAddress the address to resolve the asset contents. This may be the original asset address or an address resolving to generated content.
+     * @deprecated please use {@link #canHandle(TransferProcess)}
      */
-    boolean canHandle(DataRequest dataRequest, DataAddress contentAddress);
+    @Deprecated(since = "0.2.1", forRemoval = true)
+    default boolean canHandle(DataRequest dataRequest, DataAddress contentAddress) {
+        return canHandle(TransferProcess.Builder.newInstance().dataRequest(dataRequest).contentDataAddress(contentAddress).build());
+    }
 
     /**
      * Initiate a data flow.
@@ -44,8 +69,12 @@ public interface DataFlowController {
      * @param dataRequest    the request
      * @param contentAddress the address to resolve the asset contents. This may be the original asset address or an address resolving to generated content.
      * @param policy         the contract agreement usage policy for the asset being transferred
+     * @deprecated please use {@link #initiateFlow(TransferProcess, Policy)}
      */
     @NotNull
-    StatusResult<DataFlowResponse> initiateFlow(DataRequest dataRequest, DataAddress contentAddress, Policy policy);
+    @Deprecated(since = "0.2.1", forRemoval = true)
+    default StatusResult<DataFlowResponse> initiateFlow(DataRequest dataRequest, DataAddress contentAddress, Policy policy) {
+        return initiateFlow(TransferProcess.Builder.newInstance().dataRequest(dataRequest).contentDataAddress(contentAddress).build(), policy);
+    }
 
 }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/flow/DataFlowManager.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/flow/DataFlowManager.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.transfer.spi.flow;
 
 import org.eclipse.edc.connector.transfer.spi.types.DataFlowResponse;
 import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
+import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import org.eclipse.edc.spi.response.StatusResult;
@@ -24,14 +25,34 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * Manages data flows and dispatches to {@link DataFlowController}s.
+ * Priority is used to decide which controller should be chosen first, higher priority values will make the controller
+ * being chosen first.
  */
 @ExtensionPoint
 public interface DataFlowManager {
 
     /**
-     * Register the controller.
+     * Register the controller. The priority is set to 0.
      */
     void register(DataFlowController controller);
+
+    /**
+     * Register the controller with a specific priority.
+     *
+     * @param priority the priority.
+     * @param controller the controller.
+     */
+    void register(int priority, DataFlowController controller);
+
+    /**
+     * Initiates a data flow.
+     *
+     * @param transferProcess the transfer process
+     * @param policy          the contract agreement usage policy for the asset being transferred
+     * @return succeeded StatusResult if flow has been initiated correctly, failed one otherwise.
+     */
+    @NotNull
+    StatusResult<DataFlowResponse> initiate(TransferProcess transferProcess, Policy policy);
 
     /**
      * Initiates a data flow.
@@ -39,7 +60,12 @@ public interface DataFlowManager {
      * @param dataRequest    the data to transfer
      * @param contentAddress the address to resolve the asset contents. This may be the original asset address or an address resolving to generated content.
      * @param policy         the contract agreement usage policy for the asset being transferred
+     * @deprecated please use {@link #initiate(TransferProcess, Policy)}
      */
     @NotNull
-    StatusResult<DataFlowResponse> initiate(DataRequest dataRequest, DataAddress contentAddress, Policy policy);
+    @Deprecated(since = "0.2.1", forRemoval = true)
+    default StatusResult<DataFlowResponse> initiate(DataRequest dataRequest, DataAddress contentAddress, Policy policy) {
+        var transferProcess = TransferProcess.Builder.newInstance().dataRequest(dataRequest).contentDataAddress(contentAddress).build();
+        return initiate(transferProcess, policy);
+    }
 }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/TransferProcess.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/TransferProcess.java
@@ -113,7 +113,6 @@ public class TransferProcess extends StatefulEntity<TransferProcess> {
     public static final String TRANSFER_PROCESS_ASSET_ID = EDC_NAMESPACE + "assetId";
     public static final String TRANSFER_PROCESS_CONTRACT_ID = EDC_NAMESPACE + "contractId";
     public static final String TRANSFER_PROCESS_CONNECTOR_ID = EDC_NAMESPACE + "connectorId";
-    public static final String TRANSFER_PROCESS_PROPERTIES = EDC_NAMESPACE + "properties";
     public static final String TRANSFER_PROCESS_PRIVATE_PROPERTIES = EDC_NAMESPACE + "privateProperties";
     public static final String TRANSFER_PROCESS_TYPE_TYPE = EDC_NAMESPACE + "type";
     public static final String TRANSFER_PROCESS_ERROR_DETAIL = EDC_NAMESPACE + "errorDetail";
@@ -377,6 +376,11 @@ public class TransferProcess extends StatefulEntity<TransferProcess> {
     @JsonIgnore
     public String getConnectorId() {
         return dataRequest.getConnectorId();
+    }
+
+    @JsonIgnore
+    public String getDestinationType() {
+        return dataRequest.getDestinationType();
     }
 
     @Override


### PR DESCRIPTION
## What this PR changes/adds

Add priority on `DataFlowController` registration

## Why it does that

to permit having multiple `DataFlowController`s that could be chosen for a particular transfer, and having other used as fallback.
This is useful when there's, for example, the `ProviderPushDataFlowController` that pretty much can transfer anything but there's a specific `DataFlowController` for a particular `source`-to`destination` transfer that will be chosen first if the priority set is bigger. 

## Further notes

- simplified the interface methods on `DataFlowManager` and `DataFlowController`, now they accept the whole `TransferProcess` object.

## Linked Issue(s)

Closes #3414

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
