### PR TITLE
feat: create pluggable CredentialService url resolver

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -28,19 +28,19 @@ maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.15.3, Apache-2.
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.16.0, Apache-2.0, approved, #11605
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.14.0, Apache-2.0, approved, #5933
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.15.1, Apache-2.0, approved, #8802
-maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.15.3, Apache-2.0, approved, #8802
+maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.16.0, , restricted, clearlydefined
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jakarta-jsonp/2.15.3, Apache-2.0, approved, #9179
+maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jakarta-jsonp/2.16.0, , restricted, clearlydefined
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.14.0, Apache-2.0, approved, #4699
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.15.1, Apache-2.0, approved, #7930
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.15.3, Apache-2.0, approved, #7930
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.16.0, , restricted, clearlydefined
-maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/2.15.3, Apache-2.0, approved, #9235
+maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/2.16.0, , restricted, clearlydefined
 maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.15.1, Apache-2.0, approved, #9236
-maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.15.3, Apache-2.0, approved, #9236
+maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.16.0, , restricted, clearlydefined
 maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.14.1, Apache-2.0, approved, #5308
-maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.15.3, Apache-2.0, approved, #9241
+maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.16.0, , restricted, clearlydefined
 maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.15.1, Apache-2.0, approved, #7929
-maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.15.3, Apache-2.0, approved, #7929
 maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.16.0, , restricted, clearlydefined
 maven/mavencentral/com.fasterxml.uuid/java-uuid-generator/4.1.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.github.cliftonlabs/json-simple/3.0.2, Apache-2.0, approved, clearlydefined
@@ -125,10 +125,10 @@ maven/mavencentral/io.netty/netty-tcnative-boringssl-static/2.0.56.Final, Apache
 maven/mavencentral/io.netty/netty-tcnative-classes/2.0.56.Final, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.netty/netty-transport-native-unix-common/4.1.86.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-transport/4.1.86.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations/1.32.0, , restricted, clearlydefined
+maven/mavencentral/io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations/1.32.0, Apache-2.0, approved, #11684
 maven/mavencentral/io.opentelemetry.proto/opentelemetry-proto/1.0.0-alpha, Apache-2.0, approved, #10044
-maven/mavencentral/io.opentelemetry/opentelemetry-api/1.32.0, , restricted, clearlydefined
-maven/mavencentral/io.opentelemetry/opentelemetry-context/1.32.0, , restricted, clearlydefined
+maven/mavencentral/io.opentelemetry/opentelemetry-api/1.32.0, Apache-2.0, approved, #11682
+maven/mavencentral/io.opentelemetry/opentelemetry-context/1.32.0, Apache-2.0, approved, #11683
 maven/mavencentral/io.prometheus/simpleclient/0.16.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.prometheus/simpleclient_common/0.16.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.prometheus/simpleclient_httpserver/0.16.0, Apache-2.0, approved, clearlydefined
@@ -310,7 +310,7 @@ maven/mavencentral/org.ow2.asm/asm-tree/9.6, BSD-3-Clause, approved, #10773
 maven/mavencentral/org.ow2.asm/asm/9.1, BSD-3-Clause, approved, CQ23029
 maven/mavencentral/org.ow2.asm/asm/9.2, BSD-3-Clause, approved, CQ23635
 maven/mavencentral/org.ow2.asm/asm/9.6, BSD-3-Clause, approved, #10776
-maven/mavencentral/org.postgresql/postgresql/42.7.0, , restricted, clearlydefined
+maven/mavencentral/org.postgresql/postgresql/42.7.0, BSD-2-Clause AND LicenseRef-scancode-free-unknown AND Apache-2.0, restricted, #11681
 maven/mavencentral/org.reflections/reflections/0.10.2, Apache-2.0 AND WTFPL, approved, clearlydefined
 maven/mavencentral/org.rnorth.duct-tape/duct-tape/1.0.8, MIT, approved, clearlydefined
 maven/mavencentral/org.slf4j/slf4j-api/1.7.22, MIT, approved, CQ11943
@@ -332,4 +332,4 @@ maven/mavencentral/org.xmlunit/xmlunit-core/2.9.1, Apache-2.0, approved, #6272
 maven/mavencentral/org.xmlunit/xmlunit-placeholders/2.9.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.yaml/snakeyaml/1.33, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.yaml/snakeyaml/2.0, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #7275
-maven/mavencentral/org.yaml/snakeyaml/2.1, Apache-2.0, approved, #9847
+maven/mavencentral/org.yaml/snakeyaml/2.2, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #10232

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/DidCredentialServiceUrlResolver.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/DidCredentialServiceUrlResolver.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.iam.identitytrust;
+
+import org.eclipse.edc.iam.did.spi.resolution.DidResolverRegistry;
+import org.eclipse.edc.identitytrust.CredentialServiceUrlResolver;
+import org.eclipse.edc.spi.result.Result;
+
+import static org.eclipse.edc.spi.result.Result.failure;
+import static org.eclipse.edc.spi.result.Result.success;
+
+/**
+ * Resolves the URL of the credential service based on the issuer's DID document.
+ */
+public class DidCredentialServiceUrlResolver implements CredentialServiceUrlResolver {
+    private static final String CREDENTIAL_SERVICE_TYPE = "CredentialService";
+    private final DidResolverRegistry didResolverRegistry;
+
+    public DidCredentialServiceUrlResolver(DidResolverRegistry didResolverRegistry) {
+        this.didResolverRegistry = didResolverRegistry;
+    }
+
+    /**
+     * Resolves the IATP credential service URL from the DID document based on the issuer. The issuer is interpreted as DID
+     * identifier, and the resolved DID is expected to contain a "CredentialServiceUrl" service endpoint.
+     *
+     * @param issuer The issuer of the DID document.
+     * @return The result containing the service URL if found, or a failure if the DID was not resolvable, or if the required service endpoint wasn't found.
+     */
+    @Override
+    public Result<String> resolve(String issuer) {
+        var didDocument = didResolverRegistry.resolve(issuer);
+        if (didDocument.failed()) {
+            return didDocument.mapTo();
+        }
+        return didDocument.getContent().getService().stream()
+                .filter(s -> s.getType().equals(CREDENTIAL_SERVICE_TYPE))
+                .findFirst()
+                .map(service -> success(service.getServiceEndpoint()))
+                .orElseGet(() -> failure("No Service endpoint '%s' found on DID Document.".formatted(CREDENTIAL_SERVICE_TYPE)));
+    }
+}

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/test/java/org/eclipse/edc/iam/identitytrust/DidCredentialServiceUrlResolverTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/test/java/org/eclipse/edc/iam/identitytrust/DidCredentialServiceUrlResolverTest.java
@@ -1,0 +1,82 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.iam.identitytrust;
+
+import org.eclipse.edc.iam.did.spi.document.DidDocument;
+import org.eclipse.edc.iam.did.spi.document.Service;
+import org.eclipse.edc.iam.did.spi.resolution.DidResolverRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.spi.result.Result.failure;
+import static org.eclipse.edc.spi.result.Result.success;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DidCredentialServiceUrlResolverTest {
+
+    public static final String CREDENTIAL_SERVICE_URL = "https://foo.bar/credentialservice";
+    private final DidResolverRegistry registryMock = mock();
+    private final DidCredentialServiceUrlResolver resolver = new DidCredentialServiceUrlResolver(registryMock);
+
+    @BeforeEach
+    void setup() {
+        when(registryMock.resolve(any())).thenReturn(success(createDid().build()));
+    }
+
+    @Test
+    void resolve() {
+        assertThat(resolver.resolve("did:web:participant")).isSucceeded().isEqualTo(CREDENTIAL_SERVICE_URL);
+    }
+
+    @Test
+    void resolve_didNotSupported() {
+        when(registryMock.resolve(any())).thenReturn(failure("DID method not supported"));
+        assertThat(resolver.resolve("did:web:participant"))
+                .isFailed()
+                .detail().isEqualTo("DID method not supported");
+    }
+
+    @Test
+    void resolve_didContainsNoServices() {
+        var did = createDid().build();
+        did.getService().clear();
+        when(registryMock.resolve(any())).thenReturn(success(did));
+        assertThat(resolver.resolve("did:web:participant"))
+                .isFailed()
+                .detail().isEqualTo("No Service endpoint 'CredentialService' found on DID Document.");
+    }
+
+    @Test
+    void resolve_serviceNotFound() {
+        var did = createDid().build();
+        did.getService().clear();
+        did.getService().add(new Service("foo", "bar", "https://foo.bar"));
+        when(registryMock.resolve(any())).thenReturn(success(did));
+        assertThat(resolver.resolve("did:web:participant"))
+                .isFailed()
+                .detail().isEqualTo("No Service endpoint 'CredentialService' found on DID Document.");
+    }
+
+    private DidDocument.Builder createDid() {
+        return DidDocument.Builder.newInstance()
+                .id("test-did")
+                .service(List.of(new Service("test-service", "CredentialService", CREDENTIAL_SERVICE_URL)));
+    }
+}

--- a/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/CredentialServiceUrlResolver.java
+++ b/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/CredentialServiceUrlResolver.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identitytrust;
+
+import org.eclipse.edc.spi.result.Result;
+
+/**
+ * This is a functional interface used to resolve the URL of the credential service based on the issuer. Typically, this
+ * is done based on the issuer's DID document
+ */
+@FunctionalInterface
+public interface CredentialServiceUrlResolver {
+    /**
+     * Resolves the URL of the credential service based on the issuer.
+     *
+     * @param issuer the issuer for which the URL needs to be resolved
+     * @return a {@link Result} object containing the resolved URL if successful, or the failure information if unsuccessful
+     */
+    Result<String> resolve(String issuer);
+}


### PR DESCRIPTION
## What this PR changes/adds

This PR adds a pluggable `CredentialServiceUrlResolver`, whos job it is to take an issuer, and resolve its CredentialService URL.
The default implementation in IATP for this will be a `DidCredentialServiceUrlResolver`, that interprets the issuer as DID and
resolves the DID, which is expected to contain a `CredentialService` endpoint entry.

## Why it does that

The relying party (RP) needs to be able to resolve the counter-party's CredentialService to obtain VCs.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #3647

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
