### PR TITLE
fix: Disable jetty server version

### DIFF
--- a/extensions/common/http/jetty-core/src/main/java/org/eclipse/edc/web/jetty/JettyService.java
+++ b/extensions/common/http/jetty-core/src/main/java/org/eclipse/edc/web/jetty/JettyService.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *       Fraunhofer Institute for Software and Systems Engineering - added method
  *       ZF Friedrichshafen AG - Set connector name
+ *       Materna Information & Communications SE - disable Jetty send server version
  *
  */
 
@@ -203,6 +204,7 @@ public class JettyService implements WebServer {
     @NotNull
     private HttpConnectionFactory httpConnectionFactory() {
         HttpConfiguration https = new HttpConfiguration();
+        https.setSendServerVersion(false);
         return new HttpConnectionFactory(https);
     }
 


### PR DESCRIPTION
## What this PR changes/adds

In the `JettyService` class I have adjusted the `HttpConnectionFactory` and disabled the Jetty server version via the `HttpConfiguration`.

## Why it does that

As mentioned in #3415, this issue can lead to a potential attacker finding a vulnerability in Jetty more quickly.

## Linked Issue(s)

Closes #3415
