### PR TITLE
chore: map claims of CredentialSubject during SerDes

### DIFF
--- a/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/model/CredentialSubject.java
+++ b/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/model/CredentialSubject.java
@@ -14,6 +14,9 @@
 
 package org.eclipse.edc.identitytrust.model;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -27,8 +30,14 @@ public class CredentialSubject {
     private Map<String, Object> claims = new HashMap<>();
     private String id;
 
+    @JsonAnyGetter
     public Map<String, Object> getClaims() {
         return claims;
+    }
+
+    @JsonAnySetter
+    public void setClaim(String name, Object value) {
+        claims.put(name, value);
     }
 
     public String getId() {


### PR DESCRIPTION
## What this PR changes/adds

This PR changes the serialization/deserialization of a `CredentialSubject` in that it avoids 
serializing claims to a JSON `claims` object.

## Why it does that

It is an implementation detail that the structure of the `CredentialSubject` is kept in a `claims` map. Java simply 
does not handle dynamic types, and in it is not relevant for the serialized form.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
