### PR TITLE
fix(docs): adjust release approach link

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Contains implementations for communication protocols a connector might use, such
 ## Releases
 
 GitHub releases are listed [here](https://github.com/eclipse-edc/Connector/releases).
-Please find more information about releases in our [release approach](https://github.com/eclipse-edc/.github/blob/main/docs/developer/releases.md).
+Please find more information about releases in our [release approach](https://github.com/eclipse-edc/docs/blob/main/developer/releases.md).
 
 ### Roadmap
 


### PR DESCRIPTION
## What this PR changes/adds

Changes the release approach link to up-to-date one.

## Why it does that

The current link points to nothing.

## Linked Issue(s)

Closes #3598 

