### PR TITLE
feat: improve DataFlow termination

### DIFF
--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/DataFlow.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/DataFlow.java
@@ -28,6 +28,7 @@ import static org.eclipse.edc.connector.dataplane.spi.DataFlowStates.COMPLETED;
 import static org.eclipse.edc.connector.dataplane.spi.DataFlowStates.FAILED;
 import static org.eclipse.edc.connector.dataplane.spi.DataFlowStates.NOTIFIED;
 import static org.eclipse.edc.connector.dataplane.spi.DataFlowStates.RECEIVED;
+import static org.eclipse.edc.connector.dataplane.spi.DataFlowStates.TERMINATED;
 
 /**
  * Entity that represent a Data Plane Transfer Flow
@@ -106,6 +107,10 @@ public class DataFlow extends StatefulEntity<DataFlow> {
 
     public void transitToNotified() {
         transitionTo(NOTIFIED.code());
+    }
+
+    public void transitToTerminated() {
+        transitionTo(TERMINATED.code());
     }
 
     @JsonPOJOBuilder(withPrefix = "")

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/DataFlowStates.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/DataFlowStates.java
@@ -24,6 +24,7 @@ public enum DataFlowStates {
     NOT_TRACKED(0),
     RECEIVED(100),
     COMPLETED(200),
+    TERMINATED(250),
     FAILED(300),
     NOTIFIED(400);
 


### PR DESCRIPTION
## What this PR changes/adds

Adds a `TERMINATED` state on the `DataFlow`, to distinguish between a completed data flow (when the data plane completed it) and a terminated one (when the data flow gets stopped by an external actor, like the policy manager).

## Why it does that

policy monitor

## Further notes

- this should fix the flaky end to end kafka that failed from time to time in the last weeks

## Linked Issue(s)

PArt of #3422 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
