### PR TITLE
feat: various minor improvements / patches for IATP

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -81,7 +81,7 @@ maven/mavencentral/com.jcraft/jzlib/1.1.3, BSD-2-Clause, approved, CQ6218
 maven/mavencentral/com.lmax/disruptor/3.4.4, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.networknt/json-schema-validator/1.0.76, Apache-2.0, approved, CQ22638
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.28, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.37, Apache-2.0, approved, #11086
+maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.37, Apache-2.0, approved, #11701
 maven/mavencentral/com.puppycrawl.tools/checkstyle/10.0, LGPL-2.1-or-later, approved, #7936
 maven/mavencentral/com.samskivert/jmustache/1.15, BSD-2-Clause, approved, clearlydefined
 maven/mavencentral/com.squareup.okhttp3/okhttp-dnsoverhttps/4.12.0, Apache-2.0, approved, #11159

--- a/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/store/ReflectionBasedQueryResolver.java
+++ b/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/store/ReflectionBasedQueryResolver.java
@@ -62,7 +62,8 @@ public class ReflectionBasedQueryResolver<T> implements QueryResolver<T> {
     public Stream<T> query(Stream<T> stream, QuerySpec spec, BinaryOperator<Predicate<Object>> accumulator) {
         var andPredicate = spec.getFilterExpression().stream()
                 .map(predicateConverter::convert)
-                .reduce(x -> true, accumulator);
+                .reduce(accumulator)
+                .orElse(x -> true);
 
         var filteredStream = stream.filter(andPredicate);
 

--- a/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/store/ReflectionBasedQueryResolver.java
+++ b/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/store/ReflectionBasedQueryResolver.java
@@ -59,11 +59,10 @@ public class ReflectionBasedQueryResolver<T> implements QueryResolver<T> {
      * @return stream result from queries.
      */
     @Override
-    public Stream<T> query(Stream<T> stream, QuerySpec spec, BinaryOperator<Predicate<Object>> accumulator) {
+    public Stream<T> query(Stream<T> stream, QuerySpec spec, BinaryOperator<Predicate<Object>> accumulator, Predicate<Object> fallback) {
         var andPredicate = spec.getFilterExpression().stream()
                 .map(predicateConverter::convert)
-                .reduce(accumulator)
-                .orElse(x -> true);
+                .reduce(fallback, accumulator);
 
         var filteredStream = stream.filter(andPredicate);
 

--- a/core/common/connector-core/src/test/java/org/eclipse/edc/connector/core/store/ReflectionBasedQueryResolverTest.java
+++ b/core/common/connector-core/src/test/java/org/eclipse/edc/connector/core/store/ReflectionBasedQueryResolverTest.java
@@ -62,7 +62,7 @@ class ReflectionBasedQueryResolverTest {
                 IntStream.range(0, 5).mapToObj(i -> new FakeItem(i, "Alice")),
                 IntStream.range(5, 10).mapToObj(i -> new FakeItem(i, "Bob")));
 
-        var spec = QuerySpec.Builder.newInstance().filter(criterion("name", "=", "Alice")).build();
+        var spec = QuerySpec.Builder.newInstance().filter(List.of(criterion("name", "=", "Alice"), criterion("name", "=", "Bob"))).build();
         assertThat(queryResolver.query(stream, spec, Predicate::or)).hasSize(10).extracting(FakeItem::getName).containsOnly("Bob", "Alice");
     }
 

--- a/core/common/connector-core/src/test/java/org/eclipse/edc/connector/core/store/ReflectionBasedQueryResolverTest.java
+++ b/core/common/connector-core/src/test/java/org/eclipse/edc/connector/core/store/ReflectionBasedQueryResolverTest.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -52,6 +53,17 @@ class ReflectionBasedQueryResolverTest {
 
         var spec = QuerySpec.Builder.newInstance().filter(criterion("name", "=", "Alice")).build();
         assertThat(queryResolver.query(stream, spec)).hasSize(5).extracting(FakeItem::getName).containsOnly("Alice");
+
+    }
+
+    @Test
+    void verifyQuery_equalStringProperty_accumulateOr() {
+        var stream = Stream.concat(
+                IntStream.range(0, 5).mapToObj(i -> new FakeItem(i, "Alice")),
+                IntStream.range(5, 10).mapToObj(i -> new FakeItem(i, "Bob")));
+
+        var spec = QuerySpec.Builder.newInstance().filter(criterion("name", "=", "Alice")).build();
+        assertThat(queryResolver.query(stream, spec, Predicate::or)).hasSize(10).extracting(FakeItem::getName).containsOnly("Bob", "Alice");
     }
 
     @Test
@@ -117,7 +129,7 @@ class ReflectionBasedQueryResolverTest {
     }
 
     private static class FakeItem {
-        private int id;
+        private final int id;
         private String name;
 
         private FakeItem(int id) {
@@ -138,16 +150,16 @@ class ReflectionBasedQueryResolverTest {
         }
 
         @Override
+        public int hashCode() {
+            return Objects.hash(id, name);
+        }
+
+        @Override
         public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             FakeItem fakeItem = (FakeItem) o;
             return id == fakeItem.id && Objects.equals(name, fakeItem.name);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(id, name);
         }
     }
 

--- a/core/common/connector-core/src/test/java/org/eclipse/edc/connector/core/store/ReflectionBasedQueryResolverTest.java
+++ b/core/common/connector-core/src/test/java/org/eclipse/edc/connector/core/store/ReflectionBasedQueryResolverTest.java
@@ -63,7 +63,7 @@ class ReflectionBasedQueryResolverTest {
                 IntStream.range(5, 10).mapToObj(i -> new FakeItem(i, "Bob")));
 
         var spec = QuerySpec.Builder.newInstance().filter(List.of(criterion("name", "=", "Alice"), criterion("name", "=", "Bob"))).build();
-        assertThat(queryResolver.query(stream, spec, Predicate::or)).hasSize(10).extracting(FakeItem::getName).containsOnly("Bob", "Alice");
+        assertThat(queryResolver.query(stream, spec, Predicate::or, x -> false)).hasSize(10).extracting(FakeItem::getName).containsOnly("Bob", "Alice");
     }
 
     @Test

--- a/core/common/util/src/main/java/org/eclipse/edc/util/uri/UriUtils.java
+++ b/core/common/util/src/main/java/org/eclipse/edc/util/uri/UriUtils.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.util.uri;
+
+import java.net.URI;
+
+public class UriUtils {
+    /**
+     * Compares two URIs to check if they are equal after ignoring the fragment part.
+     *
+     * @param u1 The first URI to compare.
+     * @param u2 The second URI to compare.
+     * @return {@code true} if the URIs are equal after ignoring the fragment part, {@code false} otherwise.
+     */
+    public static boolean equalsIgnoreFragment(URI u1, URI u2) {
+        var str1 = stripFragment(u1.toString());
+        var str2 = stripFragment(u2.toString());
+
+        return str1.equals(str2);
+    }
+
+    /**
+     * Removes the fragment part from a given string representation of a URI.
+     *
+     * @param uri The string representation of the URI.
+     * @return The string with the fragment part removed, if it exists, otherwise the original string.
+     */
+    private static String stripFragment(String uri) {
+        var ix = uri.indexOf("#");
+        return ix >= 0 ? uri.substring(0, ix) : uri;
+    }
+
+}

--- a/core/common/util/src/test/java/org/eclipse/edc/util/uri/UriUtilsTest.java
+++ b/core/common/util/src/test/java/org/eclipse/edc/util/uri/UriUtilsTest.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.util.uri;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UriUtilsTest {
+
+    @Test
+    void verifyEquality() {
+        var u1 = URI.create("https://some.url/path/foo#position1");
+        var u2 = URI.create("https://some.url/path/foo");
+        assertThat(UriUtils.equalsIgnoreFragment(u1, u2)).isTrue();
+
+        var u3 = URI.create("https://some.url/path");
+        assertThat(UriUtils.equalsIgnoreFragment(u1, u3)).isFalse();
+        assertThat(UriUtils.equalsIgnoreFragment(u2, u3)).isFalse();
+    }
+}

--- a/extensions/common/crypto/ldp-verifiable-credentials/src/main/java/org/eclipse/edc/verifiablecredentials/linkeddata/DidMethodResolver.java
+++ b/extensions/common/crypto/ldp-verifiable-credentials/src/main/java/org/eclipse/edc/verifiablecredentials/linkeddata/DidMethodResolver.java
@@ -45,8 +45,8 @@ public class DidMethodResolver implements MethodResolver {
         return didDocument.getVerificationMethod().stream()
                 .map(verificationMethod -> DataIntegrityKeyPair.createVerificationKey(
                         URI.create(verificationMethod.getId()),
-                        URI.create(verificationMethod.getController()),
                         URI.create(verificationMethod.getType()),
+                        URI.create(verificationMethod.getController()),
                         verificationMethod.serializePublicKey())
                 )
                 .findFirst()

--- a/extensions/common/crypto/ldp-verifiable-credentials/src/main/java/org/eclipse/edc/verifiablecredentials/linkeddata/LdpVerifier.java
+++ b/extensions/common/crypto/ldp-verifiable-credentials/src/main/java/org/eclipse/edc/verifiablecredentials/linkeddata/LdpVerifier.java
@@ -47,6 +47,7 @@ import org.eclipse.edc.identitytrust.verification.VerifierContext;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
 import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.util.uri.UriUtils;
 
 import java.io.IOException;
 import java.net.URI;
@@ -132,7 +133,7 @@ public class LdpVerifier implements CredentialVerifier {
             if (issuerUri.isEmpty()) {
                 return failure("Document must contain an 'issuer' property.");
             }
-            if (!issuerUri.get().equals(verificationMethod.id())) {
+            if (!UriUtils.equalsIgnoreFragment(issuerUri.get(), verificationMethod.id())) {
                 return failure("Issuer and proof.verificationMethod mismatch: %s <> %s".formatted(issuerUri.get(), verificationMethod.id()));
             }
         } catch (InvalidJsonLdValue e) {

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/IdentityAndTrustService.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/IdentityAndTrustService.java
@@ -202,12 +202,12 @@ public class IdentityAndTrustService implements IdentityService {
 
         //todo: at this point we have established what the other participant's DID is, and that it's authentic
         // so we need to make sure that `iss == sub == DID`
-        return result.compose(u -> extractClaimToken(credentials));
+        return result.compose(u -> extractClaimToken(credentials, issuer));
     }
 
 
     @NotNull
-    private Result<ClaimToken> extractClaimToken(List<VerifiableCredential> credentials) {
+    private Result<ClaimToken> extractClaimToken(List<VerifiableCredential> credentials, String issuer) {
         if (credentials.isEmpty()) {
             return failure("No VerifiableCredentials were found on VP");
         }
@@ -216,6 +216,7 @@ public class IdentityAndTrustService implements IdentityService {
                 .map(CredentialSubject::getClaims)
                 .forEach(claimSet -> claimSet.forEach(b::claim));
 
+        b.claim("client_id", issuer);
         return success(b.build());
     }
 

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/IdentityAndTrustService.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/IdentityAndTrustService.java
@@ -24,6 +24,7 @@ import org.eclipse.edc.identitytrust.CredentialServiceClient;
 import org.eclipse.edc.identitytrust.CredentialServiceUrlResolver;
 import org.eclipse.edc.identitytrust.SecureTokenService;
 import org.eclipse.edc.identitytrust.TrustedIssuerRegistry;
+import org.eclipse.edc.identitytrust.model.CredentialSubject;
 import org.eclipse.edc.identitytrust.model.Issuer;
 import org.eclipse.edc.identitytrust.model.VerifiableCredential;
 import org.eclipse.edc.identitytrust.validation.CredentialValidationRule;
@@ -36,6 +37,7 @@ import org.eclipse.edc.spi.iam.TokenParameters;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.util.string.StringUtils;
+import org.jetbrains.annotations.NotNull;
 
 import java.text.ParseException;
 import java.time.Clock;
@@ -111,7 +113,7 @@ public class IdentityAndTrustService implements IdentityService {
                 .scope(parameters.getScope())
                 .additional(parameters.getAdditional())
                 .build();
-        
+
         var scope = parameters.getScope();
         var scopeValidationResult = validateScope(scope);
 
@@ -200,12 +202,21 @@ public class IdentityAndTrustService implements IdentityService {
 
         //todo: at this point we have established what the other participant's DID is, and that it's authentic
         // so we need to make sure that `iss == sub == DID`
-        return result.map(u -> extractClaimToken(credentials));
+        return result.compose(u -> extractClaimToken(credentials));
     }
 
 
-    private ClaimToken extractClaimToken(List<VerifiableCredential> credentials) {
-        return null;
+    @NotNull
+    private Result<ClaimToken> extractClaimToken(List<VerifiableCredential> credentials) {
+        if (credentials.isEmpty()) {
+            return failure("No VerifiableCredentials were found on VP");
+        }
+        var b = ClaimToken.Builder.newInstance();
+        credentials.stream().flatMap(vc -> vc.getCredentialSubject().stream())
+                .map(CredentialSubject::getClaims)
+                .forEach(claimSet -> claimSet.forEach(b::claim));
+
+        return success(b.build());
     }
 
     private Collection<? extends CredentialValidationRule> getAdditionalValidations() {

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/IdentityAndTrustService.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/IdentityAndTrustService.java
@@ -202,7 +202,7 @@ public class IdentityAndTrustService implements IdentityService {
 
         //todo: at this point we have established what the other participant's DID is, and that it's authentic
         // so we need to make sure that `iss == sub == DID`
-        return result.compose(u -> extractClaimToken(credentials, issuer));
+        return result.compose(u -> extractClaimToken(credentials, intendedAudience));
     }
 
 

--- a/extensions/common/iam/identity-trust/identity-trust-transform/src/main/java/org/eclipse/edc/iam/identitytrust/transform/to/JsonObjectToPresentationQueryTransformer.java
+++ b/extensions/common/iam/identity-trust/identity-trust-transform/src/main/java/org/eclipse/edc/iam/identitytrust/transform/to/JsonObjectToPresentationQueryTransformer.java
@@ -27,6 +27,8 @@ import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.List;
+
 /**
  * Transforms a JsonObject into a PresentationQuery object.
  */
@@ -47,7 +49,7 @@ public class JsonObjectToPresentationQueryTransformer extends AbstractJsonLdTran
                 case PresentationQuery.PRESENTATION_QUERY_DEFINITION_PROPERTY ->
                         bldr.presentationDefinition(readPresentationDefinition(v, context));
                 case PresentationQuery.PRESENTATION_QUERY_SCOPE_PROPERTY ->
-                        transformArrayOrObject(v, Object.class, o -> bldr.scope(o.toString()), context);
+                        transformArrayOrObject(v, Object.class, o -> bldr.scopes(List.of(o.toString().split(" "))), context);
                 default -> context.reportProblem("Unknown property '%s'".formatted(k));
             }
         });

--- a/extensions/common/iam/identity-trust/identity-trust-transform/src/main/java/org/eclipse/edc/iam/identitytrust/transform/to/JsonObjectToVerifiablePresentationTransformer.java
+++ b/extensions/common/iam/identity-trust/identity-trust-transform/src/main/java/org/eclipse/edc/iam/identitytrust/transform/to/JsonObjectToVerifiablePresentationTransformer.java
@@ -58,13 +58,13 @@ public class JsonObjectToVerifiablePresentationTransformer extends AbstractJsonL
      * Credentials appear to be defined as "@graph", so that's what they're expanded to.
      */
     private void transformCredential(JsonValue jsonValue, VerifiablePresentation.Builder vpBuilder, TransformerContext context) {
-        if (jsonValue instanceof JsonArray) {
-            var content = ((JsonArray) jsonValue).get(0);
-            if (content instanceof JsonObject) {
-                var credArray = ((JsonObject) content).getJsonArray(JsonLdKeywords.GRAPH);
-                transformArrayOrObject(credArray, VerifiableCredential.class, vpBuilder::credential, context);
-
-            }
+        if (jsonValue instanceof JsonArray array) {
+            array.forEach(content -> {
+                if (content instanceof JsonObject) {
+                    var credArray = ((JsonObject) content).getJsonArray(JsonLdKeywords.GRAPH);
+                    transformArrayOrObject(credArray, VerifiableCredential.class, vpBuilder::credential, context);
+                }
+            });
         }
     }
 }

--- a/extensions/common/iam/identity-trust/identity-trust-transform/src/test/java/org/eclipse/edc/iam/identitytrust/transform/to/JsonObjectToPresentationQueryTransformerTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-transform/src/test/java/org/eclipse/edc/iam/identitytrust/transform/to/JsonObjectToPresentationQueryTransformerTest.java
@@ -78,6 +78,33 @@ class JsonObjectToPresentationQueryTransformerTest {
     }
 
     @Test
+    void transform_withScopes_separatedByWhitespace() throws JsonProcessingException {
+        var obj = """
+                {
+                  "@context": [
+                    "https://identity.foundation/presentation-exchange/submission/v1",
+                    "https://w3id.org/tractusx-trust/v0.8"
+                  ],
+                  "@type": "Query",
+                  "scope": [
+                    "org.eclipse.edc.vc.type:TestCredential:read org.eclipse.edc.vc.type:AnotherCredential:all"
+                  ]
+                }
+                """;
+        var json = mapper.readValue(obj, JsonObject.class);
+        var jo = jsonLd.expand(json);
+        assertThat(jo.succeeded()).withFailMessage(jo::getFailureDetail).isTrue();
+
+        var query = transformer.transform(jo.getContent(), context);
+        assertThat(query).isNotNull();
+        assertThat(query.getScopes()).hasSize(2)
+                .containsExactlyInAnyOrder(
+                        "org.eclipse.edc.vc.type:TestCredential:read",
+                        "org.eclipse.edc.vc.type:AnotherCredential:all");
+        assertThat(query.getPresentationDefinition()).isNull();
+    }
+
+    @Test
     void transform_withPresentationDefinition() throws JsonProcessingException {
         var json = """
                 {

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/iam/TokenParameters.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/iam/TokenParameters.java
@@ -16,7 +16,6 @@ package org.eclipse.edc.spi.iam;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * Parameter Object for {@link IdentityService#obtainClientCredentials(TokenParameters)}.
@@ -73,7 +72,6 @@ public class TokenParameters {
         }
 
         public TokenParameters build() {
-            Objects.requireNonNull(result.audience, "audience");
             return result;
         }
     }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/QueryResolver.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/QueryResolver.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.edc.spi.query;
 
+import java.util.function.BinaryOperator;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 /**
@@ -28,8 +30,20 @@ public interface QueryResolver<T> {
      * Method to query a stream by provided specification.
      *
      * @param stream stream to be queried.
-     * @param spec query specification.
+     * @param spec   query specification.
      * @return stream result from queries.
      */
-    Stream<T> query(Stream<T> stream, QuerySpec spec);
+    default Stream<T> query(Stream<T> stream, QuerySpec spec) {
+        return query(stream, spec, Predicate::and);
+    }
+
+    /**
+     * Method to query a stream by provided specification, using the provided accumulator
+     *
+     * @param stream      stream to be queried.
+     * @param spec        query specification.
+     * @param accumulator binary accumulation operator, e.g. Predicate::and, Predicate::or, etc.
+     * @return stream result from queries.
+     */
+    Stream<T> query(Stream<T> stream, QuerySpec spec, BinaryOperator<Predicate<Object>> accumulator);
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/QueryResolver.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/QueryResolver.java
@@ -34,7 +34,7 @@ public interface QueryResolver<T> {
      * @return stream result from queries.
      */
     default Stream<T> query(Stream<T> stream, QuerySpec spec) {
-        return query(stream, spec, Predicate::and);
+        return query(stream, spec, Predicate::and, x -> true);
     }
 
     /**
@@ -45,5 +45,5 @@ public interface QueryResolver<T> {
      * @param accumulator binary accumulation operator, e.g. Predicate::and, Predicate::or, etc.
      * @return stream result from queries.
      */
-    Stream<T> query(Stream<T> stream, QuerySpec spec, BinaryOperator<Predicate<Object>> accumulator);
+    Stream<T> query(Stream<T> stream, QuerySpec spec, BinaryOperator<Predicate<Object>> accumulator, Predicate<Object> fallback);
 }

--- a/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/model/credentialservice/PresentationQuery.java
+++ b/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/model/credentialservice/PresentationQuery.java
@@ -32,7 +32,7 @@ public class PresentationQuery {
     public static final String PRESENTATION_QUERY_SCOPE_PROPERTY = IATP_PREFIX + "scope";
     public static final String PRESENTATION_QUERY_DEFINITION_PROPERTY = IATP_PREFIX + "presentationDefinition";
     public static final String PRESENTATION_QUERY_TYPE_PROPERTY = IATP_PREFIX + "Query";
-    private List<String> scopes = new ArrayList<>();
+    private final List<String> scopes = new ArrayList<>();
     private PresentationDefinition presentationDefinition;
 
     private PresentationQuery() {
@@ -58,7 +58,7 @@ public class PresentationQuery {
         }
 
         public Builder scopes(List<String> scopes) {
-            this.query.scopes = scopes;
+            this.query.scopes.addAll(scopes);
             return this;
         }
 


### PR DESCRIPTION
## What this PR changes/adds

This PR adds several minor features and fixes for IATP:
- extracts a `ClaimToken` from a VC
- performs URI comparison without fragment when comparing Issuer and VerificationMethod
- fixes a wrong extracton of DID#VerificationMethod.controller and DID#VerificationMethod.type
- adds a customizable accumulator operation to the predicate-based query resolver

## Why it does that


## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #3650

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
