### PR TITLE
feat: relying-party creates SI token for VP query

### DIFF
--- a/extensions/common/crypto/ldp-verifiable-credentials/src/main/java/org/eclipse/edc/verifiablecredentials/linkeddata/LdpVerifier.java
+++ b/extensions/common/crypto/ldp-verifiable-credentials/src/main/java/org/eclipse/edc/verifiablecredentials/linkeddata/LdpVerifier.java
@@ -30,7 +30,6 @@ import com.apicatalog.ld.signature.SignatureSuiteProvider;
 import com.apicatalog.ld.signature.VerificationError;
 import com.apicatalog.ld.signature.VerificationError.Code;
 import com.apicatalog.ld.signature.key.VerificationKey;
-import com.apicatalog.ld.signature.method.DidUrlMethodResolver;
 import com.apicatalog.ld.signature.method.HttpMethodResolver;
 import com.apicatalog.ld.signature.method.MethodResolver;
 import com.apicatalog.ld.signature.method.VerificationMethod;
@@ -67,7 +66,7 @@ public class LdpVerifier implements CredentialVerifier {
     private ObjectMapper jsonLdMapper;
     private SignatureSuiteProvider suiteProvider;
     private Map<String, Object> params;
-    private Collection<MethodResolver> methodResolvers = new ArrayList<>(List.of(new DidUrlMethodResolver(), new HttpMethodResolver()));
+    private Collection<MethodResolver> methodResolvers = new ArrayList<>(List.of(new HttpMethodResolver()));
     private DocumentLoader loader;
     private URI base;
 

--- a/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtension.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtension.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.iam.identitytrust.IdentityAndTrustService;
 import org.eclipse.edc.iam.identitytrust.core.defaults.DefaultCredentialServiceClient;
 import org.eclipse.edc.iam.identitytrust.validation.SelfIssuedIdTokenValidator;
 import org.eclipse.edc.iam.identitytrust.verification.MultiFormatPresentationVerifier;
+import org.eclipse.edc.identitytrust.AudienceResolver;
 import org.eclipse.edc.identitytrust.CredentialServiceClient;
 import org.eclipse.edc.identitytrust.SecureTokenService;
 import org.eclipse.edc.identitytrust.TrustedIssuerRegistry;
@@ -91,12 +92,14 @@ public class IdentityAndTrustExtension implements ServiceExtension {
     private JwtVerifier jwtVerifier;
     private PresentationVerifier presentationVerifier;
     private CredentialServiceClient credentialServiceClient;
-    
+    @Inject
+    private AudienceResolver audienceResolver;
+
     @Provider
     public IdentityService createIdentityService(ServiceExtensionContext context) {
         var credentialServiceUrlResolver = new DidCredentialServiceUrlResolver(didResolverRegistry);
         return new IdentityAndTrustService(secureTokenService, getOwnDid(context), context.getParticipantId(), getPresentationVerifier(context),
-                getCredentialServiceClient(context), getJwtValidator(), getJwtVerifier(), registry, clock, credentialServiceUrlResolver);
+                getCredentialServiceClient(context), getJwtValidator(), getJwtVerifier(), registry, clock, credentialServiceUrlResolver, audienceResolver);
     }
 
     @Provider

--- a/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtension.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtension.java
@@ -60,10 +60,6 @@ public class IdentityAndTrustExtension implements ServiceExtension {
     @Inject
     private SecureTokenService secureTokenService;
 
-
-    @Inject
-    private CredentialServiceClient credentialServiceClient;
-
     @Inject
     private TrustedIssuerRegistry registry;
 
@@ -94,7 +90,8 @@ public class IdentityAndTrustExtension implements ServiceExtension {
     private JwtValidator jwtValidator;
     private JwtVerifier jwtVerifier;
     private PresentationVerifier presentationVerifier;
-
+    private CredentialServiceClient credentialServiceClient;
+    
     @Provider
     public IdentityService createIdentityService(ServiceExtensionContext context) {
         var credentialServiceUrlResolver = new DidCredentialServiceUrlResolver(didResolverRegistry);

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/validation/SelfIssuedIdTokenValidator.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/validation/SelfIssuedIdTokenValidator.java
@@ -24,6 +24,7 @@ import java.text.ParseException;
 import java.util.Objects;
 
 import static java.time.Instant.now;
+import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_ACCESS_TOKEN_CLAIM;
 import static org.eclipse.edc.spi.result.Result.failure;
 import static org.eclipse.edc.spi.result.Result.success;
 
@@ -77,6 +78,9 @@ public class SelfIssuedIdTokenValidator implements JwtValidator {
             }
             if (exp.toInstant().plusSeconds(EPSILON).isBefore(now())) {
                 return failure("The token must not be expired.");
+            }
+            if (claims.getClaim(PRESENTATION_ACCESS_TOKEN_CLAIM) == null) {
+                return failure("The 'access_token' claim is mandatory.");
             }
             var bldr = ClaimToken.Builder.newInstance();
             jwt.getJWTClaimsSet().getClaims().forEach(bldr::claim);

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/test/java/org/eclipse/edc/iam/identitytrust/service/IdentityAndTrustServiceTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/test/java/org/eclipse/edc/iam/identitytrust/service/IdentityAndTrustServiceTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.iam.identitytrust.service;
 
 
+import com.nimbusds.jwt.JWTClaimsSet;
 import org.eclipse.edc.iam.identitytrust.IdentityAndTrustService;
 import org.eclipse.edc.identitytrust.CredentialServiceClient;
 import org.eclipse.edc.identitytrust.CredentialServiceUrlResolver;
@@ -29,6 +30,7 @@ import org.eclipse.edc.identitytrust.verification.JwtVerifier;
 import org.eclipse.edc.identitytrust.verification.PresentationVerifier;
 import org.eclipse.edc.spi.iam.ClaimToken;
 import org.eclipse.edc.spi.iam.TokenParameters;
+import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.result.Result;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -45,6 +47,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 
+import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_ACCESS_TOKEN_CLAIM;
 import static org.eclipse.edc.identitytrust.TestFunctions.createCredentialBuilder;
 import static org.eclipse.edc.identitytrust.TestFunctions.createJwt;
 import static org.eclipse.edc.identitytrust.TestFunctions.createPresentationBuilder;
@@ -72,15 +75,20 @@ class IdentityAndTrustServiceTest {
     private final JwtValidator jwtValidatorMock = mock();
     private final JwtVerifier jwtVerfierMock = mock();
     private final TrustedIssuerRegistry trustedIssuerRegistryMock = mock();
-    private final CredentialServiceUrlResolver resolverMock = mock();
+    private final CredentialServiceUrlResolver credentialServiceUrlResolverMock = mock();
     private final IdentityAndTrustService service = new IdentityAndTrustService(mockedSts, EXPECTED_OWN_DID, EXPECTED_PARTICIPANT_ID, mockedVerifier, mockedClient,
-            jwtValidatorMock, jwtVerfierMock, trustedIssuerRegistryMock, Clock.systemUTC(), resolverMock);
+            jwtValidatorMock, jwtVerfierMock, trustedIssuerRegistryMock, Clock.systemUTC(), credentialServiceUrlResolverMock);
 
     @BeforeEach
     void setup() {
-        when(resolverMock.resolve(any())).thenReturn(success("foobar"));
-        when(jwtValidatorMock.validateToken(any(), any())).thenReturn(success(ClaimToken.Builder.newInstance().claim("iss", CONSUMER_DID).build()));
+        when(credentialServiceUrlResolverMock.resolve(any())).thenReturn(success("foobar"));
+        var jwt = createJwt(new JWTClaimsSet.Builder().claim("scope", "foo-scope").build());
+        when(jwtValidatorMock.validateToken(any(), any())).thenReturn(success(ClaimToken.Builder.newInstance()
+                .claim("iss", CONSUMER_DID)
+                .claim("client_id", "sender-id")
+                .claim(PRESENTATION_ACCESS_TOKEN_CLAIM, jwt.getToken()).build()));
         when(jwtVerfierMock.verify(any(), any())).thenReturn(success());
+        when(mockedSts.createToken(any(), any())).thenReturn(success(TokenRepresentation.Builder.newInstance().build()));
     }
 
     @Nested
@@ -242,7 +250,7 @@ class IdentityAndTrustServiceTest {
 
         @Test
         void cannotResolveCredentialServiceUrl() {
-            when(resolverMock.resolve(any())).thenReturn(Result.failure("test-failure"));
+            when(credentialServiceUrlResolverMock.resolve(any())).thenReturn(Result.failure("test-failure"));
             assertThat(service.verifyJwtToken(createJwt(), "test-audience"))
                     .isFailed()
                     .detail()

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/test/java/org/eclipse/edc/iam/identitytrust/service/IdentityAndTrustServiceTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/test/java/org/eclipse/edc/iam/identitytrust/service/IdentityAndTrustServiceTest.java
@@ -77,7 +77,7 @@ class IdentityAndTrustServiceTest {
     private final TrustedIssuerRegistry trustedIssuerRegistryMock = mock();
     private final CredentialServiceUrlResolver credentialServiceUrlResolverMock = mock();
     private final IdentityAndTrustService service = new IdentityAndTrustService(mockedSts, EXPECTED_OWN_DID, EXPECTED_PARTICIPANT_ID, mockedVerifier, mockedClient,
-            jwtValidatorMock, jwtVerfierMock, trustedIssuerRegistryMock, Clock.systemUTC(), credentialServiceUrlResolverMock);
+            jwtValidatorMock, jwtVerfierMock, trustedIssuerRegistryMock, Clock.systemUTC(), credentialServiceUrlResolverMock, i -> i);
 
     @BeforeEach
     void setup() {

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/test/java/org/eclipse/edc/iam/identitytrust/validation/SelfIssuedIdTokenValidatorTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/test/java/org/eclipse/edc/iam/identitytrust/validation/SelfIssuedIdTokenValidatorTest.java
@@ -23,6 +23,7 @@ import java.time.Instant;
 import java.util.Date;
 import java.util.UUID;
 
+import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_ACCESS_TOKEN_CLAIM;
 import static org.eclipse.edc.identitytrust.TestFunctions.createJwt;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 
@@ -43,6 +44,7 @@ class SelfIssuedIdTokenValidatorTest {
                 .issuer(CONSUMER_DID)
                 .audience(EXPECTED_OWN_DID)
                 .claim("jti", UUID.randomUUID().toString())
+                .claim(PRESENTATION_ACCESS_TOKEN_CLAIM, "foobar")
                 .claim("client_id", CONSUMER_DID)
                 .expirationTime(new Date(new Date().getTime() + 60 * 1000))
                 .build();
@@ -87,7 +89,7 @@ class SelfIssuedIdTokenValidatorTest {
                 .isFailed()
                 .detail().isEqualTo("The aud claim expected to be %s but was [%s]".formatted(EXPECTED_OWN_DID, "invalid-audience"));
     }
-    
+
     @Test
     void subJwkClaimPresent() {
         var claimsSet = new JWTClaimsSet.Builder()

--- a/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-core/src/main/java/org/eclipse/edc/iam/identitytrust/sts/core/defaults/service/StsClientTokenGeneratorServiceImpl.java
+++ b/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-core/src/main/java/org/eclipse/edc/iam/identitytrust/sts/core/defaults/service/StsClientTokenGeneratorServiceImpl.java
@@ -29,8 +29,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
-import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.ACCESS_TOKEN;
 import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.BEARER_ACCESS_ALIAS;
+import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_ACCESS_TOKEN_CLAIM;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.AUDIENCE;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.CLIENT_ID;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.ISSUER;
@@ -39,7 +39,7 @@ import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.SUBJECT;
 public class StsClientTokenGeneratorServiceImpl implements StsClientTokenGeneratorService {
 
     private static final Map<String, Function<StsClientTokenAdditionalParams, String>> CLAIM_MAPPERS = Map.of(
-            ACCESS_TOKEN, StsClientTokenAdditionalParams::getAccessToken,
+            PRESENTATION_ACCESS_TOKEN_CLAIM, StsClientTokenAdditionalParams::getAccessToken,
             BEARER_ACCESS_ALIAS, StsClientTokenAdditionalParams::getBearerAccessAlias);
 
     private final long tokenExpiration;

--- a/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-core/src/test/java/org/eclipse/edc/iam/identitytrust/sts/core/defaults/StsClientTokenIssuanceIntegrationTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-core/src/test/java/org/eclipse/edc/iam/identitytrust/sts/core/defaults/StsClientTokenIssuanceIntegrationTest.java
@@ -38,7 +38,7 @@ import java.util.Objects;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.iam.identitytrust.sts.store.fixtures.TestFunctions.createClientBuilder;
-import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.ACCESS_TOKEN;
+import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_ACCESS_TOKEN_CLAIM;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.AUDIENCE;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.CLIENT_ID;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.EXPIRATION_TIME;
@@ -163,7 +163,7 @@ public class StsClientTokenIssuanceIntegrationTest {
                 .containsEntry(SUBJECT, id)
                 .containsEntry(AUDIENCE, List.of(audience))
                 .containsEntry(CLIENT_ID, clientId)
-                .containsEntry(ACCESS_TOKEN, accessToken)
+                .containsEntry(PRESENTATION_ACCESS_TOKEN_CLAIM, accessToken)
                 .containsKeys(JWT_ID, EXPIRATION_TIME, ISSUED_AT);
 
     }

--- a/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-embedded/src/main/java/org/eclipse/edc/iam/identitytrust/sts/embedded/EmbeddedSecureTokenService.java
+++ b/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-embedded/src/main/java/org/eclipse/edc/iam/identitytrust/sts/embedded/EmbeddedSecureTokenService.java
@@ -30,8 +30,8 @@ import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static java.util.Optional.ofNullable;
-import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.ACCESS_TOKEN;
 import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.BEARER_ACCESS_ALIAS;
+import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_ACCESS_TOKEN_CLAIM;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.AUDIENCE;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.ISSUER;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.SCOPE;
@@ -69,7 +69,7 @@ public class EmbeddedSecureTokenService implements SecureTokenService {
     private Result<Void> createAndAcceptAccessToken(Map<String, String> claims, String scope, BiConsumer<String, String> consumer) {
         return createAccessToken(claims, scope)
                 .compose(tokenRepresentation -> success(tokenRepresentation.getToken()))
-                .onSuccess(withClaim(ACCESS_TOKEN, consumer))
+                .onSuccess(withClaim(PRESENTATION_ACCESS_TOKEN_CLAIM, consumer))
                 .mapTo();
     }
 

--- a/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-embedded/src/test/java/org/eclipse/edc/iam/identitytrust/sts/embedded/EmbeddedSecureTokenServiceIntegrationTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-embedded/src/test/java/org/eclipse/edc/iam/identitytrust/sts/embedded/EmbeddedSecureTokenServiceIntegrationTest.java
@@ -40,8 +40,8 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
-import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.ACCESS_TOKEN;
 import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.BEARER_ACCESS_ALIAS;
+import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_ACCESS_TOKEN_CLAIM;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.AUDIENCE;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.EXPIRATION_TIME;
@@ -83,7 +83,7 @@ public class EmbeddedSecureTokenServiceIntegrationTest {
                     assertThat(jwt.getJWTClaimsSet().getClaims())
                             .containsEntry(ISSUER, issuer)
                             .containsKeys(JWT_ID, EXPIRATION_TIME, ISSUED_AT)
-                            .doesNotContainKey(ACCESS_TOKEN);
+                            .doesNotContainKey(PRESENTATION_ACCESS_TOKEN_CLAIM);
                 });
 
     }
@@ -104,7 +104,7 @@ public class EmbeddedSecureTokenServiceIntegrationTest {
                     assertThat(jwt.getJWTClaimsSet().getClaims())
                             .containsEntry(ISSUER, issuer)
                             .containsKeys(JWT_ID, EXPIRATION_TIME, ISSUED_AT)
-                            .extractingByKey(ACCESS_TOKEN, as(STRING))
+                            .extractingByKey(PRESENTATION_ACCESS_TOKEN_CLAIM, as(STRING))
                             .satisfies(accessToken -> {
                                 var accessTokenJwt = SignedJWT.parse(accessToken);
                                 assertThat(accessTokenJwt.verify(createVerifier(accessTokenJwt.getHeader(), keyPair.getPublic()))).isTrue();
@@ -135,7 +135,7 @@ public class EmbeddedSecureTokenServiceIntegrationTest {
                     assertThat(jwt.getJWTClaimsSet().getClaims())
                             .containsEntry(ISSUER, issuer)
                             .containsKeys(JWT_ID, EXPIRATION_TIME, ISSUED_AT)
-                            .extractingByKey(ACCESS_TOKEN, as(STRING))
+                            .extractingByKey(PRESENTATION_ACCESS_TOKEN_CLAIM, as(STRING))
                             .satisfies(accessToken -> {
                                 var accessTokenJwt = SignedJWT.parse(accessToken);
                                 assertThat(accessTokenJwt.verify(createVerifier(accessTokenJwt.getHeader(), keyPair.getPublic()))).isTrue();
@@ -148,7 +148,7 @@ public class EmbeddedSecureTokenServiceIntegrationTest {
                             });
                 });
     }
-    
+
     @ParameterizedTest
     @ArgumentsSource(ClaimsArguments.class)
     void createToken_shouldFail_withMissingClaims(Map<String, String> claims) {

--- a/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-remote/src/main/java/org/eclipse/edc/iam/identitytrust/sts/remote/RemoteSecureTokenService.java
+++ b/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-remote/src/main/java/org/eclipse/edc/iam/identitytrust/sts/remote/RemoteSecureTokenService.java
@@ -26,9 +26,9 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.ACCESS_TOKEN;
 import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.BEARER_ACCESS_ALIAS;
 import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.BEARER_ACCESS_SCOPE;
+import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_ACCESS_TOKEN_CLAIM;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.AUDIENCE;
 
 public class RemoteSecureTokenService implements SecureTokenService {
@@ -39,7 +39,7 @@ public class RemoteSecureTokenService implements SecureTokenService {
     private static final Map<String, String> CLAIM_MAPPING = Map.of(
             AUDIENCE, AUDIENCE_PARAM,
             BEARER_ACCESS_ALIAS, BEARER_ACCESS_ALIAS,
-            ACCESS_TOKEN, ACCESS_TOKEN);
+            PRESENTATION_ACCESS_TOKEN_CLAIM, PRESENTATION_ACCESS_TOKEN_CLAIM);
 
     private final Oauth2Client oauth2Client;
     private final StsRemoteClientConfiguration configuration;

--- a/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-remote/src/test/java/org/eclipse/edc/iam/identitytrust/sts/remote/RemoteSecureTokenServiceTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-remote/src/test/java/org/eclipse/edc/iam/identitytrust/sts/remote/RemoteSecureTokenServiceTest.java
@@ -27,9 +27,9 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.iam.identitytrust.sts.remote.RemoteSecureTokenService.AUDIENCE_PARAM;
 import static org.eclipse.edc.iam.identitytrust.sts.remote.RemoteSecureTokenService.GRANT_TYPE;
-import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.ACCESS_TOKEN;
 import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.BEARER_ACCESS_ALIAS;
 import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.BEARER_ACCESS_SCOPE;
+import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_ACCESS_TOKEN_CLAIM;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.AUDIENCE;
 import static org.mockito.ArgumentMatchers.any;
@@ -93,7 +93,7 @@ public class RemoteSecureTokenServiceTest {
         var audience = "aud";
         var accessToken = "accessToken";
         when(oauth2Client.requestToken(any())).thenReturn(Result.success(TokenRepresentation.Builder.newInstance().build()));
-        assertThat(secureTokenService.createToken(Map.of(AUDIENCE, audience, ACCESS_TOKEN, accessToken), null)).isSucceeded();
+        assertThat(secureTokenService.createToken(Map.of(AUDIENCE, audience, PRESENTATION_ACCESS_TOKEN_CLAIM, accessToken), null)).isSucceeded();
 
         var captor = ArgumentCaptor.forClass(SharedSecretOauth2CredentialsRequest.class);
         verify(oauth2Client).requestToken(captor.capture());
@@ -105,7 +105,7 @@ public class RemoteSecureTokenServiceTest {
             assertThat(request.getClientSecret()).isEqualTo(configuration.clientSecret());
             assertThat(request.getParams())
                     .containsEntry(AUDIENCE_PARAM, audience)
-                    .containsEntry(ACCESS_TOKEN, accessToken);
+                    .containsEntry(PRESENTATION_ACCESS_TOKEN_CLAIM, accessToken);
         });
     }
 

--- a/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/SelfIssuedTokenConstants.java
+++ b/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/SelfIssuedTokenConstants.java
@@ -22,7 +22,7 @@ public final class SelfIssuedTokenConstants {
     /**
      * VP access token claim
      */
-    public static final String ACCESS_TOKEN = "access_token";
+    public static final String PRESENTATION_ACCESS_TOKEN_CLAIM = "access_token";
 
     /**
      * Alias to be used in the sub of the VP access token
@@ -33,7 +33,7 @@ public final class SelfIssuedTokenConstants {
      * Scopes to be encoded in the VP access token
      */
     public static final String BEARER_ACCESS_SCOPE = "bearer_access_scope";
-    
+
     private SelfIssuedTokenConstants() {
 
     }

--- a/spi/common/identity-trust-spi/src/testFixtures/java/org/eclipse/edc/identitytrust/TestFunctions.java
+++ b/spi/common/identity-trust-spi/src/testFixtures/java/org/eclipse/edc/identitytrust/TestFunctions.java
@@ -36,6 +36,7 @@ import java.util.Date;
 import java.util.Map;
 
 import static java.time.Instant.now;
+import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_ACCESS_TOKEN_CLAIM;
 
 public class TestFunctions {
 
@@ -78,6 +79,7 @@ public class TestFunctions {
         var claimsSet = new JWTClaimsSet.Builder()
                 .subject(subject)
                 .issuer(issuer)
+                .claim(PRESENTATION_ACCESS_TOKEN_CLAIM, createJwt(new JWTClaimsSet.Builder().claim("scope", "fooscope").build()).getToken())
                 .expirationTime(new Date(new Date().getTime() + 60 * 1000))
                 .build();
         return createJwt(claimsSet);

--- a/system-tests/sts-api/sts-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/sts/api/RemoteStsEndToEndTest.java
+++ b/system-tests/sts-api/sts-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/sts/api/RemoteStsEndToEndTest.java
@@ -31,8 +31,8 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.ACCESS_TOKEN;
 import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.BEARER_ACCESS_ALIAS;
+import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_ACCESS_TOKEN_CLAIM;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.junit.testfixtures.TestUtils.getFreePort;
 import static org.eclipse.edc.junit.testfixtures.TestUtils.testHttpClient;
@@ -64,7 +64,7 @@ public class RemoteStsEndToEndTest extends StsEndToEndTestBase {
             }
     );
     private final StsRemoteClientConfiguration config = new StsRemoteClientConfiguration(STS_TOKEN_PATH, "client_id", "client_secret");
-    
+
     private RemoteSecureTokenService remoteSecureTokenService;
 
     @BeforeEach
@@ -116,7 +116,7 @@ public class RemoteStsEndToEndTest extends StsEndToEndTestBase {
                             .containsEntry(AUDIENCE, List.of(audience))
                             .containsEntry(CLIENT_ID, client.getClientId())
                             .containsKeys(JWT_ID, EXPIRATION_TIME, ISSUED_AT)
-                            .hasEntrySatisfying(ACCESS_TOKEN, (accessToken) -> {
+                            .hasEntrySatisfying(PRESENTATION_ACCESS_TOKEN_CLAIM, (accessToken) -> {
                                 assertThat(parseClaims((String) accessToken))
                                         .containsEntry(ISSUER, client.getId())
                                         .containsEntry(SUBJECT, bearerAccessAlias)
@@ -134,7 +134,7 @@ public class RemoteStsEndToEndTest extends StsEndToEndTestBase {
         var accessToken = "test_token";
         var params = Map.of(
                 AUDIENCE, audience,
-                ACCESS_TOKEN, accessToken);
+                PRESENTATION_ACCESS_TOKEN_CLAIM, accessToken);
 
         var client = initClient(config.clientId(), config.clientSecret());
 
@@ -147,7 +147,7 @@ public class RemoteStsEndToEndTest extends StsEndToEndTestBase {
                             .containsEntry(SUBJECT, client.getId())
                             .containsEntry(AUDIENCE, List.of(audience))
                             .containsEntry(CLIENT_ID, client.getClientId())
-                            .containsEntry(ACCESS_TOKEN, accessToken)
+                            .containsEntry(PRESENTATION_ACCESS_TOKEN_CLAIM, accessToken)
                             .containsKeys(JWT_ID, EXPIRATION_TIME, ISSUED_AT);
                 });
     }

--- a/system-tests/sts-api/sts-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/sts/api/StsApiEndToEndTest.java
+++ b/system-tests/sts-api/sts-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/sts/api/StsApiEndToEndTest.java
@@ -30,7 +30,7 @@ import java.util.Map;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.ACCESS_TOKEN;
+import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_ACCESS_TOKEN_CLAIM;
 import static org.eclipse.edc.junit.testfixtures.TestUtils.getFreePort;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.AUDIENCE;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.CLIENT_ID;
@@ -126,7 +126,7 @@ public class StsApiEndToEndTest extends StsEndToEndTestBase {
                 .containsEntry(AUDIENCE, List.of(audience))
                 .containsEntry(CLIENT_ID, client.getClientId())
                 .containsKeys(JWT_ID, EXPIRATION_TIME, ISSUED_AT)
-                .hasEntrySatisfying(ACCESS_TOKEN, (accessToken) -> {
+                .hasEntrySatisfying(PRESENTATION_ACCESS_TOKEN_CLAIM, (accessToken) -> {
                     assertThat(parseClaims((String) accessToken))
                             .containsEntry(ISSUER, client.getId())
                             .containsEntry(SUBJECT, audience)
@@ -159,13 +159,13 @@ public class StsApiEndToEndTest extends StsEndToEndTestBase {
                 .body()
                 .jsonPath().getString("access_token");
 
-        
+
         assertThat(parseClaims(token))
                 .containsEntry(ISSUER, client.getId())
                 .containsEntry(SUBJECT, client.getId())
                 .containsEntry(AUDIENCE, List.of(audience))
                 .containsEntry(CLIENT_ID, client.getClientId())
-                .containsEntry(ACCESS_TOKEN, accessToken)
+                .containsEntry(PRESENTATION_ACCESS_TOKEN_CLAIM, accessToken)
                 .containsKeys(JWT_ID, EXPIRATION_TIME, ISSUED_AT);
     }
 


### PR DESCRIPTION
## What this PR changes/adds

This PR extends the `IdentityAndTrustService` and generates another SI token on the relying-party side 
which is then used to execute the VP query against the counter-party's CredentialService (= presentation endpoint).


## Why it does that

Complete the circle of the presentation flow

## Further notes

- **Be aware that currently we need to parse the `access_token` to get the `scope` string. This is a workaround, until we can extract the scope from the verification context. This behaviour will change in subsequent developments and is only there for the immediate future. The related code has been marked accordingly.**
- the `access_token` constant was renamed to `PRESENTATION_ACCESS_TOKEN_CLAIM` and is now used everywhere
- this PR also adds the temporary `AudienceResolver` object, which maps a DSP url to an audience, which can be used to resolve key material

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
