### PR TITLE
feat: stop policy monitor job when transfer is already completed/terminated

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -319,7 +319,7 @@ maven/mavencentral/org.testcontainers/jdbc/1.19.1, Apache-2.0, approved, #10348
 maven/mavencentral/org.testcontainers/junit-jupiter/1.19.1, MIT, approved, #10344
 maven/mavencentral/org.testcontainers/postgresql/1.19.1, MIT, approved, #10350
 maven/mavencentral/org.testcontainers/testcontainers/1.19.1, Apache-2.0 AND MIT, approved, #10347
-maven/mavencentral/org.testcontainers/vault/1.19.1, None, restricted, #10852
+maven/mavencentral/org.testcontainers/vault/1.19.1, MIT, approved, #10852
 maven/mavencentral/org.xerial.snappy/snappy-java/1.1.10.4, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #9098
 maven/mavencentral/org.xmlunit/xmlunit-core/2.9.1, Apache-2.0, approved, #6272
 maven/mavencentral/org.xmlunit/xmlunit-placeholders/2.9.1, Apache-2.0, approved, clearlydefined

--- a/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/manager/PolicyMonitorManagerImpl.java
+++ b/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/manager/PolicyMonitorManagerImpl.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorManager;
 import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorStore;
 import org.eclipse.edc.connector.spi.contractagreement.ContractAgreementService;
 import org.eclipse.edc.connector.spi.transferprocess.TransferProcessService;
+import org.eclipse.edc.connector.transfer.spi.types.TransferProcessStates;
 import org.eclipse.edc.connector.transfer.spi.types.command.TerminateTransferCommand;
 import org.eclipse.edc.policy.engine.spi.PolicyContextImpl;
 import org.eclipse.edc.policy.engine.spi.PolicyEngine;
@@ -70,6 +71,19 @@ public class PolicyMonitorManagerImpl extends AbstractStateEntityManager<PolicyM
     }
 
     private boolean processMonitoring(PolicyMonitorEntry entry) {
+        var transferProcess = transferProcessService.findById(entry.getId());
+        if (transferProcess == null) {
+            entry.transitionToFailed("TransferProcess %s does not exist".formatted(entry.getId()));
+            update(entry);
+            return true;
+        }
+
+        if (transferProcess.getState() >= TransferProcessStates.COMPLETING.code()) {
+            entry.transitionToCompleted();
+            update(entry);
+            return true;
+        }
+
         var contractAgreement = contractAgreementService.findById(entry.getContractId());
         if (contractAgreement == null) {
             entry.transitionToFailed("ContractAgreement %s does not exist".formatted(entry.getContractId()));
@@ -95,7 +109,8 @@ public class PolicyMonitorManagerImpl extends AbstractStateEntityManager<PolicyM
             }
         }
 
-        return false;
+        breakLease(entry);
+        return true;
     }
 
     private Processor processEntriesInState(PolicyMonitorEntryStates state, Function<PolicyMonitorEntry, Boolean> function) {


### PR DESCRIPTION
## What this PR changes/adds

Check the `TransferProcess` state on every iteration, if it is completed/terminated/deprovisioned by other processes or user actions, move the `PolicyMonitorEntry` to `COMPLETED`

## Why it does that

policy monitor

## Further notes

-

## Linked Issue(s)

Closes #3506 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
