### PR TITLE
docs: decision record about Transfer type

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -57,7 +57,7 @@ maven/mavencentral/com.github.stephenc.jcip/jcip-annotations/1.0-1, Apache-2.0, 
 maven/mavencentral/com.google.code.findbugs/jsr305/2.0.1, BSD-3-Clause AND CC-BY-2.5 AND LGPL-2.1+, approved, CQ13390
 maven/mavencentral/com.google.code.findbugs/jsr305/3.0.2, Apache-2.0, approved, #20
 maven/mavencentral/com.google.code.gson/gson/2.10.1, Apache-2.0, approved, #6159
-maven/mavencentral/com.google.crypto.tink/tink/1.12.0, , restricted, clearlydefined
+maven/mavencentral/com.google.crypto.tink/tink/1.12.0, Apache-2.0, approved, #12041
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.11.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.22.0, Apache-2.0, approved, #10661
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.7.1, Apache-2.0, approved, clearlydefined
@@ -132,10 +132,10 @@ maven/mavencentral/io.prometheus/simpleclient_httpserver/0.16.0, Apache-2.0, app
 maven/mavencentral/io.prometheus/simpleclient_tracer_common/0.16.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.prometheus/simpleclient_tracer_otel/0.16.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.prometheus/simpleclient_tracer_otel_agent/0.16.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.rest-assured/json-path/5.4.0, , restricted, clearlydefined
-maven/mavencentral/io.rest-assured/rest-assured-common/5.4.0, , restricted, clearlydefined
-maven/mavencentral/io.rest-assured/rest-assured/5.4.0, , restricted, clearlydefined
-maven/mavencentral/io.rest-assured/xml-path/5.4.0, , restricted, clearlydefined
+maven/mavencentral/io.rest-assured/json-path/5.4.0, Apache-2.0, approved, #12042
+maven/mavencentral/io.rest-assured/rest-assured-common/5.4.0, Apache-2.0, approved, #12039
+maven/mavencentral/io.rest-assured/rest-assured/5.4.0, Apache-2.0, approved, #12040
+maven/mavencentral/io.rest-assured/xml-path/5.4.0, Apache-2.0, approved, #12038
 maven/mavencentral/io.setl/rdf-urdna/1.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.15, Apache-2.0, approved, #5947
 maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.19, Apache-2.0, approved, #5947

--- a/docs/developer/decision-records/2023-11-20-transfer-type/README.md
+++ b/docs/developer/decision-records/2023-11-20-transfer-type/README.md
@@ -1,0 +1,71 @@
+# Transfer Type
+
+## Decision
+
+We will decouple `DataAddress#type` from the actual type of transfer by introducing a `transferType` concept, that will drive 
+the selection of the right `DataPlane` for a specific `TransferRequest`. 
+
+## Rationale
+
+Currently `EDC` chooses the `DataPlane` using the `DataFlowController`s mechanism:
+
+For `Pull` and `Push` scenario `EDC` ships:
+
+- `ConsumerPullTransferDataFlowController`
+- `ProviderPushTransferDataFlowController`
+
+That are engaged with the following rules:
+
+`ConsumerPullTransferDataFlowController`:
+
+```java
+ public boolean canHandle(TransferProcess transferProcess) {
+    return HTTP_PROXY.equals(transferProcess.getDestinationType());
+ }
+```
+
+and `ProviderPushTransferDataFlowController`:
+
+```java
+public boolean canHandle(TransferProcess transferProcess) {
+   return !HTTP_PROXY.equals(transferProcess.getDestinationType());
+}
+```
+
+which limits the `ConsumerPullTransferDataFlowController` to `HttpProxy`, while the `ProviderPushTransferDataFlowController`
+takes the rest.
+
+Additionally by using the `DataAddress#type` of the destination as the driver for the `DataFlowController`'s selection,
+users are forced to pass a `DataAddress` even in the case where it's not really a `DataAddress` but just a marker e.g. `HttpProxy`.
+
+How `DataPlane`s are selected through the `DataFlowManager` will change with the `Data Signaling DR`, 
+but in the meanwhile we will introduce the `transferType` to provide additional information about the transfer request
+to `DataFlowController`s.
+
+## Approach
+
+The introduction of a `transferType` will impact the following area/components:
+
+- Catalog
+- Transfer
+- DataFlowControllers
+
+### Catalog
+
+The new `transferType` will be taken into account when creating the `Distribution` list for an `Asset` using the `DistributionResolver`.
+
+The `DataFlowManager` will be the component with the responsibility for creating such list.
+
+### Transfer
+
+An additional field `transferType` will be required when starting a transfer process in:
+
+- `TransferRequest`
+- `TransferProcess`
+
+The `transferType` will be reflected also in the DSP `TransferRequestMessage` with the field [`format`](https://docs.internationaldataspaces.org/ids-knowledgebase/v/dataspace-protocol/transfer-process/transfer.process.binding.https#2.5-the-provider-transfers-request-resource) .
+
+### DataFlowControllers
+
+Implementors of `DataFlowController` should take into account the new `transferType` field when checking if they    
+can handle a transfer process. The default EDC implementations will be tackle with `Data Signaling DR`.

--- a/docs/developer/decision-records/README.md
+++ b/docs/developer/decision-records/README.md
@@ -50,5 +50,5 @@
 - [2023-09-07 Policy Monitor](./2023-09-07-policy-monitor)
 - [2023-10-04 JSON-LD Scopes](./2023-10-04-json-ld-scopes)
 - [2023-11-09 API Versioning](./2023-11-09-api-versioning)
-- [2023-11-09 Protocol Services Refactor](./2023-11-27-refactor-protocol-services)
-
+- [2023-11-20 Transfer_Type](./2023-11-20-transfer-type)
+- [2023-11-27 Protocol Services Refactor](./2023-11-27-refactor-protocol-services)


### PR DESCRIPTION
## What this PR changes/adds

Adds a decision record about introduction of `Transfer Type` concept

## Why it does that

Extensibility of the `DataFlowManager` and `DataFlowController`, in preparation for #3705 

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #3615 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
