### PR TITLE
refactor: create distributions from `DataFlowManager` transfer types

### DIFF
--- a/core/control-plane/catalog-core/build.gradle.kts
+++ b/core/control-plane/catalog-core/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
 dependencies {
     api(project(":spi:common:catalog-spi"))
     api(project(":spi:control-plane:contract-spi"))
-    api(project(":spi:data-plane-selector:data-plane-selector-spi"))
+    api(project(":spi:control-plane:transfer-spi"))
 
     testImplementation(project(":core:common:junit"))
     testImplementation(project(":core:control-plane:control-plane-core"))

--- a/core/control-plane/catalog-core/src/main/java/org/eclipse/edc/connector/catalog/CatalogDefaultServicesExtension.java
+++ b/core/control-plane/catalog-core/src/main/java/org/eclipse/edc/connector/catalog/CatalogDefaultServicesExtension.java
@@ -16,7 +16,7 @@ package org.eclipse.edc.connector.catalog;
 
 import org.eclipse.edc.catalog.spi.DataServiceRegistry;
 import org.eclipse.edc.catalog.spi.DistributionResolver;
-import org.eclipse.edc.connector.dataplane.selector.spi.store.DataPlaneInstanceStore;
+import org.eclipse.edc.connector.transfer.spi.flow.DataFlowManager;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
@@ -29,7 +29,7 @@ public class CatalogDefaultServicesExtension implements ServiceExtension {
     public static final String NAME = "Catalog Default Services";
 
     @Inject
-    private DataPlaneInstanceStore dataPlaneInstanceStore;
+    private DataFlowManager dataFlowManager;
     
     private DataServiceRegistry dataServiceRegistry;
 
@@ -50,6 +50,6 @@ public class CatalogDefaultServicesExtension implements ServiceExtension {
 
     @Provider(isDefault = true)
     public DistributionResolver distributionResolver() {
-        return new DefaultDistributionResolver(dataServiceRegistry, dataPlaneInstanceStore);
+        return new DefaultDistributionResolver(dataServiceRegistry, dataFlowManager);
     }
 }

--- a/core/control-plane/catalog-core/src/main/java/org/eclipse/edc/connector/catalog/DatasetResolverImpl.java
+++ b/core/control-plane/catalog-core/src/main/java/org/eclipse/edc/connector/catalog/DatasetResolverImpl.java
@@ -76,7 +76,7 @@ public class DatasetResolverImpl implements DatasetResolver {
 
     private Dataset toDataset(List<ContractDefinition> contractDefinitions, Asset asset) {
 
-        var distributions = distributionResolver.getDistributions(asset, null); // TODO: data addresses should be retrieved
+        var distributions = distributionResolver.getDistributions(asset);
         var datasetBuilder = Dataset.Builder.newInstance()
                 .id(asset.getId())
                 .distributions(distributions)

--- a/core/control-plane/catalog-core/src/main/java/org/eclipse/edc/connector/catalog/DefaultDistributionResolver.java
+++ b/core/control-plane/catalog-core/src/main/java/org/eclipse/edc/connector/catalog/DefaultDistributionResolver.java
@@ -18,29 +18,24 @@ package org.eclipse.edc.connector.catalog;
 import org.eclipse.edc.catalog.spi.DataServiceRegistry;
 import org.eclipse.edc.catalog.spi.Distribution;
 import org.eclipse.edc.catalog.spi.DistributionResolver;
-import org.eclipse.edc.connector.dataplane.selector.spi.store.DataPlaneInstanceStore;
-import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.connector.transfer.spi.flow.DataFlowManager;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class DefaultDistributionResolver implements DistributionResolver {
 
     private final DataServiceRegistry dataServiceRegistry;
-    private final DataPlaneInstanceStore dataPlaneInstanceStore;
+    private final DataFlowManager dataFlowManager;
 
-    public DefaultDistributionResolver(DataServiceRegistry dataServiceRegistry, DataPlaneInstanceStore dataPlaneInstanceStore) {
+    public DefaultDistributionResolver(DataServiceRegistry dataServiceRegistry, DataFlowManager dataFlowManager) {
         this.dataServiceRegistry = dataServiceRegistry;
-        this.dataPlaneInstanceStore = dataPlaneInstanceStore;
+        this.dataFlowManager = dataFlowManager;
     }
 
     @Override
-    public List<Distribution> getDistributions(Asset asset, DataAddress dataAddress) {
-        return dataPlaneInstanceStore.getAll()
-                .flatMap(it -> it.getAllowedDestTypes().stream())
-                .map(this::createDistribution)
-                .collect(Collectors.toList());
+    public List<Distribution> getDistributions(Asset asset) {
+        return dataFlowManager.transferTypesFor(asset).stream().map(this::createDistribution).toList();
     }
     
     private Distribution createDistribution(String format) {

--- a/core/control-plane/catalog-core/src/test/java/org/eclipse/edc/connector/catalog/DatasetResolverImplTest.java
+++ b/core/control-plane/catalog-core/src/test/java/org/eclipse/edc/connector/catalog/DatasetResolverImplTest.java
@@ -81,7 +81,7 @@ class DatasetResolverImplTest {
         when(contractDefinitionResolver.definitionsFor(any())).thenReturn(Stream.of(contractDefinition));
         when(assetIndex.queryAssets(isA(QuerySpec.class))).thenReturn(Stream.of(createAsset("assetId").property("key", "value").build()));
         when(policyStore.findById("contractPolicyId")).thenReturn(PolicyDefinition.Builder.newInstance().policy(contractPolicy).build());
-        when(distributionResolver.getDistributions(isA(Asset.class), any())).thenReturn(List.of(distribution));
+        when(distributionResolver.getDistributions(isA(Asset.class))).thenReturn(List.of(distribution));
 
         var datasets = datasetResolver.query(createParticipantAgent(), QuerySpec.none());
 

--- a/core/control-plane/catalog-core/src/test/java/org/eclipse/edc/connector/catalog/DefaultDistributionResolverTest.java
+++ b/core/control-plane/catalog-core/src/test/java/org/eclipse/edc/connector/catalog/DefaultDistributionResolverTest.java
@@ -16,38 +16,36 @@ package org.eclipse.edc.connector.catalog;
 
 import org.eclipse.edc.catalog.spi.DataService;
 import org.eclipse.edc.catalog.spi.DataServiceRegistry;
-import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
-import org.eclipse.edc.connector.dataplane.selector.spi.store.DataPlaneInstanceStore;
+import org.eclipse.edc.connector.transfer.spi.flow.DataFlowManager;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.stream.Stream;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class DefaultDistributionResolverTest {
 
     private final DataService dataService = DataService.Builder.newInstance().build();
-    private DataServiceRegistry dataServiceRegistry = mock(DataServiceRegistry.class);
-    private final DataPlaneInstanceStore dataPlaneInstanceStore = mock(DataPlaneInstanceStore.class);
+    private final DataServiceRegistry dataServiceRegistry = mock();
+    private final DataFlowManager dataFlowManager = mock();
 
-    private final DefaultDistributionResolver resolver = new DefaultDistributionResolver(dataServiceRegistry, dataPlaneInstanceStore);
+    private final DefaultDistributionResolver resolver = new DefaultDistributionResolver(dataServiceRegistry, dataFlowManager);
 
     @Test
-    void shouldReturnDistributionForEverySupportedDestType() {
+    void shouldReturnDistributionsForEveryTransferType() {
         when(dataServiceRegistry.getDataServices()).thenReturn(List.of(dataService));
-        
-        var dataPlane1 = DataPlaneInstance.Builder.newInstance().url("http://data-plane-one").allowedDestType("type1").build();
-        var dataPlane2 = DataPlaneInstance.Builder.newInstance().url("http://data-plane-two").allowedDestType("type2").build();
-        when(dataPlaneInstanceStore.getAll()).thenReturn(Stream.of(dataPlane1, dataPlane2));
-        var asset = Asset.Builder.newInstance().build();
-        var dataAddress = DataAddress.Builder.newInstance().type("any").build();
+        when(dataFlowManager.transferTypesFor(any())).thenReturn(Set.of("type1", "type2"));
 
-        var distributions = resolver.getDistributions(asset, dataAddress);
+        var dataAddress = DataAddress.Builder.newInstance().type("any").build();
+        var asset = Asset.Builder.newInstance().dataAddress(dataAddress).build();
+
+        var distributions = resolver.getDistributions(asset);
 
         assertThat(distributions).hasSize(2)
                 .anySatisfy(distribution -> {

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
@@ -61,7 +61,6 @@ import static org.mockito.Mockito.when;
 @ExtendWith(EdcExtension.class)
 class ContractNegotiationEventDispatchTest {
     private static final String CONSUMER = "consumer";
-    private static final String PROVIDER = "provider";
 
     private final EventSubscriber eventSubscriber = mock(EventSubscriber.class);
     private final ClaimToken token = ClaimToken.Builder.newInstance().claim(ParticipantAgentService.DEFAULT_IDENTITY_CLAIM_KEY, CONSUMER).build();

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/flow/DataFlowManagerImpl.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/flow/DataFlowManagerImpl.java
@@ -21,14 +21,18 @@ import org.eclipse.edc.connector.transfer.spi.types.DataFlowResponse;
 import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
 
 import static java.lang.String.format;
+import static java.util.stream.Collectors.toSet;
 import static org.eclipse.edc.spi.response.ResponseStatus.FATAL_ERROR;
 
 /**
@@ -61,6 +65,15 @@ public class DataFlowManagerImpl implements DataFlowManager {
     @Override
     public @NotNull StatusResult<Void> terminate(TransferProcess transferProcess) {
         return chooseControllerAndApply(transferProcess, controller -> controller.terminate(transferProcess));
+    }
+
+    @Override
+    public Set<String> transferTypesFor(Asset asset) {
+        return controllers.stream()
+                .map(it -> it.controller)
+                .map(it -> it.transferTypesFor(asset))
+                .flatMap(Collection::stream)
+                .collect(toSet());
     }
 
     @NotNull

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/flow/DataFlowManagerImplTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/flow/DataFlowManagerImplTest.java
@@ -22,7 +22,11 @@ import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.asset.Asset;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
@@ -37,94 +41,120 @@ class DataFlowManagerImplTest {
 
     private final DataFlowManagerImpl manager = new DataFlowManagerImpl();
 
-    @Test
-    void initiate_shouldInitiateFlowOnCorrectController() {
-        var controller = mock(DataFlowController.class);
-        var dataRequest = DataRequest.Builder.newInstance().destinationType("test-dest-type").build();
-        var policy = Policy.Builder.newInstance().build();
-        var dataAddress = DataAddress.Builder.newInstance().type("test-type").build();
-        var transferProcess = TransferProcess.Builder.newInstance().dataRequest(dataRequest).contentDataAddress(dataAddress).build();
+    @Nested
+    class Initiate {
+        @Test
+        void shouldInitiateFlowOnCorrectController() {
+            var controller = mock(DataFlowController.class);
+            var dataRequest = DataRequest.Builder.newInstance().destinationType("test-dest-type").build();
+            var policy = Policy.Builder.newInstance().build();
+            var dataAddress = DataAddress.Builder.newInstance().type("test-type").build();
+            var transferProcess = TransferProcess.Builder.newInstance().dataRequest(dataRequest).contentDataAddress(dataAddress).build();
 
-        when(controller.canHandle(any())).thenReturn(true);
-        when(controller.initiateFlow(any(), any())).thenReturn(StatusResult.success(DataFlowResponse.Builder.newInstance().build()));
-        manager.register(controller);
+            when(controller.canHandle(any())).thenReturn(true);
+            when(controller.initiateFlow(any(), any())).thenReturn(StatusResult.success(DataFlowResponse.Builder.newInstance().build()));
+            manager.register(controller);
 
-        var response = manager.initiate(transferProcess, policy);
+            var response = manager.initiate(transferProcess, policy);
 
-        assertThat(response.succeeded()).isTrue();
+            assertThat(response.succeeded()).isTrue();
+        }
+
+        @Test
+        void shouldReturnFatalError_whenNoControllerCanHandleTheRequest() {
+            var controller = mock(DataFlowController.class);
+            var dataRequest = DataRequest.Builder.newInstance().destinationType("test-dest-type").build();
+            var dataAddress = DataAddress.Builder.newInstance().type("test-type").build();
+            var policy = Policy.Builder.newInstance().build();
+            var transferProcess = TransferProcess.Builder.newInstance().dataRequest(dataRequest).contentDataAddress(dataAddress).build();
+
+            when(controller.canHandle(any())).thenReturn(false);
+            manager.register(controller);
+
+            var response = manager.initiate(transferProcess, policy);
+
+            assertThat(response.succeeded()).isFalse();
+            assertThat(response.getFailure().status()).isEqualTo(FATAL_ERROR);
+        }
+
+        @Test
+        void shouldCatchExceptionsAndReturnFatalError() {
+            var controller = mock(DataFlowController.class);
+            var dataRequest = DataRequest.Builder.newInstance().destinationType("test-dest-type").build();
+            var dataAddress = DataAddress.Builder.newInstance().type("test-type").build();
+            var policy = Policy.Builder.newInstance().build();
+            var transferProcess = TransferProcess.Builder.newInstance().dataRequest(dataRequest).contentDataAddress(dataAddress).build();
+
+            var errorMsg = "Test Error Message";
+            when(controller.canHandle(any())).thenReturn(true);
+            when(controller.initiateFlow(any(), any())).thenThrow(new EdcException(errorMsg));
+            manager.register(controller);
+
+            var response = manager.initiate(transferProcess, policy);
+
+            assertThat(response.succeeded()).isFalse();
+            assertThat(response.getFailure().status()).isEqualTo(FATAL_ERROR);
+            assertThat(response.getFailureMessages()).hasSize(1).first().matches(message -> message.contains(errorMsg));
+        }
+
+        @Test
+        void shouldChooseHighestPriorityController() {
+            var highPriority = createDataFlowController();
+            var lowPriority = createDataFlowController();
+            manager.register(1, lowPriority);
+            manager.register(2, highPriority);
+
+            manager.initiate(TransferProcess.Builder.newInstance().build(), Policy.Builder.newInstance().build());
+
+            verify(highPriority).initiateFlow(any(), any());
+            verifyNoInteractions(lowPriority);
+        }
+
+        private DataFlowController createDataFlowController() {
+            var dataFlowController = mock(DataFlowController.class);
+            when(dataFlowController.canHandle(any())).thenReturn(true);
+            when(dataFlowController.initiateFlow(any(), any())).thenReturn(StatusResult.success(DataFlowResponse.Builder.newInstance().build()));
+            return dataFlowController;
+        }
     }
 
-    @Test
-    void initiate_shouldReturnFatalError_whenNoControllerCanHandleTheRequest() {
-        var controller = mock(DataFlowController.class);
-        var dataRequest = DataRequest.Builder.newInstance().destinationType("test-dest-type").build();
-        var dataAddress = DataAddress.Builder.newInstance().type("test-type").build();
-        var policy = Policy.Builder.newInstance().build();
-        var transferProcess = TransferProcess.Builder.newInstance().dataRequest(dataRequest).contentDataAddress(dataAddress).build();
+    @Nested
+    class Terminate {
+        @Test
+        void shouldChooseControllerAndTerminate() {
+            var controller = mock(DataFlowController.class);
+            var dataRequest = DataRequest.Builder.newInstance().destinationType("test-dest-type").build();
+            var dataAddress = DataAddress.Builder.newInstance().type("test-type").build();
+            var transferProcess = TransferProcess.Builder.newInstance().dataRequest(dataRequest).contentDataAddress(dataAddress).build();
 
-        when(controller.canHandle(any())).thenReturn(false);
-        manager.register(controller);
+            when(controller.canHandle(any())).thenReturn(true);
+            when(controller.terminate(any())).thenReturn(StatusResult.success());
+            manager.register(controller);
 
-        var response = manager.initiate(transferProcess, policy);
+            var result = manager.terminate(transferProcess);
 
-        assertThat(response.succeeded()).isFalse();
-        assertThat(response.getFailure().status()).isEqualTo(FATAL_ERROR);
+            assertThat(result).isSucceeded();
+            verify(controller).terminate(transferProcess);
+        }
     }
 
-    @Test
-    void initiate_shouldCatchExceptionsAndReturnFatalError() {
-        var controller = mock(DataFlowController.class);
-        var dataRequest = DataRequest.Builder.newInstance().destinationType("test-dest-type").build();
-        var dataAddress = DataAddress.Builder.newInstance().type("test-type").build();
-        var policy = Policy.Builder.newInstance().build();
-        var transferProcess = TransferProcess.Builder.newInstance().dataRequest(dataRequest).contentDataAddress(dataAddress).build();
+    @Nested
+    class TransferTypesFor {
+        @Test
+        void shouldReturnTransferTypesFromControllers() {
+            var controllerOne = mock(DataFlowController.class);
+            when(controllerOne.transferTypesFor(any())).thenReturn(Set.of("Type1"));
+            var controllerTwo = mock(DataFlowController.class);
+            when(controllerTwo.transferTypesFor(any())).thenReturn(Set.of("Type2", "Type3"));
+            manager.register(controllerOne);
+            manager.register(controllerTwo);
+            var asset = Asset.Builder.newInstance().build();
 
-        var errorMsg = "Test Error Message";
-        when(controller.canHandle(any())).thenReturn(true);
-        when(controller.initiateFlow(any(), any())).thenThrow(new EdcException(errorMsg));
-        manager.register(controller);
 
-        var response = manager.initiate(transferProcess, policy);
+            var result = manager.transferTypesFor(asset);
 
-        assertThat(response.succeeded()).isFalse();
-        assertThat(response.getFailure().status()).isEqualTo(FATAL_ERROR);
-        assertThat(response.getFailureMessages()).hasSize(1).first().matches(message -> message.contains(errorMsg));
+            assertThat(result).containsExactlyInAnyOrder("Type1", "Type2", "Type3");
+        }
     }
 
-    @Test
-    void initiate_shouldChooseHighestPriorityController() {
-        var highPriority = createDataFlowController();
-        var lowPriority = createDataFlowController();
-        manager.register(1, lowPriority);
-        manager.register(2, highPriority);
-
-        manager.initiate(TransferProcess.Builder.newInstance().build(), Policy.Builder.newInstance().build());
-
-        verify(highPriority).initiateFlow(any(), any());
-        verifyNoInteractions(lowPriority);
-    }
-
-    @Test
-    void terminate_shouldChooseControllerAndTerminate() {
-        var controller = mock(DataFlowController.class);
-        var dataRequest = DataRequest.Builder.newInstance().destinationType("test-dest-type").build();
-        var dataAddress = DataAddress.Builder.newInstance().type("test-type").build();
-        var transferProcess = TransferProcess.Builder.newInstance().dataRequest(dataRequest).contentDataAddress(dataAddress).build();
-
-        when(controller.canHandle(any())).thenReturn(true);
-        when(controller.terminate(any())).thenReturn(StatusResult.success());
-        manager.register(controller);
-
-        var result = manager.terminate(transferProcess);
-
-        assertThat(result).isSucceeded();
-        verify(controller).terminate(transferProcess);
-    }
-
-    private DataFlowController createDataFlowController() {
-        var dataFlowController = mock(DataFlowController.class);
-        when(dataFlowController.canHandle(any())).thenReturn(true);
-        when(dataFlowController.initiateFlow(any(), any())).thenReturn(StatusResult.success(DataFlowResponse.Builder.newInstance().build()));
-        return dataFlowController;
-    }
 }

--- a/extensions/control-plane/transfer/transfer-data-plane/src/main/java/org/eclipse/edc/connector/transfer/dataplane/flow/ConsumerPullTransferDataFlowController.java
+++ b/extensions/control-plane/transfer/transfer-data-plane/src/main/java/org/eclipse/edc/connector/transfer/dataplane/flow/ConsumerPullTransferDataFlowController.java
@@ -22,12 +22,15 @@ import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Optional;
+import java.util.Set;
 
 import static java.lang.String.format;
 import static org.eclipse.edc.connector.transfer.dataplane.spi.TransferDataPlaneConstants.HTTP_PROXY;
+import static org.eclipse.edc.connector.transfer.spi.flow.FlowType.PULL;
 import static org.eclipse.edc.spi.response.ResponseStatus.FATAL_ERROR;
 import static org.eclipse.edc.spi.response.StatusResult.failure;
 
@@ -61,6 +64,11 @@ public class ConsumerPullTransferDataFlowController implements DataFlowControlle
     @Override
     public StatusResult<Void> terminate(TransferProcess transferProcess) {
         return StatusResult.success();
+    }
+
+    @Override
+    public Set<String> transferTypesFor(Asset asset) {
+        return Set.of("%s-%s".formatted("Http", PULL));
     }
 
     private DataFlowResponse toResponse(DataAddress address) {

--- a/extensions/control-plane/transfer/transfer-data-plane/src/test/java/org/eclipse/edc/connector/transfer/dataplane/flow/ConsumerPullTransferDataFlowControllerTest.java
+++ b/extensions/control-plane/transfer/transfer-data-plane/src/test/java/org/eclipse/edc/connector/transfer/dataplane/flow/ConsumerPullTransferDataFlowControllerTest.java
@@ -23,6 +23,7 @@ import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.result.Failure;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
@@ -108,6 +109,15 @@ class ConsumerPullTransferDataFlowControllerTest {
         var result = flowController.terminate(transferProcess);
 
         assertThat(result).isSucceeded();
+    }
+
+    @Test
+    void transferTypes_shouldReturnHttpPull() {
+        var asset = Asset.Builder.newInstance().dataAddress(DataAddress.Builder.newInstance().type("any").build()).build();
+
+        var transferTypes = flowController.transferTypesFor(asset);
+
+        assertThat(transferTypes).hasSize(1).contains("Http-PULL");
     }
 
     private TransferProcess transferProcess(String destinationType) {

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/flow/DataFlowController.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/flow/DataFlowController.java
@@ -15,13 +15,14 @@
 package org.eclipse.edc.connector.transfer.spi.flow;
 
 import org.eclipse.edc.connector.transfer.spi.types.DataFlowResponse;
-import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
 import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.response.ResponseStatus;
 import org.eclipse.edc.spi.response.StatusResult;
-import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
 
 /**
  * Handles a data flow.
@@ -57,32 +58,9 @@ public interface DataFlowController {
     StatusResult<Void> terminate(TransferProcess transferProcess);
 
     /**
-     * Returns true if the manager can handle the data type.
+     * Returns transfer types that the controller can handle for the specified Asset.
      *
-     * @param dataRequest    the request
-     * @param contentAddress the address to resolve the asset contents. This may be the original asset address or an address resolving to generated content.
-     * @deprecated please use {@link #canHandle(TransferProcess)}
+     * @return transfer type set.
      */
-    @Deprecated(since = "0.2.1", forRemoval = true)
-    default boolean canHandle(DataRequest dataRequest, DataAddress contentAddress) {
-        return canHandle(TransferProcess.Builder.newInstance().dataRequest(dataRequest).contentDataAddress(contentAddress).build());
-    }
-
-    /**
-     * Initiate a data flow.
-     *
-     * <p>Implementations should not throw exceptions. If an unexpected exception occurs and the flow should be re-attempted, set {@link ResponseStatus#ERROR_RETRY} in the
-     * response. If an exception occurs and re-tries should not be re-attempted, set {@link ResponseStatus#FATAL_ERROR} in the response. </p>
-     *
-     * @param dataRequest    the request
-     * @param contentAddress the address to resolve the asset contents. This may be the original asset address or an address resolving to generated content.
-     * @param policy         the contract agreement usage policy for the asset being transferred
-     * @deprecated please use {@link #initiateFlow(TransferProcess, Policy)}
-     */
-    @NotNull
-    @Deprecated(since = "0.2.1", forRemoval = true)
-    default StatusResult<DataFlowResponse> initiateFlow(DataRequest dataRequest, DataAddress contentAddress, Policy policy) {
-        return initiateFlow(TransferProcess.Builder.newInstance().dataRequest(dataRequest).contentDataAddress(contentAddress).build(), policy);
-    }
-
+    Set<String> transferTypesFor(Asset asset);
 }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/flow/DataFlowManager.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/flow/DataFlowManager.java
@@ -19,7 +19,10 @@ import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.types.domain.asset.Asset;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
 
 /**
  * Manages data flows and dispatches to {@link DataFlowController}s.
@@ -61,4 +64,11 @@ public interface DataFlowManager {
     @NotNull
     StatusResult<Void> terminate(TransferProcess transferProcess);
 
+    /**
+     * Returns the transfer types available for a specific asset.
+     *
+     * @param asset the asset.
+     * @return tranfer types list.
+     */
+    Set<String> transferTypesFor(Asset asset);
 }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/flow/FlowType.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/flow/FlowType.java
@@ -12,21 +12,12 @@
  *
  */
 
-package org.eclipse.edc.catalog.spi;
-
-import org.eclipse.edc.spi.types.domain.asset.Asset;
-
-import java.util.List;
+package org.eclipse.edc.connector.transfer.spi.flow;
 
 /**
- * Resolves the {@link Distribution}s
+ * Data Flow types, generally they can be Push (provider pushing data to the consumer) and Pull (consumer pulling data
+ * from the provider)
  */
-public interface DistributionResolver {
-
-    /**
-     * Return all the {@link Distribution}s for the given {@link Asset}.
-     *
-     * @return a list of Distributions, always not null
-     */
-    List<Distribution> getDistributions(Asset asset);
+public enum FlowType {
+    PUSH, PULL
 }


### PR DESCRIPTION
## What this PR changes/adds

Makes `Catalog`'s `Distribution` list being built by the knowledge of the `DataFlowManager`, because that's where the supported transfer types knowledge is stored.

This is the `DataFlowController` details:
- the `ProviderPush` will get the distributions out of the `DataPlaneInstance`s registered on the connector and associate them with the `PUSH` flow type
- the `ConsumerPull` for the moment will only return a single `Http-PULL` type, in the future it will be able to provide other pull mechanism as well (ref. #3637)

## Why it does that

interoperability

## Further notes

-

## Linked Issue(s)

Closes #3631

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
