### PR TITLE
feat(build): publish directly from GHA using a reusable WF

### DIFF
--- a/.github/workflows/trigger_snapshot.yml
+++ b/.github/workflows/trigger_snapshot.yml
@@ -1,4 +1,4 @@
-name: "Create Snapshot Build"
+name: "Publish Snapshot Build"
 
 on:
   push:
@@ -6,24 +6,7 @@ on:
       - main
 
 jobs:
-  Trigger-Snapshot:
-    runs-on: ubuntu-latest
-    # forks cannot trigger Jenkins
-    if: github.repository == 'eclipse-edc/Connector'
-    steps:
-      # Trigger EF Jenkins. This job waits for Jenkins to complete the publishing, which may take a long time, because every
-      # module is signed individually, and parallelism is not available. Hence, the increased timeout of 3600 seconds.
-      # There is no way to cancel the process on Jenkins from withing GitHub.
-      - name: Call Jenkins API to trigger build
-        uses: toptal/jenkins-job-trigger-action@master
-        with:
-          jenkins_url: "https://ci.eclipse.org/edc/"
-          jenkins_user: ${{ secrets.EF_JENKINS_USER }}
-          jenkins_token: ${{ secrets.EF_JENKINS_TOKEN }}
-          # empty params are needed, otherwise the job will fail.
-          job_params: |
-            {
-              "REPO": "https://github.com/eclipse-edc/Connector"
-            }
-          job_name: "Publish-Component"
-          job_timeout: "3600" # Default 30 sec. (optional)
+  Publish-Snapshot:
+    # This workflow will abort if the required secrets don't exist
+    uses: eclipse-edc/.github/.github/workflows/publish-snapshot.yml@main
+    secrets: inherit


### PR DESCRIPTION
## What this PR changes/adds

Publishes snapshot artefacts directly from GHA using the reusable workflow from the `.github` repo.

## Why it does that

reusability, better integration with GHA

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes https://github.com/eclipse-edc/.github/issues/71

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
