### PR TITLE
fix: add missing type transformer registrations

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -125,10 +125,10 @@ maven/mavencentral/io.netty/netty-tcnative-boringssl-static/2.0.56.Final, Apache
 maven/mavencentral/io.netty/netty-tcnative-classes/2.0.56.Final, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.netty/netty-transport-native-unix-common/4.1.86.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-transport/4.1.86.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations/1.32.0, , restricted, clearlydefined
+maven/mavencentral/io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations/1.32.0, Apache-2.0, approved, #11684
 maven/mavencentral/io.opentelemetry.proto/opentelemetry-proto/1.0.0-alpha, Apache-2.0, approved, #10044
-maven/mavencentral/io.opentelemetry/opentelemetry-api/1.32.0, , restricted, clearlydefined
-maven/mavencentral/io.opentelemetry/opentelemetry-context/1.32.0, , restricted, clearlydefined
+maven/mavencentral/io.opentelemetry/opentelemetry-api/1.32.0, Apache-2.0, approved, #11682
+maven/mavencentral/io.opentelemetry/opentelemetry-context/1.32.0, Apache-2.0, approved, #11683
 maven/mavencentral/io.prometheus/simpleclient/0.16.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.prometheus/simpleclient_common/0.16.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.prometheus/simpleclient_httpserver/0.16.0, Apache-2.0, approved, clearlydefined
@@ -310,7 +310,7 @@ maven/mavencentral/org.ow2.asm/asm-tree/9.6, BSD-3-Clause, approved, #10773
 maven/mavencentral/org.ow2.asm/asm/9.1, BSD-3-Clause, approved, CQ23029
 maven/mavencentral/org.ow2.asm/asm/9.2, BSD-3-Clause, approved, CQ23635
 maven/mavencentral/org.ow2.asm/asm/9.6, BSD-3-Clause, approved, #10776
-maven/mavencentral/org.postgresql/postgresql/42.7.0, , restricted, clearlydefined
+maven/mavencentral/org.postgresql/postgresql/42.7.0, BSD-2-Clause AND LicenseRef-scancode-free-unknown AND Apache-2.0, restricted, #11681
 maven/mavencentral/org.reflections/reflections/0.10.2, Apache-2.0 AND WTFPL, approved, clearlydefined
 maven/mavencentral/org.rnorth.duct-tape/duct-tape/1.0.8, MIT, approved, clearlydefined
 maven/mavencentral/org.slf4j/slf4j-api/1.7.22, MIT, approved, CQ11943

--- a/extensions/common/iam/identity-trust/identity-trust-transform/src/main/java/org/eclipse/edc/iam/identitytrust/IdentityTrustTransformExtension.java
+++ b/extensions/common/iam/identity-trust/identity-trust-transform/src/main/java/org/eclipse/edc/iam/identitytrust/IdentityTrustTransformExtension.java
@@ -15,7 +15,12 @@
 package org.eclipse.edc.iam.identitytrust;
 
 import org.eclipse.edc.iam.identitytrust.transform.from.JsonObjectFromPresentationQueryTransformer;
+import org.eclipse.edc.iam.identitytrust.transform.to.JsonObjectToCredentialStatusTransformer;
+import org.eclipse.edc.iam.identitytrust.transform.to.JsonObjectToCredentialSubjectTransformer;
+import org.eclipse.edc.iam.identitytrust.transform.to.JsonObjectToIssuerTransformer;
 import org.eclipse.edc.iam.identitytrust.transform.to.JsonObjectToPresentationQueryTransformer;
+import org.eclipse.edc.iam.identitytrust.transform.to.JsonObjectToVerifiableCredentialTransformer;
+import org.eclipse.edc.iam.identitytrust.transform.to.JsonObjectToVerifiablePresentationTransformer;
 import org.eclipse.edc.iam.identitytrust.transform.to.JwtToVerifiableCredentialTransformer;
 import org.eclipse.edc.iam.identitytrust.transform.to.JwtToVerifiablePresentationTransformer;
 import org.eclipse.edc.jsonld.spi.JsonLd;
@@ -59,6 +64,11 @@ public class IdentityTrustTransformExtension implements ServiceExtension {
 
         typeTransformerRegistry.register(new JsonObjectToPresentationQueryTransformer(typeManager.getMapper(JSON_LD)));
         typeTransformerRegistry.register(new JsonObjectFromPresentationQueryTransformer());
+        typeTransformerRegistry.register(new JsonObjectToVerifiablePresentationTransformer());
+        typeTransformerRegistry.register(new JsonObjectToVerifiableCredentialTransformer());
+        typeTransformerRegistry.register(new JsonObjectToIssuerTransformer());
+        typeTransformerRegistry.register(new JsonObjectToCredentialSubjectTransformer());
+        typeTransformerRegistry.register(new JsonObjectToCredentialStatusTransformer());
         typeTransformerRegistry.register(new JwtToVerifiablePresentationTransformer(context.getMonitor(), typeManager.getMapper(JSON_LD), jsonLdService));
         typeTransformerRegistry.register(new JwtToVerifiableCredentialTransformer(context.getMonitor()));
     }

--- a/extensions/common/iam/identity-trust/identity-trust-transform/src/test/java/org/eclipse/edc/iam/identitytrust/IdentityTrustTransformExtensionTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-transform/src/test/java/org/eclipse/edc/iam/identitytrust/IdentityTrustTransformExtensionTest.java
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.iam.identitytrust;
+
+import org.eclipse.edc.iam.identitytrust.transform.to.JsonObjectToCredentialStatusTransformer;
+import org.eclipse.edc.iam.identitytrust.transform.to.JsonObjectToCredentialSubjectTransformer;
+import org.eclipse.edc.iam.identitytrust.transform.to.JsonObjectToIssuerTransformer;
+import org.eclipse.edc.iam.identitytrust.transform.to.JsonObjectToPresentationQueryTransformer;
+import org.eclipse.edc.iam.identitytrust.transform.to.JsonObjectToVerifiableCredentialTransformer;
+import org.eclipse.edc.iam.identitytrust.transform.to.JsonObjectToVerifiablePresentationTransformer;
+import org.eclipse.edc.iam.identitytrust.transform.to.JwtToVerifiableCredentialTransformer;
+import org.eclipse.edc.iam.identitytrust.transform.to.JwtToVerifiablePresentationTransformer;
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(DependencyInjectionExtension.class)
+class IdentityTrustTransformExtensionTest {
+
+    private final TypeTransformerRegistry mockRegistry = mock();
+
+    @BeforeEach
+    void setup(ServiceExtensionContext context) {
+        context.registerService(TypeTransformerRegistry.class, mockRegistry);
+    }
+
+    @Test
+    void initialize_assertTransformerRegistrations(IdentityTrustTransformExtension extension, ServiceExtensionContext context) {
+        extension.initialize(context);
+
+        verify(mockRegistry).register(isA(JsonObjectToCredentialStatusTransformer.class));
+        verify(mockRegistry).register(isA(JsonObjectToCredentialSubjectTransformer.class));
+        verify(mockRegistry).register(isA(JsonObjectToIssuerTransformer.class));
+        verify(mockRegistry).register(isA(JsonObjectToPresentationQueryTransformer.class));
+        verify(mockRegistry).register(isA(JsonObjectToVerifiableCredentialTransformer.class));
+        verify(mockRegistry).register(isA(JsonObjectToVerifiablePresentationTransformer.class));
+        verify(mockRegistry).register(isA(JwtToVerifiableCredentialTransformer.class));
+        verify(mockRegistry).register(isA(JwtToVerifiablePresentationTransformer.class));
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

Adds missing type transformer registrations

## Why it does that

Well... they were missing.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #3648

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
