### PR TITLE
fix: IdentityAndTrustService handle multiple VPs

### DIFF
--- a/spi/common/identity-trust-spi/src/testFixtures/java/org/eclipse/edc/identitytrust/TestFunctions.java
+++ b/spi/common/identity-trust-spi/src/testFixtures/java/org/eclipse/edc/identitytrust/TestFunctions.java
@@ -40,6 +40,8 @@ import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATIO
 
 public class TestFunctions {
 
+    public static final Issuer TRUSTED_ISSUER = new Issuer("http://test.issuer", Map.of());
+
     public static VerifiableCredential createCredential() {
         return createCredentialBuilder().build();
     }
@@ -51,7 +53,7 @@ public class TestFunctions {
                         .claim("test-claim", "test-value")
                         .build())
                 .type("test-type")
-                .issuer(new Issuer("http://test.issuer", Map.of()))
+                .issuer(TRUSTED_ISSUER)
                 .issuanceDate(now());
     }
 


### PR DESCRIPTION
## What this PR changes/adds

This PR improves the `IdentityAndTrustService` in that it makes it handle multiple VPs.

## Why it does that

As per the spec, a CredentialService may return multiple VP tokens, i.e. VerifiablePresentations. So naturally, the
`IdentityAndTrustService` must verify and parse them all, not just the first one.

## Further notes

Receiving an empty list of VPs is technically allowed too, but that would result in an empty `ClaimToken`, so the policy evaluation would then fail.

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
