### PR TITLE
refactor: make Services return Lists and not Streams

### DIFF
--- a/core/control-plane/catalog-core/src/test/java/org/eclipse/edc/connector/catalog/DatasetResolverImplTest.java
+++ b/core/control-plane/catalog-core/src/test/java/org/eclipse/edc/connector/catalog/DatasetResolverImplTest.java
@@ -73,7 +73,7 @@ class DatasetResolverImplTest {
     }
 
     @Test
-    void query_shouldReturnOneDatasetPerAsset() {
+    void search_shouldReturnOneDatasetPerAsset() {
         var dataService = createDataService();
         var contractDefinition = contractDefinitionBuilder("definitionId").contractPolicyId("contractPolicyId").build();
         var contractPolicy = Policy.Builder.newInstance().build();

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/asset/AssetServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/asset/AssetServiceImplTest.java
@@ -90,11 +90,11 @@ class AssetServiceImplTest {
     }
 
     @Test
-    void query_shouldRelyOnAssetIndex() {
+    void search_shouldRelyOnAssetIndex() {
         var asset = createAsset("assetId");
         when(index.queryAssets(any(QuerySpec.class))).thenReturn(Stream.of(asset));
 
-        var assets = service.query(QuerySpec.none());
+        var assets = service.search(QuerySpec.none());
 
         assertThat(assets.succeeded()).isTrue();
         assertThat(assets.getContent()).hasSize(1).first().matches(hasId("assetId"));
@@ -102,20 +102,20 @@ class AssetServiceImplTest {
 
     @ParameterizedTest
     @ValueSource(strings = { Asset.PROPERTY_ID, Asset.PROPERTY_NAME, Asset.PROPERTY_DESCRIPTION, Asset.PROPERTY_VERSION, Asset.PROPERTY_CONTENT_TYPE })
-    void query_validFilter(String filter) {
+    void search_validFilter(String filter) {
         var query = QuerySpec.Builder.newInstance().filter(criterion(filter, "=", "somevalue")).build();
 
-        service.query(query);
+        service.search(query);
 
         verify(index).queryAssets(query);
     }
 
     @ParameterizedTest
     @ArgumentsSource(InvalidFilters.class)
-    void query_invalidFilter(Criterion filter) {
+    void search_invalidFilter(Criterion filter) {
         var query = QuerySpec.Builder.newInstance().filter(filter).build();
 
-        var result = service.query(query);
+        var result = service.search(query);
 
         assertThat(result).isFailed().extracting(Failure::getMessages).asList().hasSize(1);
     }

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractagreement/ContractAgreementServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractagreement/ContractAgreementServiceImplTest.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.service.contractagreement;
 
 import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.spi.contractagreement.ContractAgreementService;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.types.domain.agreement.ContractAgreement;
@@ -40,9 +41,9 @@ import static org.mockito.Mockito.when;
 
 class ContractAgreementServiceImplTest {
 
-    private final ContractNegotiationStore store = mock(ContractNegotiationStore.class);
+    private final ContractNegotiationStore store = mock();
     private final TransactionContext transactionContext = new NoopTransactionContext();
-    private final ContractAgreementServiceImpl service = new ContractAgreementServiceImpl(store, transactionContext);
+    private final ContractAgreementService service = new ContractAgreementServiceImpl(store, transactionContext);
 
     @Test
     void findById_filtersById() {
@@ -64,11 +65,11 @@ class ContractAgreementServiceImplTest {
     }
 
     @Test
-    void query_filtersBySpec() {
+    void search_filtersBySpec() {
         var agreement = createContractAgreement("agreementId");
         when(store.queryAgreements(isA(QuerySpec.class))).thenReturn(Stream.of(agreement));
 
-        var result = service.query(QuerySpec.none());
+        var result = service.search(QuerySpec.none());
 
         assertThat(result.succeeded()).isTrue();
         assertThat(result.getContent()).hasSize(1).first().matches(it -> it.getId().equals("agreementId"));

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionServiceImplTest.java
@@ -69,10 +69,10 @@ class PolicyDefinitionServiceImplTest {
     }
 
     @Test
-    void query_shouldRelyOnPolicyStore() {
+    void search_shouldRelyOnPolicyStore() {
         var policy = createPolicy("policyId");
         when(policyStore.findAll(any(QuerySpec.class))).thenReturn(Stream.of(policy));
-        var policies = policyServiceImpl.query(QuerySpec.none());
+        var policies = policyServiceImpl.search(QuerySpec.none());
 
         assertThat(policies.succeeded()).isTrue();
         assertThat(policies.getContent()).containsExactly(policy);
@@ -80,12 +80,12 @@ class PolicyDefinitionServiceImplTest {
 
     @ParameterizedTest
     @ArgumentsSource(InvalidFilters.class)
-    void query_invalidExpression_raiseException(Criterion invalidFilter) {
+    void search_invalidExpression_raiseException(Criterion invalidFilter) {
         var query = QuerySpec.Builder.newInstance()
                 .filter(invalidFilter)
                 .build();
 
-        var result = policyServiceImpl.query(query);
+        var result = policyServiceImpl.search(query);
 
         assertThat(result).isFailed();
     }

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessServiceImplTest.java
@@ -92,24 +92,32 @@ class TransferProcessServiceImplTest {
     }
 
     @Test
-    void query() {
+    void search() {
         when(store.findAll(query)).thenReturn(Stream.of(process1, process2));
-        assertThat(service.query(query).getContent()).containsExactly(process1, process2);
+
+        var result = service.search(query);
+
+        assertThat(result.getContent()).containsExactly(process1, process2);
         verify(transactionContext).execute(any(TransactionContext.ResultTransactionBlock.class));
     }
 
     @ParameterizedTest
     @ArgumentsSource(InvalidFilters.class)
-    void query_invalidFilter_raiseException(Criterion invalidFilter) {
+    void search_invalidFilter_raiseException(Criterion invalidFilter) {
         var spec = QuerySpec.Builder.newInstance().filter(invalidFilter).build();
-        assertThat(service.query(spec).failed()).isTrue();
+
+        var result = service.search(spec);
+
+        assertThat(result.failed()).isTrue();
     }
 
     @ParameterizedTest
     @ArgumentsSource(ValidFilters.class)
-    void query_validFilter(Criterion validFilter) {
+    void search_validFilter(Criterion validFilter) {
         var spec = QuerySpec.Builder.newInstance().filter(validFilter).build();
-        service.query(spec);
+
+        service.search(spec);
+
         verify(store).findAll(spec);
         verify(transactionContext).execute(any(TransactionContext.ResultTransactionBlock.class));
     }

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/v3/AssetApiController.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/api/management/asset/v3/AssetApiController.java
@@ -94,14 +94,12 @@ public class AssetApiController implements AssetApi {
                     .orElseThrow(InvalidRequestException::new);
         }
 
-        try (var assets = service.query(querySpec).orElseThrow(exceptionMapper(QuerySpec.class, null))) {
-            return assets
-                    .map(it -> transformerRegistry.transform(it, JsonObject.class))
-                    .peek(r -> r.onFailure(f -> monitor.warning(f.getFailureDetail())))
-                    .filter(Result::succeeded)
-                    .map(Result::getContent)
-                    .collect(toJsonArray());
-        }
+        return service.search(querySpec).orElseThrow(exceptionMapper(QuerySpec.class, null)).stream()
+                .map(it -> transformerRegistry.transform(it, JsonObject.class))
+                .peek(r -> r.onFailure(f -> monitor.warning(f.getFailureDetail())))
+                .filter(Result::succeeded)
+                .map(Result::getContent)
+                .collect(toJsonArray());
     }
 
     @GET

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/v3/AssetApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/api/management/asset/v3/AssetApiControllerTest.java
@@ -32,8 +32,8 @@ import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
@@ -89,8 +89,8 @@ class AssetApiControllerTest extends RestControllerTestBase {
 
     @Test
     void requestAsset() {
-        when(service.query(any()))
-                .thenReturn(ServiceResult.success(Stream.of(Asset.Builder.newInstance().build())));
+        when(service.search(any()))
+                .thenReturn(ServiceResult.success(List.of(Asset.Builder.newInstance().build())));
         when(transformerRegistry.transform(isA(Asset.class), eq(JsonObject.class)))
                 .thenReturn(Result.success(createAssetJson().build()));
         when(transformerRegistry.transform(isA(JsonObject.class), eq(QuerySpec.class)))
@@ -106,15 +106,15 @@ class AssetApiControllerTest extends RestControllerTestBase {
                 .statusCode(200)
                 .contentType(JSON)
                 .body("size()", is(1));
-        verify(service).query(argThat(s -> s.getOffset() == 10));
+        verify(service).search(argThat(s -> s.getOffset() == 10));
         verify(transformerRegistry).transform(isA(Asset.class), eq(JsonObject.class));
         verify(transformerRegistry).transform(isA(JsonObject.class), eq(QuerySpec.class));
     }
 
     @Test
     void requestAsset_filtersOutFailedTransforms() {
-        when(service.query(any()))
-                .thenReturn(ServiceResult.success(Stream.of(Asset.Builder.newInstance().build())));
+        when(service.search(any()))
+                .thenReturn(ServiceResult.success(List.of(Asset.Builder.newInstance().build())));
         when(transformerRegistry.transform(isA(JsonObject.class), eq(QuerySpec.class)))
                 .thenReturn(Result.success(QuerySpec.Builder.newInstance().offset(10).build()));
         when(transformerRegistry.transform(isA(Asset.class), eq(JsonObject.class)))
@@ -133,7 +133,7 @@ class AssetApiControllerTest extends RestControllerTestBase {
     @Test
     void requestAsset_shouldReturnBadRequest_whenQueryIsInvalid() {
         when(transformerRegistry.transform(any(JsonObject.class), eq(QuerySpec.class))).thenReturn(Result.success(QuerySpec.Builder.newInstance().build()));
-        when(service.query(any())).thenReturn(ServiceResult.badRequest("test-message"));
+        when(service.search(any())).thenReturn(ServiceResult.badRequest("test-message"));
         when(validator.validate(any(), any())).thenReturn(ValidationResult.success());
 
         baseRequest()
@@ -148,7 +148,7 @@ class AssetApiControllerTest extends RestControllerTestBase {
     void requestAsset_shouldReturnBadRequest_whenQueryTransformFails() {
         when(transformerRegistry.transform(isA(JsonObject.class), eq(QuerySpec.class)))
                 .thenReturn(Result.failure("error"));
-        when(service.query(any())).thenReturn(ServiceResult.success());
+        when(service.search(any())).thenReturn(ServiceResult.success());
         when(validator.validate(any(), any())).thenReturn(ValidationResult.success());
 
         baseRequest()
@@ -163,7 +163,7 @@ class AssetApiControllerTest extends RestControllerTestBase {
     void requestAsset_shouldReturnBadRequest_whenServiceReturnsBadRequest() {
         when(transformerRegistry.transform(isA(JsonObject.class), eq(QuerySpec.class)))
                 .thenReturn(Result.success(QuerySpec.Builder.newInstance().build()));
-        when(service.query(any())).thenReturn(ServiceResult.badRequest());
+        when(service.search(any())).thenReturn(ServiceResult.badRequest());
         when(validator.validate(any(), any())).thenReturn(ValidationResult.success());
 
         baseRequest()

--- a/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/api/management/contractagreement/ContractAgreementApiController.java
+++ b/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/api/management/contractagreement/ContractAgreementApiController.java
@@ -71,14 +71,12 @@ public class ContractAgreementApiController implements ContractAgreementApi {
                     .orElseThrow(InvalidRequestException::new);
         }
 
-        try (var stream = service.query(querySpec).orElseThrow(exceptionMapper(ContractDefinition.class, null))) {
-            return stream
-                    .map(it -> transformerRegistry.transform(it, JsonObject.class))
-                    .peek(r -> r.onFailure(f -> monitor.warning(f.getFailureDetail())))
-                    .filter(Result::succeeded)
-                    .map(Result::getContent)
-                    .collect(toJsonArray());
-        }
+        return service.search(querySpec).orElseThrow(exceptionMapper(ContractDefinition.class, null)).stream()
+                .map(it -> transformerRegistry.transform(it, JsonObject.class))
+                .peek(r -> r.onFailure(f -> monitor.warning(f.getFailureDetail())))
+                .filter(Result::succeeded)
+                .map(Result::getContent)
+                .collect(toJsonArray());
     }
 
     @GET

--- a/extensions/control-plane/api/management-api/contract-agreement-api/src/test/java/org/eclipse/edc/connector/api/management/contractagreement/ContractAgreementApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-agreement-api/src/test/java/org/eclipse/edc/connector/api/management/contractagreement/ContractAgreementApiControllerTest.java
@@ -35,10 +35,10 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Stream;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
+import static java.util.Collections.emptyList;
 import static java.util.UUID.randomUUID;
 import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE;
 import static org.hamcrest.Matchers.equalTo;
@@ -66,7 +66,7 @@ class ContractAgreementApiControllerTest extends RestControllerTestBase {
         var expanded = Json.createObjectBuilder().build();
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
         when(transformerRegistry.transform(any(JsonObject.class), eq(QuerySpec.class))).thenReturn(Result.success(QuerySpec.none()));
-        when(service.query(any(QuerySpec.class))).thenReturn(ServiceResult.success(Stream.of(createContractAgreement("id1"), createContractAgreement("id2"))));
+        when(service.search(any(QuerySpec.class))).thenReturn(ServiceResult.success(List.of(createContractAgreement("id1"), createContractAgreement("id2"))));
         when(transformerRegistry.transform(any(ContractAgreement.class), eq(JsonObject.class))).thenReturn(Result.success(expanded));
 
         baseRequest()
@@ -79,7 +79,7 @@ class ContractAgreementApiControllerTest extends RestControllerTestBase {
 
         verify(validatorRegistry).validate(eq(EDC_QUERY_SPEC_TYPE), any());
         verify(transformerRegistry).transform(any(JsonObject.class), eq(QuerySpec.class));
-        verify(service).query(any(QuerySpec.class));
+        verify(service).search(any(QuerySpec.class));
         verify(transformerRegistry, times(2)).transform(any(ContractAgreement.class), eq(JsonObject.class));
         verifyNoMoreInteractions(service, transformerRegistry);
     }
@@ -88,7 +88,7 @@ class ContractAgreementApiControllerTest extends RestControllerTestBase {
     void queryAllAgreements_whenNoneExists() {
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
         when(transformerRegistry.transform(any(JsonObject.class), eq(QuerySpec.class))).thenReturn(Result.success(QuerySpec.none()));
-        when(service.query(any(QuerySpec.class))).thenReturn(ServiceResult.success(Stream.of()));
+        when(service.search(any(QuerySpec.class))).thenReturn(ServiceResult.success(emptyList()));
 
         baseRequest()
                 .contentType(JSON)
@@ -99,7 +99,7 @@ class ContractAgreementApiControllerTest extends RestControllerTestBase {
                 .body("size()", equalTo(0));
 
         verify(transformerRegistry).transform(any(JsonObject.class), eq(QuerySpec.class));
-        verify(service).query(any(QuerySpec.class));
+        verify(service).search(any(QuerySpec.class));
         verify(transformerRegistry, never()).transform(any(ContractAgreement.class), eq(JsonObject.class));
         verifyNoMoreInteractions(service, transformerRegistry);
     }
@@ -122,7 +122,7 @@ class ContractAgreementApiControllerTest extends RestControllerTestBase {
     void queryAllAgreements_whenTransformationFails() {
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
         when(transformerRegistry.transform(any(JsonObject.class), eq(QuerySpec.class))).thenReturn(Result.success(QuerySpec.none()));
-        when(service.query(any(QuerySpec.class))).thenReturn(ServiceResult.success(Stream.of(createContractAgreement("id1"), createContractAgreement("id2"))));
+        when(service.search(any(QuerySpec.class))).thenReturn(ServiceResult.success(List.of(createContractAgreement("id1"), createContractAgreement("id2"))));
         when(transformerRegistry.transform(any(ContractAgreement.class), eq(JsonObject.class))).thenReturn(Result.failure("test-failure"));
 
         baseRequest()
@@ -134,7 +134,7 @@ class ContractAgreementApiControllerTest extends RestControllerTestBase {
                 .body("size()", equalTo(0));
 
         verify(transformerRegistry).transform(any(JsonObject.class), eq(QuerySpec.class));
-        verify(service).query(any(QuerySpec.class));
+        verify(service).search(any(QuerySpec.class));
         verify(transformerRegistry, times(2)).transform(any(ContractAgreement.class), eq(JsonObject.class));
         verify(monitor, times(2)).warning(eq("test-failure"));
         verifyNoMoreInteractions(service, transformerRegistry);

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionApiController.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionApiController.java
@@ -75,14 +75,12 @@ public class ContractDefinitionApiController implements ContractDefinitionApi {
                     .orElseThrow(InvalidRequestException::new);
         }
 
-        try (var stream = service.query(querySpec).orElseThrow(exceptionMapper(ContractDefinition.class))) {
-            return stream
-                    .map(contractDefinition -> transformerRegistry.transform(contractDefinition, JsonObject.class))
-                    .peek(r -> r.onFailure(f -> monitor.warning(f.getFailureDetail())))
-                    .filter(Result::succeeded)
-                    .map(Result::getContent)
-                    .collect(toJsonArray());
-        }
+        return service.search(querySpec).orElseThrow(exceptionMapper(ContractDefinition.class)).stream()
+                .map(contractDefinition -> transformerRegistry.transform(contractDefinition, JsonObject.class))
+                .peek(r -> r.onFailure(f -> monitor.warning(f.getFailureDetail())))
+                .filter(Result::succeeded)
+                .map(Result::getContent)
+                .collect(toJsonArray());
     }
 
     @GET

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionApiControllerTest.java
@@ -37,7 +37,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.List;
-import java.util.stream.Stream;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
@@ -73,7 +72,7 @@ class ContractDefinitionApiControllerTest extends RestControllerTestBase {
     @ValueSource(strings = { "", "{}" })
     void queryAllContractDefinitions(String body) {
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
-        when(service.query(any())).thenReturn(ServiceResult.success(Stream.of(createContractDefinition().build())));
+        when(service.search(any())).thenReturn(ServiceResult.success(List.of(createContractDefinition().build())));
         when(transformerRegistry.transform(any(JsonObject.class), eq(QuerySpec.class))).thenReturn(Result.success(QuerySpec.Builder.newInstance().build()));
         when(transformerRegistry.transform(any(ContractDefinition.class), eq(JsonObject.class))).thenReturn(Result.success(createExpandedJsonObject()));
 
@@ -85,7 +84,7 @@ class ContractDefinitionApiControllerTest extends RestControllerTestBase {
                 .statusCode(200)
                 .body("size()", greaterThan(0));
 
-        verify(service).query(eq(QuerySpec.Builder.newInstance().build()));
+        verify(service).search(eq(QuerySpec.Builder.newInstance().build()));
         if (!body.isEmpty()) {
             verify(validatorRegistry).validate(eq(EDC_QUERY_SPEC_TYPE), any());
         }
@@ -109,7 +108,7 @@ class ContractDefinitionApiControllerTest extends RestControllerTestBase {
     void queryAll_queryTransformationFails() {
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
         when(transformerRegistry.transform(any(JsonObject.class), eq(QuerySpec.class))).thenReturn(Result.failure("test-failure"));
-        when(service.query(any())).thenReturn(ServiceResult.success(Stream.of(createContractDefinition().build())));
+        when(service.search(any())).thenReturn(ServiceResult.success(List.of(createContractDefinition().build())));
 
         baseRequest()
                 .contentType(JSON)
@@ -126,7 +125,7 @@ class ContractDefinitionApiControllerTest extends RestControllerTestBase {
     void queryAll_serviceBadRequest() {
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
         when(transformerRegistry.transform(any(JsonObject.class), eq(QuerySpec.class))).thenReturn(Result.success(QuerySpec.Builder.newInstance().build()));
-        when(service.query(any())).thenReturn(ServiceResult.badRequest("test-message"));
+        when(service.search(any())).thenReturn(ServiceResult.badRequest("test-message"));
 
         var error = baseRequest()
                 .contentType(JSON)
@@ -141,7 +140,7 @@ class ContractDefinitionApiControllerTest extends RestControllerTestBase {
         assertThat(error.getMessage()).contains("test-message");
 
         verify(transformerRegistry).transform(any(JsonObject.class), eq(QuerySpec.class));
-        verify(service).query(eq(QuerySpec.Builder.newInstance().build()));
+        verify(service).search(eq(QuerySpec.Builder.newInstance().build()));
         verifyNoMoreInteractions(transformerRegistry);
     }
 

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiController.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiController.java
@@ -82,14 +82,12 @@ public class ContractNegotiationApiController implements ContractNegotiationApi 
                     .orElseThrow(InvalidRequestException::new);
         }
 
-        try (var stream = service.query(querySpec).orElseThrow(exceptionMapper(ContractNegotiation.class, null))) {
-            return stream
-                    .map(it -> transformerRegistry.transform(it, JsonObject.class))
-                    .peek(this::logIfError)
-                    .filter(Result::succeeded)
-                    .map(Result::getContent)
-                    .collect(toJsonArray());
-        }
+        return service.search(querySpec).orElseThrow(exceptionMapper(ContractNegotiation.class, null)).stream()
+                .map(it -> transformerRegistry.transform(it, JsonObject.class))
+                .peek(this::logIfError)
+                .filter(Result::succeeded)
+                .map(Result::getContent)
+                .collect(toJsonArray());
     }
 
     @GET

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerTest.java
@@ -40,7 +40,6 @@ import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.stream.Stream;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
@@ -76,7 +75,7 @@ class ContractNegotiationApiControllerTest extends RestControllerTestBase {
 
     @Test
     void getAll() {
-        when(service.query(any(QuerySpec.class))).thenReturn(ServiceResult.success(Stream.of(
+        when(service.search(any(QuerySpec.class))).thenReturn(ServiceResult.success(List.of(
                 createContractNegotiation("cn1"),
                 createContractNegotiation("cn2")
         )));
@@ -94,7 +93,7 @@ class ContractNegotiationApiControllerTest extends RestControllerTestBase {
                 .body("size()", is(2));
 
         verifyNoInteractions(validatorRegistry);
-        verify(service).query(any(QuerySpec.class));
+        verify(service).search(any(QuerySpec.class));
         verify(transformerRegistry, times(2)).transform(any(ContractNegotiation.class), eq(JsonObject.class));
     }
 
@@ -116,7 +115,7 @@ class ContractNegotiationApiControllerTest extends RestControllerTestBase {
     @Test
     void getAll_queryTransformationFails() {
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
-        when(service.query(any(QuerySpec.class))).thenReturn(ServiceResult.success(Stream.of(
+        when(service.search(any(QuerySpec.class))).thenReturn(ServiceResult.success(List.of(
                 createContractNegotiation("cn1"),
                 createContractNegotiation("cn2")
         )));
@@ -138,7 +137,7 @@ class ContractNegotiationApiControllerTest extends RestControllerTestBase {
     @Test
     void getAll_dtoTransformationFails() {
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
-        when(service.query(any(QuerySpec.class))).thenReturn(ServiceResult.success(Stream.of(
+        when(service.search(any(QuerySpec.class))).thenReturn(ServiceResult.success(List.of(
                 createContractNegotiation("cn1"),
                 createContractNegotiation("cn2")
         )));
@@ -153,12 +152,12 @@ class ContractNegotiationApiControllerTest extends RestControllerTestBase {
                 .contentType(JSON)
                 .body("size()", is(0));
 
-        verify(service).query(any(QuerySpec.class));
+        verify(service).search(any(QuerySpec.class));
     }
 
     @Test
     void getAll_singleFailure_shouldLogError() {
-        when(service.query(any(QuerySpec.class))).thenReturn(ServiceResult.success(Stream.of(
+        when(service.search(any(QuerySpec.class))).thenReturn(ServiceResult.success(List.of(
                 createContractNegotiation("cn1"),
                 createContractNegotiation("cn2")
         )));
@@ -174,7 +173,7 @@ class ContractNegotiationApiControllerTest extends RestControllerTestBase {
                 .contentType(JSON)
                 .body("size()", is(1));
 
-        verify(service).query(any(QuerySpec.class));
+        verify(service).search(any(QuerySpec.class));
         verify(transformerRegistry, times(2)).transform(any(ContractNegotiation.class), eq(JsonObject.class));
         verify(monitor).warning(contains("test-failure"));
     }
@@ -182,7 +181,7 @@ class ContractNegotiationApiControllerTest extends RestControllerTestBase {
     @Test
     void getAll_jsonObjectTransformationFails() {
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
-        when(service.query(any(QuerySpec.class))).thenReturn(ServiceResult.success(Stream.of(
+        when(service.search(any(QuerySpec.class))).thenReturn(ServiceResult.success(List.of(
                 createContractNegotiation("cn1"),
                 createContractNegotiation("cn2")
         )));
@@ -200,7 +199,7 @@ class ContractNegotiationApiControllerTest extends RestControllerTestBase {
                 .contentType(JSON)
                 .body("size()", is(0));
 
-        verify(service).query(any(QuerySpec.class));
+        verify(service).search(any(QuerySpec.class));
         verify(transformerRegistry).transform(any(JsonObject.class), eq(QuerySpec.class));
         verify(transformerRegistry, times(2)).transform(any(ContractNegotiation.class), eq(JsonObject.class));
     }

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiController.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiController.java
@@ -76,13 +76,11 @@ public class PolicyDefinitionApiController implements PolicyDefinitionApi {
                     .orElseThrow(InvalidRequestException::new);
         }
 
-        try (var stream = service.query(querySpec).orElseThrow(exceptionMapper(PolicyDefinition.class))) {
-            return stream
-                    .map(policyDefinition -> transformerRegistry.transform(policyDefinition, JsonObject.class))
-                    .filter(Result::succeeded)
-                    .map(Result::getContent)
-                    .collect(toJsonArray());
-        }
+        return service.search(querySpec).orElseThrow(exceptionMapper(PolicyDefinition.class)).stream()
+                .map(policyDefinition -> transformerRegistry.transform(policyDefinition, JsonObject.class))
+                .filter(Result::succeeded)
+                .map(Result::getContent)
+                .collect(toJsonArray());
     }
 
     @GET

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiControllerTest.java
@@ -31,7 +31,7 @@ import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
-import java.util.stream.Stream;
+import java.util.List;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
@@ -319,13 +319,13 @@ class PolicyDefinitionApiControllerTest extends RestControllerTestBase {
     }
 
     @Test
-    void query_shouldReturnQueriedPolicyDefinitions() {
+    void search_shouldReturnQueriedPolicyDefinitions() {
         var querySpec = QuerySpec.none();
         var policyDefinition = createPolicyDefinition().id("id").build();
         var expandedResponseBody = Json.createObjectBuilder().add("id", "id").add("createdAt", 1234).build();
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
         when(transformerRegistry.transform(any(), eq(QuerySpec.class))).thenReturn(Result.success(querySpec));
-        when(service.query(any())).thenReturn(ServiceResult.success(Stream.of(policyDefinition)));
+        when(service.search(any())).thenReturn(ServiceResult.success(List.of(policyDefinition)));
         when(transformerRegistry.transform(any(), eq(JsonObject.class))).thenReturn(Result.success(expandedResponseBody));
         var requestBody = Json.createObjectBuilder().build();
 
@@ -343,12 +343,12 @@ class PolicyDefinitionApiControllerTest extends RestControllerTestBase {
 
         verify(validatorRegistry).validate(eq(EDC_QUERY_SPEC_TYPE), any());
         verify(transformerRegistry).transform(isA(JsonObject.class), eq(QuerySpec.class));
-        verify(service).query(querySpec);
+        verify(service).search(querySpec);
         verify(transformerRegistry).transform(policyDefinition, JsonObject.class);
     }
 
     @Test
-    void query_shouldBadRequest_whenValidationFails() {
+    void search_shouldBadRequest_whenValidationFails() {
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.failure(violation("failure", "failure path")));
         var requestBody = Json.createObjectBuilder().build();
 
@@ -365,7 +365,7 @@ class PolicyDefinitionApiControllerTest extends RestControllerTestBase {
     }
 
     @Test
-    void query_shouldReturn400_whenInvalidQuery() {
+    void search_shouldReturn400_whenInvalidQuery() {
         var requestBody = Json.createObjectBuilder()
                 .add("offset", -1)
                 .build();
@@ -387,7 +387,7 @@ class PolicyDefinitionApiControllerTest extends RestControllerTestBase {
     }
 
     @Test
-    void query_shouldReturnBadRequest_whenQuerySpecTransformFails() {
+    void search_shouldReturnBadRequest_whenQuerySpecTransformFails() {
         var requestBody = Json.createObjectBuilder().build();
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
         when(transformerRegistry.transform(any(), eq(QuerySpec.class))).thenReturn(Result.failure("error"));
@@ -404,11 +404,11 @@ class PolicyDefinitionApiControllerTest extends RestControllerTestBase {
     }
 
     @Test
-    void query_shouldReturnBadRequest_whenServiceReturnsBadRequest() {
+    void search_shouldReturnBadRequest_whenServiceReturnsBadRequest() {
         var querySpec = QuerySpec.none();
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
         when(transformerRegistry.transform(any(), eq(QuerySpec.class))).thenReturn(Result.success(querySpec));
-        when(service.query(any())).thenReturn(ServiceResult.badRequest("error"));
+        when(service.search(any())).thenReturn(ServiceResult.badRequest("error"));
         var requestBody = Json.createObjectBuilder().build();
 
         given()
@@ -422,12 +422,12 @@ class PolicyDefinitionApiControllerTest extends RestControllerTestBase {
     }
 
     @Test
-    void query_shouldFilterOutResults_whenTransformFails() {
+    void search_shouldFilterOutResults_whenTransformFails() {
         var querySpec = QuerySpec.none();
         var policyDefinition = createPolicyDefinition().id("id").build();
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
         when(transformerRegistry.transform(any(), eq(QuerySpec.class))).thenReturn(Result.success(querySpec));
-        when(service.query(any())).thenReturn(ServiceResult.success(Stream.of(policyDefinition)));
+        when(service.search(any())).thenReturn(ServiceResult.success(List.of(policyDefinition)));
         when(transformerRegistry.transform(any(), eq(JsonObject.class))).thenReturn(Result.failure("error"));
         var requestBody = Json.createObjectBuilder().build();
 

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/TransferProcessApiController.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/api/management/transferprocess/TransferProcessApiController.java
@@ -82,14 +82,12 @@ public class TransferProcessApiController implements TransferProcessApi {
                     .orElseThrow(InvalidRequestException::new);
         }
 
-        try (var stream = service.query(querySpec).orElseThrow(exceptionMapper(TransferProcess.class))) {
-            return stream
-                    .map(transferProcess -> transformerRegistry.transform(transferProcess, JsonObject.class)
-                            .onFailure(f -> monitor.warning(f.getFailureDetail())))
-                    .filter(Result::succeeded)
-                    .map(Result::getContent)
-                    .collect(toJsonArray());
-        }
+        return service.search(querySpec).orElseThrow(exceptionMapper(TransferProcess.class)).stream()
+                .map(transferProcess -> transformerRegistry.transform(transferProcess, JsonObject.class)
+                        .onFailure(f -> monitor.warning(f.getFailureDetail())))
+                .filter(Result::succeeded)
+                .map(Result::getContent)
+                .collect(toJsonArray());
     }
 
     @GET

--- a/spi/common/core-spi/src/testFixtures/java/org/eclipse/edc/spi/testfixtures/asset/AssetIndexTestBase.java
+++ b/spi/common/core-spi/src/testFixtures/java/org/eclipse/edc/spi/testfixtures/asset/AssetIndexTestBase.java
@@ -319,7 +319,7 @@ public abstract class AssetIndexTestBase {
 
         @Test
         @DisplayName("Verify an asset query based on an Asset property, where the property value is actually a complex object")
-        void query_assetPropertyAsObject() {
+        void assetPropertyAsObject() {
             var nested = Map.of("text", "test123", "number", 42, "bool", false);
             var dataAddress = createDataAddress();
             var asset = createAssetBuilder("id1")

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/asset/AssetService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/asset/AssetService.java
@@ -18,6 +18,8 @@ import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.stream.Stream;
 
 public interface AssetService {
@@ -31,12 +33,24 @@ public interface AssetService {
     Asset findById(String assetId);
 
     /**
+     * Search Assets
+     *
+     * @param query the query
+     * @return the collection of assets that matches the query
+     */
+    ServiceResult<List<Asset>> search(QuerySpec query);
+
+    /**
      * Query assets
      *
      * @param query request
      * @return the collection of assets that matches the query
+     * @deprecated please use {@link #search(QuerySpec)}
      */
-    ServiceResult<Stream<Asset>> query(QuerySpec query);
+    @Deprecated(since = "0.4.1")
+    default ServiceResult<Stream<Asset>> query(QuerySpec query) {
+        return search(query).map(Collection::stream);
+    }
 
     /**
      * Create an asset

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/contractagreement/ContractAgreementService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/contractagreement/ContractAgreementService.java
@@ -19,6 +19,8 @@ import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.types.domain.agreement.ContractAgreement;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.stream.Stream;
 
 /**
@@ -35,12 +37,24 @@ public interface ContractAgreementService {
     ContractAgreement findById(String contractAgreementId);
 
     /**
-     * Query contract agreements
+     * Search contract agreements
      *
      * @param query request
      * @return the collection of contract agreements that match the query
      */
-    ServiceResult<Stream<ContractAgreement>> query(QuerySpec query);
+    ServiceResult<List<ContractAgreement>> search(QuerySpec query);
+
+    /**
+     * Query contract agreements
+     *
+     * @param query request
+     * @return the collection of contract agreements that match the query
+     * @deprecated please use {{@link #search(QuerySpec)}}
+     */
+    @Deprecated(since = "0.4.1")
+    default ServiceResult<Stream<ContractAgreement>> query(QuerySpec query) {
+        return search(query).map(Collection::stream);
+    }
 
     /**
      * Returns a contract negotiation by the agreement id.

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/contractdefinition/ContractDefinitionService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/contractdefinition/ContractDefinitionService.java
@@ -18,6 +18,8 @@ import org.eclipse.edc.connector.contract.spi.types.offer.ContractDefinition;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.ServiceResult;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.stream.Stream;
 
 /**
@@ -34,12 +36,24 @@ public interface ContractDefinitionService {
     ContractDefinition findById(String contractDefinitionId);
 
     /**
-     * Query contract definitions
+     * Search contract definitions
      *
      * @param query request
      * @return the collection of contract definitions that match the query
      */
-    ServiceResult<Stream<ContractDefinition>> query(QuerySpec query);
+    ServiceResult<List<ContractDefinition>> search(QuerySpec query);
+
+    /**
+     * Query contract definitions
+     *
+     * @param query request
+     * @return the collection of contract definitions that match the query
+     * @deprecated please use {@link #search(QuerySpec)}
+     */
+    @Deprecated(since = "0.4.1")
+    default ServiceResult<Stream<ContractDefinition>> query(QuerySpec query) {
+        return search(query).map(Collection::stream);
+    }
 
     /**
      * Create a contract definition with its related data address. If a definition with the same id exists, returns

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/contractnegotiation/ContractNegotiationService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/contractnegotiation/ContractNegotiationService.java
@@ -21,6 +21,8 @@ import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.types.domain.agreement.ContractAgreement;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.stream.Stream;
 
 public interface ContractNegotiationService {
@@ -34,12 +36,24 @@ public interface ContractNegotiationService {
     ContractNegotiation findbyId(String contractNegotiationId);
 
     /**
-     * Query contract negotiations
+     * Search contract negotiations
      *
      * @param query request
      * @return the collection of contract negotiations that match the query
      */
-    ServiceResult<Stream<ContractNegotiation>> query(QuerySpec query);
+    ServiceResult<List<ContractNegotiation>> search(QuerySpec query);
+
+    /**
+     * Query contract negotiations
+     *
+     * @param query request
+     * @return the collection of contract negotiations that match the query
+     * @deprecated please use {@link #search(QuerySpec)}
+     */
+    @Deprecated(since = "0.4.1")
+    default ServiceResult<Stream<ContractNegotiation>> query(QuerySpec query) {
+        return search(query).map(Collection::stream);
+    }
 
     /**
      * Get negotiation state

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/policydefinition/PolicyDefinitionService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/policydefinition/PolicyDefinitionService.java
@@ -20,6 +20,8 @@ import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.stream.Stream;
 
 /**
@@ -38,13 +40,24 @@ public interface PolicyDefinitionService {
     PolicyDefinition findById(String policyId);
 
     /**
-     * Query policies
+     * Search policies
      *
      * @param query request
      * @return the stream of policies that match the query
      */
+    ServiceResult<List<PolicyDefinition>> search(QuerySpec query);
 
-    ServiceResult<Stream<PolicyDefinition>> query(QuerySpec query);
+    /**
+     * Query policies
+     *
+     * @param query request
+     * @return the stream of policies that match the query
+     * @deprecated please use {@link #search(QuerySpec)}
+     */
+    @Deprecated(since = "0.4.1")
+    default ServiceResult<Stream<PolicyDefinition>> query(QuerySpec query) {
+        return search(query).map(Collection::stream);
+    }
 
     /**
      * Delete a policy

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/transferprocess/TransferProcessService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/transferprocess/TransferProcessService.java
@@ -25,6 +25,8 @@ import org.eclipse.edc.spi.result.ServiceResult;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.stream.Stream;
 
 /**
@@ -42,12 +44,24 @@ public interface TransferProcessService {
     TransferProcess findById(String transferProcessId);
 
     /**
-     * Query transferProcess.
+     * Search transferProcess.
      *
      * @param query request
      * @return the collection of transferProcesses that match the query
      */
-    ServiceResult<Stream<TransferProcess>> query(QuerySpec query);
+    ServiceResult<List<TransferProcess>> search(QuerySpec query);
+
+    /**
+     * Query transferProcess.
+     *
+     * @param query request
+     * @return the collection of transferProcesses that match the query
+     * @deprecated please use {@link #search(QuerySpec)}
+     */
+    @Deprecated(since = "0.4.1")
+    default ServiceResult<Stream<TransferProcess>> query(QuerySpec query) {
+        return search(query).map(Collection::stream);
+    }
 
     /**
      * Returns the state of a transferProcess by its id.

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TransferProcessApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TransferProcessApiEndToEndTest.java
@@ -158,7 +158,7 @@ public class TransferProcessApiEndToEndTest extends BaseManagementApiEndToEndTes
     }
 
     @Test
-    void query_byState() throws JsonProcessingException {
+    void request_byState() throws JsonProcessingException {
 
         var state = DEPROVISIONED;
         var tp = createTransferProcessBuilder("test-tp")


### PR DESCRIPTION
## What this PR changes/adds

Make services return collected `List`s instead of `Stream`s.

## Why it does that

transactional context scope

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #3682

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
