### PR TITLE
feat: register @vocab context definition

### DIFF
--- a/extensions/common/api/api-core/src/main/java/org/eclipse/edc/api/model/ApiCoreSchema.java
+++ b/extensions/common/api/api-core/src/main/java/org/eclipse/edc/api/model/ApiCoreSchema.java
@@ -36,7 +36,7 @@ public interface ApiCoreSchema {
 
         public static final String CRITERION_EXAMPLE = """
                 {
-                    "@context": { "edc": "https://w3id.org/edc/v0.0.1/ns/" },
+                    "@context": { "@vocab": "https://w3id.org/edc/v0.0.1/ns/" },
                     "@type": "Criterion",
                     "operandLeft": "fieldName",
                     "operator": "=",
@@ -57,7 +57,7 @@ public interface ApiCoreSchema {
     ) {
         public static final String QUERY_SPEC_EXAMPLE = """
                 {
-                    "@context": { "edc": "https://w3id.org/edc/v0.0.1/ns/" },
+                    "@context": { "@vocab": "https://w3id.org/edc/v0.0.1/ns/" },
                     "@type": "QuerySpec",
                     "offset": 5,
                     "limit": 10,
@@ -76,7 +76,7 @@ public interface ApiCoreSchema {
     ) {
         public static final String ID_RESPONSE_EXAMPLE = """
                 {
-                    "@context": { "edc": "https://w3id.org/edc/v0.0.1/ns/" },
+                    "@context": { "@vocab": "https://w3id.org/edc/v0.0.1/ns/" },
                     "@id": "id-value",
                     "createdAt": 1688465655
                 }

--- a/extensions/common/api/management-api-configuration/src/main/java/org/eclipse/edc/connector/api/management/configuration/ManagementApiSchema.java
+++ b/extensions/common/api/management-api-configuration/src/main/java/org/eclipse/edc/connector/api/management/configuration/ManagementApiSchema.java
@@ -46,7 +46,7 @@ public interface ManagementApiSchema {
     ) {
         public static final String CONTRACT_AGREEMENT_EXAMPLE = """
                 {
-                    "@context": { "edc": "https://w3id.org/edc/v0.0.1/ns/" },
+                    "@context": { "@vocab": "https://w3id.org/edc/v0.0.1/ns/" },
                     "@type": "https://w3id.org/edc/v0.0.1/ns/ContractAgreement",
                     "@id": "negotiation-id",
                     "providerId": "provider-id",
@@ -88,7 +88,7 @@ public interface ManagementApiSchema {
     ) {
         public static final String DATA_ADDRESS_EXAMPLE = """
                 {
-                    "@context": { "edc": "https://w3id.org/edc/v0.0.1/ns/" },
+                    "@context": { "@vocab": "https://w3id.org/edc/v0.0.1/ns/" },
                     "@type": "https://w3id.org/edc/v0.0.1/ns/DataAddress",
                     "type": "HttpData",
                     "baseUrl": "http://example.com"
@@ -137,7 +137,7 @@ public interface ManagementApiSchema {
     ) {
         public static final String CONTRACT_NEGOTIATION_EXAMPLE = """
                 {
-                    "@context": { "edc": "https://w3id.org/edc/v0.0.1/ns/" },
+                    "@context": { "@vocab": "https://w3id.org/edc/v0.0.1/ns/" },
                     "@type": "https://w3id.org/edc/v0.0.1/ns/ContractNegotiation",
                     "@id": "negotiation-id",
                     "type": "PROVIDER",

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/JsonLdExtension.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/JsonLdExtension.java
@@ -34,6 +34,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 import static java.lang.String.format;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
 import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 import static org.eclipse.edc.spi.CoreConstants.EDC_PREFIX;
 import static org.eclipse.edc.spi.CoreConstants.JSON_LD;
@@ -58,6 +59,9 @@ public class JsonLdExtension implements ServiceExtension {
     private static final String HTTP_ENABLE_SETTING = "edc.jsonld.http.enabled";
     @Setting(value = "If set enable https json-ld document resolution", type = "boolean", defaultValue = DEFAULT_HTTP_HTTPS_RESOLUTION + "")
     private static final String HTTPS_ENABLE_SETTING = "edc.jsonld.https.enabled";
+    private static final String DEFAULT_AVOID_VOCAB_CONTEXT = "false";
+    @Setting(value = "If true disable the @vocab context definition. This could be used to avoid api breaking changes", type = "boolean", defaultValue = DEFAULT_AVOID_VOCAB_CONTEXT)
+    private static final String AVOID_VOCAB_CONTEXT = "edc.jsonld.vocab.disable";
     @Inject
     private TypeManager typeManager;
 
@@ -80,6 +84,9 @@ public class JsonLdExtension implements ServiceExtension {
                 .build();
         var monitor = context.getMonitor();
         var service = new TitaniumJsonLd(monitor, configuration);
+        if (!config.getBoolean(AVOID_VOCAB_CONTEXT, Boolean.valueOf(DEFAULT_AVOID_VOCAB_CONTEXT))) {
+            service.registerNamespace(VOCAB, EDC_NAMESPACE);
+        }
         service.registerNamespace(EDC_PREFIX, EDC_NAMESPACE);
 
         getResourceUri("document" + File.separator + "odrl.jsonld")

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/JsonLdExtensionTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/JsonLdExtensionTest.java
@@ -17,9 +17,7 @@ package org.eclipse.edc.jsonld;
 import com.apicatalog.jsonld.loader.DocumentLoader;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
-import org.eclipse.edc.spi.system.configuration.Config;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
-import org.eclipse.edc.spi.system.injection.ObjectFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -29,30 +27,25 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.util.reflection.ReflectionUtil.getFieldValue;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(DependencyInjectionExtension.class)
 class JsonLdExtensionTest {
 
     @Test
-    void createService(ServiceExtensionContext context, ObjectFactory factory) {
-        var extension = factory.constructInstance(JsonLdExtension.class);
-
+    void createService(ServiceExtensionContext context, JsonLdExtension extension) {
         var service = extension.createJsonLdService(context);
 
         assertThat(service).isNotNull();
     }
 
     @Test
-    void verifyCachedDocsFromConfig_oneValidEntry(ServiceExtensionContext context, ObjectFactory factory) throws URISyntaxException {
-        Config config = ConfigFactory.fromMap(Map.of(
+    void verifyCachedDocsFromConfig_oneValidEntry(ServiceExtensionContext context, JsonLdExtension extension) throws URISyntaxException {
+        var config = ConfigFactory.fromMap(Map.of(
                 "edc.jsonld.document.foo.url", "http://foo.org/doc.json",
                 "edc.jsonld.document.foo.path", "/tmp/foo/doc.json")
         );
-        context = spy(context);
         when(context.getConfig()).thenReturn(config);
-        var extension = factory.constructInstance(JsonLdExtension.class);
         var service = (TitaniumJsonLd) extension.createJsonLdService(context);
 
         DocumentLoader documentLoader = getFieldValue("documentLoader", service);
@@ -62,15 +55,13 @@ class JsonLdExtensionTest {
     }
 
     @Test
-    void verifyCachedDocsFromConfig_oneValidEntry_withSuperfluous(ServiceExtensionContext context, ObjectFactory factory) throws URISyntaxException {
-        Config config = ConfigFactory.fromMap(Map.of(
+    void verifyCachedDocsFromConfig_oneValidEntry_withSuperfluous(ServiceExtensionContext context, JsonLdExtension extension) throws URISyntaxException {
+        var config = ConfigFactory.fromMap(Map.of(
                 "edc.jsonld.document.foo.url", "http://foo.org/doc.json",
                 "edc.jsonld.document.foo.invalid", "should be ignored",
                 "edc.jsonld.document.foo.path", "/tmp/foo/doc.json")
         );
-        context = spy(context);
         when(context.getConfig()).thenReturn(config);
-        var extension = factory.constructInstance(JsonLdExtension.class);
         var service = (TitaniumJsonLd) extension.createJsonLdService(context);
 
         DocumentLoader documentLoader = getFieldValue("documentLoader", service);
@@ -80,16 +71,14 @@ class JsonLdExtensionTest {
     }
 
     @Test
-    void verifyCachedDocsFromConfig_multipleValidEntries(ServiceExtensionContext context, ObjectFactory factory) throws URISyntaxException {
-        Config config = ConfigFactory.fromMap(Map.of(
+    void verifyCachedDocsFromConfig_multipleValidEntries(ServiceExtensionContext context, JsonLdExtension extension) throws URISyntaxException {
+        var config = ConfigFactory.fromMap(Map.of(
                 "edc.jsonld.document.foo.url", "http://foo.org/doc.json",
                 "edc.jsonld.document.foo.path", "/tmp/foo/doc.json",
                 "edc.jsonld.document.bar.url", "http://bar.org/doc.json",
                 "edc.jsonld.document.bar.path", "/tmp/bar/doc.json"
         ));
-        context = spy(context);
         when(context.getConfig()).thenReturn(config);
-        var extension = factory.constructInstance(JsonLdExtension.class);
         var service = (TitaniumJsonLd) extension.createJsonLdService(context);
 
         DocumentLoader documentLoader = getFieldValue("documentLoader", service);
@@ -100,15 +89,13 @@ class JsonLdExtensionTest {
     }
 
     @Test
-    void verifyCachedDocsFromConfig_multipleEntries_oneIncomplete(ServiceExtensionContext context, ObjectFactory factory) throws URISyntaxException {
-        Config config = ConfigFactory.fromMap(Map.of(
+    void verifyCachedDocsFromConfig_multipleEntries_oneIncomplete(ServiceExtensionContext context, JsonLdExtension extension) throws URISyntaxException {
+        var config = ConfigFactory.fromMap(Map.of(
                 "edc.jsonld.document.foo.url", "http://foo.org/doc.json",
                 "edc.jsonld.document.foo.path", "/tmp/foo/doc.json",
                 "edc.jsonld.document.bar.url", "http://bar.org/doc.json"
         ));
-        context = spy(context);
         when(context.getConfig()).thenReturn(config);
-        var extension = factory.constructInstance(JsonLdExtension.class);
         var service = (TitaniumJsonLd) extension.createJsonLdService(context);
 
         DocumentLoader documentLoader = getFieldValue("documentLoader", service);
@@ -120,15 +107,13 @@ class JsonLdExtensionTest {
     }
 
     @Test
-    void verifyCachedDocsFromConfig_multipleEntries_oneInvalid(ServiceExtensionContext context, ObjectFactory factory) throws URISyntaxException {
-        Config config = ConfigFactory.fromMap(Map.of(
+    void verifyCachedDocsFromConfig_multipleEntries_oneInvalid(ServiceExtensionContext context, JsonLdExtension extension) throws URISyntaxException {
+        var config = ConfigFactory.fromMap(Map.of(
                 "edc.jsonld.document.foo.url", "http://foo.org/doc.json",
                 "edc.jsonld.document.foo.path", "/tmp/foo/doc.json",
                 "edc.jsonld.document.bar.invalid", "http://bar.org/doc.json"
         ));
-        context = spy(context);
         when(context.getConfig()).thenReturn(config);
-        var extension = factory.constructInstance(JsonLdExtension.class);
         var service = (TitaniumJsonLd) extension.createJsonLdService(context);
 
         DocumentLoader documentLoader = getFieldValue("documentLoader", service);

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/v3/AssetApi.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/v3/AssetApi.java
@@ -113,7 +113,7 @@ public interface AssetApi {
     ) {
         public static final String ASSET_INPUT_EXAMPLE = """
                 {
-                    "@context": { "edc": "https://w3id.org/edc/v0.0.1/ns/" },
+                    "@context": { "@vocab": "https://w3id.org/edc/v0.0.1/ns/" },
                     "@id": "asset-id",
                     "properties": {
                         "key": "value"
@@ -143,19 +143,19 @@ public interface AssetApi {
     ) {
         public static final String ASSET_OUTPUT_EXAMPLE = """
                 {
-                    "@context": { "edc": "https://w3id.org/edc/v0.0.1/ns/" },
+                    "@context": { "@vocab": "https://w3id.org/edc/v0.0.1/ns/" },
                     "@id": "asset-id",
-                    "edc:properties": {
-                        "edc:key": "value"
+                    "properties": {
+                        "key": "value"
                     },
-                    "edc:privateProperties": {
-                        "edc:privateKey": "privateValue"
+                    "privateProperties": {
+                        "privateKey": "privateValue"
                     },
-                    "edc:dataAddress": {
-                        "edc:type": "HttpData",
-                        "edc:baseUrl": "https://jsonplaceholder.typicode.com/todos"
+                    "dataAddress": {
+                        "type": "HttpData",
+                        "baseUrl": "https://jsonplaceholder.typicode.com/todos"
                     },
-                    "edc:createdAt": 1688465655
+                    "createdAt": 1688465655
                 }
                 """;
     }

--- a/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/api/management/catalog/CatalogApi.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/api/management/catalog/CatalogApi.java
@@ -68,7 +68,7 @@ public interface CatalogApi {
 
         public static final String CATALOG_REQUEST_EXAMPLE = """
                 {
-                    "@context": { "edc": "https://w3id.org/edc/v0.0.1/ns/" },
+                    "@context": { "@vocab": "https://w3id.org/edc/v0.0.1/ns/" },
                     "@type": "CatalogRequest",
                     "counterPartyAddress": "http://provider-address",
                     "protocol": "dataspace-protocol-http",
@@ -93,7 +93,7 @@ public interface CatalogApi {
 
         public static final String DATASET_REQUEST_EXAMPLE = """
                 {
-                    "@context": { "edc": "https://w3id.org/edc/v0.0.1/ns/" },
+                    "@context": { "@vocab": "https://w3id.org/edc/v0.0.1/ns/" },
                     "@type": "DatasetRequest",
                     "@id": "dataset-id",
                     "counterPartyAddress": "http://counter-party-address",
@@ -152,8 +152,8 @@ public interface CatalogApi {
                                 "dcat:accessService": "5e839777-d93e-4785-8972-1005f51cf367"
                             }
                         ],
-                        "edc:description": "description",
-                        "edc:id": "bcca61be-e82e-4da6-bfec-9716a56cef35"
+                        "description": "description",
+                        "id": "bcca61be-e82e-4da6-bfec-9716a56cef35"
                     },
                     "dcat:service": {
                         "@id": "5e839777-d93e-4785-8972-1005f51cf367",
@@ -161,8 +161,9 @@ public interface CatalogApi {
                         "dct:terms": "connector",
                         "dct:endpointUrl": "http://localhost:16806/protocol"
                     },
-                    "edc:participantId": "urn:connector:provider",
+                    "participantId": "urn:connector:provider",
                     "@context": {
+                        "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
                         "dct": "https://purl.org/dc/terms/",
                         "edc": "https://w3id.org/edc/v0.0.1/ns/",
                         "dcat": "https://www.w3.org/ns/dcat/",
@@ -220,9 +221,10 @@ public interface CatalogApi {
                             "dcat:accessService": "5e839777-d93e-4785-8972-1005f51cf367"
                         }
                     ],
-                    "edc:description": "description",
-                    "edc:id": "bcca61be-e82e-4da6-bfec-9716a56cef35",
+                    "description": "description",
+                    "id": "bcca61be-e82e-4da6-bfec-9716a56cef35",
                     "@context": {
+                        "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
                         "dct": "https://purl.org/dc/terms/",
                         "edc": "https://w3id.org/edc/v0.0.1/ns/",
                         "dcat": "https://www.w3.org/ns/dcat/",

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionApi.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionApi.java
@@ -109,7 +109,7 @@ public interface ContractDefinitionApi {
 
         public static final String CONTRACT_DEFINITION_INPUT_EXAMPLE = """
                 {
-                    "@context": { "edc": "https://w3id.org/edc/v0.0.1/ns/" },
+                    "@context": { "@vocab": "https://w3id.org/edc/v0.0.1/ns/" },
                     "@id": "definition-id",
                     "accessPolicyId": "asset-policy-id",
                     "contractPolicyId": "contract-policy-id",
@@ -131,12 +131,12 @@ public interface ContractDefinitionApi {
 
         public static final String CONTRACT_DEFINITION_OUTPUT_EXAMPLE = """
                 {
-                    "@context": { "edc": "https://w3id.org/edc/v0.0.1/ns/" },
+                    "@context": { "@vocab": "https://w3id.org/edc/v0.0.1/ns/" },
                     "@id": "definition-id",
-                    "edc:accessPolicyId": "asset-policy-id",
-                    "edc:contractPolicyId": "contract-policy-id",
-                    "edc:assetsSelector": [],
-                    "edc:createdAt": 1688465655
+                    "accessPolicyId": "asset-policy-id",
+                    "contractPolicyId": "contract-policy-id",
+                    "assetsSelector": [],
+                    "createdAt": 1688465655
                 }
                 """;
     }

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApi.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApi.java
@@ -130,7 +130,7 @@ public interface ContractNegotiationApi {
         // policy example took from https://w3c.github.io/odrl/bp/
         public static final String CONTRACT_REQUEST_EXAMPLE = """
                 {
-                    "@context": { "edc": "https://w3id.org/edc/v0.0.1/ns/" },
+                    "@context": { "@vocab": "https://w3id.org/edc/v0.0.1/ns/" },
                     "@type": "https://w3id.org/edc/v0.0.1/ns/ContractRequest",
                     "connectorAddress": "http://provider-address",
                     "protocol": "dataspace-protocol-http",
@@ -167,7 +167,7 @@ public interface ContractNegotiationApi {
     ) {
         public static final String NEGOTIATION_STATE_EXAMPLE = """
                 {
-                    "@context": { "edc": "https://w3id.org/edc/v0.0.1/ns/" },
+                    "@context": { "@vocab": "https://w3id.org/edc/v0.0.1/ns/" },
                     "@type": "https://w3id.org/edc/v0.0.1/ns/NegotiationState",
                     "state": "REQUESTED"
                 }
@@ -195,7 +195,7 @@ public interface ContractNegotiationApi {
     ) {
         public static final String TERMINATE_NEGOTIATION_EXAMPLE = """
                 {
-                    "@context": { "edc": "https://w3id.org/edc/v0.0.1/ns/" },
+                    "@context": { "@vocab": "https://w3id.org/edc/v0.0.1/ns/" },
                     "@type": "https://w3id.org/edc/v0.0.1/ns/TerminateNegotiation",
                     "@id": "negotiation-id",
                     "reason": "a reason to terminate"

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerTest.java
@@ -51,6 +51,8 @@ import static org.eclipse.edc.connector.api.management.contractnegotiation.model
 import static org.eclipse.edc.connector.contract.spi.types.command.TerminateNegotiationCommand.TERMINATE_NEGOTIATION_TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE;
 import static org.eclipse.edc.validator.spi.Violation.violation;
 import static org.hamcrest.Matchers.is;
@@ -255,8 +257,9 @@ class ContractNegotiationApiControllerTest extends RestControllerTestBase {
     @Test
     void getSingleContractNegotiationState() {
         var compacted = createObjectBuilder()
+                .add(VOCAB, EDC_NAMESPACE)
                 .add(TYPE, NEGOTIATION_STATE_TYPE)
-                .add("edc:state", "REQUESTED")
+                .add("state", "REQUESTED")
                 .build();
 
         when(service.getState(eq("cn1"))).thenReturn("REQUESTED");
@@ -268,7 +271,7 @@ class ContractNegotiationApiControllerTest extends RestControllerTestBase {
                 .then()
                 .statusCode(200)
                 .contentType(JSON)
-                .body("'edc:state'", is("REQUESTED"));
+                .body("state", is("REQUESTED"));
         verify(service).getState(eq("cn1"));
         verify(transformerRegistry).transform(any(NegotiationState.class), eq(JsonObject.class));
         verifyNoMoreInteractions(service, transformerRegistry);

--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/test/system/utils/Participant.java
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/test/system/utils/Participant.java
@@ -36,7 +36,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static jakarta.json.Json.createObjectBuilder;
-import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.FINALIZED;
@@ -385,7 +384,7 @@ public class Participant {
                 .then()
                 .statusCode(200)
                 .extract().body().jsonPath()
-                .getString(format("%s", fieldName));
+                .getString(fieldName);
     }
 
     /**

--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/test/system/utils/Participant.java
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/test/system/utils/Participant.java
@@ -343,7 +343,7 @@ public class Participant {
                 .get("/v2/transferprocesses/{id}/state", id)
                 .then()
                 .statusCode(200)
-                .extract().body().jsonPath().getString("'edc:state'");
+                .extract().body().jsonPath().getString("state");
     }
 
     private ContractOfferId extractContractDefinitionId(JsonObject dataset) {
@@ -358,7 +358,7 @@ public class Participant {
                 .get("/v2/contractnegotiations/{id}/state", id)
                 .then()
                 .statusCode(200)
-                .extract().body().jsonPath().getString("'edc:state'");
+                .extract().body().jsonPath().getString("state");
     }
 
 
@@ -385,7 +385,7 @@ public class Participant {
                 .then()
                 .statusCode(200)
                 .extract().body().jsonPath()
-                .getString(format("'edc:%s'", fieldName));
+                .getString(format("%s", fieldName));
     }
 
     /**

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApi.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApi.java
@@ -107,7 +107,7 @@ public interface PolicyDefinitionApi {
         // policy example took from https://w3c.github.io/odrl/bp/
         public static final String POLICY_DEFINITION_INPUT_EXAMPLE = """
                 {
-                    "@context": { "edc": "https://w3id.org/edc/v0.0.1/ns/" },
+                    "@context": { "@vocab": "https://w3id.org/edc/v0.0.1/ns/" },
                     "@id": "definition-id",
                     "policy": {
                         "@context": "http://www.w3.org/ns/odrl.jsonld",
@@ -139,7 +139,7 @@ public interface PolicyDefinitionApi {
         // policy example took from https://w3c.github.io/odrl/bp/
         public static final String POLICY_DEFINITION_OUTPUT_EXAMPLE = """
                 {
-                    "@context": { "edc": "https://w3id.org/edc/v0.0.1/ns/" },
+                    "@context": { "@vocab": "https://w3id.org/edc/v0.0.1/ns/" },
                     "@id": "definition-id",
                     "policy": {
                         "@context": "http://www.w3.org/ns/odrl.jsonld",

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/TransferProcessApi.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/TransferProcessApi.java
@@ -136,7 +136,7 @@ public interface TransferProcessApi {
 
         public static final String TRANSFER_REQUEST_EXAMPLE = """
                 {
-                    "@context": { "edc": "https://w3id.org/edc/v0.0.1/ns/" },
+                    "@context": { "@vocab": "https://w3id.org/edc/v0.0.1/ns/" },
                     "@type": "https://w3id.org/edc/v0.0.1/ns/TransferRequest",
                     "protocol": "dataspace-protocol-http",
                     "connectorAddress": "http://provider-address",
@@ -181,7 +181,7 @@ public interface TransferProcessApi {
     ) {
         public static final String TRANSFER_PROCESS_EXAMPLE = """
                 {
-                    "@context": { "edc": "https://w3id.org/edc/v0.0.1/ns/" },
+                    "@context": { "@vocab": "https://w3id.org/edc/v0.0.1/ns/" },
                     "@type": "https://w3id.org/edc/v0.0.1/ns/TransferProcess",
                     "@id": "process-id",
                     "correlationId": "correlation-id",
@@ -218,7 +218,7 @@ public interface TransferProcessApi {
     ) {
         public static final String TRANSFER_STATE_EXAMPLE = """
                 {
-                    "@context": { "edc": "https://w3id.org/edc/v0.0.1/ns/" },
+                    "@context": { "@vocab": "https://w3id.org/edc/v0.0.1/ns/" },
                     "@type": "https://w3id.org/edc/v0.0.1/ns/TransferState",
                     "state": "STARTED"
                 }
@@ -233,7 +233,7 @@ public interface TransferProcessApi {
     ) {
         public static final String TERMINATE_TRANSFER_EXAMPLE = """
                 {
-                    "@context": { "edc": "https://w3id.org/edc/v0.0.1/ns/" },
+                    "@context": { "@vocab": "https://w3id.org/edc/v0.0.1/ns/" },
                     "@type": "https://w3id.org/edc/v0.0.1/ns/TerminateTransfer",
                     "reason": "a reason to terminate"
                 }

--- a/extensions/control-plane/transfer/transfer-pull-http-dynamic-receiver/README.md
+++ b/extensions/control-plane/transfer/transfer-pull-http-dynamic-receiver/README.md
@@ -8,7 +8,7 @@ and will be used by the consumer connector to dispatch the EDR
 ```json
 {
   "@context": {
-    "edc": "https://w3id.org/edc/v0.0.1/ns/"
+    "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
   },
   "@type": "TransferRequest",
   "protocol": "dataspace-protocol-http",

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/schemas/DataPlaneInstanceSchema.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/schemas/DataPlaneInstanceSchema.java
@@ -36,7 +36,7 @@ public record DataPlaneInstanceSchema(@Schema(name = TYPE, example = DATAPLANE_I
     public static final String DATAPLANE_INSTANCE_EXAMPLE = """
             {
                 "@context": {
-                    "edc": "https://w3id.org/edc/v0.0.1/ns/"
+                    "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
                 },
                 "@id": "your-dataplane-id",
                 "url": "http://somewhere.com:1234/api/v1",

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/schemas/SelectionRequestSchema.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/schemas/SelectionRequestSchema.java
@@ -31,7 +31,7 @@ public record SelectionRequestSchema(
     public static final String SELECTION_REQUEST_INPUT_EXAMPLE = """
             {
                 "@context": {
-                    "edc": "https://w3id.org/edc/v0.0.1/ns/"
+                    "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
                 },
                 "source": {
                     "@type": "https://w3id.org/edc/v0.0.1/ns/DataAddress",

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/AssetApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/AssetApiEndToEndTest.java
@@ -61,14 +61,14 @@ public class AssetApiEndToEndTest extends BaseManagementApiEndToEndTest {
 
         assertThat(body).isNotNull();
         assertThat(body.getString(ID)).isEqualTo(TEST_ASSET_ID);
-        assertThat(body.getMap("edc:properties"))
+        assertThat(body.getMap("properties"))
                 .hasSize(5)
-                .containsEntry("edc:name", TEST_ASSET_NAME)
-                .containsEntry("edc:description", TEST_ASSET_DESCRIPTION)
-                .containsEntry("edc:contenttype", TEST_ASSET_CONTENTTYPE)
-                .containsEntry("edc:version", TEST_ASSET_VERSION);
-        assertThat(body.getMap("'edc:dataAddress'"))
-                .containsEntry("edc:type", "addressType");
+                .containsEntry("name", TEST_ASSET_NAME)
+                .containsEntry("description", TEST_ASSET_DESCRIPTION)
+                .containsEntry("contenttype", TEST_ASSET_CONTENTTYPE)
+                .containsEntry("version", TEST_ASSET_VERSION);
+        assertThat(body.getMap("'dataAddress'"))
+                .containsEntry("type", "addressType");
     }
 
     @Test

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/CatalogApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/CatalogApiEndToEndTest.java
@@ -117,7 +117,7 @@ public class CatalogApiEndToEndTest extends BaseManagementApiEndToEndTest {
                 .statusCode(200)
                 .contentType(JSON)
                 .body(TYPE, is("dcat:Catalog"))
-                .body("'dcat:dataset'.'edc:id'", is("id-2"));
+                .body("'dcat:dataset'.id", is("id-2"));
     }
 
     @Test

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractAgreementApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractAgreementApiEndToEndTest.java
@@ -51,8 +51,8 @@ public class ContractAgreementApiEndToEndTest extends BaseManagementApiEndToEndT
                 .body("size()", is(2))
                 .extract().jsonPath();
 
-        assertThat(jsonPath.getString("[0]['edc:assetId']")).isNotNull();
-        assertThat(jsonPath.getString("[1]['edc:assetId']")).isNotNull();
+        assertThat(jsonPath.getString("[0].assetId")).isNotNull();
+        assertThat(jsonPath.getString("[1].assetId")).isNotNull();
         assertThat(jsonPath.getString("[0].@id")).isIn("cn1", "cn2");
         assertThat(jsonPath.getString("[1].@id")).isIn("cn1", "cn2");
     }
@@ -71,7 +71,7 @@ public class ContractAgreementApiEndToEndTest extends BaseManagementApiEndToEndT
                 .extract().jsonPath();
 
         assertThat(json.getString("@id")).isEqualTo("cn1");
-        assertThat(json.getString("'edc:assetId'")).isNotNull();
+        assertThat(json.getString("assetId")).isNotNull();
     }
 
     @Test

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractDefinitionApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractDefinitionApiEndToEndTest.java
@@ -55,7 +55,7 @@ public class ContractDefinitionApiEndToEndTest extends BaseManagementApiEndToEnd
                 .body("size()", greaterThan(0))
                 .extract().body().as(JsonArray.class);
 
-        var criteria = body.getJsonObject(0).getJsonArray("edc:assetsSelector");
+        var criteria = body.getJsonObject(0).getJsonArray("assetsSelector");
         assertThat(criteria).hasSize(2);
     }
 

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractNegotiationApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractNegotiationApiEndToEndTest.java
@@ -66,11 +66,11 @@ public class ContractNegotiationApiEndToEndTest extends BaseManagementApiEndToEn
                 .body("size()", is(2))
                 .extract().jsonPath();
 
-        assertThat(jsonPath.getString("[0]['edc:counterPartyAddress']")).isEqualTo(protocolUrl);
+        assertThat(jsonPath.getString("[0].counterPartyAddress")).isEqualTo(protocolUrl);
         assertThat(jsonPath.getString("[0].@id")).isIn("cn1", "cn2");
         assertThat(jsonPath.getString("[1].@id")).isIn("cn1", "cn2");
-        assertThat(jsonPath.getString("[0]['edc:protocol']")).isEqualTo("dataspace-protocol-http");
-        assertThat(jsonPath.getString("[1]['edc:protocol']")).isEqualTo("dataspace-protocol-http");
+        assertThat(jsonPath.getString("[0].protocol")).isEqualTo("dataspace-protocol-http");
+        assertThat(jsonPath.getString("[1].protocol")).isEqualTo("dataspace-protocol-http");
     }
 
     @Test
@@ -87,7 +87,7 @@ public class ContractNegotiationApiEndToEndTest extends BaseManagementApiEndToEn
                 .extract().jsonPath();
 
         assertThat((String) json.get("@id")).isEqualTo("cn1");
-        assertThat(json.getString("'edc:protocol'")).isEqualTo("dataspace-protocol-http");
+        assertThat(json.getString("protocol")).isEqualTo("dataspace-protocol-http");
     }
 
     @Test
@@ -102,7 +102,7 @@ public class ContractNegotiationApiEndToEndTest extends BaseManagementApiEndToEn
                 .then()
                 .statusCode(200)
                 .contentType(JSON)
-                .body("'edc:state'", is("FINALIZED"));
+                .body("state", is("FINALIZED"));
     }
 
     @Test
@@ -120,8 +120,8 @@ public class ContractNegotiationApiEndToEndTest extends BaseManagementApiEndToEn
                 .extract().jsonPath();
 
         assertThat(json.getString("@id")).isEqualTo("cn1");
-        assertThat((Object) json.get("'edc:policy'")).isNotNull().isInstanceOf(Map.class);
-        assertThat(json.getString("'edc:assetId'")).isEqualTo(agreement.getAssetId());
+        assertThat((Object) json.get("policy")).isNotNull().isInstanceOf(Map.class);
+        assertThat(json.getString("assetId")).isEqualTo(agreement.getAssetId());
     }
 
     @Test

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/PolicyDefinitionApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/PolicyDefinitionApiEndToEndTest.java
@@ -71,7 +71,7 @@ public class PolicyDefinitionApiEndToEndTest extends BaseManagementApiEndToEndTe
                 .body(CONTEXT, hasEntry(EDC_PREFIX, EDC_NAMESPACE))
                 .body(CONTEXT, hasEntry(ODRL_PREFIX, ODRL_SCHEMA))
                 .log().all()
-                .body("'edc:policy'.'odrl:permission'.'odrl:constraint'.'odrl:operator'.@id", is("odrl:eq"));
+                .body("policy.'odrl:permission'.'odrl:constraint'.'odrl:operator'.@id", is("odrl:eq"));
     }
 
     @Test
@@ -99,7 +99,7 @@ public class PolicyDefinitionApiEndToEndTest extends BaseManagementApiEndToEndTe
                 .statusCode(200)
                 .extract().as(JsonArray.class)
                 .get(0).asJsonObject()
-                .getJsonNumber("edc:createdAt").longValue();
+                .getJsonNumber("createdAt").longValue();
 
         baseRequest()
                 .contentType(JSON)

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TransferProcessApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TransferProcessApiEndToEndTest.java
@@ -33,7 +33,6 @@ import java.util.UUID;
 
 import static io.restassured.http.ContentType.JSON;
 import static jakarta.json.Json.createObjectBuilder;
-import static java.lang.String.format;
 import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.transfer.spi.types.TransferProcessStates.COMPLETED;
@@ -79,7 +78,7 @@ public class TransferProcessApiEndToEndTest extends BaseManagementApiEndToEndTes
                 .then()
                 .statusCode(200)
                 .body("@id", is("tp2"))
-                .body(TYPE, is("edc:TransferProcess"));
+                .body(TYPE, is("TransferProcess"));
     }
 
     @Test
@@ -91,8 +90,8 @@ public class TransferProcessApiEndToEndTest extends BaseManagementApiEndToEndTes
                 .then()
                 .statusCode(200)
                 .contentType(JSON)
-                .body(TYPE, is("edc:TransferState"))
-                .body("'edc:state'", is("COMPLETED"));
+                .body(TYPE, is("TransferState"))
+                .body("'state'", is("COMPLETED"));
     }
 
     @Test
@@ -171,7 +170,7 @@ public class TransferProcessApiEndToEndTest extends BaseManagementApiEndToEndTes
         var content = """
                 {
                     "@context": {
-                        "edc": "https://w3id.org/edc/v0.0.1/ns/"
+                        "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
                     },
                     "@type": "QuerySpec",
                     "filterExpression": [
@@ -184,9 +183,8 @@ public class TransferProcessApiEndToEndTest extends BaseManagementApiEndToEndTes
                     "limit": 100,
                     "offset": 0
                 }
-                """;
-        content = format(content, state.code());
-        JsonObject query = JacksonJsonLd.createObjectMapper()
+                """.formatted(state.code());
+        var query = JacksonJsonLd.createObjectMapper()
                 .readValue(content, JsonObject.class);
 
         var result = baseRequest()
@@ -198,7 +196,7 @@ public class TransferProcessApiEndToEndTest extends BaseManagementApiEndToEndTes
                 .extract().body().as(JsonArray.class);
 
         assertThat(result).isNotEmpty();
-        assertThat(result).anySatisfy(it -> assertThat(it.asJsonObject().getString("edc:state")).isEqualTo(state.toString()));
+        assertThat(result).anySatisfy(it -> assertThat(it.asJsonObject().getString("state")).isEqualTo(state.toString()));
     }
 
     private TransferProcessStore getStore() {


### PR DESCRIPTION
## What this PR changes/adds

Registers `@vocab` context definition (with the `https://w3id.org/edc/v0.0.1/ns/` value) at the global scope

## Why it does that

To have consistent output jsonld responses

## Further notes

- this way, every json-ld produced by the edc won't have the "edc:" prefix in the edc namespaced properties
- as this could be considered as a breaking change (but technically it is not because the compacted json-ld responses will expand in the same way as the old ones) I added a `edc.jsonld.vocab.disable` that could be used to switch to the old behavior.

## Linked Issue(s)

Closes #3525 
Closes #3522 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
