### PR TITLE
fix: add missing transaction block on `CatalogService`

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/ControlPlaneServicesExtension.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/ControlPlaneServicesExtension.java
@@ -159,7 +159,8 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
 
     @Provider
     public CatalogProtocolService catalogProtocolService(ServiceExtensionContext context) {
-        return new CatalogProtocolServiceImpl(datasetResolver, participantAgentService, dataServiceRegistry, identityService, monitor, context.getParticipantId());
+        return new CatalogProtocolServiceImpl(datasetResolver, participantAgentService, dataServiceRegistry,
+                identityService, monitor, context.getParticipantId(), transactionContext);
     }
 
     @Provider


### PR DESCRIPTION
## What this PR changes/adds

Add missing transaction block on `CatalogService`

## Why it does that

To ensure that all the database calls are finalized correctly

## Further notes

- to better handling `Stream` over cursor all the service will always return only collected iterables and not streams, and the operations will be wrapped by transaction blocks, that will take care of finalizing the connections. 

## Linked Issue(s)

Closes #3640 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
