### PR TITLE
chore: refactor move DspRequestHandlerImpl 

### DIFF
--- a/data-protocols/dsp/dsp-api-configuration/build.gradle.kts
+++ b/data-protocols/dsp/dsp-api-configuration/build.gradle.kts
@@ -23,9 +23,6 @@ dependencies {
     api(project(":data-protocols:dsp:dsp-http-spi"))
     implementation(project(":core:common:jersey-providers"))
     implementation(project(":core:common:transform-core"))
-    implementation(project(":extensions:common:http"))
-
-    implementation(libs.jakarta.rsApi)
 
     testImplementation(project(":core:common:junit"))
 }

--- a/data-protocols/dsp/dsp-api-configuration/src/main/java/org/eclipse/edc/protocol/dsp/api/configuration/DspApiConfigurationExtension.java
+++ b/data-protocols/dsp/dsp-api-configuration/src/main/java/org/eclipse/edc/protocol/dsp/api/configuration/DspApiConfigurationExtension.java
@@ -37,18 +37,14 @@ import org.eclipse.edc.core.transform.transformer.to.JsonValueToGenericTypeTrans
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.policy.model.AtomicConstraint;
 import org.eclipse.edc.policy.model.LiteralExpression;
-import org.eclipse.edc.protocol.dsp.api.configuration.message.DspRequestHandlerImpl;
-import org.eclipse.edc.protocol.dsp.spi.message.DspRequestHandler;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provides;
-import org.eclipse.edc.spi.iam.IdentityService;
 import org.eclipse.edc.spi.protocol.ProtocolWebhook;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
-import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 import org.eclipse.edc.web.jersey.jsonld.JerseyJsonLdInterceptor;
 import org.eclipse.edc.web.jersey.jsonld.ObjectMapperProvider;
 import org.eclipse.edc.web.spi.WebServer;
@@ -76,7 +72,7 @@ import static org.eclipse.edc.spi.CoreConstants.JSON_LD;
  * parameters.
  */
 @Extension(value = DspApiConfigurationExtension.NAME)
-@Provides({ DspApiConfiguration.class, ProtocolWebhook.class, DspRequestHandler.class })
+@Provides({ DspApiConfiguration.class, ProtocolWebhook.class })
 public class DspApiConfigurationExtension implements ServiceExtension {
 
     public static final String NAME = "Dataspace Protocol API Configuration Extension";
@@ -108,10 +104,6 @@ public class DspApiConfigurationExtension implements ServiceExtension {
     private JsonLd jsonLd;
     @Inject
     private TypeTransformerRegistry transformerRegistry;
-    @Inject
-    private IdentityService identityService;
-    @Inject
-    private JsonObjectValidatorRegistry validatorRegistry;
 
     @Override
     public String name() {
@@ -124,7 +116,6 @@ public class DspApiConfigurationExtension implements ServiceExtension {
         var dspWebhookAddress = context.getSetting(DSP_CALLBACK_ADDRESS, DEFAULT_DSP_CALLBACK_ADDRESS);
         context.registerService(DspApiConfiguration.class, new DspApiConfiguration(config.getContextAlias(), dspWebhookAddress));
         context.registerService(ProtocolWebhook.class, () -> dspWebhookAddress);
-        context.registerService(DspRequestHandler.class, new DspRequestHandlerImpl(context.getMonitor(), dspWebhookAddress, identityService, validatorRegistry, transformerRegistry));
 
         var jsonLdMapper = typeManager.getMapper(JSON_LD);
 

--- a/data-protocols/dsp/dsp-api-configuration/src/test/java/org/eclipse/edc/protocol/dsp/api/configuration/DspApiConfigurationExtensionTest.java
+++ b/data-protocols/dsp/dsp-api-configuration/src/test/java/org/eclipse/edc/protocol/dsp/api/configuration/DspApiConfigurationExtensionTest.java
@@ -15,8 +15,6 @@
 package org.eclipse.edc.protocol.dsp.api.configuration;
 
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
-import org.eclipse.edc.protocol.dsp.api.configuration.message.DspRequestHandlerImpl;
-import org.eclipse.edc.protocol.dsp.spi.message.DspRequestHandler;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.eclipse.edc.spi.types.TypeManager;
@@ -46,7 +44,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(DependencyInjectionExtension.class)
 class DspApiConfigurationExtensionTest {
-    
+
     private final WebServiceConfigurer configurer = mock();
     private final WebServer webServer = mock();
     private final WebService webService = mock();
@@ -67,20 +65,20 @@ class DspApiConfigurationExtensionTest {
         when(configurer.configure(any(), any(), any())).thenReturn(webServiceConfiguration);
         when(typeManager.getMapper(any())).thenReturn(mock());
     }
-    
+
     @Test
     void initialize_noSettingsProvided_useDspDefault(DspApiConfigurationExtension extension, ServiceExtensionContext context) {
         when(context.getConfig()).thenReturn(ConfigFactory.empty());
         when(context.getSetting(DSP_CALLBACK_ADDRESS, DEFAULT_DSP_CALLBACK_ADDRESS)).thenReturn(DEFAULT_DSP_CALLBACK_ADDRESS);
-        
+
         extension.initialize(context);
-        
+
         verify(configurer).configure(context, webServer, SETTINGS);
         var apiConfig = context.getService(DspApiConfiguration.class);
         assertThat(apiConfig.getContextAlias()).isEqualTo(CONTEXT_ALIAS);
         assertThat(apiConfig.getDspCallbackAddress()).isEqualTo(DEFAULT_DSP_CALLBACK_ADDRESS);
     }
-    
+
     @Test
     void initialize_settingsProvided_useSettings(DspApiConfigurationExtension extension, ServiceExtensionContext context) {
         var webhookAddress = "http://webhook";
@@ -89,9 +87,9 @@ class DspApiConfigurationExtensionTest {
                 "web.http.protocol.path", "/path"))
         );
         when(context.getSetting(DSP_CALLBACK_ADDRESS, DEFAULT_DSP_CALLBACK_ADDRESS)).thenReturn(webhookAddress);
-        
+
         extension.initialize(context);
-    
+
         verify(configurer).configure(context, webServer, SETTINGS);
         var apiConfig = context.getService(DspApiConfiguration.class);
         assertThat(apiConfig.getContextAlias()).isEqualTo(CONTEXT_ALIAS);
@@ -105,11 +103,5 @@ class DspApiConfigurationExtensionTest {
         verify(webService).registerResource(eq(CONTEXT_ALIAS), isA(ObjectMapperProvider.class));
         verify(webService).registerResource(eq(CONTEXT_ALIAS), isA(JerseyJsonLdInterceptor.class));
     }
-
-    @Test
-    void initialize_shouldProvideServices(DspApiConfigurationExtension extension, ServiceExtensionContext context) {
-        extension.initialize(context);
-
-        verify(context).registerService(eq(DspRequestHandler.class), isA(DspRequestHandlerImpl.class));
-    }
+    
 }

--- a/data-protocols/dsp/dsp-http-core/build.gradle.kts
+++ b/data-protocols/dsp/dsp-http-core/build.gradle.kts
@@ -19,11 +19,13 @@ plugins {
 dependencies {
     api(project(":spi:common:http-spi"))
     api(project(":spi:common:json-ld-spi"))
+    api(project(":spi:common:validator-spi"))
     api(project(":spi:control-plane:contract-spi"))
     api(project(":spi:control-plane:transfer-spi"))
     api(project(":extensions:common:json-ld"))
     api(project(":data-protocols:dsp:dsp-spi"))
     api(project(":data-protocols:dsp:dsp-http-spi"))
-
+    
+    testImplementation(project(":extensions:common:http"))
     testImplementation(project(":core:common:junit"))
 }

--- a/data-protocols/dsp/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/message/DspRequestHandlerImpl.java
+++ b/data-protocols/dsp/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/message/DspRequestHandlerImpl.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.protocol.dsp.api.configuration.message;
+package org.eclipse.edc.protocol.dsp.message;
 
 import jakarta.json.JsonObject;
 import jakarta.ws.rs.core.MediaType;
@@ -32,7 +32,7 @@ import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 import java.util.Objects;
 import java.util.UUID;
 
-import static org.eclipse.edc.protocol.dsp.api.configuration.error.DspErrorResponse.type;
+import static org.eclipse.edc.protocol.dsp.spi.error.DspErrorResponse.type;
 import static org.eclipse.edc.protocol.dsp.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP;
 
 public class DspRequestHandlerImpl implements DspRequestHandler {
@@ -163,7 +163,7 @@ public class DspRequestHandlerImpl implements DspRequestHandler {
                         return Objects.equals(request.getProcessId(), processRemoteMessage.getProcessId())
                                 ? Result.success(message)
                                 : Result.failure("DSP: Invalid process ID. Expected: %s, actual: %s"
-                                    .formatted(request.getProcessId(), processRemoteMessage.getProcessId()));
+                                .formatted(request.getProcessId(), processRemoteMessage.getProcessId()));
                     } else {
                         return Result.success(message);
                     }

--- a/data-protocols/dsp/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/DspHttpCoreExtensionTest.java
+++ b/data-protocols/dsp/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/DspHttpCoreExtensionTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.protocol.dsp;
 
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.protocol.dsp.message.DspRequestHandlerImpl;
 import org.eclipse.edc.spi.iam.IdentityService;
 import org.eclipse.edc.spi.iam.TokenDecorator;
 import org.eclipse.edc.spi.result.Result;
@@ -25,6 +26,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
@@ -68,5 +70,15 @@ class DspHttpCoreExtensionTest {
         dispatcher.dispatch(String.class, new TestMessage("protocol", "address"));
 
         verify(identityService).obtainClientCredentials(argThat(tokenParams -> tokenParams.getScope().equals("test-scope")));
+    }
+
+    @Test
+    @DisplayName("Assert creation of a DspRequestHandlerImpl")
+    void createDspRequestHandler(DspHttpCoreExtension extension) {
+
+        var handler = extension.dspRequestHandler();
+
+        assertThat(handler).isInstanceOf(DspRequestHandlerImpl.class);
+
     }
 }

--- a/data-protocols/dsp/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/message/DspRequestHandlerImplTest.java
+++ b/data-protocols/dsp/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/message/DspRequestHandlerImplTest.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.protocol.dsp.api.configuration.message;
+package org.eclipse.edc.protocol.dsp.message;
 
 import jakarta.json.Json;
 import jakarta.json.JsonObject;

--- a/data-protocols/dsp/dsp-http-spi/build.gradle.kts
+++ b/data-protocols/dsp/dsp-http-spi/build.gradle.kts
@@ -19,6 +19,7 @@ plugins {
 
 dependencies {
     api(project(":spi:common:core-spi"))
+    api(project(":data-protocols:dsp:dsp-spi"))
 
     api(libs.okhttp)
     api(libs.jakartaJson)

--- a/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/spi/error/DspErrorResponse.java
+++ b/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/spi/error/DspErrorResponse.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.protocol.dsp.api.configuration.error;
+package org.eclipse.edc.protocol.dsp.spi.error;
 
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
@@ -25,7 +25,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Utility class for building DSP error {@link jakarta.ws.rs.core.Response}
+ * Utility class for building DSP error {@link Response}
  */
 public class DspErrorResponse {
 

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-api/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/api/controller/DspTransferProcessApiController.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-api/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/api/controller/DspTransferProcessApiController.java
@@ -30,7 +30,7 @@ import org.eclipse.edc.connector.transfer.spi.types.protocol.TransferCompletionM
 import org.eclipse.edc.connector.transfer.spi.types.protocol.TransferRequestMessage;
 import org.eclipse.edc.connector.transfer.spi.types.protocol.TransferStartMessage;
 import org.eclipse.edc.connector.transfer.spi.types.protocol.TransferTerminationMessage;
-import org.eclipse.edc.protocol.dsp.api.configuration.error.DspErrorResponse;
+import org.eclipse.edc.protocol.dsp.spi.error.DspErrorResponse;
 import org.eclipse.edc.protocol.dsp.spi.message.DspRequestHandler;
 import org.eclipse.edc.protocol.dsp.spi.message.GetDspRequest;
 import org.eclipse.edc.protocol.dsp.spi.message.PostDspRequest;


### PR DESCRIPTION
## What this PR changes/adds

- move `DspRequestHandlerImpl`  into `dsp-http-core` module.
- move `DspErrorResponse` into `dsp-http-spi` module.

## Why it does that

preparatory refactor for #3662 


_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
