### PR TITLE
feat: add configurable JSON-LD namespaces/context for each scope

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -319,7 +319,7 @@ maven/mavencentral/org.testcontainers/jdbc/1.19.1, Apache-2.0, approved, #10348
 maven/mavencentral/org.testcontainers/junit-jupiter/1.19.1, MIT, approved, #10344
 maven/mavencentral/org.testcontainers/postgresql/1.19.1, MIT, approved, #10350
 maven/mavencentral/org.testcontainers/testcontainers/1.19.1, Apache-2.0 AND MIT, approved, #10347
-maven/mavencentral/org.testcontainers/vault/1.19.1, None, restricted, #10852
+maven/mavencentral/org.testcontainers/vault/1.19.1, MIT, approved, #10852
 maven/mavencentral/org.xerial.snappy/snappy-java/1.1.10.4, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #9098
 maven/mavencentral/org.xmlunit/xmlunit-core/2.9.1, Apache-2.0, approved, #6272
 maven/mavencentral/org.xmlunit/xmlunit-placeholders/2.9.1, Apache-2.0, approved, clearlydefined

--- a/core/common/jersey-providers/src/main/java/org/eclipse/edc/web/jersey/jsonld/JerseyJsonLdInterceptor.java
+++ b/core/common/jersey-providers/src/main/java/org/eclipse/edc/web/jersey/jsonld/JerseyJsonLdInterceptor.java
@@ -37,9 +37,12 @@ public class JerseyJsonLdInterceptor implements ReaderInterceptor, WriterInterce
     private final JsonLd jsonLd;
     private final ObjectMapper objectMapper;
 
-    public JerseyJsonLdInterceptor(JsonLd jsonLd, ObjectMapper objectMapper) {
+    private final String scope;
+
+    public JerseyJsonLdInterceptor(JsonLd jsonLd, ObjectMapper objectMapper, String scope) {
         this.jsonLd = jsonLd;
         this.objectMapper = objectMapper;
+        this.scope = scope;
     }
 
     @Override
@@ -80,7 +83,7 @@ public class JerseyJsonLdInterceptor implements ReaderInterceptor, WriterInterce
     }
 
     private JsonObject compact(JsonObject jsonObject) {
-        return jsonLd.compact(jsonObject)
+        return jsonLd.compact(jsonObject, scope)
                 .orElseThrow(f -> new InternalServerErrorException("Failed to compact JsonObject: " + f.getFailureDetail()));
     }
 }

--- a/data-protocols/dsp/dsp-api-configuration/src/main/java/org/eclipse/edc/protocol/dsp/api/configuration/DspApiConfigurationExtension.java
+++ b/data-protocols/dsp/dsp-api-configuration/src/main/java/org/eclipse/edc/protocol/dsp/api/configuration/DspApiConfigurationExtension.java
@@ -58,6 +58,15 @@ import org.eclipse.edc.web.spi.configuration.WebServiceSettings;
 
 import java.util.Map;
 
+import static org.eclipse.edc.jsonld.spi.Namespaces.DCAT_PREFIX;
+import static org.eclipse.edc.jsonld.spi.Namespaces.DCAT_SCHEMA;
+import static org.eclipse.edc.jsonld.spi.Namespaces.DCT_PREFIX;
+import static org.eclipse.edc.jsonld.spi.Namespaces.DCT_SCHEMA;
+import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_PREFIX;
+import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+import static org.eclipse.edc.policy.model.OdrlNamespace.ODRL_PREFIX;
+import static org.eclipse.edc.policy.model.OdrlNamespace.ODRL_SCHEMA;
+import static org.eclipse.edc.protocol.dsp.type.DspConstants.DSP_SCOPE;
 import static org.eclipse.edc.spi.CoreConstants.JSON_LD;
 
 /**
@@ -87,28 +96,20 @@ public class DspApiConfigurationExtension implements ServiceExtension {
             .defaultPort(DEFAULT_PROTOCOL_PORT)
             .name("Protocol API")
             .build();
-
     @Inject
     private TypeManager typeManager;
-
     @Inject
     private WebService webService;
-
     @Inject
     private WebServer webServer;
-
     @Inject
     private WebServiceConfigurer configurator;
-
     @Inject
     private JsonLd jsonLd;
-
     @Inject
     private TypeTransformerRegistry transformerRegistry;
-
     @Inject
     private IdentityService identityService;
-
     @Inject
     private JsonObjectValidatorRegistry validatorRegistry;
 
@@ -126,8 +127,16 @@ public class DspApiConfigurationExtension implements ServiceExtension {
         context.registerService(DspRequestHandler.class, new DspRequestHandlerImpl(context.getMonitor(), dspWebhookAddress, identityService, validatorRegistry, transformerRegistry));
 
         var jsonLdMapper = typeManager.getMapper(JSON_LD);
+
+
+        // registers ns for DSP scope
+        jsonLd.registerNamespace(DCAT_PREFIX, DCAT_SCHEMA, DSP_SCOPE);
+        jsonLd.registerNamespace(DCT_PREFIX, DCT_SCHEMA, DSP_SCOPE);
+        jsonLd.registerNamespace(ODRL_PREFIX, ODRL_SCHEMA, DSP_SCOPE);
+        jsonLd.registerNamespace(DSPACE_PREFIX, DSPACE_SCHEMA, DSP_SCOPE);
+
         webService.registerResource(config.getContextAlias(), new ObjectMapperProvider(jsonLdMapper));
-        webService.registerResource(config.getContextAlias(), new JerseyJsonLdInterceptor(jsonLd, jsonLdMapper));
+        webService.registerResource(config.getContextAlias(), new JerseyJsonLdInterceptor(jsonLd, jsonLdMapper, DSP_SCOPE));
 
         registerTransformers();
     }

--- a/data-protocols/dsp/dsp-http-core/build.gradle.kts
+++ b/data-protocols/dsp/dsp-http-core/build.gradle.kts
@@ -21,7 +21,8 @@ dependencies {
     api(project(":spi:common:json-ld-spi"))
     api(project(":spi:control-plane:transfer-spi"))
     api(project(":extensions:common:json-ld"))
+    api(project(":data-protocols:dsp:dsp-spi"))
     api(project(":data-protocols:dsp:dsp-http-spi"))
-
+    
     testImplementation(project(":core:common:junit"))
 }

--- a/data-protocols/dsp/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/DspHttpCoreExtension.java
+++ b/data-protocols/dsp/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/DspHttpCoreExtension.java
@@ -46,6 +46,7 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 
+import static org.eclipse.edc.protocol.dsp.type.DspConstants.DSP_SCOPE;
 import static org.eclipse.edc.spi.CoreConstants.JSON_LD;
 
 /**
@@ -118,7 +119,7 @@ public class DspHttpCoreExtension implements ServiceExtension {
 
     @Provider
     public JsonLdRemoteMessageSerializer jsonLdRemoteMessageSerializer() {
-        return new JsonLdRemoteMessageSerializerImpl(transformerRegistry, typeManager.getMapper(JSON_LD), jsonLdService);
+        return new JsonLdRemoteMessageSerializerImpl(transformerRegistry, typeManager.getMapper(JSON_LD), jsonLdService, DSP_SCOPE);
     }
 
     private void registerNegotiationPolicyScopes(DspHttpRemoteMessageDispatcher dispatcher) {

--- a/data-protocols/dsp/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/serialization/JsonLdRemoteMessageSerializerImpl.java
+++ b/data-protocols/dsp/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/serialization/JsonLdRemoteMessageSerializerImpl.java
@@ -35,10 +35,13 @@ public class JsonLdRemoteMessageSerializerImpl implements JsonLdRemoteMessageSer
     private final ObjectMapper mapper;
     private final JsonLd jsonLdService;
 
-    public JsonLdRemoteMessageSerializerImpl(TypeTransformerRegistry registry, ObjectMapper mapper, JsonLd jsonLdService) {
+    private final String scope;
+
+    public JsonLdRemoteMessageSerializerImpl(TypeTransformerRegistry registry, ObjectMapper mapper, JsonLd jsonLdService, String scope) {
         this.registry = registry;
         this.mapper = mapper;
         this.jsonLdService = jsonLdService;
+        this.scope = scope;
     }
 
     /**
@@ -55,7 +58,7 @@ public class JsonLdRemoteMessageSerializerImpl implements JsonLdRemoteMessageSer
             var transformResult = registry.transform(message, JsonObject.class);
 
             if (transformResult.succeeded()) {
-                var compacted = jsonLdService.compact(transformResult.getContent());
+                var compacted = jsonLdService.compact(transformResult.getContent(), scope);
                 if (compacted.succeeded()) {
                     return mapper.writeValueAsString(compacted.getContent());
                 }

--- a/data-protocols/dsp/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/serialization/JsonLdRemoteMessageSerializerImplTest.java
+++ b/data-protocols/dsp/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/serialization/JsonLdRemoteMessageSerializerImplTest.java
@@ -42,13 +42,12 @@ class JsonLdRemoteMessageSerializerImplTest {
     private final ObjectMapper mapper = mock(ObjectMapper.class);
     private final RemoteMessage message = mock(RemoteMessage.class);
     private JsonLdRemoteMessageSerializerImpl serializer;
-    private TitaniumJsonLd jsonLdService;
 
     @BeforeEach
     void setUp() {
-        jsonLdService = new TitaniumJsonLd(mock(Monitor.class));
+        var jsonLdService = new TitaniumJsonLd(mock(Monitor.class));
         jsonLdService.registerNamespace("schema", "http://schema/"); //needed for compaction
-        serializer = new JsonLdRemoteMessageSerializerImpl(registry, mapper, jsonLdService);
+        serializer = new JsonLdRemoteMessageSerializerImpl(registry, mapper, jsonLdService, "scope");
     }
 
     @Test

--- a/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/type/DspConstants.java
+++ b/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/type/DspConstants.java
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.type;
+
+/**
+ * Dataspace protocol constants.
+ */
+public interface DspConstants {
+    String DSP_SCOPE = "DSP";
+}

--- a/extensions/common/api/management-api-configuration/src/main/java/org/eclipse/edc/connector/api/management/configuration/ManagementApiConfigurationExtension.java
+++ b/extensions/common/api/management-api-configuration/src/main/java/org/eclipse/edc/connector/api/management/configuration/ManagementApiConfigurationExtension.java
@@ -40,6 +40,8 @@ import org.eclipse.edc.web.spi.configuration.WebServiceSettings;
 
 import java.util.Map;
 
+import static org.eclipse.edc.policy.model.OdrlNamespace.ODRL_PREFIX;
+import static org.eclipse.edc.policy.model.OdrlNamespace.ODRL_SCHEMA;
 import static org.eclipse.edc.spi.CoreConstants.JSON_LD;
 
 /**
@@ -62,25 +64,19 @@ public class ManagementApiConfigurationExtension implements ServiceExtension {
             .useDefaultContext(true)
             .name(WEB_SERVICE_NAME)
             .build();
-
+    private static final String MANAGEMENT_SCOPE = "MANAGEMENT_API";
     @Inject
     private WebService webService;
-
     @Inject
     private WebServer webServer;
-
     @Inject
     private AuthenticationService authenticationService;
-
     @Inject
     private WebServiceConfigurer configurator;
-
     @Inject
     private TypeManager typeManager;
-
     @Inject
     private JsonLd jsonLd;
-
     @Inject
     private TypeTransformerRegistry transformerRegistry;
 
@@ -96,9 +92,10 @@ public class ManagementApiConfigurationExtension implements ServiceExtension {
         context.registerService(ManagementApiConfiguration.class, new ManagementApiConfiguration(webServiceConfiguration));
         webService.registerResource(webServiceConfiguration.getContextAlias(), new AuthenticationRequestFilter(authenticationService));
 
+        jsonLd.registerNamespace(ODRL_PREFIX, ODRL_SCHEMA, MANAGEMENT_SCOPE);
         var jsonLdMapper = typeManager.getMapper(JSON_LD);
         webService.registerResource(webServiceConfiguration.getContextAlias(), new ObjectMapperProvider(jsonLdMapper));
-        webService.registerResource(webServiceConfiguration.getContextAlias(), new JerseyJsonLdInterceptor(jsonLd, jsonLdMapper));
+        webService.registerResource(webServiceConfiguration.getContextAlias(), new JerseyJsonLdInterceptor(jsonLd, jsonLdMapper, MANAGEMENT_SCOPE));
     }
 
     @Provider

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/JsonLdExtension.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/JsonLdExtension.java
@@ -34,14 +34,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 import static java.lang.String.format;
-import static org.eclipse.edc.jsonld.spi.Namespaces.DCAT_PREFIX;
-import static org.eclipse.edc.jsonld.spi.Namespaces.DCAT_SCHEMA;
-import static org.eclipse.edc.jsonld.spi.Namespaces.DCT_PREFIX;
-import static org.eclipse.edc.jsonld.spi.Namespaces.DCT_SCHEMA;
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_PREFIX;
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
-import static org.eclipse.edc.policy.model.OdrlNamespace.ODRL_PREFIX;
-import static org.eclipse.edc.policy.model.OdrlNamespace.ODRL_SCHEMA;
 import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 import static org.eclipse.edc.spi.CoreConstants.EDC_PREFIX;
 import static org.eclipse.edc.spi.CoreConstants.JSON_LD;
@@ -89,10 +81,6 @@ public class JsonLdExtension implements ServiceExtension {
         var monitor = context.getMonitor();
         var service = new TitaniumJsonLd(monitor, configuration);
         service.registerNamespace(EDC_PREFIX, EDC_NAMESPACE);
-        service.registerNamespace(DCAT_PREFIX, DCAT_SCHEMA);
-        service.registerNamespace(DCT_PREFIX, DCT_SCHEMA);
-        service.registerNamespace(ODRL_PREFIX, ODRL_SCHEMA);
-        service.registerNamespace(DSPACE_PREFIX, DSPACE_SCHEMA);
 
         getResourceUri("document" + File.separator + "odrl.jsonld")
                 .onSuccess(uri -> service.registerCachedDocument("http://www.w3.org/ns/odrl.jsonld", uri))

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/TitaniumJsonLd.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/TitaniumJsonLd.java
@@ -24,16 +24,24 @@ import com.apicatalog.jsonld.loader.FileLoader;
 import com.apicatalog.jsonld.loader.HttpLoader;
 import com.apicatalog.jsonld.loader.SchemeRouter;
 import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
 import org.eclipse.edc.jsonld.document.JarLoader;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
 
 import java.net.URI;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import static jakarta.json.Json.createArrayBuilder;
 import static jakarta.json.Json.createBuilderFactory;
 import static jakarta.json.Json.createObjectBuilder;
 import static java.util.Optional.ofNullable;
@@ -45,8 +53,13 @@ import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
  * Implementation of the {@link JsonLd} interface that uses the Titanium library for all JSON-LD operations.
  */
 public class TitaniumJsonLd implements JsonLd {
+    private static final Map<String, String> EMPTY_NAMESPACES = Collections.emptyMap();
+
+    private static final Set<String> EMPTY_CONTEXTS = Collections.emptySet();
+
     private final Monitor monitor;
-    private final Map<String, String> additionalNamespaces = new HashMap<>();
+    private final Map<String, Map<String, String>> scopedNamespaces = new HashMap<>();
+    private final Map<String, Set<String>> scopedContexts = new HashMap<>();
     private final CachedDocumentLoader documentLoader;
 
     public TitaniumJsonLd(Monitor monitor) {
@@ -76,14 +89,16 @@ public class TitaniumJsonLd implements JsonLd {
     }
 
     @Override
-    public Result<JsonObject> compact(JsonObject json) {
+    public Result<JsonObject> compact(JsonObject json, String scope) {
         try {
             var document = JsonDocument.of(json);
             var jsonFactory = createBuilderFactory(Map.of());
             var contextDocument = JsonDocument.of(jsonFactory.createObjectBuilder()
-                    .add(CONTEXT, createContextObject())
+                    .add(CONTEXT, createContext(scope))
                     .build());
-            var compacted = com.apicatalog.jsonld.JsonLd.compact(document, contextDocument).get();
+            var compacted = com.apicatalog.jsonld.JsonLd.compact(document, contextDocument)
+                    .options(new JsonLdOptions(documentLoader))
+                    .get();
             return Result.success(compacted);
         } catch (JsonLdError e) {
             monitor.warning("Error compacting JSON-LD structure", e);
@@ -92,8 +107,15 @@ public class TitaniumJsonLd implements JsonLd {
     }
 
     @Override
-    public void registerNamespace(String prefix, String contextIri) {
-        additionalNamespaces.put(prefix, contextIri);
+    public void registerNamespace(String prefix, String contextIri, String scope) {
+        var namespaces = scopedNamespaces.computeIfAbsent(scope, k -> new LinkedHashMap<>());
+        namespaces.put(prefix, contextIri);
+    }
+
+    @Override
+    public void registerContext(String contextIri, String scope) {
+        var contexts = scopedContexts.computeIfAbsent(scope, k -> new LinkedHashSet<>());
+        contexts.add(contextIri);
     }
 
     @Override
@@ -118,10 +140,39 @@ public class TitaniumJsonLd implements JsonLd {
         return jsonObjectBuilder.build();
     }
 
-    private JsonObject createContextObject() {
+    private JsonValue createContext(String scope) {
         var builder = createObjectBuilder();
-        additionalNamespaces.forEach(builder::add);
-        return builder.build();
+        // Adds the configured namespaces for * and the input scope
+        Stream.concat(namespacesForScope(DEFAULT_SCOPE), namespacesForScope(scope))
+                .forEach(entry -> builder.add(entry.getKey(), entry.getValue()));
+
+        // Compute the additional context IRI defined for * and the input scope
+        var contexts = Stream.concat(contextsForScope(DEFAULT_SCOPE), contextsForScope(scope))
+                .collect(Collectors.toSet());
+
+        // if not empty we build a JsonArray
+        if (!contexts.isEmpty()) {
+            var arrayBuilder = createArrayBuilder();
+            contexts.forEach(arrayBuilder::add);
+
+            var namespaces = builder.build();
+            // don't append an empty object
+            if (!namespaces.isEmpty()) {
+                arrayBuilder.add(namespaces);
+            }
+            return arrayBuilder.build();
+        } else {
+            // return only the JsonObject with the namespaces
+            return builder.build();
+        }
+    }
+
+    private Stream<Map.Entry<String, String>> namespacesForScope(String scope) {
+        return scopedNamespaces.getOrDefault(scope, EMPTY_NAMESPACES).entrySet().stream();
+    }
+
+    private Stream<String> contextsForScope(String scope) {
+        return scopedContexts.getOrDefault(scope, EMPTY_CONTEXTS).stream();
     }
 
     private static class CachedDocumentLoader implements DocumentLoader {

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/TitaniumJsonLd.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/TitaniumJsonLd.java
@@ -150,20 +150,20 @@ public class TitaniumJsonLd implements JsonLd {
         var contexts = Stream.concat(contextsForScope(DEFAULT_SCOPE), contextsForScope(scope))
                 .collect(Collectors.toSet());
 
+        var contextObject = builder.build();
         // if not empty we build a JsonArray
         if (!contexts.isEmpty()) {
-            var arrayBuilder = createArrayBuilder();
-            contexts.forEach(arrayBuilder::add);
+            var contextArray = createArrayBuilder();
+            contexts.forEach(contextArray::add);
 
-            var namespaces = builder.build();
             // don't append an empty object
-            if (!namespaces.isEmpty()) {
-                arrayBuilder.add(namespaces);
+            if (!contextObject.isEmpty()) {
+                contextArray.add(contextObject);
             }
-            return arrayBuilder.build();
+            return contextArray.build();
         } else {
             // return only the JsonObject with the namespaces
-            return builder.build();
+            return contextObject;
         }
     }
 

--- a/extensions/common/json-ld/src/test/resources/schema-org-light.jsonld
+++ b/extensions/common/json-ld/src/test/resources/schema-org-light.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "http://schema.org/",
+    "schema": "http://schema.org/",
+    "Person": {
+      "@id": "schema:Person"
+    },
+    "name": {
+      "@id": "schema:name"
+    },
+    "jobTitle": {
+      "@id": "schema:jobTitle"
+    }
+  }
+}

--- a/extensions/common/json-ld/src/test/resources/test-org-light.jsonld
+++ b/extensions/common/json-ld/src/test/resources/test-org-light.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "http://test.org/",
+    "testSchema": "http://test.org/",
+    "Person": {
+      "@id": "testSchema:Person"
+    },
+    "name": {
+      "@id": "testSchema:name"
+    },
+    "jobTitle": {
+      "@id": "testSchema:jobTitle"
+    }
+  }
+}

--- a/extensions/data-plane-selector/data-plane-selector-client/src/test/java/org/eclipse/edc/connector/dataplane/selector/client/RemoteDataPlaneSelectorClientTest.java
+++ b/extensions/data-plane-selector/data-plane-selector-client/src/test/java/org/eclipse/edc/connector/dataplane/selector/client/RemoteDataPlaneSelectorClientTest.java
@@ -113,6 +113,6 @@ class RemoteDataPlaneSelectorClientTest extends RestControllerTestBase {
 
     @Override
     protected Object additionalResource() {
-        return new JerseyJsonLdInterceptor(new TitaniumJsonLd(mock()), JacksonJsonLd.createObjectMapper());
+        return new JerseyJsonLdInterceptor(new TitaniumJsonLd(mock()), JacksonJsonLd.createObjectMapper(), "scope");
     }
 }

--- a/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/JsonLd.java
+++ b/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/JsonLd.java
@@ -23,6 +23,7 @@ import java.net.URI;
  * Provides JsonLD expansion/compaction functionalities.
  */
 public interface JsonLd {
+    String DEFAULT_SCOPE = "*";
 
     /**
      * Expand a JsonLD document
@@ -38,15 +39,54 @@ public interface JsonLd {
      * @param json the expanded json.
      * @return a successful {@link Result} containing the compacted {@link JsonObject} if the operation succeed, a failed one otherwise
      */
-    Result<JsonObject> compact(JsonObject json);
+    default Result<JsonObject> compact(JsonObject json) {
+        return compact(json, DEFAULT_SCOPE);
+    }
 
     /**
-     * Register a JsonLD namespace
+     * Compact a JsonLD document. The context will be generated from registered contexts and namespaces.
      *
-     * @param prefix the prefix
+     * @param json  the expanded json.
+     * @param scope the scope to apply during the compaction process
+     * @return a successful {@link Result} containing the compacted {@link JsonObject} if the operation succeed, a failed one otherwise
+     */
+    Result<JsonObject> compact(JsonObject json, String scope);
+
+    /**
+     * Register a JsonLD namespace in the default scope
+     *
+     * @param prefix     the prefix
      * @param contextIri the string representing the IRI where the context is located
      */
-    void registerNamespace(String prefix, String contextIri);
+    default void registerNamespace(String prefix, String contextIri) {
+        registerNamespace(prefix, contextIri, DEFAULT_SCOPE);
+    }
+
+    /**
+     * Register a JsonLD namespace in a provided scope
+     *
+     * @param prefix     the prefix
+     * @param contextIri the string representing the IRI where the context is located
+     * @param scope      the scope where the prefix will be applied
+     */
+    void registerNamespace(String prefix, String contextIri, String scope);
+
+    /**
+     * Register a JsonLD context URL in the default scope
+     *
+     * @param contextIri the string representing the IRI where the context is located
+     */
+    default void registerContext(String contextIri) {
+        registerContext(contextIri, DEFAULT_SCOPE);
+    }
+
+    /**
+     * Register a JsonLD context URL in the provided scope
+     *
+     * @param contextIri the string representing the IRI where the context is located
+     */
+    void registerContext(String contextIri, String scope);
+
 
     /**
      * Register a JsonLD file document loader.

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/PolicyDefinitionApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/PolicyDefinitionApiEndToEndTest.java
@@ -30,6 +30,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.policy.model.OdrlNamespace.ODRL_PREFIX;
+import static org.eclipse.edc.policy.model.OdrlNamespace.ODRL_SCHEMA;
 import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 import static org.eclipse.edc.spi.CoreConstants.EDC_PREFIX;
 import static org.hamcrest.Matchers.hasEntry;
@@ -67,6 +69,7 @@ public class PolicyDefinitionApiEndToEndTest extends BaseManagementApiEndToEndTe
                 .contentType(JSON)
                 .body(ID, is(id))
                 .body(CONTEXT, hasEntry(EDC_PREFIX, EDC_NAMESPACE))
+                .body(CONTEXT, hasEntry(ODRL_PREFIX, ODRL_SCHEMA))
                 .log().all()
                 .body("'edc:policy'.'odrl:permission'.'odrl:constraint'.'odrl:operator'.@id", is("odrl:eq"));
     }
@@ -148,9 +151,9 @@ public class PolicyDefinitionApiEndToEndTest extends BaseManagementApiEndToEndTe
                                 .add("target", "http://example.com/asset:9898.movie")
                                 .add("action", "use")
                                 .add("constraint", createObjectBuilder()
-                                                .add("leftOperand", "left")
-                                                .add("operator", "eq")
-                                                .add("rightOperand", "value"))
+                                        .add("leftOperand", "left")
+                                        .add("operator", "eq")
+                                        .add("rightOperand", "value"))
                                 .build())
                         .build())
                 .build();


### PR DESCRIPTION
## What this PR changes/adds

Add configurable JSON-LD namespaces/prefix according to the DR #3509 

## Why it does that

Flexibility and clean API

## Further notes

Still not sure about the management API scopes. For now only the base `edc` and the `odrl` are registered there,
bit the mgmt catalog API might speak also `dcat` and `dct`. As today we just forward the JSON-LD from the provider without touching it, so at code level it works and we might not care for now. 

## Linked Issue(s)

Implements #3508

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
