### PR TITLE
fix: disallow multiple auth headers

### DIFF
--- a/extensions/common/auth/auth-tokenbased/src/main/java/org/eclipse/edc/api/auth/token/TokenBasedAuthenticationService.java
+++ b/extensions/common/auth/auth-tokenbased/src/main/java/org/eclipse/edc/api/auth/token/TokenBasedAuthenticationService.java
@@ -50,6 +50,6 @@ public class TokenBasedAuthenticationService implements AuthenticationService {
     }
 
     private boolean checkApiKeyValid(List<String> apiKeys) {
-        return apiKeys.stream().anyMatch(hardCodedApiKey::equalsIgnoreCase);
+        return apiKeys.size() == 1 && apiKeys.stream().allMatch(hardCodedApiKey::equalsIgnoreCase);
     }
 }

--- a/extensions/common/auth/auth-tokenbased/src/test/java/org/eclipse/edc/api/auth/token/TokenBasedAuthenticationServiceTest.java
+++ b/extensions/common/auth/auth-tokenbased/src/test/java/org/eclipse/edc/api/auth/token/TokenBasedAuthenticationServiceTest.java
@@ -69,8 +69,8 @@ class TokenBasedAuthenticationServiceTest {
     }
 
     @Test
-    void isAuthorized_multipleValues_oneAuthorized() {
+    void isAuthorized_multipleValues_oneAuthorized_shouldReturnFalse() {
         var map = Map.of("x-api-key", List.of("invalid_api_key", TEST_API_KEY));
-        assertThat(service.isAuthenticated(map)).isTrue();
+        assertThat(service.isAuthenticated(map)).isFalse();
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

This PR disallows the use of multiple `x-api-key` headers to avoid Header Duplication Exploitation.

## Why it does that

I honestly don't know why issuing 100 billion requests is harder than 1 billion requests with 100 headers each, but a 
security report has been filed.

## Further notes

.

## Linked Issue(s)

Closes https://github.com/eclipse-tractusx/tractusx-edc/security/advisories/GHSA-wqpq-r4w2-5q5x

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
