### PR TITLE
feat: verification of (consumer) VP (VC-JWT)

### DIFF
--- a/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtension.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtension.java
@@ -32,6 +32,9 @@ import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.iam.IdentityService;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+
+import static org.eclipse.edc.spi.CoreConstants.JSON_LD;
 
 @Extension("Identity And Trust Extension")
 public class IdentityAndTrustExtension implements ServiceExtension {
@@ -54,6 +57,9 @@ public class IdentityAndTrustExtension implements ServiceExtension {
     @Inject
     private TrustedIssuerRegistry registry;
 
+    @Inject
+    private TypeManager typeManager;
+
     private JwtValidator jwtValidator;
     private JwtVerifier jwtVerifier;
 
@@ -72,8 +78,13 @@ public class IdentityAndTrustExtension implements ServiceExtension {
     }
 
     @Provider
-    public PresentationVerifier createPresentationVerifier() {
-        return new MultiFormatPresentationVerifier();
+    public PresentationVerifier createPresentationVerifier(ServiceExtensionContext context) {
+        return new MultiFormatPresentationVerifier(jwtVerifier, getOwnDid(context), typeManager.getMapper(JSON_LD));
+    }
+
+    private String getOwnDid(ServiceExtensionContext context) {
+        // todo: this must be config value
+        return null;
     }
 
     @Provider

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/IdentityAndTrustService.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/IdentityAndTrustService.java
@@ -129,7 +129,7 @@ public class IdentityAndTrustService implements IdentityService {
         var verifiablePresentation = vpResponse.getContent();
         var credentials = verifiablePresentation.presentation().getCredentials();
         // verify, that the VP and all VPs are cryptographically OK
-        var result = presentationVerifier.verifyPresentation(verifiablePresentation.rawVp(), verifiablePresentation.format())
+        var result = presentationVerifier.verifyPresentation(verifiablePresentation)
                 .compose(u -> {
                     // in addition, verify that all VCs are valid
                     var filters = new ArrayList<>(List.of(

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/IdentityAndTrustService.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/IdentityAndTrustService.java
@@ -110,7 +110,7 @@ public class IdentityAndTrustService implements IdentityService {
     public Result<ClaimToken> verifyJwtToken(TokenRepresentation tokenRepresentation, String audience) {
 
         // verify and validate incoming SI Token
-        var issuerResult = jwtVerifier.verify(tokenRepresentation, audience)
+        var issuerResult = jwtVerifier.verify(tokenRepresentation.getToken(), audience)
                 .compose(v -> jwtValidator.validateToken(tokenRepresentation, audience))
                 .compose(claimToken -> success(claimToken.getStringClaim("iss")));
 

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/verification/JsonLdPresentationVerifier.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/verification/JsonLdPresentationVerifier.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.iam.identitytrust.verification;
 
+import org.eclipse.edc.identitytrust.model.VerifiablePresentationContainer;
 import org.eclipse.edc.spi.result.Result;
 
 /**
@@ -24,9 +25,9 @@ class JsonLdPresentationVerifier {
     /**
      * Computes the cryptographic integrity of a VerifiablePresentation
      *
-     * @param rawVp The unaltered JSON-LD string, as it was received from the holder.
+     * @param presentation The unaltered JSON-LD string, as it was received from the holder.
      */
-    public Result<Void> verifyPresentation(String rawVp) {
+    public Result<Void> verifyPresentation(VerifiablePresentationContainer presentation) {
         throw new UnsupportedOperationException("not yet implemented!");
     }
 }

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/verification/JsonLdPresentationVerifier.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/verification/JsonLdPresentationVerifier.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.iam.identitytrust.verification;
 
-import org.eclipse.edc.identitytrust.model.VerifiablePresentationContainer;
 import org.eclipse.edc.spi.result.Result;
 
 /**
@@ -25,9 +24,9 @@ class JsonLdPresentationVerifier {
     /**
      * Computes the cryptographic integrity of a VerifiablePresentation
      *
-     * @param presentation The unaltered JSON-LD string, as it was received from the holder.
+     * @param rawPresentation The unaltered JSON-LD string, as it was received from the holder.
      */
-    public Result<Void> verifyPresentation(VerifiablePresentationContainer presentation) {
+    public Result<Void> verifyPresentation(String rawPresentation) {
         throw new UnsupportedOperationException("not yet implemented!");
     }
 }

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/verification/JwtPresentationVerifier.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/verification/JwtPresentationVerifier.java
@@ -26,7 +26,27 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Verifies VerifiablePresentations, which are present in JWT format. Only the cryptographic integrity is asserted
+ * Computes the cryptographic integrity of a VerifiablePresentation when it's represented as JWT.
+ * In order to be successfully verified, a VP-JWT must contain a "vp" claim, that contains a JSON structure containing a
+ * "verifiableCredentials" object.
+ * This object contains an array of strings, each representing one VerifiableCredential, represented in JWT format.
+ * <p><br/>
+ * Both VP-JWTs and VC-JWTs must fulfill the following requirements:
+ *
+ * <ul>
+ *     <li>contain a JWS, that can be verified using the issuer's public key</li>
+ *     <li>have in its header a key-id ("kid"), which references the public key in the DID document of the VP-issuer</li>
+ *     <li>contain the following claims:
+ *     <ul>
+ *         <li>aud: must be equal to this connector's DID</li>
+ *         <li>sub: only presence is asserted</li>
+ *         <li>iss: is used to resolve the DID, that contains the key-id</li>
+ *     </ul>
+ *     <li>A VP is only verified, if it and all VCs it contains are verified</li>
+ *     </li>
+ * </ul>
+ *
+ * <em>Note: VP-JWTs may only contain VCs also represented in JWT format. Mixing formats is not allowed.</em>
  */
 class JwtPresentationVerifier {
     public static final String VERIFIABLE_CREDENTIAL_JSON_KEY = "verifiableCredential";
@@ -47,10 +67,12 @@ class JwtPresentationVerifier {
         this.objectMapper = objectMapper;
     }
 
+
     /**
-     * Computes the cryptographic integrity of a VerifiablePresentation when it's represented as JWT
+     * Verifies the presentation by checking the cryptographic integrity as well as the presence of mandatory claims in the JWT.
      *
-     * @param serializedJwt The base64-encoded JWT string
+     * @param serializedJwt The serialized JWT presentation to be verified.
+     * @return A Result object representing the verification result, containing specific error messages in case of failure.
      */
     public Result<Void> verifyPresentation(String serializedJwt) {
 

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/verification/JwtPresentationVerifier.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/verification/JwtPresentationVerifier.java
@@ -14,19 +14,90 @@
 
 package org.eclipse.edc.iam.identitytrust.verification;
 
-import org.eclipse.edc.identitytrust.model.VerifiablePresentationContainer;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jwt.SignedJWT;
+import org.eclipse.edc.identitytrust.verification.JwtVerifier;
 import org.eclipse.edc.spi.result.Result;
+
+import java.text.ParseException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Verifies VerifiablePresentations, which are present in JWT format. Only the cryptographic integrity is asserted
  */
 class JwtPresentationVerifier {
+    public static final String VERIFIABLE_CREDENTIAL_JSON_KEY = "verifiableCredential";
+    public static final String VP_CLAIM = "vp";
+    private final JwtVerifier jwtVerifier;
+    private final String thisAudience;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Verifies the JWT presentation by checking the cryptographic integrity.
+     *
+     * @param jwtVerifier  The JwtVerifier instance used to verify the JWT token.
+     * @param thisAudience The audience to which the token is intended. This must be "this connector's identifier"
+     */
+    JwtPresentationVerifier(JwtVerifier jwtVerifier, String thisAudience, ObjectMapper objectMapper) {
+        this.jwtVerifier = jwtVerifier;
+        this.thisAudience = thisAudience;
+        this.objectMapper = objectMapper;
+    }
+
     /**
      * Computes the cryptographic integrity of a VerifiablePresentation when it's represented as JWT
      *
-     * @param container The base64-encoded JWT string
+     * @param serializedJwt The base64-encoded JWT string
      */
-    public Result<Void> verifyPresentation(VerifiablePresentationContainer container) {
-        throw new UnsupportedOperationException("not yet implemented!");
+    public Result<Void> verifyPresentation(String serializedJwt) {
+
+        // verify the "outer" JWT, i.e. the VP JWT
+        var vpResult = jwtVerifier.verify(serializedJwt, thisAudience);
+        if (vpResult.failed()) {
+            return vpResult;
+        }
+
+        // verify all "inner" VC JWTs
+        try {
+            // obtain the actual VP JSON structure
+            var signedVpJwt = SignedJWT.parse(serializedJwt);
+            var vpClaim = signedVpJwt.getJWTClaimsSet().getClaim(VP_CLAIM);
+            if (vpClaim == null) {
+                return Result.failure("VP-JWT does not contain mandatory claim: " + VP_CLAIM);
+            }
+            var vpJson = vpClaim.toString();
+
+            // obtain the "verifiableCredentials" object inside
+            var map = objectMapper.readValue(vpJson, Map.class);
+            if (!map.containsKey(VERIFIABLE_CREDENTIAL_JSON_KEY)) {
+                return Result.failure("Presentation object did not contain mandatory object: " + VERIFIABLE_CREDENTIAL_JSON_KEY);
+            }
+            var vcTokens = extractCredentials(map.get(VERIFIABLE_CREDENTIAL_JSON_KEY));
+
+            if (vcTokens.isEmpty()) {
+                // todo: this is allowed by the spec, but it is semantic nonsense. Should we return failure or not?
+                return Result.failure("No credential found in presentation.");
+            }
+
+            // every VC is represented as another JWT, so we verify all of them
+            for (String token : vcTokens) {
+                vpResult = vpResult.merge(jwtVerifier.verify(token, signedVpJwt.getJWTClaimsSet().getIssuer()));
+            }
+
+        } catch (ParseException | JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+        return vpResult;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> extractCredentials(Object credentialsObject) {
+        if (credentialsObject instanceof Collection<?>) {
+            return ((Collection) credentialsObject).stream().map(Object::toString).toList();
+        }
+        return List.of(credentialsObject.toString());
     }
 }

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/verification/JwtPresentationVerifier.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/verification/JwtPresentationVerifier.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.iam.identitytrust.verification;
 
+import org.eclipse.edc.identitytrust.model.VerifiablePresentationContainer;
 import org.eclipse.edc.spi.result.Result;
 
 /**
@@ -21,11 +22,11 @@ import org.eclipse.edc.spi.result.Result;
  */
 class JwtPresentationVerifier {
     /**
-     * Computes the cryptographic integrity of a VerifiablePresentation
+     * Computes the cryptographic integrity of a VerifiablePresentation when it's represented as JWT
      *
-     * @param rawVp The base64-encoded JWT string
+     * @param container The base64-encoded JWT string
      */
-    public Result<Void> verifyPresentation(String rawVp) {
+    public Result<Void> verifyPresentation(VerifiablePresentationContainer container) {
         throw new UnsupportedOperationException("not yet implemented!");
     }
 }

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/verification/MultiFormatPresentationVerifier.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/verification/MultiFormatPresentationVerifier.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.edc.iam.identitytrust.verification;
 
-import org.eclipse.edc.identitytrust.model.CredentialFormat;
+import org.eclipse.edc.identitytrust.model.VerifiablePresentationContainer;
 import org.eclipse.edc.identitytrust.verification.PresentationVerifier;
 import org.eclipse.edc.spi.result.Result;
 
@@ -23,10 +23,10 @@ public class MultiFormatPresentationVerifier implements PresentationVerifier {
     private final JsonLdPresentationVerifier jsonLdVerifier = new JsonLdPresentationVerifier();
 
     @Override
-    public Result<Void> verifyPresentation(String rawVp, CredentialFormat format) {
-        return switch (format) {
-            case JSON_LD -> jsonLdVerifier.verifyPresentation(rawVp);
-            case JWT -> jwtVerifier.verifyPresentation(rawVp);
+    public Result<Void> verifyPresentation(VerifiablePresentationContainer container) {
+        return switch (container.format()) {
+            case JSON_LD -> jsonLdVerifier.verifyPresentation(container);
+            case JWT -> jwtVerifier.verifyPresentation(container);
         };
     }
 

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/verification/MultiFormatPresentationVerifier.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/verification/MultiFormatPresentationVerifier.java
@@ -26,14 +26,14 @@ public class MultiFormatPresentationVerifier implements PresentationVerifier {
 
     public MultiFormatPresentationVerifier(JwtVerifier tokenVerifier, String audience, ObjectMapper mapper) {
         jwtPresentationVerifier = new JwtPresentationVerifier(tokenVerifier, audience, mapper);
-        jsonLdVerifier = new JsonLdPresentationVerifier();
+        jsonLdPresentationVerifier = new JsonLdPresentationVerifier();
     }
 
     @Override
     public Result<Void> verifyPresentation(VerifiablePresentationContainer container) {
 
         return switch (container.format()) {
-            case JSON_LD -> jsonLdVerifier.verifyPresentation(container.rawVp());
+            case JSON_LD -> jsonLdPresentationVerifier.verifyPresentation(container.rawVp());
             case JWT -> jwtPresentationVerifier.verifyPresentation(container.rawVp());
         };
     }

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/verification/MultiFormatPresentationVerifier.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/verification/MultiFormatPresentationVerifier.java
@@ -31,13 +31,11 @@ public class MultiFormatPresentationVerifier implements PresentationVerifier {
 
     @Override
     public Result<Void> verifyPresentation(VerifiablePresentationContainer container) {
-        var vpResult = switch (container.format()) {
+
+        return switch (container.format()) {
             case JSON_LD -> jsonLdVerifier.verifyPresentation(container.rawVp());
             case JWT -> jwtPresentationVerifier.verifyPresentation(container.rawVp());
         };
-
-
-        return vpResult;
     }
 
 }

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/verification/MultiFormatPresentationVerifier.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/verification/MultiFormatPresentationVerifier.java
@@ -22,7 +22,7 @@ import org.eclipse.edc.spi.result.Result;
 
 public class MultiFormatPresentationVerifier implements PresentationVerifier {
     private final JwtPresentationVerifier jwtPresentationVerifier;
-    private final JsonLdPresentationVerifier jsonLdVerifier;
+    private final JsonLdPresentationVerifier jsonLdPresentationVerifier;
 
     public MultiFormatPresentationVerifier(JwtVerifier tokenVerifier, String audience, ObjectMapper mapper) {
         jwtPresentationVerifier = new JwtPresentationVerifier(tokenVerifier, audience, mapper);

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/verification/SelfIssuedIdTokenVerifier.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/verification/SelfIssuedIdTokenVerifier.java
@@ -22,7 +22,6 @@ import org.eclipse.edc.iam.did.spi.document.DidDocument;
 import org.eclipse.edc.iam.did.spi.document.VerificationMethod;
 import org.eclipse.edc.iam.did.spi.resolution.DidResolverRegistry;
 import org.eclipse.edc.identitytrust.verification.JwtVerifier;
-import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.result.Result;
 import org.jetbrains.annotations.NotNull;
 
@@ -52,11 +51,11 @@ public class SelfIssuedIdTokenVerifier implements JwtVerifier {
     }
 
     @Override
-    public Result<Void> verify(TokenRepresentation tokenRepresentation, String audience) {
+    public Result<Void> verify(String serializedJwt, String audience) {
 
         SignedJWT jwt;
         try {
-            jwt = SignedJWT.parse(tokenRepresentation.getToken());
+            jwt = SignedJWT.parse(serializedJwt);
             var didResult = resolverRegistry.resolve(jwt.getJWTClaimsSet().getIssuer());
             if (didResult.failed()) {
                 return Result.failure("Unable to resolve DID: %s".formatted(didResult.getFailureDetail()));

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/test/java/org/eclipse/edc/iam/identitytrust/JwtCreationUtils.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/test/java/org/eclipse/edc/iam/identitytrust/JwtCreationUtils.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.iam.identitytrust;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
+import java.sql.Date;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+public class JwtCreationUtils {
+    public static String createJwt(ECKey privateKey, String issuerId, String subject, String audience, Map<String, Object> claims) {
+        try {
+            var signer = new ECDSASigner(privateKey.toECPrivateKey());
+
+            // Prepare JWT with claims set
+            var now = Date.from(Instant.now());
+            var claimsSet = new JWTClaimsSet.Builder()
+                    .issuer(issuerId)
+                    .subject(subject)
+                    .issueTime(now)
+                    .audience(audience)
+                    .notBeforeTime(now)
+                    .claim("jti", UUID.randomUUID().toString())
+                    .expirationTime(Date.from(Instant.now().plusSeconds(60)));
+
+            claims.forEach(claimsSet::claim);
+
+            var signedJwt = new SignedJWT(new JWSHeader.Builder(JWSAlgorithm.ES256).keyID(privateKey.getKeyID()).build(), claimsSet.build());
+
+            signedJwt.sign(signer);
+
+            return signedJwt.serialize();
+        } catch (JOSEException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/test/java/org/eclipse/edc/iam/identitytrust/service/IdentityAndTrustServiceTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/test/java/org/eclipse/edc/iam/identitytrust/service/IdentityAndTrustServiceTest.java
@@ -49,7 +49,6 @@ import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.spi.result.Result.failure;
 import static org.eclipse.edc.spi.result.Result.success;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -144,7 +143,7 @@ class IdentityAndTrustServiceTest {
 
         @Test
         void cryptographicError() {
-            when(mockedVerifier.verifyPresentation(anyString(), any(CredentialFormat.class))).thenReturn(Result.failure("Cryptographic error"));
+            when(mockedVerifier.verifyPresentation(any())).thenReturn(Result.failure("Cryptographic error"));
             when(mockedClient.requestPresentation(any(), any(), any())).thenReturn(success(createPresentationContainer()));
             var token = createJwt();
             var result = service.verifyJwtToken(token, "test-audience");
@@ -163,7 +162,7 @@ class IdentityAndTrustServiceTest {
                             .build()))
                     .build();
             var vpContainer = new VerifiablePresentationContainer("test-vp", CredentialFormat.JSON_LD, presentation);
-            when(mockedVerifier.verifyPresentation(anyString(), any(CredentialFormat.class))).thenReturn(success());
+            when(mockedVerifier.verifyPresentation(any())).thenReturn(success());
             when(mockedClient.requestPresentation(any(), any(), any())).thenReturn(success(vpContainer));
             var token = createJwt(CONSUMER_DID, EXPECTED_OWN_DID);
             var result = service.verifyJwtToken(token, "test-audience");
@@ -188,7 +187,7 @@ class IdentityAndTrustServiceTest {
                             .build()))
                     .build();
             var vpContainer = new VerifiablePresentationContainer("test-vp", CredentialFormat.JSON_LD, presentation);
-            when(mockedVerifier.verifyPresentation(anyString(), any(CredentialFormat.class))).thenReturn(success());
+            when(mockedVerifier.verifyPresentation(any())).thenReturn(success());
             when(mockedClient.requestPresentation(any(), any(), any())).thenReturn(success(vpContainer));
             var token = createJwt(consumerDid, EXPECTED_OWN_DID);
             var result = service.verifyJwtToken(token, "test-audience");

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/test/java/org/eclipse/edc/iam/identitytrust/verification/JwtPresentationVerifierTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/test/java/org/eclipse/edc/iam/identitytrust/verification/JwtPresentationVerifierTest.java
@@ -1,0 +1,250 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.iam.identitytrust.verification;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import org.eclipse.edc.iam.did.spi.document.DidConstants;
+import org.eclipse.edc.iam.did.spi.document.DidDocument;
+import org.eclipse.edc.iam.did.spi.document.Service;
+import org.eclipse.edc.iam.did.spi.document.VerificationMethod;
+import org.eclipse.edc.iam.did.spi.resolution.DidResolverRegistry;
+import org.eclipse.edc.iam.identitytrust.JwtCreationUtils;
+import org.eclipse.edc.spi.result.Result;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class JwtPresentationVerifierTest {
+    public static final String CENTRAL_ISSUER_KEY_ID = "#central-issuer-key1";
+    public static final String PRESENTER_KEY_ID = "#my-key1";
+    private static final String VP_HOLDER_ID = "did:web:test-issuer";
+    private static final String MY_OWN_DID = "did:web:myself";
+    private static final String CENTRAL_ISSUER_DID = "did:web:some-official-issuer";
+    private final DidResolverRegistry didRegistryMock = mock();
+    private ECKey vpSigningKey;
+    private ECKey vcSigningKey;
+
+    @BeforeEach
+    void setup() throws JOSEException {
+        vpSigningKey = new ECKeyGenerator(Curve.P_256)
+                .keyID(PRESENTER_KEY_ID)
+                .generate();
+
+        vcSigningKey = new ECKeyGenerator(Curve.P_256)
+                .keyID(CENTRAL_ISSUER_KEY_ID)
+                .generate();
+
+
+        // the DID document of the VP presenter (i.e. a participant agent)
+        var vpPresenterDid = DidDocument.Builder.newInstance()
+                .verificationMethod(List.of(VerificationMethod.Builder.create()
+                        .id(PRESENTER_KEY_ID)
+                        .type(DidConstants.ECDSA_SECP_256_K_1_VERIFICATION_KEY_2019)
+                        .publicKeyJwk(vpSigningKey.toPublicJWK().toJSONObject())
+                        .build()))
+                .service(Collections.singletonList(new Service("#my-service1", "MyService", "http://doesnotexi.st")))
+                .build();
+
+        // the DID document of the central issuer, e.g. a government body, etc.
+        var vcIssuerDid = DidDocument.Builder.newInstance()
+                .verificationMethod(List.of(VerificationMethod.Builder.create()
+                        .id(CENTRAL_ISSUER_KEY_ID)
+                        .type(DidConstants.ECDSA_SECP_256_K_1_VERIFICATION_KEY_2019)
+                        .publicKeyJwk(vcSigningKey.toPublicJWK().toJSONObject())
+                        .build()))
+                .build();
+
+        when(didRegistryMock.resolve(eq(VP_HOLDER_ID))).thenReturn(Result.success(vpPresenterDid));
+        when(didRegistryMock.resolve(eq(CENTRAL_ISSUER_DID))).thenReturn(Result.success(vcIssuerDid));
+    }
+
+    @Test
+    @DisplayName("VP-JWT does not contain mandatory \"vp\" claim")
+    void verifyPresentation_noVpClaim() {
+        // create VP-JWT (signed by the presenter) that contains the VP as a claim
+        var vpJwt = JwtCreationUtils.createJwt(vpSigningKey, VP_HOLDER_ID, "degreePres", MY_OWN_DID, Map.of());
+
+        var verifier = new JwtPresentationVerifier(new SelfIssuedIdTokenVerifier(didRegistryMock), MY_OWN_DID, new ObjectMapper());
+        var result = verifier.verifyPresentation(vpJwt);
+        assertThat(result).isFailed().detail().contains("VP-JWT does not contain mandatory claim: vp");
+    }
+
+    @DisplayName("VP-JWT does not contain any credential")
+    @Test
+    void verifyPresentation_noCredential() {
+        // create VP-JWT (signed by the presenter) that contains the VP as a claim
+        var vpJwt = JwtCreationUtils.createJwt(vpSigningKey, VP_HOLDER_ID, "degreePres", MY_OWN_DID, Map.of("vp", TestData.VP_CONTENT_FOR_JWT.formatted("")));
+
+        var verifier = new JwtPresentationVerifier(new SelfIssuedIdTokenVerifier(didRegistryMock), MY_OWN_DID, new ObjectMapper());
+        var result = verifier.verifyPresentation(vpJwt);
+        assertThat(result).isFailed().detail().contains("No credential found in presentation.");
+    }
+
+    @DisplayName("VP-JWT does not contain \"verifiablePresentation\" object")
+    @Test
+    void verifyPresentation_invalidVpJson() {
+        // create VP-JWT (signed by the presenter) that contains the VP as a claim
+        var vpJwt = JwtCreationUtils.createJwt(vpSigningKey, VP_HOLDER_ID, "degreePres", MY_OWN_DID, Map.of("vp", """
+                {
+                    "key": "this is very invalid!"
+                }
+                """));
+
+        var verifier = new JwtPresentationVerifier(new SelfIssuedIdTokenVerifier(didRegistryMock), MY_OWN_DID, new ObjectMapper());
+        var result = verifier.verifyPresentation(vpJwt);
+        assertThat(result).isFailed().detail().contains("Presentation object did not contain mandatory object: verifiableCredential");
+    }
+
+    @DisplayName("VP-JWT with a single VC-JWT - both are successfully verified")
+    @Test
+    void verifyPresentation_singleVc_valid() {
+        // create VC-JWT (signed by the central issuer)
+        var vcJwt1 = JwtCreationUtils.createJwt(vcSigningKey, CENTRAL_ISSUER_DID, "degreeSub", VP_HOLDER_ID, Map.of("vc", TestData.VC_CONTENT_FOR_JWT_DEGREE_EXAMPLE));
+
+        // create VP-JWT (signed by the presenter) that contains the VP as a claim
+        var vpJwt = JwtCreationUtils.createJwt(vpSigningKey, VP_HOLDER_ID, "degreePres", MY_OWN_DID, Map.of("vp", TestData.VP_CONTENT_FOR_JWT.formatted("\"" + vcJwt1 + "\"")));
+
+        var verifier = new JwtPresentationVerifier(new SelfIssuedIdTokenVerifier(didRegistryMock), MY_OWN_DID, new ObjectMapper());
+        var result = verifier.verifyPresentation(vpJwt);
+        assertThat(result).isSucceeded();
+    }
+
+    @DisplayName("VP-JWT with a multiple VC-JWTs - all are successfully verified")
+    @Test
+    void verifyPresentation_multipleVc_valid() {
+        // create first VC-JWT (signed by the central issuer)
+        var vcJwt1 = JwtCreationUtils.createJwt(vcSigningKey, CENTRAL_ISSUER_DID, "degreeSub", VP_HOLDER_ID, Map.of("vc", TestData.VC_CONTENT_FOR_JWT_DEGREE_EXAMPLE));
+
+        // create first VC-JWT (signed by the central issuer)
+        var vcJwt2 = JwtCreationUtils.createJwt(vcSigningKey, CENTRAL_ISSUER_DID, "isoCred", VP_HOLDER_ID, Map.of("vc", TestData.VC_CONTENT_FOR_JWT_CERTIFICATE_EXAMPLE));
+
+        // create VP-JWT (signed by the presenter) that contains the VP as a claim
+        var vpContent = "\"%s\", \"%s\"".formatted(vcJwt1, vcJwt2);
+        var vpJwt = JwtCreationUtils.createJwt(vpSigningKey, VP_HOLDER_ID, "testSub", MY_OWN_DID, Map.of("vp", TestData.VP_CONTENT_FOR_JWT.formatted(vpContent)));
+
+        var verifier = new JwtPresentationVerifier(new SelfIssuedIdTokenVerifier(didRegistryMock), MY_OWN_DID, new ObjectMapper());
+        var result = verifier.verifyPresentation(vpJwt);
+        assertThat(result).isSucceeded();
+    }
+
+    @DisplayName("VP-JWT with one spoofed VC-JWT - expect a failure")
+    @Test
+    void verifyPresentation_oneVcIsInvalid() throws JOSEException {
+
+        var spoofedKey = new ECKeyGenerator(Curve.P_256)
+                .keyID(CENTRAL_ISSUER_KEY_ID) //this bit is important for the DID resolution
+                .generate();
+        // create VC-JWT (signed by the central issuer)
+        var vcJwt1 = JwtCreationUtils.createJwt(spoofedKey, CENTRAL_ISSUER_DID, "degreeSub", VP_HOLDER_ID, Map.of("vc", TestData.VC_CONTENT_FOR_JWT_DEGREE_EXAMPLE));
+
+        // create VP-JWT (signed by the presenter) that contains the VP as a claim
+        var vpJwt = JwtCreationUtils.createJwt(vpSigningKey, VP_HOLDER_ID, "degreePres", MY_OWN_DID, Map.of("vp", TestData.VP_CONTENT_FOR_JWT.formatted("\"" + vcJwt1 + "\"")));
+
+        var verifier = new JwtPresentationVerifier(new SelfIssuedIdTokenVerifier(didRegistryMock), MY_OWN_DID, new ObjectMapper());
+        var result = verifier.verifyPresentation(vpJwt);
+        assertThat(result).isFailed().detail().contains("Token could not be verified: Invalid signature");
+    }
+
+    @DisplayName("VP-JWT with a spoofed signature - expect a failure")
+    @Test
+    void verifyPresentation_vpJwtInvalid() throws JOSEException {
+        var spoofedKey = new ECKeyGenerator(Curve.P_256)
+                .keyID(PRESENTER_KEY_ID) //this bit is important for the DID resolution
+                .generate();
+        // create VC-JWT (signed by the central issuer)
+        var vcJwt1 = JwtCreationUtils.createJwt(vcSigningKey, CENTRAL_ISSUER_DID, "degreeSub", VP_HOLDER_ID, Map.of("vc", TestData.VC_CONTENT_FOR_JWT_DEGREE_EXAMPLE));
+
+        // create VP-JWT (signed by the presenter) that contains the VP as a claim
+        var vpJwt = JwtCreationUtils.createJwt(spoofedKey, VP_HOLDER_ID, "degreePres", MY_OWN_DID, Map.of("vp", TestData.VP_CONTENT_FOR_JWT.formatted(vcJwt1)));
+
+        var verifier = new JwtPresentationVerifier(new SelfIssuedIdTokenVerifier(didRegistryMock), MY_OWN_DID, new ObjectMapper());
+        var result = verifier.verifyPresentation(vpJwt);
+        assertThat(result).isFailed().detail().contains("Token could not be verified: Invalid signature");
+    }
+
+    @DisplayName("VP-JWT with a missing claim - expect a failure")
+    @Test
+    void verifyPresentation_vpJwt_invalidClaims() {
+        // create VC-JWT (signed by the central issuer)
+        var vcJwt1 = JwtCreationUtils.createJwt(vcSigningKey, CENTRAL_ISSUER_DID, "degreeSub", VP_HOLDER_ID, Map.of("vc", TestData.VC_CONTENT_FOR_JWT_DEGREE_EXAMPLE));
+
+        // create VP-JWT (signed by the presenter) that contains the VP as a claim
+        var vpJwt = JwtCreationUtils.createJwt(vpSigningKey, VP_HOLDER_ID, null, MY_OWN_DID, Map.of("vp", TestData.VP_CONTENT_FOR_JWT.formatted(vcJwt1)));
+
+        var verifier = new JwtPresentationVerifier(new SelfIssuedIdTokenVerifier(didRegistryMock), MY_OWN_DID, new ObjectMapper());
+        var result = verifier.verifyPresentation(vpJwt);
+        assertThat(result).isFailed().detail().contains("Token could not be verified: Claim verification failed. JWT missing required claims: [sub]");
+    }
+
+    @DisplayName("VP-JWT with a VC-JWT, which misses a claim - expect a failure")
+    @Test
+    void verifyPresentation_vcJwt_invalidClaims() {
+        // create VC-JWT (signed by the central issuer)
+        var vcJwt1 = JwtCreationUtils.createJwt(vcSigningKey, CENTRAL_ISSUER_DID, null, VP_HOLDER_ID, Map.of("vc", TestData.VC_CONTENT_FOR_JWT_DEGREE_EXAMPLE));
+
+        // create VP-JWT (signed by the presenter) that contains the VP as a claim
+        var vpJwt = JwtCreationUtils.createJwt(vpSigningKey, VP_HOLDER_ID, "test-subject", MY_OWN_DID, Map.of("vp", TestData.VP_CONTENT_FOR_JWT.formatted("\"" + vcJwt1 + "\"")));
+
+        var verifier = new JwtPresentationVerifier(new SelfIssuedIdTokenVerifier(didRegistryMock), MY_OWN_DID, new ObjectMapper());
+        var result = verifier.verifyPresentation(vpJwt);
+        assertThat(result).isFailed().detail().contains("Token could not be verified: Claim verification failed. JWT missing required claims: [sub]");
+    }
+
+    @DisplayName("VP-JWT with a wrong audience")
+    @Test
+    void verifyPresentation_wrongAudience() {
+        // create VC-JWT (signed by the central issuer)
+        var vcJwt1 = JwtCreationUtils.createJwt(vcSigningKey, CENTRAL_ISSUER_DID, "test-cred-sub", VP_HOLDER_ID, Map.of("vc", TestData.VC_CONTENT_FOR_JWT_DEGREE_EXAMPLE));
+
+        // create VP-JWT (signed by the presenter) that contains the VP as a claim
+        var vpJwt = JwtCreationUtils.createJwt(vpSigningKey, VP_HOLDER_ID, "test-pres-sub", "invalid-vp-audience", Map.of("vp", TestData.VP_CONTENT_FOR_JWT.formatted(vcJwt1)));
+
+        var verifier = new JwtPresentationVerifier(new SelfIssuedIdTokenVerifier(didRegistryMock), MY_OWN_DID, new ObjectMapper());
+        var result = verifier.verifyPresentation(vpJwt);
+        assertThat(result).isFailed().detail().contains("JWT aud claim has value [invalid-vp-audience], must be [did:web:myself]");
+    }
+
+    @DisplayName("VP-JWT containing a VC-JWT, where the VC-audience does not match the VP-issuer")
+    @Test
+    void verifyPresentation_vcJwt_wrongAudience() {
+        // create first VC-JWT (signed by the central issuer)
+        var vcJwt1 = JwtCreationUtils.createJwt(vcSigningKey, CENTRAL_ISSUER_DID, "degreeSub", VP_HOLDER_ID, Map.of("vc", TestData.VC_CONTENT_FOR_JWT_DEGREE_EXAMPLE));
+
+        // create first VC-JWT (signed by the central issuer)
+        var vcJwt2 = JwtCreationUtils.createJwt(vcSigningKey, CENTRAL_ISSUER_DID, "isoCred", "invalid-vc-audience", Map.of("vc", TestData.VC_CONTENT_FOR_JWT_CERTIFICATE_EXAMPLE));
+
+        // create VP-JWT (signed by the presenter) that contains the VP as a claim
+        var vpContent = "\"%s\", \"%s\"".formatted(vcJwt1, vcJwt2);
+        var vpJwt = JwtCreationUtils.createJwt(vpSigningKey, VP_HOLDER_ID, "testSub", MY_OWN_DID, Map.of("vp", TestData.VP_CONTENT_FOR_JWT.formatted(vpContent)));
+
+        var verifier = new JwtPresentationVerifier(new SelfIssuedIdTokenVerifier(didRegistryMock), MY_OWN_DID, new ObjectMapper());
+        var result = verifier.verifyPresentation(vpJwt);
+        assertThat(result).isFailed().detail().contains("JWT aud claim has value [invalid-vc-audience], must be [did:web:test-issuer]");
+    }
+
+}

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/test/java/org/eclipse/edc/iam/identitytrust/verification/SelfIssuedIdTokenVerifierTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/test/java/org/eclipse/edc/iam/identitytrust/verification/SelfIssuedIdTokenVerifierTest.java
@@ -70,21 +70,21 @@ class SelfIssuedIdTokenVerifierTest {
                 .audience("test-audience")
                 .expirationTime(new Date(new Date().getTime() + 60 * 1000))
                 .build();
-        assertThat(verifier.verify(createJwt(claimsSet, didVerificationMethod), "test-audience")).isSucceeded();
+        assertThat(verifier.verify(createJwt(claimsSet, didVerificationMethod).getToken(), "test-audience")).isSucceeded();
     }
 
     @Test
     void verify_didResolutionFailed() {
         when(didResolverRegistry.resolve(any())).thenReturn(Result.failure("test failure"));
         var jwt = createJwt();
-        assertThat(verifier.verify(jwt, "test-audience")).isFailed()
+        assertThat(verifier.verify(jwt.getToken(), "test-audience")).isFailed()
                 .detail()
                 .isEqualTo("Unable to resolve DID: test failure");
     }
 
     @Test
     void verify_publicKeyNotFound() {
-        assertThat(verifier.verify(createJwt(), "test-audience")).isFailed()
+        assertThat(verifier.verify(createJwt().getToken(), "test-audience")).isFailed()
                 .detail()
                 .isEqualTo("Public Key not found in DID Document.");
     }
@@ -102,7 +102,7 @@ class SelfIssuedIdTokenVerifierTest {
                 .build();
 
         var jwt = createJwt(claimsSet, signKey);
-        assertThat(verifier.verify(jwt, "test-audience"))
+        assertThat(verifier.verify(jwt.getToken(), "test-audience"))
                 .isFailed()
                 .detail().isEqualTo("Token could not be verified: Invalid signature");
 
@@ -116,7 +116,7 @@ class SelfIssuedIdTokenVerifierTest {
                 // aud claim missing
                 .expirationTime(new Date(new Date().getTime() + 60 * 1000))
                 .build();
-        assertThat(verifier.verify(createJwt(claimsSet, didVerificationMethod), "test-audience"))
+        assertThat(verifier.verify(createJwt(claimsSet, didVerificationMethod).getToken(), "test-audience"))
                 .isFailed()
                 .detail().contains("Claim verification failed. JWT missing required claims: [aud]");
     }
@@ -129,7 +129,7 @@ class SelfIssuedIdTokenVerifierTest {
                 .audience("test-audience")
                 .expirationTime(new Date(new Date().getTime() + 60 * 1000))
                 .build();
-        assertThat(verifier.verify(createJwt(claimsSet, didVerificationMethod), "test-audience"))
+        assertThat(verifier.verify(createJwt(claimsSet, didVerificationMethod).getToken(), "test-audience"))
                 .isFailed()
                 .detail().contains("Claim verification failed. JWT missing required claims: [iss]");
     }
@@ -142,7 +142,7 @@ class SelfIssuedIdTokenVerifierTest {
                 .audience("test-audience")
                 .expirationTime(new Date(new Date().getTime() + 60 * 1000))
                 .build();
-        assertThat(verifier.verify(createJwt(claimsSet, didVerificationMethod), "invalid-audience"))
+        assertThat(verifier.verify(createJwt(claimsSet, didVerificationMethod).getToken(), "invalid-audience"))
                 .isFailed()
                 .detail().contains("Claim verification failed. JWT aud claim has value [test-audience], must be [invalid-audience]");
     }

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/test/java/org/eclipse/edc/iam/identitytrust/verification/TestData.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/test/java/org/eclipse/edc/iam/identitytrust/verification/TestData.java
@@ -1,0 +1,76 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.iam.identitytrust.verification;
+
+public interface TestData {
+
+    // taken straight from here: https://www.w3.org/TR/vc-data-model/#example-verifiable-presentation-using-jwt-compact-serialization-non-normative
+    String VC_CONTENT_FOR_JWT_DEGREE_EXAMPLE = """
+            {
+                "@context": [
+                  "https://www.w3.org/2018/credentials/v1",
+                  "https://www.w3.org/2018/credentials/examples/v1"
+                ],
+                "type": [
+                  "VerifiableCredential",
+                  "UniversityDegreeCredential"
+                ],
+                "credentialSubject": {
+                  "id": "degreeSub"
+                  "degree": {
+                    "type": "BachelorDegree",
+                    "name": "<span lang='fr-CA'>Baccalauréat en musiques numériques</span>"
+                  }
+                }
+              }
+            """;
+
+    String VC_CONTENT_FOR_JWT_CERTIFICATE_EXAMPLE = """
+            {
+                "@context": [
+                  "https://www.w3.org/2018/credentials/v1",
+                  "https://www.w3.org/2018/credentials/examples/v1"
+                ],
+                "type": [
+                  "VerifiableCredential",
+                  "IsoCertificateCredential"
+                ],
+                "credentialSubject": {
+                  "id": "isoCred"
+                  "degree": {
+                    "type": "Iso9001Certificate",
+                    "name": "ISO 9001 Certificate for excellence in many things"
+                  }
+                }
+              }
+            """;
+
+    // taken straight from here: https://www.w3.org/TR/vc-data-model/#example-verifiable-presentation-using-jwt-compact-serialization-non-normative
+    String VP_CONTENT_FOR_JWT = """
+            {
+                "@context": [
+                  "https://www.w3.org/2018/credentials/v1",
+                  "https://www.w3.org/2018/credentials/examples/v1"
+                ],
+                "type": [
+                  "VerifiablePresentation",
+                  "CredentialManagerPresentation"
+                ],
+                "verifiableCredential": [
+                  %s
+                ]
+            }
+            """;
+}

--- a/extensions/common/iam/identity-trust/identity-trust-transform/src/main/java/org/eclipse/edc/iam/identitytrust/transform/to/JsonObjectToVerifiablePresentationTransformer.java
+++ b/extensions/common/iam/identity-trust/identity-trust-transform/src/main/java/org/eclipse/edc/iam/identitytrust/transform/to/JsonObjectToVerifiablePresentationTransformer.java
@@ -52,7 +52,7 @@ public class JsonObjectToVerifiablePresentationTransformer extends AbstractJsonL
     }
 
     /**
-     * Credentials appear to be defined as "@graph", so thats what they're expanded to.
+     * Credentials appear to be defined as "@graph", so that's what they're expanded to.
      */
     private void transformCredential(JsonValue jsonValue, VerifiablePresentation.Builder vpBuilder, TransformerContext context) {
         if (jsonValue instanceof JsonArray) {

--- a/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/verification/JwtVerifier.java
+++ b/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/verification/JwtVerifier.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.identitytrust.verification;
 
-import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.result.Result;
 
 /**
@@ -23,5 +22,5 @@ import org.eclipse.edc.spi.result.Result;
  * @see org.eclipse.edc.identitytrust.validation.JwtValidator structural validation
  */
 public interface JwtVerifier {
-    Result<Void> verify(TokenRepresentation tokenRepresentation, String audience);
+    Result<Void> verify(String serializedJwt, String audience);
 }

--- a/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/verification/PresentationVerifier.java
+++ b/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/verification/PresentationVerifier.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.edc.identitytrust.verification;
 
-import org.eclipse.edc.identitytrust.model.CredentialFormat;
+import org.eclipse.edc.identitytrust.model.VerifiablePresentationContainer;
 import org.eclipse.edc.spi.result.Result;
 
 /**
@@ -29,9 +29,8 @@ public interface PresentationVerifier {
     /**
      * Verifies the cryptographic integrity of a VerifiablePresentation.
      *
-     * @param rawVp  The VP in its raw String representation. This could be JSON-LD or a JWT
-     * @param format Determines, which format the VP is specified in.
+     * @param container The VP in its raw String representation. This could be JSON-LD or a JWT
      * @return {@link Result#success()} if valid, {@link Result#failure(String)} otherwise, giving an indication of the error.
      */
-    Result<Void> verifyPresentation(String rawVp, CredentialFormat format);
+    Result<Void> verifyPresentation(VerifiablePresentationContainer container);
 }

--- a/spi/common/identity-trust-spi/src/testFixtures/java/org/eclipse/edc/identitytrust/TestFunctions.java
+++ b/spi/common/identity-trust-spi/src/testFixtures/java/org/eclipse/edc/identitytrust/TestFunctions.java
@@ -27,6 +27,7 @@ import org.eclipse.edc.identitytrust.model.CredentialFormat;
 import org.eclipse.edc.identitytrust.model.CredentialSubject;
 import org.eclipse.edc.identitytrust.model.Issuer;
 import org.eclipse.edc.identitytrust.model.VerifiableCredential;
+import org.eclipse.edc.identitytrust.model.VerifiableCredentialContainer;
 import org.eclipse.edc.identitytrust.model.VerifiablePresentation;
 import org.eclipse.edc.identitytrust.model.VerifiablePresentationContainer;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
@@ -62,6 +63,10 @@ public class TestFunctions {
 
     public static VerifiablePresentationContainer createPresentationContainer() {
         return new VerifiablePresentationContainer("RAW_VP", CredentialFormat.JSON_LD, createPresentationBuilder().type("VerifiableCredential").build());
+    }
+
+    public static VerifiableCredentialContainer createCredentialContainer() {
+        return new VerifiableCredentialContainer("RAW_VC", CredentialFormat.JSON_LD, createCredentialBuilder().type("VerifiableCredential").build());
     }
 
     public static TokenRepresentation createJwt() {


### PR DESCRIPTION
## What this PR changes/adds

This PR adds the cryptographic verification of VerifiablePresentations for the following formats:
- JSON-LD: verification is done based on LinkedDataProofs (**edit: will come in another PR**)
- JWT: verification is done based on JWS

## Why it does that

Verifiers (e.g. a provider connector) must be able to ensure the cryptographic integrity of a presenter's VP

## Further notes

VPs must be homogenous, i.e. if a VP is presented as JWT, it may only contain VC's that are also encoded as JWT. 
**This is a restriction imposed by the [Verfiable Credentials Data Model v1.1](https://www.w3.org/TR/vc-data-model/#json-web-token-extensions).**

## Linked Issue(s)

Closes #3533

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
