### PR TITLE
fix(test): JSON-LD Unit tests fail on Windows

### DIFF
--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/JsonLdExtensionTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/JsonLdExtensionTest.java
@@ -21,6 +21,7 @@ import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
@@ -51,7 +52,7 @@ class JsonLdExtensionTest {
         DocumentLoader documentLoader = getFieldValue("documentLoader", service);
         Map<String, URI> cache = getFieldValue("uriCache", documentLoader);
 
-        assertThat(cache).containsEntry("http://foo.org/doc.json", new URI("file:/tmp/foo/doc.json"));
+        assertThat(cache).containsEntry("http://foo.org/doc.json", new File("/tmp/foo/doc.json").toURI());
     }
 
     @Test
@@ -67,7 +68,7 @@ class JsonLdExtensionTest {
         DocumentLoader documentLoader = getFieldValue("documentLoader", service);
         Map<String, URI> cache = getFieldValue("uriCache", documentLoader);
 
-        assertThat(cache).containsEntry("http://foo.org/doc.json", new URI("file:/tmp/foo/doc.json"));
+        assertThat(cache).containsEntry("http://foo.org/doc.json", new File("/tmp/foo/doc.json").toURI());
     }
 
     @Test
@@ -84,8 +85,8 @@ class JsonLdExtensionTest {
         DocumentLoader documentLoader = getFieldValue("documentLoader", service);
         Map<String, URI> cache = getFieldValue("uriCache", documentLoader);
 
-        assertThat(cache).containsEntry("http://foo.org/doc.json", new URI("file:/tmp/foo/doc.json"));
-        assertThat(cache).containsEntry("http://bar.org/doc.json", new URI("file:/tmp/bar/doc.json"));
+        assertThat(cache).containsEntry("http://foo.org/doc.json", new File("/tmp/foo/doc.json").toURI());
+        assertThat(cache).containsEntry("http://bar.org/doc.json", new File("/tmp/bar/doc.json").toURI());
     }
 
     @Test
@@ -101,7 +102,7 @@ class JsonLdExtensionTest {
         DocumentLoader documentLoader = getFieldValue("documentLoader", service);
         Map<String, URI> cache = getFieldValue("uriCache", documentLoader);
 
-        assertThat(cache).containsEntry("http://foo.org/doc.json", new URI("file:/tmp/foo/doc.json"))
+        assertThat(cache).containsEntry("http://foo.org/doc.json", new File("/tmp/foo/doc.json").toURI())
                 .noneSatisfy((s, uri) -> assertThat(s).isEqualTo("http://bar.org/doc.json"));
 
     }
@@ -119,7 +120,7 @@ class JsonLdExtensionTest {
         DocumentLoader documentLoader = getFieldValue("documentLoader", service);
         Map<String, URI> cache = getFieldValue("uriCache", documentLoader);
 
-        assertThat(cache).containsEntry("http://foo.org/doc.json", new URI("file:/tmp/foo/doc.json"))
+        assertThat(cache).containsEntry("http://foo.org/doc.json", new File("/tmp/foo/doc.json").toURI())
                 .noneSatisfy((s, uri) -> assertThat(s).isEqualTo("http://bar.org/doc.json"));
 
     }


### PR DESCRIPTION
## What this PR changes/adds
Fixes issue JSON-LD Unit tests fail on Windows #3408 

The URI is asserted against the value: "file:/tmp/foo/doc.json" but on Windows the value will include the drive name such as: "file:/C:/tmp/foo/doc.json".

Implemented suggested fix  to replace:
`assertThat(cache).containsEntry("http://foo.org/doc.json", new URI("file:/tmp/foo/doc.json"));`

With:
`assertThat(cache).containsEntry("http://foo.org/doc.json", new File("/tmp/foo/doc.json").toURI());`


## Why it does that

If not fixed the bug prevents building connector with extensions on Windows systems. 

## Linked Issue(s)

Closes #3408 
