### PR TITLE
chore: Decouple `oauth2-spi` from `data-address-http-data-spi`

### DIFF
--- a/spi/common/oauth2-spi/build.gradle.kts
+++ b/spi/common/oauth2-spi/build.gradle.kts
@@ -17,7 +17,6 @@ plugins {
 }
 
 dependencies {
-    api(project(":spi:common:data-address:data-address-http-data-spi"))
     api(project(":spi:common:jwt-spi"))
 }
 

--- a/spi/common/oauth2-spi/src/main/java/org/eclipse/edc/iam/oauth2/spi/Oauth2DataAddressValidator.java
+++ b/spi/common/oauth2-spi/src/main/java/org/eclipse/edc/iam/oauth2/spi/Oauth2DataAddressValidator.java
@@ -28,7 +28,6 @@ import static org.eclipse.edc.iam.oauth2.spi.Oauth2DataAddressSchema.TOKEN_URL;
  */
 public class Oauth2DataAddressValidator implements Predicate<DataAddress> {
 
-    private final Predicate<DataAddress> isHttpDataType = dataAddress -> "HttpData".equals(dataAddress.getType());
     private final Predicate<DataAddress> hasClientId = dataAddress -> dataAddress.hasProperty(CLIENT_ID);
     private final Predicate<DataAddress> hasClientSecretKey = dataAddress -> dataAddress.hasProperty(CLIENT_SECRET_KEY);
     private final Predicate<DataAddress> hasPrivateKeySecretName = dataAddress -> dataAddress.hasProperty(PRIVATE_KEY_NAME);
@@ -37,11 +36,7 @@ public class Oauth2DataAddressValidator implements Predicate<DataAddress> {
 
     @Override
     public boolean test(DataAddress dataAddress) {
-        return isHttpDataType
-                .and(hasClientId)
-                .and(hasTokenUrl)
-                .and(hasSecretInfo)
-                .test(dataAddress);
+        return hasClientId.and(hasTokenUrl).and(hasSecretInfo).test(dataAddress);
     }
 
 }

--- a/spi/common/oauth2-spi/src/test/java/org/eclipse/edc/iam/oauth2/spi/Oauth2DataAddressValidatorTest.java
+++ b/spi/common/oauth2-spi/src/test/java/org/eclipse/edc/iam/oauth2/spi/Oauth2DataAddressValidatorTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.iam.oauth2.spi;
 
-import org.eclipse.edc.dataaddress.httpdata.spi.HttpDataAddressSchema;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -43,33 +42,33 @@ class Oauth2DataAddressValidatorTest {
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
             var addressWithPrivateKeyName = DataAddress.Builder.newInstance()
-                    .type(HttpDataAddressSchema.HTTP_DATA_TYPE)
+                    .type("TestType")
                     .property(Oauth2DataAddressSchema.CLIENT_ID, "aClientId")
                     .property(Oauth2DataAddressSchema.PRIVATE_KEY_NAME, "aPrivateKeyName")
                     .property(Oauth2DataAddressSchema.TOKEN_URL, "aTokenUrl")
                     .build();
 
             var addressWithSharedSecret = DataAddress.Builder.newInstance()
-                    .type(HttpDataAddressSchema.HTTP_DATA_TYPE)
+                    .type("TestType")
                     .property(Oauth2DataAddressSchema.CLIENT_ID, "aClientId")
                     .property(Oauth2DataAddressSchema.CLIENT_SECRET_KEY, "aSecret")
                     .property(Oauth2DataAddressSchema.TOKEN_URL, "aTokenUrl")
                     .build();
 
             var missingTokenUrl = DataAddress.Builder.newInstance()
-                    .type(HttpDataAddressSchema.HTTP_DATA_TYPE)
+                    .type("TestType")
                     .property(Oauth2DataAddressSchema.CLIENT_ID, "aClientId")
                     .property(Oauth2DataAddressSchema.CLIENT_SECRET_KEY, "aSecret")
                     .build();
 
             var missingClientId = DataAddress.Builder.newInstance()
-                    .type(HttpDataAddressSchema.HTTP_DATA_TYPE)
+                    .type("TestType")
                     .property(Oauth2DataAddressSchema.CLIENT_SECRET_KEY, "secret-key")
                     .property(Oauth2DataAddressSchema.TOKEN_URL, "aTokenUrl")
                     .build();
 
             var missingPrivateKeyOrSharedSecret = DataAddress.Builder.newInstance()
-                    .type(HttpDataAddressSchema.HTTP_DATA_TYPE)
+                    .type("TestType")
                     .property(Oauth2DataAddressSchema.CLIENT_ID, "aClientId")
                     .property(Oauth2DataAddressSchema.TOKEN_URL, "aTokenUrl")
                     .build();


### PR DESCRIPTION
## What this PR changes/adds

The `oauth2-spi` should not reference `data-address-http-data-spi` since the latter is an implementation detail of a data reference.

## Linked Issue(s)

Closes #3583


