### PR TITLE
fix: transform policy to contract offer

### DIFF
--- a/core/common/transform-core/src/main/java/org/eclipse/edc/core/transform/transformer/from/JsonObjectFromPolicyTransformer.java
+++ b/core/common/transform-core/src/main/java/org/eclipse/edc/core/transform/transformer/from/JsonObjectFromPolicyTransformer.java
@@ -157,7 +157,11 @@ public class JsonObjectFromPolicyTransformer extends AbstractJsonLdTransformer<P
                     .add(ODRL_PROHIBITION_ATTRIBUTE, prohibitionsBuilder)
                     .add(ODRL_OBLIGATION_ATTRIBUTE, obligationsBuilder);
 
-            Optional.ofNullable(policy.getTarget()).ifPresent(it -> builder.add(ODRL_TARGET_ATTRIBUTE, it));
+            Optional.ofNullable(policy.getTarget())
+                    .ifPresent(target -> builder.add(
+                            ODRL_TARGET_ATTRIBUTE,
+                            jsonFactory.createArrayBuilder().add(jsonFactory.createObjectBuilder().add(ID, target)))
+                    );
 
             return builder.build();
         }

--- a/core/common/transform-core/src/test/java/org/eclipse/edc/core/transform/transformer/from/JsonObjectFromPolicyTransformerTest.java
+++ b/core/common/transform-core/src/test/java/org/eclipse/edc/core/transform/transformer/from/JsonObjectFromPolicyTransformerTest.java
@@ -17,6 +17,8 @@ package org.eclipse.edc.core.transform.transformer.from;
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
 import org.eclipse.edc.policy.model.Action;
 import org.eclipse.edc.policy.model.AndConstraint;
 import org.eclipse.edc.policy.model.AtomicConstraint;
@@ -36,6 +38,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
@@ -90,7 +93,14 @@ class JsonObjectFromPolicyTransformerTest {
         
         assertThat(result).isNotNull();
         assertThat(result.getJsonString(TYPE).getString()).isEqualTo(OdrlNamespace.ODRL_SCHEMA + "Set");
-        assertThat(result.getString(ODRL_TARGET_ATTRIBUTE)).isEqualTo("target");
+        assertThat(result.get(ODRL_TARGET_ATTRIBUTE))
+                .isNotNull()
+                .isInstanceOf(JsonArray.class)
+                .extracting(JsonValue::asJsonArray)
+                .matches(it -> !it.isEmpty())
+                .asList().first()
+                .asInstanceOf(type(JsonObject.class))
+                .matches(it -> it.getString(ID).equals("target"));
     
         assertThat(result.get(ODRL_PERMISSION_ATTRIBUTE))
                 .isNotNull()

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiExtension.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiExtension.java
@@ -21,6 +21,7 @@ import org.eclipse.edc.connector.api.management.configuration.transform.Manageme
 import org.eclipse.edc.connector.api.management.contractnegotiation.transform.JsonObjectFromContractNegotiationTransformer;
 import org.eclipse.edc.connector.api.management.contractnegotiation.transform.JsonObjectFromNegotiationStateTransformer;
 import org.eclipse.edc.connector.api.management.contractnegotiation.transform.JsonObjectToContractOfferDescriptionTransformer;
+import org.eclipse.edc.connector.api.management.contractnegotiation.transform.JsonObjectToContractOfferTransformer;
 import org.eclipse.edc.connector.api.management.contractnegotiation.transform.JsonObjectToContractRequestTransformer;
 import org.eclipse.edc.connector.api.management.contractnegotiation.transform.JsonObjectToTerminateNegotiationCommandTransformer;
 import org.eclipse.edc.connector.api.management.contractnegotiation.validation.ContractRequestValidator;
@@ -69,6 +70,7 @@ public class ContractNegotiationApiExtension implements ServiceExtension {
         var monitor = context.getMonitor();
 
         transformerRegistry.register(new JsonObjectToContractRequestTransformer());
+        transformerRegistry.register(new JsonObjectToContractOfferTransformer());
         transformerRegistry.register(new JsonObjectToContractOfferDescriptionTransformer());
         transformerRegistry.register(new JsonObjectToTerminateNegotiationCommandTransformer());
         transformerRegistry.register(new JsonObjectFromContractNegotiationTransformer(factory));

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiExtension.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiExtension.java
@@ -68,7 +68,7 @@ public class ContractNegotiationApiExtension implements ServiceExtension {
         var factory = Json.createBuilderFactory(Map.of());
         var monitor = context.getMonitor();
 
-        transformerRegistry.register(new JsonObjectToContractRequestTransformer(monitor));
+        transformerRegistry.register(new JsonObjectToContractRequestTransformer());
         transformerRegistry.register(new JsonObjectToContractOfferDescriptionTransformer());
         transformerRegistry.register(new JsonObjectToTerminateNegotiationCommandTransformer());
         transformerRegistry.register(new JsonObjectFromContractNegotiationTransformer(factory));

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectToContractOfferTransformer.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectToContractOfferTransformer.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.contractnegotiation.transform;
+
+import jakarta.json.JsonObject;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class JsonObjectToContractOfferTransformer extends AbstractJsonLdTransformer<JsonObject, ContractOffer>  {
+
+    public JsonObjectToContractOfferTransformer() {
+        super(JsonObject.class, ContractOffer.class);
+    }
+
+    @Override
+    public @Nullable ContractOffer transform(@NotNull JsonObject jsonObject, @NotNull TransformerContext context) {
+        var policy = context.transform(jsonObject, Policy.class);
+        if (policy == null) {
+            return null;
+        }
+        var id = nodeId(jsonObject);
+        return ContractOffer.Builder.newInstance()
+                .id(id)
+                .assetId(policy.getTarget())
+                .policy(policy)
+                .build();
+    }
+}

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerTest.java
@@ -327,7 +327,7 @@ class ContractNegotiationApiControllerTest extends RestControllerTestBase {
     }
 
     @Test
-    void initiate_with_contractOffer() {
+    void initiate() {
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
         var contractNegotiation = createContractNegotiation("cn1");
         var responseBody = createObjectBuilder().add(TYPE, ID_RESPONSE_TYPE).add(ID, contractNegotiation.getId()).build();
@@ -342,39 +342,6 @@ class ContractNegotiationApiControllerTest extends RestControllerTestBase {
                                 .assetId(randomUUID().toString())
                                 .policy(Policy.Builder.newInstance().build())
                                 .build())
-                        .build()));
-
-        when(transformerRegistry.transform(any(), eq(JsonObject.class))).thenReturn(Result.success(responseBody));
-        when(service.initiateNegotiation(any(ContractRequest.class))).thenReturn(contractNegotiation);
-
-        when(transformerRegistry.transform(any(IdResponse.class), eq(JsonObject.class))).thenReturn(Result.success(responseBody));
-
-        baseRequest()
-                .contentType(JSON)
-                .body(createObjectBuilder().build())
-                .post()
-                .then()
-                .statusCode(200)
-                .body(ID, is(contractNegotiation.getId()));
-
-        verify(service).initiateNegotiation(any());
-        verify(transformerRegistry).transform(any(JsonObject.class), eq(ContractRequest.class));
-        verify(transformerRegistry).transform(any(IdResponse.class), eq(JsonObject.class));
-        verifyNoMoreInteractions(transformerRegistry, service);
-    }
-
-    @Test
-    void initiate_with_policy() {
-        when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
-        var contractNegotiation = createContractNegotiation("cn1");
-        var responseBody = createObjectBuilder().add(TYPE, ID_RESPONSE_TYPE).add(ID, contractNegotiation.getId()).build();
-
-        when(transformerRegistry.transform(any(JsonObject.class), eq(ContractRequest.class))).thenReturn(Result.success(
-                ContractRequest.Builder.newInstance()
-                        .protocol("test-protocol")
-                        .providerId("test-provider-id")
-                        .counterPartyAddress("test-cb")
-                        .policy(Policy.Builder.newInstance().build())
                         .build()));
 
         when(transformerRegistry.transform(any(), eq(JsonObject.class))).thenReturn(Result.success(responseBody));

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiTest.java
@@ -56,7 +56,7 @@ class ContractNegotiationApiTest {
 
     @BeforeEach
     void setUp() {
-        transformer.register(new JsonObjectToContractRequestTransformer(monitor));
+        transformer.register(new JsonObjectToContractRequestTransformer());
         transformer.register(new JsonObjectToContractOfferDescriptionTransformer());
         transformer.register(new JsonObjectToCallbackAddressTransformer());
         transformer.register(new JsonObjectToTerminateNegotiationCommandTransformer());

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiTest.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.api.transformer.JsonObjectToCallbackAddressTransformer;
 import org.eclipse.edc.connector.api.management.contractnegotiation.transform.JsonObjectToContractOfferDescriptionTransformer;
+import org.eclipse.edc.connector.api.management.contractnegotiation.transform.JsonObjectToContractOfferTransformer;
 import org.eclipse.edc.connector.api.management.contractnegotiation.transform.JsonObjectToContractRequestTransformer;
 import org.eclipse.edc.connector.api.management.contractnegotiation.transform.JsonObjectToTerminateNegotiationCommandTransformer;
 import org.eclipse.edc.connector.api.management.contractnegotiation.validation.ContractRequestValidator;
@@ -57,6 +58,7 @@ class ContractNegotiationApiTest {
     @BeforeEach
     void setUp() {
         transformer.register(new JsonObjectToContractRequestTransformer());
+        transformer.register(new JsonObjectToContractOfferTransformer());
         transformer.register(new JsonObjectToContractOfferDescriptionTransformer());
         transformer.register(new JsonObjectToCallbackAddressTransformer());
         transformer.register(new JsonObjectToTerminateNegotiationCommandTransformer());

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectToContractOfferTransformerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectToContractOfferTransformerTest.java
@@ -1,0 +1,87 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.contractnegotiation.transform;
+
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import org.eclipse.edc.jsonld.TitaniumJsonLd;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static jakarta.json.Json.createObjectBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_OBLIGATION_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_PERMISSION_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_SET;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_PROHIBITION_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIBUTE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class JsonObjectToContractOfferTransformerTest {
+
+    private final JsonLd jsonLd = new TitaniumJsonLd(mock(Monitor.class));
+    private final TransformerContext context = mock();
+    private JsonObjectToContractOfferTransformer transformer;
+
+    @BeforeEach
+    void setUp() {
+        transformer = new JsonObjectToContractOfferTransformer();
+    }
+
+    @Test
+    void transform() {
+        var offerPolicy = createObjectBuilder()
+                .add(TYPE, ODRL_POLICY_TYPE_SET)
+                .add(ID, "test-offer-id")
+                .add(ODRL_TARGET_ATTRIBUTE, "test-asset")
+                .add(ODRL_PERMISSION_ATTRIBUTE, getJsonObject("permission"))
+                .add(ODRL_PROHIBITION_ATTRIBUTE, getJsonObject("prohibition"))
+                .add(ODRL_OBLIGATION_ATTRIBUTE, getJsonObject("duty"))
+                .build();
+
+        var policy = Policy.Builder.newInstance().target("test-asset").build();
+        when(context.transform(any(JsonValue.class), eq(Policy.class))).thenReturn(policy);
+        
+        var result = transformer.transform(jsonLd.expand(offerPolicy).getContent(), context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo("test-offer-id");
+        assertThat(result.getAssetId()).isEqualTo("test-asset");
+    }
+
+    @Test
+    void shouldReturnNull_whenPolicyIsNull() {
+        when(context.transform(any(JsonValue.class), eq(Policy.class))).thenReturn(null);
+
+        var result = transformer.transform(createObjectBuilder().build(), context);
+
+        assertThat(result).isNull();
+    }
+
+    private JsonObject getJsonObject(String type) {
+        return createObjectBuilder()
+                .add(TYPE, type)
+                .build();
+    }
+}

--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/test/system/utils/Participant.java
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/test/system/utils/Participant.java
@@ -237,12 +237,10 @@ public class Participant {
      * Initiate negotiation with a provider.
      *
      * @param provider data provider
-     * @param offerId  contract definition id
-     * @param assetId  asset id
      * @param policy   policy
      * @return id of the contract agreement.
      */
-    public String negotiateContract(Participant provider, String offerId, String assetId, JsonObject policy) {
+    public String negotiateContract(Participant provider, JsonObject policy) {
         var requestBody = createObjectBuilder()
                 .add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
                 .add(TYPE, "ContractRequestDto")
@@ -258,6 +256,7 @@ public class Participant {
                 .when()
                 .post("/v2/contractnegotiations")
                 .then()
+                .log().ifError()
                 .statusCode(200)
                 .extract().body().jsonPath().getString(ID);
 
@@ -318,9 +317,7 @@ public class Participant {
     public String requestAsset(Participant provider, String assetId, JsonObject privateProperties, JsonObject destination) {
         var dataset = getDatasetForAsset(provider, assetId);
         var policy = dataset.getJsonArray(ODRL_POLICY_ATTRIBUTE).get(0).asJsonObject();
-        var contractDefinitionId = ContractOfferId.parseId(policy.getString(ID))
-                .orElseThrow(failure -> new RuntimeException(failure.getFailureDetail()));
-        var contractAgreementId = negotiateContract(provider, contractDefinitionId.toString(), assetId, policy);
+        var contractAgreementId = negotiateContract(provider, policy);
         var transferProcessId = initiateTransfer(provider, contractAgreementId, assetId, privateProperties, destination);
         assertThat(transferProcessId).isNotNull();
         return transferProcessId;

--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/test/system/utils/Participant.java
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/test/system/utils/Participant.java
@@ -249,11 +249,7 @@ public class Participant {
                 .add("providerId", provider.id)
                 .add("counterPartyAddress", provider.protocolEndpoint.url.toString())
                 .add("protocol", DSP_PROTOCOL)
-                .add("offer", createObjectBuilder()
-                        .add("offerId", offerId)
-                        .add("assetId", assetId)
-                        .add("policy", jsonLd.compact(policy).getContent())
-                )
+                .add("policy", jsonLd.compact(policy).getContent())
                 .build();
 
         var negotiationId = managementEndpoint.baseRequest()

--- a/extensions/control-plane/transfer/transfer-pull-http-dynamic-receiver/README.md
+++ b/extensions/control-plane/transfer/transfer-pull-http-dynamic-receiver/README.md
@@ -18,7 +18,7 @@ and will be used by the consumer connector to dispatch the EDR
     "@type": "DataAddress",
     "type": "HttpProxy"
   },
-  "connectorAddress": "http://localhost:8282/api/v1/ids/data",
+  "counterPartyAddress": "http://localhost:8282/api/v1/ids/data",
   "connectorId": "consumer",
   "privateProperties": {
     "receiverHttpEndpoint" : "http://localhost:9999"

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequest.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.connector.contract.spi.types.negotiation;
 
-import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 
@@ -44,7 +43,6 @@ public class ContractRequest {
     private String protocol;
     private String counterPartyAddress;
     private ContractOffer contractOffer;
-    private Policy policy;
     private List<CallbackAddress> callbackAddresses = new ArrayList<>();
 
     public List<CallbackAddress> getCallbackAddresses() {
@@ -65,10 +63,6 @@ public class ContractRequest {
 
     public ContractOffer getContractOffer() {
         return contractOffer;
-    }
-
-    public Policy getPolicy() {
-        return policy;
     }
 
     public static class Builder {
@@ -107,20 +101,10 @@ public class ContractRequest {
             return this;
         }
 
-        public Builder policy(Policy policy) {
-            contractRequest.policy = policy;
-            return this;
-        }
-
         public ContractRequest build() {
             Objects.requireNonNull(contractRequest.protocol, "protocol");
             Objects.requireNonNull(contractRequest.counterPartyAddress, "counterPartyAddress");
-            if (contractRequest.contractOffer == null) {
-                Objects.requireNonNull(contractRequest.policy, "policy");
-            }
-            if (contractRequest.policy == null) {
-                Objects.requireNonNull(contractRequest.contractOffer, "contractOffer");
-            }
+            Objects.requireNonNull(contractRequest.contractOffer, "contractOffer");
             return contractRequest;
         }
     }

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractNegotiationApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractNegotiationApiEndToEndTest.java
@@ -151,6 +151,38 @@ public class ContractNegotiationApiEndToEndTest extends BaseManagementApiEndToEn
         assertThat(store.findById(id)).isNotNull();
     }
 
+    @Deprecated(since = "0.3.2")
+    @Test
+    void deprecated_initiateNegotiation() {
+
+        var requestJson = createObjectBuilder()
+                .add(CONTEXT, createObjectBuilder().add(EDC_PREFIX, EDC_NAMESPACE))
+                .add(TYPE, "ContractRequest")
+                .add("counterPartyAddress", "test-address")
+                .add("protocol", "test-protocol")
+                .add("providerId", "test-provider-id")
+                .add("callbackAddresses", createCallbackAddress())
+                .add("offer", createObjectBuilder()
+                        .add("offerId", "offer-id")
+                        .add("assetId", "assetId")
+                        .add("policy", createPolicy()))
+                .build();
+
+        var id = baseRequest()
+                .contentType(JSON)
+                .body(requestJson)
+                .post("/v2/contractnegotiations")
+                .then()
+                .log().ifError()
+                .statusCode(200)
+                .contentType(JSON)
+                .extract().jsonPath().getString(ID);
+
+        var store = controlPlane.getContext().getService(ContractNegotiationStore.class);
+
+        assertThat(store.findById(id)).isNotNull();
+    }
+
     @Test
     void terminate() {
         var store = controlPlane.getContext().getService(ContractNegotiationStore.class);
@@ -222,9 +254,11 @@ public class ContractNegotiationApiEndToEndTest extends BaseManagementApiEndToEn
         return createObjectBuilder()
                 .add(CONTEXT, "http://www.w3.org/ns/odrl.jsonld")
                 .add(TYPE, "Offer")
+                .add(ID, "offer-id")
                 .add("permission", permissionJson)
                 .add("prohibition", prohibitionJson)
                 .add("obligation", dutyJson)
+                .add("target", "asset-id")
                 .build();
     }
 

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractNegotiationApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractNegotiationApiEndToEndTest.java
@@ -130,15 +130,11 @@ public class ContractNegotiationApiEndToEndTest extends BaseManagementApiEndToEn
         var requestJson = createObjectBuilder()
                 .add(CONTEXT, createObjectBuilder().add(EDC_PREFIX, EDC_NAMESPACE))
                 .add(TYPE, "ContractRequest")
-                .add("connectorAddress", "test-address")
+                .add("counterPartyAddress", "test-address")
                 .add("protocol", "test-protocol")
                 .add("providerId", "test-provider-id")
                 .add("callbackAddresses", createCallbackAddress())
-                .add("offer", createObjectBuilder()
-                        .add("offerId", "test-offer-id")
-                        .add("assetId", "test-asset")
-                        .add("policy", createPolicy())
-                        .build())
+                .add("policy", createPolicy())
                 .build();
 
         var id = baseRequest()

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TransferProcessApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TransferProcessApiEndToEndTest.java
@@ -109,7 +109,7 @@ public class TransferProcessApiEndToEndTest extends BaseManagementApiEndToEndTes
                 )
                 .add("callbackAddresses", createCallbackAddress())
                 .add("protocol", "dataspace-protocol-http")
-                .add("connectorAddress", "http://connector-address")
+                .add("counterPartyAddress", "http://connector-address")
                 .add("connectorId", "connectorId")
                 .add("contractId", "contractId")
                 .add("assetId", "assetId")

--- a/system-tests/telemetry/telemetry-test-runner/src/test/java/org/eclipse/edc/test/e2e/tracing/TracingEndToEndTest.java
+++ b/system-tests/telemetry/telemetry-test-runner/src/test/java/org/eclipse/edc/test/e2e/tracing/TracingEndToEndTest.java
@@ -37,8 +37,10 @@ import static io.restassured.http.ContentType.JSON;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
 import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 
 /**
@@ -71,14 +73,17 @@ public class TracingEndToEndTest extends BaseTelemetryEndToEndTest {
         traceCollectorServer.when(HttpRequest.request()).respond(HttpResponse.response().withStatusCode(200));
 
         var requestJson = Json.createObjectBuilder()
-                .add(TYPE, EDC_NAMESPACE + "ContractRequest")
-                .add(EDC_NAMESPACE + "counterPartyAddress", "test-address")
-                .add(EDC_NAMESPACE + "protocol", "test-protocol")
-                .add(EDC_NAMESPACE + "providerId", "test-provider-id")
-                .add(EDC_NAMESPACE + "consumerId", "test-consumer-id")
-                .add(EDC_NAMESPACE + "policy", Json.createObjectBuilder()
+                .add(CONTEXT, Json.createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
+                .add(TYPE, "ContractRequest")
+                .add("counterPartyAddress", "test-address")
+                .add("protocol", "test-protocol")
+                .add("providerId", "test-provider-id")
+                .add("consumerId", "test-consumer-id")
+                .add("policy", Json.createObjectBuilder()
+                        .add(CONTEXT, "http://www.w3.org/ns/odrl.jsonld")
                         .add(TYPE, "use")
-                        .add(EDC_NAMESPACE + "target", "test-asset")
+                        .add(ID, "offer-id")
+                        .add("target", "test-asset")
                         .build())
                 .build();
 
@@ -89,6 +94,7 @@ public class TracingEndToEndTest extends BaseTelemetryEndToEndTest {
                 .body(requestJson)
                 .post("/management/v2/contractnegotiations")
                 .then()
+                .log().ifError()
                 .statusCode(200)
                 .contentType(JSON)
                 .extract().jsonPath().getString(ID);

--- a/system-tests/telemetry/telemetry-test-runner/src/test/java/org/eclipse/edc/test/e2e/tracing/TracingEndToEndTest.java
+++ b/system-tests/telemetry/telemetry-test-runner/src/test/java/org/eclipse/edc/test/e2e/tracing/TracingEndToEndTest.java
@@ -18,7 +18,6 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.trace.v1.Span;
 import jakarta.json.Json;
-import jakarta.json.JsonObject;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -73,14 +72,13 @@ public class TracingEndToEndTest extends BaseTelemetryEndToEndTest {
 
         var requestJson = Json.createObjectBuilder()
                 .add(TYPE, EDC_NAMESPACE + "ContractRequest")
-                .add(EDC_NAMESPACE + "connectorAddress", "test-address")
+                .add(EDC_NAMESPACE + "counterPartyAddress", "test-address")
                 .add(EDC_NAMESPACE + "protocol", "test-protocol")
                 .add(EDC_NAMESPACE + "providerId", "test-provider-id")
                 .add(EDC_NAMESPACE + "consumerId", "test-consumer-id")
-                .add(EDC_NAMESPACE + "offer", Json.createObjectBuilder()
-                        .add(EDC_NAMESPACE + "offerId", "test-offer-id")
-                        .add(EDC_NAMESPACE + "assetId", "test-asset")
-                        .add(EDC_NAMESPACE + "policy", noConstraintPolicy())
+                .add(EDC_NAMESPACE + "policy", Json.createObjectBuilder()
+                        .add(TYPE, "use")
+                        .add(EDC_NAMESPACE + "target", "test-asset")
                         .build())
                 .build();
 
@@ -128,9 +126,4 @@ public class TracingEndToEndTest extends BaseTelemetryEndToEndTest {
                 .collect(Collectors.toList());
     }
 
-    private JsonObject noConstraintPolicy() {
-        return Json.createObjectBuilder()
-                .add(TYPE, "use")
-                .build();
-    }
 }


### PR DESCRIPTION
## What this PR changes/adds

Map the new `policy` field to `ContractOffer`

## Why it does that

avoid null pointer exceptions, because `ContractOffer` cannot be missing in a `ContractRequest` object.

## Further notes

- make all the test use the new fields defined (`policy`, `counterPartyAddress`) instead of the deprecated ones
- policy transformer now sets the `target` as an `@id`, as requested by the [ODRL information model](https://www.w3.org/TR/odrl-model/#policy-has)

## Linked Issue(s)

Closes #3624 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
