### PR TITLE
chore: fix Kafka flaky test

### DIFF
--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/EndToEndKafkaTransferTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/EndToEndKafkaTransferTest.java
@@ -143,7 +143,13 @@ class EndToEndKafkaTransferTest {
         destinationServer.clear(request)
                 .when(request).respond(response());
         await().pollDelay(5, SECONDS).atMost(TIMEOUT).untilAsserted(() -> {
-            destinationServer.verify(request, never());
+            try {
+                destinationServer.verify(request, never());
+            } catch (AssertionError assertionError) {
+                destinationServer.clear(request)
+                        .when(request).respond(response());
+                throw assertionError;
+            }
         });
 
         stopQuietly(destinationServer);


### PR DESCRIPTION
## What this PR changes/adds

This PR should fix the test `EndToEndKafkaTransferTest#kafkaToHttpTransfer` which currently fails sometime.

I've tracked down the reason and it seems due the fact that even though at consumer side the transfer is terminated
and on the provider side the data source is closed, there could be some stream records still waiting to be pushed via HTTP.

The fix is in the assert lambda clear the expectations on the `destinationServer` if the verify fails.

## Why it does that

fix flaky test
