### PR TITLE
feat: implement policy-monitor

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -75,7 +75,7 @@ maven/mavencentral/com.jcraft/jzlib/1.1.3, BSD-2-Clause, approved, CQ6218
 maven/mavencentral/com.lmax/disruptor/3.4.4, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.networknt/json-schema-validator/1.0.76, Apache-2.0, approved, CQ22638
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.28, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.32, , restricted, clearlydefined
+maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.32, Apache-2.0, approved, #10561
 maven/mavencentral/com.puppycrawl.tools/checkstyle/10.0, LGPL-2.1-or-later, approved, #7936
 maven/mavencentral/com.samskivert/jmustache/1.15, BSD-2-Clause, approved, clearlydefined
 maven/mavencentral/com.squareup.okhttp3/okhttp-dnsoverhttps/4.11.0, Apache-2.0, approved, clearlydefined

--- a/core/common/connector-core/build.gradle.kts
+++ b/core/common/connector-core/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     api(project(":spi:common:validator-spi"))
 
     implementation(project(":core:common:policy-engine"))
+    implementation(project(":core:common:state-machine"))
     implementation(project(":core:common:transform-core"))
     implementation(project(":core:common:util"))
 

--- a/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/entity/AbstractStateEntityManager.java
+++ b/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/entity/AbstractStateEntityManager.java
@@ -30,6 +30,12 @@ import org.jetbrains.annotations.NotNull;
 import java.time.Clock;
 import java.util.Objects;
 
+/**
+ * Abstraction that provides a common ground for state machine manager implementation.
+ *
+ * @param <E> the entity type.
+ * @param <S> the store type.
+ */
 public abstract class AbstractStateEntityManager<E extends StatefulEntity<E>, S extends StateEntityStore<E>> implements StateEntityManager {
 
     public static final long DEFAULT_ITERATION_WAIT = 1000;
@@ -66,7 +72,7 @@ public abstract class AbstractStateEntityManager<E extends StatefulEntity<E>, S 
     }
 
     /**
-     * configure the State Machine Manager builder
+     * configures the State Machine Manager builder
      *
      * @param builder the builder.
      * @return the builder.

--- a/core/control-plane/contract-core/build.gradle.kts
+++ b/core/control-plane/contract-core/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     api(project(":spi:common:policy-engine-spi"))
     api(project(":spi:control-plane:contract-spi"))
 
+    implementation(project(":core:common:connector-core"))
     implementation(project(":core:common:state-machine"))
     implementation(libs.opentelemetry.instrumentation.annotations)
 

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/ContractCoreExtension.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/ContractCoreExtension.java
@@ -60,6 +60,10 @@ import java.time.Clock;
 
 import static org.eclipse.edc.connector.contract.spi.validation.ContractValidationService.TRANSFER_SCOPE;
 import static org.eclipse.edc.connector.contract.validation.ContractExpiryCheckFunction.CONTRACT_EXPIRY_EVALUATION_KEY;
+import static org.eclipse.edc.connector.core.entity.AbstractStateEntityManager.DEFAULT_BATCH_SIZE;
+import static org.eclipse.edc.connector.core.entity.AbstractStateEntityManager.DEFAULT_ITERATION_WAIT;
+import static org.eclipse.edc.connector.core.entity.AbstractStateEntityManager.DEFAULT_SEND_RETRY_BASE_DELAY;
+import static org.eclipse.edc.connector.core.entity.AbstractStateEntityManager.DEFAULT_SEND_RETRY_LIMIT;
 import static org.eclipse.edc.policy.model.OdrlNamespace.ODRL_SCHEMA;
 
 @Provides({
@@ -71,11 +75,6 @@ import static org.eclipse.edc.policy.model.OdrlNamespace.ODRL_SCHEMA;
 public class ContractCoreExtension implements ServiceExtension {
 
     public static final String NAME = "Contract Core";
-
-    public static final long DEFAULT_ITERATION_WAIT = 1000;
-    public static final int DEFAULT_BATCH_SIZE = 20;
-    public static final int DEFAULT_SEND_RETRY_LIMIT = 7;
-    public static final long DEFAULT_SEND_RETRY_BASE_DELAY = 1000L;
 
     @Setting(value = "the iteration wait time in milliseconds in the negotiation state machine. Default value " + DEFAULT_ITERATION_WAIT, type = "long")
     private static final String NEGOTIATION_STATE_MACHINE_ITERATION_WAIT_MILLIS = "edc.negotiation.state-machine.iteration-wait-millis";

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/AbstractContractNegotiationManager.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/AbstractContractNegotiationManager.java
@@ -22,47 +22,28 @@ import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationTerminationMessage;
+import org.eclipse.edc.connector.core.entity.AbstractStateEntityManager;
 import org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
-import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.protocol.ProtocolWebhook;
 import org.eclipse.edc.spi.query.Criterion;
-import org.eclipse.edc.spi.retry.ExponentialWaitStrategy;
-import org.eclipse.edc.spi.retry.WaitStrategy;
-import org.eclipse.edc.spi.system.ExecutorInstrumentation;
-import org.eclipse.edc.spi.telemetry.Telemetry;
 import org.eclipse.edc.statemachine.Processor;
 import org.eclipse.edc.statemachine.ProcessorImpl;
-import org.eclipse.edc.statemachine.retry.EntityRetryProcessConfiguration;
-import org.eclipse.edc.statemachine.retry.EntityRetryProcessFactory;
-import org.jetbrains.annotations.NotNull;
 
-import java.time.Clock;
 import java.util.Objects;
 import java.util.function.Function;
 
 import static java.lang.String.format;
-import static org.eclipse.edc.connector.contract.ContractCoreExtension.DEFAULT_BATCH_SIZE;
-import static org.eclipse.edc.connector.contract.ContractCoreExtension.DEFAULT_ITERATION_WAIT;
-import static org.eclipse.edc.connector.contract.ContractCoreExtension.DEFAULT_SEND_RETRY_BASE_DELAY;
-import static org.eclipse.edc.connector.contract.ContractCoreExtension.DEFAULT_SEND_RETRY_LIMIT;
 import static org.eclipse.edc.spi.persistence.StateEntityStore.hasState;
 import static org.eclipse.edc.spi.persistence.StateEntityStore.isNotPending;
 
-public abstract class AbstractContractNegotiationManager {
+public abstract class AbstractContractNegotiationManager extends AbstractStateEntityManager {
+
     protected String participantId;
     protected ContractNegotiationStore negotiationStore;
     protected RemoteMessageDispatcherRegistry dispatcherRegistry;
     protected ContractNegotiationObservable observable;
-    protected Monitor monitor;
-    protected Clock clock;
-    protected Telemetry telemetry;
-    protected ExecutorInstrumentation executorInstrumentation;
-    protected int batchSize = DEFAULT_BATCH_SIZE;
-    protected WaitStrategy waitStrategy = () -> DEFAULT_ITERATION_WAIT;
     protected PolicyDefinitionStore policyStore;
-    protected EntityRetryProcessFactory entityRetryProcessFactory;
-    protected EntityRetryProcessConfiguration entityRetryProcessConfiguration = defaultEntityRetryProcessConfiguration();
     protected ProtocolWebhook protocolWebhook;
     protected ContractNegotiationPendingGuard pendingGuard = it -> false;
 
@@ -209,15 +190,15 @@ public abstract class AbstractContractNegotiationManager {
                 negotiation.getType(), negotiation.getId(), ContractNegotiationStates.from(negotiation.getState())));
     }
 
-    public static class Builder<T extends AbstractContractNegotiationManager> {
-
-        private final T manager;
+    public static class Builder<T extends AbstractContractNegotiationManager> extends AbstractStateEntityManager.Builder<T, Builder<T>> {
 
         protected Builder(T manager) {
-            this.manager = manager;
-            this.manager.clock = Clock.systemUTC(); // default implementation
-            this.manager.telemetry = new Telemetry(); // default noop implementation
-            this.manager.executorInstrumentation = ExecutorInstrumentation.noop(); // default noop implementation
+            super(manager);
+        }
+
+        @Override
+        public Builder<T> self() {
+            return this;
         }
 
         public Builder<T> participantId(String id) {
@@ -225,38 +206,8 @@ public abstract class AbstractContractNegotiationManager {
             return this;
         }
 
-        public Builder<T> monitor(Monitor monitor) {
-            manager.monitor = monitor;
-            return this;
-        }
-
-        public Builder<T> batchSize(int batchSize) {
-            manager.batchSize = batchSize;
-            return this;
-        }
-
-        public Builder<T> waitStrategy(WaitStrategy waitStrategy) {
-            manager.waitStrategy = waitStrategy;
-            return this;
-        }
-
         public Builder<T> dispatcherRegistry(RemoteMessageDispatcherRegistry dispatcherRegistry) {
             manager.dispatcherRegistry = dispatcherRegistry;
-            return this;
-        }
-
-        public Builder<T> clock(Clock clock) {
-            manager.clock = clock;
-            return this;
-        }
-
-        public Builder<T> telemetry(Telemetry telemetry) {
-            manager.telemetry = telemetry;
-            return this;
-        }
-
-        public Builder<T> executorInstrumentation(ExecutorInstrumentation executorInstrumentation) {
-            manager.executorInstrumentation = executorInstrumentation;
             return this;
         }
 
@@ -275,11 +226,6 @@ public abstract class AbstractContractNegotiationManager {
             return this;
         }
 
-        public Builder<T> entityRetryProcessConfiguration(EntityRetryProcessConfiguration entityRetryProcessConfiguration) {
-            manager.entityRetryProcessConfiguration = entityRetryProcessConfiguration;
-            return this;
-        }
-
         public Builder<T> protocolWebhook(ProtocolWebhook protocolWebhook) {
             manager.protocolWebhook = protocolWebhook;
             return this;
@@ -290,19 +236,14 @@ public abstract class AbstractContractNegotiationManager {
             return this;
         }
 
+        @Override
         public T build() {
+            super.build();
             Objects.requireNonNull(manager.participantId, "participantId");
-            Objects.requireNonNull(manager.monitor, "monitor");
             Objects.requireNonNull(manager.dispatcherRegistry, "dispatcherRegistry");
             Objects.requireNonNull(manager.observable, "observable");
-            Objects.requireNonNull(manager.clock, "clock");
-            Objects.requireNonNull(manager.telemetry, "telemetry");
-            Objects.requireNonNull(manager.executorInstrumentation, "executorInstrumentation");
             Objects.requireNonNull(manager.negotiationStore, "store");
             Objects.requireNonNull(manager.policyStore, "policyStore");
-
-            manager.entityRetryProcessFactory = new EntityRetryProcessFactory(manager.monitor, manager.clock, manager.entityRetryProcessConfiguration);
-
             return manager;
         }
     }
@@ -311,10 +252,4 @@ public abstract class AbstractContractNegotiationManager {
         negotiationStore.save(negotiation);
     }
 
-
-    @NotNull
-    private EntityRetryProcessConfiguration defaultEntityRetryProcessConfiguration() {
-        return new EntityRetryProcessConfiguration(DEFAULT_SEND_RETRY_LIMIT, () -> new ExponentialWaitStrategy(DEFAULT_SEND_RETRY_BASE_DELAY));
-
-    }
 }

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -45,28 +45,18 @@ import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractN
  */
 public class ConsumerContractNegotiationManagerImpl extends AbstractContractNegotiationManager implements ConsumerContractNegotiationManager {
 
-    private StateMachineManager stateMachineManager;
-
     private ConsumerContractNegotiationManagerImpl() {
     }
 
-    public void start() {
-        stateMachineManager = StateMachineManager.Builder.newInstance("consumer-contract-negotiation", monitor, executorInstrumentation, waitStrategy)
+    @Override
+    protected StateMachineManager.Builder configureStateMachineManager(StateMachineManager.Builder builder) {
+        return builder
                 .processor(processNegotiationsInState(INITIAL, this::processInitial))
                 .processor(processNegotiationsInState(REQUESTING, this::processRequesting))
                 .processor(processNegotiationsInState(ACCEPTING, this::processAccepting))
                 .processor(processNegotiationsInState(AGREED, this::processAgreed))
                 .processor(processNegotiationsInState(VERIFYING, this::processVerifying))
-                .processor(processNegotiationsInState(TERMINATING, this::processTerminating))
-                .build();
-
-        stateMachineManager.start();
-    }
-
-    public void stop() {
-        if (stateMachineManager != null) {
-            stateMachineManager.stop();
-        }
+                .processor(processNegotiationsInState(TERMINATING, this::processTerminating));
     }
 
     /**

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -123,7 +123,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
                 .build();
 
         return entityRetryProcessFactory.doAsyncStatusResultProcess(negotiation, () -> dispatcherRegistry.dispatch(Object.class, request))
-                .entityRetrieve(negotiationStore::findById)
+                .entityRetrieve(store::findById)
                 .onSuccess((n, result) -> transitionToRequested(n))
                 .onFailure((n, throwable) -> transitionToRequesting(n))
                 .onFatalError((n, failure) -> transitionToTerminated(n, failure.getFailureDetail()))
@@ -160,7 +160,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
                 .build();
 
         return entityRetryProcessFactory.doAsyncStatusResultProcess(negotiation, () -> dispatcherRegistry.dispatch(Object.class, request))
-                .entityRetrieve(negotiationStore::findById)
+                .entityRetrieve(store::findById)
                 .onSuccess((n, result) -> transitionToAccepted(n))
                 .onFailure((n, throwable) -> transitionToAccepting(n))
                 .onFatalError((n, failure) -> transitionToTerminated(n, failure.getFailureDetail()))
@@ -196,7 +196,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
                 .build();
 
         return entityRetryProcessFactory.doAsyncStatusResultProcess(negotiation, () -> dispatcherRegistry.dispatch(Object.class, message))
-                .entityRetrieve(negotiationStore::findById)
+                .entityRetrieve(store::findById)
                 .onSuccess((n, result) -> transitionToVerified(n))
                 .onFailure((n, throwable) -> transitionToVerifying(n))
                 .onFatalError((n, failure) -> transitionToTerminated(n, failure.getFailureDetail()))

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -81,7 +81,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
                 .build();
 
         return entityRetryProcessFactory.doAsyncStatusResultProcess(negotiation, () -> dispatcherRegistry.dispatch(Object.class, contractOfferMessage))
-                .entityRetrieve(negotiationStore::findById)
+                .entityRetrieve(store::findById)
                 .onSuccess((n, result) -> transitionToOffered(n))
                 .onFailure((n, throwable) -> transitionToOffering(n))
                 .onFatalError((n, failure) -> transitionToTerminated(n, failure.getFailureDetail()))
@@ -145,7 +145,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
                 .build();
 
         return entityRetryProcessFactory.doAsyncStatusResultProcess(negotiation, () -> dispatcherRegistry.dispatch(Object.class, request))
-                .entityRetrieve(negotiationStore::findById)
+                .entityRetrieve(store::findById)
                 .onSuccess((n, result) -> transitionToAgreed(n, agreement))
                 .onFailure((n, throwable) -> transitionToAgreeing(n))
                 .onFatalError((n, failure) -> transitionToTerminated(n, failure.getFailureDetail()))
@@ -182,7 +182,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
                 .build();
 
         return entityRetryProcessFactory.doAsyncStatusResultProcess(negotiation, () -> dispatcherRegistry.dispatch(Object.class, message))
-                .entityRetrieve(negotiationStore::findById)
+                .entityRetrieve(store::findById)
                 .onSuccess((n, result) -> transitionToFinalized(n))
                 .onFailure((n, throwable) -> transitionToFinalizing(n))
                 .onFatalError((n, failure) -> transitionToTerminated(n, failure.getFailureDetail()))

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -42,29 +42,19 @@ import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractN
  */
 public class ProviderContractNegotiationManagerImpl extends AbstractContractNegotiationManager implements ProviderContractNegotiationManager {
 
-    private StateMachineManager stateMachineManager;
-
     private ProviderContractNegotiationManagerImpl() {
     }
 
-    public void start() {
-        stateMachineManager = StateMachineManager.Builder.newInstance("provider-contract-negotiation", monitor, executorInstrumentation, waitStrategy)
+    @Override
+    protected StateMachineManager.Builder configureStateMachineManager(StateMachineManager.Builder builder) {
+        return builder
                 .processor(processNegotiationsInState(OFFERING, this::processOffering))
                 .processor(processNegotiationsInState(REQUESTED, this::processRequested))
                 .processor(processNegotiationsInState(ACCEPTED, this::processAccepted))
                 .processor(processNegotiationsInState(AGREEING, this::processAgreeing))
                 .processor(processNegotiationsInState(VERIFIED, this::processVerified))
                 .processor(processNegotiationsInState(FINALIZING, this::processFinalizing))
-                .processor(processNegotiationsInState(TERMINATING, this::processTerminating))
-                .build();
-
-        stateMachineManager.start();
-    }
-
-    public void stop() {
-        if (stateMachineManager != null) {
-            stateMachineManager.stop();
-        }
+                .processor(processNegotiationsInState(TERMINATING, this::processTerminating));
     }
 
     @Override

--- a/core/control-plane/transfer-core/build.gradle.kts
+++ b/core/control-plane/transfer-core/build.gradle.kts
@@ -19,8 +19,11 @@ dependencies {
     api(project(":spi:control-plane:policy-spi"))
     api(project(":spi:control-plane:transfer-spi"))
     api(project(":spi:common:transform-spi"))
+
+    implementation(project(":core:common:connector-core"))
     implementation(project(":core:common:state-machine"))
     implementation(project(":core:common:util"))
+
     implementation(libs.opentelemetry.instrumentation.annotations)
 
     testImplementation(project(":core:common:junit"))

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/TransferCoreExtension.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/TransferCoreExtension.java
@@ -187,7 +187,7 @@ public class TransferCoreExtension implements ServiceExtension {
                 .vault(vault)
                 .clock(clock)
                 .observable(observable)
-                .transferProcessStore(transferProcessStore)
+                .store(transferProcessStore)
                 .policyArchive(policyArchive)
                 .batchSize(context.getSetting(TRANSFER_STATE_MACHINE_BATCH_SIZE, DEFAULT_BATCH_SIZE))
                 .addressResolver(addressResolver)

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/TransferCoreExtension.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/TransferCoreExtension.java
@@ -61,6 +61,11 @@ import org.jetbrains.annotations.NotNull;
 
 import java.time.Clock;
 
+import static org.eclipse.edc.connector.core.entity.AbstractStateEntityManager.DEFAULT_BATCH_SIZE;
+import static org.eclipse.edc.connector.core.entity.AbstractStateEntityManager.DEFAULT_ITERATION_WAIT;
+import static org.eclipse.edc.connector.core.entity.AbstractStateEntityManager.DEFAULT_SEND_RETRY_BASE_DELAY;
+import static org.eclipse.edc.connector.core.entity.AbstractStateEntityManager.DEFAULT_SEND_RETRY_LIMIT;
+
 /**
  * Provides core data transfer services to the system.
  */
@@ -70,11 +75,6 @@ import java.time.Clock;
 public class TransferCoreExtension implements ServiceExtension {
 
     public static final String NAME = "Transfer Core";
-
-    public static final long DEFAULT_ITERATION_WAIT = 1000;
-    public static final int DEFAULT_BATCH_SIZE = 20;
-    public static final int DEFAULT_SEND_RETRY_LIMIT = 7;
-    public static final long DEFAULT_SEND_RETRY_BASE_DELAY = 1000L;
 
     @Setting(value = "the iteration wait time in milliseconds in the transfer process state machine. Default value " + DEFAULT_ITERATION_WAIT, type = "long")
     private static final String TRANSFER_STATE_MACHINE_ITERATION_WAIT_MILLIS = "edc.transfer.state-machine.iteration-wait-millis";

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/listener/TransferProcessEventListener.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/listener/TransferProcessEventListener.java
@@ -90,6 +90,8 @@ public class TransferProcessEventListener implements TransferProcessListener {
                 .transferProcessId(process.getId())
                 .dataAddress(additionalData.getDataAddress())
                 .callbackAddresses(process.getCallbackAddresses())
+                .contractId(process.getContractId())
+                .type(process.getType().name())
                 .build();
 
         publish(event);

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImplIntegrationTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImplIntegrationTest.java
@@ -88,7 +88,7 @@ class TransferProcessManagerImplIntegrationTest {
                 .clock(clock)
                 .statusCheckerRegistry(mock())
                 .observable(mock())
-                .transferProcessStore(store)
+                .store(store)
                 .policyArchive(policyArchive)
                 .addressResolver(mock())
                 .provisionResponsesHandler(new ProvisionResponsesHandler(mock(), mock(), mock(), mock()))

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImplTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImplTest.java
@@ -163,7 +163,7 @@ class TransferProcessManagerImplTest {
                 .clock(clock)
                 .statusCheckerRegistry(statusCheckerRegistry)
                 .observable(observable)
-                .transferProcessStore(transferProcessStore)
+                .store(transferProcessStore)
                 .policyArchive(policyArchive)
                 .vault(vault)
                 .addressResolver(addressResolver)

--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/DataPlaneFrameworkExtension.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/DataPlaneFrameworkExtension.java
@@ -41,6 +41,11 @@ import org.jetbrains.annotations.NotNull;
 import java.time.Clock;
 import java.util.concurrent.Executors;
 
+import static org.eclipse.edc.connector.core.entity.AbstractStateEntityManager.DEFAULT_BATCH_SIZE;
+import static org.eclipse.edc.connector.core.entity.AbstractStateEntityManager.DEFAULT_ITERATION_WAIT;
+import static org.eclipse.edc.connector.core.entity.AbstractStateEntityManager.DEFAULT_SEND_RETRY_BASE_DELAY;
+import static org.eclipse.edc.connector.core.entity.AbstractStateEntityManager.DEFAULT_SEND_RETRY_LIMIT;
+
 /**
  * Provides core services for the Data Plane Framework.
  */
@@ -48,11 +53,6 @@ import java.util.concurrent.Executors;
 @Extension(value = DataPlaneFrameworkExtension.NAME)
 public class DataPlaneFrameworkExtension implements ServiceExtension {
     public static final String NAME = "Data Plane Framework";
-
-    public static final long DEFAULT_ITERATION_WAIT = 1000;
-    public static final int DEFAULT_BATCH_SIZE = 20;
-    public static final int DEFAULT_SEND_RETRY_LIMIT = 7;
-    public static final long DEFAULT_SEND_RETRY_BASE_DELAY = 1000L;
 
     @Setting(value = "the iteration wait time in milliseconds in the data plane state machine. Default value " + DEFAULT_ITERATION_WAIT, type = "long")
     private static final String DATAPLANE_MACHINE_ITERATION_WAIT_MILLIS = "edc.dataplane.state-machine.iteration-wait-millis";

--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImpl.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImpl.java
@@ -46,10 +46,9 @@ import static org.eclipse.edc.spi.persistence.StateEntityStore.hasState;
 /**
  * Default data manager implementation.
  */
-public class DataPlaneManagerImpl extends AbstractStateEntityManager implements DataPlaneManager {
+public class DataPlaneManagerImpl extends AbstractStateEntityManager<DataFlow, DataPlaneStore> implements DataPlaneManager {
 
     private PipelineService pipelineService;
-    private DataPlaneStore store;
     private TransferServiceRegistry transferServiceRegistry;
     private TransferProcessApiClient transferProcessClient;
 
@@ -156,16 +155,7 @@ public class DataPlaneManagerImpl extends AbstractStateEntityManager implements 
                 .build();
     }
 
-    private void breakLease(DataFlow dataFlow) {
-        store.save(dataFlow);
-    }
-
-    private void update(DataFlow entity) {
-        store.save(entity);
-        monitor.debug(format("DataFlow %s is now in state %s", entity.getId(), entity.stateAsString()));
-    }
-
-    public static class Builder extends AbstractStateEntityManager.Builder<DataPlaneManagerImpl, Builder> {
+    public static class Builder extends AbstractStateEntityManager.Builder<DataFlow, DataPlaneStore, DataPlaneManagerImpl, Builder> {
 
         public static Builder newInstance() {
             return new Builder();
@@ -187,11 +177,6 @@ public class DataPlaneManagerImpl extends AbstractStateEntityManager implements 
 
         public Builder transferServiceRegistry(TransferServiceRegistry transferServiceRegistry) {
             manager.transferServiceRegistry = transferServiceRegistry;
-            return this;
-        }
-
-        public Builder store(DataPlaneStore store) {
-            manager.store = store;
             return this;
         }
 

--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImpl.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImpl.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.connector.dataplane.framework.manager;
 
 import org.eclipse.edc.connector.api.client.spi.transferprocess.TransferProcessApiClient;
+import org.eclipse.edc.connector.core.entity.AbstractStateEntityManager;
 import org.eclipse.edc.connector.dataplane.spi.DataFlow;
 import org.eclipse.edc.connector.dataplane.spi.DataFlowStates;
 import org.eclipse.edc.connector.dataplane.spi.manager.DataPlaneManager;
@@ -24,30 +25,19 @@ import org.eclipse.edc.connector.dataplane.spi.pipeline.StreamResult;
 import org.eclipse.edc.connector.dataplane.spi.registry.TransferServiceRegistry;
 import org.eclipse.edc.connector.dataplane.spi.store.DataPlaneStore;
 import org.eclipse.edc.spi.entity.StatefulEntity;
-import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.result.Result;
-import org.eclipse.edc.spi.retry.ExponentialWaitStrategy;
-import org.eclipse.edc.spi.retry.WaitStrategy;
-import org.eclipse.edc.spi.system.ExecutorInstrumentation;
-import org.eclipse.edc.spi.telemetry.Telemetry;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
 import org.eclipse.edc.statemachine.Processor;
 import org.eclipse.edc.statemachine.ProcessorImpl;
 import org.eclipse.edc.statemachine.StateMachineManager;
-import org.eclipse.edc.statemachine.retry.EntityRetryProcessConfiguration;
-import org.eclipse.edc.statemachine.retry.EntityRetryProcessFactory;
-import org.jetbrains.annotations.NotNull;
 
-import java.time.Clock;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 import static java.lang.String.format;
-import static org.eclipse.edc.connector.dataplane.framework.DataPlaneFrameworkExtension.DEFAULT_BATCH_SIZE;
-import static org.eclipse.edc.connector.dataplane.framework.DataPlaneFrameworkExtension.DEFAULT_ITERATION_WAIT;
 import static org.eclipse.edc.connector.dataplane.spi.DataFlowStates.COMPLETED;
 import static org.eclipse.edc.connector.dataplane.spi.DataFlowStates.FAILED;
 import static org.eclipse.edc.connector.dataplane.spi.DataFlowStates.RECEIVED;
@@ -56,40 +46,23 @@ import static org.eclipse.edc.spi.persistence.StateEntityStore.hasState;
 /**
  * Default data manager implementation.
  */
-public class DataPlaneManagerImpl implements DataPlaneManager {
-    private int batchSize = DEFAULT_BATCH_SIZE;
-    private WaitStrategy waitStrategy = () -> DEFAULT_ITERATION_WAIT;
+public class DataPlaneManagerImpl extends AbstractStateEntityManager implements DataPlaneManager {
+
     private PipelineService pipelineService;
-    private ExecutorInstrumentation executorInstrumentation;
-    private Monitor monitor;
-    private Telemetry telemetry;
     private DataPlaneStore store;
     private TransferServiceRegistry transferServiceRegistry;
     private TransferProcessApiClient transferProcessClient;
-    private StateMachineManager stateMachineManager;
-    private EntityRetryProcessConfiguration entityRetryProcessConfiguration = defaultEntityRetryProcessConfiguration();
-    private EntityRetryProcessFactory entityRetryProcessFactory;
-    private Clock clock = Clock.systemUTC();
 
     private DataPlaneManagerImpl() {
 
     }
 
-    public void start() {
-        entityRetryProcessFactory = new EntityRetryProcessFactory(monitor, clock, entityRetryProcessConfiguration);
-        stateMachineManager = StateMachineManager.Builder.newInstance("data-plane", monitor, executorInstrumentation, waitStrategy)
+    @Override
+    protected StateMachineManager.Builder configureStateMachineManager(StateMachineManager.Builder builder) {
+        return builder
                 .processor(processDataFlowInState(RECEIVED, this::processReceived))
                 .processor(processDataFlowInState(COMPLETED, this::processCompleted))
-                .processor(processDataFlowInState(FAILED, this::processFailed))
-                .build();
-
-        stateMachineManager.start();
-    }
-
-    public void stop() {
-        if (stateMachineManager != null) {
-            stateMachineManager.stop();
-        }
+                .processor(processDataFlowInState(FAILED, this::processFailed));
     }
 
     @Override
@@ -192,30 +165,18 @@ public class DataPlaneManagerImpl implements DataPlaneManager {
         monitor.debug(format("DataFlow %s is now in state %s", entity.getId(), entity.stateAsString()));
     }
 
-    @NotNull
-    private EntityRetryProcessConfiguration defaultEntityRetryProcessConfiguration() {
-        return new EntityRetryProcessConfiguration(7, () -> new ExponentialWaitStrategy(1000L));
-    }
-
-    public static class Builder {
-        private final DataPlaneManagerImpl manager;
-
-        private Builder() {
-            manager = new DataPlaneManagerImpl();
-            manager.telemetry = new Telemetry(); // default noop implementation
-        }
+    public static class Builder extends AbstractStateEntityManager.Builder<DataPlaneManagerImpl, Builder> {
 
         public static Builder newInstance() {
             return new Builder();
         }
 
-        public Builder batchSize(int size) {
-            manager.batchSize = size;
-            return this;
+        private Builder() {
+            super(new DataPlaneManagerImpl());
         }
 
-        public Builder waitStrategy(WaitStrategy waitStrategy) {
-            manager.waitStrategy = waitStrategy;
+        @Override
+        public Builder self() {
             return this;
         }
 
@@ -224,33 +185,8 @@ public class DataPlaneManagerImpl implements DataPlaneManager {
             return this;
         }
 
-        public Builder executorInstrumentation(ExecutorInstrumentation executorInstrumentation) {
-            manager.executorInstrumentation = executorInstrumentation;
-            return this;
-        }
-
-        public Builder clock(Clock clock) {
-            manager.clock = clock;
-            return this;
-        }
-
-        public Builder entityRetryProcessConfiguration(EntityRetryProcessConfiguration entityRetryProcessConfiguration) {
-            manager.entityRetryProcessConfiguration = entityRetryProcessConfiguration;
-            return this;
-        }
-
         public Builder transferServiceRegistry(TransferServiceRegistry transferServiceRegistry) {
             manager.transferServiceRegistry = transferServiceRegistry;
-            return this;
-        }
-
-        public Builder monitor(Monitor monitor) {
-            manager.monitor = monitor;
-            return this;
-        }
-
-        public Builder telemetry(Telemetry telemetry) {
-            manager.telemetry = telemetry;
             return this;
         }
 

--- a/core/policy-monitor/policy-monitor-core/build.gradle.kts
+++ b/core/policy-monitor/policy-monitor-core/build.gradle.kts
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(project(":spi:policy-monitor:policy-monitor-spi"))
+    api(project(":spi:control-plane:control-plane-spi"))
+    api(project(":spi:control-plane:policy-spi"))
+    api(project(":spi:control-plane:transfer-spi"))
+    implementation(project(":core:common:state-machine"))
+    implementation(project(":core:common:connector-core"))
+
+    testImplementation(project(":core:common:junit"))
+    testImplementation(libs.awaitility)
+}
+
+

--- a/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/PolicyMonitorExtension.java
+++ b/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/PolicyMonitorExtension.java
@@ -1,0 +1,112 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.policy.monitor;
+
+import org.eclipse.edc.connector.policy.monitor.manager.PolicyMonitorManagerImpl;
+import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorManager;
+import org.eclipse.edc.connector.policy.monitor.store.InMemoryPolicyMonitorStore;
+import org.eclipse.edc.connector.policy.monitor.subscriber.StartMonitoring;
+import org.eclipse.edc.connector.spi.contractagreement.ContractAgreementService;
+import org.eclipse.edc.connector.spi.transferprocess.TransferProcessService;
+import org.eclipse.edc.connector.transfer.spi.event.TransferProcessStarted;
+import org.eclipse.edc.policy.engine.spi.PolicyEngine;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provides;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.spi.event.EventRouter;
+import org.eclipse.edc.spi.retry.ExponentialWaitStrategy;
+import org.eclipse.edc.spi.system.ExecutorInstrumentation;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.telemetry.Telemetry;
+
+import java.time.Clock;
+
+import static org.eclipse.edc.connector.core.entity.AbstractStateEntityManager.DEFAULT_BATCH_SIZE;
+import static org.eclipse.edc.connector.core.entity.AbstractStateEntityManager.DEFAULT_ITERATION_WAIT;
+import static org.eclipse.edc.connector.policy.monitor.PolicyMonitorExtension.NAME;
+
+@Extension(value = NAME)
+@Provides({ PolicyMonitorManager.class })
+public class PolicyMonitorExtension implements ServiceExtension {
+
+    public static final String NAME = "Policy Monitor";
+
+    @Setting(value = "the iteration wait time in milliseconds in the policy monitor state machine. Default value " + DEFAULT_ITERATION_WAIT, type = "long")
+    private static final String POLICY_MONITOR_ITERATION_WAIT_MILLIS = "edc.policy.monitor.state-machine.iteration-wait-millis";
+
+    @Setting(value = "the batch size in the policy monitor state machine. Default value " + DEFAULT_BATCH_SIZE, type = "int")
+    private static final String POLICY_MONITOR_BATCH_SIZE = "edc.policy.monitor.state-machine.batch-size";
+
+    @Inject
+    private ExecutorInstrumentation executorInstrumentation;
+
+    @Inject
+    private Telemetry telemetry;
+
+    @Inject
+    private Clock clock;
+
+    @Inject
+    private EventRouter eventRouter;
+
+    @Inject
+    private ContractAgreementService contractAgreementService;
+
+    @Inject
+    private PolicyEngine policyEngine;
+
+    @Inject
+    private TransferProcessService transferProcessService;
+
+    private PolicyMonitorManager manager;
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        var iterationWaitMillis = context.getSetting(POLICY_MONITOR_ITERATION_WAIT_MILLIS, DEFAULT_ITERATION_WAIT);
+        var waitStrategy = new ExponentialWaitStrategy(iterationWaitMillis);
+
+        manager = PolicyMonitorManagerImpl.Builder.newInstance()
+                .clock(clock)
+                .batchSize(context.getSetting(POLICY_MONITOR_BATCH_SIZE, DEFAULT_BATCH_SIZE))
+                .waitStrategy(waitStrategy)
+                .executorInstrumentation(executorInstrumentation)
+                .monitor(context.getMonitor())
+                .telemetry(telemetry)
+                .contractAgreementService(contractAgreementService)
+                .policyEngine(policyEngine)
+                .transferProcessService(transferProcessService)
+                .store(new InMemoryPolicyMonitorStore())
+                .build();
+
+        context.registerService(PolicyMonitorManager.class, manager);
+
+        eventRouter.registerSync(TransferProcessStarted.class, new StartMonitoring(manager));
+    }
+
+    @Override
+    public void start() {
+        manager.start();
+    }
+
+    @Override
+    public void shutdown() {
+        if (manager != null) {
+            manager.stop();
+        }
+    }
+
+}

--- a/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/manager/PolicyMonitorManagerImpl.java
+++ b/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/manager/PolicyMonitorManagerImpl.java
@@ -35,6 +35,9 @@ import java.util.function.Function;
 import static org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntryStates.STARTED;
 import static org.eclipse.edc.spi.persistence.StateEntityStore.hasState;
 
+/**
+ * Implementation of the {@link PolicyMonitorManager}
+ */
 public class PolicyMonitorManagerImpl extends AbstractStateEntityManager<PolicyMonitorEntry, PolicyMonitorStore>
         implements PolicyMonitorManager {
 

--- a/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/manager/PolicyMonitorManagerImpl.java
+++ b/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/manager/PolicyMonitorManagerImpl.java
@@ -1,0 +1,150 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.policy.monitor.manager;
+
+import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
+import org.eclipse.edc.connector.core.entity.AbstractStateEntityManager;
+import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntry;
+import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntryStates;
+import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorManager;
+import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorStore;
+import org.eclipse.edc.connector.spi.contractagreement.ContractAgreementService;
+import org.eclipse.edc.connector.spi.transferprocess.TransferProcessService;
+import org.eclipse.edc.policy.engine.spi.PolicyContextImpl;
+import org.eclipse.edc.policy.engine.spi.PolicyEngine;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.statemachine.Processor;
+import org.eclipse.edc.statemachine.ProcessorImpl;
+import org.eclipse.edc.statemachine.StateMachineManager;
+
+import java.time.Instant;
+import java.util.function.Function;
+
+import static java.lang.String.format;
+import static org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntryStates.STARTED;
+import static org.eclipse.edc.spi.persistence.StateEntityStore.hasState;
+
+public class PolicyMonitorManagerImpl extends AbstractStateEntityManager implements PolicyMonitorManager {
+
+    private PolicyMonitorStore store;
+    private PolicyEngine policyEngine;
+    private TransferProcessService transferProcessService;
+    private ContractAgreementService contractAgreementService;
+
+    private PolicyMonitorManagerImpl() {
+
+    }
+
+    @Override
+    protected StateMachineManager.Builder configureStateMachineManager(StateMachineManager.Builder builder) {
+        return builder
+                .processor(processEntriesInState(STARTED, this::processMonitoring));
+    }
+
+    @Override
+    public void startMonitoring(String transferProcessId, String contractId) {
+        var entry = PolicyMonitorEntry.Builder.newInstance()
+                .id(transferProcessId)
+                .contractId(contractId)
+                .traceContext(telemetry.getCurrentTraceContext())
+                .build();
+
+        entry.transitionToStarted();
+
+        update(entry);
+    }
+
+    private boolean processMonitoring(PolicyMonitorEntry entry) {
+        var contractAgreement = contractAgreementService.findById(entry.getContractId());
+        if (contractAgreement == null) {
+            entry.transitionToFailed("ContractAgreement %s does not exist".formatted(entry.getContractId()));
+            update(entry);
+            return true;
+        }
+
+        var policy = contractAgreement.getPolicy();
+        var policyContext = PolicyContextImpl.Builder.newInstance()
+                .additional(Instant.class, Instant.now(clock))
+                .additional(ContractAgreement.class, contractAgreement)
+                .build();
+
+        var result = policyEngine.evaluate("transfer.process", policy, policyContext);
+        if (result.failed()) {
+            monitor.debug(() -> "[policy-monitor] Policy evaluation for TP %s failed: %s".formatted(entry.getId(), result.getFailureDetail()));
+            var completeResult = transferProcessService.complete(entry.getId());
+            if (completeResult.succeeded()) {
+                entry.transitionToCompleted();
+                update(entry);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private void update(PolicyMonitorEntry entity) {
+        store.save(entity);
+        monitor.debug(() -> format("PolicyMonitorEntry %s is now in state %s", entity.getId(), entity.stateAsString()));
+    }
+
+    private Processor processEntriesInState(PolicyMonitorEntryStates state, Function<PolicyMonitorEntry, Boolean> function) {
+        var filter = new Criterion[]{ hasState(state.code()) };
+        return ProcessorImpl.Builder.newInstance(() -> store.nextNotLeased(batchSize, filter))
+                .process(telemetry.contextPropagationMiddleware(function))
+                .onNotProcessed(this::breakLease)
+                .build();
+    }
+
+    private void breakLease(PolicyMonitorEntry entry) {
+        store.save(entry);
+    }
+
+    public static class Builder extends AbstractStateEntityManager.Builder<PolicyMonitorManagerImpl, Builder> {
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        private Builder() {
+            super(new PolicyMonitorManagerImpl());
+        }
+
+        public Builder contractAgreementService(ContractAgreementService contractAgreementService) {
+            manager.contractAgreementService = contractAgreementService;
+            return this;
+        }
+
+        public Builder policyEngine(PolicyEngine policyEngine) {
+            manager.policyEngine = policyEngine;
+            return this;
+        }
+
+        public Builder transferProcessService(TransferProcessService transferProcessService) {
+            manager.transferProcessService = transferProcessService;
+            return this;
+        }
+
+        public Builder store(PolicyMonitorStore store) {
+            manager.store = store;
+            return this;
+        }
+
+        @Override
+        public Builder self() {
+            return this;
+        }
+    }
+
+}

--- a/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/store/InMemoryPolicyMonitorStore.java
+++ b/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/store/InMemoryPolicyMonitorStore.java
@@ -27,6 +27,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * In-memory implementation of the {@link PolicyMonitorStore}
+ */
 public class InMemoryPolicyMonitorStore implements PolicyMonitorStore {
 
     private final InMemoryStatefulEntityStore<PolicyMonitorEntry> store;

--- a/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/store/InMemoryPolicyMonitorStore.java
+++ b/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/store/InMemoryPolicyMonitorStore.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.policy.monitor.store;
+
+import org.eclipse.edc.connector.core.store.InMemoryStatefulEntityStore;
+import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntry;
+import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorStore;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.result.StoreResult;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.time.Clock;
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+
+public class InMemoryPolicyMonitorStore implements PolicyMonitorStore {
+
+    private final InMemoryStatefulEntityStore<PolicyMonitorEntry> store;
+
+    public InMemoryPolicyMonitorStore() {
+        store = new InMemoryStatefulEntityStore<>(PolicyMonitorEntry.class, UUID.randomUUID().toString(), Clock.systemUTC(), new HashMap<>());
+    }
+
+    @Override
+    public @Nullable PolicyMonitorEntry findById(String id) {
+        return store.find(id);
+    }
+
+    @Override
+    public @NotNull List<PolicyMonitorEntry> nextNotLeased(int max, Criterion... criteria) {
+        return store.leaseAndGet(max, criteria);
+    }
+
+    @Override
+    public StoreResult<PolicyMonitorEntry> findByIdAndLease(String id) {
+        return store.leaseAndGet(id);
+    }
+
+    @Override
+    public void save(PolicyMonitorEntry entity) {
+        store.upsert(entity);
+    }
+}

--- a/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/subscriber/StartMonitoring.java
+++ b/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/subscriber/StartMonitoring.java
@@ -22,6 +22,9 @@ import org.eclipse.edc.spi.event.EventSubscriber;
 
 import static org.eclipse.edc.connector.transfer.spi.types.TransferProcess.Type.PROVIDER;
 
+/**
+ * Event subscriber that will start monitoring a transfer process whenever it gets started and it's a PROVIDER one.
+ */
 public class StartMonitoring implements EventSubscriber {
 
     private final PolicyMonitorManager manager;

--- a/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/subscriber/StartMonitoring.java
+++ b/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/subscriber/StartMonitoring.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.policy.monitor.subscriber;
+
+import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorManager;
+import org.eclipse.edc.connector.transfer.spi.event.TransferProcessStarted;
+import org.eclipse.edc.spi.event.Event;
+import org.eclipse.edc.spi.event.EventEnvelope;
+import org.eclipse.edc.spi.event.EventSubscriber;
+
+import static org.eclipse.edc.connector.transfer.spi.types.TransferProcess.Type.PROVIDER;
+
+public class StartMonitoring implements EventSubscriber {
+
+    private final PolicyMonitorManager manager;
+
+    public StartMonitoring(PolicyMonitorManager manager) {
+        this.manager = manager;
+    }
+
+    @Override
+    public <E extends Event> void on(EventEnvelope<E> event) {
+        if (event.getPayload() instanceof TransferProcessStarted started && PROVIDER.name().equals(started.getType())) {
+            manager.startMonitoring(started.getTransferProcessId(), started.getContractId());
+        }
+    }
+}

--- a/core/policy-monitor/policy-monitor-core/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/core/policy-monitor/policy-monitor-core/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+#
+#
+
+org.eclipse.edc.connector.policy.monitor.PolicyMonitorExtension

--- a/core/policy-monitor/policy-monitor-core/src/test/java/org/eclipse/edc/connector/policy/monitor/manager/PolicyMonitorManagerImplTest.java
+++ b/core/policy-monitor/policy-monitor-core/src/test/java/org/eclipse/edc/connector/policy/monitor/manager/PolicyMonitorManagerImplTest.java
@@ -1,0 +1,187 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.policy.monitor.manager;
+
+import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
+import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntry;
+import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorManager;
+import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorStore;
+import org.eclipse.edc.connector.spi.contractagreement.ContractAgreementService;
+import org.eclipse.edc.connector.spi.transferprocess.TransferProcessService;
+import org.eclipse.edc.policy.engine.spi.PolicyContext;
+import org.eclipse.edc.policy.engine.spi.PolicyContextImpl;
+import org.eclipse.edc.policy.engine.spi.PolicyEngine;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.service.spi.result.ServiceResult;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.system.ExecutorInstrumentation;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntryStates.COMPLETED;
+import static org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntryStates.FAILED;
+import static org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntryStates.STARTED;
+import static org.eclipse.edc.spi.persistence.StateEntityStore.hasState;
+import static org.mockito.AdditionalMatchers.aryEq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class PolicyMonitorManagerImplTest {
+
+    private final PolicyMonitorStore store = mock();
+    private final ContractAgreementService contractAgreementService = mock();
+    private final TransferProcessService transferProcessService = mock();
+    private final PolicyEngine policyEngine = mock();
+    private PolicyMonitorManager manager;
+
+    @BeforeEach
+    void setUp() {
+        manager = PolicyMonitorManagerImpl.Builder.newInstance()
+                .executorInstrumentation(ExecutorInstrumentation.noop())
+                .monitor(mock())
+                .clock(mock())
+                .contractAgreementService(contractAgreementService)
+                .policyEngine(policyEngine)
+                .transferProcessService(transferProcessService)
+                .store(store)
+                .build();
+    }
+
+    @Test
+    void startMonitoring() {
+        manager.startMonitoring("transferProcessId", "contractId");
+
+        var captor = ArgumentCaptor.forClass(PolicyMonitorEntry.class);
+        verify(store).save(captor.capture());
+        var entry = captor.getValue();
+        assertThat(entry.getId()).isEqualTo("transferProcessId");
+        assertThat(entry.getContractId()).isEqualTo("contractId");
+        assertThat(entry.getState()).isEqualTo(STARTED.code());
+    }
+
+    @Test
+    void started_shouldTransitionToComplete_whenPolicyIsNotValidAndTransferProcessGetsCompleted() {
+        var entry = PolicyMonitorEntry.Builder.newInstance()
+                .id("transferProcessId")
+                .contractId("contractId")
+                .state(STARTED.code())
+                .build();
+        var policy = Policy.Builder.newInstance().build();
+        var contractAgreement = createContractAgreement(policy);
+        when(store.nextNotLeased(anyInt(), stateIs(STARTED.code()))).thenReturn(List.of(entry)).thenReturn(emptyList());
+        when(contractAgreementService.findById(any())).thenReturn(contractAgreement);
+        when(policyEngine.evaluate(any(), any(), isA(PolicyContext.class))).thenReturn(Result.failure("policy is not valid"));
+        when(transferProcessService.complete(any())).thenReturn(ServiceResult.success());
+
+        manager.start();
+
+        await().untilAsserted(() -> {
+            verify(contractAgreementService).findById("contractId");
+            var captor = ArgumentCaptor.forClass(PolicyContextImpl.class);
+            verify(policyEngine).evaluate(eq("transfer.process"), same(policy), captor.capture());
+            var policyContext = captor.getValue();
+            assertThat(policyContext.getContextData(ContractAgreement.class)).isSameAs(contractAgreement);
+            verify(transferProcessService).complete("transferProcessId");
+            verify(store).save(argThat(it -> it.getState() == COMPLETED.code()));
+        });
+    }
+
+    @Test
+    void started_shouldNotTransitionToComplete_whenTransferProcessCompletionFails() {
+        var entry = PolicyMonitorEntry.Builder.newInstance()
+                .id("transferProcessId")
+                .contractId("contractId")
+                .state(STARTED.code())
+                .build();
+        var policy = Policy.Builder.newInstance().build();
+        when(store.nextNotLeased(anyInt(), stateIs(STARTED.code()))).thenReturn(List.of(entry)).thenReturn(emptyList());
+        when(contractAgreementService.findById(any())).thenReturn(createContractAgreement(policy));
+        when(policyEngine.evaluate(any(), any(), isA(PolicyContext.class))).thenReturn(Result.failure("policy is not valid"));
+        when(transferProcessService.complete(any())).thenReturn(ServiceResult.conflict("failure"));
+
+        manager.start();
+
+        await().untilAsserted(() -> {
+            verify(store).save(argThat(it -> it.getState() == STARTED.code()));
+        });
+    }
+
+    @Test
+    void started_shouldDoNothing_whenPolicyIsValid() {
+        var entry = PolicyMonitorEntry.Builder.newInstance()
+                .id("transferProcessId")
+                .contractId("contractId")
+                .state(STARTED.code())
+                .build();
+        var policy = Policy.Builder.newInstance().build();
+        when(store.nextNotLeased(anyInt(), stateIs(STARTED.code()))).thenReturn(List.of(entry)).thenReturn(emptyList());
+        when(contractAgreementService.findById(any())).thenReturn(createContractAgreement(policy));
+        when(policyEngine.evaluate(any(), any(), isA(PolicyContext.class))).thenReturn(Result.success());
+        when(transferProcessService.complete(any())).thenReturn(ServiceResult.conflict("failure"));
+
+        manager.start();
+
+        await().untilAsserted(() -> {
+            verifyNoInteractions(transferProcessService);
+            verify(store).save(argThat(it -> it.getState() == STARTED.code()));
+        });
+    }
+
+    @Test
+    void started_shouldTransitionToFailed_whenContractAgreementNotFound() {
+        var entry = PolicyMonitorEntry.Builder.newInstance()
+                .id("transferProcessId")
+                .contractId("contractId")
+                .state(STARTED.code())
+                .build();
+        when(store.nextNotLeased(anyInt(), stateIs(STARTED.code()))).thenReturn(List.of(entry)).thenReturn(emptyList());
+        when(contractAgreementService.findById(any())).thenReturn(null);
+
+        manager.start();
+
+        await().untilAsserted(() -> {
+            verifyNoInteractions(policyEngine, transferProcessService);
+            verify(store).save(argThat(it -> it.getState() == FAILED.code()));
+        });
+    }
+
+    private ContractAgreement createContractAgreement(Policy policy) {
+        return ContractAgreement.Builder.newInstance()
+                .providerId("providerId")
+                .consumerId("consumerId")
+                .assetId("assetIt")
+                .policy(policy)
+                .build();
+    }
+
+    private Criterion[] stateIs(int state) {
+        return aryEq(new Criterion[]{ hasState(state) });
+    }
+}

--- a/core/policy-monitor/policy-monitor-core/src/test/java/org/eclipse/edc/connector/policy/monitor/subscriber/StartMonitoringTest.java
+++ b/core/policy-monitor/policy-monitor-core/src/test/java/org/eclipse/edc/connector/policy/monitor/subscriber/StartMonitoringTest.java
@@ -1,0 +1,73 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.policy.monitor.subscriber;
+
+import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorManager;
+import org.eclipse.edc.connector.transfer.spi.event.TransferProcessStarted;
+import org.eclipse.edc.spi.event.EventEnvelope;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.eclipse.edc.connector.transfer.spi.types.TransferProcess.Type.CONSUMER;
+import static org.eclipse.edc.connector.transfer.spi.types.TransferProcess.Type.PROVIDER;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+class StartMonitoringTest {
+
+    private long now;
+    private final PolicyMonitorManager manager = mock();
+
+    @Test
+    void shouldStartMonitoring_whenTransferProcessIsProvider() {
+        var subscriber = new StartMonitoring(manager);
+        now = Instant.now().toEpochMilli();
+        var event = TransferProcessStarted.Builder.newInstance()
+                .transferProcessId("transferProcessId")
+                .contractId("contractId")
+                .type(PROVIDER.name())
+                .build();
+
+        subscriber.on(envelope(event));
+
+        verify(manager).startMonitoring("transferProcessId", "contractId");
+    }
+
+    @Test
+    void shouldNotStartMonitoring_whenTransferProcessIsConsumer() {
+        var subscriber = new StartMonitoring(manager);
+        now = Instant.now().toEpochMilli();
+        var event = TransferProcessStarted.Builder.newInstance()
+                .transferProcessId("transferProcessId")
+                .contractId("contractId")
+                .type(CONSUMER.name())
+                .build();
+
+        subscriber.on(envelope(event));
+
+        verifyNoInteractions(manager);
+    }
+
+
+
+    private EventEnvelope<TransferProcessStarted> envelope(TransferProcessStarted event) {
+        return EventEnvelope.Builder.newInstance()
+                .at(now)
+                .payload(event)
+                .build();
+    }
+}

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -17,6 +17,7 @@
 - [Dynamic SQL Queries](sql_queries.md)
 - [Events](events.md)
 - [Metrics](metrics.md)
+- [Policy Monitor](policy-monitor.md)
 - [State Machine](state-machine.md)
 
 
@@ -24,5 +25,5 @@
 > [Decision Records](decision-records/README.md). Therefore, during implementation, please refer to the dedicated
 > [style guide](https://github.com/eclipse-edc/.github/blob/main/contributing/styleguide.md) and
 > [contribution guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md), and the patterns we
-> documented in [architecture principles](https://github.com/eclipse-edc/.github/blob/main/contributing/coding-principles.md).
+> documented in [coding principles](https://github.com/eclipse-edc/.github/blob/main/contributing/coding-principles.md).
 > _Make sure to continuously check and extend the list._

--- a/docs/developer/policy-monitor.md
+++ b/docs/developer/policy-monitor.md
@@ -1,0 +1,28 @@
+# Policy Monitor
+
+The Policy Monitor is one EDC connector module that permits to continuously enforce policies on running Transfer Processes.
+
+## Overview
+
+Not finite transfers like streaming flows, that are started but, in fact, technically they don't complete, need to be
+under control to ensure that they don't continue transferring data also when the contract policy is not valid anymore.
+
+The Policy Monitor takes care of that, it's implemented as a State Machine, that starts when a new provider Transfer Process
+gets started, continuously loop and evaluate the contract policy using the Policy Engine.
+In the very moment that the Policy is not valid anymore, the Policy Monitor completes the Transfer Process.
+
+## Embedded deployment
+To deploy the Policy Monitor embedded in the control-plane requires to add the `policy-monitor-core` extension
+to the bundle.
+
+The Policy Monitor state machine can be configured in the same way other state machines are configured, using these properties:
+```
+edc.policy.monitor.state-machine.iteration-wait-millis
+edc.policy.monitor.state-machine.batch-size
+```
+
+Take a look at the [performance tuning page](performance-tuning.md) for further details.
+
+## Standalone deployment
+
+[Not implemented yet](https://github.com/eclipse-edc/Connector/issues/3446)

--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/test/system/utils/PolicyFixtures.java
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/test/system/utils/PolicyFixtures.java
@@ -30,22 +30,37 @@ import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 public class PolicyFixtures {
 
     private static final String CONTRACT_EXPIRY_EVALUATION_KEY = EDC_NAMESPACE + "inForceDate";
+    private static final String ODRL_JSONLD = "http://www.w3.org/ns/odrl.jsonld";
 
     private PolicyFixtures() {
     }
 
     public static JsonObject noConstraintPolicy() {
         return createObjectBuilder()
-                .add(CONTEXT, "http://www.w3.org/ns/odrl.jsonld")
+                .add(CONTEXT, ODRL_JSONLD)
                 .add(TYPE, "use")
                 .build();
     }
 
     public static JsonObject policy(List<JsonObject> permissions) {
         return createObjectBuilder()
-                .add(CONTEXT, "http://www.w3.org/ns/odrl.jsonld")
+                .add(CONTEXT, ODRL_JSONLD)
                 .add("permission", createArrayBuilder(permissions))
                 .build();
+    }
+
+    /**
+     * Create a policy with "inForceDate" permissions, to enforce contract date being in a certain range.
+     * Please check the ContractExpiryCheckFunction documentation for details.
+     *
+     * @param operatorStart the operator used for the start date.
+     * @param startDate the start date.
+     * @param operatorEnd the operator used for the end date.
+     * @param endDate the end date.
+     * @return the policy json-ld representation object.
+     */
+    public static JsonObject inForceDatePolicy(String operatorStart, Object startDate, String operatorEnd, Object endDate) {
+        return policy(List.of(inForceDatePermission(operatorStart, startDate, operatorEnd, endDate)));
     }
 
     public static JsonObject atomicConstraint(String leftOperand, String operator, Object rightOperand) {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -63,6 +63,8 @@ include(":core:data-plane:data-plane-core")
 
 include(":core:data-plane-selector:data-plane-selector-core")
 
+include(":core:policy-monitor:policy-monitor-core")
+
 // modules that provide implementations for data ingress/egress ------------------------------------
 include(":data-protocols:dsp:dsp-api-configuration")
 include(":data-protocols:dsp:dsp-catalog")
@@ -200,6 +202,7 @@ include(":spi:data-plane:data-plane-spi")
 include(":spi:data-plane:data-plane-http-spi")
 
 include(":spi:data-plane-selector:data-plane-selector-spi")
+include(":spi:policy-monitor:policy-monitor-spi")
 
 // modules for system tests ------------------------------------------------------------------------
 include(":system-tests:e2e-transfer-test:backend-service")

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/entity/StateEntityManager.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/entity/StateEntityManager.java
@@ -15,7 +15,7 @@
 package org.eclipse.edc.spi.entity;
 
 /**
- * Is a long-running process that takes care of managing entity and their status.
+ * A long-running process that manages entities and their states
  */
 public interface StateEntityManager {
 

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/entity/StateEntityManager.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/entity/StateEntityManager.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.spi.entity;
+
+/**
+ * Is a long-running process that takes care of managing entity and their status.
+ */
+public interface StateEntityManager {
+
+    /**
+     * start the manager.
+     */
+    void start();
+
+    /**
+     * stop the manager.
+     */
+    void stop();
+}

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/negotiation/ConsumerContractNegotiationManager.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/negotiation/ConsumerContractNegotiationManager.java
@@ -18,6 +18,7 @@ package org.eclipse.edc.connector.contract.spi.negotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
+import org.eclipse.edc.spi.entity.StateEntityManager;
 import org.eclipse.edc.spi.response.StatusResult;
 
 /**
@@ -26,7 +27,7 @@ import org.eclipse.edc.spi.response.StatusResult;
  * All operations are idempotent.
  */
 @ExtensionPoint
-public interface ConsumerContractNegotiationManager {
+public interface ConsumerContractNegotiationManager extends StateEntityManager {
 
     /**
      * Initiates a contract negotiation for the given provider offer. The offer will have been obtained from a previous contract offer request sent to the provider.

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/negotiation/ProviderContractNegotiationManager.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/negotiation/ProviderContractNegotiationManager.java
@@ -16,6 +16,7 @@
 package org.eclipse.edc.connector.contract.spi.negotiation;
 
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
+import org.eclipse.edc.spi.entity.StateEntityManager;
 
 /**
  * Manages contract negotiations on the provider.
@@ -24,6 +25,6 @@ import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
  */
 
 @ExtensionPoint
-public interface ProviderContractNegotiationManager {
+public interface ProviderContractNegotiationManager extends StateEntityManager {
 
 }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/TransferProcessManager.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/TransferProcessManager.java
@@ -17,13 +17,14 @@ package org.eclipse.edc.connector.transfer.spi;
 import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.connector.transfer.spi.types.TransferRequest;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
+import org.eclipse.edc.spi.entity.StateEntityManager;
 import org.eclipse.edc.spi.response.StatusResult;
 
 /**
  * Manages data transfer processes. Currently synchronous and asynchronous data transfers are supported.
  */
 @ExtensionPoint
-public interface TransferProcessManager {
+public interface TransferProcessManager extends StateEntityManager {
 
     /**
      * Initiates a data transfer process on the consumer.

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/event/TransferProcessStarted.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/event/TransferProcessStarted.java
@@ -25,8 +25,9 @@ import org.eclipse.edc.spi.types.domain.DataAddress;
 @JsonDeserialize(builder = TransferProcessStarted.Builder.class)
 public class TransferProcessStarted extends TransferProcessEvent {
 
-
     private DataAddress dataAddress;
+    private String contractId;
+    private String type;
 
     private TransferProcessStarted() {
     }
@@ -38,6 +39,14 @@ public class TransferProcessStarted extends TransferProcessEvent {
     @Override
     public String name() {
         return "transfer.process.started";
+    }
+
+    public String getContractId() {
+        return contractId;
+    }
+
+    public String getType() {
+        return type;
     }
 
     @JsonPOJOBuilder(withPrefix = "")
@@ -54,6 +63,16 @@ public class TransferProcessStarted extends TransferProcessEvent {
 
         public Builder dataAddress(DataAddress dataAddress) {
             event.dataAddress = dataAddress;
+            return this;
+        }
+
+        public Builder contractId(String contractId) {
+            event.contractId = contractId;
+            return this;
+        }
+
+        public Builder type(String type) {
+            event.type = type;
             return this;
         }
 

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/manager/DataPlaneManager.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/manager/DataPlaneManager.java
@@ -18,6 +18,7 @@ import org.eclipse.edc.connector.dataplane.spi.DataFlowStates;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSink;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.StreamResult;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
+import org.eclipse.edc.spi.entity.StateEntityManager;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
 
@@ -48,7 +49,7 @@ import java.util.concurrent.CompletableFuture;
  * </pre>
  */
 @ExtensionPoint
-public interface DataPlaneManager {
+public interface DataPlaneManager extends StateEntityManager {
 
     /**
      * Determines if the data flow request is valid and can be processed by this runtime.

--- a/spi/policy-monitor/policy-monitor-spi/build.gradle.kts
+++ b/spi/policy-monitor/policy-monitor-spi/build.gradle.kts
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(project(":spi:common:core-spi"))
+}
+
+
+

--- a/spi/policy-monitor/policy-monitor-spi/src/main/java/org/eclipse/edc/connector/policy/monitor/spi/PolicyMonitorEntry.java
+++ b/spi/policy-monitor/policy-monitor-spi/src/main/java/org/eclipse/edc/connector/policy/monitor/spi/PolicyMonitorEntry.java
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.policy.monitor.spi;
+
+import org.eclipse.edc.spi.entity.StatefulEntity;
+
+import static org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntryStates.COMPLETED;
+import static org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntryStates.FAILED;
+import static org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntryStates.STARTED;
+
+public class PolicyMonitorEntry extends StatefulEntity<PolicyMonitorEntry> {
+
+    private String contractId;
+
+    @Override
+    public PolicyMonitorEntry copy() {
+        var builder = Builder.newInstance().contractId(contractId);
+        return copy(builder);
+    }
+
+    @Override
+    public String stateAsString() {
+        return PolicyMonitorEntryStates.from(state).name();
+    }
+
+    public String getContractId() {
+        return contractId;
+    }
+
+    public void transitionToStarted() {
+        transitionTo(STARTED.code());
+    }
+
+    public void transitionToCompleted() {
+        transitionTo(COMPLETED.code());
+    }
+
+    public void transitionToFailed(String errorDetail) {
+        this.errorDetail = errorDetail;
+        transitionTo(FAILED.code());
+    }
+
+    public static class Builder extends StatefulEntity.Builder<PolicyMonitorEntry, Builder> {
+
+        private Builder(PolicyMonitorEntry entity) {
+            super(entity);
+        }
+
+        public static Builder newInstance() {
+            return new Builder(new PolicyMonitorEntry());
+        }
+
+        public Builder contractId(String contractId) {
+            entity.contractId = contractId;
+            return this;
+        }
+
+        @Override
+        public Builder self() {
+            return this;
+        }
+
+        @Override
+        public PolicyMonitorEntry build() {
+            return super.build();
+        }
+    }
+}

--- a/spi/policy-monitor/policy-monitor-spi/src/main/java/org/eclipse/edc/connector/policy/monitor/spi/PolicyMonitorEntry.java
+++ b/spi/policy-monitor/policy-monitor-spi/src/main/java/org/eclipse/edc/connector/policy/monitor/spi/PolicyMonitorEntry.java
@@ -20,6 +20,9 @@ import static org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntrySta
 import static org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntryStates.FAILED;
 import static org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntryStates.STARTED;
 
+/**
+ * Entity that represent a transfer process into the Policy Monitor context.
+ */
 public class PolicyMonitorEntry extends StatefulEntity<PolicyMonitorEntry> {
 
     private String contractId;

--- a/spi/policy-monitor/policy-monitor-spi/src/main/java/org/eclipse/edc/connector/policy/monitor/spi/PolicyMonitorEntryStates.java
+++ b/spi/policy-monitor/policy-monitor-spi/src/main/java/org/eclipse/edc/connector/policy/monitor/spi/PolicyMonitorEntryStates.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.policy.monitor.spi;
+
+import java.util.Arrays;
+
+public enum PolicyMonitorEntryStates {
+    STARTED(100),
+    COMPLETED(200),
+    FAILED(300);
+
+    private final int code;
+
+    PolicyMonitorEntryStates(int code) {
+        this.code = code;
+    }
+
+    public static PolicyMonitorEntryStates from(int code) {
+        return Arrays.stream(values()).filter(tps -> tps.code == code).findFirst().orElse(null);
+    }
+
+    public int code() {
+        return code;
+    }
+}

--- a/spi/policy-monitor/policy-monitor-spi/src/main/java/org/eclipse/edc/connector/policy/monitor/spi/PolicyMonitorEntryStates.java
+++ b/spi/policy-monitor/policy-monitor-spi/src/main/java/org/eclipse/edc/connector/policy/monitor/spi/PolicyMonitorEntryStates.java
@@ -16,6 +16,9 @@ package org.eclipse.edc.connector.policy.monitor.spi;
 
 import java.util.Arrays;
 
+/**
+ * States for the {@link PolicyMonitorEntry} entity.
+ */
 public enum PolicyMonitorEntryStates {
     STARTED(100),
     COMPLETED(200),

--- a/spi/policy-monitor/policy-monitor-spi/src/main/java/org/eclipse/edc/connector/policy/monitor/spi/PolicyMonitorManager.java
+++ b/spi/policy-monitor/policy-monitor-spi/src/main/java/org/eclipse/edc/connector/policy/monitor/spi/PolicyMonitorManager.java
@@ -17,8 +17,7 @@ package org.eclipse.edc.connector.policy.monitor.spi;
 import org.eclipse.edc.spi.entity.StateEntityManager;
 
 /**
- * Takes care to iterate over the ongoing transfers verifying their policy, completing them whenever the policy
- * cannot be evaluated anymore.
+ * Iterates over ongoing transfers, verifying their policies and completing when the policy can no longer be evaluated.
  */
 public interface PolicyMonitorManager extends StateEntityManager {
 

--- a/spi/policy-monitor/policy-monitor-spi/src/main/java/org/eclipse/edc/connector/policy/monitor/spi/PolicyMonitorManager.java
+++ b/spi/policy-monitor/policy-monitor-spi/src/main/java/org/eclipse/edc/connector/policy/monitor/spi/PolicyMonitorManager.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.policy.monitor.spi;
+
+import org.eclipse.edc.spi.entity.StateEntityManager;
+
+/**
+ * Takes care to iterate over the ongoing transfers verifying their policy, completing them whenever the policy
+ * cannot be evaluated anymore.
+ */
+public interface PolicyMonitorManager extends StateEntityManager {
+
+    /**
+     * Start to monitor a transfer process to ensure that
+     *
+     * @param transferProcessId the transfer process id
+     * @param contractId the contract id
+     */
+    void startMonitoring(String transferProcessId, String contractId);
+}

--- a/spi/policy-monitor/policy-monitor-spi/src/main/java/org/eclipse/edc/connector/policy/monitor/spi/PolicyMonitorStore.java
+++ b/spi/policy-monitor/policy-monitor-spi/src/main/java/org/eclipse/edc/connector/policy/monitor/spi/PolicyMonitorStore.java
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.policy.monitor.spi;
+
+import org.eclipse.edc.spi.persistence.StateEntityStore;
+
+public interface PolicyMonitorStore extends StateEntityStore<PolicyMonitorEntry> {
+}

--- a/system-tests/e2e-transfer-test/control-plane/build.gradle.kts
+++ b/system-tests/e2e-transfer-test/control-plane/build.gradle.kts
@@ -36,6 +36,8 @@ dependencies {
     implementation(project(":extensions:control-plane:transfer:transfer-pull-http-receiver"))
     implementation(project(":extensions:control-plane:transfer:transfer-pull-http-dynamic-receiver"))
     implementation(project(":extensions:common:api:management-api-configuration"))
+
+    implementation(project(":core:policy-monitor:policy-monitor-core"))
 }
 
 edcBuild {

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/AbstractEndToEndTransfer.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/AbstractEndToEndTransfer.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -37,9 +36,8 @@ import static org.eclipse.edc.connector.transfer.spi.types.TransferProcessStates
 import static org.eclipse.edc.connector.transfer.spi.types.TransferProcessStates.TERMINATED;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
-import static org.eclipse.edc.test.system.utils.PolicyFixtures.inForceDatePermission;
+import static org.eclipse.edc.test.system.utils.PolicyFixtures.inForceDatePolicy;
 import static org.eclipse.edc.test.system.utils.PolicyFixtures.noConstraintPolicy;
-import static org.eclipse.edc.test.system.utils.PolicyFixtures.policy;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.is;
@@ -91,7 +89,7 @@ public abstract class AbstractEndToEndTransfer {
         var now = Instant.now();
 
         // contract was valid from t-10d to t-5d, so "now" it is expired
-        var contractPolicy = inForcePolicy("gteq", now.minus(ofDays(10)), "lteq", now.minus(ofDays(5)));
+        var contractPolicy = inForceDatePolicy("gteq", now.minus(ofDays(10)), "lteq", now.minus(ofDays(5)));
         createResourcesOnProvider(assetId, contractPolicy, httpDataAddressProperties());
 
         var transferProcessId = CONSUMER.requestAsset(PROVIDER, assetId, noPrivateProperty(), syncDataAddress());
@@ -107,7 +105,7 @@ public abstract class AbstractEndToEndTransfer {
         var assetId = UUID.randomUUID().toString();
         var now = Instant.now();
         // contract was valid from t-10d to t-5d, so "now" it is expired
-        var contractPolicy = inForcePolicy("gteq", now.minus(ofDays(10)), "lteq", "contractAgreement+1s");
+        var contractPolicy = inForceDatePolicy("gteq", now.minus(ofDays(10)), "lteq", "contractAgreement+1s");
         createResourcesOnProvider(assetId, contractPolicy, httpDataAddressProperties());
 
         var transferProcessId = CONSUMER.requestAsset(PROVIDER, assetId, noPrivateProperty(), syncDataAddress());
@@ -233,10 +231,6 @@ public abstract class AbstractEndToEndTransfer {
         var accessPolicyId = PROVIDER.createPolicyDefinition(noConstraintPolicy());
         var contractPolicyId = PROVIDER.createPolicyDefinition(contractPolicy);
         PROVIDER.createContractDefinition(assetId, UUID.randomUUID().toString(), accessPolicyId, contractPolicyId);
-    }
-
-    private JsonObject inForcePolicy(String operatorStart, Object startDate, String operatorEnd, Object endDate) {
-        return policy(List.of(inForceDatePermission(operatorStart, startDate, operatorEnd, endDate)));
     }
 
     private JsonObject noPrivateProperty() {

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/participant/EndToEndTransferParticipant.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/participant/EndToEndTransferParticipant.java
@@ -29,6 +29,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -148,12 +149,16 @@ public class EndToEndTransferParticipant extends Participant {
     }
 
     public void registerDataPlane() {
+        registerDataPlane(Set.of("HttpData", "HttpProvision", "Kafka"), Set.of("HttpData", "HttpProvision", "HttpProxy", "Kafka"));
+    }
+
+    public void registerDataPlane(Set<String> sources, Set<String> destinations) {
         var jsonObject = Json.createObjectBuilder()
                 .add(CONTEXT, createObjectBuilder().add(EDC_PREFIX, EDC_NAMESPACE))
                 .add(ID, UUID.randomUUID().toString())
                 .add(EDC_NAMESPACE + "url", dataPlaneControl + "/transfer")
-                .add(EDC_NAMESPACE + "allowedSourceTypes", createArrayBuilder(List.of("HttpData", "HttpProvision", "Kafka")))
-                .add(EDC_NAMESPACE + "allowedDestTypes", createArrayBuilder(List.of("HttpData", "HttpProvision", "HttpProxy", "Kafka")))
+                .add(EDC_NAMESPACE + "allowedSourceTypes", createArrayBuilder(sources))
+                .add(EDC_NAMESPACE + "allowedDestTypes", createArrayBuilder(destinations))
                 .add(EDC_NAMESPACE + "properties", createObjectBuilder().add("publicApiUrl", dataPlanePublic.toString()))
                 .build();
 


### PR DESCRIPTION
## What this PR changes/adds

Implements the first version of the `PolicyMonitor`: embedded in the controlplane, with in-memory storage

## Why it does that

streaming data transfer

## Further notes

- extracted a `StateManager` hierarchy, that permits to avoid some duplication, this can be pushed a little further, will do it in the subsequent PRs
- the `EndToEndKafkaTransferTest` is showing the PolicyMonitor in action, defining a policy that expires in 10s, the transfer gets completed. there still is a missing part to actually shut down the data flow, described in this issue: #3453 
- the `InMemoryPolicyMonitorStore` is not tested as it is a simple wrapper of the `InMemoryStatefulEntityStore`, tests will be added with the implementation of the Sql storage (#3447 )

## Linked Issue(s)

Closes #3445

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
