### PR TITLE
chore(docs): remove specific docker base image from readme

### DIFF
--- a/extensions/common/api/api-observability/README.md
+++ b/extensions/common/api/api-observability/README.md
@@ -58,13 +58,6 @@ Docker supports [health check](https://docs.docker.com/engine/reference/builder/
 the Observability API for that, simply add this line to your `Dockerfile`:
 
 ```dockerfile
-FROM openjdk:17-slim-buster
-
-# by default curl is not available, so install it
-RUN apt update && apt install curl -y
-
-# HERE you should put all your other instructions, like exposing ports, etc.
-
 # health status is determined by the availability of the /health endpoint
 HEALTHCHECK --interval=5s --timeout=5s --retries=10 CMD curl --fail -X GET http://localhost:8181/api/check/health || exit 1
 


### PR DESCRIPTION
## What this PR changes/adds

Removes the "recommended" docker base image from the docs.

## Why it does that

the specific base image is not relevant here and should not be misconstrued as recommendation

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #3333

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
