### PR TITLE
feat: allow unchecked SQL operators

### DIFF
--- a/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/store/CriterionToPredicateConverterImpl.java
+++ b/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/store/CriterionToPredicateConverterImpl.java
@@ -81,9 +81,13 @@ public class CriterionToPredicateConverterImpl implements CriterionToPredicateCo
                 return false;
             }
 
-            if (property.getClass().isEnum() && criterion.getOperandRight() instanceof String) {
+            if (property.getClass().isEnum()) {
                 var enumProperty = (Enum<?>) property;
-                return Objects.equals(enumProperty.name(), criterion.getOperandRight());
+                if (criterion.getOperandRight() instanceof String) {
+                    return Objects.equals(enumProperty.name(), criterion.getOperandRight());
+                } else if (criterion.getOperandRight() instanceof Number) {
+                    return Objects.equals(enumProperty.ordinal(), criterion.getOperandRight());
+                }
             }
 
             if (property instanceof Number c1 && criterion.getOperandRight() instanceof Number c2) {

--- a/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/store/ReflectionBasedQueryResolver.java
+++ b/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/store/ReflectionBasedQueryResolver.java
@@ -36,16 +36,28 @@ import static java.lang.String.format;
 public class ReflectionBasedQueryResolver<T> implements QueryResolver<T> {
 
     private final Class<T> typeParameterClass;
-    private final CriterionToPredicateConverter predicateConverter = new CriterionToPredicateConverterImpl();
+    private final CriterionToPredicateConverter predicateConverter;
 
     /**
-     * Constructor for StreamQueryResolver
+     * Constructor for ReflectionBasedQueryResolver
      *
      * @param typeParameterClass class of the type parameter. Used in reflection operation to recursively fetch a property from an object.
      */
     public ReflectionBasedQueryResolver(Class<T> typeParameterClass) {
-        this.typeParameterClass = typeParameterClass;
+        this(typeParameterClass, new CriterionToPredicateConverterImpl());
     }
+
+    /**
+     * Constructor for ReflectionBasedQueryResolver
+     *
+     * @param typeParameterClass            class of the type parameter. Used in reflection operation to recursively fetch a property from an object.
+     * @param criterionToPredicateConverter converts from a criterion to a predicate
+     */
+    public ReflectionBasedQueryResolver(Class<T> typeParameterClass, CriterionToPredicateConverter criterionToPredicateConverter) {
+        this.typeParameterClass = typeParameterClass;
+        this.predicateConverter = criterionToPredicateConverter;
+    }
+
 
     /**
      * Method to query a stream by provided specification.

--- a/core/common/connector-core/src/test/java/org/eclipse/edc/connector/core/store/CriterionToPredicateConverterImplTest.java
+++ b/core/common/connector-core/src/test/java/org/eclipse/edc/connector/core/store/CriterionToPredicateConverterImplTest.java
@@ -47,6 +47,25 @@ class CriterionToPredicateConverterImplTest {
     }
 
     @Test
+    void equal_enumShouldCheckOrdinal() {
+        var predicate = converter.convert(new Criterion("enumValue", "=", ENTRY2.ordinal()));
+
+        assertThat(predicate)
+                .accepts(new TestObject("any", ENTRY2))
+                .rejects(new TestObject("any", ENTRY1), new TestObject("any", null));
+    }
+
+    @Test
+    void equal_enumShouldRejectInvalidOrdinal() {
+        var predicate = converter.convert(new Criterion("enumValue", "=", -42));
+
+        assertThat(predicate)
+                .rejects(new TestObject("any", ENTRY2))
+                .rejects(new TestObject("any", ENTRY1), new TestObject("any", null));
+    }
+
+
+    @Test
     void equal_integerAndDouble() {
         var predicate = converter.convert(new Criterion("intValue", "=", 42));
 

--- a/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/SqlConditionExpression.java
+++ b/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/SqlConditionExpression.java
@@ -30,19 +30,12 @@ import static java.lang.String.format;
  * Parses a {@link Criterion} and provides methods to validate it and extract SQL prepared statement placeholders and
  * parameters.
  */
-public class SqlConditionExpression {
-
+public record SqlConditionExpression(Criterion criterion) {
     private static final String IN_OPERATOR = "in";
     private static final String LIKE_OPERATOR = "like";
     private static final String EQUALS_OPERATOR = "=";
     private static final List<String> SUPPORTED_PREPARED_STATEMENT_OPERATORS = List.of(EQUALS_OPERATOR, LIKE_OPERATOR, IN_OPERATOR);
     private static final String PREPARED_STATEMENT_PLACEHOLDER = "?";
-    private final Criterion criterion;
-
-    public SqlConditionExpression(Criterion criterion) {
-
-        this.criterion = criterion;
-    }
 
     /**
      * Returns condition expression SQL representation.

--- a/extensions/common/sql/sql-core/src/test/java/org/eclipse/edc/sql/translation/SqlQueryStatementTest.java
+++ b/extensions/common/sql/sql-core/src/test/java/org/eclipse/edc/sql/translation/SqlQueryStatementTest.java
@@ -121,6 +121,15 @@ class SqlQueryStatementTest {
         assertThat(t.getParameters()).containsExactly("testid1", customParameter, 50, 0);
     }
 
+    @Test
+    void expression_withUnsupportedOperator_noValidate() {
+        var criterion = new Criterion("field1", "??", "testid1");
+        var t = new SqlQueryStatement(SELECT_STATEMENT, query(criterion), new TestMapping(), false);
+
+        assertThat(t.getQueryAsString()).isEqualToIgnoringCase(SELECT_STATEMENT + " WHERE edc_field_1 ?? ? LIMIT ? OFFSET ?;");
+        assertThat(t.getParameters()).containsOnly("testid1", 50, 0);
+    }
+
     private QuerySpec.Builder queryBuilder(Criterion... criterion) {
         return QuerySpec.Builder.newInstance().filter(List.of(criterion));
     }


### PR DESCRIPTION
## What this PR changes/adds

This PR adds an overloaded constructor for the `SqlQueryStatement` class that allows 
to disable the operator checking. 
That means, that the `SqlQueryStatement` won't throw an `IllegalArgumentException` anymore when it encounters
a supposedly illegal operator.

## Why it does that

Postgres has some very specific operators, such as the `?`, which can be used for JSONB (not JSON!) types. The `?` can be used to comfortably check if a value occurs in a JSON array:
```sql
SELECT *
FROM sometable
WHERE (someJsonColumn -> 'stringarray_prop')::jsonb ? 'someval_that_occurs_in_the_array';
```
Check out [this stackoverflow article](https://stackoverflow.com/a/27144175/7079724) for another example.

Now, since we do strict checks on `=`, `in`, `like`, constructing such a query would not be possible. 

## Further notes
- It would have been possible to simply at the `?` operator to the `SqlConditionExpression.SUPPORTED_PREPARED_STATEMENT_OPERATORS` list, but then we're dragging Postgres-specific operators into the otherwise generic `SqlQueryExpression` and that felt wrong.

  Although I haven't verified this, there could be other operators. Typically, if the usage of those operators is needed, we're dealing with a very niche use case, where operator validation can likely be foregone.

- In passing, I added a branch in the the criterion converter to account for enum ordinals, not just literals. That appears to have been a bug.
- Added an overloaded constructor for the `ReflectionBasedQueryResolver` to customize the criterion-to-predicate conversion


## Linked Issue(s)

Needed for https://github.com/eclipse-edc/IdentityHub/issues/188

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
