### PR TITLE
chore: moved IATP model classes up from IdentityHub

### DIFF
--- a/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtension.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtension.java
@@ -30,10 +30,12 @@ import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.spi.http.EdcHttpClient;
 import org.eclipse.edc.spi.iam.IdentityService;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.verifiablecredentials.jwt.JwtPresentationVerifier;
 import org.eclipse.edc.verifiablecredentials.linkeddata.LdpVerifier;
 import org.eclipse.edc.verification.jwt.SelfIssuedIdTokenVerifier;
@@ -51,7 +53,6 @@ public class IdentityAndTrustExtension implements ServiceExtension {
     @Inject
     private SecureTokenService secureTokenService;
 
-    private PresentationVerifier presentationVerifier;
 
     @Inject
     private CredentialServiceClient credentialServiceClient;
@@ -71,10 +72,18 @@ public class IdentityAndTrustExtension implements ServiceExtension {
     @Inject
     private JsonLd jsonLd;
 
-    private JwtValidator jwtValidator;
-    private JwtVerifier jwtVerifier;
     @Inject
     private Clock clock;
+
+    @Inject
+    private TypeTransformerRegistry typeTransformerRegistry;
+
+    @Inject
+    private EdcHttpClient httpClient;
+
+    private JwtValidator jwtValidator;
+    private JwtVerifier jwtVerifier;
+    private PresentationVerifier presentationVerifier;
 
     @Provider
     public IdentityService createIdentityService(ServiceExtensionContext context) {
@@ -113,6 +122,12 @@ public class IdentityAndTrustExtension implements ServiceExtension {
             jwtVerifier = new SelfIssuedIdTokenVerifier(resolverRegistry);
         }
         return jwtVerifier;
+    }
+
+    @Provider
+    public CredentialServiceClient createClient(ServiceExtensionContext context) {
+        context.getMonitor().warning("Using a dummy CredentialServiceClient, that'll return null always. Don't use this in production use cases!");
+        return (csUrl, siTokenJwt, scopes) -> null;
     }
 
     private String getOwnDid(ServiceExtensionContext context) {

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/IdentityAndTrustService.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/IdentityAndTrustService.java
@@ -122,8 +122,6 @@ public class IdentityAndTrustService implements IdentityService {
             return issuerResult.mapTo();
         }
 
-        //todo: implement actual VP request, currently it's a stub
-        // https://github.com/eclipse-edc/Connector/issues/3495
         var vpResponse = credentialServiceClient.requestPresentation(null, null, null);
 
         if (vpResponse.failed()) {

--- a/extensions/common/iam/identity-trust/identity-trust-transform/build.gradle.kts
+++ b/extensions/common/iam/identity-trust/identity-trust-transform/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
 
     testImplementation(project(":extensions:common:json-ld"))
     testImplementation(project(":core:common:transform-core")) //for the TransformerContextImpl
+    testImplementation(project(":core:common:junit")) //for the TestUtils
     testImplementation(testFixtures(project(":spi:common:identity-trust-spi")))
 }
 

--- a/extensions/common/iam/identity-trust/identity-trust-transform/src/main/java/org/eclipse/edc/iam/identitytrust/transform/to/JsonObjectToPresentationQueryTransformer.java
+++ b/extensions/common/iam/identity-trust/identity-trust-transform/src/main/java/org/eclipse/edc/iam/identitytrust/transform/to/JsonObjectToPresentationQueryTransformer.java
@@ -1,0 +1,73 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.iam.identitytrust.transform.to;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import org.eclipse.edc.identitytrust.model.credentialservice.PresentationQuery;
+import org.eclipse.edc.identitytrust.model.presentationdefinition.PresentationDefinition;
+import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Transforms a JsonObject into a PresentationQuery object.
+ */
+public class JsonObjectToPresentationQueryTransformer extends AbstractJsonLdTransformer<JsonObject, PresentationQuery> {
+
+    private final ObjectMapper mapper;
+
+    public JsonObjectToPresentationQueryTransformer(ObjectMapper mapper) {
+        super(JsonObject.class, PresentationQuery.class);
+        this.mapper = mapper;
+    }
+
+    @Override
+    public @Nullable PresentationQuery transform(@NotNull JsonObject jsonObject, @NotNull TransformerContext context) {
+        var bldr = PresentationQuery.Builder.newinstance();
+        visitProperties(jsonObject, (k, v) -> {
+            switch (k) {
+                case PresentationQuery.PRESENTATION_QUERY_DEFINITION_PROPERTY ->
+                        bldr.presentationDefinition(readPresentationDefinition(v, context));
+                case PresentationQuery.PRESENTATION_QUERY_SCOPE_PROPERTY ->
+                        transformArrayOrObject(v, Object.class, o -> bldr.scope(o.toString()), context);
+                default -> context.reportProblem("Unknown property '%s'".formatted(k));
+            }
+        });
+
+        return bldr.build();
+    }
+
+    private PresentationDefinition readPresentationDefinition(JsonValue v, TransformerContext context) {
+        JsonObject jo;
+        if (v.getValueType() == JsonValue.ValueType.ARRAY && !((JsonArray) v).isEmpty()) {
+            jo = v.asJsonArray().getJsonObject(0);
+        } else {
+            jo = v.asJsonObject();
+        }
+        var rawJson = jo.get(JsonLdKeywords.VALUE);
+        try {
+            return mapper.readValue(rawJson.toString(), PresentationDefinition.class);
+        } catch (JsonProcessingException e) {
+            context.reportProblem("Error reading JSON literal: %s".formatted(e.getMessage()));
+            return null;
+        }
+    }
+}

--- a/extensions/common/iam/identity-trust/identity-trust-transform/src/test/java/org/eclipse/edc/iam/identitytrust/transform/to/JsonObjectToPresentationQueryTransformerTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-transform/src/test/java/org/eclipse/edc/iam/identitytrust/transform/to/JsonObjectToPresentationQueryTransformerTest.java
@@ -1,0 +1,175 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.iam.identitytrust.transform.to;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.core.transform.TransformerContextImpl;
+import org.eclipse.edc.core.transform.TypeTransformerRegistryImpl;
+import org.eclipse.edc.core.transform.transformer.to.JsonValueToGenericTypeTransformer;
+import org.eclipse.edc.jsonld.TitaniumJsonLd;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.jsonld.util.JacksonJsonLd;
+import org.eclipse.edc.junit.testfixtures.TestUtils;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class JsonObjectToPresentationQueryTransformerTest {
+    private final ObjectMapper mapper = JacksonJsonLd.createObjectMapper();
+    private final JsonObjectToPresentationQueryTransformer transformer = new JsonObjectToPresentationQueryTransformer(mapper);
+    private final JsonLd jsonLd = new TitaniumJsonLd(mock());
+    private final TypeTransformerRegistry trr = new TypeTransformerRegistryImpl();
+    private final TransformerContext context = new TransformerContextImpl(trr);
+
+
+    @BeforeEach
+    void setUp() {
+        jsonLd.registerCachedDocument("https://identity.foundation/presentation-exchange/submission/v1", TestUtils.getFileFromResourceName("presentation_ex.json").toURI());
+        jsonLd.registerCachedDocument("https://w3id.org/tractusx-trust/v0.8", TestUtils.getFileFromResourceName("presentation_query.json").toURI());
+        // delegate to the generic transformer
+
+        trr.register(new JsonValueToGenericTypeTransformer(mapper));
+    }
+
+    @Test
+    void transform_withScopes() throws JsonProcessingException {
+        var obj = """
+                {
+                  "@context": [
+                    "https://identity.foundation/presentation-exchange/submission/v1",
+                    "https://w3id.org/tractusx-trust/v0.8"
+                  ],
+                  "@type": "Query",
+                  "scope": [
+                    "org.eclipse.edc.vc.type:TestCredential:read",
+                    "org.eclipse.edc.vc.type:AnotherCredential:all"
+                  ]
+                }
+                """;
+        var json = mapper.readValue(obj, JsonObject.class);
+        var jo = jsonLd.expand(json);
+        assertThat(jo.succeeded()).withFailMessage(jo::getFailureDetail).isTrue();
+
+        var query = transformer.transform(jo.getContent(), context);
+        assertThat(query).isNotNull();
+        assertThat(query.getScopes()).hasSize(2)
+                .containsExactlyInAnyOrder(
+                        "org.eclipse.edc.vc.type:TestCredential:read",
+                        "org.eclipse.edc.vc.type:AnotherCredential:all");
+        assertThat(query.getPresentationDefinition()).isNull();
+    }
+
+    @Test
+    void transform_withPresentationDefinition() throws JsonProcessingException {
+        var json = """
+                {
+                  "@context": [
+                    "https://identity.foundation/presentation-exchange/submission/v1",
+                    "https://w3id.org/tractusx-trust/v0.8"
+                  ],
+                  "@type": "Query",
+                   "presentationDefinition": {
+                       "id": "first simple example",
+                       "input_descriptors": [
+                         {
+                           "id": "descriptor-id-1",
+                           "name": "A specific type of VC",
+                           "purpose": "We want a VC of this type",
+                           "constraints": {
+                             "fields": [
+                               {
+                                 "path": [
+                                   "$.type"
+                                 ],
+                                 "filter": {
+                                   "type": "string",
+                                   "pattern": "<the type of VC e.g. degree certificate>"
+                                 }
+                               }
+                             ]
+                           }
+                         }
+                       ]
+                     }
+                }
+                """;
+        var jobj = mapper.readValue(json, JsonObject.class);
+
+        var expansion = jsonLd.expand(jobj);
+        assertThat(expansion.succeeded()).withFailMessage(expansion::getFailureDetail).isTrue();
+
+        var query = transformer.transform(expansion.getContent(), context);
+        assertThat(query).isNotNull();
+        assertThat(query.getScopes()).isNotNull().isEmpty();
+        assertThat(query.getPresentationDefinition()).isNotNull();
+        assertThat(query.getPresentationDefinition().getInputDescriptors()).isNotEmpty()
+                .allSatisfy(id -> assertThat(id.getId()).isEqualTo("descriptor-id-1"));
+
+    }
+
+    @Test
+    void transform_withScopesAndPresDef() throws JsonProcessingException {
+        var json = """
+                {
+                  "@context": [
+                    "https://identity.foundation/presentation-exchange/submission/v1",
+                    "https://w3id.org/tractusx-trust/v0.8"
+                  ],
+                  "@type": "Query",
+                  "scope": ["test-scope1"],
+                   "presentationDefinition": {
+                       "id": "first simple example",
+                       "input_descriptors": [
+                         {
+                           "id": "descriptor-id-1",
+                           "name": "A specific type of VC",
+                           "purpose": "We want a VC of this type",
+                           "constraints": {
+                             "fields": [
+                               {
+                                 "path": [
+                                   "$.type"
+                                 ],
+                                 "filter": {
+                                   "type": "string",
+                                   "pattern": "<the type of VC e.g. degree certificate>"
+                                 }
+                               }
+                             ]
+                           }
+                         }
+                       ]
+                     }
+                }
+                """;
+        var jobj = mapper.readValue(json, JsonObject.class);
+
+        var expansion = jsonLd.expand(jobj);
+        assertThat(expansion.succeeded()).withFailMessage(expansion::getFailureDetail).isTrue();
+
+        var query = transformer.transform(expansion.getContent(), context);
+        assertThat(query).isNotNull();
+        assertThat(query.getScopes()).isNotNull().containsExactly("test-scope1");
+        assertThat(query.getPresentationDefinition()).isNotNull();
+        assertThat(query.getPresentationDefinition().getInputDescriptors()).isNotEmpty()
+                .allSatisfy(id -> assertThat(id.getId()).isEqualTo("descriptor-id-1"));
+    }
+}

--- a/extensions/common/iam/identity-trust/identity-trust-transform/src/test/resources/presentation_ex.json
+++ b/extensions/common/iam/identity-trust/identity-trust-transform/src/test/resources/presentation_ex.json
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "PresentationSubmission": {
+      "@id": "https://identity.foundation/presentation-exchange/#presentation-submission",
+      "@context": {
+        "@version": 1.1,
+        "presentation_submission": {
+          "@id": "https://identity.foundation/presentation-exchange/#presentation-submission",
+          "@type": "@json"
+        }
+      }
+    }
+  }
+}

--- a/extensions/common/iam/identity-trust/identity-trust-transform/src/test/resources/presentation_query.json
+++ b/extensions/common/iam/identity-trust/identity-trust-transform/src/test/resources/presentation_query.json
@@ -1,0 +1,12 @@
+{
+  "@context": {
+    "scope": {
+      "@id": "https://w3id.org/tractusx-trust/v0.8/scope",
+      "@container": "@set"
+    },
+    "presentationDefinition": {
+      "@id": "https://w3id.org/tractusx-trust/v0.8/presentationDefinition",
+      "@type": "@json"
+    }
+  }
+}

--- a/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/VcConstants.java
+++ b/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/VcConstants.java
@@ -18,4 +18,15 @@ public interface VcConstants {
 
     String VC_PREFIX = "https://www.w3.org/2018/credentials#";
     String SCHEMA_ORG_NAMESPACE = "https://schema.org/";
+
+    String IATP_CONTEXT_URL = "https://w3id.org/tractusx-trust/v0.8";
+    String IATP_PREFIX = IATP_CONTEXT_URL + "/";
+    String PRESENTATION_EXCHANGE_URL = "https://identity.foundation/presentation-exchange/submission/v1";
+    String W3C_CREDENTIALS_URL = "https://www.w3.org/2018/credentials/v1";
+    String VERIFIABLE_PRESENTATION_TYPE = "VerifiablePresentation";
+    String JWS_2020_URL = "https://w3id.org/security/suites/jws-2020/v1";
+    String DID_CONTEXT_URL = "https://www.w3.org/ns/did/v1";
+    String PRESENTATION_SUBMISSION_URL = "https://identity.foundation/presentation-exchange/submission/v1/";
+    String JWS_2020_SIGNATURE_SUITE = "JsonWebSignature2020";
+    String ED25519_SIGNATURE_SUITE = "Ed25519Signature2020"; // not used right now
 }

--- a/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/model/credentialservice/InputDescriptorMapping.java
+++ b/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/model/credentialservice/InputDescriptorMapping.java
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identitytrust.model.credentialservice;
+
+/**
+ * Represents the {@code descriptor_map} of a <a href="https://identity.foundation/presentation-exchange/spec/v2.0.0/#presentation-submission">Presentation Submission</a>
+ */
+public record InputDescriptorMapping(String id, String format, String path) {
+}

--- a/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/model/credentialservice/PresentationQuery.java
+++ b/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/model/credentialservice/PresentationQuery.java
@@ -1,0 +1,79 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identitytrust.model.credentialservice;
+
+
+import org.eclipse.edc.identitytrust.model.presentationdefinition.PresentationDefinition;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.eclipse.edc.identitytrust.VcConstants.IATP_PREFIX;
+
+
+/**
+ * Represents a query DTO that is sent to a CredentialService. Must be serialized to JSON-LD.
+ *
+ * @see <a href="https://github.com/eclipse-tractusx/identity-trust/blob/main/specifications/M1/verifiable.presentation.protocol.md#411-query-for-presentations">IATP Specification</a>
+ */
+public class PresentationQuery {
+    public static final String PRESENTATION_QUERY_SCOPE_PROPERTY = IATP_PREFIX + "scope";
+    public static final String PRESENTATION_QUERY_DEFINITION_PROPERTY = IATP_PREFIX + "presentationDefinition";
+    public static final String PRESENTATION_QUERY_TYPE_PROPERTY = IATP_PREFIX + "Query";
+    private List<String> scopes = new ArrayList<>();
+    private PresentationDefinition presentationDefinition;
+
+    private PresentationQuery() {
+    }
+
+    public List<String> getScopes() {
+        return scopes;
+    }
+
+    public PresentationDefinition getPresentationDefinition() {
+        return presentationDefinition;
+    }
+
+    public static final class Builder {
+        private final PresentationQuery query;
+
+        private Builder() {
+            query = new PresentationQuery();
+        }
+
+        public static Builder newinstance() {
+            return new Builder();
+        }
+
+        public Builder scopes(List<String> scopes) {
+            this.query.scopes = scopes;
+            return this;
+        }
+
+        public Builder scope(String scope) {
+            this.query.scopes.add(scope);
+            return this;
+        }
+
+        public Builder presentationDefinition(PresentationDefinition presentationDefinition) {
+            this.query.presentationDefinition = presentationDefinition;
+            return this;
+        }
+
+        public PresentationQuery build() {
+            return query;
+        }
+    }
+}

--- a/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/model/credentialservice/PresentationResponse.java
+++ b/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/model/credentialservice/PresentationResponse.java
@@ -1,0 +1,25 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identitytrust.model.credentialservice;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * A representation of a <a href="https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-response-parameters">Presentation Response</a>
+ * that the credential service sends back to the requester.
+ */
+public record PresentationResponse(@JsonProperty("vp_token") String vpToken,
+                                   @JsonProperty("presentation_submission") PresentationSubmission presentationSubmission) {
+}

--- a/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/model/credentialservice/PresentationSubmission.java
+++ b/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/model/credentialservice/PresentationSubmission.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identitytrust.model.credentialservice;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Representation of a <a href="https://identity.foundation/presentation-exchange/spec/v2.0.0/#presentation-submission">DIF Presentation Submission</a>.
+ */
+public record PresentationSubmission(@JsonProperty("id") String id,
+                                     @JsonProperty("definition_id") String definitionId,
+                                     @JsonProperty("descriptor_map") List<InputDescriptorMapping> descriptorMap) {
+}

--- a/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/model/presentationdefinition/Constraints.java
+++ b/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/model/presentationdefinition/Constraints.java
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identitytrust.model.presentationdefinition;
+
+import java.util.List;
+
+public record Constraints(List<Field> fields) {
+}

--- a/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/model/presentationdefinition/Field.java
+++ b/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/model/presentationdefinition/Field.java
@@ -1,0 +1,94 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identitytrust.model.presentationdefinition;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class Field {
+    private List<String> paths = new ArrayList<>();
+    private String id;
+    private String name;
+    private String purpose;
+    private FilterExpression expr;
+
+    private Field() {
+
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getPurpose() {
+        return purpose;
+    }
+
+    public List<String> getPaths() {
+        return paths;
+    }
+
+    public FilterExpression getExpr() {
+        return expr;
+    }
+
+
+    public static final class Builder {
+        private final Field field;
+
+        private Builder() {
+            field = new Field();
+        }
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder paths(List<String> paths) {
+            this.field.paths = paths;
+            return this;
+        }
+
+        public Builder id(String id) {
+            this.field.id = id;
+            return this;
+        }
+
+        public Builder name(String name) {
+            this.field.name = name;
+            return this;
+        }
+
+        public Builder purpose(String purpose) {
+            this.field.purpose = purpose;
+            return this;
+        }
+
+        public Builder expr(FilterExpression expr) {
+            this.field.expr = expr;
+            return this;
+        }
+
+        public Field build() {
+            Objects.requireNonNull(field.paths, "Must contain a paths property.");
+            return field;
+        }
+    }
+}

--- a/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/model/presentationdefinition/FilterExpression.java
+++ b/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/model/presentationdefinition/FilterExpression.java
@@ -1,0 +1,18 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identitytrust.model.presentationdefinition;
+
+public record FilterExpression(String type, String pattern) {
+}

--- a/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/model/presentationdefinition/Format.java
+++ b/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/model/presentationdefinition/Format.java
@@ -1,0 +1,19 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identitytrust.model.presentationdefinition;
+
+public class Format {
+    //todo
+}

--- a/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/model/presentationdefinition/InputDescriptor.java
+++ b/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/model/presentationdefinition/InputDescriptor.java
@@ -1,0 +1,88 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identitytrust.model.presentationdefinition;
+
+import java.util.Objects;
+
+public class InputDescriptor {
+    private String id;
+    private String name;
+    private String purpose;
+    private Format format;
+    private Constraints constraints;
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getPurpose() {
+        return purpose;
+    }
+
+    public Format getFormat() {
+        return format;
+    }
+
+    public Constraints getConstraints() {
+        return constraints;
+    }
+
+    public static final class Builder {
+        private final InputDescriptor descriptor;
+
+        private Builder() {
+            descriptor = new InputDescriptor();
+        }
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder id(String id) {
+            this.descriptor.id = id;
+            return this;
+        }
+
+        public Builder name(String name) {
+            this.descriptor.name = name;
+            return this;
+        }
+
+        public Builder purpose(String purpose) {
+            this.descriptor.purpose = purpose;
+            return this;
+        }
+
+        public Builder format(Format format) {
+            this.descriptor.format = format;
+            return this;
+        }
+
+        public Builder constraints(Constraints constraints) {
+            this.descriptor.constraints = constraints;
+            return this;
+        }
+
+        public InputDescriptor build() {
+            Objects.requireNonNull(descriptor.id, "InputDescriptor must have an ID.");
+            Objects.requireNonNull(descriptor.constraints, "InputDescriptor must have a Constraints object.");
+            return descriptor;
+        }
+    }
+}

--- a/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/model/presentationdefinition/PresentationDefinition.java
+++ b/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/model/presentationdefinition/PresentationDefinition.java
@@ -1,0 +1,102 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identitytrust.model.presentationdefinition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Represents a <a href="https://identity.foundation/presentation-exchange/spec/v2.0.0/#presentation-definition">DIF Presentation Definition</a>
+ */
+
+public class PresentationDefinition {
+    private String id;
+    private String name;
+    private String purpose;
+    @JsonProperty("input_descriptors")
+    private List<InputDescriptor> inputDescriptors;
+    private Format format;
+
+    private PresentationDefinition() {
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getPurpose() {
+        return purpose;
+    }
+
+    public List<InputDescriptor> getInputDescriptors() {
+        return inputDescriptors;
+    }
+
+    public Format getFormat() {
+        return format;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static final class Builder {
+        private final PresentationDefinition presentationDefinition;
+
+        private Builder() {
+            presentationDefinition = new PresentationDefinition();
+        }
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder id(String id) {
+            this.presentationDefinition.id = id;
+            return this;
+        }
+
+        public Builder name(String name) {
+            this.presentationDefinition.name = name;
+            return this;
+        }
+
+        public Builder purpose(String purpose) {
+            this.presentationDefinition.purpose = purpose;
+            return this;
+        }
+
+        public Builder inputDescriptors(List<InputDescriptor> inputDescriptor) {
+            this.presentationDefinition.inputDescriptors = inputDescriptor;
+            return this;
+        }
+
+        public Builder format(Format format) {
+            this.presentationDefinition.format = format;
+            return this;
+        }
+
+        public PresentationDefinition build() {
+            Objects.requireNonNull(presentationDefinition.id, "PresentationDefinition must have an ID.");
+            return presentationDefinition;
+        }
+    }
+}

--- a/spi/common/identity-trust-spi/src/test/java/org/eclipse/edc/identitytrust/model/credentialservice/PresentationSubmissionSerDesTest.java
+++ b/spi/common/identity-trust-spi/src/test/java/org/eclipse/edc/identitytrust/model/credentialservice/PresentationSubmissionSerDesTest.java
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identitytrust.model.credentialservice;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PresentationSubmissionSerDesTest {
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void verifyDeserialization() throws JsonProcessingException {
+        var json = """
+                 {
+                    "id": "a30e3b91-fb77-4d22-95fa-871689c322e2",
+                    "definition_id": "32f54163-7166-48f1-93d8-ff217bdb0653",
+                    "descriptor_map": [
+                      {
+                        "id": "banking_input_2",
+                        "format": "jwt_vc",
+                        "path": "$.verifiableCredential[0]"
+                      },
+                      {
+                        "id": "employment_input",
+                        "format": "ldp_vc",
+                        "path": "$.verifiableCredential[1]"
+                      },
+                      {
+                        "id": "citizenship_input_1",
+                        "format": "ldp_vc",
+                        "path": "$.verifiableCredential[2]"
+                      }
+                    ]
+                  }
+                """;
+        var pd = mapper.readValue(json, PresentationSubmission.class);
+        assertThat(pd).isNotNull();
+
+        assertThat(pd.id()).isEqualTo("a30e3b91-fb77-4d22-95fa-871689c322e2");
+        assertThat(pd.definitionId()).isEqualTo("32f54163-7166-48f1-93d8-ff217bdb0653");
+        assertThat(pd.descriptorMap()).hasSize(3);
+    }
+
+    @Test
+    void verifySerialization() throws JsonProcessingException {
+        var pd = new PresentationSubmission("test-id", "test-def-id", List.of(new InputDescriptorMapping("test-input", "ldp_vc", "$.verifiableCredentials[0]")));
+        var json = mapper.writeValueAsString(pd);
+
+        var deser = mapper.readValue(json, PresentationSubmission.class);
+        assertThat(deser).usingRecursiveComparison().isEqualTo(pd);
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

This PR moves most of the commonly used IATP model classes up into EDC from the IdentityHub. Most notably:

- model classes that are used to query the CredentialServce (=IdentityHub)
- Transformers for the model classes
- constants

## Why it does that

The model classes will be shared by the connector and IdentityHub

## Further notes

- This PR does not introduce any functional changes, only moves classes from one repo to another
- once this PR is merged, the classes will be deleted from IdentityHub

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
