### PR TITLE
chore: Remove unused dependencies from `control-plane-spi`

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/build.gradle.kts
+++ b/core/control-plane/control-plane-aggregate-services/build.gradle.kts
@@ -20,6 +20,9 @@ dependencies {
     implementation(project(":spi:common:validator-spi"))
     implementation(project(":spi:control-plane:control-plane-spi"))
     implementation(project(":core:common:util"))
+    implementation(project(":spi:common:transaction-spi"))
+    implementation(project(":spi:control-plane:asset-spi"))
+    implementation(project(":spi:control-plane:transfer-data-plane-spi"))
 
     implementation(libs.opentelemetry.instrumentation.annotations)
 

--- a/spi/control-plane/control-plane-spi/build.gradle.kts
+++ b/spi/control-plane/control-plane-spi/build.gradle.kts
@@ -17,16 +17,10 @@ plugins {
 }
 
 dependencies {
-    api(project(":spi:common:catalog-spi"))
     api(project(":spi:common:core-spi"))
-    api(project(":spi:common:transaction-spi"))
-    api(project(":spi:common:transform-spi"))
+    api(project(":spi:common:catalog-spi"))
     api(project(":spi:control-plane:contract-spi"))
-    api(project(":spi:control-plane:transfer-data-plane-spi"))
-    api(project(":spi:control-plane:policy-spi"))
     api(project(":spi:control-plane:transfer-spi"))
-    api(project(":spi:control-plane:asset-spi"))
-
 }
 
 


### PR DESCRIPTION
This PR removes the following unused dependencies from the `control-plane-spi` module:

 - api(project(":spi:control-plane:transfer-data-plane-spi"))
 - api(project(":spi:control-plane:policy-spi"))
 - api(project(":spi:control-plane:asset-spi"))

## Linked Issue(s)

Closes #3587 
