### PR TITLE
fix: transition DataFlow to started when transfer starts

### DIFF
--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImpl.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImpl.java
@@ -138,6 +138,9 @@ public class DataPlaneManagerImpl extends AbstractStateEntityManager<DataFlow, D
             return true;
         }
 
+        dataFlow.transitionToStarted();
+        store.save(dataFlow);
+
         return entityRetryProcessFactory.doAsyncProcess(dataFlow, () -> transferService.transfer(request))
                 .entityRetrieve(id -> store.findById(id))
                 .onSuccess((f, r) -> {

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/DataFlow.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/DataFlow.java
@@ -28,6 +28,7 @@ import static org.eclipse.edc.connector.dataplane.spi.DataFlowStates.COMPLETED;
 import static org.eclipse.edc.connector.dataplane.spi.DataFlowStates.FAILED;
 import static org.eclipse.edc.connector.dataplane.spi.DataFlowStates.NOTIFIED;
 import static org.eclipse.edc.connector.dataplane.spi.DataFlowStates.RECEIVED;
+import static org.eclipse.edc.connector.dataplane.spi.DataFlowStates.STARTED;
 import static org.eclipse.edc.connector.dataplane.spi.DataFlowStates.TERMINATED;
 
 /**
@@ -111,6 +112,10 @@ public class DataFlow extends StatefulEntity<DataFlow> {
 
     public void transitToTerminated() {
         transitionTo(TERMINATED.code());
+    }
+
+    public void transitionToStarted() {
+        transitionTo(STARTED.code());
     }
 
     @JsonPOJOBuilder(withPrefix = "")

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/DataFlowStates.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/DataFlowStates.java
@@ -23,6 +23,7 @@ public enum DataFlowStates {
 
     NOT_TRACKED(0),
     RECEIVED(100),
+    STARTED(150),
     COMPLETED(200),
     TERMINATED(250),
     FAILED(300),


### PR DESCRIPTION
## What this PR changes/adds

Transition `DataFlow` to `STARTED` when the transfer gets started

## Why it does that

Avoid multiple transfers start

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #3563 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
