### PR TITLE
feat: add `contractId` to `EndpointDataReference`

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -14,28 +14,33 @@ maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.14.0, Apache
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.14.1, Apache-2.0, approved, #5303
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.15.1, Apache-2.0, approved, #7947
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.15.2, Apache-2.0, approved, #7947
+maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.15.3, Apache-2.0, approved, #7947
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.14.1, Apache-2.0 AND MIT, approved, #4303
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.15.1, MIT AND Apache-2.0, approved, #7932
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.15.2, MIT AND Apache-2.0, approved, #7932
+maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.15.3, MIT AND Apache-2.0, approved, #7932
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.11.0, Apache-2.0, approved, CQ23093
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.14.0, Apache-2.0, approved, #4105
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.14.1, Apache-2.0, approved, #4105
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.15.1, Apache-2.0, approved, #7934
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.15.2, Apache-2.0, approved, #7934
+maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.15.3, Apache-2.0, approved, #7934
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.14.0, Apache-2.0, approved, #5933
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.15.1, Apache-2.0, approved, #8802
-maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.15.2, Apache-2.0, approved, #8802
+maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.15.3, Apache-2.0, approved, #8802
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jakarta-jsonp/2.15.2, Apache-2.0, approved, #9179
+maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jakarta-jsonp/2.15.3, Apache-2.0, approved, #9179
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.14.0, Apache-2.0, approved, #4699
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.15.1, Apache-2.0, approved, #7930
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.15.2, Apache-2.0, approved, #7930
-maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/2.15.2, Apache-2.0, approved, #9235
+maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.15.3, Apache-2.0, approved, #7930
+maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/2.15.3, Apache-2.0, approved, #9235
 maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.15.1, Apache-2.0, approved, #9236
-maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.15.2, Apache-2.0, approved, #9236
+maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.15.3, Apache-2.0, approved, #9236
 maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.14.1, Apache-2.0, approved, #5308
-maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.15.2, Apache-2.0, approved, #9241
+maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.15.3, Apache-2.0, approved, #9241
 maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.15.1, Apache-2.0, approved, #7929
-maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.15.2, Apache-2.0, approved, #7929
+maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.15.3, Apache-2.0, approved, #7929
 maven/mavencentral/com.fasterxml.uuid/java-uuid-generator/4.1.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.github.cliftonlabs/json-simple/3.0.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.github.docker-java/docker-java-api/3.3.3, Apache-2.0, approved, #10346
@@ -325,3 +330,4 @@ maven/mavencentral/org.xmlunit/xmlunit-core/2.9.1, Apache-2.0, approved, #6272
 maven/mavencentral/org.xmlunit/xmlunit-placeholders/2.9.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.yaml/snakeyaml/1.33, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.yaml/snakeyaml/2.0, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #7275
+maven/mavencentral/org.yaml/snakeyaml/2.1, Apache-2.0, approved, #9847

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/edr/DataAddressToEndpointDataReferenceTransformer.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/edr/DataAddressToEndpointDataReferenceTransformer.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 import static java.lang.String.format;
 import static org.eclipse.edc.spi.types.domain.edr.EndpointDataReference.AUTH_CODE;
 import static org.eclipse.edc.spi.types.domain.edr.EndpointDataReference.AUTH_KEY;
+import static org.eclipse.edc.spi.types.domain.edr.EndpointDataReference.CONTRACT_ID;
 import static org.eclipse.edc.spi.types.domain.edr.EndpointDataReference.EDR_SIMPLE_TYPE;
 import static org.eclipse.edc.spi.types.domain.edr.EndpointDataReference.ENDPOINT;
 import static org.eclipse.edc.spi.types.domain.edr.EndpointDataReference.ID;
@@ -36,6 +37,7 @@ public class DataAddressToEndpointDataReferenceTransformer implements TypeTransf
 
     private static final Set<String> PROPERTIES = Set.of(
             ID,
+            CONTRACT_ID,
             ENDPOINT,
             AUTH_CODE,
             DataAddress.EDC_DATA_ADDRESS_TYPE_PROPERTY,
@@ -64,6 +66,7 @@ public class DataAddressToEndpointDataReferenceTransformer implements TypeTransf
 
         return EndpointDataReference.Builder.newInstance()
                 .id(address.getStringProperty(ID))
+                .contractId(address.getStringProperty(CONTRACT_ID))
                 .authCode(address.getStringProperty(AUTH_CODE))
                 .authKey(address.getStringProperty(AUTH_KEY))
                 .endpoint(address.getStringProperty(ENDPOINT))

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/edr/DataAddressToEndpointDataReferenceTransformerTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/edr/DataAddressToEndpointDataReferenceTransformerTest.java
@@ -40,6 +40,7 @@ class DataAddressToEndpointDataReferenceTransformerTest {
                 .property(EndpointDataReference.AUTH_KEY, "test-authkey")
                 .property(EndpointDataReference.AUTH_CODE, UUID.randomUUID().toString())
                 .property(EndpointDataReference.ID, UUID.randomUUID().toString())
+                .property(EndpointDataReference.CONTRACT_ID, UUID.randomUUID().toString())
                 .build();
 
         var edr = transformer.transform(address, context);
@@ -52,6 +53,7 @@ class DataAddressToEndpointDataReferenceTransformerTest {
                         .authKey(address.getStringProperty(EndpointDataReference.AUTH_KEY))
                         .authCode(address.getStringProperty(EndpointDataReference.AUTH_CODE))
                         .id(address.getStringProperty(EndpointDataReference.ID))
+                        .contractId(address.getStringProperty(EndpointDataReference.CONTRACT_ID))
                         .build());
     }
 

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/edr/EndpointDataReferenceReceiverRegistryImplTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/edr/EndpointDataReferenceReceiverRegistryImplTest.java
@@ -45,7 +45,22 @@ class EndpointDataReferenceReceiverRegistryImplTest {
     private final TypeTransformerRegistry typeTransformerRegistry = mock(TypeTransformerRegistry.class);
 
     private final EndpointDataReferenceReceiverRegistryImpl registry = new EndpointDataReferenceReceiverRegistryImpl(typeTransformerRegistry);
-    
+
+    private static DataAddress dataAddress() {
+        return DataAddress.Builder.newInstance().type("test").build();
+    }
+
+    private static EndpointDataReference createEndpointDataReference() {
+        return EndpointDataReference.Builder.newInstance()
+                .endpoint("test.endpoint.url")
+                .authKey("authKey")
+                .authCode("authCode")
+                .id("id")
+                .contractId("contract-id")
+                .properties(Map.of("test-key", UUID.randomUUID().toString()))
+                .build();
+    }
+
     @Test
     void onEvent_success() {
         var address = DataAddress.Builder.newInstance().type("test").build();
@@ -123,20 +138,6 @@ class EndpointDataReferenceReceiverRegistryImplTest {
                 .at(10)
                 .id("id")
                 .payload(e)
-                .build();
-    }
-
-    private static DataAddress dataAddress() {
-        return DataAddress.Builder.newInstance().type("test").build();
-    }
-
-    private static EndpointDataReference createEndpointDataReference() {
-        return EndpointDataReference.Builder.newInstance()
-                .endpoint("test.endpoint.url")
-                .authKey("test-authkey")
-                .authCode(UUID.randomUUID().toString())
-                .id(UUID.randomUUID().toString())
-                .properties(Map.of("test-key", UUID.randomUUID().toString()))
                 .build();
     }
 }

--- a/extensions/control-plane/transfer/transfer-data-plane/src/main/java/org/eclipse/edc/connector/transfer/dataplane/proxy/ConsumerPullDataPlaneProxyResolver.java
+++ b/extensions/control-plane/transfer/transfer-data-plane/src/main/java/org/eclipse/edc/connector/transfer/dataplane/proxy/ConsumerPullDataPlaneProxyResolver.java
@@ -58,6 +58,7 @@ public class ConsumerPullDataPlaneProxyResolver {
                         .map(token -> DataAddress.Builder.newInstance()
                                 .type(EndpointDataReference.EDR_SIMPLE_TYPE)
                                 .property(EndpointDataReference.ID, request.getId())
+                                .property(EndpointDataReference.CONTRACT_ID, request.getContractId())
                                 .property(EndpointDataReference.ENDPOINT, proxyUrl)
                                 .property(EndpointDataReference.AUTH_KEY, HttpHeaders.AUTHORIZATION)
                                 .property(EndpointDataReference.AUTH_CODE, token)

--- a/extensions/control-plane/transfer/transfer-data-plane/src/test/java/org/eclipse/edc/connector/transfer/dataplane/proxy/ConsumerPullDataPlaneProxyResolverTest.java
+++ b/extensions/control-plane/transfer/transfer-data-plane/src/test/java/org/eclipse/edc/connector/transfer/dataplane/proxy/ConsumerPullDataPlaneProxyResolverTest.java
@@ -81,6 +81,7 @@ class ConsumerPullDataPlaneProxyResolverTest {
         assertThat(proxyAddress.getType()).isEqualTo(EndpointDataReference.EDR_SIMPLE_TYPE);
         assertThat(proxyAddress.getProperties())
                 .containsEntry(EndpointDataReference.ID, request.getId())
+                .containsEntry(EndpointDataReference.CONTRACT_ID, request.getContractId())
                 .containsEntry(EndpointDataReference.ENDPOINT, proxyUrl)
                 .containsEntry(EndpointDataReference.AUTH_KEY, HttpHeaders.AUTHORIZATION)
                 .containsEntry(EndpointDataReference.AUTH_CODE, token);

--- a/extensions/control-plane/transfer/transfer-pull-http-dynamic-receiver/src/test/java/org/eclipse/edc/connector/receiver/http/dynamic/HttpDynamicEndpointDataReferenceReceiverTest.java
+++ b/extensions/control-plane/transfer/transfer-pull-http-dynamic-receiver/src/test/java/org/eclipse/edc/connector/receiver/http/dynamic/HttpDynamicEndpointDataReferenceReceiverTest.java
@@ -218,7 +218,8 @@ public class HttpDynamicEndpointDataReferenceReceiverTest {
                 .endpoint("some.endpoint.url")
                 .authKey("test-authkey")
                 .authCode(UUID.randomUUID().toString())
-                .id(UUID.randomUUID().toString());
+                .id(UUID.randomUUID().toString())
+                .contractId("contractId");
     }
 
     private String receiverUrl() {

--- a/extensions/control-plane/transfer/transfer-pull-http-receiver/src/test/java/org/eclipse/edc/connector/receiver/http/HttpEndpointDataReferenceReceiverTest.java
+++ b/extensions/control-plane/transfer/transfer-pull-http-receiver/src/test/java/org/eclipse/edc/connector/receiver/http/HttpEndpointDataReferenceReceiverTest.java
@@ -124,7 +124,9 @@ public class HttpEndpointDataReferenceReceiverTest {
                 .endpoint("some.endpoint.url")
                 .authKey("test-authkey")
                 .authCode(UUID.randomUUID().toString())
-                .id(UUID.randomUUID().toString()).build();
+                .id(UUID.randomUUID().toString())
+                .contractId("contractId")
+                .build();
     }
 
     private String receiverUrl() {

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/edr/EndpointDataReference.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/edr/EndpointDataReference.java
@@ -24,7 +24,6 @@ import org.jetbrains.annotations.Nullable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.UUID;
 
 import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 
@@ -38,26 +37,28 @@ public class EndpointDataReference {
     public static final String EDR_SIMPLE_TYPE = "EDR";
 
     public static final String ID = EDC_NAMESPACE + "id";
+    public static final String CONTRACT_ID = EDC_NAMESPACE + "contractId";
     public static final String AUTH_CODE = EDC_NAMESPACE + "authCode";
     public static final String AUTH_KEY = EDC_NAMESPACE + "authKey";
     public static final String ENDPOINT = EDC_NAMESPACE + "endpoint";
-    private final String id;
-    private final String endpoint;
-    private final String authKey;
-    private final String authCode;
-    private final Map<String, Object> properties;
+    private final Map<String, Object> properties = new HashMap<>();
+    private String id;
+    private String contractId;
+    private String endpoint;
+    private String authKey;
+    private String authCode;
 
-    private EndpointDataReference(String id, String endpoint, String authKey, String authCode, Map<String, Object> properties) {
-        this.id = id;
-        this.endpoint = endpoint;
-        this.authKey = authKey;
-        this.authCode = authCode;
-        this.properties = properties;
+    private EndpointDataReference() {
     }
 
     @NotNull
     public String getId() {
         return id;
+    }
+
+    @NotNull
+    public String getContractId() {
+        return contractId;
     }
 
     @NotNull
@@ -82,13 +83,10 @@ public class EndpointDataReference {
 
     @JsonPOJOBuilder(withPrefix = "")
     public static class Builder {
-        private final Map<String, Object> properties = new HashMap<>();
-        private String id = UUID.randomUUID().toString();
-        private String endpoint;
-        private String authKey;
-        private String authCode;
+        private final EndpointDataReference edr;
 
         private Builder() {
+            edr = new EndpointDataReference();
         }
 
         @JsonCreator
@@ -97,39 +95,51 @@ public class EndpointDataReference {
         }
 
         public EndpointDataReference.Builder id(String id) {
-            this.id = id;
+            edr.id = id;
+            return this;
+        }
+
+        public EndpointDataReference.Builder contractId(String contractId) {
+            edr.contractId = contractId;
             return this;
         }
 
         public EndpointDataReference.Builder endpoint(String address) {
-            this.endpoint = address;
+            edr.endpoint = address;
             return this;
         }
 
         public EndpointDataReference.Builder authKey(String authKey) {
-            this.authKey = authKey;
+            edr.authKey = authKey;
             return this;
         }
 
         public EndpointDataReference.Builder authCode(String authCode) {
-            this.authCode = authCode;
+            edr.authCode = authCode;
+            return this;
+        }
+
+        public EndpointDataReference.Builder property(String key, Object value) {
+            edr.properties.put(key, value);
             return this;
         }
 
         public EndpointDataReference.Builder properties(Map<String, Object> properties) {
-            this.properties.putAll(properties);
+            edr.properties.putAll(properties);
             return this;
         }
 
         public EndpointDataReference build() {
-            Objects.requireNonNull(endpoint, "endpoint");
-            if (authKey != null) {
-                Objects.requireNonNull(authCode, "authCode");
+            Objects.requireNonNull(edr.id, "id");
+            Objects.requireNonNull(edr.contractId, "contractId");
+            Objects.requireNonNull(edr.endpoint, "endpoint");
+            if (edr.authKey != null) {
+                Objects.requireNonNull(edr.authCode, "authCode");
             }
-            if (authCode != null) {
-                Objects.requireNonNull(authKey, "authKey");
+            if (edr.authCode != null) {
+                Objects.requireNonNull(edr.authKey, "authKey");
             }
-            return new EndpointDataReference(id, endpoint, authKey, authCode, properties);
+            return edr;
         }
     }
 }

--- a/spi/common/core-spi/src/test/java/org/eclipse/edc/spi/types/domain/edr/EndpointDataReferenceTest.java
+++ b/spi/common/core-spi/src/test/java/org/eclipse/edc/spi/types/domain/edr/EndpointDataReferenceTest.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2023 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.spi.types.domain.edr;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+class EndpointDataReferenceTest {
+
+    @Test
+    void buildMinimalEdr() {
+        assertThatNoException().isThrownBy(() -> EndpointDataReference.Builder.newInstance()
+                .endpoint("http://foo.bar")
+                .id("id")
+                .contractId("contractId")
+                .build());
+    }
+
+    @Test
+    void buildEdrWithAuth() {
+        assertThatNoException().isThrownBy(() -> EndpointDataReference.Builder.newInstance()
+                .endpoint("http://foo.bar")
+                .authKey("authKey")
+                .authCode("authCode")
+                .id("id")
+                .contractId("contractId")
+                .build());
+    }
+
+    @Test
+    void assertIdMandatory() {
+        assertThatNullPointerException().isThrownBy(() -> EndpointDataReference.Builder.newInstance()
+                        .endpoint("http://foo.bar")
+                        .contractId("contractId")
+                        .build())
+                .withMessageContaining("id");
+    }
+
+    @Test
+    void assertContractIdMandatory() {
+        assertThatNullPointerException().isThrownBy(() -> EndpointDataReference.Builder.newInstance()
+                        .endpoint("http://foo.bar")
+                        .id("id")
+                        .build())
+                .withMessageContaining("contractId");
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

Duplicate the content of the `cid` claim in the access token generated for accessing the Data Plane into a dedicated field of `EndpointDataReference`.

## Why it does that

Prevent collision in the access token if `cid` claim is already taken.

## Linked Issue(s)

Closes #3477 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
