### PR TITLE
fix: permit query `Asset` json properties

### DIFF
--- a/core/common/util/build.gradle.kts
+++ b/core/common/util/build.gradle.kts
@@ -18,6 +18,8 @@ plugins {
 }
 
 dependencies {
+    api(project(":spi:common:core-spi"))
+
     testImplementation(libs.junit.pioneer)
 }
 

--- a/core/common/util/src/test/java/org/eclipse/edc/util/reflection/ReflectionUtilTest.java
+++ b/core/common/util/src/test/java/org/eclipse/edc/util/reflection/ReflectionUtilTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.util.reflection;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
@@ -27,154 +28,177 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ReflectionUtilTest {
 
-    @Test
-    void getFieldValue() {
-        var value = ReflectionUtil.getFieldValue("description", new TestObject("test-desc", 1));
-        assertThat(value).isInstanceOf(String.class).isEqualTo("test-desc");
+    @Nested
+    class GetFieldValue {
 
-        var value2 = ReflectionUtil.getFieldValue("priority", new TestObject("test-desc", 1));
-        assertThat(value2).isInstanceOf(Integer.class).isEqualTo(1);
+        @Test
+        void getFieldValue() {
+            var value = ReflectionUtil.getFieldValue("description", new TestObject("test-desc", 1));
+            assertThat(value).isInstanceOf(String.class).isEqualTo("test-desc");
+
+            var value2 = ReflectionUtil.getFieldValue("priority", new TestObject("test-desc", 1));
+            assertThat(value2).isInstanceOf(Integer.class).isEqualTo(1);
+        }
+
+        @Test
+        void getFieldValue_isNull() {
+            var value = ReflectionUtil.getFieldValue("description", new TestObject(null, 1));
+            assertThat(value).isNull();
+        }
+
+        @Test
+        void getFieldValue_notExist() {
+            assertThatThrownBy(() -> ReflectionUtil.getFieldValue("notExist", new TestObject("test-desc", 1)))
+                    .isInstanceOf(ReflectionException.class);
+        }
+
+        @Test
+        void getFieldValue_invalidArgs() {
+
+            assertThatThrownBy(() -> ReflectionUtil.getFieldValue("", new TestObject("test-desc", 1)))
+                    .isInstanceOf(ReflectionException.class);
+
+            assertThatThrownBy(() -> ReflectionUtil.getFieldValue((String) null, new TestObject("test-desc", 1)))
+                    .isInstanceOf(NullPointerException.class).hasMessage("propertyName");
+
+            assertThatThrownBy(() -> ReflectionUtil.getFieldValue("description", null))
+                    .isInstanceOf(NullPointerException.class).hasMessage("object");
+        }
+
+        @Test
+        void getFieldValue_fromMap() {
+            var value = ReflectionUtil.getFieldValue("key", Map.of("key", "value"));
+
+            assertThat(value).isEqualTo("value");
+        }
+
+        @Test
+        void getFieldValue_whenParentExist() {
+            var to = new TestObjectSubSubclass("test-desc", 1, "foobar");
+            to.setAnotherObject(new AnotherObject("another-desc"));
+
+            String fieldValue = ReflectionUtil.getFieldValue("anotherObject.anotherDescription", to);
+            assertThat(fieldValue).isEqualTo("another-desc");
+        }
+
+        @Test
+        void getFieldValue_whenParentNotExist() {
+            var to = new TestObjectSubSubclass("test-desc", 1, "foobar");
+            to.setAnotherObject(null);
+
+            String fieldValue = ReflectionUtil.getFieldValue("anotherObject.anotherDescription", to);
+            assertThat(fieldValue).isNull();
+        }
+
+        @Test
+        void getFieldValue_withArrayIndex() {
+            var to1 = new TestObject("to1", 420);
+            var o = new TestObjectWithList("test-desc", 0, List.of(to1, new TestObject("to2", 69)));
+            assertThat((TestObject) ReflectionUtil.getFieldValue("nestedObjects[0]", o)).isEqualTo(to1);
+        }
+
+        @Test
+        void getFieldValue_arrayWithoutIndex() {
+            var nestedObjects = List.of(
+                    new TestObject("to1", 420),
+                    new TestObject("to2", 69)
+            );
+            var object = new TestObjectWithList("test-desc", 0, nestedObjects);
+
+            var result = ReflectionUtil.getFieldValue("nestedObjects.description", object);
+
+            assertThat(result).isEqualTo(List.of("to1", "to2"));
+        }
+
+        @Test
+        void getFieldValue_withArrayIndex_andDotAccess() {
+            var to1 = new TestObject("to1", 420);
+            var o = new TestObjectWithList("test-desc", 0, List.of(to1, new TestObject("to2", 69)));
+
+            var fieldValue = ReflectionUtil.getFieldValue("nestedObjects[0].priority", o);
+
+            assertThat(fieldValue).isEqualTo(420);
+        }
+
+        @Test
+        void getFieldValue_withArrayIndex_outOfBounds() {
+            var o = new TestObjectWithList("test-desc", 0, List.of(new TestObject("to1", 420), new TestObject("to2", 69)));
+            assertThatThrownBy(() -> ReflectionUtil.getFieldValue("nestedObjects[3]", o)).isInstanceOf(IndexOutOfBoundsException.class);
+        }
+
+        @Test
+        void shouldGetNestedValue_whenKeyContainsDot() {
+            var object = Map.of("http://namespace.domain/nested", Map.of("http://namespace.domain/key", "value"));
+
+            var value = ReflectionUtil.getFieldValue("'http://namespace.domain/nested'.'http://namespace.domain/key'", object);
+
+            assertThat(value).isInstanceOf(String.class).isEqualTo("value");
+        }
+
     }
 
-    @Test
-    void getFieldValue_isNull() {
-        var value = ReflectionUtil.getFieldValue("description", new TestObject(null, 1));
-        assertThat(value).isNull();
+    @Nested
+    class GetFieldRecursive {
+
+        @Test
+        void getAllFieldsRecursive() {
+            var to = new TestObjectSubclass("test-desc", 1, "foobar");
+
+            assertThat(ReflectionUtil.getAllFieldsRecursive(to.getClass())).hasSize(5).extracting(Field::getName)
+                    .containsExactlyInAnyOrder("description", "priority", "testProperty", "listField", "embedded");
+        }
+
+        @Test
+        void getFieldRecursive_whenDeclaredInSuperclass() {
+            var to = new TestObjectSubclass("test-desc", 1, "foobar");
+            assertThat(ReflectionUtil.getFieldRecursive(to.getClass(), "description")).isNotNull();
+        }
+
+        @Test
+        void getFieldRecursive_whenDeclaredInClass() {
+            var to = new TestObjectSubclass("test-desc", 1, "foobar");
+
+            var testProperty = ReflectionUtil.getFieldRecursive(to.getClass(), "testProperty");
+
+            assertThat(testProperty).isNotNull();
+        }
+
+        @Test
+        @DisplayName("Should pick the property from the object highest in the object hierarchy")
+        void getFieldRecursive_whenDeclaredInBoth() {
+            var to = new TestObjectSubSubclass("test-desc", 2, "foobar");
+            assertThat(ReflectionUtil.getFieldRecursive(to.getClass(), "description")).isNotNull().extracting(Field::getDeclaringClass)
+                    .isEqualTo(TestObject.class);
+        }
+
+        @Test
+        void getFieldRecursive_whenNotDeclared() {
+            var to = new TestObjectSubclass("test-desc", 1, "foobar");
+            assertThat(ReflectionUtil.getFieldRecursive(to.getClass(), "notExist")).isNull();
+        }
+
     }
 
-    @Test
-    void getFieldValue_notExist() {
-        assertThatThrownBy(() -> ReflectionUtil.getFieldValue("notExist", new TestObject("test-desc", 1)))
-                .isInstanceOf(ReflectionException.class);
+    @Nested
+    class GetSingleSuperTypeGenericArgument {
+        @Test
+        void getSingleSuperTypeGenericArgument() {
+            var fields = ReflectionUtil.getSingleSuperTypeGenericArgument(TestGenericSubclass.class, TestGenericObject.class);
+            assertThat(fields).isEqualTo(String.class);
+        }
+
+        @Test
+        void getSingleSuperTypeGenericArgument_whenNoGenericSuperclass() {
+            var fields = ReflectionUtil.getSingleSuperTypeGenericArgument(TestObjectWithList.class, TestObject.class);
+            assertThat(fields).isNull();
+        }
+
+        @Test
+        void getSingleSuperTypeGenericArgument_whenGenericClass() {
+            var genericList = new TestGenericArrayList<String>();
+            var fields = ReflectionUtil.getSingleSuperTypeGenericArgument(genericList.getClass(), ArrayList.class);
+            assertThat(fields).isNull();
+        }
     }
 
-    @Test
-    void getFieldValue_invalidArgs() {
-
-        assertThatThrownBy(() -> ReflectionUtil.getFieldValue("", new TestObject("test-desc", 1)))
-                .isInstanceOf(ReflectionException.class);
-
-        assertThatThrownBy(() -> ReflectionUtil.getFieldValue(null, new TestObject("test-desc", 1)))
-                .isInstanceOf(NullPointerException.class).hasMessage("propertyName");
-
-        assertThatThrownBy(() -> ReflectionUtil.getFieldValue("description", null))
-                .isInstanceOf(NullPointerException.class).hasMessage("object");
-    }
-
-    @Test
-    void getFieldValue_fromMap() {
-        var value = ReflectionUtil.getFieldValue("key", Map.of("key", "value"));
-
-        assertThat(value).isEqualTo("value");
-    }
-
-    @Test
-    void getAllFieldsRecursive() {
-        var to = new TestObjectSubclass("test-desc", 1, "foobar");
-
-        assertThat(ReflectionUtil.getAllFieldsRecursive(to.getClass())).hasSize(5).extracting(Field::getName)
-                .containsExactlyInAnyOrder("description", "priority", "testProperty", "listField", "embedded");
-    }
-
-    @Test
-    void getFieldRecursive_whenDeclaredInSuperclass() {
-        var to = new TestObjectSubclass("test-desc", 1, "foobar");
-        assertThat(ReflectionUtil.getFieldRecursive(to.getClass(), "description")).isNotNull();
-    }
-
-    @Test
-    void getFieldRecursive_whenDeclaredInClass() {
-        var to = new TestObjectSubclass("test-desc", 1, "foobar");
-
-        var testProperty = ReflectionUtil.getFieldRecursive(to.getClass(), "testProperty");
-
-        assertThat(testProperty).isNotNull();
-    }
-
-    @Test
-    @DisplayName("Should pick the property from the object highest in the object hierarchy")
-    void getFieldRecursive_whenDeclaredInBoth() {
-        var to = new TestObjectSubSubclass("test-desc", 2, "foobar");
-        assertThat(ReflectionUtil.getFieldRecursive(to.getClass(), "description")).isNotNull().extracting(Field::getDeclaringClass)
-                .isEqualTo(TestObject.class);
-    }
-
-    @Test
-    void getFieldRecursive_whenNotDeclared() {
-        var to = new TestObjectSubclass("test-desc", 1, "foobar");
-        assertThat(ReflectionUtil.getFieldRecursive(to.getClass(), "notExist")).isNull();
-    }
-
-    @Test
-    void getFieldValue_whenParentExist() {
-        var to = new TestObjectSubSubclass("test-desc", 1, "foobar");
-        to.setAnotherObject(new AnotherObject("another-desc"));
-
-        String fieldValue = ReflectionUtil.getFieldValue("anotherObject.anotherDescription", to);
-        assertThat(fieldValue).isEqualTo("another-desc");
-    }
-
-    @Test
-    void getFieldValue_whenParentNotExist() {
-        var to = new TestObjectSubSubclass("test-desc", 1, "foobar");
-        to.setAnotherObject(null);
-
-        String fieldValue = ReflectionUtil.getFieldValue("anotherObject.anotherDescription", to);
-        assertThat(fieldValue).isNull();
-    }
-
-    @Test
-    void getFieldValue_withArrayIndex() {
-        var to1 = new TestObject("to1", 420);
-        var o = new TestObjectWithList("test-desc", 0, List.of(to1, new TestObject("to2", 69)));
-        assertThat((TestObject) ReflectionUtil.getFieldValue("nestedObjects[0]", o)).isEqualTo(to1);
-    }
-
-    @Test
-    void getFieldValue_arrayWithoutIndex() {
-        var nestedObjects = List.of(
-                new TestObject("to1", 420),
-                new TestObject("to2", 69)
-        );
-        var object = new TestObjectWithList("test-desc", 0, nestedObjects);
-
-        var result = ReflectionUtil.getFieldValue("nestedObjects.description", object);
-
-        assertThat(result).isEqualTo(List.of("to1", "to2"));
-    }
-
-    @Test
-    void getFieldValue_withArrayIndex_andDotAccess() {
-        var to1 = new TestObject("to1", 420);
-        var o = new TestObjectWithList("test-desc", 0, List.of(to1, new TestObject("to2", 69)));
-
-        var fieldValue = ReflectionUtil.getFieldValue("nestedObjects[0].priority", o);
-
-        assertThat(fieldValue).isEqualTo(420);
-    }
-
-    @Test
-    void getFieldValue_withArrayIndex_outOfBounds() {
-        var o = new TestObjectWithList("test-desc", 0, List.of(new TestObject("to1", 420), new TestObject("to2", 69)));
-        assertThatThrownBy(() -> ReflectionUtil.getFieldValue("nestedObjects[3]", o)).isInstanceOf(IndexOutOfBoundsException.class);
-    }
-
-    @Test
-    void getSingleSuperTypeGenericArgument() {
-        var fields = ReflectionUtil.getSingleSuperTypeGenericArgument(TestGenericSubclass.class, TestGenericObject.class);
-        assertThat(fields).isEqualTo(String.class);
-    }
-
-    @Test
-    void getSingleSuperTypeGenericArgument_whenNoGenericSuperclass() {
-        var fields = ReflectionUtil.getSingleSuperTypeGenericArgument(TestObjectWithList.class, TestObject.class);
-        assertThat(fields).isNull();
-    }
-
-    @Test
-    void getSingleSuperTypeGenericArgument_whenGenericClass() {
-        var genericList = new TestGenericArrayList<String>();
-        var fields = ReflectionUtil.getSingleSuperTypeGenericArgument(genericList.getClass(), ArrayList.class);
-        assertThat(fields).isNull();
-    }
 }

--- a/core/control-plane/catalog-core/src/test/java/org/eclipse/edc/connector/catalog/DatasetResolverImplIntegrationTest.java
+++ b/core/control-plane/catalog-core/src/test/java/org/eclipse/edc/connector/catalog/DatasetResolverImplIntegrationTest.java
@@ -122,8 +122,8 @@ class DatasetResolverImplIntegrationTest {
 
     @Test
     void shouldLimitResult_insufficientAssets() {
-        var assets1 = range(0, 12).mapToObj(i -> createAsset("asset" + i).build()).collect(Collectors.toList());
-        var assets2 = range(12, 18).mapToObj(i -> createAsset("asset" + i).build()).collect(Collectors.toList());
+        var assets1 = range(0, 12).mapToObj(i -> createAsset("asset" + i).build()).toList();
+        var assets2 = range(12, 18).mapToObj(i -> createAsset("asset" + i).build()).toList();
 
         assets1.forEach(assetIndex::create);
         assets2.forEach(assetIndex::create);
@@ -163,7 +163,7 @@ class DatasetResolverImplIntegrationTest {
     }
 
     private List<Criterion> selectorFrom(Collection<Asset> assets1) {
-        var ids = assets1.stream().map(Asset::getId).collect(Collectors.toList());
+        var ids = assets1.stream().map(Asset::getId).toList();
         return List.of(new Criterion(Asset.PROPERTY_ID, "in", ids));
     }
 

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/asset/AssetServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/asset/AssetServiceImpl.java
@@ -22,7 +22,6 @@ import org.eclipse.edc.service.spi.result.ServiceResult;
 import org.eclipse.edc.spi.asset.AssetIndex;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
-import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 import org.eclipse.edc.validator.spi.DataAddressValidator;
@@ -124,12 +123,4 @@ public class AssetServiceImpl implements AssetService {
         });
     }
 
-    @Override
-    public ServiceResult<DataAddress> update(String assetId, DataAddress dataAddress) {
-        return transactionContext.execute(() -> {
-            var result = index.updateDataAddress(assetId, dataAddress);
-            result.onSuccess(da -> observable.invokeForEach(l -> l.updated(findById(assetId))));
-            return ServiceResult.from(result);
-        });
-    }
 }

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/asset/AssetServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/asset/AssetServiceImplTest.java
@@ -291,36 +291,6 @@ class AssetServiceImplTest {
         verifyNoInteractions(index);
     }
 
-    @Test
-    void updateDataAddress_shouldUpdateWhenExists() {
-        when(dataAddressValidator.validate(any())).thenReturn(ValidationResult.success());
-        var assetId = "assetId";
-        var asset = createAsset(assetId);
-        var dataAddress = DataAddress.Builder.newInstance().type("test-type").build();
-        when(index.updateDataAddress(assetId, dataAddress)).thenReturn(StoreResult.success(dataAddress));
-
-        var updated = service.update(assetId, dataAddress);
-
-        assertThat(updated.succeeded()).isTrue();
-        verify(index).updateDataAddress(eq(assetId), eq(dataAddress));
-        verify(observable).invokeForEach(any());
-    }
-
-    @Test
-    void updateDataAddress_shouldReturnNotFound_whenNotExists() {
-        var assetId = "assetId";
-        var dataAddress = DataAddress.Builder.newInstance().type("test-type").build();
-        when(index.updateDataAddress(assetId, dataAddress)).thenReturn(StoreResult.notFound("test"));
-
-        var updated = service.update(assetId, dataAddress);
-
-        assertThat(updated.failed()).isTrue();
-        assertThat(updated.reason()).isEqualTo(NOT_FOUND);
-        verify(index).updateDataAddress(eq(assetId), eq(dataAddress));
-        verifyNoMoreInteractions(index);
-        verify(observable, never()).invokeForEach(any());
-    }
-
     private static class InvalidFilters implements ArgumentsProvider {
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) {

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/assetindex/InMemoryAssetIndex.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/assetindex/InMemoryAssetIndex.java
@@ -130,22 +130,6 @@ public class InMemoryAssetIndex implements AssetIndex {
     }
 
     @Override
-    public StoreResult<DataAddress> updateDataAddress(String assetId, DataAddress dataAddress) {
-        lock.writeLock().lock();
-        try {
-            Objects.requireNonNull(dataAddress, "dataAddress");
-            Objects.requireNonNull(assetId, "asset.getId()");
-            if (dataAddresses.containsKey(assetId)) {
-                dataAddresses.put(assetId, dataAddress);
-                return StoreResult.success(dataAddress);
-            }
-            return StoreResult.notFound(format(DATA_ADDRESS_NOT_FOUND_TEMPLATE, assetId));
-        } finally {
-            lock.writeLock().unlock();
-        }
-    }
-
-    @Override
     public DataAddress resolveForAsset(String assetId) {
         Objects.requireNonNull(assetId, "assetId");
         lock.readLock().lock();

--- a/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/JsonFieldMapping.java
+++ b/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/JsonFieldMapping.java
@@ -14,7 +14,12 @@
 
 package org.eclipse.edc.sql.translation;
 
+import org.eclipse.edc.spi.types.PathItem;
+
+import java.util.List;
+
 import static java.lang.String.format;
+import static java.util.stream.IntStream.range;
 
 public class JsonFieldMapping extends TranslationMapping {
     protected final String columnName;
@@ -24,18 +29,15 @@ public class JsonFieldMapping extends TranslationMapping {
     }
 
     @Override
-    public String getStatement(String canonicalPropertyName, Class<?> type) {
-        var tokens = canonicalPropertyName.split("\\.");
-
+    public String getStatement(List<PathItem> path, Class<?> type) {
         var statementBuilder = new StringBuilder(columnName);
-        var length = tokens.length;
-        for (var i = 0; i < length - 1; i++) {
-            statementBuilder.append(" -> ");
-            statementBuilder.append("'").append(tokens[i]).append("'");
-        }
 
-        statementBuilder.append(" ->> ");
-        statementBuilder.append("'").append(tokens[length - 1]).append("'");
+        var length = path.size();
+        range(0, length - 1)
+                .mapToObj(i -> " -> '%s'".formatted(path.get(i)))
+                .forEach(statementBuilder::append);
+
+        statementBuilder.append(" ->> '%s'".formatted(path.get(length - 1)));
         var statement = statementBuilder.toString();
 
         if (type.equals(Boolean.class)) {

--- a/extensions/common/sql/sql-core/src/test/java/org/eclipse/edc/sql/translation/SqlQueryStatementTest.java
+++ b/extensions/common/sql/sql-core/src/test/java/org/eclipse/edc/sql/translation/SqlQueryStatementTest.java
@@ -110,15 +110,6 @@ class SqlQueryStatementTest {
     }
 
     @Test
-    void singleExpression_orderBy_WithNestedProperty() {
-        var builder = queryBuilder().sortField("complex");
-
-        assertThatThrownBy(() -> new SqlQueryStatement(SELECT_STATEMENT, builder.sortOrder(SortOrder.ASC).build(), new TestMapping()))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageStartingWith("Translation failed for Model");
-    }
-
-    @Test
     void addWhereClause() {
         var criterion = new Criterion("field1", "=", "testid1");
         var customParameter = 3;

--- a/extensions/common/sql/sql-core/src/testFixtures/java/org/eclipse/edc/sql/testfixtures/PostgresqlLocalInstance.java
+++ b/extensions/common/sql/sql-core/src/testFixtures/java/org/eclipse/edc/sql/testfixtures/PostgresqlLocalInstance.java
@@ -56,18 +56,6 @@ public final class PostgresqlLocalInstance {
         }
     }
 
-    public Connection getConnection() {
-        try {
-            return DriverManager.getConnection(jdbcUrlPrefix, username, password);
-        } catch (SQLException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public String getJdbcUrlPrefix() {
-        return jdbcUrlPrefix;
-    }
-
     private DataSource createTestDataSource(String hostName, int port, String dbName) {
         var dataSource = new PGSimpleDataSource();
         dataSource.setServerNames(new String[]{ hostName });

--- a/extensions/control-plane/store/sql/asset-index-sql/docs/schema.sql
+++ b/extensions/control-plane/store/sql/asset-index-sql/docs/schema.sql
@@ -1,5 +1,5 @@
 --
---  Copyright (c) 2022 Daimler TSS GmbH
+--  Copyright (c) 2022 - 2023 Daimler TSS GmbH
 --
 --  This program and the accompanying materials are made available under the
 --  terms of the Apache License, Version 2.0 which is available at
@@ -9,6 +9,7 @@
 --
 --  Contributors:
 --       Daimler TSS GmbH - Initial SQL Query
+--       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
 --
 
 -- THIS SCHEMA HAS BEEN WRITTEN AND TESTED ONLY FOR POSTGRES
@@ -16,41 +17,14 @@
 -- table: edc_asset
 CREATE TABLE IF NOT EXISTS edc_asset
 (
-    asset_id   VARCHAR NOT NULL,
-    created_at BIGINT  NOT NULL,
+    asset_id           VARCHAR NOT NULL,
+    created_at         BIGINT  NOT NULL,
+    properties         JSON    DEFAULT '{}',
+    private_properties JSON    DEFAULT '{}',
+    data_address       JSON    DEFAULT '{}',
     PRIMARY KEY (asset_id)
 );
 
--- table: edc_asset_dataaddress
-CREATE TABLE IF NOT EXISTS edc_asset_dataaddress
-(
-    asset_id_fk VARCHAR NOT NULL,
-    properties  JSON    NOT NULL,
-    PRIMARY KEY (asset_id_fk),
-    FOREIGN KEY (asset_id_fk) REFERENCES edc_asset (asset_id) ON DELETE CASCADE
-);
-COMMENT ON COLUMN edc_asset_dataaddress.properties IS 'DataAddress properties serialized as JSON';
-
--- table: edc_asset_property
-CREATE TABLE IF NOT EXISTS edc_asset_property
-(
-    asset_id_fk         VARCHAR NOT NULL,
-    property_name       VARCHAR NOT NULL,
-    property_value      VARCHAR NOT NULL,
-    property_type       VARCHAR NOT NULL,
-    property_is_private BOOLEAN NOT NULL,
-    PRIMARY KEY (asset_id_fk, property_name),
-    FOREIGN KEY (asset_id_fk) REFERENCES edc_asset (asset_id) ON DELETE CASCADE
-);
-
-COMMENT ON COLUMN edc_asset_property.property_name IS
-    'Asset property key';
-COMMENT ON COLUMN edc_asset_property.property_value IS
-    'Asset property value';
-COMMENT ON COLUMN edc_asset_property.property_type IS
-    'Asset property class name';
-COMMENT ON COLUMN edc_asset_property.property_is_private IS
-    'Asset property private flag';
-
-CREATE INDEX IF NOT EXISTS idx_edc_asset_property_value
-    ON edc_asset_property (property_name, property_value);
+COMMENT ON COLUMN edc_asset.properties IS 'Asset properties serialized as JSON';
+COMMENT ON COLUMN edc_asset.private_properties IS 'Asset private properties serialized as JSON';
+COMMENT ON COLUMN edc_asset.data_address IS 'Asset DataAddress serialized as JSON';

--- a/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/assetindex/schema/AssetStatements.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/assetindex/schema/AssetStatements.java
@@ -43,6 +43,18 @@ public interface AssetStatements extends SqlStatements {
         return "asset_id";
     }
 
+    default String getPropertiesColumn() {
+        return "properties";
+    }
+
+    default String getPrivatePropertiesColumn() {
+        return "private_properties";
+    }
+
+    default String getDataAddressColumn() {
+        return "data_address";
+    }
+
     /**
      * The data address table name.
      */
@@ -110,29 +122,14 @@ public interface AssetStatements extends SqlStatements {
     String getInsertAssetTemplate();
 
     /**
-     * INSERT clause for data addresses.
+     * UPDATE clause for assets.
      */
-    String getInsertDataAddressTemplate();
-
-    /**
-     * INSERT clause for properties.
-     */
-    String getInsertPropertyTemplate();
+    String getUpdateAssetTemplate();
 
     /**
      * SELECT COUNT clause for assets.
      */
     String getCountAssetByIdClause();
-
-    /**
-     * SELECT clause for properties.
-     */
-    String getFindPropertyByIdTemplate();
-
-    /**
-     * SELECT clause for data addresses.
-     */
-    String getFindDataAddressByIdTemplate();
 
     /**
      * SELECT clause for all assets.
@@ -145,25 +142,9 @@ public interface AssetStatements extends SqlStatements {
     String getDeleteAssetByIdTemplate();
 
     /**
-     * UPDATE statement for data addresses
-     */
-    String getUpdateDataAddressTemplate();
-
-    /**
-     * DELETE statement for properties of an Asset. Useful for delete-insert (=update) operations
-     */
-    String getDeletePropertyByIdTemplate();
-
-    /**
      * The COUNT variable used in SELECT COUNT queries.
      */
     String getCountVariableName();
-
-    /**
-     * Provides a dynamically assembled SELECT statement for use with
-     * {@link QuerySpec} queries.
-     */
-    String getQuerySubSelectTemplate();
 
     /**
      * Generates a SQL query using sub-select statements out of the query spec.
@@ -178,11 +159,5 @@ public interface AssetStatements extends SqlStatements {
      * @return A {@link SqlQueryStatement} that contains the SQL and statement parameters
      */
     SqlQueryStatement createQuery(List<Criterion> query);
-
-    /**
-     * Select single asset by ID
-     */
-    String getSelectAssetByIdTemplate();
-
 
 }

--- a/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/assetindex/schema/postgres/AssetMapping.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/assetindex/schema/postgres/AssetMapping.java
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.store.sql.assetindex.schema.postgres;
+
+import org.eclipse.edc.connector.store.sql.assetindex.schema.AssetStatements;
+import org.eclipse.edc.spi.types.PathItem;
+import org.eclipse.edc.sql.translation.JsonFieldMapping;
+import org.eclipse.edc.sql.translation.TranslationMapping;
+
+/**
+ * Maps fields of a {@link org.eclipse.edc.spi.types.domain.asset.Asset} onto the
+ * corresponding SQL schema (= column names) enabling access through Postgres JSON operators where applicable
+ */
+public class AssetMapping extends TranslationMapping {
+
+    public AssetMapping(AssetStatements statements) {
+        add("id", statements.getAssetIdColumn());
+        add("createdAt", statements.getCreatedAtColumn());
+        add("properties", new JsonFieldMapping(statements.getPropertiesColumn()));
+        add("privateProperties", new JsonFieldMapping(statements.getPrivatePropertiesColumn()));
+        add("dataAddress", new JsonFieldMapping(statements.getDataAddressColumn()));
+    }
+
+    @Override
+    public String getStatement(String canonicalPropertyName, Class<?> type) {
+        var standardPath = getStatement(PathItem.parse(canonicalPropertyName), type);
+
+        if (standardPath == null) {
+            var amendedCanonicalPropertyName = canonicalPropertyName.contains("'")
+                    ? "properties.%s".formatted(canonicalPropertyName)
+                    : "properties.'%s'".formatted(canonicalPropertyName);
+            return getStatement(amendedCanonicalPropertyName, type);
+        }
+
+        return standardPath;
+    }
+
+}

--- a/extensions/control-plane/store/sql/asset-index-sql/src/test/java/org/eclipse/edc/connector/store/sql/assetindex/PostgresAssetIndexTest.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/test/java/org/eclipse/edc/connector/store/sql/assetindex/PostgresAssetIndexTest.java
@@ -55,8 +55,6 @@ class PostgresAssetIndexTest extends AssetIndexTestBase {
     @AfterEach
     void tearDown(PostgresqlStoreSetupExtension setupExtension) {
         setupExtension.runQuery("DROP TABLE " + sqlStatements.getAssetTable() + " CASCADE");
-        setupExtension.runQuery("DROP TABLE " + sqlStatements.getDataAddressTable() + " CASCADE");
-        setupExtension.runQuery("DROP TABLE " + sqlStatements.getAssetPropertyTable() + " CASCADE");
     }
 
     @Override

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/asset/AssetIndex.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/asset/AssetIndex.java
@@ -20,7 +20,6 @@ import org.eclipse.edc.spi.persistence.EdcPersistenceException;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.StoreResult;
-import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
 
 import java.util.List;
@@ -38,7 +37,6 @@ public interface AssetIndex extends DataAddressResolver {
 
     String ASSET_EXISTS_TEMPLATE = "Asset with ID %s already exists";
     String ASSET_NOT_FOUND_TEMPLATE = "Asset with ID %s not found";
-    String DATA_ADDRESS_NOT_FOUND_TEMPLATE = "DataAddress with ID %s not found";
 
     /**
      * Finds all assets that are covered by a specific {@link QuerySpec}. Results are always sorted. If no {@link QuerySpec#getSortField()}
@@ -98,15 +96,4 @@ public interface AssetIndex extends DataAddressResolver {
      */
     StoreResult<Asset> updateAsset(Asset asset);
 
-    /**
-     * Updates a {@link DataAddress} that is associated with the {@link Asset} that is identified by the {@code assetId} argument.
-     * If the asset is not found, no further database interaction takes place.
-     *
-     * @param assetId     the database of the Asset to update
-     * @param dataAddress The DataAddress containing the new values.
-     * @return {@link StoreResult#success(Object)} if the object was updated, {@link StoreResult#notFound(String)} when an object with that ID was not found.
-     * @deprecated Updating only the DataAddress is deprecated and will be removed in future releases. Please use the {@link AssetIndex#updateAsset(Asset)} method.
-     */
-    @Deprecated(since = "0.3.0", forRemoval = true)
-    StoreResult<DataAddress> updateDataAddress(String assetId, DataAddress dataAddress);
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/PathItem.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/PathItem.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.spi.types;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represent an object path instance, e.g. "properties.'https://w3id.org/edc/v0.0.1/ns/id'" can be parsed into two
+ * {@link PathItem}s one representing "properties" and the other "https://w3id.org/edc/v0.0.1/ns/id"
+ */
+public class PathItem {
+
+    public static List<PathItem> parse(String propertyName) {
+        var result = new ArrayList<PathItem>();
+        result.add(new PathItem());
+        for (var i = 0; i < propertyName.length(); i++) {
+            var character = propertyName.charAt(i);
+
+            var lastEntry = result.get(result.size() - 1);
+
+            switch (character) {
+                case '\'' -> lastEntry.toggle();
+                case '.' -> {
+                    if (lastEntry.opened) {
+                        lastEntry.append(character);
+                    } else {
+                        result.add(new PathItem());
+                    }
+                }
+                default -> lastEntry.append(character);
+            }
+
+        }
+        return result.stream().toList();
+    }
+
+    private boolean opened;
+    private final StringBuilder builder = new StringBuilder();
+
+    public void open() {
+        this.opened = true;
+    }
+
+    public void close() {
+        this.opened = false;
+    }
+
+    public void append(char character) {
+        builder.append(character);
+    }
+
+    @Override
+    public String toString() {
+        return builder.toString();
+    }
+
+    public void toggle() {
+        if (opened) {
+            close();
+        } else {
+            open();
+        }
+    }
+}

--- a/spi/common/core-spi/src/test/java/org/eclipse/edc/spi/types/PathItemTest.java
+++ b/spi/common/core-spi/src/test/java/org/eclipse/edc/spi/types/PathItemTest.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.spi.types;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PathItemTest {
+
+    @Test
+    void shouldParse_singleElement() {
+        var result = PathItem.parse("test");
+
+        assertThat(result).hasSize(1).first().extracting(PathItem::toString).isEqualTo("test");
+    }
+
+    @Test
+    void shouldParse_singleWrappedElement() {
+        var result = PathItem.parse("'test.data'");
+
+        assertThat(result).hasSize(1).first().extracting(PathItem::toString).isEqualTo("test.data");
+    }
+
+    @Test
+    void shouldParse_multipleSeparatedByDots() {
+        var result = PathItem.parse("test.data.path");
+
+        assertThat(result).hasSize(3).extracting(PathItem::toString)
+                .containsExactly("test", "data", "path");
+    }
+
+    @Test
+    void shouldParse_multipleWrappedSeparatedByDots() {
+        var result = PathItem.parse("'test.test'.data.'path.path'");
+
+        assertThat(result).hasSize(3).extracting(PathItem::toString)
+                .containsExactly("test.test", "data", "path.path");
+    }
+}

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/asset/AssetService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/asset/AssetService.java
@@ -16,7 +16,6 @@ package org.eclipse.edc.connector.spi.asset;
 
 import org.eclipse.edc.service.spi.result.ServiceResult;
 import org.eclipse.edc.spi.query.QuerySpec;
-import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
 
 import java.util.stream.Stream;
@@ -63,12 +62,4 @@ public interface AssetService {
      */
     ServiceResult<Asset> update(Asset asset);
 
-    /**
-     * Updates a {@link DataAddress}. If the associated asset does not yet exist, {@link ServiceResult#notFound(String)} will be returned;
-     *
-     * @param assetId     The ID of the asset to update.
-     * @param dataAddress The content of the DataAddress.
-     * @return successful if updated, a failure otherwise.
-     */
-    ServiceResult<DataAddress> update(String assetId, DataAddress dataAddress);
 }

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/PostgresUtil.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/PostgresUtil.java
@@ -31,11 +31,11 @@ import static org.eclipse.edc.test.e2e.PostgresConstants.USER;
 
 public class PostgresUtil {
 
-    public static void createDatabase(EndToEndTransferParticipant consumer) throws ClassNotFoundException, SQLException, IOException {
+    public static void createDatabase(EndToEndTransferParticipant participant) throws ClassNotFoundException, SQLException, IOException {
         Class.forName("org.postgresql.Driver");
 
-        var helper = new PostgresqlLocalInstance(USER, PASSWORD, JDBC_URL_PREFIX, consumer.getName());
-        helper.createDatabase(consumer.getName());
+        var helper = new PostgresqlLocalInstance(USER, PASSWORD, JDBC_URL_PREFIX, participant.getName());
+        helper.createDatabase(participant.getName());
 
         var scripts = Stream.of(
                 "extensions/control-plane/store/sql/asset-index-sql",
@@ -50,7 +50,7 @@ public class PostgresUtil {
                 .map(Paths::get)
                 .toList();
 
-        try (var connection = DriverManager.getConnection(consumer.jdbcUrl(), USER, PASSWORD)) {
+        try (var connection = DriverManager.getConnection(participant.jdbcUrl(), USER, PASSWORD)) {
             for (var script : scripts) {
                 var sql = Files.readString(script);
 

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/AssetApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/AssetApiEndToEndTest.java
@@ -24,6 +24,7 @@ import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static jakarta.json.Json.createArrayBuilder;
 import static jakarta.json.Json.createObjectBuilder;
@@ -184,7 +185,6 @@ public class AssetApiEndToEndTest extends BaseManagementApiEndToEndTest {
 
     @Test
     void queryAsset_byCustomStringProperty() {
-        //insert one asset into the index
         getAssetIndex().create(Asset.Builder.newInstance()
                 .id("test-asset")
                 .contentType("application/octet-stream")
@@ -205,19 +205,16 @@ public class AssetApiEndToEndTest extends BaseManagementApiEndToEndTest {
     }
 
     @Test
-    void queryAsset_byCustomComplexProperty_whenJsonPathQuery_expectNoResult() {
-        //insert one asset into the index
+    void queryAsset_byCustomComplexProperty() {
         getAssetIndex().create(Asset.Builder.newInstance()
                 .id("test-asset")
                 .contentType("application/octet-stream")
-                // use a custom, complex object type
-                .property("myProp", new TestObject("test desc", 42))
+                .property("myProp", Map.of("description", "test desc", "number", 42))
                 .dataAddress(createDataAddress().build())
                 .build());
 
         var query = createSingleFilterQuery("myProp.description", "=", "test desc");
 
-        // querying custom complex types in "json-path" style is expected not to work.
         baseRequest()
                 .contentType(ContentType.JSON)
                 .body(query)
@@ -225,7 +222,7 @@ public class AssetApiEndToEndTest extends BaseManagementApiEndToEndTest {
                 .then()
                 .log().ifError()
                 .statusCode(200)
-                .body("size()", is(0));
+                .body("size()", is(1));
     }
 
     @Test
@@ -300,5 +297,4 @@ public class AssetApiEndToEndTest extends BaseManagementApiEndToEndTest {
                 .build();
     }
 
-    private record TestObject(String description, int number) { }
 }


### PR DESCRIPTION
## What this PR changes/adds

Permits to query over nested properties in Asset.
To do that, the notation should be, e.g.:
```
{
  "edc:operandLeft": "'https://w3id.org/edc/v0.0.1/ns/nested'.'https://w3id.org/edc/v0.0.1/ns/key'",
  "edc:operator": "=",
  "edc:operandRight": "value"
}
```

to navigate through the property tree, the wrapping `'` are needed to clearly separate path items (because keys could contain the `.`).
Current behavior without wrapping `'` for a not nested property is still valid.

## Why it does that

fix bug

## Further notes

- refactored the asset related sql tables, now collapsed into a single table with JSON fields. **THIS IS A BREAKING CHANGE**. please refer to the `asset-index-sql` extension README to get migration instructions.
- removed the unused `updateDataAddress` method from `AssetService` 

## Linked Issue(s)

Closes #3423 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
