### PR TITLE
feat: bring back the custom DataSink overload

### DIFF
--- a/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImplTest.java
+++ b/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImplTest.java
@@ -73,7 +73,6 @@ class DataPlaneManagerImplTest {
     private final DataPlaneStore store = mock();
     private final DataFlowRequest request = createRequest();
     private final TransferServiceRegistry registry = mock();
-
     private DataPlaneManagerImpl manager;
 
     @BeforeEach

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/edr/EndpointDataReference.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/edr/EndpointDataReference.java
@@ -81,6 +81,18 @@ public class EndpointDataReference {
         return properties;
     }
 
+    @Override
+    public String toString() {
+        return "EndpointDataReference{" +
+                "properties=" + properties +
+                ", id='" + id + '\'' +
+                ", contractId='" + contractId + '\'' +
+                ", endpoint='" + endpoint + '\'' +
+                ", authKey='" + authKey + '\'' +
+                ", authCode='" + authCode + '\'' +
+                '}';
+    }
+
     @JsonPOJOBuilder(withPrefix = "")
     public static class Builder {
         private final EndpointDataReference edr;

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/manager/DataPlaneManager.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/manager/DataPlaneManager.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.connector.dataplane.spi.manager;
 
 import org.eclipse.edc.connector.dataplane.spi.DataFlowStates;
+import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSink;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.StreamResult;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import org.eclipse.edc.spi.entity.StateEntityManager;
@@ -62,7 +63,12 @@ public interface DataPlaneManager extends StateEntityManager {
     void initiate(DataFlowRequest dataRequest);
 
     /**
-     * Performs a data transfer using the supplied data sink.
+     * Transfers data from a source to a destination asynchronously using the provided DataFlowRequest. The {@link org.eclipse.edc.connector.dataplane.spi.pipeline.DataSource}
+     * and {@link DataSink} will be resolved from the supplied DataFlowRequest, more specifically the source and destination address
+     * within.
+     *
+     * @param request The DataFlowRequest that specifies the source, destination, and other necessary details.
+     * @return A CompletableFuture that completes with a StreamResult indicating the success or failure of the transfer.
      */
     CompletableFuture<StreamResult<Object>> transfer(DataFlowRequest request);
 

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/pipeline/DataSink.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/pipeline/DataSink.java
@@ -19,6 +19,7 @@ import java.util.concurrent.CompletableFuture;
 /**
  * A data sink.
  */
+@FunctionalInterface
 public interface DataSink {
 
     /**

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/pipeline/TransferService.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/pipeline/TransferService.java
@@ -37,9 +37,21 @@ public interface TransferService {
     Result<Boolean> validate(DataFlowRequest request);
 
     /**
-     * Transfers data from source to destination.
+     * Transfers data from a source to a destination using the provided data flow request.
+     *
+     * @param request The data flow request containing the necessary information for the transfer.
+     * @return A CompletableFuture wrapping a StreamResult indicating the success or failure of the transfer.
      */
     CompletableFuture<StreamResult<Object>> transfer(DataFlowRequest request);
+
+    /**
+     * Transfers data from a source to a destination using the provided data flow request and data sink.
+     *
+     * @param request The data flow request containing the necessary information for the transfer.
+     * @param sink    The data sink that will receive the transferred data.
+     * @return A CompletableFuture wrapping a StreamResult indicating the success or failure of the transfer.
+     */
+    CompletableFuture<StreamResult<Object>> transfer(DataFlowRequest request, DataSink sink);
 
     /**
      * Terminate a data flow.


### PR DESCRIPTION
## What this PR changes/adds

This PR brings back the overloaded method in the `DataPlaneManager` that takes a `DataSink` parameter.
If specified, the `DataPlaneManager`(`Impl`) will immediately delegate to the `PipelineService`.

This effectively restores the behaviour before #3486

## Why it does that

For streaming, e.g. HTTP, we need to be able to supply just any random data sink

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
