### PR TITLE
fix: require key-id when resolving key material

### DIFF
--- a/extensions/common/crypto/jwt-verifiable-credentials/build.gradle.kts
+++ b/extensions/common/crypto/jwt-verifiable-credentials/build.gradle.kts
@@ -28,4 +28,5 @@ dependencies {
     testImplementation(project(":core:common:junit"))
     testImplementation(project(":extensions:common:crypto:crypto-core"))
     testFixturesImplementation(libs.nimbus.jwt)
+    testFixturesImplementation(project(":spi:common:identity-did-spi"))
 }

--- a/extensions/common/crypto/jwt-verifiable-credentials/src/testFixtures/java/org/eclipse/edc/verifiablecredentials/TestFunctions.java
+++ b/extensions/common/crypto/jwt-verifiable-credentials/src/testFixtures/java/org/eclipse/edc/verifiablecredentials/TestFunctions.java
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.verifiablecredentials;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWEEncrypter;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jose.crypto.ECDHEncrypter;
+import com.nimbusds.jose.crypto.ECDSAVerifier;
+import com.nimbusds.jose.jwk.ECKey;
+import org.eclipse.edc.iam.did.spi.key.PublicKeyWrapper;
+import org.jetbrains.annotations.NotNull;
+
+public class TestFunctions {
+
+    @NotNull
+    public static PublicKeyWrapper createPublicKeyWrapper(ECKey vpSigningKey) {
+        return new PublicKeyWrapper() {
+            @Override
+            public JWEEncrypter encrypter() {
+                try {
+                    return new ECDHEncrypter(vpSigningKey);
+                } catch (JOSEException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            @Override
+            public JWSVerifier verifier() {
+                try {
+                    return new ECDSAVerifier(vpSigningKey);
+                } catch (JOSEException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+    }
+}

--- a/extensions/common/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/edc/iam/did/resolution/DidPublicKeyResolverImpl.java
+++ b/extensions/common/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/edc/iam/did/resolution/DidPublicKeyResolverImpl.java
@@ -15,10 +15,12 @@
 package org.eclipse.edc.iam.did.resolution;
 
 import org.eclipse.edc.iam.did.crypto.key.KeyConverter;
+import org.eclipse.edc.iam.did.spi.document.VerificationMethod;
 import org.eclipse.edc.iam.did.spi.key.PublicKeyWrapper;
 import org.eclipse.edc.iam.did.spi.resolution.DidPublicKeyResolver;
 import org.eclipse.edc.iam.did.spi.resolution.DidResolverRegistry;
 import org.eclipse.edc.spi.result.Result;
+import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.iam.did.spi.document.DidConstants.ALLOWED_VERIFICATION_TYPES;
 
@@ -30,10 +32,10 @@ public class DidPublicKeyResolverImpl implements DidPublicKeyResolver {
     }
 
     @Override
-    public Result<PublicKeyWrapper> resolvePublicKey(String didUrl) {
+    public Result<PublicKeyWrapper> resolvePublicKey(String didUrl, @Nullable String keyId) {
         var didResult = resolverRegistry.resolve(didUrl);
         if (didResult.failed()) {
-            return Result.failure("Invalid DID: " + didResult.getFailureDetail());
+            return didResult.mapTo();
         }
         var didDocument = didResult.getContent();
         if (didDocument.getVerificationMethod() == null || didDocument.getVerificationMethod().isEmpty()) {
@@ -43,12 +45,25 @@ public class DidPublicKeyResolverImpl implements DidPublicKeyResolver {
         var verificationMethods = didDocument.getVerificationMethod().stream()
                 .filter(vm -> ALLOWED_VERIFICATION_TYPES.contains(vm.getType()))
                 .toList();
-        if (verificationMethods.size() > 1) {
-            return Result.failure("DID contains more than one allowed verification type");
-        }
 
-        var verificationMethod = didDocument.getVerificationMethod().get(0);
-        return KeyConverter.toPublicKeyWrapper(verificationMethod.getPublicKeyJwk(), verificationMethod.getId());
+        // if there are more than 1 verification methods with the same ID
+        if (verificationMethods.stream().map(VerificationMethod::getId).distinct().count() != verificationMethods.size()) {
+            return Result.failure("Every verification method must have a unique ID");
+        }
+        Result<VerificationMethod> verificationMethod;
+
+        if (keyId == null) { // only valid if exactly 1 verification method
+            if (verificationMethods.size() > 1) {
+                return Result.failure("The key ID ('kid') is mandatory if DID contains >1 verification methods.");
+            }
+            verificationMethod = Result.from(verificationMethods.stream().findFirst());
+        } else { // look up VerificationMEthods by key ID
+            verificationMethod = verificationMethods.stream().filter(vm -> vm.getId().equals(keyId))
+                    .findFirst()
+                    .map(Result::success)
+                    .orElseGet(() -> Result.failure("No verification method found with key ID '%s'".formatted(keyId)));
+        }
+        return verificationMethod.compose(vm -> KeyConverter.toPublicKeyWrapper(vm.getPublicKeyJwk(), vm.getId()));
     }
 
 }

--- a/extensions/common/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/edc/iam/did/resolution/DidPublicKeyResolverImplTest.java
+++ b/extensions/common/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/edc/iam/did/resolution/DidPublicKeyResolverImplTest.java
@@ -32,26 +32,32 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Scanner;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class DidPublicKeyResolverImplTest {
 
+    public static final String KEYID = "#my-key1";
     private static final String DID_URL = "did:web:example.com";
-
-    private DidDocument didDocument;
-
     private final DidResolverRegistry resolverRegistry = mock(DidResolverRegistry.class);
     private final DidPublicKeyResolverImpl resolver = new DidPublicKeyResolverImpl(resolverRegistry);
+    private DidDocument didDocument;
+
+    public static String readFile(String filename) throws IOException {
+        try (var is = Thread.currentThread().getContextClassLoader().getResourceAsStream(filename)) {
+            var s = new Scanner(Objects.requireNonNull(is)).useDelimiter("\\A");
+            return s.hasNext() ? s.next() : "";
+        }
+    }
 
     @BeforeEach
     public void setUp() throws JOSEException, IOException {
         var eckey = (ECKey) ECKey.parseFromPEMEncodedObjects(readFile("public_secp256k1.pem"));
 
         var vm = VerificationMethod.Builder.create()
-                .id("#my-key1")
+                .id(KEYID)
                 .type(DidConstants.ECDSA_SECP_256_K_1_VERIFICATION_KEY_2019)
                 .publicKeyJwk(eckey.toPublicJWK().toJSONObject())
                 .build();
@@ -66,10 +72,9 @@ class DidPublicKeyResolverImplTest {
     void resolve() {
         when(resolverRegistry.resolve(DID_URL)).thenReturn(Result.success(didDocument));
 
-        var result = resolver.resolvePublicKey(DID_URL);
+        var result = resolver.resolvePublicKey(DID_URL, KEYID);
 
-        assertThat(result.succeeded()).isTrue();
-        assertThat(result.getContent()).isNotNull();
+        assertThat(result).isSucceeded().isNotNull();
         verify(resolverRegistry).resolve(DID_URL);
     }
 
@@ -77,9 +82,9 @@ class DidPublicKeyResolverImplTest {
     void resolve_didNotFound() {
         when(resolverRegistry.resolve(DID_URL)).thenReturn(Result.failure("Not found"));
 
-        var result = resolver.resolvePublicKey(DID_URL);
+        var result = resolver.resolvePublicKey(DID_URL, KEYID);
 
-        assertThat(result.failed()).isTrue();
+        assertThat(result).isFailed();
         verify(resolverRegistry).resolve(DID_URL);
     }
 
@@ -88,24 +93,25 @@ class DidPublicKeyResolverImplTest {
         didDocument.getVerificationMethod().clear();
         when(resolverRegistry.resolve(DID_URL)).thenReturn(Result.success(didDocument));
 
-        var result = resolver.resolvePublicKey(DID_URL);
+        var result = resolver.resolvePublicKey(DID_URL, KEYID);
 
-        assertThat(result.failed()).isTrue();
+        assertThat(result).isFailed();
         verify(resolverRegistry).resolve(DID_URL);
     }
 
     @Test
-    void resolve_didContainsMultipleKeys() throws JOSEException, IOException {
+    void resolve_didContainsMultipleKeysWithSameKeyId() throws JOSEException, IOException {
         var publicKey = (ECKey) ECKey.parseFromPEMEncodedObjects(readFile("public_secp256k1.pem"));
-        var vm = VerificationMethod.Builder.create().id("second-key").type(DidConstants.JSON_WEB_KEY_2020).controller("")
+        var vm = VerificationMethod.Builder.create().id(KEYID).type(DidConstants.JSON_WEB_KEY_2020).controller("")
                 .publicKeyJwk(publicKey.toJSONObject())
                 .build();
         didDocument.getVerificationMethod().add(vm);
         when(resolverRegistry.resolve(DID_URL)).thenReturn(Result.success(didDocument));
 
-        var result = resolver.resolvePublicKey(DID_URL);
+        var result = resolver.resolvePublicKey(DID_URL, KEYID);
 
-        assertThat(result.failed()).isTrue();
+        assertThat(result).isFailed()
+                .detail().isEqualTo("Every verification method must have a unique ID");
         verify(resolverRegistry).resolve(DID_URL);
     }
 
@@ -119,16 +125,33 @@ class DidPublicKeyResolverImplTest {
 
         when(resolverRegistry.resolve(DID_URL)).thenReturn(Result.success(didDocument));
 
-        var result = resolver.resolvePublicKey(DID_URL);
+        var result = resolver.resolvePublicKey(DID_URL, KEYID);
 
-        assertThat(result.failed()).isTrue();
+        assertThat(result).isFailed();
         verify(resolverRegistry).resolve(DID_URL);
     }
 
-    public static String readFile(String filename) throws IOException {
-        try (var is = Thread.currentThread().getContextClassLoader().getResourceAsStream(filename)) {
-            var s = new Scanner(Objects.requireNonNull(is)).useDelimiter("\\A");
-            return s.hasNext() ? s.next() : "";
-        }
+    @Test
+    void resolve_keyIdNullMultipleKeys() throws JOSEException, IOException {
+        var publicKey = (ECKey) ECKey.parseFromPEMEncodedObjects(readFile("public_secp256k1.pem"));
+        var vm = VerificationMethod.Builder.create().id("#my-key2").type(DidConstants.JSON_WEB_KEY_2020).controller("")
+                .publicKeyJwk(publicKey.toJSONObject())
+                .build();
+        didDocument.getVerificationMethod().add(vm);
+        when(resolverRegistry.resolve(DID_URL)).thenReturn(Result.success(didDocument));
+
+        var result = resolver.resolvePublicKey(DID_URL, null);
+        assertThat(result).isFailed()
+                .detail().isEqualTo("The key ID ('kid') is mandatory if DID contains >1 verification methods.");
+    }
+
+    @Test
+    void resolve_keyIdIsNull_onlyOneVerificationMethod() {
+        when(resolverRegistry.resolve(DID_URL)).thenReturn(Result.success(didDocument));
+
+        var result = resolver.resolvePublicKey(DID_URL, null);
+
+        assertThat(result).isSucceeded().isNotNull();
+        verify(resolverRegistry).resolve(DID_URL);
     }
 }

--- a/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtension.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtension.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.iam.identitytrust.core;
 
 import jakarta.json.Json;
+import org.eclipse.edc.iam.did.spi.resolution.DidPublicKeyResolver;
 import org.eclipse.edc.iam.did.spi.resolution.DidResolverRegistry;
 import org.eclipse.edc.iam.identitytrust.DidCredentialServiceUrlResolver;
 import org.eclipse.edc.iam.identitytrust.IdentityAndTrustService;
@@ -63,9 +64,6 @@ public class IdentityAndTrustExtension implements ServiceExtension {
     private CredentialServiceClient credentialServiceClient;
 
     @Inject
-    private DidResolverRegistry resolverRegistry;
-
-    @Inject
     private TrustedIssuerRegistry registry;
 
     @Inject
@@ -79,10 +77,16 @@ public class IdentityAndTrustExtension implements ServiceExtension {
 
     @Inject
     private Clock clock;
+
     @Inject
     private EdcHttpClient httpClient;
+
     @Inject
     private TypeTransformerRegistry typeTransformerRegistry;
+
+    @Inject
+    private DidPublicKeyResolver didPublicKeyResolver;
+
     @Inject
     private DidResolverRegistry didResolverRegistry;
 
@@ -134,7 +138,7 @@ public class IdentityAndTrustExtension implements ServiceExtension {
     @Provider
     public JwtVerifier getJwtVerifier() {
         if (jwtVerifier == null) {
-            jwtVerifier = new SelfIssuedIdTokenVerifier(resolverRegistry);
+            jwtVerifier = new SelfIssuedIdTokenVerifier(didPublicKeyResolver);
         }
         return jwtVerifier;
     }

--- a/spi/common/identity-did-spi/src/main/java/org/eclipse/edc/iam/did/spi/resolution/DidPublicKeyResolver.java
+++ b/spi/common/identity-did-spi/src/main/java/org/eclipse/edc/iam/did/spi/resolution/DidPublicKeyResolver.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.iam.did.spi.resolution;
 import org.eclipse.edc.iam.did.spi.key.PublicKeyWrapper;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import org.eclipse.edc.spi.result.Result;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Resolves a public key contained in a DID document associated with a DID.
@@ -25,8 +26,14 @@ import org.eclipse.edc.spi.result.Result;
 public interface DidPublicKeyResolver {
 
     /**
-     * Resolves the public key.
+     * Resolves a public key contained in a DID document.
+     *
+     * @param did   The DID (Decentralized Identifier) that references a DID document that contains the public key.
+     * @param keyId The optional key ID of the public key to resolve. Can <strong>only</strong> be omitted, if the DID document
+     *              contains exactly 1 public key. If the key ID is omitted, but the DID document contains >1 public key, an error
+     *              is returned.
+     * @return A Result object containing a {@link PublicKeyWrapper} if the resolution is successful, or a Failure object if it fails.
      */
-    Result<PublicKeyWrapper> resolvePublicKey(String did);
+    Result<PublicKeyWrapper> resolvePublicKey(String did, @Nullable String keyId);
 
 }


### PR DESCRIPTION
## What this PR changes/adds

This PR changes the public key resolution, in that the `kid` is only required, if the DID contains multiple verification methods.


## Why it does that

Taking the _first_ verification method if no `kid` is given is dangerous and wrong.

## Further notes

- In addition, the `JwtPresentationVerifier` now uses the `DidPublicKeyResolver` instead of the `DidResolverRegistry`, which is better, because it limits the API surface

## Linked Issue(s)

Closes #3649

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
