### PR TITLE
feat: cache registered LD documents in memory

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -153,12 +153,12 @@ maven/mavencentral/io.swagger.core.v3/swagger-jaxrs2/2.2.15, Apache-2.0, approve
 maven/mavencentral/io.swagger.core.v3/swagger-models-jakarta/2.2.15, Apache-2.0, approved, #5919
 maven/mavencentral/io.swagger.core.v3/swagger-models/2.2.15, Apache-2.0, approved, #10353
 maven/mavencentral/io.swagger.core.v3/swagger-models/2.2.8, Apache-2.0, approved, #10353
-maven/mavencentral/io.swagger.parser.v3/swagger-parser-core/2.1.10, None, restricted, #11478
+maven/mavencentral/io.swagger.parser.v3/swagger-parser-core/2.1.10, Apache-2.0, approved, #11478
 maven/mavencentral/io.swagger.parser.v3/swagger-parser-v2-converter/2.1.10, Apache-2.0, approved, #9330
 maven/mavencentral/io.swagger.parser.v3/swagger-parser-v3/2.1.10, Apache-2.0, approved, #9323
-maven/mavencentral/io.swagger.parser.v3/swagger-parser/2.1.10, None, restricted, #11316
+maven/mavencentral/io.swagger.parser.v3/swagger-parser/2.1.10, Apache-2.0, approved, #11316
 maven/mavencentral/io.swagger/swagger-annotations/1.6.9, Apache-2.0, approved, #3792
-maven/mavencentral/io.swagger/swagger-compat-spec-parser/1.0.64, None, restricted, #11479
+maven/mavencentral/io.swagger/swagger-compat-spec-parser/1.0.64, Apache-2.0, approved, #11479
 maven/mavencentral/io.swagger/swagger-core/1.6.9, Apache-2.0, approved, #4358
 maven/mavencentral/io.swagger/swagger-models/1.6.9, Apache-2.0, approved, #11476
 maven/mavencentral/io.swagger/swagger-parser/1.0.64, Apache-2.0, approved, #4359

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -160,7 +160,7 @@ maven/mavencentral/io.swagger.parser.v3/swagger-parser/2.1.10, None, restricted,
 maven/mavencentral/io.swagger/swagger-annotations/1.6.9, Apache-2.0, approved, #3792
 maven/mavencentral/io.swagger/swagger-compat-spec-parser/1.0.64, None, restricted, #11479
 maven/mavencentral/io.swagger/swagger-core/1.6.9, Apache-2.0, approved, #4358
-maven/mavencentral/io.swagger/swagger-models/1.6.9, LicenseRef-scancode-proprietary-license, restricted, #11476
+maven/mavencentral/io.swagger/swagger-models/1.6.9, Apache-2.0, approved, #11476
 maven/mavencentral/io.swagger/swagger-parser/1.0.64, Apache-2.0, approved, #4359
 maven/mavencentral/jakarta.activation/jakarta.activation-api/1.2.1, EPL-2.0 OR BSD-3-Clause OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jaf
 maven/mavencentral/jakarta.activation/jakarta.activation-api/2.1.0, EPL-2.0 OR BSD-3-Clause OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jaf

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/TitaniumJsonLd.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/TitaniumJsonLd.java
@@ -205,7 +205,7 @@ public class TitaniumJsonLd implements JsonLd {
             try {
                 documentCache.put(uri, loader.loadDocument(uri, new DocumentLoaderOptions()));
             } catch (JsonLdError e) {
-                throw new EdcException(e);
+                throw new EdcException("Error in caching json ld context %s from URI %s".formatted(contextUrl, uri), e);
             }
         }
 

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/TitaniumJsonLd.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/TitaniumJsonLd.java
@@ -196,7 +196,7 @@ public class TitaniumJsonLd implements JsonLd {
                     .map(uriCache::get)
                     .orElse(url);
 
-            return Optional.of(documentCache.get(uri))
+            return Optional.ofNullable(documentCache.get(uri))
                     .orElse(loader.loadDocument(uri, options));
         }
 

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/TitaniumJsonLd.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/TitaniumJsonLd.java
@@ -205,7 +205,7 @@ public class TitaniumJsonLd implements JsonLd {
             try {
                 documentCache.put(uri, loader.loadDocument(uri, new DocumentLoaderOptions()));
             } catch (JsonLdError e) {
-                throw new EdcException("Error in caching json ld context %s from URI %s".formatted(contextUrl, uri), e);
+                throw new EdcException("Error caching Json-Ld context %s from URI %s".formatted(contextUrl, uri), e);
             }
         }
 

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/JsonLdExtensionTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/JsonLdExtensionTest.java
@@ -49,7 +49,7 @@ class JsonLdExtensionTest {
         var service = (TitaniumJsonLd) extension.createJsonLdService(context);
 
         DocumentLoader documentLoader = getFieldValue("documentLoader", service);
-        Map<String, URI> cache = getFieldValue("cache", documentLoader);
+        Map<String, URI> cache = getFieldValue("uriCache", documentLoader);
 
         assertThat(cache).containsEntry("http://foo.org/doc.json", new URI("file:/tmp/foo/doc.json"));
     }
@@ -65,7 +65,7 @@ class JsonLdExtensionTest {
         var service = (TitaniumJsonLd) extension.createJsonLdService(context);
 
         DocumentLoader documentLoader = getFieldValue("documentLoader", service);
-        Map<String, URI> cache = getFieldValue("cache", documentLoader);
+        Map<String, URI> cache = getFieldValue("uriCache", documentLoader);
 
         assertThat(cache).containsEntry("http://foo.org/doc.json", new URI("file:/tmp/foo/doc.json"));
     }
@@ -82,7 +82,7 @@ class JsonLdExtensionTest {
         var service = (TitaniumJsonLd) extension.createJsonLdService(context);
 
         DocumentLoader documentLoader = getFieldValue("documentLoader", service);
-        Map<String, URI> cache = getFieldValue("cache", documentLoader);
+        Map<String, URI> cache = getFieldValue("uriCache", documentLoader);
 
         assertThat(cache).containsEntry("http://foo.org/doc.json", new URI("file:/tmp/foo/doc.json"));
         assertThat(cache).containsEntry("http://bar.org/doc.json", new URI("file:/tmp/bar/doc.json"));
@@ -99,7 +99,7 @@ class JsonLdExtensionTest {
         var service = (TitaniumJsonLd) extension.createJsonLdService(context);
 
         DocumentLoader documentLoader = getFieldValue("documentLoader", service);
-        Map<String, URI> cache = getFieldValue("cache", documentLoader);
+        Map<String, URI> cache = getFieldValue("uriCache", documentLoader);
 
         assertThat(cache).containsEntry("http://foo.org/doc.json", new URI("file:/tmp/foo/doc.json"))
                 .noneSatisfy((s, uri) -> assertThat(s).isEqualTo("http://bar.org/doc.json"));
@@ -117,7 +117,7 @@ class JsonLdExtensionTest {
         var service = (TitaniumJsonLd) extension.createJsonLdService(context);
 
         DocumentLoader documentLoader = getFieldValue("documentLoader", service);
-        Map<String, URI> cache = getFieldValue("cache", documentLoader);
+        Map<String, URI> cache = getFieldValue("uriCache", documentLoader);
 
         assertThat(cache).containsEntry("http://foo.org/doc.json", new URI("file:/tmp/foo/doc.json"))
                 .noneSatisfy((s, uri) -> assertThat(s).isEqualTo("http://bar.org/doc.json"));

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/TitaniumJsonLdTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/TitaniumJsonLdTest.java
@@ -264,7 +264,6 @@ class TitaniumJsonLdTest {
                 .add("test:key", "value")
                 .build();
         var service = defaultService();
-        service.registerCachedDocument("http//any.other/url", URI.create("any:uri"));
 
         var expanded = service.expand(jsonObject);
 
@@ -280,7 +279,7 @@ class TitaniumJsonLdTest {
                 .add("test:key", "value")
                 .build();
         var service = httpEnabledService();
-        service.registerCachedDocument("http//any.other/url", URI.create("any:uri"));
+        service.registerCachedDocument("http//any.other/url", URI.create("http://localhost:" + server.getLocalPort()));
 
         var expanded = service.expand(jsonObject);
 


### PR DESCRIPTION
## What this PR changes/adds

This PR caches registered linked documents in memory for easy access.

## Why it does that

speeding up the expansion process

## Further notes


Closes #3619

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
