### PR TITLE
feat: add public api swagger hub page

### DIFF
--- a/.github/workflows/apidoc.yaml
+++ b/.github/workflows/apidoc.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        apiGroup: [ 'management-api', 'control-api' ]
+        apiGroup: [ 'public-api', 'management-api', 'control-api' ]
     env:
       rootDir: resources/openapi/yaml/${{ matrix.apiGroup }}
       SWAGGERHUB_API_KEY: ${{ secrets.SWAGGERHUB_TOKEN }}


### PR DESCRIPTION
## What this PR changes/adds

- create & publish new `public-api` swagger hub page

## Why it does that

- APIs which are publicly exposed (example: `DataPlanePublicApi)` should not be grouped under `control-api` or `management-api`. Therefore a new API group is necessary

## Further notes

## Linked Issue(s)

Closes #3373