### PR TITLE
docs: add control api endpoint 

### DIFF
--- a/extensions/common/api/control-api-configuration/README.md
+++ b/extensions/common/api/control-api-configuration/README.md
@@ -10,4 +10,8 @@ Exemplary configuration:
 ```properties
 web.http.control.port=9191
 web.http.control.path=/api/v1/control
+edc.control.endpoint=<control-api-endpoint>
 ```
+
+The `edc.control.endpoint` will be used by the data plane to notify the control plane when data transfer completes or
+fails.  

--- a/extensions/control-plane/api/control-plane-api-client/src/main/java/org/eclipse/edc/connector/api/client/ControlPlaneApiClientExtension.java
+++ b/extensions/control-plane/api/control-plane-api-client/src/main/java/org/eclipse/edc/connector/api/client/ControlPlaneApiClientExtension.java
@@ -20,7 +20,6 @@ import org.eclipse.edc.connector.api.client.transferprocess.model.TransferProces
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
-import org.eclipse.edc.runtime.metamodel.annotation.Provides;
 import org.eclipse.edc.spi.http.EdcHttpClient;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
@@ -31,7 +30,6 @@ import org.eclipse.edc.spi.types.TypeManager;
  * Extensions that contains clients for Control Plane HTTP APIs
  */
 @Extension(value = ControlPlaneApiClientExtension.NAME)
-@Provides(TransferProcessApiClient.class)
 public class ControlPlaneApiClientExtension implements ServiceExtension {
 
     public static final String NAME = "Control Plane HTTP API client";


### PR DESCRIPTION
## What this PR changes/adds

Adds docs for `edc.control.endpoint` which is needed for notify the CP once the transfer has finished at the DP level.

## Why it does that

documentation

## Further notes

Removes also `@Provides(TransferProcessApiClient.class)` not needed since there is a `Provider` annotation.
