### PR TITLE
docs: add link to "build your own connector" in docs/developer/README.md

### DIFF
--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -8,6 +8,7 @@
 - [Performance Tuning](performance-tuning.md)
 
 ## Build and testing
+- [Build your own connector](build-your-own-connector.md)
 - [OpenApi Spec Generation](openapi.md)
 - [Cloud Testing](cloud_testing.md)
 


### PR DESCRIPTION
## What this PR changes/adds

This PR adds a link to the already existing documentation about how to build your own connector in the developer documentation. 

## Why it does that

The documentation is very valuable for newcomers, but hard to find. Furthermore, it is not accessible on github pages.

