### PR TITLE
docs: add required field documentation on management api

### DIFF
--- a/extensions/common/api/api-core/src/main/java/org/eclipse/edc/api/model/ApiCoreSchema.java
+++ b/extensions/common/api/api-core/src/main/java/org/eclipse/edc/api/model/ApiCoreSchema.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.spi.query.SortOrder;
 
 import java.util.List;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.spi.query.Criterion.CRITERION_TYPE;
@@ -30,8 +31,11 @@ public interface ApiCoreSchema {
     record CriterionSchema(
             @Schema(name = TYPE, example = CRITERION_TYPE)
             String type,
+            @Schema(requiredMode = REQUIRED)
             Object operandLeft,
+            @Schema(requiredMode = REQUIRED)
             String operator,
+            @Schema(requiredMode = REQUIRED)
             Object operandRight) {
 
         public static final String CRITERION_EXAMPLE = """

--- a/extensions/common/vault/vault-hashicorp/src/main/java/org/eclipse/edc/vault/hashicorp/HashicorpVaultHealthCheck.java
+++ b/extensions/common/vault/vault-hashicorp/src/main/java/org/eclipse/edc/vault/hashicorp/HashicorpVaultHealthCheck.java
@@ -52,36 +52,35 @@ public class HashicorpVaultHealthCheck implements ReadinessProvider, LivenessPro
 
         switch (response.getCodeAsEnum()) {
             case INITIALIZED_UNSEALED_AND_ACTIVE -> {
-                monitor.debug("HashiCorp Vault HealthCheck successful. " + response.getPayload());
                 result = HealthCheckResult.success();
             }
             case UNSEALED_AND_STANDBY -> {
-                final String standbyMsg = format(HEALTH_CHECK_ERROR_TEMPLATE, "Vault is in standby", response.getPayload());
+                var standbyMsg = format(HEALTH_CHECK_ERROR_TEMPLATE, "Vault is in standby", response.getPayload());
                 monitor.warning(standbyMsg);
                 result = HealthCheckResult.failed(standbyMsg);
             }
             case DISASTER_RECOVERY_MODE_REPLICATION_SECONDARY_AND_ACTIVE -> {
-                final String recoveryModeMsg = format(HEALTH_CHECK_ERROR_TEMPLATE, "Vault is in recovery mode", response.getPayload());
+                var recoveryModeMsg = format(HEALTH_CHECK_ERROR_TEMPLATE, "Vault is in recovery mode", response.getPayload());
                 monitor.warning(recoveryModeMsg);
                 result = HealthCheckResult.failed(recoveryModeMsg);
             }
             case PERFORMANCE_STANDBY -> {
-                final String performanceStandbyMsg = format(HEALTH_CHECK_ERROR_TEMPLATE, "Vault is in performance standby", response.getPayload());
+                var performanceStandbyMsg = format(HEALTH_CHECK_ERROR_TEMPLATE, "Vault is in performance standby", response.getPayload());
                 monitor.warning(performanceStandbyMsg);
                 result = HealthCheckResult.failed(performanceStandbyMsg);
             }
             case NOT_INITIALIZED -> {
-                final String notInitializedMsg = format(HEALTH_CHECK_ERROR_TEMPLATE, "Vault is not initialized", response.getPayload());
+                var notInitializedMsg = format(HEALTH_CHECK_ERROR_TEMPLATE, "Vault is not initialized", response.getPayload());
                 monitor.warning(notInitializedMsg);
                 result = HealthCheckResult.failed(notInitializedMsg);
             }
             case SEALED -> {
-                final String sealedMsg = format(HEALTH_CHECK_ERROR_TEMPLATE, "Vault is sealed", response.getPayload());
+                var sealedMsg = format(HEALTH_CHECK_ERROR_TEMPLATE, "Vault is sealed", response.getPayload());
                 monitor.warning(sealedMsg);
                 result = HealthCheckResult.failed(sealedMsg);
             }
             default -> {
-                final String unspecifiedMsg = format(HEALTH_CHECK_ERROR_TEMPLATE, "Unspecified response from vault. Code: " + response.getCode(), response.getPayload());
+                var unspecifiedMsg = format(HEALTH_CHECK_ERROR_TEMPLATE, "Unspecified response from vault. Code: " + response.getCode(), response.getPayload());
                 monitor.warning(unspecifiedMsg);
                 result = HealthCheckResult.failed(unspecifiedMsg);
             }

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/v3/AssetApi.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/v3/AssetApi.java
@@ -30,6 +30,8 @@ import org.eclipse.edc.connector.api.management.configuration.ManagementApiSchem
 
 import java.util.Map;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.spi.types.domain.asset.Asset.EDC_ASSET_TYPE;
@@ -94,7 +96,7 @@ public interface AssetApi {
             "DANGER ZONE: Note that updating assets can have unexpected results, especially for contract offers that have been sent out or are ongoing in contract negotiations.",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = AssetInputSchema.class))),
             responses = {
-                    @ApiResponse(responseCode = "200", description = "Asset was updated successfully"),
+                    @ApiResponse(responseCode = "204", description = "Asset was updated successfully"),
                     @ApiResponse(responseCode = "404", description = "Asset could not be updated, because it does not exist."),
                     @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
@@ -103,12 +105,16 @@ public interface AssetApi {
 
     @Schema(name = "AssetInput", example = AssetInputSchema.ASSET_INPUT_EXAMPLE)
     record AssetInputSchema(
+            @Schema(name = CONTEXT, requiredMode = REQUIRED)
+            Object context,
             @Schema(name = ID)
             String id,
             @Schema(name = TYPE, example = EDC_ASSET_TYPE)
             String type,
+            @Schema(requiredMode = REQUIRED)
             Map<String, Object> properties,
             Map<String, Object> privateProperties,
+            @Schema(requiredMode = REQUIRED)
             ManagementApiSchema.DataAddressSchema dataAddress
     ) {
         public static final String ASSET_INPUT_EXAMPLE = """

--- a/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/api/management/catalog/CatalogApi.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/api/management/catalog/CatalogApi.java
@@ -26,7 +26,9 @@ import jakarta.ws.rs.container.AsyncResponse;
 import jakarta.ws.rs.container.Suspended;
 import org.eclipse.edc.api.model.ApiCoreSchema;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import static org.eclipse.edc.catalog.spi.CatalogRequest.CATALOG_REQUEST_TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 
 @OpenAPIDefinition
@@ -57,12 +59,16 @@ public interface CatalogApi {
 
     @Schema(name = "CatalogRequest", example = CatalogRequestSchema.CATALOG_REQUEST_EXAMPLE)
     record CatalogRequestSchema(
+            @Schema(name = CONTEXT, requiredMode = REQUIRED)
+            Object context,
             @Schema(name = TYPE, example = CATALOG_REQUEST_TYPE)
             String type,
             @Deprecated(since = "0.2.0")
             @Schema(deprecated = true, description = "please use counterPartyAddress instead")
             String providerUrl,
+            @Schema(requiredMode = REQUIRED)
             String counterPartyAddress,
+            @Schema(requiredMode = REQUIRED)
             String protocol,
             ApiCoreSchema.QuerySpecSchema querySpec) {
 

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionApi.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionApi.java
@@ -28,9 +28,11 @@ import org.eclipse.edc.api.model.ApiCoreSchema;
 
 import java.util.List;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import static org.eclipse.edc.connector.api.management.contractdefinition.ContractDefinitionApi.ContractDefinitionInputSchema.CONTRACT_DEFINITION_INPUT_EXAMPLE;
 import static org.eclipse.edc.connector.api.management.contractdefinition.ContractDefinitionApi.ContractDefinitionOutputSchema.CONTRACT_DEFINITION_OUTPUT_EXAMPLE;
 import static org.eclipse.edc.connector.contract.spi.types.offer.ContractDefinition.CONTRACT_DEFINITION_TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 
@@ -99,12 +101,17 @@ public interface ContractDefinitionApi {
 
     @Schema(name = "ContractDefinitionInput", example = CONTRACT_DEFINITION_INPUT_EXAMPLE)
     record ContractDefinitionInputSchema(
+            @Schema(name = CONTEXT, requiredMode = REQUIRED)
+            Object context,
             @Schema(name = ID)
             String id,
             @Schema(name = TYPE, example = CONTRACT_DEFINITION_TYPE)
             String type,
+            @Schema(requiredMode = REQUIRED)
             String accessPolicyId,
+            @Schema(requiredMode = REQUIRED)
             String contractPolicyId,
+            @Schema(requiredMode = REQUIRED)
             List<ApiCoreSchema.CriterionSchema> assetsSelector) {
 
         public static final String CONTRACT_DEFINITION_INPUT_EXAMPLE = """

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApi.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApi.java
@@ -33,8 +33,10 @@ import org.eclipse.edc.connector.api.management.contractnegotiation.model.Negoti
 
 import java.util.List;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import static org.eclipse.edc.connector.contract.spi.types.command.TerminateNegotiationCommand.TERMINATE_NEGOTIATION_TYPE;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.CONTRACT_REQUEST_TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 
@@ -119,10 +121,15 @@ public interface ContractNegotiationApi {
 
     @Schema(name = "ContractRequest", example = ContractRequestSchema.CONTRACT_REQUEST_EXAMPLE)
     record ContractRequestSchema(
+            @Schema(name = CONTEXT, requiredMode = REQUIRED)
+            Object context,
             @Schema(name = TYPE, example = CONTRACT_REQUEST_TYPE)
             String type,
+            @Schema(requiredMode = REQUIRED)
             String protocol,
+            @Schema(requiredMode = REQUIRED)
             String connectorAddress,
+            @Schema(requiredMode = REQUIRED)
             String providerId,
             ContractOfferDescriptionSchema offer,
             List<ManagementApiSchema.CallbackAddressSchema> callbackAddresses) {

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApi.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApi.java
@@ -27,7 +27,9 @@ import jakarta.json.JsonObject;
 import org.eclipse.edc.api.model.ApiCoreSchema;
 import org.eclipse.edc.connector.api.management.configuration.ManagementApiSchema;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import static org.eclipse.edc.connector.policy.spi.PolicyDefinition.EDC_POLICY_DEFINITION_TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 
@@ -87,7 +89,7 @@ public interface PolicyDefinitionApi {
     @Operation(description = "Updates an existing Policy, If the Policy is not found, an error is reported",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = PolicyDefinitionInputSchema.class))),
             responses = {
-                    @ApiResponse(responseCode = "200", description = "policy definition was updated successfully. Returns the Policy Definition Id and updated timestamp"),
+                    @ApiResponse(responseCode = "204", description = "policy definition was updated successfully."),
                     @ApiResponse(responseCode = "400", description = "Request body was malformed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
                     @ApiResponse(responseCode = "404", description = "policy definition could not be updated, because it does not exists",
@@ -98,10 +100,13 @@ public interface PolicyDefinitionApi {
 
     @Schema(name = "PolicyDefinitionInput", example = PolicyDefinitionInputSchema.POLICY_DEFINITION_INPUT_EXAMPLE)
     record PolicyDefinitionInputSchema(
+            @Schema(name = CONTEXT, requiredMode = REQUIRED)
+            Object context,
             @Schema(name = ID)
             String id,
             @Schema(name = TYPE, example = EDC_POLICY_DEFINITION_TYPE)
             String type,
+            @Schema(requiredMode = REQUIRED)
             ManagementApiSchema.PolicySchema policy) {
 
         // policy example took from https://w3c.github.io/odrl/bp/

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/TransferProcessApi.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/TransferProcessApi.java
@@ -34,8 +34,10 @@ import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import java.util.List;
 import java.util.Map;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import static org.eclipse.edc.connector.transfer.spi.types.TransferProcess.TRANSFER_PROCESS_TYPE;
 import static org.eclipse.edc.connector.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 
@@ -121,13 +123,21 @@ public interface TransferProcessApi {
 
     @Schema(name = "TransferRequest", example = TransferRequestSchema.TRANSFER_REQUEST_EXAMPLE)
     record TransferRequestSchema(
+            @Schema(name = CONTEXT, requiredMode = REQUIRED)
+            Object context,
             @Schema(name = TYPE, example = TRANSFER_REQUEST_TYPE)
             String type,
+            @Schema(requiredMode = REQUIRED)
             String protocol,
+            @Schema(requiredMode = REQUIRED)
             String connectorAddress,
+            @Schema(requiredMode = REQUIRED)
             String connectorId,
+            @Schema(requiredMode = REQUIRED)
             String contractId,
+            @Schema(requiredMode = REQUIRED)
             String assetId,
+            @Schema(requiredMode = REQUIRED)
             ManagementApiSchema.DataAddressSchema dataDestination,
             @Schema(deprecated = true, description = "Deprecated as this field is not used anymore, please use privateProperties instead")
             Map<String, String> properties,

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/schemas/DataPlaneInstanceSchema.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/schemas/DataPlaneInstanceSchema.java
@@ -19,20 +19,28 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.net.URL;
 import java.util.Set;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.DATAPLANE_INSTANCE_TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 
 @Schema(example = DataPlaneInstanceSchema.DATAPLANE_INSTANCE_EXAMPLE)
-public record DataPlaneInstanceSchema(@Schema(name = TYPE, example = DATAPLANE_INSTANCE_TYPE)
-                                      String type,
-                                      @Schema(name = ID)
-                                      String id,
-                                      Set<String> allowedSourceTypes,
-                                      Set<String> allowedDestTypes,
-                                      Integer turnCount,
-                                      Long lastActive,
-                                      URL url) {
+public record DataPlaneInstanceSchema(
+        @Schema(name = CONTEXT, requiredMode = REQUIRED)
+        Object context,
+        @Schema(name = TYPE, example = DATAPLANE_INSTANCE_TYPE)
+        String type,
+        @Schema(name = ID)
+        String id,
+        @Schema(requiredMode = REQUIRED)
+        URL url,
+        @Schema(requiredMode = REQUIRED)
+        Set<String> allowedSourceTypes,
+        @Schema(requiredMode = REQUIRED)
+        Set<String> allowedDestTypes,
+        Integer turnCount,
+        Long lastActive) {
     public static final String DATAPLANE_INSTANCE_EXAMPLE = """
             {
                 "@context": {


### PR DESCRIPTION
## What this PR changes/adds

Add `required` attribute where needed on the input schema objects for management api

## Why it does that

documentation

## Further notes

- 2 update methods were marked with a `200` status code but they are actually returning `204`
- added `@context` objects as well, marked as required.
- remove flooding debug log

## Linked Issue(s)

Closes #3552

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
