### PR TITLE
feat: create DidMethodResolver for use in the LdpVerifier

### DIFF
--- a/extensions/common/crypto/crypto-core/src/test/java/org/eclipse/edc/verification/jwt/SelfIssuedIdTokenVerifierTest.java
+++ b/extensions/common/crypto/crypto-core/src/test/java/org/eclipse/edc/verification/jwt/SelfIssuedIdTokenVerifierTest.java
@@ -46,7 +46,7 @@ class SelfIssuedIdTokenVerifierTest {
                 .keyID("#my-key1")
                 .generate();
 
-        var vm = VerificationMethod.Builder.create()
+        var vm = VerificationMethod.Builder.newInstance()
                 .id("#my-key1")
                 .type(DidConstants.ECDSA_SECP_256_K_1_VERIFICATION_KEY_2019)
                 .publicKeyJwk(didVerificationMethod.toPublicJWK().toJSONObject())

--- a/extensions/common/crypto/jws2020/src/main/java/org/eclipse/edc/security/signature/jws2020/JwkMethod.java
+++ b/extensions/common/crypto/jws2020/src/main/java/org/eclipse/edc/security/signature/jws2020/JwkMethod.java
@@ -17,9 +17,6 @@ package org.eclipse.edc.security.signature.jws2020;
 import com.apicatalog.ld.signature.key.KeyPair;
 import com.nimbusds.jose.jwk.JWK;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.ObjectOutputStream;
 import java.net.URI;
 
 public record JwkMethod(URI id, URI type, URI controller, JWK keyPair) implements KeyPair {
@@ -36,14 +33,7 @@ public record JwkMethod(URI id, URI type, URI controller, JWK keyPair) implement
     }
 
     private byte[] serializeKeyPair(JWK keyPair) {
-        try {
-            var bos = new ByteArrayOutputStream();
-            var out = new ObjectOutputStream(bos);
-            out.writeObject(keyPair);
-            return bos.toByteArray();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        return keyPair.toJSONString().getBytes();
     }
 
 }

--- a/extensions/common/crypto/jws2020/src/main/java/org/eclipse/edc/security/signature/jws2020/Jws2020SignatureProvider.java
+++ b/extensions/common/crypto/jws2020/src/main/java/org/eclipse/edc/security/signature/jws2020/Jws2020SignatureProvider.java
@@ -31,9 +31,6 @@ import com.nimbusds.jose.jwk.OctetKeyPair;
 import com.nimbusds.jose.jwk.RSAKey;
 import org.eclipse.edc.spi.EdcException;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.ObjectInputStream;
 import java.text.ParseException;
 import java.util.Collections;
 
@@ -117,12 +114,11 @@ class Jws2020SignatureProvider implements SignatureAlgorithm {
     }
 
     private JWK deserialize(byte[] privateKey) {
-        var bis = new ByteArrayInputStream(privateKey);
+        var str = new String(privateKey);
         try {
-            var in = new ObjectInputStream(bis);
-            return (JWK) in.readObject();
-        } catch (IOException | ClassNotFoundException e) {
-            return null;
+            return JWK.parse(str);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
         }
     }
 }

--- a/extensions/common/crypto/ldp-verifiable-credentials/src/main/java/org/eclipse/edc/verifiablecredentials/linkeddata/DidMethodResolver.java
+++ b/extensions/common/crypto/ldp-verifiable-credentials/src/main/java/org/eclipse/edc/verifiablecredentials/linkeddata/DidMethodResolver.java
@@ -26,6 +26,10 @@ import org.eclipse.edc.spi.EdcException;
 
 import java.net.URI;
 
+/**
+ * This class implements the MethodResolver interface and is responsible for resolving verification methods for a given DID by
+ * delegating to the {@link DidResolverRegistry}.
+ */
 public class DidMethodResolver implements MethodResolver {
     private final DidResolverRegistry resolverRegistry;
 
@@ -49,6 +53,12 @@ public class DidMethodResolver implements MethodResolver {
                 .orElseThrow(() -> new DocumentError(DocumentError.ErrorType.Unknown, suite.getSchema().tagged(VcTag.VerificationMethod.name()).term()));
     }
 
+    /**
+     * Determines whether the given ID is accepted by checking if it is supported by the resolverRegistry.
+     *
+     * @param id The ID to check.
+     * @return {@code true} if the ID is supported, {@code false} otherwise.
+     */
     @Override
     public boolean isAccepted(URI id) {
         return resolverRegistry.isSupported(id.toString());

--- a/extensions/common/crypto/ldp-verifiable-credentials/src/main/java/org/eclipse/edc/verifiablecredentials/linkeddata/DidMethodResolver.java
+++ b/extensions/common/crypto/ldp-verifiable-credentials/src/main/java/org/eclipse/edc/verifiablecredentials/linkeddata/DidMethodResolver.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.verifiablecredentials.linkeddata;
+
+import com.apicatalog.jsonld.loader.DocumentLoader;
+import com.apicatalog.ld.DocumentError;
+import com.apicatalog.ld.signature.SignatureSuite;
+import com.apicatalog.ld.signature.method.MethodResolver;
+import com.apicatalog.ld.signature.method.VerificationMethod;
+import org.eclipse.edc.iam.did.spi.resolution.DidResolverRegistry;
+
+import java.net.URI;
+
+public class DidMethodResolver implements MethodResolver {
+    private final DidResolverRegistry resolverRegistry;
+
+    public DidMethodResolver(DidResolverRegistry resolverRegistry) {
+        this.resolverRegistry = resolverRegistry;
+    }
+
+    @Override
+    public VerificationMethod resolve(URI id, DocumentLoader loader, SignatureSuite suite) throws DocumentError {
+        return null;
+    }
+
+    @Override
+    public boolean isAccepted(URI id) {
+        return resolverRegistry.isSupported(id.toString());
+    }
+}

--- a/extensions/common/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/edc/iam/did/resolution/DidResolverRegistryImpl.java
+++ b/extensions/common/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/edc/iam/did/resolution/DidResolverRegistryImpl.java
@@ -29,6 +29,7 @@ import java.util.Objects;
  * Default implementation, that delegates to several {@link DidResolver} objects, caching the results in a {@link ConcurrentLruCache}
  */
 public class DidResolverRegistryImpl implements DidResolverRegistry {
+    public static final String DID_SEPARATOR = ":";
     private static final String DID = "did";
     private static final int DID_PREFIX = 0;
     private static final int DID_METHOD_NAME = 1;
@@ -57,27 +58,38 @@ public class DidResolverRegistryImpl implements DidResolverRegistry {
     public Result<DidDocument> resolve(String didKey) {
         Objects.requireNonNull(didKey);
 
-        // for the definition of DID syntax, .cf https://www.w3.org/TR/did-core/#did-syntax
-        var tokens = didKey.split(":");
-        if (tokens.length < 3) {
-            return Result.failure("Invalid DID format. The DID must be in the form:  \"did:\" method-name \":\" method-specific-id");
+        if (!isSupported(didKey)) {
+            return Result.failure("This DID is not supported by any of the resolvers: %s".formatted(didKey));
         }
-        if (!DID.equalsIgnoreCase(tokens[DID_PREFIX])) {
-            return Result.failure("Invalid DID prefix");
-        }
+        // no need to validate the token length here
+        var tokens = didKey.split(DID_SEPARATOR);
         var methodName = tokens[DID_METHOD_NAME];
 
-        return resolveCachedDocument(didKey, methodName);
+        var resolver = resolvers.get(methodName);
+        if (resolver == null) {
+            return Result.failure("No resolver registered for DID Method: " + methodName);
+        }
+        return resolveCachedDocument(didKey, resolver);
+    }
+
+    @Override
+    public boolean isSupported(String didKey) {
+        var tokens = didKey.split(DID_SEPARATOR);
+        if (tokens.length < 3) {
+            return false;
+        }
+        if (!DID.equalsIgnoreCase(tokens[DID_PREFIX])) {
+            return false;
+        }
+        var methodName = tokens[DID_METHOD_NAME];
+        return resolvers.containsKey(methodName);
     }
 
     @NotNull
-    private Result<DidDocument> resolveCachedDocument(String didKey, String methodName) {
+    private Result<DidDocument> resolveCachedDocument(String didKey, DidResolver resolver) {
         var didDocument = didCache.get(didKey);
         if (didDocument == null) {
-            var resolver = resolvers.get(methodName);
-            if (resolver == null) {
-                return Result.failure("No resolver registered for DID Method: " + methodName);
-            }
+
             var resolveResult = resolver.resolve(didKey);
             if (resolveResult.failed()) {
                 return resolveResult;

--- a/extensions/common/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/edc/iam/did/resolution/DidPublicKeyResolverImplTest.java
+++ b/extensions/common/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/edc/iam/did/resolution/DidPublicKeyResolverImplTest.java
@@ -56,7 +56,7 @@ class DidPublicKeyResolverImplTest {
     public void setUp() throws JOSEException, IOException {
         var eckey = (ECKey) ECKey.parseFromPEMEncodedObjects(readFile("public_secp256k1.pem"));
 
-        var vm = VerificationMethod.Builder.create()
+        var vm = VerificationMethod.Builder.newInstance()
                 .id(KEYID)
                 .type(DidConstants.ECDSA_SECP_256_K_1_VERIFICATION_KEY_2019)
                 .publicKeyJwk(eckey.toPublicJWK().toJSONObject())
@@ -102,7 +102,7 @@ class DidPublicKeyResolverImplTest {
     @Test
     void resolve_didContainsMultipleKeysWithSameKeyId() throws JOSEException, IOException {
         var publicKey = (ECKey) ECKey.parseFromPEMEncodedObjects(readFile("public_secp256k1.pem"));
-        var vm = VerificationMethod.Builder.create().id(KEYID).type(DidConstants.JSON_WEB_KEY_2020).controller("")
+        var vm = VerificationMethod.Builder.newInstance().id(KEYID).type(DidConstants.JSON_WEB_KEY_2020).controller("")
                 .publicKeyJwk(publicKey.toJSONObject())
                 .build();
         didDocument.getVerificationMethod().add(vm);
@@ -118,7 +118,7 @@ class DidPublicKeyResolverImplTest {
     @Test
     void resolve_publicKeyNotInPemFormat() {
         didDocument.getVerificationMethod().clear();
-        var vm = VerificationMethod.Builder.create().id("second-key").type(DidConstants.ECDSA_SECP_256_K_1_VERIFICATION_KEY_2019).controller("")
+        var vm = VerificationMethod.Builder.newInstance().id("second-key").type(DidConstants.ECDSA_SECP_256_K_1_VERIFICATION_KEY_2019).controller("")
                 .publicKeyJwk(Map.of("kty", "EC"))
                 .build();
         didDocument.getVerificationMethod().add(vm);
@@ -134,7 +134,7 @@ class DidPublicKeyResolverImplTest {
     @Test
     void resolve_keyIdNullMultipleKeys() throws JOSEException, IOException {
         var publicKey = (ECKey) ECKey.parseFromPEMEncodedObjects(readFile("public_secp256k1.pem"));
-        var vm = VerificationMethod.Builder.create().id("#my-key2").type(DidConstants.JSON_WEB_KEY_2020).controller("")
+        var vm = VerificationMethod.Builder.newInstance().id("#my-key2").type(DidConstants.JSON_WEB_KEY_2020).controller("")
                 .publicKeyJwk(publicKey.toJSONObject())
                 .build();
         didDocument.getVerificationMethod().add(vm);

--- a/extensions/common/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/edc/iam/did/resolution/DidResolverRegistryImplTest.java
+++ b/extensions/common/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/edc/iam/did/resolution/DidResolverRegistryImplTest.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -30,6 +31,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class DidResolverRegistryImplTest {
     public static final String FOO_METHOD = "foo";
     private DidResolverRegistryImpl registry;
+
+    @BeforeEach
+    void setUp() {
+        registry = new DidResolverRegistryImpl();
+    }
 
     @Test
     void verifyResolveInvalidDid() {
@@ -54,9 +60,11 @@ class DidResolverRegistryImplTest {
         assertNotNull(result.getContent());
     }
 
-    @BeforeEach
-    void setUp() {
-        registry = new DidResolverRegistryImpl();
+    @Test
+    void isSupported() {
+        registry.register(new MockResolver());
+        assertThat(registry.isSupported("did:%s:whatever".formatted(FOO_METHOD))).isTrue();
+        assertThat(registry.isSupported("did:unsupported:whatever")).isFalse();
     }
 
     /**

--- a/extensions/common/iam/decentralized-identity/identity-did-service/src/test/java/org/eclipse/edc/iam/did/service/BaseDecentralizedIdentityServiceTest.java
+++ b/extensions/common/iam/decentralized-identity/identity-did-service/src/test/java/org/eclipse/edc/iam/did/service/BaseDecentralizedIdentityServiceTest.java
@@ -59,6 +59,13 @@ abstract class BaseDecentralizedIdentityServiceTest {
         this.keyPair = keyPair;
     }
 
+    private static TokenParameters defaultTokenParameters() {
+        return TokenParameters.Builder.newInstance()
+                .scope("Foo")
+                .audience("Bar")
+                .build();
+    }
+
     @BeforeEach
     void setUp() {
         identityService = new DecentralizedIdentityService(didResolverRegistryMock, credentialsVerifierMock, new ConsoleMonitor(), privateKeyWrapper(keyPair), DID_URL, Clock.systemUTC());
@@ -118,17 +125,16 @@ abstract class BaseDecentralizedIdentityServiceTest {
         assertThat(verificationResult.getFailureDetail()).contains(errorMsg);
     }
 
-    private static TokenParameters defaultTokenParameters() {
-        return TokenParameters.Builder.newInstance()
-                .scope("Foo")
-                .audience("Bar")
-                .build();
-    }
+    @NotNull
+    protected abstract JWK generateKeyPair();
+
+    @NotNull
+    protected abstract PrivateKeyWrapper privateKeyWrapper(JWK keyPair);
 
     private DidDocument createDidDocument(JWK keyPair) {
         try {
             var did = new ObjectMapper().readValue(DID_DOCUMENT, DidDocument.class);
-            var verificationMethod = VerificationMethod.Builder.create()
+            var verificationMethod = VerificationMethod.Builder.newInstance()
                     .type("JsonWebKey2020")
                     .id("test-key")
                     .publicKeyJwk(keyPair.toPublicJWK().toJSONObject())
@@ -139,10 +145,4 @@ abstract class BaseDecentralizedIdentityServiceTest {
             throw new AssertionError(e);
         }
     }
-
-    @NotNull
-    protected abstract JWK generateKeyPair();
-
-    @NotNull
-    protected abstract PrivateKeyWrapper privateKeyWrapper(JWK keyPair);
 }

--- a/extensions/common/iam/decentralized-identity/identity-did-web/src/main/java/org/eclipse/edc/iam/did/web/resolution/WebDidResolver.java
+++ b/extensions/common/iam/decentralized-identity/identity-did-web/src/main/java/org/eclipse/edc/iam/did/web/resolution/WebDidResolver.java
@@ -73,7 +73,7 @@ public class WebDidResolver implements DidResolver {
                 if (body == null) {
                     return Result.failure("DID response contained an empty body: " + didKey);
                 }
-                DidDocument didDocument = mapper.readValue(body.string(), DidDocument.class);
+                var didDocument = mapper.readValue(body.string(), DidDocument.class);
                 return Result.success(didDocument);
             }
         } catch (IOException e) {

--- a/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtension.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtension.java
@@ -41,6 +41,7 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.verifiablecredentials.jwt.JwtPresentationVerifier;
+import org.eclipse.edc.verifiablecredentials.linkeddata.DidMethodResolver;
 import org.eclipse.edc.verifiablecredentials.linkeddata.LdpVerifier;
 import org.eclipse.edc.verification.jwt.SelfIssuedIdTokenVerifier;
 
@@ -128,6 +129,7 @@ public class IdentityAndTrustExtension implements ServiceExtension {
                     .signatureSuites(signatureSuiteRegistry)
                     .jsonLd(jsonLd)
                     .objectMapper(mapper)
+                    .methodResolver(new DidMethodResolver(didResolverRegistry))
                     .build();
 
             presentationVerifier = new MultiFormatPresentationVerifier(getOwnDid(context), jwtVerifier, ldpVerifier);

--- a/spi/common/identity-did-spi/src/main/java/org/eclipse/edc/iam/did/spi/resolution/DidResolverRegistry.java
+++ b/spi/common/identity-did-spi/src/main/java/org/eclipse/edc/iam/did/spi/resolution/DidResolverRegistry.java
@@ -34,4 +34,11 @@ public interface DidResolverRegistry {
      */
     Result<DidDocument> resolve(String didKey);
 
+    /**
+     * Checks if the given DID ID is supported.
+     *
+     * @param didKey The DID key to check. This string must contain the "did" keyword, followed by the DID method, followed by the identifier, separated by a ":".
+     * @return {@code true} if the given DID key is supported, {@code false} otherwise.
+     */
+    boolean isSupported(String didKey);
 }


### PR DESCRIPTION
## What this PR changes/adds

This PR adds the `DidMethodResolver`, that implements the `MethodResolver` interface, so that it can be used in the `LdpVerifier`.
The `DidMethodResolver` delegates DID resolution to the `DidResolverRegistry`.

## Why it does that

Avoid code duplication: previously the `LdpVerifier` used a class from the Titanium library, which in addition to duplicating code, was hard coded, and not pluggable.\

## Further notes

- The `VerificationMethod` received a new method `serializePublicKEy`, and the ability to contain Multibase public keys.
- The `DidResolverRegistry` received a new method `isSupported`

- the `JwkMethod` class has been adapted to use the same serialization method (JSON)

## Linked Issue(s)

Closes #3646

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
