### PR TITLE
fix: update DataAddress in SqlAssetIndex

### DIFF
--- a/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/assetindex/SqlAssetIndex.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/assetindex/SqlAssetIndex.java
@@ -180,6 +180,8 @@ public class SqlAssetIndex extends AbstractSqlStore implements AssetIndex {
                 if (existsById(assetId, connection)) {
                     queryExecutor.execute(connection, assetStatements.getDeletePropertyByIdTemplate(), assetId);
                     insertProperties(asset, assetId, connection);
+                    var updateTemplate = assetStatements.getUpdateDataAddressTemplate();
+                    queryExecutor.execute(connection, updateTemplate, toJson(asset.getDataAddress().getProperties()), assetId);
                     return StoreResult.success(asset);
                 }
                 return StoreResult.notFound(format(ASSET_NOT_FOUND_TEMPLATE, assetId));

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/asset/AssetIndex.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/asset/AssetIndex.java
@@ -100,7 +100,7 @@ public interface AssetIndex extends DataAddressResolver {
      * Stores a {@link Asset} in the asset index, if no asset with the same ID already exists.
      * Implementors must ensure that it's stored in a transactional way.
      *
-     * @param asset       The {@link Asset} to store
+     * @param asset The {@link Asset} to store
      * @return {@link StoreResult#success()} if the objects were stored, {@link StoreResult#alreadyExists(String)} when an object with the same ID already exists.
      */
     default StoreResult<Void> create(Asset asset) {
@@ -139,6 +139,8 @@ public interface AssetIndex extends DataAddressResolver {
      * @param assetId     the database of the Asset to update
      * @param dataAddress The DataAddress containing the new values.
      * @return {@link StoreResult#success(Object)} if the object was updated, {@link StoreResult#notFound(String)} when an object with that ID was not found.
+     * @deprecated Updating only the DataAddress is deprecated and will be removed in future releases. Please use the {@link AssetIndex#updateAsset(Asset)} method.
      */
+    @Deprecated(forRemoval = true)
     StoreResult<DataAddress> updateDataAddress(String assetId, DataAddress dataAddress);
 }


### PR DESCRIPTION
## What this PR changes/adds

Adds an update statement for the DataAddress to the `SqlAssetIndex` whenever the Asset is updated.

## Why it does that

DataAddresses could only be updated through a separate method on the AssetIndex, which was never invoked through the v3 AssetApiController.

## Further notes

.
## Linked Issue(s)

Closes #3469 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
