### PR TITLE
refactor: make postgresql integration tests use real components

### DIFF
--- a/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/ConnectionFactory.java
+++ b/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/ConnectionFactory.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.sql;
 
 import java.sql.Connection;
+import java.util.Properties;
 
 /**
  * A ConnectionFactory combines a set of connection configuration
@@ -24,9 +25,11 @@ import java.sql.Connection;
 public interface ConnectionFactory {
 
     /**
-     * Creates a fresh connection.
+     * Creates a fresh connection to the specified database
      *
-     * @return connection created from a defined set of connection configuration parameters.
+     * @param jdbcUrl the JDBC url.
+     * @param properties the properties.
+     * @return a new Connection.
      */
-    Connection create();
+    Connection create(String jdbcUrl, Properties properties);
 }

--- a/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/DriverManagerConnectionFactory.java
+++ b/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/DriverManagerConnectionFactory.java
@@ -12,31 +12,23 @@
  *
  */
 
-package org.eclipse.edc.sql.pool.commons;
+package org.eclipse.edc.sql;
 
 import org.eclipse.edc.spi.persistence.EdcPersistenceException;
-import org.eclipse.edc.sql.ConnectionFactory;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
-import java.util.Objects;
 import java.util.Properties;
 
 public class DriverManagerConnectionFactory implements ConnectionFactory {
-    private final String jdbcUrl;
-    private final Properties properties;
-
-    public DriverManagerConnectionFactory(String jdbcUrl, Properties properties) {
-        this.jdbcUrl = Objects.requireNonNull(jdbcUrl);
-        this.properties = Objects.requireNonNull(properties);
-    }
 
     @Override
-    public Connection create() {
+    public Connection create(String jdbcUrl, Properties properties) {
         try {
             return DriverManager.getConnection(jdbcUrl, properties);
         } catch (Exception exception) {
             throw new EdcPersistenceException(exception.getMessage(), exception);
         }
     }
+
 }

--- a/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/SqlCoreExtension.java
+++ b/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/SqlCoreExtension.java
@@ -39,4 +39,9 @@ public class SqlCoreExtension implements ServiceExtension {
         var configuration = new SqlQueryExecutorConfiguration(fetchSize);
         return new SqlQueryExecutor(configuration);
     }
+
+    @Provider(isDefault = true)
+    public ConnectionFactory connectionFactory() {
+        return new DriverManagerConnectionFactory();
+    }
 }

--- a/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/SqlQueryExecutor.java
+++ b/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/SqlQueryExecutor.java
@@ -99,8 +99,8 @@ public class SqlQueryExecutor implements QueryExecutor {
     }
 
     private void setArguments(PreparedStatement statement, Object[] arguments) throws SQLException {
-        for (int index = 0; index < arguments.length; index++) {
-            int position = index + 1;
+        for (var index = 0; index < arguments.length; index++) {
+            var position = index + 1;
             setArgument(statement, position, arguments[index]);
         }
     }
@@ -118,7 +118,7 @@ public class SqlQueryExecutor implements QueryExecutor {
 
     @NotNull
     private <T> Spliterators.AbstractSpliterator<T> createSpliterator(ResultSetMapper<T> resultSetMapper, ResultSet resultSet) {
-        return new Spliterators.AbstractSpliterator<T>(Long.MAX_VALUE, Spliterator.ORDERED) {
+        return new Spliterators.AbstractSpliterator<>(Long.MAX_VALUE, Spliterator.ORDERED) {
             @Override
             public boolean tryAdvance(Consumer<? super T> action) {
                 try {

--- a/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/datasource/ConnectionFactoryDataSource.java
+++ b/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/datasource/ConnectionFactoryDataSource.java
@@ -21,6 +21,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.Objects;
+import java.util.Properties;
 import java.util.logging.Logger;
 import javax.sql.DataSource;
 
@@ -30,19 +31,23 @@ import javax.sql.DataSource;
 public class ConnectionFactoryDataSource implements DataSource {
 
     private final ConnectionFactory connectionFactory;
+    private final String jdbcUrl;
+    private final Properties properties;
 
-    public ConnectionFactoryDataSource(ConnectionFactory connectionFactory) {
+    public ConnectionFactoryDataSource(ConnectionFactory connectionFactory, String jdbcUrl, Properties properties) {
         this.connectionFactory = Objects.requireNonNull(connectionFactory);
+        this.jdbcUrl = jdbcUrl;
+        this.properties = properties;
     }
 
     @Override
     public Connection getConnection() throws SQLException {
-        return connectionFactory.create();
+        return connectionFactory.create(jdbcUrl, properties);
     }
 
     @Override
     public Connection getConnection(String username, String password) throws SQLException {
-        return connectionFactory.create();
+        return connectionFactory.create(jdbcUrl, properties);
     }
 
     @Override

--- a/extensions/common/sql/sql-core/src/test/java/org/eclipse/edc/sql/SqlQueryExecutorIntegrationTest.java
+++ b/extensions/common/sql/sql-core/src/test/java/org/eclipse/edc/sql/SqlQueryExecutorIntegrationTest.java
@@ -32,8 +32,6 @@ import java.util.UUID;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 
 @ComponentTest
 @ExtendWith(PostgresqlStoreSetupExtension.class)
@@ -64,7 +62,7 @@ public class SqlQueryExecutorIntegrationTest {
         var result = executor.query(connection, false, mapper, sql);
 
         assertThat(result).isNotNull().hasSize(1).contains(1L);
-        verify(connection, never()).close();
+        assertThat(connection.isClosed()).isFalse();
     }
 
     @Test
@@ -75,7 +73,7 @@ public class SqlQueryExecutorIntegrationTest {
         var result = executor.query(connection, true, mapper, sql);
 
         assertThat(result).isNotNull().hasSize(1).contains(1L);
-        verify(connection).close();
+        assertThat(connection.isClosed()).isTrue();
     }
 
     @Test

--- a/extensions/common/sql/sql-core/src/test/java/org/eclipse/edc/sql/datasource/ConnectionFactoryDataSourceTest.java
+++ b/extensions/common/sql/sql-core/src/test/java/org/eclipse/edc/sql/datasource/ConnectionFactoryDataSourceTest.java
@@ -17,145 +17,102 @@ package org.eclipse.edc.sql.datasource;
 import org.eclipse.edc.sql.ConnectionFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
-import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 class ConnectionFactoryDataSourceTest {
 
-    @Test
-    void constructor() {
-        Assertions.assertThrows(NullPointerException.class, () -> new ConnectionFactoryDataSource(null));
-
-        ConnectionFactory connectionFactory = Mockito.mock(ConnectionFactory.class);
-
-        new ConnectionFactoryDataSource(connectionFactory);
-
-        Mockito.verifyNoInteractions(connectionFactory);
-    }
+    private final ConnectionFactory connectionFactory = mock();
+    private final Connection connection = mock();
+    private final ConnectionFactoryDataSource connectionFactoryDataSource = new ConnectionFactoryDataSource(
+            connectionFactory, "jdbcUrl", new Properties());
 
     @Test
     void getConnection() throws SQLException {
-        Connection connection = Mockito.mock(Connection.class);
-        ConnectionFactory connectionFactory = Mockito.mock(ConnectionFactory.class);
-        Mockito.when(connectionFactory.create()).thenReturn(connection);
+        when(connectionFactory.create(any(), any())).thenReturn(connection);
 
-        ConnectionFactoryDataSource connectionFactoryDataSource = new ConnectionFactoryDataSource(connectionFactory);
+        var result = connectionFactoryDataSource.getConnection();
 
-        Connection result = connectionFactoryDataSource.getConnection();
-
-        Assertions.assertEquals(connection, result);
-
-        Mockito.verify(connectionFactory, Mockito.times(1)).create();
+        assertThat(result).isSameAs(connection);
+        verify(connectionFactory, times(1)).create(any(), any());
     }
 
     @Test
     void getConnectionWithArgument() throws SQLException {
-        Connection connection = Mockito.mock(Connection.class);
-        ConnectionFactory connectionFactory = Mockito.mock(ConnectionFactory.class);
-        Mockito.when(connectionFactory.create()).thenReturn(connection);
+        when(connectionFactory.create(any(), any())).thenReturn(connection);
 
-        ConnectionFactoryDataSource connectionFactoryDataSource = new ConnectionFactoryDataSource(connectionFactory);
+        var result = connectionFactoryDataSource.getConnection(null, null);
 
-        Connection result = connectionFactoryDataSource.getConnection(null, null);
-
-        Assertions.assertEquals(connection, result);
-
-        Mockito.verify(connectionFactory, Mockito.times(1)).create();
+        assertThat(result).isSameAs(connection);
+        verify(connectionFactory, times(1)).create(any(), any());
     }
 
     @Test
     void getLogWriter() {
-        ConnectionFactory connectionFactory = Mockito.mock(ConnectionFactory.class);
+        assertThrows(SQLFeatureNotSupportedException.class, connectionFactoryDataSource::getLogWriter);
 
-        ConnectionFactoryDataSource connectionFactoryDataSource = new ConnectionFactoryDataSource(connectionFactory);
-
-        Assertions.assertThrows(SQLFeatureNotSupportedException.class, connectionFactoryDataSource::getLogWriter);
-
-        Mockito.verifyNoInteractions(connectionFactory);
+        verifyNoInteractions(connectionFactory);
     }
 
     @Test
     void setLogWriter() {
-        PrintWriter printWriter = Mockito.mock(PrintWriter.class);
+        assertThrows(SQLFeatureNotSupportedException.class, () -> connectionFactoryDataSource.setLogWriter(mock()));
 
-        ConnectionFactory connectionFactory = Mockito.mock(ConnectionFactory.class);
-
-        ConnectionFactoryDataSource connectionFactoryDataSource = new ConnectionFactoryDataSource(connectionFactory);
-
-        Assertions.assertThrows(SQLFeatureNotSupportedException.class, () -> connectionFactoryDataSource.setLogWriter(printWriter));
-
-        Mockito.verifyNoInteractions(connectionFactory);
+        verifyNoInteractions(connectionFactory);
     }
 
     @Test
     void setLoginTimeout() {
-        ConnectionFactory connectionFactory = Mockito.mock(ConnectionFactory.class);
+        assertThrows(SQLFeatureNotSupportedException.class, () -> connectionFactoryDataSource.setLoginTimeout(1));
 
-        ConnectionFactoryDataSource connectionFactoryDataSource = new ConnectionFactoryDataSource(connectionFactory);
-
-        Assertions.assertThrows(SQLFeatureNotSupportedException.class, () -> connectionFactoryDataSource.setLoginTimeout(1));
-
-        Mockito.verifyNoInteractions(connectionFactory);
+        verifyNoInteractions(connectionFactory);
     }
 
     @Test
     void getLoginTimeout() {
-        ConnectionFactory connectionFactory = Mockito.mock(ConnectionFactory.class);
+        assertThrows(SQLFeatureNotSupportedException.class, connectionFactoryDataSource::getLoginTimeout);
 
-        ConnectionFactoryDataSource connectionFactoryDataSource = new ConnectionFactoryDataSource(connectionFactory);
-
-        Assertions.assertThrows(SQLFeatureNotSupportedException.class, connectionFactoryDataSource::getLoginTimeout);
-
-        Mockito.verifyNoInteractions(connectionFactory);
+        verifyNoInteractions(connectionFactory);
     }
 
     @Test
     void getParentLogger() {
-        ConnectionFactory connectionFactory = Mockito.mock(ConnectionFactory.class);
+        assertThrows(SQLFeatureNotSupportedException.class, connectionFactoryDataSource::getParentLogger);
 
-        ConnectionFactoryDataSource connectionFactoryDataSource = new ConnectionFactoryDataSource(connectionFactory);
-
-        Assertions.assertThrows(SQLFeatureNotSupportedException.class, connectionFactoryDataSource::getParentLogger);
-
-        Mockito.verifyNoInteractions(connectionFactory);
+        verifyNoInteractions(connectionFactory);
     }
 
     @Test
     void unwrap() {
-        ConnectionFactory connectionFactory = Mockito.mock(ConnectionFactory.class);
+        assertThrows(SQLFeatureNotSupportedException.class, () -> connectionFactoryDataSource.unwrap(Class.class));
 
-        ConnectionFactoryDataSource connectionFactoryDataSource = new ConnectionFactoryDataSource(connectionFactory);
-
-        Assertions.assertThrows(SQLFeatureNotSupportedException.class, () -> connectionFactoryDataSource.unwrap(Class.class));
-
-        Mockito.verifyNoInteractions(connectionFactory);
+        verifyNoInteractions(connectionFactory);
     }
 
     @Test
     void isWrapperFor() throws SQLException {
-        ConnectionFactory connectionFactory = Mockito.mock(ConnectionFactory.class);
-
-        ConnectionFactoryDataSource connectionFactoryDataSource = new ConnectionFactoryDataSource(connectionFactory);
-
-        boolean result = connectionFactoryDataSource.isWrapperFor(Class.class);
+        var result = connectionFactoryDataSource.isWrapperFor(Class.class);
 
         Assertions.assertFalse(result);
 
-        Mockito.verifyNoInteractions(connectionFactory);
+        verifyNoInteractions(connectionFactory);
     }
 
     @Test
     void createConnectionBuilder() {
-        ConnectionFactory connectionFactory = Mockito.mock(ConnectionFactory.class);
-
-        ConnectionFactoryDataSource connectionFactoryDataSource = new ConnectionFactoryDataSource(connectionFactory);
-
-        Assertions.assertThrows(SQLFeatureNotSupportedException.class, connectionFactoryDataSource::createConnectionBuilder);
-
-        Mockito.verifyNoInteractions(connectionFactory);
+        assertThrows(SQLFeatureNotSupportedException.class, connectionFactoryDataSource::createConnectionBuilder);
+        verifyNoInteractions(connectionFactory);
     }
 }

--- a/extensions/common/sql/sql-core/src/testFixtures/java/org/eclipse/edc/sql/testfixtures/PostgresqlLocalInstance.java
+++ b/extensions/common/sql/sql-core/src/testFixtures/java/org/eclipse/edc/sql/testfixtures/PostgresqlLocalInstance.java
@@ -14,12 +14,9 @@
 
 package org.eclipse.edc.sql.testfixtures;
 
-import org.postgresql.ds.PGSimpleDataSource;
-
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import javax.sql.DataSource;
 
 import static java.lang.String.format;
 
@@ -29,40 +26,27 @@ public final class PostgresqlLocalInstance {
     private final String username;
     private final String databaseName;
 
-    public PostgresqlLocalInstance(String user, String password, String jdbcUrlPrefix, String db) {
-        username = user;
+    public PostgresqlLocalInstance(String username, String password, String jdbcUrlPrefix, String databaseName) {
+        this.username = username;
         this.password = password;
         this.jdbcUrlPrefix = jdbcUrlPrefix;
-        databaseName = db;
+        this.databaseName = databaseName;
     }
 
     public void createDatabase() {
-        createDatabase(databaseName);
-    }
-
-    public void createDatabase(String name) {
-        try (var connection = DriverManager.getConnection(jdbcUrlPrefix + username, username, password)) {
-            connection.createStatement().execute(format("create database %s;", name));
+        try (var connection = getConnection("postgres")) {
+            connection.createStatement().execute(format("create database %s;", databaseName));
         } catch (SQLException e) {
             // database could already exist
         }
     }
 
-    public Connection getTestConnection(String hostName, int port, String dbName) {
+    public Connection getConnection(String databaseName) {
         try {
-            return createTestDataSource(hostName, port, dbName).getConnection();
+            return DriverManager.getConnection(jdbcUrlPrefix + databaseName, username, password);
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }
     }
 
-    private DataSource createTestDataSource(String hostName, int port, String dbName) {
-        var dataSource = new PGSimpleDataSource();
-        dataSource.setServerNames(new String[]{ hostName });
-        dataSource.setPortNumbers(new int[]{ port });
-        dataSource.setUser(username);
-        dataSource.setPassword(password);
-        dataSource.setDatabaseName(dbName);
-        return dataSource;
-    }
 }

--- a/extensions/common/sql/sql-pool/sql-pool-apache-commons/src/main/java/org/eclipse/edc/sql/pool/commons/CommonsConnectionPool.java
+++ b/extensions/common/sql/sql-pool/sql-pool-apache-commons/src/main/java/org/eclipse/edc/sql/pool/commons/CommonsConnectionPool.java
@@ -46,7 +46,7 @@ public final class CommonsConnectionPool implements ConnectionPool, AutoCloseabl
     }
 
     private static GenericObjectPoolConfig<Connection> getGenericObjectPoolConfig(CommonsConnectionPoolConfig commonsConnectionPoolConfig) {
-        GenericObjectPoolConfig<Connection> genericObjectPoolConfig = new GenericObjectPoolConfig<>();
+        var genericObjectPoolConfig = new GenericObjectPoolConfig<Connection>();
 
         // no need for JMX
         genericObjectPoolConfig.setJmxEnabled(false);

--- a/extensions/common/sql/sql-pool/sql-pool-apache-commons/src/test/java/org/eclipse/edc/sql/pool/commons/DriverManagerConnectionFactoryTest.java
+++ b/extensions/common/sql/sql-pool/sql-pool-apache-commons/src/test/java/org/eclipse/edc/sql/pool/commons/DriverManagerConnectionFactoryTest.java
@@ -15,7 +15,7 @@
 package org.eclipse.edc.sql.pool.commons;
 
 import org.eclipse.edc.spi.persistence.EdcPersistenceException;
-import org.junit.jupiter.api.BeforeEach;
+import org.eclipse.edc.sql.DriverManagerConnectionFactory;
 import org.junit.jupiter.api.Test;
 
 import java.sql.Connection;
@@ -33,18 +33,13 @@ import static org.mockito.Mockito.mockStatic;
 public class DriverManagerConnectionFactoryTest {
     private static final String DS_NAME = "datasource";
     private final Connection connection = mock();
-    private DriverManagerConnectionFactory factory;
-
-    @BeforeEach
-    void setup() {
-        factory = new DriverManagerConnectionFactory(DS_NAME, new Properties());
-    }
+    private final DriverManagerConnectionFactory factory = new DriverManagerConnectionFactory();
 
     @Test
     void create() throws SQLException {
         try (var driverManagerMock = mockStatic(DriverManager.class)) {
             driverManagerMock.when(() -> DriverManager.getConnection(eq(DS_NAME), any(Properties.class))).thenReturn(connection);
-            try (var conn = factory.create()) {
+            try (var conn = factory.create(DS_NAME, new Properties())) {
                 assertThat(conn).isEqualTo(connection);
             }
         }
@@ -55,7 +50,8 @@ public class DriverManagerConnectionFactoryTest {
         try (var driverManagerMock = mockStatic(DriverManager.class)) {
             driverManagerMock.when(() -> DriverManager.getConnection(eq(DS_NAME), any(Properties.class)))
                     .thenThrow(SQLException.class);
-            assertThatThrownBy(() -> factory.create()).isInstanceOf(EdcPersistenceException.class);
+
+            assertThatThrownBy(() -> factory.create(DS_NAME, new Properties())).isInstanceOf(EdcPersistenceException.class);
         }
     }
 }

--- a/extensions/common/transaction/transaction-local/build.gradle.kts
+++ b/extensions/common/transaction/transaction-local/build.gradle.kts
@@ -21,6 +21,9 @@ dependencies {
     api(project(":spi:common:core-spi"))
     api(project(":spi:common:transaction-spi"))
     implementation(project(":spi:common:transaction-datasource-spi"))
+
+    testImplementation(project(":core:common:junit"))
+    testImplementation(testFixtures(project(":extensions:common:sql:sql-core")))
 }
 
 

--- a/extensions/control-plane/store/sql/control-plane-sql/build.gradle.kts
+++ b/extensions/control-plane/store/sql/control-plane-sql/build.gradle.kts
@@ -25,6 +25,12 @@ dependencies {
     implementation(project(":extensions:control-plane:store:sql:contract-negotiation-store-sql"))
     implementation(project(":extensions:control-plane:store:sql:policy-definition-store-sql"))
     implementation(project(":extensions:control-plane:store:sql:transfer-process-store-sql"))
+
+    testImplementation(project(":core:common:junit"))
+    testImplementation(project(":core:control-plane:catalog-core"))
+    testImplementation(project(":core:control-plane:contract-core"))
+    testImplementation(project(":core:control-plane:control-plane-core"))
+    testImplementation(testFixtures(project(":extensions:common:sql:sql-core")))
 }
 
 

--- a/spi/common/core-spi/src/testFixtures/java/org/eclipse/edc/spi/testfixtures/asset/AssetIndexTestBase.java
+++ b/spi/common/core-spi/src/testFixtures/java/org/eclipse/edc/spi/testfixtures/asset/AssetIndexTestBase.java
@@ -205,8 +205,7 @@ public abstract class AssetIndexTestBase {
 
             var result = getAssetIndex().queryAssets(QuerySpec.none());
 
-            var result1 = result.toList();
-            assertThat(result1).hasSize(5).usingRecursiveFieldByFieldElementComparator().containsAll(assets);
+            assertThat(result).hasSize(5).usingRecursiveFieldByFieldElementComparator().containsAll(assets);
         }
 
         @Test

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/PostgresUtil.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/PostgresUtil.java
@@ -21,7 +21,6 @@ import org.eclipse.edc.test.e2e.participant.EndToEndTransferParticipant;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.stream.Stream;
 
@@ -34,8 +33,8 @@ public class PostgresUtil {
     public static void createDatabase(EndToEndTransferParticipant participant) throws ClassNotFoundException, SQLException, IOException {
         Class.forName("org.postgresql.Driver");
 
-        var helper = new PostgresqlLocalInstance(USER, PASSWORD, JDBC_URL_PREFIX, participant.getName());
-        helper.createDatabase(participant.getName());
+        var postgres = new PostgresqlLocalInstance(USER, PASSWORD, JDBC_URL_PREFIX, participant.getName());
+        postgres.createDatabase();
 
         var scripts = Stream.of(
                 "extensions/control-plane/store/sql/asset-index-sql",
@@ -50,7 +49,7 @@ public class PostgresUtil {
                 .map(Paths::get)
                 .toList();
 
-        try (var connection = DriverManager.getConnection(participant.jdbcUrl(), USER, PASSWORD)) {
+        try (var connection = postgres.getConnection(participant.getName())) {
             for (var script : scripts) {
                 var sql = Files.readString(script);
 


### PR DESCRIPTION
## What this PR changes/adds

Postgres tests are using mocks and not real connections/connections factory. This makes certain issues harder to discover.
This PR removes mocks from `PostgresqlStoreSetupExtension`

## Why it does that

test scope

## Further notes


## Linked Issue(s)

Work done in the process of debugging #3640 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
