### PR TITLE
feat: add IdResponse on addEntry API

### DIFF
--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/DataPlaneSelectorApiExtension.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/DataPlaneSelectorApiExtension.java
@@ -31,6 +31,7 @@ import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 import org.eclipse.edc.web.spi.WebService;
 
+import java.time.Clock;
 import java.util.Map;
 
 import static jakarta.json.Json.createBuilderFactory;
@@ -57,6 +58,9 @@ public class DataPlaneSelectorApiExtension implements ServiceExtension {
     @Inject
     private JsonObjectValidatorRegistry validatorRegistry;
 
+    @Inject
+    private Clock clock;
+
     @Override
     public void initialize(ServiceExtensionContext context) {
         typeManager.registerTypes(DataPlaneInstance.class);
@@ -65,7 +69,7 @@ public class DataPlaneSelectorApiExtension implements ServiceExtension {
         transformerRegistry.register(new JsonObjectToSelectionRequestTransformer());
         transformerRegistry.register(new JsonObjectToDataPlaneInstanceTransformer());
         transformerRegistry.register(new JsonObjectFromDataPlaneInstanceTransformer(createBuilderFactory(Map.of()), typeManager.getMapper(JSON_LD)));
-        var controller = new DataplaneSelectorApiController(selectionService, transformerRegistry, validatorRegistry);
+        var controller = new DataplaneSelectorApiController(selectionService, transformerRegistry, validatorRegistry, clock);
 
         webservice.registerResource(managementApiConfiguration.getContextAlias(), controller);
     }

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/DataplaneSelectorApi.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/DataplaneSelectorApi.java
@@ -53,17 +53,18 @@ public interface DataplaneSelectorApi {
             description = "Adds one datatplane instance to the internal database of the selector",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = DataPlaneInstanceSchema.class))),
             responses = {
-                    @ApiResponse(responseCode = "200", description = "Entry was added successfully to the database"),
+                    @ApiResponse(responseCode = "200", description = "Entry was added successfully to the database", content = @Content(schema = @Schema(implementation = ApiCoreSchema.IdResponseSchema.class))),
                     @ApiResponse(responseCode = "400", description = "Request body was malformed", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             }
     )
     @POST
-    void addEntry(JsonObject instance);
+    JsonObject addEntry(JsonObject instance);
 
     @Operation(method = "GET",
             description = "Returns a list of all currently registered data plane instances",
             responses = {
-                    @ApiResponse(responseCode = "204", description = "A (potentially empty) list of currently registered data plane instances"),
+                    @ApiResponse(responseCode = "200", description = "A (potentially empty) list of currently registered data plane instances",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = DataPlaneInstanceSchema.class)))),
                     @ApiResponse(responseCode = "400", description = "Request body was malformed", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             }
     )

--- a/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/api/DataPlaneSelectorApiControllerTest.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/api/DataPlaneSelectorApiControllerTest.java
@@ -78,13 +78,15 @@ public class DataPlaneSelectorApiControllerTest {
     void addEntry(DataPlaneInstanceStore store) {
         var dpi = createInstanceJson("test-id");
 
-        baseRequest()
+        var result = baseRequest()
                 .body(dpi)
                 .contentType(JSON)
                 .post()
                 .then()
-                .statusCode(204);
+                .statusCode(200)
+                .extract().body().as(JsonObject.class);
 
+        assertThat(result.getString(ID)).isEqualTo("test-id");
         assertThat(store.getAll()).hasSize(1)
                 .allMatch(d -> d.getId().equals("test-id"));
     }
@@ -99,7 +101,7 @@ public class DataPlaneSelectorApiControllerTest {
                 .post()
                 .then()
                 .statusCode(400);
-        
+
     }
 
     @Test
@@ -119,7 +121,7 @@ public class DataPlaneSelectorApiControllerTest {
                 .contentType(JSON)
                 .post()
                 .then()
-                .statusCode(204);
+                .statusCode(200);
 
 
         assertThat(store.getAll()).hasSize(3)

--- a/extensions/data-plane-selector/data-plane-selector-client/src/test/java/org/eclipse/edc/connector/dataplane/selector/client/RemoteDataPlaneSelectorClientTest.java
+++ b/extensions/data-plane-selector/data-plane-selector-client/src/test/java/org/eclipse/edc/connector/dataplane/selector/client/RemoteDataPlaneSelectorClientTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.Clock;
 import java.util.List;
 import java.util.Map;
 
@@ -107,7 +108,7 @@ class RemoteDataPlaneSelectorClientTest extends RestControllerTestBase {
 
     @Override
     protected Object controller() {
-        return new DataplaneSelectorApiController(SELECTOR_SERVICE_MOCK, typeTransformerRegistry, validator);
+        return new DataplaneSelectorApiController(SELECTOR_SERVICE_MOCK, typeTransformerRegistry, validator, Clock.systemUTC());
     }
 
     @Override

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/participant/EndToEndTransferParticipant.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/participant/EndToEndTransferParticipant.java
@@ -163,7 +163,7 @@ public class EndToEndTransferParticipant extends Participant {
                 .when()
                 .post("/v2/dataplanes")
                 .then()
-                .statusCode(204);
+                .statusCode(200);
     }
 
     public Map<String, String> controlPlaneConfiguration() {
@@ -199,7 +199,7 @@ public class EndToEndTransferParticipant extends Participant {
             }
         };
     }
-    
+
     public Map<String, String> controlPlanePostgresConfiguration() {
         var baseConfiguration = controlPlaneConfiguration();
 


### PR DESCRIPTION
## What this PR changes/adds

Returns `IdResponse` in the  `POST /v2/dataplanes`  API.

## Why it does that

consistency

## Linked Issue(s)

Closes #3352 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
