### PR TITLE
fix: data-plane-http - HttpSink loosing messages #3417 

### DIFF
--- a/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSink.java
+++ b/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSink.java
@@ -47,8 +47,6 @@ public class HttpDataSink extends ParallelSink {
                             response.code(), response.message(), part.name(), request.url().url(), request));
                     return ERROR_WRITING_DATA;
                 }
-
-                return StreamResult.success();
             } catch (Exception e) {
                 monitor.severe(format("Error writing HTTP data %s to endpoint %s for request: %s", part.name(), request.url().url(), request), e);
                 return ERROR_WRITING_DATA;

--- a/spi/data-plane/data-plane-spi/src/testFixtures/java/org/eclipse/edc/connector/dataplane/spi/pipeline/MultipleBinaryPartsDataSource.java
+++ b/spi/data-plane/data-plane-spi/src/testFixtures/java/org/eclipse/edc/connector/dataplane/spi/pipeline/MultipleBinaryPartsDataSource.java
@@ -14,9 +14,9 @@
 
 package org.eclipse.edc.connector.dataplane.spi.pipeline;
 
-import java.util.stream.Stream;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.util.stream.Stream;
 
 import static org.eclipse.edc.connector.dataplane.spi.pipeline.StreamResult.success;
 

--- a/spi/data-plane/data-plane-spi/src/testFixtures/java/org/eclipse/edc/connector/dataplane/spi/pipeline/MultipleBinaryPartsDataSource.java
+++ b/spi/data-plane/data-plane-spi/src/testFixtures/java/org/eclipse/edc/connector/dataplane/spi/pipeline/MultipleBinaryPartsDataSource.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (c) 2023 T-Systems International GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       T-Systems International GmbH - initial implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.spi.pipeline;
+
+import java.util.stream.Stream;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import static org.eclipse.edc.connector.dataplane.spi.pipeline.StreamResult.success;
+
+/**
+ * A {@link DataSource} backed by a byte array message which produces multiple instances
+ */
+public class MultipleBinaryPartsDataSource implements DataSource {
+    private final String name;
+    private final byte[] message;
+    private final int messageCount;
+
+    public MultipleBinaryPartsDataSource(String name, byte[] message, int messageCount) {
+        this.name = name;
+        this.message = message;
+        this.messageCount = messageCount;
+    }
+
+    @Override
+    public StreamResult<Stream<Part>> openPartStream() {
+        Stream.Builder<Part> builder = Stream.builder();
+        for (int count = 0; count < messageCount; count++) {
+            builder.add(new Part() {
+                @Override
+                public String name() {
+                    return name;
+                }
+
+                @Override
+                public InputStream openStream() {
+                    return new ByteArrayInputStream(message);
+                }
+
+                @Override
+                public long size() {
+                    return message.length;
+                }
+            });
+        }
+        return success(builder.build());
+    }
+
+    @Override
+    public void close() {
+    }
+
+}


### PR DESCRIPTION
## What this PR changes/adds

This PR introduces a test case to verify the loss of messages by HttpSink under various partitioning conditions.
This PR removes an early return statement in the partition transfer loop of HttpSink which leads to the loss of messages.

## Why it does that

Currently, HttpSink looses messages even in completely deterministic settings. It may only be safely applied with partition.size=1

## Further notes

## Linked Issue(s)

Closes #3417

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
