### PR TITLE
refactor: moved security checks in protocol service layer

### DIFF
--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -37,6 +37,8 @@ import org.eclipse.edc.policy.model.Duty;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.policy.model.PolicyType;
 import org.eclipse.edc.spi.iam.ClaimToken;
+import org.eclipse.edc.spi.iam.IdentityService;
+import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.monitor.ConsoleMonitor;
 import org.eclipse.edc.spi.protocol.ProtocolWebhook;
@@ -85,7 +87,9 @@ class ContractNegotiationIntegrationTest {
     private final ContractValidationService validationService = mock(ContractValidationService.class);
     private final RemoteMessageDispatcherRegistry providerDispatcherRegistry = mock(RemoteMessageDispatcherRegistry.class);
     private final RemoteMessageDispatcherRegistry consumerDispatcherRegistry = mock(RemoteMessageDispatcherRegistry.class);
+    private final IdentityService identityService = mock();
     protected ClaimToken token = ClaimToken.Builder.newInstance().build();
+    protected TokenRepresentation tokenRepresentation = TokenRepresentation.Builder.newInstance().build();
     private final ProtocolWebhook protocolWebhook = () -> "http://dummy";
     private String consumerNegotiationId;
 
@@ -119,8 +123,9 @@ class ContractNegotiationIntegrationTest {
                 .protocolWebhook(protocolWebhook)
                 .build();
 
-        consumerService = new ContractNegotiationProtocolServiceImpl(consumerStore, new NoopTransactionContext(), validationService, new ContractNegotiationObservableImpl(), monitor, mock(Telemetry.class));
-        providerService = new ContractNegotiationProtocolServiceImpl(providerStore, new NoopTransactionContext(), validationService, new ContractNegotiationObservableImpl(), monitor, mock(Telemetry.class));
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(token));
+        consumerService = new ContractNegotiationProtocolServiceImpl(consumerStore, new NoopTransactionContext(), validationService, identityService, new ContractNegotiationObservableImpl(), monitor, mock(Telemetry.class));
+        providerService = new ContractNegotiationProtocolServiceImpl(providerStore, new NoopTransactionContext(), validationService, identityService, new ContractNegotiationObservableImpl(), monitor, mock(Telemetry.class));
     }
 
     @AfterEach
@@ -261,7 +266,7 @@ class ContractNegotiationIntegrationTest {
         return i -> {
             ContractRequestMessage request = i.getArgument(1);
             consumerNegotiationId = request.getProcessId();
-            var result = providerService.notifyRequested(request, token);
+            var result = providerService.notifyRequested(request, tokenRepresentation);
             return toFuture(result);
         };
     }
@@ -270,7 +275,7 @@ class ContractNegotiationIntegrationTest {
     private Answer<Object> onConsumerSentRejection() {
         return i -> {
             ContractNegotiationTerminationMessage request = i.getArgument(1);
-            var result = providerService.notifyTerminated(request, token);
+            var result = providerService.notifyTerminated(request, tokenRepresentation);
             return toFuture(result);
         };
     }
@@ -279,7 +284,7 @@ class ContractNegotiationIntegrationTest {
     private Answer<Object> onProviderSentAgreementRequest() {
         return i -> {
             ContractAgreementMessage request = i.getArgument(1);
-            var result = consumerService.notifyAgreed(request, token);
+            var result = consumerService.notifyAgreed(request, tokenRepresentation);
             return toFuture(result);
         };
     }
@@ -288,7 +293,7 @@ class ContractNegotiationIntegrationTest {
     private Answer<Object> onProviderSentNegotiationEventMessage() {
         return i -> {
             ContractNegotiationEventMessage request = i.getArgument(1);
-            var result = consumerService.notifyFinalized(request, token);
+            var result = consumerService.notifyFinalized(request, tokenRepresentation);
             return toFuture(result);
         };
     }
@@ -297,7 +302,7 @@ class ContractNegotiationIntegrationTest {
     private Answer<Object> onConsumerSentAgreementVerification() {
         return i -> {
             ContractAgreementVerificationMessage request = i.getArgument(1);
-            var result = providerService.notifyVerified(request, token);
+            var result = providerService.notifyVerified(request, tokenRepresentation);
             return toFuture(result);
         };
     }
@@ -306,7 +311,7 @@ class ContractNegotiationIntegrationTest {
     private Answer<Object> onProviderSentRejection() {
         return i -> {
             ContractNegotiationTerminationMessage request = i.getArgument(1);
-            var result = consumerService.notifyTerminated(request, token);
+            var result = consumerService.notifyTerminated(request, tokenRepresentation);
             return toFuture(result);
         };
     }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/ControlPlaneServicesExtension.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/ControlPlaneServicesExtension.java
@@ -58,6 +58,7 @@ import org.eclipse.edc.spi.agent.ParticipantAgentService;
 import org.eclipse.edc.spi.asset.AssetIndex;
 import org.eclipse.edc.spi.command.CommandHandlerRegistry;
 import org.eclipse.edc.spi.event.EventRouter;
+import org.eclipse.edc.spi.iam.IdentityService;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.system.ServiceExtension;
@@ -136,6 +137,9 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     @Inject
     private DataAddressValidatorRegistry dataAddressValidator;
 
+    @Inject
+    private IdentityService identityService;
+
     @Override
     public String name() {
         return NAME;
@@ -155,7 +159,7 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
 
     @Provider
     public CatalogProtocolService catalogProtocolService(ServiceExtensionContext context) {
-        return new CatalogProtocolServiceImpl(datasetResolver, participantAgentService, dataServiceRegistry, context.getParticipantId());
+        return new CatalogProtocolServiceImpl(datasetResolver, participantAgentService, dataServiceRegistry, identityService, monitor, context.getParticipantId());
     }
 
     @Provider
@@ -178,7 +182,7 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     @Provider
     public ContractNegotiationProtocolService contractNegotiationProtocolService() {
         return new ContractNegotiationProtocolServiceImpl(contractNegotiationStore,
-                transactionContext, contractValidationService, contractNegotiationObservable,
+                transactionContext, contractValidationService, identityService, contractNegotiationObservable,
                 monitor, telemetry);
     }
 
@@ -198,6 +202,6 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     @Provider
     public TransferProcessProtocolService transferProcessProtocolService() {
         return new TransferProcessProtocolServiceImpl(transferProcessStore, transactionContext, contractNegotiationStore,
-                contractValidationService, dataAddressValidator, transferProcessObservable, clock, monitor, telemetry);
+                contractValidationService, identityService, dataAddressValidator, transferProcessObservable, clock, monitor, telemetry);
     }
 }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/catalog/CatalogProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/catalog/CatalogProtocolServiceImpl.java
@@ -19,9 +19,12 @@ import org.eclipse.edc.catalog.spi.CatalogRequestMessage;
 import org.eclipse.edc.catalog.spi.DataServiceRegistry;
 import org.eclipse.edc.catalog.spi.Dataset;
 import org.eclipse.edc.catalog.spi.DatasetResolver;
+import org.eclipse.edc.connector.service.protocol.BaseProtocolService;
 import org.eclipse.edc.connector.spi.catalog.CatalogProtocolService;
 import org.eclipse.edc.spi.agent.ParticipantAgentService;
-import org.eclipse.edc.spi.iam.ClaimToken;
+import org.eclipse.edc.spi.iam.IdentityService;
+import org.eclipse.edc.spi.iam.TokenRepresentation;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.jetbrains.annotations.NotNull;
 
@@ -29,7 +32,7 @@ import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 
-public class CatalogProtocolServiceImpl implements CatalogProtocolService {
+public class CatalogProtocolServiceImpl extends BaseProtocolService implements CatalogProtocolService {
 
     private static final String PARTICIPANT_ID_PROPERTY_KEY = "participantId";
 
@@ -40,7 +43,11 @@ public class CatalogProtocolServiceImpl implements CatalogProtocolService {
 
     public CatalogProtocolServiceImpl(DatasetResolver datasetResolver,
                                       ParticipantAgentService participantAgentService,
-                                      DataServiceRegistry dataServiceRegistry, String participantId) {
+                                      DataServiceRegistry dataServiceRegistry,
+                                      IdentityService identityService,
+                                      Monitor monitor,
+                                      String participantId) {
+        super(identityService, monitor);
         this.datasetResolver = datasetResolver;
         this.participantAgentService = participantAgentService;
         this.dataServiceRegistry = dataServiceRegistry;
@@ -49,32 +56,36 @@ public class CatalogProtocolServiceImpl implements CatalogProtocolService {
 
     @Override
     @NotNull
-    public ServiceResult<Catalog> getCatalog(CatalogRequestMessage message, ClaimToken claimToken) {
-        var agent = participantAgentService.createFor(claimToken);
+    public ServiceResult<Catalog> getCatalog(CatalogRequestMessage message, TokenRepresentation tokenRepresentation) {
+        return withClaimToken(tokenRepresentation, (claimToken) -> {
+            var agent = participantAgentService.createFor(claimToken);
 
-        try (var datasets = datasetResolver.query(agent, message.getQuerySpec())) {
-            var dataServices = dataServiceRegistry.getDataServices();
+            try (var datasets = datasetResolver.query(agent, message.getQuerySpec())) {
+                var dataServices = dataServiceRegistry.getDataServices();
 
-            var catalog = Catalog.Builder.newInstance()
-                    .dataServices(dataServices)
-                    .datasets(datasets.collect(toList()))
-                    .property(EDC_NAMESPACE + PARTICIPANT_ID_PROPERTY_KEY, participantId)
-                    .build();
+                var catalog = Catalog.Builder.newInstance()
+                        .dataServices(dataServices)
+                        .datasets(datasets.collect(toList()))
+                        .property(EDC_NAMESPACE + PARTICIPANT_ID_PROPERTY_KEY, participantId)
+                        .build();
 
-            return ServiceResult.success(catalog);
-        }
+                return ServiceResult.success(catalog);
+            }
+        });
     }
 
     @Override
-    public @NotNull ServiceResult<Dataset> getDataset(String datasetId, ClaimToken claimToken) {
-        var agent = participantAgentService.createFor(claimToken);
+    public @NotNull ServiceResult<Dataset> getDataset(String datasetId, TokenRepresentation tokenRepresentation) {
+        return withClaimToken(tokenRepresentation, (claimToken) -> {
+            var agent = participantAgentService.createFor(claimToken);
 
-        var dataset = datasetResolver.getById(agent, datasetId);
+            var dataset = datasetResolver.getById(agent, datasetId);
 
-        if (dataset == null) {
-            return ServiceResult.notFound(format("Dataset %s does not exist", datasetId));
-        }
+            if (dataset == null) {
+                return ServiceResult.notFound(format("Dataset %s does not exist", datasetId));
+            }
 
-        return ServiceResult.success(dataset);
+            return ServiceResult.success(dataset);
+        });
     }
 }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
@@ -72,7 +72,7 @@ public class ContractNegotiationProtocolServiceImpl extends BaseProtocolService 
     @WithSpan
     @NotNull
     public ServiceResult<ContractNegotiation> notifyRequested(ContractRequestMessage message, TokenRepresentation tokenRepresentation) {
-        return withClaimToken(tokenRepresentation, claimToken -> transactionContext.execute(() -> validateOffer(message, claimToken)
+        return verifyToken(tokenRepresentation).compose(claimToken -> transactionContext.execute(() -> validateOffer(message, claimToken)
                 .compose(validatedOffer -> getNegotiation(message)
                         .recover(f -> createNegotiation(message, validatedOffer))
                         .onSuccess(n -> n.addContractOffer(validatedOffer.getOffer()))
@@ -89,7 +89,7 @@ public class ContractNegotiationProtocolServiceImpl extends BaseProtocolService 
     @WithSpan
     @NotNull
     public ServiceResult<ContractNegotiation> notifyOffered(ContractOfferMessage message, TokenRepresentation tokenRepresentation) {
-        return withClaimToken(tokenRepresentation, claimToken -> transactionContext.execute(() -> getNegotiation(message)
+        return verifyToken(tokenRepresentation).compose(claimToken -> transactionContext.execute(() -> getNegotiation(message)
                 .compose(negotiation -> validateRequest(claimToken, negotiation))
                 .onSuccess(negotiation -> {
                     negotiation.addContractOffer(message.getContractOffer());
@@ -103,7 +103,7 @@ public class ContractNegotiationProtocolServiceImpl extends BaseProtocolService 
     @WithSpan
     @NotNull
     public ServiceResult<ContractNegotiation> notifyAccepted(ContractNegotiationEventMessage message, TokenRepresentation tokenRepresentation) {
-        return withClaimToken(tokenRepresentation, claimToken -> transactionContext.execute(() -> getNegotiation(message)
+        return verifyToken(tokenRepresentation).compose(claimToken -> transactionContext.execute(() -> getNegotiation(message)
                 .compose(negotiation -> validateRequest(claimToken, negotiation))
                 .onSuccess(negotiation -> {
                     negotiation.transitionAccepted();
@@ -117,7 +117,7 @@ public class ContractNegotiationProtocolServiceImpl extends BaseProtocolService 
     @WithSpan
     @NotNull
     public ServiceResult<ContractNegotiation> notifyAgreed(ContractAgreementMessage message, TokenRepresentation tokenRepresentation) {
-        return withClaimToken(tokenRepresentation, claimToken -> transactionContext.execute(() -> getNegotiation(message)
+        return verifyToken(tokenRepresentation).compose(claimToken -> transactionContext.execute(() -> getNegotiation(message)
                 .compose(negotiation -> validateAgreed(message, claimToken, negotiation))
                 .onSuccess(negotiation -> {
                     negotiation.setContractAgreement(message.getContractAgreement());
@@ -131,7 +131,7 @@ public class ContractNegotiationProtocolServiceImpl extends BaseProtocolService 
     @WithSpan
     @NotNull
     public ServiceResult<ContractNegotiation> notifyVerified(ContractAgreementVerificationMessage message, TokenRepresentation tokenRepresentation) {
-        return withClaimToken(tokenRepresentation, claimToken -> transactionContext.execute(() -> getNegotiation(message)
+        return verifyToken(tokenRepresentation).compose(claimToken -> transactionContext.execute(() -> getNegotiation(message)
                 .compose(negotiation -> validateRequest(claimToken, negotiation))
                 .onSuccess(negotiation -> {
                     negotiation.transitionVerified();
@@ -144,7 +144,7 @@ public class ContractNegotiationProtocolServiceImpl extends BaseProtocolService 
     @WithSpan
     @NotNull
     public ServiceResult<ContractNegotiation> notifyFinalized(ContractNegotiationEventMessage message, TokenRepresentation tokenRepresentation) {
-        return withClaimToken(tokenRepresentation, claimToken -> transactionContext.execute(() -> getNegotiation(message)
+        return verifyToken(tokenRepresentation).compose(claimToken -> transactionContext.execute(() -> getNegotiation(message)
                 .compose(negotiation -> validateRequest(claimToken, negotiation))
                 .onSuccess(negotiation -> {
                     negotiation.transitionFinalized();
@@ -157,7 +157,7 @@ public class ContractNegotiationProtocolServiceImpl extends BaseProtocolService 
     @WithSpan
     @NotNull
     public ServiceResult<ContractNegotiation> notifyTerminated(ContractNegotiationTerminationMessage message, TokenRepresentation tokenRepresentation) {
-        return withClaimToken(tokenRepresentation, claimToken -> transactionContext.execute(() -> getNegotiation(message)
+        return verifyToken(tokenRepresentation).compose(claimToken -> transactionContext.execute(() -> getNegotiation(message)
                 .compose(negotiation -> validateRequest(claimToken, negotiation))
                 .onSuccess(negotiation -> {
                     negotiation.transitionTerminated();
@@ -170,7 +170,7 @@ public class ContractNegotiationProtocolServiceImpl extends BaseProtocolService 
     @WithSpan
     @NotNull
     public ServiceResult<ContractNegotiation> findById(String id, TokenRepresentation tokenRepresentation) {
-        return withClaimToken(tokenRepresentation, claimToken -> transactionContext.execute(() -> Optional.ofNullable(store.findById(id))
+        return verifyToken(tokenRepresentation).compose(claimToken -> transactionContext.execute(() -> Optional.ofNullable(store.findById(id))
                 .map(negotiation -> validateRequest(claimToken, negotiation))
                 .orElse(ServiceResult.notFound("No negotiation with id %s found".formatted(id)))));
     }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
@@ -28,8 +28,11 @@ import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestM
 import org.eclipse.edc.connector.contract.spi.types.protocol.ContractRemoteMessage;
 import org.eclipse.edc.connector.contract.spi.validation.ContractValidationService;
 import org.eclipse.edc.connector.contract.spi.validation.ValidatedConsumerOffer;
+import org.eclipse.edc.connector.service.protocol.BaseProtocolService;
 import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationProtocolService;
 import org.eclipse.edc.spi.iam.ClaimToken;
+import org.eclipse.edc.spi.iam.IdentityService;
+import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.telemetry.Telemetry;
@@ -41,7 +44,7 @@ import java.util.UUID;
 
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation.Type.PROVIDER;
 
-public class ContractNegotiationProtocolServiceImpl implements ContractNegotiationProtocolService {
+public class ContractNegotiationProtocolServiceImpl extends BaseProtocolService implements ContractNegotiationProtocolService {
 
     private final ContractNegotiationStore store;
     private final TransactionContext transactionContext;
@@ -52,8 +55,11 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
 
     public ContractNegotiationProtocolServiceImpl(ContractNegotiationStore store,
                                                   TransactionContext transactionContext,
-                                                  ContractValidationService validationService, ContractNegotiationObservable observable,
+                                                  ContractValidationService validationService,
+                                                  IdentityService identityService,
+                                                  ContractNegotiationObservable observable,
                                                   Monitor monitor, Telemetry telemetry) {
+        super(identityService, monitor);
         this.store = store;
         this.transactionContext = transactionContext;
         this.validationService = validationService;
@@ -65,106 +71,108 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
     @Override
     @WithSpan
     @NotNull
-    public ServiceResult<ContractNegotiation> notifyRequested(ContractRequestMessage message, ClaimToken claimToken) {
-        return transactionContext.execute(() -> validateOffer(message, claimToken)
-                    .compose(validatedOffer -> getNegotiation(message)
-                            .recover(f -> createNegotiation(message, validatedOffer))
-                            .onSuccess(n -> n.addContractOffer(validatedOffer.getOffer()))
-                    )
-                    .onSuccess(negotiation -> {
-                        negotiation.transitionRequested();
-                        update(negotiation);
-                        observable.invokeForEach(l -> l.requested(negotiation));
-                    }));
+    public ServiceResult<ContractNegotiation> notifyRequested(ContractRequestMessage message, TokenRepresentation tokenRepresentation) {
+        return withClaimToken(tokenRepresentation, claimToken -> transactionContext.execute(() -> validateOffer(message, claimToken)
+                .compose(validatedOffer -> getNegotiation(message)
+                        .recover(f -> createNegotiation(message, validatedOffer))
+                        .onSuccess(n -> n.addContractOffer(validatedOffer.getOffer()))
+                )
+                .onSuccess(negotiation -> {
+                    negotiation.transitionRequested();
+                    update(negotiation);
+                    observable.invokeForEach(l -> l.requested(negotiation));
+                })));
+
     }
 
     @Override
     @WithSpan
     @NotNull
-    public ServiceResult<ContractNegotiation> notifyOffered(ContractOfferMessage message, ClaimToken claimToken) {
-        return transactionContext.execute(() -> getNegotiation(message)
+    public ServiceResult<ContractNegotiation> notifyOffered(ContractOfferMessage message, TokenRepresentation tokenRepresentation) {
+        return withClaimToken(tokenRepresentation, claimToken -> transactionContext.execute(() -> getNegotiation(message)
                 .compose(negotiation -> validateRequest(claimToken, negotiation))
                 .onSuccess(negotiation -> {
                     negotiation.addContractOffer(message.getContractOffer());
                     negotiation.transitionOffered();
                     update(negotiation);
                     observable.invokeForEach(l -> l.offered(negotiation));
-                }));
+                })));
     }
 
     @Override
     @WithSpan
     @NotNull
-    public ServiceResult<ContractNegotiation> notifyAccepted(ContractNegotiationEventMessage message, ClaimToken claimToken) {
-        return transactionContext.execute(() -> getNegotiation(message)
+    public ServiceResult<ContractNegotiation> notifyAccepted(ContractNegotiationEventMessage message, TokenRepresentation tokenRepresentation) {
+        return withClaimToken(tokenRepresentation, claimToken -> transactionContext.execute(() -> getNegotiation(message)
                 .compose(negotiation -> validateRequest(claimToken, negotiation))
                 .onSuccess(negotiation -> {
                     negotiation.transitionAccepted();
                     update(negotiation);
                     observable.invokeForEach(l -> l.accepted(negotiation));
-                }));
+                })));
+
     }
 
     @Override
     @WithSpan
     @NotNull
-    public ServiceResult<ContractNegotiation> notifyAgreed(ContractAgreementMessage message, ClaimToken claimToken) {
-        return transactionContext.execute(() -> getNegotiation(message)
+    public ServiceResult<ContractNegotiation> notifyAgreed(ContractAgreementMessage message, TokenRepresentation tokenRepresentation) {
+        return withClaimToken(tokenRepresentation, claimToken -> transactionContext.execute(() -> getNegotiation(message)
                 .compose(negotiation -> validateAgreed(message, claimToken, negotiation))
                 .onSuccess(negotiation -> {
                     negotiation.setContractAgreement(message.getContractAgreement());
                     negotiation.transitionAgreed();
                     update(negotiation);
                     observable.invokeForEach(l -> l.agreed(negotiation));
-                }));
+                })));
     }
 
     @Override
     @WithSpan
     @NotNull
-    public ServiceResult<ContractNegotiation> notifyVerified(ContractAgreementVerificationMessage message, ClaimToken claimToken) {
-        return transactionContext.execute(() -> getNegotiation(message)
+    public ServiceResult<ContractNegotiation> notifyVerified(ContractAgreementVerificationMessage message, TokenRepresentation tokenRepresentation) {
+        return withClaimToken(tokenRepresentation, claimToken -> transactionContext.execute(() -> getNegotiation(message)
                 .compose(negotiation -> validateRequest(claimToken, negotiation))
                 .onSuccess(negotiation -> {
                     negotiation.transitionVerified();
                     update(negotiation);
                     observable.invokeForEach(l -> l.verified(negotiation));
-                }));
+                })));
     }
 
     @Override
     @WithSpan
     @NotNull
-    public ServiceResult<ContractNegotiation> notifyFinalized(ContractNegotiationEventMessage message, ClaimToken claimToken) {
-        return transactionContext.execute(() -> getNegotiation(message)
+    public ServiceResult<ContractNegotiation> notifyFinalized(ContractNegotiationEventMessage message, TokenRepresentation tokenRepresentation) {
+        return withClaimToken(tokenRepresentation, claimToken -> transactionContext.execute(() -> getNegotiation(message)
                 .compose(negotiation -> validateRequest(claimToken, negotiation))
                 .onSuccess(negotiation -> {
                     negotiation.transitionFinalized();
                     update(negotiation);
                     observable.invokeForEach(l -> l.finalized(negotiation));
-                }));
+                })));
     }
 
     @Override
     @WithSpan
     @NotNull
-    public ServiceResult<ContractNegotiation> notifyTerminated(ContractNegotiationTerminationMessage message, ClaimToken claimToken) {
-        return transactionContext.execute(() -> getNegotiation(message)
+    public ServiceResult<ContractNegotiation> notifyTerminated(ContractNegotiationTerminationMessage message, TokenRepresentation tokenRepresentation) {
+        return withClaimToken(tokenRepresentation, claimToken -> transactionContext.execute(() -> getNegotiation(message)
                 .compose(negotiation -> validateRequest(claimToken, negotiation))
                 .onSuccess(negotiation -> {
                     negotiation.transitionTerminated();
                     update(negotiation);
                     observable.invokeForEach(l -> l.terminated(negotiation));
-                }));
+                })));
     }
 
     @Override
     @WithSpan
     @NotNull
-    public ServiceResult<ContractNegotiation> findById(String id, ClaimToken claimToken) {
-        return transactionContext.execute(() -> Optional.ofNullable(store.findById(id))
+    public ServiceResult<ContractNegotiation> findById(String id, TokenRepresentation tokenRepresentation) {
+        return withClaimToken(tokenRepresentation, claimToken -> transactionContext.execute(() -> Optional.ofNullable(store.findById(id))
                 .map(negotiation -> validateRequest(claimToken, negotiation))
-                .orElse(ServiceResult.notFound("No negotiation with id %s found".formatted(id))));
+                .orElse(ServiceResult.notFound("No negotiation with id %s found".formatted(id)))));
     }
 
     @NotNull

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/protocol/BaseProtocolService.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/protocol/BaseProtocolService.java
@@ -20,8 +20,6 @@ import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.ServiceResult;
 
-import java.util.function.Function;
-
 /**
  * Base class for all protocol service implementation. This will contain common logic such as validating the JWT token
  * and extracting the {@link ClaimToken}
@@ -41,10 +39,9 @@ public abstract class BaseProtocolService {
      * Validate and extract the {@link ClaimToken} from the input {@link TokenRepresentation} by using the {@link IdentityService}
      *
      * @param tokenRepresentation The input {@link TokenRepresentation}
-     * @param callback            The callback to invoke once the token has been validated and extracted
-     * @return The result of the callback invocation
+     * @return The {@link ClaimToken} if success, failure otherwise
      */
-    public <T> ServiceResult<T> withClaimToken(TokenRepresentation tokenRepresentation, Function<ClaimToken, ServiceResult<T>> callback) {
+    public ServiceResult<ClaimToken> verifyToken(TokenRepresentation tokenRepresentation) {
         // TODO: since we are pushing here the invocation of the IdentityService we don't know the audience here
         //  The audience removal will be tackle next. IdentityService that relies on this parameter would not work
         //  for the time being.
@@ -54,6 +51,6 @@ public abstract class BaseProtocolService {
             monitor.debug(() -> "Unauthorized: %s".formatted(result.getFailureDetail()));
             return ServiceResult.unauthorized("Unauthorized");
         }
-        return callback.apply(result.getContent());
+        return ServiceResult.success(result.getContent());
     }
 }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/protocol/BaseProtocolService.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/protocol/BaseProtocolService.java
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.service.protocol;
+
+import org.eclipse.edc.spi.iam.ClaimToken;
+import org.eclipse.edc.spi.iam.IdentityService;
+import org.eclipse.edc.spi.iam.TokenRepresentation;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.result.ServiceResult;
+
+import java.util.function.Function;
+
+/**
+ * Base class for all protocol service implementation. This will contain common logic such as validating the JWT token
+ * and extracting the {@link ClaimToken}
+ */
+public abstract class BaseProtocolService {
+
+    private final IdentityService identityService;
+
+    private final Monitor monitor;
+
+    protected BaseProtocolService(IdentityService identityService, Monitor monitor) {
+        this.identityService = identityService;
+        this.monitor = monitor;
+    }
+
+    /**
+     * Validate and extract the {@link ClaimToken} from the input {@link TokenRepresentation} by using the {@link IdentityService}
+     *
+     * @param tokenRepresentation The input {@link TokenRepresentation}
+     * @param callback            The callback to invoke once the token has been validated and extracted
+     * @return The result of the callback invocation
+     */
+    public <T> ServiceResult<T> withClaimToken(TokenRepresentation tokenRepresentation, Function<ClaimToken, ServiceResult<T>> callback) {
+        // TODO: since we are pushing here the invocation of the IdentityService we don't know the audience here
+        //  The audience removal will be tackle next. IdentityService that relies on this parameter would not work
+        //  for the time being.
+        var result = identityService.verifyJwtToken(tokenRepresentation, null);
+
+        if (result.failed()) {
+            monitor.debug(() -> "Unauthorized: %s".formatted(result.getFailureDetail()));
+            return ServiceResult.unauthorized("Unauthorized");
+        }
+        return callback.apply(result.getContent());
+    }
+}

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImpl.java
@@ -18,6 +18,7 @@ package org.eclipse.edc.connector.service.transferprocess;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.connector.contract.spi.validation.ContractValidationService;
+import org.eclipse.edc.connector.service.protocol.BaseProtocolService;
 import org.eclipse.edc.connector.spi.transferprocess.TransferProcessProtocolService;
 import org.eclipse.edc.connector.transfer.spi.observe.TransferProcessObservable;
 import org.eclipse.edc.connector.transfer.spi.observe.TransferProcessStartedData;
@@ -31,6 +32,8 @@ import org.eclipse.edc.connector.transfer.spi.types.protocol.TransferRequestMess
 import org.eclipse.edc.connector.transfer.spi.types.protocol.TransferStartMessage;
 import org.eclipse.edc.connector.transfer.spi.types.protocol.TransferTerminationMessage;
 import org.eclipse.edc.spi.iam.ClaimToken;
+import org.eclipse.edc.spi.iam.IdentityService;
+import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.ServiceResult;
@@ -50,7 +53,7 @@ import static org.eclipse.edc.connector.transfer.dataplane.spi.TransferDataPlane
 import static org.eclipse.edc.connector.transfer.spi.types.TransferProcess.Type.CONSUMER;
 import static org.eclipse.edc.connector.transfer.spi.types.TransferProcess.Type.PROVIDER;
 
-public class TransferProcessProtocolServiceImpl implements TransferProcessProtocolService {
+public class TransferProcessProtocolServiceImpl extends BaseProtocolService implements TransferProcessProtocolService {
 
     private final TransferProcessStore transferProcessStore;
     private final TransactionContext transactionContext;
@@ -65,8 +68,10 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
     public TransferProcessProtocolServiceImpl(TransferProcessStore transferProcessStore,
                                               TransactionContext transactionContext, ContractNegotiationStore negotiationStore,
                                               ContractValidationService contractValidationService,
+                                              IdentityService identityService,
                                               DataAddressValidatorRegistry dataAddressValidator, TransferProcessObservable observable,
                                               Clock clock, Monitor monitor, Telemetry telemetry) {
+        super(identityService, monitor);
         this.transferProcessStore = transferProcessStore;
         this.transactionContext = transactionContext;
         this.negotiationStore = negotiationStore;
@@ -81,50 +86,53 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
     @Override
     @WithSpan
     @NotNull
-    public ServiceResult<TransferProcess> notifyRequested(TransferRequestMessage message, ClaimToken claimToken) {
-        var destination = message.getDataDestination();
-        if (destination != null) {
-            var validDestination = dataAddressValidator.validateDestination(destination);
-            if (validDestination.failed()) {
-                return ServiceResult.badRequest(validDestination.getFailureMessages());
+    public ServiceResult<TransferProcess> notifyRequested(TransferRequestMessage message, TokenRepresentation tokenRepresentation) {
+        return withClaimToken(tokenRepresentation, (claimToken -> {
+            var destination = message.getDataDestination();
+            if (destination != null) {
+                var validDestination = dataAddressValidator.validateDestination(destination);
+                if (validDestination.failed()) {
+                    return ServiceResult.badRequest(validDestination.getFailureMessages());
+                }
             }
-        }
 
-        return transactionContext.execute(() ->
-                Optional.ofNullable(negotiationStore.findContractAgreement(message.getContractId()))
-                        .filter(agreement -> contractValidationService.validateAgreement(claimToken, agreement).succeeded())
-                        .map(agreement -> requestedAction(message, agreement.getAssetId()))
-                        .orElse(ServiceResult.conflict(format("Cannot process %s because %s", message.getClass().getSimpleName(), "agreement not found or not valid"))));
+            return transactionContext.execute(() ->
+                    Optional.ofNullable(negotiationStore.findContractAgreement(message.getContractId()))
+                            .filter(agreement -> contractValidationService.validateAgreement(claimToken, agreement).succeeded())
+                            .map(agreement -> requestedAction(message, agreement.getAssetId()))
+                            .orElse(ServiceResult.conflict(format("Cannot process %s because %s", message.getClass().getSimpleName(), "agreement not found or not valid"))));
+        }));
+
     }
 
     @Override
     @WithSpan
     @NotNull
-    public ServiceResult<TransferProcess> notifyStarted(TransferStartMessage message, ClaimToken claimToken) {
-        return onMessageDo(message, claimToken, transferProcess -> startedAction(message, transferProcess));
+    public ServiceResult<TransferProcess> notifyStarted(TransferStartMessage message, TokenRepresentation tokenRepresentation) {
+        return withClaimToken(tokenRepresentation, claimToken -> onMessageDo(message, claimToken, transferProcess -> startedAction(message, transferProcess)));
     }
 
     @Override
     @WithSpan
     @NotNull
-    public ServiceResult<TransferProcess> notifyCompleted(TransferCompletionMessage message, ClaimToken claimToken) {
-        return onMessageDo(message, claimToken, transferProcess -> completedAction(message, transferProcess));
+    public ServiceResult<TransferProcess> notifyCompleted(TransferCompletionMessage message, TokenRepresentation tokenRepresentation) {
+        return withClaimToken(tokenRepresentation, claimToken -> onMessageDo(message, claimToken, transferProcess -> completedAction(message, transferProcess)));
     }
 
     @Override
     @WithSpan
     @NotNull
-    public ServiceResult<TransferProcess> notifyTerminated(TransferTerminationMessage message, ClaimToken claimToken) {
-        return onMessageDo(message, claimToken, transferProcess -> terminatedAction(message, transferProcess));
+    public ServiceResult<TransferProcess> notifyTerminated(TransferTerminationMessage message, TokenRepresentation tokenRepresentation) {
+        return withClaimToken(tokenRepresentation, claimToken -> onMessageDo(message, claimToken, transferProcess -> terminatedAction(message, transferProcess)));
     }
 
     @Override
     @WithSpan
     @NotNull
-    public ServiceResult<TransferProcess> findById(String id, ClaimToken claimToken) {
-        return transactionContext.execute(() -> Optional.ofNullable(transferProcessStore.findById(id))
+    public ServiceResult<TransferProcess> findById(String id, TokenRepresentation tokenRepresentation) {
+        return withClaimToken(tokenRepresentation, claimToken -> transactionContext.execute(() -> Optional.ofNullable(transferProcessStore.findById(id))
                 .map(tp -> validateCounterParty(claimToken, tp))
-                .orElse(notFound(id)));
+                .orElse(notFound(id))));
     }
 
     @NotNull

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/asset/AssetEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/asset/AssetEventDispatchTest.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.connector.spi.asset.AssetService;
 import org.eclipse.edc.junit.extensions.EdcExtension;
 import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.event.EventSubscriber;
+import org.eclipse.edc.spi.iam.IdentityService;
 import org.eclipse.edc.spi.protocol.ProtocolWebhook;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
@@ -49,6 +50,7 @@ public class AssetEventDispatchTest {
     void setUp(EdcExtension extension) {
         extension.registerServiceMock(ProtocolWebhook.class, mock(ProtocolWebhook.class));
         extension.registerServiceMock(DataPlaneInstanceStore.class, mock(DataPlaneInstanceStore.class));
+        extension.registerServiceMock(IdentityService.class, mock());
         extension.setConfiguration(Map.of(
                 "web.http.port", String.valueOf(getFreePort()),
                 "web.http.path", "/api"

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/catalog/CatalogProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/catalog/CatalogProtocolServiceImplTest.java
@@ -24,7 +24,10 @@ import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.agent.ParticipantAgent;
 import org.eclipse.edc.spi.agent.ParticipantAgentService;
 import org.eclipse.edc.spi.iam.ClaimToken;
+import org.eclipse.edc.spi.iam.IdentityService;
+import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.ServiceFailure;
 import org.junit.jupiter.api.Test;
 
@@ -36,6 +39,7 @@ import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.spi.result.ServiceFailure.Reason.NOT_FOUND;
+import static org.eclipse.edc.spi.result.ServiceFailure.Reason.UNAUTHORIZED;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -47,21 +51,24 @@ class CatalogProtocolServiceImplTest {
     private final DatasetResolver datasetResolver = mock(DatasetResolver.class);
     private final ParticipantAgentService participantAgentService = mock(ParticipantAgentService.class);
     private final DataServiceRegistry dataServiceRegistry = mock(DataServiceRegistry.class);
-
-    private final CatalogProtocolServiceImpl service = new CatalogProtocolServiceImpl(datasetResolver, participantAgentService, dataServiceRegistry, "participantId");
+    private final IdentityService identityService = mock();
+    private final CatalogProtocolServiceImpl service = new CatalogProtocolServiceImpl(datasetResolver, participantAgentService, dataServiceRegistry, identityService, mock(), "participantId");
 
     @Test
     void getCatalog_shouldReturnCatalogWithConnectorDataServiceAndItsDataset() {
         var querySpec = QuerySpec.none();
         var message = CatalogRequestMessage.Builder.newInstance().protocol("protocol").querySpec(querySpec).build();
-        var token = createToken();
+        var token = create();
+        var tokenRepresentation = createTokenRepresentation();
         var participantAgent = createParticipantAgent();
         var dataService = DataService.Builder.newInstance().build();
+
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(token));
         when(dataServiceRegistry.getDataServices()).thenReturn(List.of(dataService));
         when(datasetResolver.query(any(), any())).thenReturn(Stream.of(createDataset()));
         when(participantAgentService.createFor(any())).thenReturn(participantAgent);
 
-        var result = service.getCatalog(message, token);
+        var result = service.getCatalog(message, tokenRepresentation);
 
         assertThat(result).isSucceeded().satisfies(catalog -> {
             assertThat(catalog.getDataServices()).hasSize(1).first().isSameAs(dataService);
@@ -72,14 +79,31 @@ class CatalogProtocolServiceImplTest {
     }
 
     @Test
+    void getCatalog_shouldFail_whenTokenValidationFails() {
+        var querySpec = QuerySpec.none();
+        var message = CatalogRequestMessage.Builder.newInstance().protocol("protocol").querySpec(querySpec).build();
+        var tokenRepresentation = createTokenRepresentation();
+
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.failure("unauthorized"));
+
+        var result = service.getCatalog(message, tokenRepresentation);
+
+        assertThat(result).isFailed().extracting(ServiceFailure::getReason).isEqualTo(UNAUTHORIZED);
+    }
+
+    @Test
     void getDataset_shouldReturnDataset() {
-        var claimToken = createToken();
+        var claimToken = create();
+        var tokenRepresentation = createTokenRepresentation();
+
         var participantAgent = createParticipantAgent();
         var dataset = createDataset();
+
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(claimToken));
         when(participantAgentService.createFor(any())).thenReturn(participantAgent);
         when(datasetResolver.getById(any(), any())).thenReturn(dataset);
 
-        var result = service.getDataset("datasetId", claimToken);
+        var result = service.getDataset("datasetId", tokenRepresentation);
 
         assertThat(result).isSucceeded().isEqualTo(dataset);
         verify(participantAgentService).createFor(claimToken);
@@ -88,14 +112,29 @@ class CatalogProtocolServiceImplTest {
 
     @Test
     void getDataset_shouldFail_whenDatasetIsNull() {
-        var claimToken = createToken();
+        var claimToken = create();
+        var tokenRepresentation = createTokenRepresentation();
         var participantAgent = createParticipantAgent();
+
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(claimToken));
         when(participantAgentService.createFor(any())).thenReturn(participantAgent);
         when(datasetResolver.getById(any(), any())).thenReturn(null);
 
-        var result = service.getDataset("datasetId", claimToken);
+        var result = service.getDataset("datasetId", tokenRepresentation);
 
         assertThat(result).isFailed().extracting(ServiceFailure::getReason).isEqualTo(NOT_FOUND);
+    }
+
+    @Test
+    void getDataset_shouldFail_whenTokenValidationFails() {
+        var querySpec = QuerySpec.none();
+        var tokenRepresentation = createTokenRepresentation();
+
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.failure("unauthorized"));
+
+        var result = service.getDataset("datasetId", tokenRepresentation);
+
+        assertThat(result).isFailed().extracting(ServiceFailure::getReason).isEqualTo(UNAUTHORIZED);
     }
 
     private ParticipantAgent createParticipantAgent() {
@@ -111,7 +150,11 @@ class CatalogProtocolServiceImplTest {
                 .build();
     }
 
-    private ClaimToken createToken() {
+    private ClaimToken create() {
         return ClaimToken.Builder.newInstance().build();
+    }
+
+    private TokenRepresentation createTokenRepresentation() {
+        return TokenRepresentation.Builder.newInstance().build();
     }
 }

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractdefinition/ContractDefinitionEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractdefinition/ContractDefinitionEventDispatchTest.java
@@ -23,6 +23,7 @@ import org.eclipse.edc.connector.spi.contractdefinition.ContractDefinitionServic
 import org.eclipse.edc.junit.extensions.EdcExtension;
 import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.event.EventSubscriber;
+import org.eclipse.edc.spi.iam.IdentityService;
 import org.eclipse.edc.spi.protocol.ProtocolWebhook;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -47,6 +48,7 @@ public class ContractDefinitionEventDispatchTest {
     void setUp(EdcExtension extension) {
         extension.registerServiceMock(ProtocolWebhook.class, mock(ProtocolWebhook.class));
         extension.registerServiceMock(DataPlaneInstanceStore.class, mock(DataPlaneInstanceStore.class));
+        extension.registerServiceMock(IdentityService.class, mock());
         extension.setConfiguration(Map.of(
                 "web.http.port", String.valueOf(getFreePort()),
                 "web.http.path", "/api"

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
@@ -33,10 +33,13 @@ import org.eclipse.edc.spi.asset.AssetIndex;
 import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.event.EventSubscriber;
 import org.eclipse.edc.spi.iam.ClaimToken;
+import org.eclipse.edc.spi.iam.IdentityService;
+import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcher;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.protocol.ProtocolWebhook;
 import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
@@ -46,6 +49,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Map;
+import java.util.UUID;
 
 import static java.util.Collections.emptyList;
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -54,6 +58,7 @@ import static org.eclipse.edc.junit.matchers.EventEnvelopeMatcher.isEnvelopeOf;
 import static org.eclipse.edc.junit.testfixtures.TestUtils.getFreePort;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -64,7 +69,11 @@ class ContractNegotiationEventDispatchTest {
     private static final String PROVIDER = "provider";
 
     private final EventSubscriber eventSubscriber = mock(EventSubscriber.class);
+    private final IdentityService identityService = mock();
     private final ClaimToken token = ClaimToken.Builder.newInstance().claim(ParticipantAgentService.DEFAULT_IDENTITY_CLAIM_KEY, CONSUMER).build();
+
+    private final TokenRepresentation tokenRepresentation = TokenRepresentation.Builder.newInstance().token(UUID.randomUUID().toString()).build();
+
 
     @BeforeEach
     void setUp(EdcExtension extension) {
@@ -77,6 +86,7 @@ class ContractNegotiationEventDispatchTest {
         extension.registerServiceMock(NegotiationWaitStrategy.class, () -> 1);
         extension.registerServiceMock(ProtocolWebhook.class, mock(ProtocolWebhook.class));
         extension.registerServiceMock(DataPlaneInstanceStore.class, mock(DataPlaneInstanceStore.class));
+        extension.registerServiceMock(IdentityService.class, identityService);
     }
 
     @Test
@@ -88,6 +98,7 @@ class ContractNegotiationEventDispatchTest {
                                                                        AssetIndex assetIndex) {
         dispatcherRegistry.register(succeedingDispatcher());
 
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(token));
         eventRouter.register(ContractNegotiationEvent.class, eventSubscriber);
         var policy = Policy.Builder.newInstance().build();
         var contractDefinition = ContractDefinition.Builder.newInstance()
@@ -100,7 +111,7 @@ class ContractNegotiationEventDispatchTest {
         policyDefinitionStore.create(PolicyDefinition.Builder.newInstance().id("policyId").policy(policy).build());
         assetIndex.create(Asset.Builder.newInstance().id("assetId").dataAddress(DataAddress.Builder.newInstance().type("any").build()).build());
 
-        service.notifyRequested(createContractOfferRequest(policy, "assetId"), token);
+        service.notifyRequested(createContractOfferRequest(policy, "assetId"), tokenRepresentation);
 
         await().untilAsserted(() -> {
             verify(eventSubscriber).on(argThat(isEnvelopeOf(ContractNegotiationRequested.class)));

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
@@ -30,6 +30,8 @@ import org.eclipse.edc.connector.contract.spi.validation.ValidatedConsumerOffer;
 import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationProtocolService;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.iam.ClaimToken;
+import org.eclipse.edc.spi.iam.IdentityService;
+import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.ServiceFailure;
 import org.eclipse.edc.spi.result.ServiceResult;
@@ -65,6 +67,7 @@ import static org.eclipse.edc.connector.service.contractnegotiation.ContractNego
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.spi.result.ServiceFailure.Reason.BAD_REQUEST;
 import static org.eclipse.edc.spi.result.ServiceFailure.Reason.NOT_FOUND;
+import static org.eclipse.edc.spi.result.ServiceFailure.Reason.UNAUTHORIZED;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -84,23 +87,23 @@ class ContractNegotiationProtocolServiceImplTest {
     private final TransactionContext transactionContext = spy(new NoopTransactionContext());
     private final ContractValidationService validationService = mock();
     private final ContractNegotiationListener listener = mock();
+    private final IdentityService identityService = mock();
     private ContractNegotiationProtocolService service;
 
     @BeforeEach
     void setUp() {
         var observable = new ContractNegotiationObservableImpl();
         observable.registerListener(listener);
-        service = new ContractNegotiationProtocolServiceImpl(store, transactionContext, validationService, observable,
+        service = new ContractNegotiationProtocolServiceImpl(store, transactionContext, validationService, identityService, observable,
                 mock(), mock());
     }
 
     @Test
     void notifyRequested_shouldInitiateNegotiation_whenNegotiationDoesNotExist() {
-        var token = ClaimToken.Builder.newInstance().build();
+        var claimToken = ClaimToken.Builder.newInstance().build();
+        var tokenRepresentation = tokenRepresentation();
         var contractOffer = contractOffer();
         var validatedOffer = new ValidatedConsumerOffer(CONSUMER_ID, contractOffer);
-        when(store.findByCorrelationIdAndLease(any())).thenReturn(StoreResult.notFound("not found"));
-        when(validationService.validateInitialOffer(token, contractOffer)).thenReturn(Result.success(validatedOffer));
         var message = ContractRequestMessage.Builder.newInstance()
                 .callbackAddress("callbackAddress")
                 .protocol("protocol")
@@ -108,7 +111,11 @@ class ContractNegotiationProtocolServiceImplTest {
                 .processId("processId")
                 .build();
 
-        var result = service.notifyRequested(message, token);
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(claimToken));
+        when(store.findByCorrelationIdAndLease(any())).thenReturn(StoreResult.notFound("not found"));
+        when(validationService.validateInitialOffer(claimToken, contractOffer)).thenReturn(Result.success(validatedOffer));
+
+        var result = service.notifyRequested(message, tokenRepresentation);
 
         assertThat(result).isSucceeded();
         var calls = ArgumentCaptor.forClass(ContractNegotiation.class);
@@ -122,18 +129,17 @@ class ContractNegotiationProtocolServiceImplTest {
             assertThat(n.getLastContractOffer()).isEqualTo(contractOffer);
         });
         verify(listener).requested(any());
-        verify(validationService).validateInitialOffer(token, contractOffer);
+        verify(validationService).validateInitialOffer(claimToken, contractOffer);
         verify(transactionContext, atLeastOnce()).execute(any(TransactionContext.ResultTransactionBlock.class));
     }
 
     @Test
     void notifyRequested_shouldTransitionToRequested_whenNegotiationFound() {
-        var token = ClaimToken.Builder.newInstance().build();
+        var claimToken = claimToken();
+        var tokenRepresentation = tokenRepresentation();
         var contractOffer = contractOffer();
         var validatedOffer = new ValidatedConsumerOffer(CONSUMER_ID, contractOffer);
         var negotiation = createContractNegotiationOffered();
-        when(store.findByCorrelationIdAndLease(any())).thenReturn(StoreResult.success(negotiation));
-        when(validationService.validateInitialOffer(token, contractOffer)).thenReturn(Result.success(validatedOffer));
         var message = ContractRequestMessage.Builder.newInstance()
                 .callbackAddress("callbackAddress")
                 .protocol("protocol")
@@ -141,7 +147,12 @@ class ContractNegotiationProtocolServiceImplTest {
                 .processId("processId")
                 .build();
 
-        var result = service.notifyRequested(message, token);
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(claimToken));
+        when(store.findByCorrelationIdAndLease(any())).thenReturn(StoreResult.success(negotiation));
+        when(validationService.validateInitialOffer(claimToken, contractOffer)).thenReturn(Result.success(validatedOffer));
+
+
+        var result = service.notifyRequested(message, tokenRepresentation);
 
         assertThat(result).isSucceeded();
         var calls = ArgumentCaptor.forClass(ContractNegotiation.class);
@@ -156,14 +167,15 @@ class ContractNegotiationProtocolServiceImplTest {
         });
         verify(listener).requested(any());
         verify(store).findByCorrelationIdAndLease("processId");
-        verify(validationService).validateInitialOffer(token, contractOffer);
+        verify(validationService).validateInitialOffer(claimToken, contractOffer);
         verify(transactionContext, atLeastOnce()).execute(any(TransactionContext.ResultTransactionBlock.class));
     }
 
     @Test
     void notifyOffered_shouldTransitionToOffered_whenNegotiationFound() {
         var processId = "processId";
-        var token = ClaimToken.Builder.newInstance().build();
+        var claimToken = claimToken();
+        var tokenRepresentation = tokenRepresentation();
         var contractOffer = contractOffer();
         var message = ContractOfferMessage.Builder.newInstance()
                 .callbackAddress("callbackAddress")
@@ -173,10 +185,11 @@ class ContractNegotiationProtocolServiceImplTest {
                 .build();
         var negotiation = createContractNegotiationRequested();
 
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(claimToken));
         when(store.findByCorrelationIdAndLease(processId)).thenReturn(StoreResult.success(negotiation));
-        when(validationService.validateRequest(token, negotiation)).thenReturn(Result.success());
+        when(validationService.validateRequest(claimToken, negotiation)).thenReturn(Result.success());
 
-        var result = service.notifyOffered(message, token);
+        var result = service.notifyOffered(message, tokenRepresentation);
 
         assertThat(result).isSucceeded();
         var updatedNegotiation = result.getContent();
@@ -190,9 +203,8 @@ class ContractNegotiationProtocolServiceImplTest {
     @Test
     void notifyAccepted_shouldTransitionToAccepted() {
         var contractNegotiation = createContractNegotiationOffered();
-        var token = ClaimToken.Builder.newInstance().build();
-        when(store.findByCorrelationIdAndLease("processId")).thenReturn(StoreResult.success(contractNegotiation));
-        when(validationService.validateRequest(eq(token), any(ContractNegotiation.class))).thenReturn(Result.success());
+        var claimToken = claimToken();
+        var tokenRepresentation = tokenRepresentation();
         var message = ContractNegotiationEventMessage.Builder.newInstance()
                 .protocol("protocol")
                 .counterPartyAddress("http://any")
@@ -201,11 +213,15 @@ class ContractNegotiationProtocolServiceImplTest {
                 .policy(Policy.Builder.newInstance().build())
                 .build();
 
-        var result = service.notifyAccepted(message, token);
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(claimToken));
+        when(store.findByCorrelationIdAndLease("processId")).thenReturn(StoreResult.success(contractNegotiation));
+        when(validationService.validateRequest(eq(claimToken), any(ContractNegotiation.class))).thenReturn(Result.success());
+
+        var result = service.notifyAccepted(message, tokenRepresentation);
 
         assertThat(result).isSucceeded();
         verify(store).save(argThat(negotiation -> negotiation.getState() == ACCEPTED.code()));
-        verify(validationService).validateRequest(token, contractNegotiation);
+        verify(validationService).validateRequest(claimToken, contractNegotiation);
         verify(listener).accepted(any());
         verify(transactionContext, atLeastOnce()).execute(any(TransactionContext.ResultTransactionBlock.class));
     }
@@ -213,10 +229,11 @@ class ContractNegotiationProtocolServiceImplTest {
     @Test
     void notifyAgreed_shouldTransitionToAgreed() {
         var negotiationConsumerRequested = createContractNegotiationRequested();
-        var token = ClaimToken.Builder.newInstance().build();
+        var claimToken = claimToken();
+        var tokenRepresentation = tokenRepresentation();
+
         var contractAgreement = mock(ContractAgreement.class);
-        when(store.findByCorrelationIdAndLease("processId")).thenReturn(StoreResult.success(negotiationConsumerRequested));
-        when(validationService.validateConfirmed(eq(token), eq(contractAgreement), any(ContractOffer.class))).thenReturn(Result.success());
+
         var message = ContractAgreementMessage.Builder.newInstance()
                 .protocol("protocol")
                 .counterPartyAddress("http://any")
@@ -224,30 +241,38 @@ class ContractNegotiationProtocolServiceImplTest {
                 .contractAgreement(contractAgreement)
                 .build();
 
-        var result = service.notifyAgreed(message, token);
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(claimToken));
+        when(store.findByCorrelationIdAndLease("processId")).thenReturn(StoreResult.success(negotiationConsumerRequested));
+        when(validationService.validateConfirmed(eq(claimToken), eq(contractAgreement), any(ContractOffer.class))).thenReturn(Result.success());
+
+        var result = service.notifyAgreed(message, tokenRepresentation);
 
         assertThat(result).isSucceeded();
         verify(store).save(argThat(negotiation ->
                 negotiation.getState() == AGREED.code() &&
                         negotiation.getContractAgreement() == contractAgreement
         ));
-        verify(validationService).validateConfirmed(eq(token), eq(contractAgreement), any(ContractOffer.class));
+        verify(validationService).validateConfirmed(eq(claimToken), eq(contractAgreement), any(ContractOffer.class));
         verify(listener).agreed(any());
         verify(transactionContext, atLeastOnce()).execute(any(TransactionContext.ResultTransactionBlock.class));
     }
 
     @Test
     void notifyVerified_shouldTransitionToVerified() {
+        var claimToken = claimToken();
+        var tokenRepresentation = tokenRepresentation();
         var negotiation = contractNegotiationBuilder().id("negotiationId").type(PROVIDER).state(AGREED.code()).build();
-        when(store.findByCorrelationIdAndLease("processId")).thenReturn(StoreResult.success(negotiation));
-        when(validationService.validateRequest(any(), any(ContractNegotiation.class))).thenReturn(Result.success());
         var message = ContractAgreementVerificationMessage.Builder.newInstance()
                 .protocol("protocol")
                 .counterPartyAddress("http://any")
                 .processId("processId")
                 .build();
 
-        var result = service.notifyVerified(message, claimToken());
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(claimToken));
+        when(store.findByCorrelationIdAndLease("processId")).thenReturn(StoreResult.success(negotiation));
+        when(validationService.validateRequest(any(), any(ContractNegotiation.class))).thenReturn(Result.success());
+
+        var result = service.notifyVerified(message, tokenRepresentation);
 
         assertThat(result).isSucceeded();
         verify(store).save(argThat(n -> n.getState() == VERIFIED.code()));
@@ -259,17 +284,20 @@ class ContractNegotiationProtocolServiceImplTest {
     @Test
     void notifyFinalized_shouldTransitionToFinalized() {
         var negotiation = contractNegotiationBuilder().id("negotiationId").type(PROVIDER).state(VERIFIED.code()).build();
-        when(store.findByCorrelationIdAndLease("processId")).thenReturn(StoreResult.success(negotiation));
-        when(validationService.validateRequest(any(), any(ContractNegotiation.class))).thenReturn(Result.success());
         var message = ContractNegotiationEventMessage.Builder.newInstance()
                 .type(ContractNegotiationEventMessage.Type.FINALIZED)
                 .protocol("protocol")
                 .counterPartyAddress("http://any")
                 .processId("processId")
                 .build();
-        var token = ClaimToken.Builder.newInstance().build();
+        var claimToken = ClaimToken.Builder.newInstance().build();
+        var tokenRepresentation = tokenRepresentation();
 
-        var result = service.notifyFinalized(message, token);
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(claimToken));
+        when(store.findByCorrelationIdAndLease("processId")).thenReturn(StoreResult.success(negotiation));
+        when(validationService.validateRequest(any(), any(ContractNegotiation.class))).thenReturn(Result.success());
+
+        var result = service.notifyFinalized(message, tokenRepresentation);
 
         assertThat(result).isSucceeded();
         verify(store).save(argThat(n -> n.getState() == FINALIZED.code()));
@@ -281,17 +309,20 @@ class ContractNegotiationProtocolServiceImplTest {
     @Test
     void notifyTerminated_shouldTransitionToTerminated() {
         var negotiation = contractNegotiationBuilder().id("negotiationId").type(PROVIDER).state(VERIFIED.code()).build();
-        when(store.findByCorrelationIdAndLease("processId")).thenReturn(StoreResult.success(negotiation));
-        when(validationService.validateRequest(any(), any(ContractNegotiation.class))).thenReturn(Result.success());
         var message = ContractNegotiationTerminationMessage.Builder.newInstance()
                 .protocol("protocol")
                 .processId("processId")
                 .counterPartyAddress("http://any")
                 .rejectionReason("any")
                 .build();
-        var token = ClaimToken.Builder.newInstance().build();
+        var claimToken = claimToken();
+        var tokenRepresentation = tokenRepresentation();
 
-        var result = service.notifyTerminated(message, token);
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(claimToken));
+        when(store.findByCorrelationIdAndLease("processId")).thenReturn(StoreResult.success(negotiation));
+        when(validationService.validateRequest(any(), any(ContractNegotiation.class))).thenReturn(Result.success());
+
+        var result = service.notifyTerminated(message, tokenRepresentation);
 
         assertThat(result).isSucceeded();
         verify(store).save(argThat(n -> n.getState() == TERMINATED.code()));
@@ -303,13 +334,15 @@ class ContractNegotiationProtocolServiceImplTest {
     @Test
     void findById_shouldReturnNegotiation_whenValidCounterParty() {
         var id = "negotiationId";
-        var token = ClaimToken.Builder.newInstance().build();
+        var claimToken = claimToken();
+        var tokenRepresentation = tokenRepresentation();
         var negotiation = contractNegotiationBuilder().id(id).type(PROVIDER).state(VERIFIED.code()).build();
 
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(claimToken));
         when(store.findById(id)).thenReturn(negotiation);
-        when(validationService.validateRequest(token, negotiation)).thenReturn(Result.success());
+        when(validationService.validateRequest(claimToken, negotiation)).thenReturn(Result.success());
 
-        var result = service.findById(id, token);
+        var result = service.findById(id, tokenRepresentation);
 
         assertThat(result)
                 .isSucceeded()
@@ -318,9 +351,13 @@ class ContractNegotiationProtocolServiceImplTest {
 
     @Test
     void findById_shouldReturnNotFound_whenNegotiationNotFound() {
+        var claimToken = claimToken();
+        var tokenRepresentation = tokenRepresentation();
+
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(claimToken));
         when(store.findById(any())).thenReturn(null);
 
-        var result = service.findById("invalidId", ClaimToken.Builder.newInstance().build());
+        var result = service.findById("invalidId", tokenRepresentation);
 
         assertThat(result)
                 .isFailed()
@@ -331,13 +368,16 @@ class ContractNegotiationProtocolServiceImplTest {
     @Test
     void findById_shouldReturnBadRequest_whenCounterPartyUnauthorized() {
         var id = "negotiationId";
-        var token = ClaimToken.Builder.newInstance().build();
+        var claimToken = claimToken();
+        var tokenRepresentation = tokenRepresentation();
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(claimToken));
+
         var negotiation = contractNegotiationBuilder().id(id).type(PROVIDER).state(VERIFIED.code()).build();
 
         when(store.findById(id)).thenReturn(negotiation);
-        when(validationService.validateRequest(token, negotiation)).thenReturn(Result.failure("validation error"));
+        when(validationService.validateRequest(claimToken, negotiation)).thenReturn(Result.failure("validation error"));
 
-        var result = service.findById(id, token);
+        var result = service.findById(id, tokenRepresentation);
 
         assertThat(result)
                 .isFailed()
@@ -348,11 +388,14 @@ class ContractNegotiationProtocolServiceImplTest {
     @ParameterizedTest
     @ArgumentsSource(NotifyArguments.class)
     <M extends RemoteMessage> void notify_shouldReturnNotFound_whenNotFound(MethodCall<M> methodCall, M message) {
+        var claimToken = claimToken();
+        var tokenRepresentation = tokenRepresentation();
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(claimToken));
         when(store.findByCorrelationIdAndLease(any())).thenReturn(StoreResult.notFound("not found"));
 
         // currently ContractRequestMessage cannot happen on an already existing negotiation
         if (!(message instanceof ContractRequestMessage)) {
-            var result = methodCall.call(service, message, claimToken());
+            var result = methodCall.call(service, message, tokenRepresentation);
 
             assertThat(result).isFailed().extracting(ServiceFailure::getReason).isEqualTo(NOT_FOUND);
             verify(store, never()).save(any());
@@ -363,14 +406,32 @@ class ContractNegotiationProtocolServiceImplTest {
     @ParameterizedTest
     @ArgumentsSource(NotifyArguments.class)
     <M extends RemoteMessage> void notify_shouldReturnBadRequest_whenValidationFails(MethodCall<M> methodCall, M message) {
+        var claimToken = claimToken();
+        var tokenRepresentation = tokenRepresentation();
+
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(claimToken));
         when(store.findByCorrelationIdAndLease(any())).thenReturn(StoreResult.success(createContractNegotiationOffered()));
         when(validationService.validateRequest(any(), any(ContractNegotiation.class))).thenReturn(Result.failure("validation error"));
         when(validationService.validateInitialOffer(any(), any(ContractOffer.class))).thenReturn(Result.failure("error"));
         when(validationService.validateConfirmed(any(), any(), any(ContractOffer.class))).thenReturn(Result.failure("failure"));
 
-        var result = methodCall.call(service, message, claimToken());
+        var result = methodCall.call(service, message, tokenRepresentation);
 
         assertThat(result).isFailed().extracting(ServiceFailure::getReason).isEqualTo(BAD_REQUEST);
+        verify(store, never()).save(any());
+        verifyNoInteractions(listener);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(NotifyArguments.class)
+    <M extends RemoteMessage> void notify_shouldReturnBadRequest_whenTokenValidationFails(MethodCall<M> methodCall, M message) {
+        var tokenRepresentation = tokenRepresentation();
+
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.failure("unauthorized"));
+
+        var result = methodCall.call(service, message, tokenRepresentation);
+
+        assertThat(result).isFailed().extracting(ServiceFailure::getReason).isEqualTo(UNAUTHORIZED);
         verify(store, never()).save(any());
         verifyNoInteractions(listener);
     }
@@ -410,9 +471,15 @@ class ContractNegotiationProtocolServiceImplTest {
                 .stateTimestamp(Instant.now().toEpochMilli());
     }
 
+    private TokenRepresentation tokenRepresentation() {
+        return TokenRepresentation.Builder.newInstance()
+                .token(UUID.randomUUID().toString())
+                .build();
+    }
+
     @FunctionalInterface
     private interface MethodCall<M extends RemoteMessage> {
-        ServiceResult<?> call(ContractNegotiationProtocolService service, M message, ClaimToken token);
+        ServiceResult<?> call(ContractNegotiationProtocolService service, M message, TokenRepresentation token);
     }
 
     private static class NotifyArguments implements ArgumentsProvider {

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionEventDispatchTest.java
@@ -25,6 +25,7 @@ import org.eclipse.edc.junit.extensions.EdcExtension;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.event.EventSubscriber;
+import org.eclipse.edc.spi.iam.IdentityService;
 import org.eclipse.edc.spi.protocol.ProtocolWebhook;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,6 +49,7 @@ public class PolicyDefinitionEventDispatchTest {
     void setUp(EdcExtension extension) {
         extension.registerServiceMock(ProtocolWebhook.class, mock(ProtocolWebhook.class));
         extension.registerServiceMock(DataPlaneInstanceStore.class, mock(DataPlaneInstanceStore.class));
+        extension.registerServiceMock(IdentityService.class, mock());
         extension.setConfiguration(Map.of(
                 "web.http.port", String.valueOf(getFreePort()),
                 "web.http.path", "/api")

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessEventDispatchTest.java
@@ -43,10 +43,13 @@ import org.eclipse.edc.spi.event.EventEnvelope;
 import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.event.EventSubscriber;
 import org.eclipse.edc.spi.iam.ClaimToken;
+import org.eclipse.edc.spi.iam.IdentityService;
+import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcher;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.protocol.ProtocolWebhook;
 import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.agreement.ContractAgreement;
 import org.eclipse.edc.validator.spi.DataAddressValidatorRegistry;
@@ -59,6 +62,7 @@ import org.mockito.ArgumentCaptor;
 
 import java.time.Duration;
 import java.util.Map;
+import java.util.UUID;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.Executors.newSingleThreadExecutor;
@@ -68,6 +72,7 @@ import static org.eclipse.edc.junit.matchers.EventEnvelopeMatcher.isEnvelopeOf;
 import static org.eclipse.edc.junit.testfixtures.TestUtils.getFreePort;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -80,6 +85,7 @@ public class TransferProcessEventDispatchTest {
 
     public static final Duration TIMEOUT = Duration.ofSeconds(30);
     private final EventSubscriber eventSubscriber = mock(EventSubscriber.class);
+    private final IdentityService identityService = mock();
 
     @NotNull
     private static RemoteMessageDispatcher getTestDispatcher() {
@@ -101,6 +107,7 @@ public class TransferProcessEventDispatchTest {
         extension.setConfiguration(configuration);
         extension.registerServiceMock(TransferWaitStrategy.class, () -> 1);
         extension.registerServiceMock(EventExecutorServiceContainer.class, new EventExecutorServiceContainer(newSingleThreadExecutor()));
+        extension.registerServiceMock(IdentityService.class, identityService);
         extension.registerServiceMock(ProtocolWebhook.class, () -> "http://dummy");
         extension.registerServiceMock(DataPlaneInstanceStore.class, mock(DataPlaneInstanceStore.class));
         extension.registerServiceMock(PolicyArchive.class, mock(PolicyArchive.class));
@@ -122,6 +129,10 @@ public class TransferProcessEventDispatchTest {
                                                            ParticipantAgentService agentService) {
 
         var token = ClaimToken.Builder.newInstance().build();
+        var tokenRepresentation = TokenRepresentation.Builder.newInstance().token(UUID.randomUUID().toString()).build();
+
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(token));
+        
         var agent = mock(ParticipantAgent.class);
         var agreement = mock(ContractAgreement.class);
         var providerId = "ProviderId";
@@ -154,7 +165,7 @@ public class TransferProcessEventDispatchTest {
                 .dataAddress(dataAddress)
                 .build();
 
-        protocolService.notifyStarted(startMessage, token);
+        protocolService.notifyStarted(startMessage, tokenRepresentation);
 
         await().atMost(TIMEOUT).untilAsserted(() -> {
             ArgumentCaptor<EventEnvelope<TransferProcessStarted>> captor = ArgumentCaptor.forClass(EventEnvelope.class);

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImplTest.java
@@ -31,6 +31,8 @@ import org.eclipse.edc.connector.transfer.spi.types.protocol.TransferStartMessag
 import org.eclipse.edc.connector.transfer.spi.types.protocol.TransferTerminationMessage;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.iam.ClaimToken;
+import org.eclipse.edc.spi.iam.IdentityService;
+import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.ServiceFailure;
 import org.eclipse.edc.spi.result.ServiceResult;
@@ -65,9 +67,11 @@ import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.spi.result.ServiceFailure.Reason.BAD_REQUEST;
 import static org.eclipse.edc.spi.result.ServiceFailure.Reason.CONFLICT;
 import static org.eclipse.edc.spi.result.ServiceFailure.Reason.NOT_FOUND;
+import static org.eclipse.edc.spi.result.ServiceFailure.Reason.UNAUTHORIZED;
 import static org.eclipse.edc.validator.spi.Violation.violation;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -86,18 +90,21 @@ class TransferProcessProtocolServiceImplTest {
     private final DataAddressValidatorRegistry dataAddressValidator = mock();
     private final TransferProcessListener listener = mock();
 
+    private final IdentityService identityService = mock();
     private TransferProcessProtocolService service;
 
     @BeforeEach
     void setUp() {
         var observable = new TransferProcessObservableImpl();
         observable.registerListener(listener);
-        service = new TransferProcessProtocolServiceImpl(store, transactionContext, negotiationStore, validationService,
+        service = new TransferProcessProtocolServiceImpl(store, transactionContext, negotiationStore, validationService, identityService,
                 dataAddressValidator, observable, mock(), mock(), mock());
     }
 
     @Test
     void notifyRequested_validAgreement_shouldInitiateTransfer() {
+        var claimToken = claimToken();
+        var tokenRepresentation = tokenRepresentation();
         var message = TransferRequestMessage.Builder.newInstance()
                 .processId("transferProcessId")
                 .contractId("agreementId")
@@ -105,11 +112,13 @@ class TransferProcessProtocolServiceImplTest {
                 .callbackAddress("http://any")
                 .dataDestination(DataAddress.Builder.newInstance().type("any").build())
                 .build();
+
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(claimToken));
         when(negotiationStore.findContractAgreement(any())).thenReturn(contractAgreement());
         when(validationService.validateAgreement(any(), any())).thenReturn(Result.success(null));
         when(dataAddressValidator.validateDestination(any())).thenReturn(ValidationResult.success());
 
-        var result = service.notifyRequested(message, claimToken());
+        var result = service.notifyRequested(message, tokenRepresentation);
 
         assertThat(result).isSucceeded().satisfies(tp -> {
             assertThat(tp.getCorrelationId()).isEqualTo("transferProcessId");
@@ -131,12 +140,16 @@ class TransferProcessProtocolServiceImplTest {
                 .callbackAddress("http://any")
                 .dataDestination(DataAddress.Builder.newInstance().type("any").build())
                 .build();
+        var claimToken = claimToken();
+        var tokenRepresentation = tokenRepresentation();
+
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(claimToken));
         when(negotiationStore.findContractAgreement(any())).thenReturn(contractAgreement());
         when(validationService.validateAgreement(any(), any())).thenReturn(Result.success(null));
         when(dataAddressValidator.validateDestination(any())).thenReturn(ValidationResult.success());
         when(store.findForCorrelationId(any())).thenReturn(transferProcess(REQUESTED, "transferProcessId"));
 
-        var result = service.notifyRequested(message, claimToken());
+        var result = service.notifyRequested(message, tokenRepresentation);
 
         assertThat(result).isSucceeded().extracting(TransferProcess::getId).isEqualTo("transferProcessId");
         verify(store, never()).save(any());
@@ -151,11 +164,15 @@ class TransferProcessProtocolServiceImplTest {
                 .contractId("agreementId")
                 .dataDestination(DataAddress.Builder.newInstance().type("any").build())
                 .build();
+        var claimToken = claimToken();
+        var tokenRepresentation = tokenRepresentation();
+
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(claimToken));
         when(negotiationStore.findContractAgreement(any())).thenReturn(contractAgreement());
         when(validationService.validateAgreement(any(), any())).thenReturn(Result.failure("error"));
         when(dataAddressValidator.validateDestination(any())).thenReturn(ValidationResult.success());
 
-        var result = service.notifyRequested(message, claimToken());
+        var result = service.notifyRequested(message, tokenRepresentation);
 
         assertThat(result).isFailed().extracting(ServiceFailure::getReason).isEqualTo(CONFLICT);
         verify(store, never()).save(any());
@@ -164,7 +181,8 @@ class TransferProcessProtocolServiceImplTest {
 
     @Test
     void notifyRequested_invalidDestination_shouldNotInitiateTransfer() {
-        when(dataAddressValidator.validateDestination(any())).thenReturn(ValidationResult.failure(violation("invalid data address", "path")));
+        var claimToken = claimToken();
+        var tokenRepresentation = tokenRepresentation();
         var message = TransferRequestMessage.Builder.newInstance()
                 .protocol("protocol")
                 .contractId("agreementId")
@@ -172,7 +190,11 @@ class TransferProcessProtocolServiceImplTest {
                 .dataDestination(DataAddress.Builder.newInstance().type("any").build())
                 .build();
 
-        var result = service.notifyRequested(message, claimToken());
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(claimToken));
+        when(dataAddressValidator.validateDestination(any())).thenReturn(ValidationResult.failure(violation("invalid data address", "path")));
+
+
+        var result = service.notifyRequested(message, tokenRepresentation);
 
         assertThat(result).isFailed().extracting(ServiceFailure::getReason).isEqualTo(BAD_REQUEST);
         verify(store, never()).save(any());
@@ -181,16 +203,20 @@ class TransferProcessProtocolServiceImplTest {
 
     @Test
     void notifyRequested_missingDestination_shouldInitiateTransfer() {
+        var claimToken = claimToken();
+        var tokenRepresentation = tokenRepresentation();
         var message = TransferRequestMessage.Builder.newInstance()
                 .processId("transferProcessId")
                 .protocol("protocol")
                 .contractId("agreementId")
                 .callbackAddress("http://any")
                 .build();
+
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(claimToken));
         when(negotiationStore.findContractAgreement(any())).thenReturn(contractAgreement());
         when(validationService.validateAgreement(any(), any())).thenReturn(Result.success(null));
 
-        var result = service.notifyRequested(message, claimToken());
+        var result = service.notifyRequested(message, tokenRepresentation);
 
         assertThat(result).isSucceeded().satisfies(tp -> {
             assertThat(tp.getCorrelationId()).isEqualTo("transferProcessId");
@@ -206,21 +232,22 @@ class TransferProcessProtocolServiceImplTest {
 
     @Test
     void notifyStarted_shouldTransitionToStarted() {
-        when(store.findByCorrelationIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess(REQUESTED, "transferProcessId")));
+        var claimToken = claimToken();
+        var tokenRepresentation = tokenRepresentation();
         var message = TransferStartMessage.Builder.newInstance()
                 .protocol("protocol")
                 .counterPartyAddress("http://any")
                 .processId("correlationId")
                 .dataAddress(DataAddress.Builder.newInstance().type("test").build())
                 .build();
-
-        var token = claimToken();
         var agreement = contractAgreement();
 
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(claimToken));
+        when(store.findByCorrelationIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess(REQUESTED, "transferProcessId")));
         when(negotiationStore.findContractAgreement(any())).thenReturn(agreement);
-        when(validationService.validateRequest(token, agreement)).thenReturn(Result.success());
+        when(validationService.validateRequest(claimToken, agreement)).thenReturn(Result.success());
 
-        var result = service.notifyStarted(message, token);
+        var result = service.notifyStarted(message, tokenRepresentation);
 
         var captor = ArgumentCaptor.forClass(TransferProcessStartedData.class);
 
@@ -235,21 +262,22 @@ class TransferProcessProtocolServiceImplTest {
 
     @Test
     void notifyStarted_shouldReturnConflict_whenStatusIsNotValid() {
+        var claimToken = claimToken();
+        var tokenRepresentation = tokenRepresentation();
         var transferProcess = transferProcess(COMPLETED, UUID.randomUUID().toString());
-        when(store.findByCorrelationIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess));
         var message = TransferStartMessage.Builder.newInstance()
                 .protocol("protocol")
                 .counterPartyAddress("http://any")
                 .processId("correlationId")
                 .build();
-
-        var token = claimToken();
         var agreement = contractAgreement();
 
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(claimToken));
+        when(store.findByCorrelationIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess));
         when(negotiationStore.findContractAgreement(any())).thenReturn(agreement);
-        when(validationService.validateRequest(token, agreement)).thenReturn(Result.success());
+        when(validationService.validateRequest(claimToken, agreement)).thenReturn(Result.success());
 
-        var result = service.notifyStarted(message, token);
+        var result = service.notifyStarted(message, tokenRepresentation);
 
         assertThat(result).isFailed().extracting(ServiceFailure::getReason).isEqualTo(CONFLICT);
         // state didn't change
@@ -259,21 +287,22 @@ class TransferProcessProtocolServiceImplTest {
 
     @Test
     void notifyStarted_shouldReturnNotFound_whenCounterPartyUnauthorized() {
-        when(store.findByCorrelationIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess(REQUESTED, "transferProcessId")));
+        var claimToken = claimToken();
+        var tokenRepresentation = tokenRepresentation();
         var message = TransferStartMessage.Builder.newInstance()
                 .protocol("protocol")
                 .counterPartyAddress("http://any")
                 .processId("correlationId")
                 .dataAddress(DataAddress.Builder.newInstance().type("test").build())
                 .build();
-
-        var token = claimToken();
         var agreement = contractAgreement();
 
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(claimToken));
+        when(store.findByCorrelationIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess(REQUESTED, "transferProcessId")));
         when(negotiationStore.findContractAgreement(any())).thenReturn(agreement);
-        when(validationService.validateRequest(token, agreement)).thenReturn(Result.failure("error"));
+        when(validationService.validateRequest(claimToken, agreement)).thenReturn(Result.failure("error"));
 
-        var result = service.notifyStarted(message, token);
+        var result = service.notifyStarted(message, tokenRepresentation);
 
         assertThat(result)
                 .isFailed()
@@ -286,20 +315,21 @@ class TransferProcessProtocolServiceImplTest {
 
     @Test
     void notifyCompleted_shouldTransitionToCompleted() {
-        when(store.findByCorrelationIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess(STARTED, "transferProcessId")));
+        var claimToken = claimToken();
+        var tokenRepresentation = tokenRepresentation();
         var message = TransferCompletionMessage.Builder.newInstance()
                 .protocol("protocol")
                 .counterPartyAddress("http://any")
                 .processId("correlationId")
                 .build();
-
-        var token = claimToken();
         var agreement = contractAgreement();
 
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(claimToken));
+        when(store.findByCorrelationIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess(STARTED, "transferProcessId")));
         when(negotiationStore.findContractAgreement(any())).thenReturn(agreement);
-        when(validationService.validateRequest(token, agreement)).thenReturn(Result.success());
+        when(validationService.validateRequest(claimToken, agreement)).thenReturn(Result.success());
 
-        var result = service.notifyCompleted(message, token);
+        var result = service.notifyCompleted(message, tokenRepresentation);
 
         assertThat(result).isSucceeded();
         verify(listener).preCompleted(any());
@@ -310,21 +340,22 @@ class TransferProcessProtocolServiceImplTest {
 
     @Test
     void notifyCompleted_shouldReturnConflict_whenStatusIsNotValid() {
+        var claimToken = claimToken();
+        var tokenRepresentation = tokenRepresentation();
         var transferProcess = transferProcess(REQUESTED, UUID.randomUUID().toString());
-        when(store.findByCorrelationIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess));
         var message = TransferCompletionMessage.Builder.newInstance()
                 .protocol("protocol")
                 .counterPartyAddress("http://any")
                 .processId("correlationId")
                 .build();
-
-        var token = claimToken();
         var agreement = contractAgreement();
 
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(claimToken));
+        when(store.findByCorrelationIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess));
         when(negotiationStore.findContractAgreement(any())).thenReturn(agreement);
-        when(validationService.validateRequest(token, agreement)).thenReturn(Result.success());
+        when(validationService.validateRequest(claimToken, agreement)).thenReturn(Result.success());
 
-        var result = service.notifyCompleted(message, token);
+        var result = service.notifyCompleted(message, tokenRepresentation);
 
         assertThat(result).isFailed().extracting(ServiceFailure::getReason).isEqualTo(CONFLICT);
         // state didn't change
@@ -334,20 +365,22 @@ class TransferProcessProtocolServiceImplTest {
 
     @Test
     void notifyCompleted_shouldReturnNotFound_whenCounterPartyUnauthorized() {
-        when(store.findByCorrelationIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess(STARTED, "transferProcessId")));
+        var claimToken = claimToken();
+        var tokenRepresentation = tokenRepresentation();
         var message = TransferCompletionMessage.Builder.newInstance()
                 .protocol("protocol")
                 .counterPartyAddress("http://any")
                 .processId("correlationId")
                 .build();
 
-        var token = claimToken();
         var agreement = contractAgreement();
 
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(claimToken));
+        when(store.findByCorrelationIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess(STARTED, "transferProcessId")));
         when(negotiationStore.findContractAgreement(any())).thenReturn(agreement);
-        when(validationService.validateRequest(token, agreement)).thenReturn(Result.failure("error"));
+        when(validationService.validateRequest(claimToken, agreement)).thenReturn(Result.failure("error"));
 
-        var result = service.notifyCompleted(message, token);
+        var result = service.notifyCompleted(message, tokenRepresentation);
 
         assertThat(result)
                 .isFailed()
@@ -360,7 +393,8 @@ class TransferProcessProtocolServiceImplTest {
 
     @Test
     void notifyTerminated_shouldTransitionToTerminated() {
-        when(store.findByCorrelationIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess(STARTED, "transferProcessId")));
+        var claimToken = claimToken();
+        var tokenRepresentation = tokenRepresentation();
         var message = TransferTerminationMessage.Builder.newInstance()
                 .protocol("protocol")
                 .counterPartyAddress("http://any")
@@ -368,13 +402,13 @@ class TransferProcessProtocolServiceImplTest {
                 .code("TestCode")
                 .reason("TestReason")
                 .build();
-
-        var token = claimToken();
         var agreement = contractAgreement();
 
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(claimToken));
+        when(store.findByCorrelationIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess(STARTED, "transferProcessId")));
         when(negotiationStore.findContractAgreement(any())).thenReturn(agreement);
-        when(validationService.validateRequest(token, agreement)).thenReturn(Result.success());
-        var result = service.notifyTerminated(message, token);
+        when(validationService.validateRequest(claimToken, agreement)).thenReturn(Result.success());
+        var result = service.notifyTerminated(message, tokenRepresentation);
 
         assertThat(result).isSucceeded();
         verify(listener).preTerminated(any());
@@ -385,8 +419,10 @@ class TransferProcessProtocolServiceImplTest {
 
     @Test
     void notifyTerminated_shouldReturnConflict_whenStatusIsNotValid() {
+        var claimToken = claimToken();
+        var tokenRepresentation = tokenRepresentation();
         var transferProcess = transferProcess(TERMINATED, UUID.randomUUID().toString());
-        when(store.findByCorrelationIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess));
+        var agreement = contractAgreement();
         var message = TransferTerminationMessage.Builder.newInstance()
                 .protocol("protocol")
                 .counterPartyAddress("http://any")
@@ -395,13 +431,12 @@ class TransferProcessProtocolServiceImplTest {
                 .reason("TestReason")
                 .build();
 
-        var token = claimToken();
-        var agreement = contractAgreement();
-
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(claimToken));
+        when(store.findByCorrelationIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess));
         when(negotiationStore.findContractAgreement(any())).thenReturn(agreement);
-        when(validationService.validateRequest(token, agreement)).thenReturn(Result.success());
+        when(validationService.validateRequest(claimToken, agreement)).thenReturn(Result.success());
 
-        var result = service.notifyTerminated(message, token);
+        var result = service.notifyTerminated(message, tokenRepresentation);
 
         assertThat(result).isFailed().extracting(ServiceFailure::getReason).isEqualTo(CONFLICT);
         // state didn't change
@@ -411,8 +446,10 @@ class TransferProcessProtocolServiceImplTest {
 
     @Test
     void notifyTerminated_shouldReturnNotFound_whenCounterPartyUnauthorized() {
+        var claimToken = claimToken();
+        var tokenRepresentation = tokenRepresentation();
+        var agreement = contractAgreement();
         var transferProcess = transferProcess(TERMINATED, UUID.randomUUID().toString());
-        when(store.findByCorrelationIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess));
         var message = TransferTerminationMessage.Builder.newInstance()
                 .protocol("protocol")
                 .counterPartyAddress("http://any")
@@ -421,13 +458,12 @@ class TransferProcessProtocolServiceImplTest {
                 .reason("TestReason")
                 .build();
 
-        var token = claimToken();
-        var agreement = contractAgreement();
-
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(claimToken));
+        when(store.findByCorrelationIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess));
         when(negotiationStore.findContractAgreement(any())).thenReturn(agreement);
-        when(validationService.validateRequest(token, agreement)).thenReturn(Result.failure("error"));
+        when(validationService.validateRequest(claimToken, agreement)).thenReturn(Result.failure("error"));
 
-        var result = service.notifyTerminated(message, token);
+        var result = service.notifyTerminated(message, tokenRepresentation);
 
         assertThat(result)
                 .isFailed()
@@ -440,16 +476,18 @@ class TransferProcessProtocolServiceImplTest {
 
     @Test
     void findById_shouldReturnTransferProcess_whenValidCounterParty() {
+        var claimToken = claimToken();
+        var tokenRepresentation = tokenRepresentation();
         var processId = "transferProcessId";
         var transferProcess = transferProcess(INITIAL, processId);
-        var token = claimToken();
         var agreement = contractAgreement();
 
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(claimToken));
         when(store.findById(processId)).thenReturn(transferProcess);
         when(negotiationStore.findContractAgreement(any())).thenReturn(agreement);
-        when(validationService.validateRequest(token, agreement)).thenReturn(Result.success());
+        when(validationService.validateRequest(claimToken, agreement)).thenReturn(Result.success());
 
-        var result = service.findById(processId, token);
+        var result = service.findById(processId, tokenRepresentation);
 
         assertThat(result)
                 .isSucceeded()
@@ -458,9 +496,13 @@ class TransferProcessProtocolServiceImplTest {
 
     @Test
     void findById_shouldReturnNotFound_whenNegotiationNotFound() {
+        var claimToken = claimToken();
+        var tokenRepresentation = tokenRepresentation();
+
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(claimToken));
         when(store.findById(any())).thenReturn(null);
 
-        var result = service.findById("invalidId", ClaimToken.Builder.newInstance().build());
+        var result = service.findById("invalidId", tokenRepresentation);
 
         assertThat(result)
                 .isFailed()
@@ -472,14 +514,16 @@ class TransferProcessProtocolServiceImplTest {
     void findById_shouldReturnNotFound_whenCounterPartyUnauthorized() {
         var processId = "transferProcessId";
         var transferProcess = transferProcess(INITIAL, processId);
-        var token = claimToken();
+        var claimToken = claimToken();
+        var tokenRepresentation = tokenRepresentation();
         var agreement = contractAgreement();
 
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(claimToken));
         when(store.findById(processId)).thenReturn(transferProcess);
         when(negotiationStore.findContractAgreement(any())).thenReturn(agreement);
-        when(validationService.validateRequest(token, agreement)).thenReturn(Result.failure("error"));
+        when(validationService.validateRequest(claimToken, agreement)).thenReturn(Result.failure("error"));
 
-        var result = service.findById(processId, token);
+        var result = service.findById(processId, tokenRepresentation);
 
         assertThat(result)
                 .isFailed()
@@ -490,13 +534,31 @@ class TransferProcessProtocolServiceImplTest {
     @ParameterizedTest
     @ArgumentsSource(NotFoundArguments.class)
     <M extends RemoteMessage> void notify_shouldFail_whenTransferProcessNotFound(MethodCall<M> methodCall, M message) {
+        var claimToken = claimToken();
+        var tokenRepresentation = tokenRepresentation();
+
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.success(claimToken));
         when(store.findByCorrelationIdAndLease(any())).thenReturn(StoreResult.notFound("not found"));
 
-        var result = methodCall.call(service, message, claimToken());
+        var result = methodCall.call(service, message, tokenRepresentation);
 
         assertThat(result).matches(ServiceResult::failed);
         verify(store, never()).save(any());
         verify(transactionContext, atLeastOnce()).execute(any(TransactionContext.ResultTransactionBlock.class));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(NotFoundArguments.class)
+    <M extends RemoteMessage> void notify_shouldFail_whenTokenValidationFails(MethodCall<M> methodCall, M message) {
+        var tokenRepresentation = tokenRepresentation();
+
+        when(identityService.verifyJwtToken(eq(tokenRepresentation), any())).thenReturn(Result.failure("unauthorized"));
+
+        var result = methodCall.call(service, message, tokenRepresentation);
+
+        assertThat(result).isFailed().extracting(ServiceFailure::getReason).isEqualTo(UNAUTHORIZED);
+        verify(store, never()).save(any());
+        verifyNoInteractions(listener);
     }
 
     private TransferProcess transferProcess(TransferProcessStates state, String id) {
@@ -510,6 +572,12 @@ class TransferProcessProtocolServiceImplTest {
     private ClaimToken claimToken() {
         return ClaimToken.Builder.newInstance()
                 .claim("key", "value")
+                .build();
+    }
+
+    private TokenRepresentation tokenRepresentation() {
+        return TokenRepresentation.Builder.newInstance()
+                .token(UUID.randomUUID().toString())
                 .build();
     }
 
@@ -532,7 +600,7 @@ class TransferProcessProtocolServiceImplTest {
 
     @FunctionalInterface
     private interface MethodCall<M extends RemoteMessage> {
-        ServiceResult<?> call(TransferProcessProtocolService service, M message, ClaimToken token);
+        ServiceResult<?> call(TransferProcessProtocolService service, M message, TokenRepresentation token);
     }
 
     private static class NotFoundArguments implements ArgumentsProvider {

--- a/data-protocols/dsp/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/DspHttpCoreExtension.java
+++ b/data-protocols/dsp/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/DspHttpCoreExtension.java
@@ -44,7 +44,6 @@ import org.eclipse.edc.spi.iam.IdentityService;
 import org.eclipse.edc.spi.iam.TokenDecorator;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.monitor.Monitor;
-import org.eclipse.edc.spi.protocol.ProtocolWebhook;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
@@ -103,9 +102,6 @@ public class DspHttpCoreExtension implements ServiceExtension {
     private Monitor monitor;
 
     @Inject
-    private ProtocolWebhook dspWebhookAddress;
-
-    @Inject
     private JsonObjectValidatorRegistry validatorRegistry;
 
     @Override
@@ -133,7 +129,7 @@ public class DspHttpCoreExtension implements ServiceExtension {
 
     @Provider
     public DspRequestHandler dspRequestHandler() {
-        return new DspRequestHandlerImpl(monitor, dspWebhookAddress.url(), identityService, validatorRegistry, transformerRegistry);
+        return new DspRequestHandlerImpl(monitor, validatorRegistry, transformerRegistry);
     }
 
     @Provider

--- a/data-protocols/dsp/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/message/DspRequestHandlerImplTest.java
+++ b/data-protocols/dsp/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/message/DspRequestHandlerImplTest.java
@@ -19,7 +19,7 @@ import jakarta.json.JsonObject;
 import org.eclipse.edc.protocol.dsp.spi.message.GetDspRequest;
 import org.eclipse.edc.protocol.dsp.spi.message.PostDspRequest;
 import org.eclipse.edc.spi.iam.ClaimToken;
-import org.eclipse.edc.spi.iam.IdentityService;
+import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.types.domain.message.ProcessRemoteMessage;
@@ -42,7 +42,6 @@ import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_P
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_REASON;
 import static org.eclipse.edc.validator.spi.Violation.violation;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -51,23 +50,18 @@ import static org.mockito.Mockito.when;
 
 class DspRequestHandlerImplTest {
 
-    private final String callbackAddress = "http://any";
-    private final IdentityService identityService = mock();
     private final JsonObjectValidatorRegistry validatorRegistry = mock();
     private final TypeTransformerRegistry transformerRegistry = mock();
-    private final DspRequestHandlerImpl handler = new DspRequestHandlerImpl(mock(), callbackAddress, identityService,
-            validatorRegistry, transformerRegistry);
+    private final DspRequestHandlerImpl handler = new DspRequestHandlerImpl(mock(), validatorRegistry, transformerRegistry);
 
     @Nested
     class GetResource {
 
         @Test
         void shouldSucceed() {
-            var claimToken = claimToken();
             var content = new Object();
             var resourceJson = Json.createObjectBuilder().build();
-            BiFunction<String, ClaimToken, ServiceResult<Object>> serviceCall = (m, t) -> ServiceResult.success(content);
-            when(identityService.verifyJwtToken(any(), any())).thenReturn(Result.success(claimToken));
+            BiFunction<String, TokenRepresentation, ServiceResult<Object>> serviceCall = (m, t) -> ServiceResult.success(content);
             when(transformerRegistry.transform(any(), any())).thenReturn(Result.success(resourceJson));
             var request = GetDspRequest.Builder.newInstance(Object.class)
                     .token("token")
@@ -79,14 +73,12 @@ class DspRequestHandlerImplTest {
             var result = handler.getResource(request);
 
             assertThat(result.getStatus()).isEqualTo(200);
-            verify(identityService).verifyJwtToken(argThat(t -> t.getToken().equals("token")), eq(callbackAddress));
             verifyNoInteractions(validatorRegistry);
         }
 
         @Test
         void shouldFail_whenTokenIsNotValid() {
-            when(identityService.verifyJwtToken(any(), any())).thenReturn(Result.failure("error"));
-            var request = getDspRequestBuilder().errorType("errorType").build();
+            var request = getDspRequestBuilder().errorType("errorType").serviceCall((m, t) -> ServiceResult.unauthorized("unauthorized")).build();
 
             var result = handler.getResource(request);
 
@@ -100,9 +92,7 @@ class DspRequestHandlerImplTest {
 
         @Test
         void shouldFail_whenServiceCallFails() {
-            var claimToken = claimToken();
-            BiFunction<String, ClaimToken, ServiceResult<Object>> serviceCall = (m, t) -> ServiceResult.notFound("error");
-            when(identityService.verifyJwtToken(any(), any())).thenReturn(Result.success(claimToken));
+            BiFunction<String, TokenRepresentation, ServiceResult<Object>> serviceCall = (m, t) -> ServiceResult.notFound("error");
             var request = getDspRequestBuilder()
                     .serviceCall(serviceCall)
                     .build();
@@ -114,8 +104,6 @@ class DspRequestHandlerImplTest {
 
         @Test
         void shouldFail_whenTransformationFails() {
-            var claimToken = claimToken();
-            when(identityService.verifyJwtToken(any(), any())).thenReturn(Result.success(claimToken));
             when(transformerRegistry.transform(any(), any())).thenReturn(Result.failure("error"));
             var request = getDspRequestBuilder().build();
 
@@ -137,13 +125,11 @@ class DspRequestHandlerImplTest {
     class CreateResource {
         @Test
         void shouldSucceed() {
-            var claimToken = claimToken();
             var jsonMessage = Json.createObjectBuilder().build();
             var message = mock(TestMessage.class);
             var content = new Object();
             var responseJson = Json.createObjectBuilder().build();
-            BiFunction<TestMessage, ClaimToken, ServiceResult<Object>> serviceCall = (m, t) -> ServiceResult.success(content);
-            when(identityService.verifyJwtToken(any(), any())).thenReturn(Result.success(claimToken));
+            BiFunction<TestMessage, TokenRepresentation, ServiceResult<Object>> serviceCall = (m, t) -> ServiceResult.success(content);
             when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
             when(transformerRegistry.transform(any(), eq(TestMessage.class))).thenReturn(Result.success(message));
             when(transformerRegistry.transform(any(), eq(JsonObject.class))).thenReturn(Result.success(responseJson));
@@ -160,7 +146,6 @@ class DspRequestHandlerImplTest {
             assertThat(result.getStatus()).isEqualTo(200);
             assertThat(result.getEntity()).isEqualTo(responseJson);
             assertThat(result.getMediaType()).isEqualTo(APPLICATION_JSON_TYPE);
-            verify(identityService).verifyJwtToken(argThat(t -> t.getToken().equals("token")), eq(callbackAddress));
             verify(validatorRegistry).validate("expected-message-type", jsonMessage);
             verify(transformerRegistry).transform(jsonMessage, TestMessage.class);
             verify(message).setProtocol(DATASPACE_PROTOCOL_HTTP);
@@ -169,8 +154,11 @@ class DspRequestHandlerImplTest {
 
         @Test
         void shouldFail_whenTokenIsNotValid() {
-            when(identityService.verifyJwtToken(any(), any())).thenReturn(Result.failure("error"));
-            var request = postDspRequestBuilder().errorType("errorType").build();
+            var request = postDspRequestBuilder().errorType("errorType").serviceCall((m, t) -> ServiceResult.unauthorized("unauthorized")).build();
+            var message = mock(TestMessage.class);
+
+            when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
+            when(transformerRegistry.transform(any(), eq(TestMessage.class))).thenReturn(Result.success(message));
 
             var result = handler.createResource(request);
 
@@ -184,7 +172,6 @@ class DspRequestHandlerImplTest {
 
         @Test
         void shouldFail_whenValidationFails() {
-            when(identityService.verifyJwtToken(any(), any())).thenReturn(Result.success(claimToken()));
             when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.failure(violation("error", "path")));
             var request = postDspRequestBuilder().build();
 
@@ -195,7 +182,6 @@ class DspRequestHandlerImplTest {
 
         @Test
         void shouldFail_whenTransformationFails() {
-            when(identityService.verifyJwtToken(any(), any())).thenReturn(Result.success(claimToken()));
             when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
             when(transformerRegistry.transform(any(), any())).thenReturn(Result.failure("error"));
             var request = postDspRequestBuilder().build();
@@ -207,10 +193,8 @@ class DspRequestHandlerImplTest {
 
         @Test
         void shouldFail_whenServiceCallFails() {
-            var claimToken = claimToken();
             var message = mock(TestMessage.class);
-            BiFunction<TestMessage, ClaimToken, ServiceResult<Object>> serviceCall = (m, t) -> ServiceResult.conflict("error");
-            when(identityService.verifyJwtToken(any(), any())).thenReturn(Result.success(claimToken));
+            BiFunction<TestMessage, TokenRepresentation, ServiceResult<Object>> serviceCall = (m, t) -> ServiceResult.conflict("error");
             when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
             when(transformerRegistry.transform(any(), any())).thenReturn(Result.success(message));
             var request = postDspRequestBuilder().serviceCall(serviceCall).build();
@@ -222,9 +206,7 @@ class DspRequestHandlerImplTest {
 
         @Test
         void shouldReturnInternalServerError_whenOutputTransformationFails() {
-            var claimToken = claimToken();
             var message = mock(TestMessage.class);
-            when(identityService.verifyJwtToken(any(), any())).thenReturn(Result.success(claimToken));
             when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
             when(transformerRegistry.transform(any(), eq(TestMessage.class))).thenReturn(Result.success(message));
             when(transformerRegistry.transform(any(), eq(JsonObject.class))).thenReturn(Result.failure("error"));
@@ -249,12 +231,10 @@ class DspRequestHandlerImplTest {
     class UpdateResource {
         @Test
         void shouldSucceed() {
-            var claimToken = claimToken();
             var jsonMessage = Json.createObjectBuilder().build();
             var message = mock(TestMessage.class);
             var content = new Object();
-            BiFunction<TestMessage, ClaimToken, ServiceResult<Object>> serviceCall = (m, t) -> ServiceResult.success(content);
-            when(identityService.verifyJwtToken(any(), any())).thenReturn(Result.success(claimToken));
+            BiFunction<TestMessage, TokenRepresentation, ServiceResult<Object>> serviceCall = (m, t) -> ServiceResult.success(content);
             when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
             when(transformerRegistry.transform(any(), eq(TestMessage.class))).thenReturn(Result.success(message));
             var request = PostDspRequest.Builder.newInstance(TestMessage.class, Object.class)
@@ -269,7 +249,6 @@ class DspRequestHandlerImplTest {
 
             assertThat(result.getStatus()).isEqualTo(200);
             assertThat(result.getMediaType()).isEqualTo(APPLICATION_JSON_TYPE);
-            verify(identityService).verifyJwtToken(argThat(t -> t.getToken().equals("token")), eq(callbackAddress));
             verify(validatorRegistry).validate("expected-message-type", jsonMessage);
             verify(transformerRegistry).transform(jsonMessage, TestMessage.class);
             verify(message).setProtocol(DATASPACE_PROTOCOL_HTTP);
@@ -277,8 +256,18 @@ class DspRequestHandlerImplTest {
 
         @Test
         void shouldFail_whenTokenIsNotValid() {
-            when(identityService.verifyJwtToken(any(), any())).thenReturn(Result.failure("error"));
-            var request = postDspRequestBuilder().processId("processId").errorType("errorType").build();
+            var jsonMessage = Json.createObjectBuilder().build();
+            var request = postDspRequestBuilder()
+                    .processId("processId")
+                    .errorType("errorType")
+                    .message(jsonMessage)
+                    .serviceCall((m, t) -> ServiceResult.unauthorized("unauthorized"))
+                    .build();
+            var message = mock(TestMessage.class);
+            
+            when(message.getProcessId()).thenReturn("processId");
+            when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
+            when(transformerRegistry.transform(any(), eq(TestMessage.class))).thenReturn(Result.success(message));
 
             var result = handler.updateResource(request);
 
@@ -293,7 +282,6 @@ class DspRequestHandlerImplTest {
 
         @Test
         void shouldFail_whenValidationFails() {
-            when(identityService.verifyJwtToken(any(), any())).thenReturn(Result.success(claimToken()));
             when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.failure(violation("error", "path")));
             var request = postDspRequestBuilder().processId("processId").errorType("errorType").build();
 
@@ -310,7 +298,6 @@ class DspRequestHandlerImplTest {
 
         @Test
         void shouldFail_whenTransformationFails() {
-            when(identityService.verifyJwtToken(any(), any())).thenReturn(Result.success(claimToken()));
             when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
             when(transformerRegistry.transform(any(), any())).thenReturn(Result.failure("error"));
             var request = postDspRequestBuilder().processId("processId").errorType("errorType").build();
@@ -328,9 +315,7 @@ class DspRequestHandlerImplTest {
 
         @Test
         void shouldFail_whenIdIsNotValid() {
-            var claimToken = claimToken();
             var message = mock(TestMessage.class);
-            when(identityService.verifyJwtToken(any(), any())).thenReturn(Result.success(claimToken));
             when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
             when(transformerRegistry.transform(any(), any())).thenReturn(Result.success(message));
             when(message.getProcessId()).thenReturn("processId");
@@ -349,10 +334,8 @@ class DspRequestHandlerImplTest {
 
         @Test
         void shouldFail_whenServiceCallFails() {
-            var claimToken = claimToken();
             var message = mock(TestMessage.class);
-            BiFunction<TestMessage, ClaimToken, ServiceResult<Object>> serviceCall = (m, t) -> ServiceResult.conflict("error");
-            when(identityService.verifyJwtToken(any(), any())).thenReturn(Result.success(claimToken));
+            BiFunction<TestMessage, TokenRepresentation, ServiceResult<Object>> serviceCall = (m, t) -> ServiceResult.conflict("error");
             when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
             when(transformerRegistry.transform(any(), any())).thenReturn(Result.success(message));
             when(message.getProcessId()).thenReturn("processId");

--- a/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/spi/message/DspRequest.java
+++ b/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/spi/message/DspRequest.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.edc.protocol.dsp.spi.message;
 
-import org.eclipse.edc.spi.iam.ClaimToken;
+import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.result.ServiceResult;
 
 import java.util.function.BiFunction;
@@ -27,7 +27,7 @@ public class DspRequest<I, R> {
     protected final Class<I> inputClass;
     protected String token;
     protected String errorType;
-    protected BiFunction<I, ClaimToken, ServiceResult<R>> serviceCall;
+    protected BiFunction<I, TokenRepresentation, ServiceResult<R>> serviceCall;
 
     public DspRequest(Class<I> inputClass, Class<R> resultClass) {
         this.inputClass = inputClass;
@@ -46,7 +46,7 @@ public class DspRequest<I, R> {
         return resultClass;
     }
 
-    public BiFunction<I, ClaimToken, ServiceResult<R>> getServiceCall() {
+    public BiFunction<I, TokenRepresentation, ServiceResult<R>> getServiceCall() {
         return serviceCall;
     }
 
@@ -67,7 +67,7 @@ public class DspRequest<I, R> {
             return self();
         }
 
-        public B serviceCall(BiFunction<I, ClaimToken, ServiceResult<R>> serviceCall) {
+        public B serviceCall(BiFunction<I, TokenRepresentation, ServiceResult<R>> serviceCall) {
             message.serviceCall = serviceCall;
             return self();
         }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/api/controller/DspNegotiationApiController.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/api/controller/DspNegotiationApiController.java
@@ -35,7 +35,7 @@ import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationProt
 import org.eclipse.edc.protocol.dsp.spi.message.DspRequestHandler;
 import org.eclipse.edc.protocol.dsp.spi.message.GetDspRequest;
 import org.eclipse.edc.protocol.dsp.spi.message.PostDspRequest;
-import org.eclipse.edc.spi.iam.ClaimToken;
+import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
@@ -279,11 +279,11 @@ public class DspNegotiationApiController {
     }
 
     @NotNull
-    private ServiceResult<ContractNegotiation> validateAndProcessRequest(ContractRequestMessage message, ClaimToken claimToken) {
+    private ServiceResult<ContractNegotiation> validateAndProcessRequest(ContractRequestMessage message, TokenRepresentation tokenRepresentation) {
         if (message.getCallbackAddress() == null) {
             throw new InvalidRequestException(format("ContractRequestMessage must contain a '%s' property", DSPACE_PROPERTY_CALLBACK_ADDRESS));
         }
-        return protocolService.notifyRequested(message, claimToken);
+        return protocolService.notifyRequested(message, tokenRepresentation);
     }
 
 }

--- a/extensions/common/iam/iam-mock/src/main/java/org/eclipse/edc/iam/mock/MockIdentityService.java
+++ b/extensions/common/iam/iam-mock/src/main/java/org/eclipse/edc/iam/mock/MockIdentityService.java
@@ -23,10 +23,6 @@ import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.TypeManager;
 
-import java.util.Objects;
-
-import static java.lang.String.format;
-
 public class MockIdentityService implements IdentityService {
     private final String region;
     private final TypeManager typeManager;
@@ -53,9 +49,6 @@ public class MockIdentityService implements IdentityService {
     @Override
     public Result<ClaimToken> verifyJwtToken(TokenRepresentation tokenRepresentation, String audience) {
         var token = typeManager.readValue(tokenRepresentation.getToken(), MockToken.class);
-        if (!Objects.equals(token.audience, audience)) {
-            return Result.failure(format("Mismatched audience: expected %s, got %s", audience, token.audience));
-        }
         return Result.success(ClaimToken.Builder.newInstance()
                 .claim("region", token.region)
                 .claim("client_id", token.clientId)

--- a/extensions/control-plane/api/control-plane-api-client/src/test/java/org/eclipse/edc/connector/api/client/transferprocess/TransferProcessHttpClientIntegrationTest.java
+++ b/extensions/control-plane/api/control-plane-api-client/src/test/java/org/eclipse/edc/connector/api/client/transferprocess/TransferProcessHttpClientIntegrationTest.java
@@ -30,6 +30,7 @@ import org.eclipse.edc.junit.extensions.EdcExtension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.entity.StatefulEntity;
+import org.eclipse.edc.spi.iam.IdentityService;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.protocol.ProtocolWebhook;
 import org.eclipse.edc.spi.response.StatusResult;
@@ -79,6 +80,7 @@ public class TransferProcessHttpClientIntegrationTest {
 
         extension.registerSystemExtension(ServiceExtension.class, new TransferServiceMockExtension(service));
         extension.registerServiceMock(ProtocolWebhook.class, mock());
+        extension.registerServiceMock(IdentityService.class, mock());
         var registry = mock(RemoteMessageDispatcherRegistry.class);
         when(registry.dispatch(any(), any())).thenReturn(completedFuture(StatusResult.success("any")));
         extension.registerServiceMock(RemoteMessageDispatcherRegistry.class, registry);

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/catalog/CatalogProtocolService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/catalog/CatalogProtocolService.java
@@ -18,6 +18,7 @@ import org.eclipse.edc.catalog.spi.Catalog;
 import org.eclipse.edc.catalog.spi.CatalogRequestMessage;
 import org.eclipse.edc.catalog.spi.Dataset;
 import org.eclipse.edc.spi.iam.ClaimToken;
+import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.jetbrains.annotations.NotNull;
 
@@ -29,20 +30,20 @@ public interface CatalogProtocolService {
     /**
      * Returns a catalog given a {@link CatalogRequestMessage} and a {@link ClaimToken}
      *
-     * @param message the request message.
-     * @param token the claim token.
+     * @param message             the request message.
+     * @param tokenRepresentation the claim token.
      * @return succeeded result with the {@link Catalog}, failed result otherwise.
      */
     @NotNull
-    ServiceResult<Catalog> getCatalog(CatalogRequestMessage message, ClaimToken token);
+    ServiceResult<Catalog> getCatalog(CatalogRequestMessage message, TokenRepresentation tokenRepresentation);
 
     /**
      * Returns a dataset given its id and a {@link ClaimToken}
      *
-     * @param datasetId the dataset id.
-     * @param claimToken the claim token.
+     * @param datasetId           the dataset id.
+     * @param tokenRepresentation the claim token.
      * @return succeeded result with the {@link Dataset}, failed result otherwise.
      */
     @NotNull
-    ServiceResult<Dataset> getDataset(String datasetId, ClaimToken claimToken);
+    ServiceResult<Dataset> getDataset(String datasetId, TokenRepresentation tokenRepresentation);
 }

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/contractnegotiation/ContractNegotiationProtocolService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/contractnegotiation/ContractNegotiationProtocolService.java
@@ -21,7 +21,7 @@ import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiat
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationTerminationMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
-import org.eclipse.edc.spi.iam.ClaimToken;
+import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.jetbrains.annotations.NotNull;
 
@@ -34,86 +34,86 @@ public interface ContractNegotiationProtocolService {
      * Notifies the ContractNegotiation that it has been requested by the consumer.
      * Only callable on provider ContractNegotiation.
      *
-     * @param message the incoming message
-     * @param claimToken the counter-party claim token
+     * @param message             the incoming message
+     * @param tokenRepresentation the counter-party claim token
      * @return a succeeded result if the operation was successful, a failed one otherwise
      */
     @NotNull
-    ServiceResult<ContractNegotiation> notifyRequested(ContractRequestMessage message, ClaimToken claimToken);
+    ServiceResult<ContractNegotiation> notifyRequested(ContractRequestMessage message, TokenRepresentation tokenRepresentation);
 
     /**
      * Notifies the ContractNegotiation that it has been offered by the provider.
      * Only callable on consumer ContractNegotiation.
      *
-     * @param message the incoming message
-     * @param claimToken the counter-party claim token
+     * @param message             the incoming message
+     * @param tokenRepresentation the counter-party claim token
      * @return a succeeded result if the operation was successful, a failed one otherwise
      */
     @NotNull
-    ServiceResult<ContractNegotiation> notifyOffered(ContractOfferMessage message, ClaimToken claimToken);
+    ServiceResult<ContractNegotiation> notifyOffered(ContractOfferMessage message, TokenRepresentation tokenRepresentation);
 
     /**
      * Notifies the ContractNegotiation that it has been agreed by the accepted.
      * Only callable on provider ContractNegotiation.
      *
-     * @param message the incoming message
-     * @param claimToken the counter-party claim token
+     * @param message             the incoming message
+     * @param tokenRepresentation the counter-party claim token
      * @return a succeeded result if the operation was successful, a failed one otherwise
      */
     @NotNull
-    ServiceResult<ContractNegotiation> notifyAccepted(ContractNegotiationEventMessage message, ClaimToken claimToken);
+    ServiceResult<ContractNegotiation> notifyAccepted(ContractNegotiationEventMessage message, TokenRepresentation tokenRepresentation);
 
     /**
      * Notifies the ContractNegotiation that it has been agreed by the provider.
      * Only callable on consumer ContractNegotiation.
      *
-     * @param message the incoming message
-     * @param claimToken the counter-party claim token
+     * @param message             the incoming message
+     * @param tokenRepresentation the counter-party claim token
      * @return a succeeded result if the operation was successful, a failed one otherwise
      */
     @NotNull
-    ServiceResult<ContractNegotiation> notifyAgreed(ContractAgreementMessage message, ClaimToken claimToken);
+    ServiceResult<ContractNegotiation> notifyAgreed(ContractAgreementMessage message, TokenRepresentation tokenRepresentation);
 
     /**
      * Notifies the ContractNegotiation that it has been verified by the consumer.
      * Only callable on provider ContractNegotiation.
      *
-     * @param message the incoming message
-     * @param claimToken the counter-party claim token
+     * @param message             the incoming message
+     * @param tokenRepresentation the counter-party claim token
      * @return a succeeded result if the operation was successful, a failed one otherwise
      */
     @NotNull
-    ServiceResult<ContractNegotiation> notifyVerified(ContractAgreementVerificationMessage message, ClaimToken claimToken);
+    ServiceResult<ContractNegotiation> notifyVerified(ContractAgreementVerificationMessage message, TokenRepresentation tokenRepresentation);
 
     /**
      * Notifies the ContractNegotiation that it has been finalized by the provider.
      * Only callable on consumer ContractNegotiation.
      *
-     * @param message the incoming message
-     * @param claimToken the counter-party claim token
+     * @param message             the incoming message
+     * @param tokenRepresentation the counter-party claim token
      * @return a succeeded result if the operation was successful, a failed one otherwise
      */
     @NotNull
-    ServiceResult<ContractNegotiation> notifyFinalized(ContractNegotiationEventMessage message, ClaimToken claimToken);
+    ServiceResult<ContractNegotiation> notifyFinalized(ContractNegotiationEventMessage message, TokenRepresentation tokenRepresentation);
 
     /**
      * Notifies the ContractNegotiation that it has been terminated by the counter-part.
      *
-     * @param message the incoming message
-     * @param claimToken the counter-party claim token
+     * @param message             the incoming message
+     * @param tokenRepresentation the counter-party claim token
      * @return a succeeded result if the operation was successful, a failed one otherwise
      */
     @NotNull
-    ServiceResult<ContractNegotiation> notifyTerminated(ContractNegotiationTerminationMessage message, ClaimToken claimToken);
+    ServiceResult<ContractNegotiation> notifyTerminated(ContractNegotiationTerminationMessage message, TokenRepresentation tokenRepresentation);
 
     /**
      * Finds a contract negotiation that has been requested by the counter-part. An existing
      * negotiation, for which the counter-part is not authorized, is treated as non-existent.
      *
-     * @param id id of the negotiation
-     * @param claimToken the counter-party claim token
+     * @param id                  id of the negotiation
+     * @param tokenRepresentation the counter-party claim token
      * @return a succeeded result containing the negotiation if it was found, a failed one otherwise
      */
     @NotNull
-    ServiceResult<ContractNegotiation> findById(String id, ClaimToken claimToken);
+    ServiceResult<ContractNegotiation> findById(String id, TokenRepresentation tokenRepresentation);
 }

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/transferprocess/TransferProcessProtocolService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/transferprocess/TransferProcessProtocolService.java
@@ -19,7 +19,7 @@ import org.eclipse.edc.connector.transfer.spi.types.protocol.TransferCompletionM
 import org.eclipse.edc.connector.transfer.spi.types.protocol.TransferRequestMessage;
 import org.eclipse.edc.connector.transfer.spi.types.protocol.TransferStartMessage;
 import org.eclipse.edc.connector.transfer.spi.types.protocol.TransferTerminationMessage;
-import org.eclipse.edc.spi.iam.ClaimToken;
+import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.jetbrains.annotations.NotNull;
 
@@ -31,51 +31,51 @@ public interface TransferProcessProtocolService {
     /**
      * Notifies the TransferProcess that it has been requested by the counter-part.
      *
-     * @param message the incoming message
-     * @param claimToken the counter-party claim token
+     * @param message             the incoming message
+     * @param tokenRepresentation the counter-party claim token
      * @return a succeeded result if the operation was successful, a failed one otherwise
      */
     @NotNull
-    ServiceResult<TransferProcess> notifyRequested(TransferRequestMessage message, ClaimToken claimToken);
+    ServiceResult<TransferProcess> notifyRequested(TransferRequestMessage message, TokenRepresentation tokenRepresentation);
 
     /**
      * Notifies the TransferProcess that it has been started by the counter-part.
      *
-     * @param message the incoming message
-     * @param claimToken the counter-party claim token
+     * @param message             the incoming message
+     * @param tokenRepresentation the counter-party claim token
      * @return a succeeded result if the operation was successful, a failed one otherwise
      */
     @NotNull
-    ServiceResult<TransferProcess> notifyStarted(TransferStartMessage message, ClaimToken claimToken);
+    ServiceResult<TransferProcess> notifyStarted(TransferStartMessage message, TokenRepresentation tokenRepresentation);
 
     /**
      * Notifies the TransferProcess that it has been completed by the counter-part.
      *
-     * @param message the incoming message
-     * @param claimToken the counter-party claim token
+     * @param message             the incoming message
+     * @param tokenRepresentation the counter-party claim token
      * @return a succeeded result if the operation was successful, a failed one otherwise
      */
     @NotNull
-    ServiceResult<TransferProcess> notifyCompleted(TransferCompletionMessage message, ClaimToken claimToken);
+    ServiceResult<TransferProcess> notifyCompleted(TransferCompletionMessage message, TokenRepresentation tokenRepresentation);
 
     /**
      * Notifies the TransferProcess that it has been terminated by the counter-part.
      *
-     * @param message the incoming message
-     * @param claimToken the counter-party claim token
+     * @param message             the incoming message
+     * @param tokenRepresentation the counter-party claim token
      * @return a succeeded result if the operation was successful, a failed one otherwise
      */
     @NotNull
-    ServiceResult<TransferProcess> notifyTerminated(TransferTerminationMessage message, ClaimToken claimToken);
+    ServiceResult<TransferProcess> notifyTerminated(TransferTerminationMessage message, TokenRepresentation tokenRepresentation);
 
     /**
      * Finds a transfer process that has been requested by the counter-part. An existing
      * process, for which the counter-part is not authorized, is treated as non-existent.
      *
-     * @param id id of the transfer process
-     * @param claimToken the counter-party claim token
+     * @param id                  id of the transfer process
+     * @param tokenRepresentation the counter-party claim token
      * @return a succeeded result containing the transfer process if it was found, a failed one otherwise
      */
     @NotNull
-    ServiceResult<TransferProcess> findById(String id, ClaimToken claimToken);
+    ServiceResult<TransferProcess> findById(String id, TokenRepresentation tokenRepresentation);
 }


### PR DESCRIPTION
## What this PR changes/adds

Implements the refactor outlined in DR #3665 

## Why it does that

Decoupling the net protocol from the security checksm which are now delegated to the protocol service layer.

This also will allow use to attach contextual information to the verification process.

## Further notes

In this PR since we are pushing here the invocation of the `IdentityService` we don't know the audience here/ The audience removal will be tackle in subsequent PRs. 

`IdentityService` that relies on this parameter would not work for the time being.

## Linked Issue(s)

Closes #3667 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
