### PR TITLE
chore: move adding the default DID context to builder

### DIFF
--- a/spi/common/identity-did-spi/src/main/java/org/eclipse/edc/iam/did/spi/document/DidDocument.java
+++ b/spi/common/identity-did-spi/src/main/java/org/eclipse/edc/iam/did/spi/document/DidDocument.java
@@ -28,12 +28,12 @@ import java.util.List;
 @JsonDeserialize(builder = DidDocument.Builder.class)
 public class DidDocument {
 
-    private String id;
     private final List<Service> service = new ArrayList<>();
     @JsonProperty("@context")
-    private final List<Object> context = new ArrayList<>(List.of("https://w3id.org/did-resolution/v1"));
+    private final List<Object> context = new ArrayList<>();
     private final List<VerificationMethod> verificationMethod = new ArrayList<>();
     private final List<String> authentication = new ArrayList<>();
+    private String id;
 
     public String getId() {
         return id;
@@ -100,6 +100,8 @@ public class DidDocument {
         }
 
         public DidDocument build() {
+            if (document.context.isEmpty())
+                document.context.add("https://w3id.org/did-resolution/v1");
             return document;
         }
     }

--- a/spi/common/identity-did-spi/src/main/java/org/eclipse/edc/iam/did/spi/document/DidDocument.java
+++ b/spi/common/identity-did-spi/src/main/java/org/eclipse/edc/iam/did/spi/document/DidDocument.java
@@ -28,6 +28,7 @@ import java.util.List;
 @JsonDeserialize(builder = DidDocument.Builder.class)
 public class DidDocument {
 
+    public static final String DID_RESOLUTION_CONTEXT = "https://w3id.org/did-resolution/v1";
     private final List<Service> service = new ArrayList<>();
     @JsonProperty("@context")
     private final List<Object> context = new ArrayList<>();
@@ -100,8 +101,9 @@ public class DidDocument {
         }
 
         public DidDocument build() {
-            if (document.context.isEmpty())
-                document.context.add("https://w3id.org/did-resolution/v1");
+            if (!document.context.contains(DID_RESOLUTION_CONTEXT)) {
+                document.context.add(DID_RESOLUTION_CONTEXT);
+            }
             return document;
         }
     }


### PR DESCRIPTION
## What this PR changes/adds

Moves adding the default JSON-LD context for DID documents to the builder method

## Why it does that

Doing this hard-coded in the field initializer can cause problems when deserializing, for example 
when restoring a `DidDocument` from persistence.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
