### PR TITLE
feat: add private properties to policy definition entity

### DIFF
--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiExtension.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiExtension.java
@@ -24,6 +24,7 @@ import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 import org.eclipse.edc.web.spi.WebService;
@@ -31,6 +32,7 @@ import org.eclipse.edc.web.spi.WebService;
 import java.util.Map;
 
 import static org.eclipse.edc.connector.policy.spi.PolicyDefinition.EDC_POLICY_DEFINITION_TYPE;
+import static org.eclipse.edc.spi.CoreConstants.JSON_LD;
 
 
 @Extension(value = PolicyDefinitionApiExtension.NAME)
@@ -53,6 +55,9 @@ public class PolicyDefinitionApiExtension implements ServiceExtension {
     @Inject
     private JsonObjectValidatorRegistry validatorRegistry;
 
+    @Inject
+    private TypeManager typeManager;
+
     @Override
     public String name() {
         return NAME;
@@ -62,7 +67,8 @@ public class PolicyDefinitionApiExtension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
         var jsonBuilderFactory = Json.createBuilderFactory(Map.of());
         transformerRegistry.register(new JsonObjectToPolicyDefinitionTransformer());
-        transformerRegistry.register(new JsonObjectFromPolicyDefinitionTransformer(jsonBuilderFactory));
+        var mapper = typeManager.getMapper(JSON_LD);
+        transformerRegistry.register(new JsonObjectFromPolicyDefinitionTransformer(jsonBuilderFactory, mapper));
 
         validatorRegistry.register(EDC_POLICY_DEFINITION_TYPE, PolicyDefinitionValidator.instance());
 

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/transform/JsonObjectFromPolicyDefinitionTransformer.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/transform/JsonObjectFromPolicyDefinitionTransformer.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.connector.api.management.policy.transform;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
@@ -29,11 +30,13 @@ import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.EDC_CREATED_AT;
 
 public class JsonObjectFromPolicyDefinitionTransformer extends AbstractJsonLdTransformer<PolicyDefinition, JsonObject> {
 
+    private final ObjectMapper mapper;
     private final JsonBuilderFactory jsonFactory;
 
-    public JsonObjectFromPolicyDefinitionTransformer(JsonBuilderFactory jsonFactory) {
+    public JsonObjectFromPolicyDefinitionTransformer(JsonBuilderFactory jsonFactory, ObjectMapper jsonLdMapper) {
         super(PolicyDefinition.class, JsonObject.class);
         this.jsonFactory = jsonFactory;
+        this.mapper = jsonLdMapper;
     }
 
     @Override
@@ -46,6 +49,11 @@ public class JsonObjectFromPolicyDefinitionTransformer extends AbstractJsonLdTra
 
         var policy = context.transform(input.getPolicy(), JsonObject.class);
         objectBuilder.add(EDC_POLICY_DEFINITION_POLICY, policy);
+        if (!input.getPrivateProperties().isEmpty()) {
+            var privatePropBuilder = jsonFactory.createObjectBuilder();
+            transformProperties(input.getPrivateProperties(), privatePropBuilder, mapper, context);
+            objectBuilder.add(PolicyDefinition.EDC_POLICY_DEFINITION_PRIVATE_PROPERTIES, privatePropBuilder);
+        }
 
         return objectBuilder.build();
     }

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/transform/JsonObjectToPolicyDefinitionTransformer.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/transform/JsonObjectToPolicyDefinitionTransformer.java
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.connector.policy.spi.PolicyDefinition.EDC_POLICY_DEFINITION_POLICY;
+import static org.eclipse.edc.connector.policy.spi.PolicyDefinition.EDC_POLICY_DEFINITION_PRIVATE_PROPERTIES;
 
 public class JsonObjectToPolicyDefinitionTransformer extends AbstractJsonLdTransformer<JsonObject, PolicyDefinition> {
 
@@ -42,6 +43,11 @@ public class JsonObjectToPolicyDefinitionTransformer extends AbstractJsonLdTrans
     private void transformProperty(String key, JsonValue value, PolicyDefinition.Builder builder, TransformerContext context) {
         if (key.equals(EDC_POLICY_DEFINITION_POLICY)) {
             transformArrayOrObject(value, Policy.class, builder::policy, context);
+        } else if (key.equals(EDC_POLICY_DEFINITION_PRIVATE_PROPERTIES)) {
+            var props = value.asJsonArray().getJsonObject(0);
+            visitProperties(props, (k, val) -> transformProperty(k, val, builder, context));
+        } else {
+            builder.privateProperty(key, value);
         }
     }
 }

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/transform/JsonObjectFromPolicyDefinitionTransformerTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/transform/JsonObjectFromPolicyDefinitionTransformerTest.java
@@ -27,6 +27,7 @@ import static org.eclipse.edc.connector.policy.spi.PolicyDefinition.EDC_POLICY_D
 import static org.eclipse.edc.connector.policy.spi.PolicyDefinition.EDC_POLICY_DEFINITION_TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.util.JacksonJsonLd.createObjectMapper;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -35,7 +36,7 @@ import static org.mockito.Mockito.when;
 
 class JsonObjectFromPolicyDefinitionTransformerTest {
 
-    private final JsonObjectFromPolicyDefinitionTransformer transformer = new JsonObjectFromPolicyDefinitionTransformer(Json.createBuilderFactory(emptyMap()));
+    private final JsonObjectFromPolicyDefinitionTransformer transformer = new JsonObjectFromPolicyDefinitionTransformer(Json.createBuilderFactory(emptyMap()), createObjectMapper());
     private final TransformerContext context = mock(TransformerContext.class);
 
     @Test

--- a/extensions/control-plane/store/sql/policy-definition-store-sql/docs/er.puml
+++ b/extensions/control-plane/store/sql/policy-definition-store-sql/docs/er.puml
@@ -23,5 +23,6 @@ entity edc_policydefinitions {
   target: string
   type: string
   extensible_properties: string <<json>>
+  private_properties: string <<json>>
 }
 @enduml

--- a/extensions/control-plane/store/sql/policy-definition-store-sql/docs/schema.sql
+++ b/extensions/control-plane/store/sql/policy-definition-store-sql/docs/schema.sql
@@ -27,6 +27,7 @@ CREATE TABLE IF NOT EXISTS edc_policydefinitions
     assignee              VARCHAR,
     target                VARCHAR,
     policy_type           VARCHAR NOT NULL,
+    private_properties    JSON,
     PRIMARY KEY (policy_id)
 );
 

--- a/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/policydefinition/store/schema/BaseSqlDialectStatements.java
+++ b/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/policydefinition/store/schema/BaseSqlDialectStatements.java
@@ -40,6 +40,7 @@ public class BaseSqlDialectStatements implements SqlPolicyStoreStatements {
                 .column(getTargetColumn())
                 .column(getTypeColumn())
                 .column(getCreatedAtColumn())
+                .jsonColumn(getPrivatePropertiesColumn())
                 .insertInto(getPolicyTable());
     }
 
@@ -55,6 +56,7 @@ public class BaseSqlDialectStatements implements SqlPolicyStoreStatements {
                 .column(getAssigneeColumn())
                 .column(getTargetColumn())
                 .column(getTypeColumn())
+                .jsonColumn(getPrivatePropertiesColumn())
                 .update(getPolicyTable(), getPolicyIdColumn());
 
     }

--- a/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/policydefinition/store/schema/SqlPolicyStoreStatements.java
+++ b/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/policydefinition/store/schema/SqlPolicyStoreStatements.java
@@ -94,5 +94,9 @@ public interface SqlPolicyStoreStatements extends SqlStatements {
         return "created_at";
     }
 
+    default String getPrivatePropertiesColumn() {
+        return "private_properties";
+    }
+
     SqlQueryStatement createQuery(QuerySpec querySpec);
 }

--- a/spi/control-plane/policy-spi/src/main/java/org/eclipse/edc/connector/policy/spi/PolicyDefinition.java
+++ b/spi/control-plane/policy-spi/src/main/java/org/eclipse/edc/connector/policy/spi/PolicyDefinition.java
@@ -19,7 +19,10 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.entity.Entity;
+import org.jetbrains.annotations.NotNull;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -39,7 +42,9 @@ import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 public class PolicyDefinition extends Entity {
     public static final String EDC_POLICY_DEFINITION_TYPE = EDC_NAMESPACE + "PolicyDefinition";
     public static final String EDC_POLICY_DEFINITION_POLICY = EDC_NAMESPACE + "policy";
+    public static final String EDC_POLICY_DEFINITION_PRIVATE_PROPERTIES = EDC_NAMESPACE + "privateProperties";
     private Policy policy;
+    private final Map<String, Object> privateProperties = new HashMap<>();
 
     private PolicyDefinition() {
     }
@@ -50,7 +55,7 @@ public class PolicyDefinition extends Entity {
 
     @Override
     public int hashCode() {
-        return Objects.hash(Objects.hash(id), policy.hashCode());
+        return Objects.hash(Objects.hash(id), policy.hashCode(), privateProperties);
     }
 
     @Override
@@ -69,6 +74,15 @@ public class PolicyDefinition extends Entity {
         return id;
     }
 
+    @NotNull
+    public Map<String, Object> getPrivateProperties() {
+        return privateProperties;
+    }
+
+    public Object getPrivateProperty(String key) {
+        return privateProperties.get(key);
+    }
+
     @JsonPOJOBuilder(withPrefix = "")
     public static final class Builder extends Entity.Builder<PolicyDefinition, Builder> {
 
@@ -83,6 +97,17 @@ public class PolicyDefinition extends Entity {
 
         public Builder policy(Policy policy) {
             entity.policy = policy;
+            return this;
+        }
+
+        public Builder privateProperty(String key, Object value) {
+            entity.privateProperties.put(key, value);
+            return this;
+        }
+
+        public Builder privateProperties(Map<String, Object> privateProperties) {
+            Objects.requireNonNull(privateProperties);
+            entity.privateProperties.putAll(privateProperties);
             return this;
         }
 


### PR DESCRIPTION
### What this PR changes/adds
Add private properties to policy definition entity. The implementation supports in-memory and postgres as a store.

### Why it does that
The private properties are required to provide the owner with the possibility to add extra properties which should not be exposed outside. This requirement was initiated when we want to add administrative properties like (createdBy, createdAt, chnagedBy, chnagedAt), policyType(Access, Usage). We assume that the private properties can be used to store such a requirement after registering a listener on the policy definition.
More information is in this discussion:
https://github.com/eclipse-edc/Connector/discussions/2592#discussioncomment-7379257

Further notes
List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc.

Linked Issue(s)
Closes https://github.com/eclipse-edc/Connector/issues/3490