### PR TITLE
feat: define `policy.monitor` policy scope

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -319,7 +319,7 @@ maven/mavencentral/org.testcontainers/jdbc/1.19.1, Apache-2.0, approved, #10348
 maven/mavencentral/org.testcontainers/junit-jupiter/1.19.1, MIT, approved, #10344
 maven/mavencentral/org.testcontainers/postgresql/1.19.1, MIT, approved, #10350
 maven/mavencentral/org.testcontainers/testcontainers/1.19.1, Apache-2.0 AND MIT, approved, #10347
-maven/mavencentral/org.testcontainers/vault/1.19.1, None, restricted, #10852
+maven/mavencentral/org.testcontainers/vault/1.19.1, MIT, approved, #10852
 maven/mavencentral/org.xerial.snappy/snappy-java/1.1.10.4, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #9098
 maven/mavencentral/org.xmlunit/xmlunit-core/2.9.1, Apache-2.0, approved, #6272
 maven/mavencentral/org.xmlunit/xmlunit-placeholders/2.9.1, Apache-2.0, approved, clearlydefined

--- a/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/policy/ContractExpiryCheckFunction.java
+++ b/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/policy/ContractExpiryCheckFunction.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.connector.contract.validation;
+package org.eclipse.edc.connector.core.policy;
 
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.policy.engine.spi.AtomicConstraintFunction;

--- a/core/common/connector-core/src/test/java/org/eclipse/edc/connector/core/policy/ContractExpiryCheckFunctionEvaluationTest.java
+++ b/core/common/connector-core/src/test/java/org/eclipse/edc/connector/core/policy/ContractExpiryCheckFunctionEvaluationTest.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.connector.contract.validation;
+package org.eclipse.edc.connector.core.policy;
 
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.junit.annotations.ComponentTest;
@@ -45,7 +45,7 @@ import static java.time.Duration.ofDays;
 import static java.time.Duration.ofSeconds;
 import static java.time.Instant.now;
 import static org.eclipse.edc.connector.contract.spi.validation.ContractValidationService.TRANSFER_SCOPE;
-import static org.eclipse.edc.connector.contract.validation.ContractExpiryCheckFunction.CONTRACT_EXPIRY_EVALUATION_KEY;
+import static org.eclipse.edc.connector.core.policy.ContractExpiryCheckFunction.CONTRACT_EXPIRY_EVALUATION_KEY;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.policy.model.Operator.EQ;
 import static org.eclipse.edc.policy.model.Operator.GEQ;

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/ContractCoreExtension.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/ContractCoreExtension.java
@@ -30,8 +30,8 @@ import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiat
 import org.eclipse.edc.connector.contract.spi.offer.ContractDefinitionResolver;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.validation.ContractValidationService;
-import org.eclipse.edc.connector.contract.validation.ContractExpiryCheckFunction;
 import org.eclipse.edc.connector.contract.validation.ContractValidationServiceImpl;
+import org.eclipse.edc.connector.core.policy.ContractExpiryCheckFunction;
 import org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore;
 import org.eclipse.edc.policy.engine.spi.PolicyEngine;
 import org.eclipse.edc.policy.engine.spi.RuleBindingRegistry;
@@ -59,11 +59,11 @@ import org.jetbrains.annotations.NotNull;
 import java.time.Clock;
 
 import static org.eclipse.edc.connector.contract.spi.validation.ContractValidationService.TRANSFER_SCOPE;
-import static org.eclipse.edc.connector.contract.validation.ContractExpiryCheckFunction.CONTRACT_EXPIRY_EVALUATION_KEY;
 import static org.eclipse.edc.connector.core.entity.AbstractStateEntityManager.DEFAULT_BATCH_SIZE;
 import static org.eclipse.edc.connector.core.entity.AbstractStateEntityManager.DEFAULT_ITERATION_WAIT;
 import static org.eclipse.edc.connector.core.entity.AbstractStateEntityManager.DEFAULT_SEND_RETRY_BASE_DELAY;
 import static org.eclipse.edc.connector.core.entity.AbstractStateEntityManager.DEFAULT_SEND_RETRY_LIMIT;
+import static org.eclipse.edc.connector.core.policy.ContractExpiryCheckFunction.CONTRACT_EXPIRY_EVALUATION_KEY;
 import static org.eclipse.edc.policy.model.OdrlNamespace.ODRL_SCHEMA;
 
 @Provides({

--- a/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/manager/PolicyMonitorManagerImpl.java
+++ b/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/manager/PolicyMonitorManagerImpl.java
@@ -33,6 +33,7 @@ import org.eclipse.edc.statemachine.StateMachineManager;
 import java.time.Instant;
 import java.util.function.Function;
 
+import static org.eclipse.edc.connector.policy.monitor.PolicyMonitorExtension.POLICY_MONITOR_SCOPE;
 import static org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntryStates.STARTED;
 import static org.eclipse.edc.spi.persistence.StateEntityStore.hasState;
 
@@ -83,7 +84,7 @@ public class PolicyMonitorManagerImpl extends AbstractStateEntityManager<PolicyM
                 .additional(ContractAgreement.class, contractAgreement)
                 .build();
 
-        var result = policyEngine.evaluate("transfer.process", policy, policyContext);
+        var result = policyEngine.evaluate(POLICY_MONITOR_SCOPE, policy, policyContext);
         if (result.failed()) {
             monitor.debug(() -> "[policy-monitor] Policy evaluation for TP %s failed: %s".formatted(entry.getId(), result.getFailureDetail()));
             var command = new TerminateTransferCommand(entry.getId(), result.getFailureDetail());

--- a/core/policy-monitor/policy-monitor-core/src/test/java/org/eclipse/edc/connector/policy/monitor/PolicyMonitorExtensionTest.java
+++ b/core/policy-monitor/policy-monitor-core/src/test/java/org/eclipse/edc/connector/policy/monitor/PolicyMonitorExtensionTest.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.policy.monitor;
+
+import org.eclipse.edc.connector.core.policy.ContractExpiryCheckFunction;
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.policy.engine.spi.PolicyEngine;
+import org.eclipse.edc.policy.model.Permission;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.eclipse.edc.connector.core.policy.ContractExpiryCheckFunction.CONTRACT_EXPIRY_EVALUATION_KEY;
+import static org.eclipse.edc.connector.policy.monitor.PolicyMonitorExtension.POLICY_MONITOR_SCOPE;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(DependencyInjectionExtension.class)
+class PolicyMonitorExtensionTest {
+
+    private final PolicyEngine policyEngine = mock();
+
+    @BeforeEach
+    void setUp(ServiceExtensionContext context) {
+        context.registerService(PolicyEngine.class, policyEngine);
+    }
+
+    @Test
+    void shouldRegisterExpiryFunctionToPolicyEngine(PolicyMonitorExtension extension, ServiceExtensionContext context) {
+        extension.initialize(context);
+
+        verify(policyEngine).registerFunction(eq(POLICY_MONITOR_SCOPE), eq(Permission.class), eq(CONTRACT_EXPIRY_EVALUATION_KEY), isA(ContractExpiryCheckFunction.class));
+    }
+}

--- a/core/policy-monitor/policy-monitor-core/src/test/java/org/eclipse/edc/connector/policy/monitor/manager/PolicyMonitorManagerImplTest.java
+++ b/core/policy-monitor/policy-monitor-core/src/test/java/org/eclipse/edc/connector/policy/monitor/manager/PolicyMonitorManagerImplTest.java
@@ -37,6 +37,7 @@ import java.util.List;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.eclipse.edc.connector.policy.monitor.PolicyMonitorExtension.POLICY_MONITOR_SCOPE;
 import static org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntryStates.COMPLETED;
 import static org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntryStates.FAILED;
 import static org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntryStates.STARTED;
@@ -105,7 +106,7 @@ class PolicyMonitorManagerImplTest {
         await().untilAsserted(() -> {
             verify(contractAgreementService).findById("contractId");
             var captor = ArgumentCaptor.forClass(PolicyContextImpl.class);
-            verify(policyEngine).evaluate(eq("transfer.process"), same(policy), captor.capture());
+            verify(policyEngine).evaluate(eq(POLICY_MONITOR_SCOPE), same(policy), captor.capture());
             var policyContext = captor.getValue();
             assertThat(policyContext.getContextData(ContractAgreement.class)).isSameAs(contractAgreement);
             verify(transferProcessService).terminate(argThat(c -> c.getEntityId().equals("transferProcessId")));


### PR DESCRIPTION
## What this PR changes/adds

Define a new `policy.monitor` scope that will be used by the policy monitor, on which the `ContractExpiryCheckFunction` is defined by default

## Why it does that

policy monitor

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #3482 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
