### PR TITLE
build: fix flaky test

### DIFF
--- a/extensions/data-plane/data-plane-kafka/src/main/java/org/eclipse/edc/dataplane/kafka/pipeline/KafkaDataSource.java
+++ b/extensions/data-plane/data-plane-kafka/src/main/java/org/eclipse/edc/dataplane/kafka/pipeline/KafkaDataSource.java
@@ -176,10 +176,11 @@ class KafkaDataSource implements DataSource {
 
         @Override
         public ConsumerRecords<String, byte[]> next() {
-            var records = consumer.poll(Duration.ZERO);
-            while (active.get() && records.isEmpty()) {
+            ConsumerRecords<String, byte[]> records;
+            do {
                 records = consumer.poll(pollDuration);
-            }
+            } while (active.get() && records.isEmpty());
+
             return records;
         }
 

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/participant/EndToEndTransferParticipant.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/participant/EndToEndTransferParticipant.java
@@ -239,6 +239,7 @@ public class EndToEndTransferParticipant extends Participant {
                 put("edc.keystore", resourceAbsolutePath("certs/cert.pfx"));
                 put("edc.keystore.password", "123456");
                 put("edc.dataplane.token.validation.endpoint", controlPlaneControl + "/token");
+                put("edc.dataplane.http.sink.partition.size", "1");
             }
         };
     }


### PR DESCRIPTION
## What this PR changes/adds

Set http sink partition size to 1 for the `EndToEndKafkaTransferTest`

## Why it does that

Avoid test flakiness, the default partition size to 5 caused messages to be sent to the consumer slightly after termination, causing test failure.

## Further notes

- changed the implementation of the `next()` method in the `ConsumerRecordsIterator` because most of the time was doing duplicated pulls for a single `next()` call.

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
