### PR TITLE
fix(api): add `baseUrl` to asset examples for v3 API

### DIFF
--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/v3/AssetApi.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/v3/AssetApi.java
@@ -123,6 +123,7 @@ public interface AssetApi {
                     },
                     "dataAddress": {
                         "type": "HttpData"
+                        "baseUrl": "https://jsonplaceholder.typicode.com/todos"
                     }
                 }
                 """;
@@ -152,6 +153,7 @@ public interface AssetApi {
                     },
                     "edc:dataAddress": {
                         "edc:type": "HttpData"
+                        "edc:baseUrl": "https://jsonplaceholder.typicode.com/todos"
                     },
                     "edc:createdAt": 1688465655
                 }

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/v3/AssetApi.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/v3/AssetApi.java
@@ -122,7 +122,7 @@ public interface AssetApi {
                         "privateKey": "privateValue"
                     },
                     "dataAddress": {
-                        "type": "HttpData"
+                        "type": "HttpData",
                         "baseUrl": "https://jsonplaceholder.typicode.com/todos"
                     }
                 }
@@ -152,7 +152,7 @@ public interface AssetApi {
                         "edc:privateKey": "privateValue"
                     },
                     "edc:dataAddress": {
-                        "edc:type": "HttpData"
+                        "edc:type": "HttpData",
                         "edc:baseUrl": "https://jsonplaceholder.typicode.com/todos"
                     },
                     "edc:createdAt": 1688465655


### PR DESCRIPTION
## What this PR changes/adds

Adds `baseUrl` to the input/output examples for the creation of an asset in the v3 API.

## Why it does that

Current example will be rejected with a `400 Bad Request`

## Linked Issue(s)

Closes #3476 
