### PR TITLE
fix: only pass base URL for the CredentialService

### DIFF
--- a/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/defaults/DefaultCredentialServiceClient.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/defaults/DefaultCredentialServiceClient.java
@@ -46,6 +46,7 @@ import static org.eclipse.edc.spi.result.Result.failure;
 import static org.eclipse.edc.spi.result.Result.success;
 
 public class DefaultCredentialServiceClient implements CredentialServiceClient {
+    public static final String PRESENTATION_ENDPOINT = "/presentation/query";
     private final EdcHttpClient httpClient;
     private final JsonBuilderFactory jsonFactory;
     private final ObjectMapper objectMapper;
@@ -63,14 +64,16 @@ public class DefaultCredentialServiceClient implements CredentialServiceClient {
     }
 
     @Override
-    public Result<List<VerifiablePresentationContainer>> requestPresentation(String credentialServiceUrl, String selfIssuedTokenJwt, List<String> scopes) {
+    public Result<List<VerifiablePresentationContainer>> requestPresentation(String credentialServiceBaseUrl, String selfIssuedTokenJwt, List<String> scopes) {
         var query = createPresentationQuery(scopes);
+
+        var url = credentialServiceBaseUrl + PRESENTATION_ENDPOINT;
 
         try {
             var requestJson = objectMapper.writeValueAsString(query);
             var request = new Request.Builder()
                     .post(RequestBody.create(requestJson, MediaType.parse("application/json")))
-                    .url(credentialServiceUrl)
+                    .url(url)
                     .addHeader("Authorization", "%s".formatted(selfIssuedTokenJwt))
                     .build();
 

--- a/extensions/common/iam/identity-trust/identity-trust-core/src/test/java/org/eclipse/edc/iam/identitytrust/core/defaults/DefaultCredentialServiceClientTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/test/java/org/eclipse/edc/iam/identitytrust/core/defaults/DefaultCredentialServiceClientTest.java
@@ -43,8 +43,10 @@ import static org.eclipse.edc.jsonld.util.JacksonJsonLd.createObjectMapper;
 import static org.eclipse.edc.junit.testfixtures.TestUtils.getResourceFileContentAsString;
 import static org.eclipse.edc.spi.result.Result.success;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class DefaultCredentialServiceClientTest {
@@ -73,6 +75,7 @@ class DefaultCredentialServiceClientTest {
         var result = client.requestPresentation(CS_URL, "foo", List.of());
         assertThat(result.succeeded()).isTrue();
         assertThat(result.getContent()).hasSize(1).allMatch(vpc -> vpc.format() == CredentialFormat.JSON_LD);
+        verify(httpClientMock).execute(argThat(rq -> rq.url().toString().endsWith("/presentation/query")));
     }
 
     @Test
@@ -84,6 +87,7 @@ class DefaultCredentialServiceClientTest {
         var result = client.requestPresentation(CS_URL, "foo", List.of());
         assertThat(result.succeeded()).isTrue();
         assertThat(result.getContent()).hasSize(1).allMatch(vpc -> vpc.format() == CredentialFormat.JWT);
+        verify(httpClientMock).execute(argThat(rq -> rq.url().toString().endsWith("/presentation/query")));
     }
 
     @Test
@@ -97,6 +101,7 @@ class DefaultCredentialServiceClientTest {
         assertThat(result.getContent()).hasSize(2)
                 .anySatisfy(vp -> assertThat(vp.format()).isEqualTo(CredentialFormat.JSON_LD))
                 .anySatisfy(vp -> assertThat(vp.format()).isEqualTo(CredentialFormat.JWT));
+        verify(httpClientMock).execute(argThat(rq -> rq.url().toString().endsWith("/presentation/query")));
     }
 
     @Test
@@ -109,6 +114,7 @@ class DefaultCredentialServiceClientTest {
         assertThat(result.succeeded()).isTrue();
         assertThat(result.getContent()).hasSize(2)
                 .allSatisfy(vp -> assertThat(vp.format()).isEqualTo(CredentialFormat.JSON_LD));
+        verify(httpClientMock).execute(argThat(rq -> rq.url().toString().endsWith("/presentation/query")));
     }
 
     @Test
@@ -121,6 +127,7 @@ class DefaultCredentialServiceClientTest {
         assertThat(result.succeeded()).isTrue();
         assertThat(result.getContent()).hasSize(2)
                 .allSatisfy(vp -> assertThat(vp.format()).isEqualTo(CredentialFormat.JWT));
+        verify(httpClientMock).execute(argThat(rq -> rq.url().toString().endsWith("/presentation/query")));
     }
 
     @ParameterizedTest(name = "CS returns HTTP error code {0}")
@@ -132,6 +139,7 @@ class DefaultCredentialServiceClientTest {
         var res = client.requestPresentation(CS_URL, "foo", List.of());
         assertThat(res.failed()).isTrue();
         assertThat(res.getFailureDetail()).isEqualTo("Presentation Query failed: HTTP %s, message: Test failure".formatted(httpCode));
+        verify(httpClientMock).execute(argThat(rq -> rq.url().toString().endsWith("/presentation/query")));
     }
 
     @DisplayName("CS returns an empty array, because no VC was found")
@@ -143,6 +151,7 @@ class DefaultCredentialServiceClientTest {
         var res = client.requestPresentation(CS_URL, "foo", List.of());
         assertThat(res.succeeded()).isTrue();
         assertThat(res.getContent()).isNotNull().doesNotContainNull().isEmpty();
+        verify(httpClientMock).execute(argThat(rq -> rq.url().toString().endsWith("/presentation/query")));
     }
 
     private VerifiablePresentation createPresentation() {


### PR DESCRIPTION
## What this PR changes/adds

This PR changes the url that is passed into the CredentialServiceClient to be just the base URL, as opposed to: the URL including the query endpoint.

## Why it does that

Typically, these URLs are resolved from DIDs, that only should contain the base URL, because the actual endpoint is an implementation detail, that does not affect the DID. 
For example, a bump in the API version would then cause all DIDs to be regenerated, which is nonsense.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
