### PR TITLE
docs: add free form properties schema type

### DIFF
--- a/extensions/common/api/management-api-configuration/src/main/java/org/eclipse/edc/connector/api/management/configuration/ManagementApiSchema.java
+++ b/extensions/common/api/management-api-configuration/src/main/java/org/eclipse/edc/connector/api/management/configuration/ManagementApiSchema.java
@@ -96,6 +96,9 @@ public interface ManagementApiSchema {
                 """;
     }
 
+    @Schema(name = "Properties", additionalProperties = Schema.AdditionalPropertiesValue.TRUE)
+    record FreeFormPropertiesSchema() {}
+
     @Schema(name = "Policy", description = "ODRL policy", example = PolicySchema.POLICY_EXAMPLE)
     record PolicySchema() {
         public static final String POLICY_EXAMPLE = """

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/v3/AssetApi.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/v3/AssetApi.java
@@ -111,8 +111,9 @@ public interface AssetApi {
             String id,
             @Schema(name = TYPE, example = EDC_ASSET_TYPE)
             String type,
-            @Schema(requiredMode = REQUIRED)
+            @Schema(requiredMode = REQUIRED, additionalProperties = Schema.AdditionalPropertiesValue.TRUE)
             Map<String, Object> properties,
+            @Schema(additionalProperties = Schema.AdditionalPropertiesValue.TRUE)
             Map<String, Object> privateProperties,
             @Schema(requiredMode = REQUIRED)
             ManagementApiSchema.DataAddressSchema dataAddress

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/v3/AssetApi.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/v3/AssetApi.java
@@ -28,8 +28,6 @@ import jakarta.json.JsonObject;
 import org.eclipse.edc.api.model.ApiCoreSchema;
 import org.eclipse.edc.connector.api.management.configuration.ManagementApiSchema;
 
-import java.util.Map;
-
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
@@ -111,10 +109,9 @@ public interface AssetApi {
             String id,
             @Schema(name = TYPE, example = EDC_ASSET_TYPE)
             String type,
-            @Schema(requiredMode = REQUIRED, additionalProperties = Schema.AdditionalPropertiesValue.TRUE)
-            Map<String, Object> properties,
-            @Schema(additionalProperties = Schema.AdditionalPropertiesValue.TRUE)
-            Map<String, Object> privateProperties,
+            @Schema(requiredMode = REQUIRED)
+            ManagementApiSchema.FreeFormPropertiesSchema properties,
+            ManagementApiSchema.FreeFormPropertiesSchema privateProperties,
             @Schema(requiredMode = REQUIRED)
             ManagementApiSchema.DataAddressSchema dataAddress
     ) {
@@ -143,8 +140,8 @@ public interface AssetApi {
             String id,
             @Schema(name = TYPE, example = EDC_ASSET_TYPE)
             String type,
-            Map<String, Object> properties,
-            Map<String, Object> privateProperties,
+            ManagementApiSchema.FreeFormPropertiesSchema properties,
+            ManagementApiSchema.FreeFormPropertiesSchema privateProperties,
             ManagementApiSchema.DataAddressSchema dataAddress,
             long createdAt
     ) {

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/TransferProcessApi.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/TransferProcessApi.java
@@ -141,6 +141,7 @@ public interface TransferProcessApi {
             ManagementApiSchema.DataAddressSchema dataDestination,
             @Schema(deprecated = true, description = "Deprecated as this field is not used anymore, please use privateProperties instead")
             Map<String, String> properties,
+            @Schema(additionalProperties = Schema.AdditionalPropertiesValue.TRUE)
             Map<String, String> privateProperties,
             List<ManagementApiSchema.CallbackAddressSchema> callbackAddresses) {
 
@@ -186,6 +187,7 @@ public interface TransferProcessApi {
             @Deprecated(since = "0.2.0")
             @Schema(deprecated = true)
             Map<String, String> properties,
+            ManagementApiSchema.DataAddressSchema dataDestination,
             Map<String, Object> privateProperties,
             List<ManagementApiSchema.CallbackAddressSchema> callbackAddresses
     ) {

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/TransferProcessApi.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/TransferProcessApi.java
@@ -32,7 +32,6 @@ import org.eclipse.edc.connector.api.management.transferprocess.model.TransferSt
 import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 
 import java.util.List;
-import java.util.Map;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import static org.eclipse.edc.connector.transfer.spi.types.TransferProcess.TRANSFER_PROCESS_TYPE;
@@ -140,9 +139,9 @@ public interface TransferProcessApi {
             @Schema(requiredMode = REQUIRED)
             ManagementApiSchema.DataAddressSchema dataDestination,
             @Schema(deprecated = true, description = "Deprecated as this field is not used anymore, please use privateProperties instead")
-            Map<String, String> properties,
+            ManagementApiSchema.FreeFormPropertiesSchema properties,
             @Schema(additionalProperties = Schema.AdditionalPropertiesValue.TRUE)
-            Map<String, String> privateProperties,
+            ManagementApiSchema.FreeFormPropertiesSchema privateProperties,
             List<ManagementApiSchema.CallbackAddressSchema> callbackAddresses) {
 
         public static final String TRANSFER_REQUEST_EXAMPLE = """
@@ -186,9 +185,9 @@ public interface TransferProcessApi {
             String errorDetail,
             @Deprecated(since = "0.2.0")
             @Schema(deprecated = true)
-            Map<String, String> properties,
+            ManagementApiSchema.FreeFormPropertiesSchema properties,
             ManagementApiSchema.DataAddressSchema dataDestination,
-            Map<String, Object> privateProperties,
+            ManagementApiSchema.FreeFormPropertiesSchema privateProperties,
             List<ManagementApiSchema.CallbackAddressSchema> callbackAddresses
     ) {
         public static final String TRANSFER_PROCESS_EXAMPLE = """


### PR DESCRIPTION
## What this PR changes/adds

Adds the `FreeFormPropertiesSchema` type for openapi documentation

## Why it does that

It will better describe the properties field, that are not strictly `string -> object`, but `string -> any` (in java there's no difference, but in the openapi domain there is)

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Also part of #3552 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
