### PR TITLE
docs: decision record about Protocol Services refactor

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -81,7 +81,7 @@ maven/mavencentral/com.jcraft/jzlib/1.1.3, BSD-2-Clause, approved, CQ6218
 maven/mavencentral/com.lmax/disruptor/3.4.4, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.networknt/json-schema-validator/1.0.76, Apache-2.0, approved, CQ22638
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.28, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.37, Apache-2.0, approved, #11086
+maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.37, Apache-2.0, approved, #11701
 maven/mavencentral/com.puppycrawl.tools/checkstyle/10.0, LGPL-2.1-or-later, approved, #7936
 maven/mavencentral/com.samskivert/jmustache/1.15, BSD-2-Clause, approved, clearlydefined
 maven/mavencentral/com.squareup.okhttp3/okhttp-dnsoverhttps/4.12.0, Apache-2.0, approved, #11159

--- a/docs/developer/decision-records/2023-11-27-refactor-protocol-services/README.md
+++ b/docs/developer/decision-records/2023-11-27-refactor-protocol-services/README.md
@@ -8,7 +8,7 @@ to the protocol service layer.
 ## Rationale
 
 Implementations of `IdentityService`s may need additional context/request information when verifying the JWT token. At the
-DSP (or other protocols) layer we don't have such information. Moving the security checks on the protocol services layer will 
+DSP (or other protocols) layer we don't have such information. Moving the security checks to the protocol services layer will 
 allow us to attach contextual information to a specific request (e.g. current policy if any).
 
 ## Approach

--- a/docs/developer/decision-records/2023-11-27-refactor-protocol-services/README.md
+++ b/docs/developer/decision-records/2023-11-27-refactor-protocol-services/README.md
@@ -1,0 +1,34 @@
+# Protocol Services Refactor
+
+## Decision
+
+Decouple the DSP (or other) protocol from the identity service and move the security checks (`IdentityService#verifyJwtToken`) 
+to the protocol service layer.
+
+## Rationale
+
+Implementations of `IdentityService`s may need additional context/request information when verifying the JWT token. At the
+DSP (or other protocols) layer we don't have such information. Moving the security checks on the protocol services layer will 
+allow us to attach contextual information to a specific request (e.g. current policy if any).
+
+## Approach
+
+We will remove the usage of `IdentityService` from the `DspRequestHandlerImpl` and change the `serviceCall` field in `DspRequest`
+
+from:
+
+```java
+BiFunction<I, ClaimToken, ServiceResult<R>> serviceCall;
+```
+to:
+```java
+BiFunction<I, TokenRepresentation, ServiceResult<R>> serviceCall;
+```
+
+This will impact each method of the three protocol service we have now:
+
+- `CatalogProtocolService`
+- `TransferProcessProtocolService`
+- `ContractNegotiationProtocolService`
+
+In each implementation of such services, we'd have to call then the `IdentityService` for verifying the JWT token. 

--- a/docs/developer/decision-records/README.md
+++ b/docs/developer/decision-records/README.md
@@ -50,3 +50,5 @@
 - [2023-09-07 Policy Monitor](./2023-09-07-policy-monitor)
 - [2023-10-04 JSON-LD Scopes](./2023-10-04-json-ld-scopes)
 - [2023-11-09 API Versioning](./2023-11-09-api-versioning)
+- [2023-11-09 Protocol Services Refactor](./2023-11-27-refactor-protocol-services)
+


### PR DESCRIPTION
## What this PR changes/adds

Adds a Decision Record about moving the security checks (`IdentityService#verifyJwtToken`) from the DSP layer
to the protocol service layer.

## Why it does that

This refactor will allow us to attach contextual information of the current DSP request that can be used in `IdentityService` implementations.

## Linked Issue(s)

Relates #3662 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
