### PR TITLE
feat: support DSP `consumerPid` and `providerPid` for ContractNegotiation

### DIFF
--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -77,6 +77,8 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
                 .protocol(negotiation.getProtocol())
                 .counterPartyAddress(negotiation.getCounterPartyAddress())
                 .contractOffer(currentOffer)
+                .providerPid(negotiation.getId())
+                .consumerPid(negotiation.getCorrelationId())
                 .processId(negotiation.getCorrelationId())
                 .build();
 
@@ -141,6 +143,8 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
                 .protocol(negotiation.getProtocol())
                 .counterPartyAddress(negotiation.getCounterPartyAddress())
                 .contractAgreement(agreement)
+                .providerPid(negotiation.getId())
+                .consumerPid(negotiation.getCorrelationId())
                 .processId(negotiation.getCorrelationId())
                 .build();
 
@@ -177,6 +181,8 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
                 .type(ContractNegotiationEventMessage.Type.FINALIZED)
                 .protocol(negotiation.getProtocol())
                 .counterPartyAddress(negotiation.getCounterPartyAddress())
+                .providerPid(negotiation.getId())
+                .consumerPid(negotiation.getCorrelationId())
                 .processId(negotiation.getCorrelationId())
                 .policy(negotiation.getContractAgreement().getPolicy())
                 .build();

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -86,8 +86,8 @@ class ContractNegotiationIntegrationTest {
     private final InMemoryContractNegotiationStore providerStore = new InMemoryContractNegotiationStore(clock);
     private final InMemoryContractNegotiationStore consumerStore = new InMemoryContractNegotiationStore(clock);
     private final ContractValidationService validationService = mock(ContractValidationService.class);
-    private final RemoteMessageDispatcherRegistry providerDispatcherRegistry = mock(RemoteMessageDispatcherRegistry.class);
-    private final RemoteMessageDispatcherRegistry consumerDispatcherRegistry = mock(RemoteMessageDispatcherRegistry.class);
+    private final RemoteMessageDispatcherRegistry providerDispatcherRegistry = mock();
+    private final RemoteMessageDispatcherRegistry consumerDispatcherRegistry = mock();
     private final IdentityService identityService = mock();
     protected ClaimToken token = ClaimToken.Builder.newInstance().build();
     protected TokenRepresentation tokenRepresentation = TokenRepresentation.Builder.newInstance().build();

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
@@ -25,7 +25,6 @@ import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiat
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationTerminationMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
-import org.eclipse.edc.connector.contract.spi.types.protocol.ContractRemoteMessage;
 import org.eclipse.edc.connector.contract.spi.validation.ContractValidationService;
 import org.eclipse.edc.connector.contract.spi.validation.ValidatedConsumerOffer;
 import org.eclipse.edc.connector.service.protocol.BaseProtocolService;
@@ -72,44 +71,50 @@ public class ContractNegotiationProtocolServiceImpl extends BaseProtocolService 
     @WithSpan
     @NotNull
     public ServiceResult<ContractNegotiation> notifyRequested(ContractRequestMessage message, TokenRepresentation tokenRepresentation) {
-        return verifyToken(tokenRepresentation).compose(claimToken -> transactionContext.execute(() -> validateOffer(message, claimToken)
-                .compose(validatedOffer -> getNegotiation(message)
-                        .recover(f -> createNegotiation(message, validatedOffer))
-                        .onSuccess(n -> n.addContractOffer(validatedOffer.getOffer()))
-                )
-                .onSuccess(negotiation -> {
-                    negotiation.transitionRequested();
-                    update(negotiation);
-                    observable.invokeForEach(l -> l.requested(negotiation));
-                })));
+        return transactionContext.execute(() -> verifyToken(tokenRepresentation)
+                .compose(claimToken -> validateOffer(message, claimToken))
+                .compose(validatedOffer -> {
+                    var result = message.getProviderPid() == null
+                            ? createNegotiation(message, validatedOffer)
+                            : getNegotiation(message.getProviderPid());
 
+                    return result.onSuccess(negotiation -> {
+                        negotiation.addContractOffer(validatedOffer.getOffer());
+                        negotiation.transitionRequested();
+                        update(negotiation);
+                        observable.invokeForEach(l -> l.requested(negotiation));
+                    });
+                }));
     }
 
     @Override
     @WithSpan
     @NotNull
     public ServiceResult<ContractNegotiation> notifyOffered(ContractOfferMessage message, TokenRepresentation tokenRepresentation) {
-        return verifyToken(tokenRepresentation).compose(claimToken -> transactionContext.execute(() -> getNegotiation(message)
-                .compose(negotiation -> validateRequest(claimToken, negotiation))
+        return transactionContext.execute(() -> verifyToken(tokenRepresentation)
+                .compose(claimToken -> getNegotiation(message.getProcessId())
+                        .compose(negotiation -> validateRequest(claimToken, negotiation)))
                 .onSuccess(negotiation -> {
                     negotiation.addContractOffer(message.getContractOffer());
+                    negotiation.setCorrelationId(message.getProviderPid());
                     negotiation.transitionOffered();
                     update(negotiation);
                     observable.invokeForEach(l -> l.offered(negotiation));
-                })));
+                }));
     }
 
     @Override
     @WithSpan
     @NotNull
     public ServiceResult<ContractNegotiation> notifyAccepted(ContractNegotiationEventMessage message, TokenRepresentation tokenRepresentation) {
-        return verifyToken(tokenRepresentation).compose(claimToken -> transactionContext.execute(() -> getNegotiation(message)
-                .compose(negotiation -> validateRequest(claimToken, negotiation))
+        return transactionContext.execute(() -> verifyToken(tokenRepresentation)
+                .compose(claimToken -> getNegotiation(message.getProcessId())
+                        .compose(negotiation -> validateRequest(claimToken, negotiation)))
                 .onSuccess(negotiation -> {
                     negotiation.transitionAccepted();
                     update(negotiation);
                     observable.invokeForEach(l -> l.accepted(negotiation));
-                })));
+                }));
 
     }
 
@@ -117,53 +122,58 @@ public class ContractNegotiationProtocolServiceImpl extends BaseProtocolService 
     @WithSpan
     @NotNull
     public ServiceResult<ContractNegotiation> notifyAgreed(ContractAgreementMessage message, TokenRepresentation tokenRepresentation) {
-        return verifyToken(tokenRepresentation).compose(claimToken -> transactionContext.execute(() -> getNegotiation(message)
-                .compose(negotiation -> validateAgreed(message, claimToken, negotiation))
+        return transactionContext.execute(() -> verifyToken(tokenRepresentation)
+                .compose(claimToken -> getNegotiation(message.getProcessId())
+                    .compose(negotiation -> validateAgreed(message, claimToken, negotiation)))
                 .onSuccess(negotiation -> {
                     negotiation.setContractAgreement(message.getContractAgreement());
+                    negotiation.setCorrelationId(message.getProviderPid());
                     negotiation.transitionAgreed();
                     update(negotiation);
                     observable.invokeForEach(l -> l.agreed(negotiation));
-                })));
+                }));
     }
 
     @Override
     @WithSpan
     @NotNull
     public ServiceResult<ContractNegotiation> notifyVerified(ContractAgreementVerificationMessage message, TokenRepresentation tokenRepresentation) {
-        return verifyToken(tokenRepresentation).compose(claimToken -> transactionContext.execute(() -> getNegotiation(message)
-                .compose(negotiation -> validateRequest(claimToken, negotiation))
+        return transactionContext.execute(() -> verifyToken(tokenRepresentation)
+                .compose(claimToken -> getNegotiation(message.getProcessId())
+                        .compose(negotiation -> validateRequest(claimToken, negotiation)))
                 .onSuccess(negotiation -> {
                     negotiation.transitionVerified();
                     update(negotiation);
                     observable.invokeForEach(l -> l.verified(negotiation));
-                })));
+                }));
     }
 
     @Override
     @WithSpan
     @NotNull
     public ServiceResult<ContractNegotiation> notifyFinalized(ContractNegotiationEventMessage message, TokenRepresentation tokenRepresentation) {
-        return verifyToken(tokenRepresentation).compose(claimToken -> transactionContext.execute(() -> getNegotiation(message)
-                .compose(negotiation -> validateRequest(claimToken, negotiation))
+        return transactionContext.execute(() -> verifyToken(tokenRepresentation)
+                .compose(claimToken -> getNegotiation(message.getProcessId())
+                        .compose(negotiation -> validateRequest(claimToken, negotiation)))
                 .onSuccess(negotiation -> {
                     negotiation.transitionFinalized();
                     update(negotiation);
                     observable.invokeForEach(l -> l.finalized(negotiation));
-                })));
+                }));
     }
 
     @Override
     @WithSpan
     @NotNull
     public ServiceResult<ContractNegotiation> notifyTerminated(ContractNegotiationTerminationMessage message, TokenRepresentation tokenRepresentation) {
-        return verifyToken(tokenRepresentation).compose(claimToken -> transactionContext.execute(() -> getNegotiation(message)
-                .compose(negotiation -> validateRequest(claimToken, negotiation))
+        return transactionContext.execute(() -> verifyToken(tokenRepresentation)
+                .compose(claimToken -> getNegotiation(message.getProcessId())
+                        .compose(negotiation -> validateRequest(claimToken, negotiation)))
                 .onSuccess(negotiation -> {
                     negotiation.transitionTerminated();
                     update(negotiation);
                     observable.invokeForEach(l -> l.terminated(negotiation));
-                })));
+                }));
     }
 
     @Override
@@ -179,7 +189,7 @@ public class ContractNegotiationProtocolServiceImpl extends BaseProtocolService 
     private ServiceResult<ContractNegotiation> createNegotiation(ContractRequestMessage message, ValidatedConsumerOffer validatedOffer) {
         var negotiation = ContractNegotiation.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
-                .correlationId(message.getProcessId())
+                .correlationId(message.getConsumerPid())
                 .counterPartyId(validatedOffer.getConsumerIdentity())
                 .counterPartyAddress(message.getCallbackAddress())
                 .protocol(message.getProtocol())
@@ -226,8 +236,10 @@ public class ContractNegotiationProtocolServiceImpl extends BaseProtocolService 
         }
     }
 
-    private ServiceResult<ContractNegotiation> getNegotiation(ContractRemoteMessage message) {
-        return store.findByCorrelationIdAndLease(message.getProcessId()).flatMap(ServiceResult::from);
+    private ServiceResult<ContractNegotiation> getNegotiation(String negotiationId) {
+        return store.findByIdAndLease(negotiationId)
+                .recover(it -> store.findByCorrelationIdAndLease(negotiationId)) // this is to maintain backward compatibility with the processId
+                .flatMap(ServiceResult::from);
     }
 
     private void update(ContractNegotiation negotiation) {

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
@@ -132,7 +132,7 @@ class ContractNegotiationEventDispatchTest {
                 .counterPartyAddress("counterPartyAddress")
                 .callbackAddress("callbackAddress")
                 .contractOffer(contractOffer)
-                .processId("processId")
+                .consumerPid("consumerPid")
                 .build();
     }
 

--- a/data-protocols/dsp/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/message/DspRequestHandlerImpl.java
+++ b/data-protocols/dsp/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/message/DspRequestHandlerImpl.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.protocol.dsp.message;
 import jakarta.json.JsonObject;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.eclipse.edc.connector.contract.spi.types.protocol.ContractRemoteMessage;
 import org.eclipse.edc.protocol.dsp.spi.message.DspRequestHandler;
 import org.eclipse.edc.protocol.dsp.spi.message.GetDspRequest;
 import org.eclipse.edc.protocol.dsp.spi.message.PostDspRequest;
@@ -133,7 +134,16 @@ public class DspRequestHandlerImpl implements DspRequestHandler {
 
         var inputTransformation = transformerRegistry.transform(request.getMessage(), request.getInputClass())
                 .compose(message -> {
-                    if (message instanceof ProcessRemoteMessage processRemoteMessage) {
+                    if (message instanceof ContractRemoteMessage contractRemoteMessage) {
+                        var processIdValidation = contractRemoteMessage.isValidProcessId(request.getProcessId());
+                        if (processIdValidation.succeeded()) {
+                            contractRemoteMessage.setProcessId(request.getProcessId());
+                            contractRemoteMessage.setProtocol(DATASPACE_PROTOCOL_HTTP);
+                            return Result.success(message);
+                        } else {
+                            return Result.failure("DSP: %s".formatted(processIdValidation.getFailureDetail()));
+                        }
+                    } else if (message instanceof ProcessRemoteMessage processRemoteMessage) {
                         processRemoteMessage.setProtocol(DATASPACE_PROTOCOL_HTTP);
 
                         return Objects.equals(request.getProcessId(), processRemoteMessage.getProcessId())

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractAgreementMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractAgreementMessageTransformer.java
@@ -18,7 +18,6 @@ import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementMessage;
-import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
@@ -26,12 +25,15 @@ import org.jetbrains.annotations.Nullable;
 
 import static java.time.Instant.ofEpochSecond;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_AGREEMENT;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_ID;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_ID;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_TIMESTAMP;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID;
 
 
 /**
@@ -48,11 +50,12 @@ public class JsonObjectFromContractAgreementMessageTransformer extends AbstractJ
 
     @Override
     public @Nullable JsonObject transform(@NotNull ContractAgreementMessage agreementMessage, @NotNull TransformerContext context) {
-        var builder = jsonFactory.createObjectBuilder();
-        builder.add(JsonLdKeywords.ID, agreementMessage.getId());
-        builder.add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE);
-
-        builder.add(DSPACE_PROPERTY_PROCESS_ID, agreementMessage.getProcessId());
+        var builder = jsonFactory.createObjectBuilder()
+                .add(ID, agreementMessage.getId())
+                .add(TYPE, DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE)
+                .add(DSPACE_PROPERTY_PROVIDER_PID, agreementMessage.getProviderPid())
+                .add(DSPACE_PROPERTY_CONSUMER_PID, agreementMessage.getConsumerPid())
+                .add(DSPACE_PROPERTY_PROCESS_ID, agreementMessage.getProcessId());
 
         var agreement = agreementMessage.getContractAgreement();
 

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractAgreementVerificationMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractAgreementVerificationMessageTransformer.java
@@ -17,14 +17,17 @@ package org.eclipse.edc.protocol.dsp.negotiation.transform.from;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementVerificationMessage;
-import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_AGREEMENT_VERIFICATION_MESSAGE;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID;
 
 /**
  * Creates a {@link JsonObject} from a {@link ContractAgreementVerificationMessage}.
@@ -40,11 +43,12 @@ public class JsonObjectFromContractAgreementVerificationMessageTransformer exten
 
     @Override
     public @Nullable JsonObject transform(@NotNull ContractAgreementVerificationMessage verificationMessage, @NotNull TransformerContext context) {
-        var builder = jsonFactory.createObjectBuilder();
-        builder.add(JsonLdKeywords.ID, verificationMessage.getId());
-        builder.add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_AGREEMENT_VERIFICATION_MESSAGE);
-
-        builder.add(DSPACE_PROPERTY_PROCESS_ID, verificationMessage.getProcessId());
-        return builder.build();
+        return jsonFactory.createObjectBuilder()
+                .add(ID, verificationMessage.getId())
+                .add(TYPE, DSPACE_TYPE_CONTRACT_AGREEMENT_VERIFICATION_MESSAGE)
+                .add(DSPACE_PROPERTY_CONSUMER_PID, verificationMessage.getConsumerPid())
+                .add(DSPACE_PROPERTY_PROVIDER_PID, verificationMessage.getProviderPid())
+                .add(DSPACE_PROPERTY_PROCESS_ID, verificationMessage.getProcessId())
+                .build();
     }
 }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractNegotiationEventMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractNegotiationEventMessageTransformer.java
@@ -18,7 +18,6 @@ import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractNegotiationEventMessage;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
-import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -29,7 +28,9 @@ import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNam
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_VALUE_NEGOTIATION_EVENT_TYPE_ACCEPTED;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_VALUE_NEGOTIATION_EVENT_TYPE_FINALIZED;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID;
 
 
 /**
@@ -46,28 +47,17 @@ public class JsonObjectFromContractNegotiationEventMessageTransformer extends Ab
 
     @Override
     public @Nullable JsonObject transform(@NotNull ContractNegotiationEventMessage eventMessage, @NotNull TransformerContext context) {
-        var builder = jsonFactory.createObjectBuilder();
-        builder.add(ID, eventMessage.getId());
-        builder.add(TYPE, DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE);
-
-        builder.add(DSPACE_PROPERTY_PROCESS_ID, eventMessage.getProcessId());
-
-        builder.add(DSPACE_PROPERTY_EVENT_TYPE, eventType(eventMessage));
-
-        return builder.build();
-    }
-
-    @NotNull
-    private String eventType(ContractNegotiationEventMessage message) {
-        switch (message.getType()) {
-            case ACCEPTED:
-                return DSPACE_VALUE_NEGOTIATION_EVENT_TYPE_ACCEPTED;
-            case FINALIZED:
-                return DSPACE_VALUE_NEGOTIATION_EVENT_TYPE_FINALIZED;
-            default:
-                // this cannot happen
-                throw new EdcException("Unknown event type: " + message.getType());
-        }
+        return jsonFactory.createObjectBuilder()
+                .add(ID, eventMessage.getId())
+                .add(TYPE, DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE)
+                .add(DSPACE_PROPERTY_CONSUMER_PID, eventMessage.getConsumerPid())
+                .add(DSPACE_PROPERTY_PROVIDER_PID, eventMessage.getProviderPid())
+                .add(DSPACE_PROPERTY_PROCESS_ID, eventMessage.getProcessId())
+                .add(DSPACE_PROPERTY_EVENT_TYPE, switch (eventMessage.getType()) {
+                    case ACCEPTED -> DSPACE_VALUE_NEGOTIATION_EVENT_TYPE_ACCEPTED;
+                    case FINALIZED -> DSPACE_VALUE_NEGOTIATION_EVENT_TYPE_FINALIZED;
+                })
+                .build();
     }
 
 }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractNegotiationTerminationMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractNegotiationTerminationMessageTransformer.java
@@ -26,7 +26,9 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_TERMINATION_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CODE;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_REASON;
 
 /**
@@ -43,21 +45,15 @@ public class JsonObjectFromContractNegotiationTerminationMessageTransformer exte
 
     @Override
     public @Nullable JsonObject transform(@NotNull ContractNegotiationTerminationMessage terminationMessage, @NotNull TransformerContext context) {
-        var builder = jsonFactory.createObjectBuilder();
-        builder.add(ID, terminationMessage.getId());
-        builder.add(TYPE, DSPACE_TYPE_CONTRACT_NEGOTIATION_TERMINATION_MESSAGE);
+        var builder = jsonFactory.createObjectBuilder()
+                .add(ID, terminationMessage.getId())
+                .add(TYPE, DSPACE_TYPE_CONTRACT_NEGOTIATION_TERMINATION_MESSAGE)
+                .add(DSPACE_PROPERTY_CONSUMER_PID, terminationMessage.getConsumerPid())
+                .add(DSPACE_PROPERTY_PROVIDER_PID, terminationMessage.getProviderPid())
+                .add(DSPACE_PROPERTY_PROCESS_ID, terminationMessage.getProcessId());
 
-        builder.add(DSPACE_PROPERTY_PROCESS_ID, terminationMessage.getProcessId());
-
-        var rejectionReason = terminationMessage.getRejectionReason();
-        if (rejectionReason != null) {
-            builder.add(DSPACE_PROPERTY_REASON, rejectionReason);
-        }
-
-        var code = terminationMessage.getCode();
-        if (code != null) {
-            builder.add(DSPACE_PROPERTY_CODE, code);
-        }
+        addIfNotNull(terminationMessage.getRejectionReason(), DSPACE_PROPERTY_REASON, builder);
+        addIfNotNull(terminationMessage.getCode(), DSPACE_PROPERTY_CODE, builder);
 
         return builder.build();
     }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractNegotiationTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractNegotiationTransformer.java
@@ -33,7 +33,9 @@ import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNam
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_VALUE_NEGOTIATION_STATE_REQUESTED;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_VALUE_NEGOTIATION_STATE_TERMINATED;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_VALUE_NEGOTIATION_STATE_VERIFIED;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_STATE;
 
 
@@ -52,11 +54,17 @@ public class JsonObjectFromContractNegotiationTransformer extends AbstractJsonLd
     @Override
     public @Nullable JsonObject transform(@NotNull ContractNegotiation contractNegotiation, @NotNull TransformerContext context) {
         return jsonFactory.createObjectBuilder()
-                .add(ID, contractNegotiation.getCorrelationId())
+                .add(ID, pidFor(contractNegotiation, contractNegotiation.getType()))
                 .add(TYPE, DSPACE_TYPE_CONTRACT_NEGOTIATION)
-                .add(DSPACE_PROPERTY_PROCESS_ID, contractNegotiation.getCorrelationId())
+                .add(DSPACE_PROPERTY_CONSUMER_PID, pidFor(contractNegotiation, ContractNegotiation.Type.CONSUMER))
+                .add(DSPACE_PROPERTY_PROVIDER_PID, pidFor(contractNegotiation, ContractNegotiation.Type.PROVIDER))
+                .add(DSPACE_PROPERTY_PROCESS_ID, pidFor(contractNegotiation, ContractNegotiation.Type.CONSUMER))
                 .add(DSPACE_PROPERTY_STATE, state(contractNegotiation.getState(), context))
                 .build();
+    }
+
+    private String pidFor(@NotNull ContractNegotiation contractNegotiation, ContractNegotiation.Type type) {
+        return contractNegotiation.getType() == type ? contractNegotiation.getId() : contractNegotiation.getCorrelationId();
     }
 
     private String state(Integer state, TransformerContext context) {
@@ -69,29 +77,16 @@ public class JsonObjectFromContractNegotiationTransformer extends AbstractJsonLd
                     .report();
             return null;
         }
-        switch (negotiationState) {
-            case REQUESTING:
-            case REQUESTED:
-                return DSPACE_VALUE_NEGOTIATION_STATE_REQUESTED;
-            case OFFERING:
-            case OFFERED:
-                return DSPACE_VALUE_NEGOTIATION_STATE_OFFERED;
-            case ACCEPTING:
-            case ACCEPTED:
-                return DSPACE_VALUE_NEGOTIATION_STATE_ACCEPTED;
-            case AGREEING:
-            case AGREED:
-                return DSPACE_VALUE_NEGOTIATION_STATE_AGREED;
-            case VERIFYING:
-            case VERIFIED:
-                return DSPACE_VALUE_NEGOTIATION_STATE_VERIFIED;
-            case FINALIZING:
-            case FINALIZED:
-                return DSPACE_VALUE_NEGOTIATION_STATE_FINALIZED;
-            case TERMINATING:
-            case TERMINATED:
-                return DSPACE_VALUE_NEGOTIATION_STATE_TERMINATED;
-            default:
+
+        return switch (negotiationState) {
+            case REQUESTING, REQUESTED -> DSPACE_VALUE_NEGOTIATION_STATE_REQUESTED;
+            case OFFERING, OFFERED -> DSPACE_VALUE_NEGOTIATION_STATE_OFFERED;
+            case ACCEPTING, ACCEPTED -> DSPACE_VALUE_NEGOTIATION_STATE_ACCEPTED;
+            case AGREEING, AGREED -> DSPACE_VALUE_NEGOTIATION_STATE_AGREED;
+            case VERIFYING, VERIFIED -> DSPACE_VALUE_NEGOTIATION_STATE_VERIFIED;
+            case FINALIZING, FINALIZED -> DSPACE_VALUE_NEGOTIATION_STATE_FINALIZED;
+            case TERMINATING, TERMINATED -> DSPACE_VALUE_NEGOTIATION_STATE_TERMINATED;
+            default -> {
                 context.problem()
                         .unexpectedType()
                         .type(ContractNegotiation.class)
@@ -99,8 +94,9 @@ public class JsonObjectFromContractNegotiationTransformer extends AbstractJsonLd
                         .actual(negotiationState.toString())
                         .expected(ContractNegotiationStates.class)
                         .report();
-                return null;
-        }
+                yield null;
+            }
+        };
     }
 
 }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractOfferMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractOfferMessageTransformer.java
@@ -28,7 +28,9 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_OFFER_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID;
 
 /**
  * Creates a {@link JsonObject} from a {@link ContractOfferMessage}.
@@ -44,15 +46,15 @@ public class JsonObjectFromContractOfferMessageTransformer extends AbstractJsonL
     
     @Override
     public @Nullable JsonObject transform(@NotNull ContractOfferMessage message, @NotNull TransformerContext context) {
-        var builder = jsonFactory.createObjectBuilder();
-        builder.add(ID, message.getId());
-        builder.add(TYPE, DSPACE_TYPE_CONTRACT_OFFER_MESSAGE);
-        builder.add(DSPACE_PROPERTY_PROCESS_ID, message.getProcessId());
-    
-        if (message.getCallbackAddress() != null) {
-            builder.add(DSPACE_PROPERTY_CALLBACK_ADDRESS, message.getCallbackAddress());
-        }
-        
+        var builder = jsonFactory.createObjectBuilder()
+                .add(ID, message.getId())
+                .add(TYPE, DSPACE_TYPE_CONTRACT_OFFER_MESSAGE)
+                .add(DSPACE_PROPERTY_PROVIDER_PID, message.getProviderPid())
+                .add(DSPACE_PROPERTY_PROCESS_ID, message.getProcessId());
+
+        addIfNotNull(message.getConsumerPid(), DSPACE_PROPERTY_CONSUMER_PID, builder);
+        addIfNotNull(message.getCallbackAddress(), DSPACE_PROPERTY_CALLBACK_ADDRESS, builder);
+
         var offer = message.getContractOffer();
         var policy = context.transform(offer.getPolicy(), JsonObject.class);
         if (policy == null) {

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractRequestMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractRequestMessageTransformer.java
@@ -18,19 +18,21 @@ import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
-import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_DATASET;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER_ID;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID;
 
 
 /**
@@ -47,15 +49,14 @@ public class JsonObjectFromContractRequestMessageTransformer extends AbstractJso
 
     @Override
     public @Nullable JsonObject transform(@NotNull ContractRequestMessage requestMessage, @NotNull TransformerContext context) {
-        var builder = jsonFactory.createObjectBuilder();
-        builder.add(JsonLdKeywords.ID, requestMessage.getId());
-        builder.add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE);
+        var builder = jsonFactory.createObjectBuilder()
+                .add(ID, requestMessage.getId())
+                .add(TYPE, DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE)
+                .add(DSPACE_PROPERTY_CONSUMER_PID, requestMessage.getConsumerPid())
+                .add(DSPACE_PROPERTY_PROCESS_ID, requestMessage.getProcessId());
 
-        builder.add(DSPACE_PROPERTY_PROCESS_ID, requestMessage.getProcessId());
-
-        if (requestMessage.getCallbackAddress() != null) {
-            builder.add(DSPACE_PROPERTY_CALLBACK_ADDRESS, requestMessage.getCallbackAddress());
-        }
+        addIfNotNull(requestMessage.getProviderPid(), DSPACE_PROPERTY_PROVIDER_PID, builder);
+        addIfNotNull(requestMessage.getCallbackAddress(), DSPACE_PROPERTY_CALLBACK_ADDRESS, builder);
 
         if (requestMessage.getContractOffer() != null) {
             builder.add(DSPACE_PROPERTY_DATASET, requestMessage.getContractOffer().getAssetId());
@@ -76,9 +77,7 @@ public class JsonObjectFromContractRequestMessageTransformer extends AbstractJso
 
         } else {
             builder.add(DSPACE_PROPERTY_OFFER_ID, requestMessage.getContractOfferId());
-            if (requestMessage.getDataset() != null) {
-                builder.add(DSPACE_PROPERTY_DATASET, requestMessage.getDataset());
-            }
+            addIfNotNull(requestMessage.getDataset(), DSPACE_PROPERTY_DATASET, builder);
         }
 
         return builder.build();

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractAgreementMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractAgreementMessageTransformer.java
@@ -34,7 +34,9 @@ import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNam
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_ID;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_TIMESTAMP;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID;
 
 /**
  * Creates a {@link ContractAgreementMessage} from a {@link JsonObject}.
@@ -50,13 +52,30 @@ public class JsonObjectToContractAgreementMessageTransformer extends AbstractJso
     @Override
     public @Nullable ContractAgreementMessage transform(@NotNull JsonObject object, @NotNull TransformerContext context) {
         var messageBuilder = ContractAgreementMessage.Builder.newInstance();
-        if (!transformMandatoryString(object.get(DSPACE_PROPERTY_PROCESS_ID), messageBuilder::processId, context)) {
-            context.problem()
-                    .missingProperty()
-                    .type(DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE)
-                    .property(DSPACE_PROPERTY_PROCESS_ID)
-                    .report();
-            return null;
+        var processId = object.get(DSPACE_PROPERTY_PROCESS_ID);
+        if (!transformMandatoryString(object.get(DSPACE_PROPERTY_CONSUMER_PID), messageBuilder::consumerPid, context)) {
+            if (processId == null) {
+                context.problem()
+                        .missingProperty()
+                        .type(DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE)
+                        .property(DSPACE_PROPERTY_CONSUMER_PID)
+                        .report();
+                return null;
+            } else {
+                messageBuilder.consumerPid(transformString(processId, context));
+            }
+        }
+        if (!transformMandatoryString(object.get(DSPACE_PROPERTY_PROVIDER_PID), messageBuilder::providerPid, context)) {
+            if (processId == null) {
+                context.problem()
+                        .missingProperty()
+                        .type(DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE)
+                        .property(DSPACE_PROPERTY_PROVIDER_PID)
+                        .report();
+                return null;
+            } else {
+                messageBuilder.providerPid(transformString(processId, context));
+            }
         }
 
         var jsonAgreement = returnMandatoryJsonObject(object.get(DSPACE_PROPERTY_AGREEMENT), context, DSPACE_PROPERTY_AGREEMENT);

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractAgreementVerificationMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractAgreementVerificationMessageTransformer.java
@@ -22,7 +22,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_AGREEMENT_VERIFICATION_MESSAGE;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID;
 
 /**
  * Creates a {@link ContractAgreementVerificationMessage} from a {@link JsonObject}.
@@ -36,13 +38,30 @@ public class JsonObjectToContractAgreementVerificationMessageTransformer extends
     @Override
     public @Nullable ContractAgreementVerificationMessage transform(@NotNull JsonObject object, @NotNull TransformerContext context) {
         var builder = ContractAgreementVerificationMessage.Builder.newInstance();
-        if (!transformMandatoryString(object.get(DSPACE_PROPERTY_PROCESS_ID), builder::processId, context)) {
-            context.problem()
-                    .missingProperty()
-                    .type(DSPACE_TYPE_CONTRACT_AGREEMENT_VERIFICATION_MESSAGE)
-                    .property(DSPACE_PROPERTY_PROCESS_ID)
-                    .report();
-            return null;
+        var processId = object.get(DSPACE_PROPERTY_PROCESS_ID);
+        if (!transformMandatoryString(object.get(DSPACE_PROPERTY_CONSUMER_PID), builder::consumerPid, context)) {
+            if (processId == null) {
+                context.problem()
+                        .missingProperty()
+                        .type(DSPACE_TYPE_CONTRACT_AGREEMENT_VERIFICATION_MESSAGE)
+                        .property(DSPACE_PROPERTY_CONSUMER_PID)
+                        .report();
+                return null;
+            } else {
+                builder.consumerPid(transformString(processId, context));
+            }
+        }
+        if (!transformMandatoryString(object.get(DSPACE_PROPERTY_PROVIDER_PID), builder::providerPid, context)) {
+            if (processId == null) {
+                context.problem()
+                        .missingProperty()
+                        .type(DSPACE_TYPE_CONTRACT_AGREEMENT_VERIFICATION_MESSAGE)
+                        .property(DSPACE_PROPERTY_PROVIDER_PID)
+                        .report();
+                return null;
+            } else {
+                builder.providerPid(transformString(processId, context));
+            }
         }
 
         return builder.build();

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractNegotiationEventMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractNegotiationEventMessageTransformer.java
@@ -27,7 +27,9 @@ import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNam
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_VALUE_NEGOTIATION_EVENT_TYPE_ACCEPTED;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_VALUE_NEGOTIATION_EVENT_TYPE_FINALIZED;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID;
 
 /**
  * Creates a {@link ContractNegotiationEventMessage} from a {@link JsonObject}.
@@ -40,16 +42,32 @@ public class JsonObjectToContractNegotiationEventMessageTransformer extends Abst
 
     @Override
     public @Nullable ContractNegotiationEventMessage transform(@NotNull JsonObject object, @NotNull TransformerContext context) {
-
         var builder = ContractNegotiationEventMessage.Builder.newInstance();
 
-        if (!transformMandatoryString(object.get(DSPACE_PROPERTY_PROCESS_ID), builder::processId, context)) {
-            context.problem()
-                    .missingProperty()
-                    .type(DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE)
-                    .property(DSPACE_PROPERTY_PROCESS_ID)
-                    .report();
-            return null;
+        var processId = object.get(DSPACE_PROPERTY_PROCESS_ID);
+        if (!transformMandatoryString(object.get(DSPACE_PROPERTY_CONSUMER_PID), builder::consumerPid, context)) {
+            if (processId == null) {
+                context.problem()
+                        .missingProperty()
+                        .type(DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE)
+                        .property(DSPACE_PROPERTY_CONSUMER_PID)
+                        .report();
+                return null;
+            } else {
+                builder.consumerPid(transformString(processId, context));
+            }
+        }
+        if (!transformMandatoryString(object.get(DSPACE_PROPERTY_PROVIDER_PID), builder::providerPid, context)) {
+            if (processId == null) {
+                context.problem()
+                        .missingProperty()
+                        .type(DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE)
+                        .property(DSPACE_PROPERTY_PROVIDER_PID)
+                        .report();
+                return null;
+            } else {
+                builder.providerPid(transformString(processId, context));
+            }
         }
 
         var eventType = transformString(object.get(DSPACE_PROPERTY_EVENT_TYPE), context);

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractNegotiationTerminationMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractNegotiationTerminationMessageTransformer.java
@@ -25,7 +25,9 @@ import org.jetbrains.annotations.Nullable;
 import static jakarta.json.JsonValue.ValueType.ARRAY;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_TERMINATION_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CODE;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_REASON;
 
 /**
@@ -41,8 +43,30 @@ public class JsonObjectToContractNegotiationTerminationMessageTransformer extend
     public @Nullable ContractNegotiationTerminationMessage transform(@NotNull JsonObject object, @NotNull TransformerContext context) {
         var builder = ContractNegotiationTerminationMessage.Builder.newInstance();
 
-        if (!transformMandatoryString(object.get(DSPACE_PROPERTY_PROCESS_ID), builder::processId, context)) {
-            return null;
+        var processId = object.get(DSPACE_PROPERTY_PROCESS_ID);
+        if (!transformMandatoryString(object.get(DSPACE_PROPERTY_CONSUMER_PID), builder::consumerPid, context)) {
+            if (processId == null) {
+                context.problem()
+                        .missingProperty()
+                        .type(DSPACE_TYPE_CONTRACT_NEGOTIATION_TERMINATION_MESSAGE)
+                        .property(DSPACE_PROPERTY_CONSUMER_PID)
+                        .report();
+                return null;
+            } else {
+                builder.consumerPid(transformString(processId, context));
+            }
+        }
+        if (!transformMandatoryString(object.get(DSPACE_PROPERTY_PROVIDER_PID), builder::providerPid, context)) {
+            if (processId == null) {
+                context.problem()
+                        .missingProperty()
+                        .type(DSPACE_TYPE_CONTRACT_NEGOTIATION_TERMINATION_MESSAGE)
+                        .property(DSPACE_PROPERTY_PROVIDER_PID)
+                        .report();
+                return null;
+            } else {
+                builder.providerPid(transformString(processId, context));
+            }
         }
 
         var code = object.get(DSPACE_PROPERTY_CODE);

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractOfferMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractOfferMessageTransformer.java
@@ -27,7 +27,9 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_OFFER_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID;
 
 /**
  * Creates a {@link ContractOfferMessage} from a {@link JsonObject}.
@@ -41,9 +43,20 @@ public class JsonObjectToContractOfferMessageTransformer extends AbstractJsonLdT
     @Override
     public @Nullable ContractOfferMessage transform(@NotNull JsonObject jsonObject, @NotNull TransformerContext context) {
         var builder = ContractOfferMessage.Builder.newInstance();
-        if (!transformMandatoryString(jsonObject.get(DSPACE_PROPERTY_PROCESS_ID), builder::processId, context)) {
-            reportMissingProperty(DSPACE_TYPE_CONTRACT_OFFER_MESSAGE, DSPACE_PROPERTY_PROCESS_ID, context);
-            return null;
+        if (!transformMandatoryString(jsonObject.get(DSPACE_PROPERTY_PROVIDER_PID), builder::providerPid, context)) {
+            var processId = jsonObject.get(DSPACE_PROPERTY_PROCESS_ID);
+            if (processId == null) {
+                reportMissingProperty(DSPACE_TYPE_CONTRACT_OFFER_MESSAGE, DSPACE_PROPERTY_PROVIDER_PID, context);
+                return null;
+            } else {
+                builder.providerPid(transformString(processId, context));
+                builder.consumerPid(transformString(processId, context));
+            }
+        }
+
+        var consumerPid = jsonObject.get(DSPACE_PROPERTY_CONSUMER_PID);
+        if (consumerPid != null) {
+            builder.consumerPid(transformString(consumerPid, context));
         }
 
         var callback = jsonObject.get(DSPACE_PROPERTY_CALLBACK_ADDRESS);

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractRequestMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractRequestMessageTransformer.java
@@ -23,16 +23,15 @@ import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Optional;
-
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_DATASET;
-import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_DATA_SET;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER_ID;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID;
 
 /**
  * Creates a {@link ContractRequestMessage} from a {@link JsonObject}.
@@ -46,13 +45,24 @@ public class JsonObjectToContractRequestMessageTransformer extends AbstractJsonL
     @Override
     public @Nullable ContractRequestMessage transform(@NotNull JsonObject requestObject, @NotNull TransformerContext context) {
         var builder = ContractRequestMessage.Builder.newInstance();
-        if (!transformMandatoryString(requestObject.get(DSPACE_PROPERTY_PROCESS_ID), builder::processId, context)) {
-            context.problem()
-                    .missingProperty()
-                    .type(DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE)
-                    .property(DSPACE_PROPERTY_PROCESS_ID)
-                    .report();
-            return null;
+
+        if (!transformMandatoryString(requestObject.get(DSPACE_PROPERTY_CONSUMER_PID), builder::consumerPid, context)) {
+            var processId = requestObject.get(DSPACE_PROPERTY_PROCESS_ID);
+            if (processId == null) {
+                context.problem()
+                        .missingProperty()
+                        .type(DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE)
+                        .property(DSPACE_PROPERTY_CONSUMER_PID)
+                        .report();
+                return null;
+            } else {
+                builder.consumerPid(transformString(processId, context));
+            }
+        }
+
+        var providerPid = requestObject.get(DSPACE_PROPERTY_PROVIDER_PID);
+        if (providerPid != null) {
+            builder.providerPid(transformString(providerPid, context));
         }
 
         var callback = requestObject.get(DSPACE_PROPERTY_CALLBACK_ADDRESS);
@@ -60,10 +70,7 @@ public class JsonObjectToContractRequestMessageTransformer extends AbstractJsonL
             builder.callbackAddress(transformString(callback, context));
         }
 
-        var dataset = Optional.of(requestObject)
-                .map(it -> it.get(DSPACE_PROPERTY_DATASET))
-                .orElseGet(() -> requestObject.get(DSPACE_PROPERTY_DATA_SET));
-
+        var dataset = requestObject.get(DSPACE_PROPERTY_DATASET);
         if (dataset != null) {
             builder.dataset(transformString(dataset, context));
         }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractAgreementMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractAgreementMessageTransformerTest.java
@@ -40,7 +40,9 @@ import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNam
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_ID;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_TIMESTAMP;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -53,7 +55,6 @@ import static org.mockito.Mockito.when;
 class JsonObjectFromContractAgreementMessageTransformerTest {
     private static final String PROVIDER_ID = "providerId";
     private static final String CONSUMER_ID = "consumerId";
-    private static final String PROCESS_ID = "processId";
     private static final String TIMESTAMP = "1970-01-01T00:00:00Z";
     private static final String DSP = "dsp";
     public static final String AGREEMENT_ID = UUID.randomUUID().toString();
@@ -61,57 +62,66 @@ class JsonObjectFromContractAgreementMessageTransformerTest {
     private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
     private final TransformerContext context = mock(TransformerContext.class);
 
-    private JsonObjectFromContractAgreementMessageTransformer transformer;
+    private final JsonObjectFromContractAgreementMessageTransformer transformer =
+            new JsonObjectFromContractAgreementMessageTransformer(jsonFactory);
 
     @BeforeEach
     void setUp() {
-        transformer = new JsonObjectFromContractAgreementMessageTransformer(jsonFactory);
         when(context.problem()).thenReturn(new ProblemBuilder(context));
     }
 
     @Test
     void transform() {
+        var message = ContractAgreementMessage.Builder.newInstance()
+                .protocol(DSP)
+                .processId("processId")
+                .providerPid("providerPid")
+                .consumerPid("consumerPid")
+                .counterPartyAddress("https://example.com")
+                .contractAgreement(contractAgreement())
+                .build();
         var policyObject = jsonFactory.createObjectBuilder()
                 .add(ID, "contractOfferId")
                 .build();
 
         when(context.transform(any(Policy.class), eq(JsonObject.class))).thenReturn(policyObject);
 
-        var result = transformer.transform(message(), context);
+        var result = transformer.transform(message, context);
 
         assertThat(result).isNotNull();
-        assertThat(result.getJsonString(ID).getString()).isNotNull();
-        assertThat(result.getJsonString(ID).getString()).isNotEmpty();
-        assertThat(result.getJsonString(TYPE).getString()).isEqualTo(DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE);
-        assertThat(result.getJsonString(DSPACE_PROPERTY_PROCESS_ID).getString()).isEqualTo(PROCESS_ID);
+        assertThat(result.getString(ID)).isNotNull();
+        assertThat(result.getString(ID)).isNotEmpty();
+        assertThat(result.getString(TYPE)).isEqualTo(DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE);
+        assertThat(result.getString(DSPACE_PROPERTY_PROVIDER_PID)).isEqualTo("providerPid");
+        assertThat(result.getString(DSPACE_PROPERTY_CONSUMER_PID)).isEqualTo("consumerPid");
+        assertThat(result.getString(DSPACE_PROPERTY_PROCESS_ID)).isEqualTo("processId");
 
         var jsonAgreement = result.getJsonObject(DSPACE_PROPERTY_AGREEMENT);
         assertThat(jsonAgreement).isNotNull();
-        assertThat(jsonAgreement.getJsonString(ID).getString()).isEqualTo(AGREEMENT_ID);
-        assertThat(jsonAgreement.getJsonString(DSPACE_PROPERTY_TIMESTAMP).getString()).isEqualTo(TIMESTAMP);
-        assertThat(jsonAgreement.getJsonString(DSPACE_PROPERTY_CONSUMER_ID).getString()).isEqualTo(CONSUMER_ID);
-        assertThat(jsonAgreement.getJsonString(DSPACE_PROPERTY_PROVIDER_ID).getString()).isEqualTo(PROVIDER_ID);
+        assertThat(jsonAgreement.getString(ID)).isEqualTo(AGREEMENT_ID);
+        assertThat(jsonAgreement.getString(DSPACE_PROPERTY_TIMESTAMP)).isEqualTo(TIMESTAMP);
+        assertThat(jsonAgreement.getString(DSPACE_PROPERTY_CONSUMER_ID)).isEqualTo(CONSUMER_ID);
+        assertThat(jsonAgreement.getString(DSPACE_PROPERTY_PROVIDER_ID)).isEqualTo(PROVIDER_ID);
 
         verify(context, never()).reportProblem(anyString());
     }
 
     @Test
     void transform_policyError() {
-
-        when(context.transform(any(Policy.class), eq(JsonObject.class))).thenReturn(null);
-
-        assertThat(transformer.transform(message(), context)).isNull();
-
-        verify(context, times(1)).reportProblem(anyString());
-    }
-
-    private ContractAgreementMessage message() {
-        return ContractAgreementMessage.Builder.newInstance()
+        var message = ContractAgreementMessage.Builder.newInstance()
                 .protocol(DSP)
-                .processId(PROCESS_ID)
+                .processId("processId")
+                .providerPid("providerPid")
+                .consumerPid("consumerPid")
                 .counterPartyAddress("https://example.com")
                 .contractAgreement(contractAgreement())
                 .build();
+
+        when(context.transform(any(Policy.class), eq(JsonObject.class))).thenReturn(null);
+
+        assertThat(transformer.transform(message, context)).isNull();
+
+        verify(context, times(1)).reportProblem(anyString());
     }
 
     private ContractAgreement contractAgreement() {

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractAgreementVerificationMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractAgreementVerificationMessageTransformerTest.java
@@ -18,7 +18,6 @@ import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementVerificationMessage;
 import org.eclipse.edc.transform.spi.TransformerContext;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -27,7 +26,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_AGREEMENT_VERIFICATION_MESSAGE;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -36,21 +37,19 @@ import static org.mockito.Mockito.verify;
 class JsonObjectFromContractAgreementVerificationMessageTransformerTest {
 
     private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
-    private final TransformerContext context = mock(TransformerContext.class);
+    private final TransformerContext context = mock();
 
-    private JsonObjectFromContractAgreementVerificationMessageTransformer transformer;
-
-    @BeforeEach
-    void setUp() {
-        transformer = new JsonObjectFromContractAgreementVerificationMessageTransformer(jsonFactory);
-    }
+    private final JsonObjectFromContractAgreementVerificationMessageTransformer transformer =
+            new JsonObjectFromContractAgreementVerificationMessageTransformer(jsonFactory);
 
     @Test
     void transform() {
         var value = "example";
         var message = ContractAgreementVerificationMessage.Builder.newInstance()
                 .protocol(value)
-                .processId(value)
+                .processId("processId")
+                .consumerPid("consumerPid")
+                .providerPid("providerPid")
                 .counterPartyAddress(value)
                 .build();
 
@@ -59,7 +58,9 @@ class JsonObjectFromContractAgreementVerificationMessageTransformerTest {
         assertThat(result).isNotNull();
         assertThat(result.getJsonString(ID).getString()).isNotEmpty();
         assertThat(result.getJsonString(TYPE).getString()).isEqualTo(DSPACE_TYPE_CONTRACT_AGREEMENT_VERIFICATION_MESSAGE);
-        assertThat(result.getJsonString(DSPACE_PROPERTY_PROCESS_ID).getString()).isEqualTo(value);
+        assertThat(result.getJsonString(DSPACE_PROPERTY_CONSUMER_PID).getString()).isEqualTo("consumerPid");
+        assertThat(result.getJsonString(DSPACE_PROPERTY_PROVIDER_PID).getString()).isEqualTo("providerPid");
+        assertThat(result.getJsonString(DSPACE_PROPERTY_PROCESS_ID).getString()).isEqualTo("processId");
 
         verify(context, never()).reportProblem(anyString());
     }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractNegotiationEventMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractNegotiationEventMessageTransformerTest.java
@@ -18,7 +18,6 @@ import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractNegotiationEventMessage;
 import org.eclipse.edc.transform.spi.TransformerContext;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -30,31 +29,30 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_EVENT_TYPE;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_VALUE_NEGOTIATION_EVENT_TYPE_ACCEPTED;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 class JsonObjectFromContractNegotiationEventMessageTransformerTest {
-    private static final String PROCESS_ID = "processId";
     private static final String DSP = "DSP";
 
     private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
-    private final TransformerContext context = mock(TransformerContext.class);
+    private final TransformerContext context = mock();
 
-    private JsonObjectFromContractNegotiationEventMessageTransformer transformer;
-
-    @BeforeEach
-    void setUp() {
-        transformer = new JsonObjectFromContractNegotiationEventMessageTransformer(jsonFactory);
-    }
+    private final JsonObjectFromContractNegotiationEventMessageTransformer transformer =
+            new JsonObjectFromContractNegotiationEventMessageTransformer(jsonFactory);
 
     @Test
     void transform() {
         var message = ContractNegotiationEventMessage.Builder.newInstance()
                 .protocol(DSP)
-                .processId(PROCESS_ID)
+                .processId("processId")
+                .consumerPid("consumerPid")
+                .providerPid("providerPid")
                 .counterPartyAddress("https://test.com")
                 .type(ACCEPTED)
                 .build();
@@ -62,10 +60,12 @@ class JsonObjectFromContractNegotiationEventMessageTransformerTest {
         var result = transformer.transform(message, context);
 
         assertThat(result).isNotNull();
-        assertThat(result.getJsonString(ID).getString()).isNotEmpty();
-        assertThat(result.getJsonString(TYPE).getString()).isEqualTo(DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE);
-        assertThat(result.getJsonString(DSPACE_PROPERTY_PROCESS_ID).getString()).isEqualTo(PROCESS_ID);
-        assertThat(result.getJsonString(DSPACE_PROPERTY_EVENT_TYPE).getString()).isEqualTo(DSPACE_VALUE_NEGOTIATION_EVENT_TYPE_ACCEPTED);
+        assertThat(result.getString(ID)).isNotEmpty();
+        assertThat(result.getString(TYPE)).isEqualTo(DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE);
+        assertThat(result.getString(DSPACE_PROPERTY_PROVIDER_PID)).isEqualTo("providerPid");
+        assertThat(result.getString(DSPACE_PROPERTY_CONSUMER_PID)).isEqualTo("consumerPid");
+        assertThat(result.getString(DSPACE_PROPERTY_PROCESS_ID)).isEqualTo("processId");
+        assertThat(result.getString(DSPACE_PROPERTY_EVENT_TYPE)).isEqualTo(DSPACE_VALUE_NEGOTIATION_EVENT_TYPE_ACCEPTED);
 
         verify(context, never()).reportProblem(anyString());
     }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractNegotiationTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractNegotiationTransformerTest.java
@@ -55,7 +55,9 @@ import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNam
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_VALUE_NEGOTIATION_STATE_REQUESTED;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_VALUE_NEGOTIATION_STATE_TERMINATED;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_VALUE_NEGOTIATION_STATE_VERIFIED;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_STATE;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -75,23 +77,49 @@ class JsonObjectFromContractNegotiationTransformerTest {
     }
 
     @Test
-    void transform() {
-        var value = "example";
+    void transform_consumer() {
         var negotiation = ContractNegotiation.Builder.newInstance()
-                .id(value)
-                .correlationId(value)
+                .id("consumerPid")
+                .correlationId("providerPid")
                 .counterPartyId("counterPartyId")
                 .counterPartyAddress("counterPartyAddress")
                 .protocol("protocol")
                 .state(REQUESTED.code())
+                .type(ContractNegotiation.Type.CONSUMER)
                 .build();
 
         var result = transformer.transform(negotiation, context);
 
         assertThat(result).isNotNull();
-        assertThat(result.getString(ID)).isEqualTo(value);
+        assertThat(result.getString(ID)).isEqualTo("consumerPid");
         assertThat(result.getString(TYPE)).isEqualTo(DSPACE_TYPE_CONTRACT_NEGOTIATION);
-        assertThat(result.getString(DSPACE_PROPERTY_PROCESS_ID)).isEqualTo(value);
+        assertThat(result.getString(DSPACE_PROPERTY_CONSUMER_PID)).isEqualTo("consumerPid");
+        assertThat(result.getString(DSPACE_PROPERTY_PROVIDER_PID)).isEqualTo("providerPid");
+        assertThat(result.getString(DSPACE_PROPERTY_PROCESS_ID)).isEqualTo("consumerPid");
+
+        verify(context, never()).reportProblem(anyString());
+    }
+
+    @Test
+    void transform_provider() {
+        var negotiation = ContractNegotiation.Builder.newInstance()
+                .id("providerPid")
+                .correlationId("consumerPid")
+                .counterPartyId("counterPartyId")
+                .counterPartyAddress("counterPartyAddress")
+                .protocol("protocol")
+                .state(REQUESTED.code())
+                .type(ContractNegotiation.Type.PROVIDER)
+                .build();
+
+        var result = transformer.transform(negotiation, context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getString(ID)).isEqualTo("providerPid");
+        assertThat(result.getString(TYPE)).isEqualTo(DSPACE_TYPE_CONTRACT_NEGOTIATION);
+        assertThat(result.getString(DSPACE_PROPERTY_CONSUMER_PID)).isEqualTo("consumerPid");
+        assertThat(result.getString(DSPACE_PROPERTY_PROVIDER_PID)).isEqualTo("providerPid");
+        assertThat(result.getString(DSPACE_PROPERTY_PROCESS_ID)).isEqualTo("consumerPid");
 
         verify(context, never()).reportProblem(anyString());
     }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractAgreementMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractAgreementMessageTransformerTest.java
@@ -41,7 +41,9 @@ import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNam
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_ID;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_TIMESTAMP;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
@@ -56,7 +58,6 @@ class JsonObjectToContractAgreementMessageTransformerTest {
     private static final String CONSUMER_ID = "consumerId";
     private static final String PROVIDER_ID = "providerId";
     private static final String AGREEMENT_ID = "agreementId";
-    private static final String PROCESS_ID = "processId";
     private static final String MESSAGE_ID = "messageId";
     private static final String TIMESTAMP = "1970-01-01T00:00:00Z";
     private static final String TARGET = "target";
@@ -77,7 +78,8 @@ class JsonObjectToContractAgreementMessageTransformerTest {
         var message = jsonFactory.createObjectBuilder()
                 .add(JsonLdKeywords.ID, MESSAGE_ID)
                 .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE)
-                .add(DSPACE_PROPERTY_PROCESS_ID, PROCESS_ID)
+                .add(DSPACE_PROPERTY_CONSUMER_PID, "consumerPid")
+                .add(DSPACE_PROPERTY_PROVIDER_PID, "providerPid")
                 .add(DSPACE_PROPERTY_AGREEMENT, contractAgreement())
                 .build();
 
@@ -88,7 +90,40 @@ class JsonObjectToContractAgreementMessageTransformerTest {
         assertThat(result).isNotNull();
         assertThat(result.getClass()).isEqualTo(ContractAgreementMessage.class);
         assertThat(result.getProtocol()).isNotEmpty();
-        assertThat(result.getProcessId()).isEqualTo(PROCESS_ID);
+        assertThat(result.getConsumerPid()).isEqualTo("consumerPid");
+        assertThat(result.getProviderPid()).isEqualTo("providerPid");
+
+        var agreement = result.getContractAgreement();
+        assertThat(agreement).isNotNull();
+        assertThat(agreement.getClass()).isEqualTo(ContractAgreement.class);
+        assertThat(agreement.getId()).isEqualTo(AGREEMENT_ID);
+        assertThat(agreement.getConsumerId()).isEqualTo(CONSUMER_ID);
+        assertThat(agreement.getProviderId()).isEqualTo(PROVIDER_ID);
+        assertThat(agreement.getAssetId()).isEqualTo(TARGET);
+        assertThat(agreement.getContractSigningDate()).isEqualTo(Instant.parse(TIMESTAMP).getEpochSecond());
+
+        verify(context, never()).reportProblem(anyString());
+    }
+
+    @Deprecated(since = "0.4.1")
+    @Test
+    void transform_processId() {
+        var message = jsonFactory.createObjectBuilder()
+                .add(JsonLdKeywords.ID, MESSAGE_ID)
+                .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE)
+                .add(DSPACE_PROPERTY_PROCESS_ID, "processId")
+                .add(DSPACE_PROPERTY_AGREEMENT, contractAgreement())
+                .build();
+
+        when(context.transform(any(JsonObject.class), eq(Policy.class))).thenReturn(policy());
+
+        var result = transformer.transform(getExpanded(message), context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getClass()).isEqualTo(ContractAgreementMessage.class);
+        assertThat(result.getProtocol()).isNotEmpty();
+        assertThat(result.getConsumerPid()).isEqualTo("processId");
+        assertThat(result.getProviderPid()).isEqualTo("processId");
 
         var agreement = result.getContractAgreement();
         assertThat(agreement).isNotNull();
@@ -108,7 +143,8 @@ class JsonObjectToContractAgreementMessageTransformerTest {
         var message = jsonFactory.createObjectBuilder()
                 .add(JsonLdKeywords.ID, value)
                 .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE)
-                .add(DSPACE_PROPERTY_PROCESS_ID, value)
+                .add(DSPACE_PROPERTY_CONSUMER_PID, "consumerPid")
+                .add(DSPACE_PROPERTY_PROVIDER_PID, "providerPid")
                 .add(DSPACE_PROPERTY_AGREEMENT, contractAgreement())
                 .add(DSPACE_PROPERTY_TIMESTAMP, "123")
                 .build();
@@ -133,7 +169,8 @@ class JsonObjectToContractAgreementMessageTransformerTest {
         var message = jsonFactory.createObjectBuilder()
                 .add(JsonLdKeywords.ID, "messageId")
                 .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE)
-                .add(DSPACE_PROPERTY_PROCESS_ID, "processId")
+                .add(DSPACE_PROPERTY_CONSUMER_PID, "consumerPid")
+                .add(DSPACE_PROPERTY_PROVIDER_PID, "providerPid")
                 .add(DSPACE_PROPERTY_AGREEMENT, agreement)
                 .build();
 
@@ -156,7 +193,8 @@ class JsonObjectToContractAgreementMessageTransformerTest {
         var message = jsonFactory.createObjectBuilder()
                 .add(JsonLdKeywords.ID, "messageId")
                 .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE)
-                .add(DSPACE_PROPERTY_PROCESS_ID, "processId")
+                .add(DSPACE_PROPERTY_CONSUMER_PID, "consumerPid")
+                .add(DSPACE_PROPERTY_PROVIDER_PID, "providerPid")
                 .add(DSPACE_PROPERTY_AGREEMENT, agreement)
                 .build();
 

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractNegotiationEventMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractNegotiationEventMessageTransformerTest.java
@@ -30,7 +30,9 @@ import static org.eclipse.edc.protocol.dsp.negotiation.transform.to.TestInput.ge
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_EVENT_TYPE;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_VALUE_NEGOTIATION_EVENT_TYPE_ACCEPTED;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.mock;
@@ -40,16 +42,15 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class JsonObjectToContractNegotiationEventMessageTransformerTest {
-    private static final String PROCESS_ID = "processId";
 
     private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
-    private final TransformerContext context = mock(TransformerContext.class);
+    private final TransformerContext context = mock();
 
-    private JsonObjectToContractNegotiationEventMessageTransformer transformer;
+    private final JsonObjectToContractNegotiationEventMessageTransformer transformer =
+            new JsonObjectToContractNegotiationEventMessageTransformer();
 
     @BeforeEach
     void setUp() {
-        transformer = new JsonObjectToContractNegotiationEventMessageTransformer();
         when(context.problem()).thenReturn(new ProblemBuilder(context));
     }
 
@@ -58,7 +59,8 @@ class JsonObjectToContractNegotiationEventMessageTransformerTest {
         var message = jsonFactory.createObjectBuilder()
                 .add(JsonLdKeywords.ID, "id1")
                 .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE)
-                .add(DSPACE_PROPERTY_PROCESS_ID, PROCESS_ID)
+                .add(DSPACE_PROPERTY_CONSUMER_PID, "consumerPid")
+                .add(DSPACE_PROPERTY_PROVIDER_PID, "providerPid")
                 .add(DSPACE_PROPERTY_EVENT_TYPE, DSPACE_VALUE_NEGOTIATION_EVENT_TYPE_ACCEPTED)
                 .build();
 
@@ -67,7 +69,30 @@ class JsonObjectToContractNegotiationEventMessageTransformerTest {
         assertThat(result).isNotNull();
         assertThat(result.getClass()).isEqualTo(ContractNegotiationEventMessage.class);
         assertThat(result.getProtocol()).isNotEmpty();
-        assertThat(result.getProcessId()).isEqualTo(PROCESS_ID);
+        assertThat(result.getConsumerPid()).isEqualTo("consumerPid");
+        assertThat(result.getProviderPid()).isEqualTo("providerPid");
+        assertThat(result.getType()).isEqualTo(ContractNegotiationEventMessage.Type.ACCEPTED);
+
+        verify(context, never()).reportProblem(anyString());
+    }
+
+    @Deprecated(since = "0.4.1")
+    @Test
+    void transform_processId() {
+        var message = jsonFactory.createObjectBuilder()
+                .add(JsonLdKeywords.ID, "id1")
+                .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE)
+                .add(DSPACE_PROPERTY_PROCESS_ID, "processId")
+                .add(DSPACE_PROPERTY_EVENT_TYPE, DSPACE_VALUE_NEGOTIATION_EVENT_TYPE_ACCEPTED)
+                .build();
+
+        var result = transformer.transform(getExpanded(message), context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getClass()).isEqualTo(ContractNegotiationEventMessage.class);
+        assertThat(result.getProtocol()).isNotEmpty();
+        assertThat(result.getProviderPid()).isEqualTo("processId");
+        assertThat(result.getConsumerPid()).isEqualTo("processId");
         assertThat(result.getType()).isEqualTo(ContractNegotiationEventMessage.Type.ACCEPTED);
 
         verify(context, never()).reportProblem(anyString());
@@ -85,7 +110,7 @@ class JsonObjectToContractNegotiationEventMessageTransformerTest {
 
         assertThat(result).isNull();
 
-        verify(context, times(1)).reportProblem(contains(DSPACE_PROPERTY_PROCESS_ID));
+        verify(context, times(1)).reportProblem(contains(DSPACE_PROPERTY_CONSUMER_PID));
     }
 
     @Test
@@ -93,7 +118,8 @@ class JsonObjectToContractNegotiationEventMessageTransformerTest {
         var message = jsonFactory.createObjectBuilder()
                 .add(JsonLdKeywords.ID, "id1")
                 .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE)
-                .add(DSPACE_PROPERTY_PROCESS_ID, PROCESS_ID)
+                .add(DSPACE_PROPERTY_CONSUMER_PID, "consumerPid")
+                .add(DSPACE_PROPERTY_PROVIDER_PID, "providerPid")
                 .build();
 
         var result = transformer.transform(getExpanded(message), context);
@@ -108,7 +134,8 @@ class JsonObjectToContractNegotiationEventMessageTransformerTest {
         var message = jsonFactory.createObjectBuilder()
                 .add(JsonLdKeywords.ID, "id1")
                 .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE)
-                .add(DSPACE_PROPERTY_PROCESS_ID, PROCESS_ID)
+                .add(DSPACE_PROPERTY_CONSUMER_PID, "consumerPid")
+                .add(DSPACE_PROPERTY_PROVIDER_PID, "providerPid")
                 .add(DSPACE_PROPERTY_EVENT_TYPE, "InvalidType")
                 .build();
 

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractNegotiationTerminationMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractNegotiationTerminationMessageTransformerTest.java
@@ -18,7 +18,6 @@ import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
 import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
 import org.eclipse.edc.transform.spi.TransformerContext;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -29,7 +28,9 @@ import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.to.TestInput.getExpanded;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_TERMINATION_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CODE;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_REASON;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -38,17 +39,12 @@ import static org.mockito.Mockito.verify;
 
 class JsonObjectToContractNegotiationTerminationMessageTransformerTest {
 
-    public static final String PROCESS_ID = "processId";
     public static final String CODE = "code1";
     private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
-    private final TransformerContext context = mock(TransformerContext.class);
+    private final TransformerContext context = mock();
 
-    private JsonObjectToContractNegotiationTerminationMessageTransformer transformer;
-
-    @BeforeEach
-    void setUp() {
-        transformer = new JsonObjectToContractNegotiationTerminationMessageTransformer();
-    }
+    private final JsonObjectToContractNegotiationTerminationMessageTransformer transformer =
+            new JsonObjectToContractNegotiationTerminationMessageTransformer();
 
     @Test
     void transform() {
@@ -58,7 +54,8 @@ class JsonObjectToContractNegotiationTerminationMessageTransformerTest {
         var message = jsonFactory.createObjectBuilder()
                 .add(JsonLdKeywords.ID, "id1")
                 .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_NEGOTIATION_TERMINATION_MESSAGE)
-                .add(DSPACE_PROPERTY_PROCESS_ID, PROCESS_ID)
+                .add(DSPACE_PROPERTY_CONSUMER_PID, "consumerPid")
+                .add(DSPACE_PROPERTY_PROVIDER_PID, "providerPid")
                 .add(DSPACE_PROPERTY_CODE, CODE)
                 .add(DSPACE_PROPERTY_REASON, reasonArray)
                 .build();
@@ -69,7 +66,36 @@ class JsonObjectToContractNegotiationTerminationMessageTransformerTest {
 
         assertThat(result.getProtocol()).isNotNull();
         assertThat(result.getCounterPartyAddress()).isNull();
-        assertThat(result.getProcessId()).isEqualTo(PROCESS_ID);
+        assertThat(result.getConsumerPid()).isEqualTo("consumerPid");
+        assertThat(result.getProviderPid()).isEqualTo("providerPid");
+        assertThat(result.getCode()).isEqualTo(CODE);
+
+        assertThat(result.getRejectionReason()).isEqualTo(format("[{\"%sfoo\":[{\"@value\":\"bar\"}]}]", DSPACE_SCHEMA));
+
+        verify(context, never()).reportProblem(anyString());
+    }
+
+    @Test
+    void transform_processId() {
+        var reason = Json.createBuilderFactory(Map.of()).createObjectBuilder().add(DSPACE_SCHEMA + "foo", "bar");
+        var reasonArray = Json.createBuilderFactory(Map.of()).createArrayBuilder().add(reason).build();
+
+        var message = jsonFactory.createObjectBuilder()
+                .add(JsonLdKeywords.ID, "id1")
+                .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_NEGOTIATION_TERMINATION_MESSAGE)
+                .add(DSPACE_PROPERTY_PROCESS_ID, "processId")
+                .add(DSPACE_PROPERTY_CODE, CODE)
+                .add(DSPACE_PROPERTY_REASON, reasonArray)
+                .build();
+
+        var result = transformer.transform(getExpanded(message), context);
+
+        assertThat(result).isNotNull();
+
+        assertThat(result.getProtocol()).isNotNull();
+        assertThat(result.getCounterPartyAddress()).isNull();
+        assertThat(result.getConsumerPid()).isEqualTo("processId");
+        assertThat(result.getProviderPid()).isEqualTo("processId");
         assertThat(result.getCode()).isEqualTo(CODE);
 
         assertThat(result.getRejectionReason()).isEqualTo(format("[{\"%sfoo\":[{\"@value\":\"bar\"}]}]", DSPACE_SCHEMA));
@@ -82,7 +108,8 @@ class JsonObjectToContractNegotiationTerminationMessageTransformerTest {
         var message = jsonFactory.createObjectBuilder()
                 .add(JsonLdKeywords.ID, "id1")
                 .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_NEGOTIATION_TERMINATION_MESSAGE)
-                .add(DSPACE_PROPERTY_PROCESS_ID, PROCESS_ID)
+                .add(DSPACE_PROPERTY_CONSUMER_PID, "consumerPid")
+                .add(DSPACE_PROPERTY_PROVIDER_PID, "providerPid")
                 .build();
 
         var result = transformer.transform(getExpanded(message), context);
@@ -91,7 +118,6 @@ class JsonObjectToContractNegotiationTerminationMessageTransformerTest {
 
         assertThat(result.getProtocol()).isNotNull();
         assertThat(result.getCounterPartyAddress()).isNull();
-        assertThat(result.getProcessId()).isEqualTo(PROCESS_ID);
         assertThat(result.getCode()).isNull();
         assertThat(result.getRejectionReason()).isNull();
 

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractOfferMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractOfferMessageTransformerTest.java
@@ -31,7 +31,9 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_OFFER_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -43,14 +45,13 @@ import static org.mockito.Mockito.when;
 
 class JsonObjectToContractOfferMessageTransformerTest {
     
-    private static final String PROCESS_ID = "processId";
     private static final String CALLBACK_ADDRESS = "https://test.com";
     private static final String MESSAGE_ID = "messageId";
     private static final String ASSET_ID = "assetId";
     private static final String CONTRACT_OFFER_ID = "assetId";
     
     private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
-    private final TransformerContext context = mock(TransformerContext.class);
+    private final TransformerContext context = mock();
     
     private JsonObjectToContractOfferMessageTransformer transformer;
     
@@ -65,7 +66,8 @@ class JsonObjectToContractOfferMessageTransformerTest {
         var message = jsonFactory.createObjectBuilder()
                 .add(ID, MESSAGE_ID)
                 .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_OFFER_MESSAGE)
-                .add(DSPACE_PROPERTY_PROCESS_ID, PROCESS_ID)
+                .add(DSPACE_PROPERTY_CONSUMER_PID, "consumerPid")
+                .add(DSPACE_PROPERTY_PROVIDER_PID, "providerPid")
                 .add(DSPACE_PROPERTY_CALLBACK_ADDRESS, CALLBACK_ADDRESS)
                 .add(DSPACE_PROPERTY_OFFER, jsonFactory.createObjectBuilder()
                         .add(ID, CONTRACT_OFFER_ID)
@@ -79,7 +81,8 @@ class JsonObjectToContractOfferMessageTransformerTest {
         
         assertThat(result).isNotNull();
         assertThat(result.getProtocol()).isNotEmpty();
-        assertThat(result.getProcessId()).isEqualTo(PROCESS_ID);
+        assertThat(result.getConsumerPid()).isEqualTo("consumerPid");
+        assertThat(result.getProviderPid()).isEqualTo("providerPid");
         assertThat(result.getCallbackAddress()).isEqualTo(CALLBACK_ADDRESS);
     
         var contractOffer = result.getContractOffer();
@@ -88,6 +91,39 @@ class JsonObjectToContractOfferMessageTransformerTest {
         assertThat(contractOffer.getPolicy()).isEqualTo(policy);
         assertThat(contractOffer.getAssetId()).isEqualTo(ASSET_ID);
     
+        verify(context, never()).reportProblem(anyString());
+    }
+
+    @Deprecated(since = "0.4.1")
+    @Test
+    void transform_shouldReturnMessage_whenValidJsonObject_processId() {
+        var message = jsonFactory.createObjectBuilder()
+                .add(ID, MESSAGE_ID)
+                .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_OFFER_MESSAGE)
+                .add(DSPACE_PROPERTY_PROCESS_ID, "processId")
+                .add(DSPACE_PROPERTY_CALLBACK_ADDRESS, CALLBACK_ADDRESS)
+                .add(DSPACE_PROPERTY_OFFER, jsonFactory.createObjectBuilder()
+                        .add(ID, CONTRACT_OFFER_ID)
+                        .build())
+                .build();
+        var policy = policy();
+
+        when(context.transform(any(JsonObject.class), eq(Policy.class))).thenReturn(policy);
+
+        var result = transformer.transform(message, context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getProtocol()).isNotEmpty();
+        assertThat(result.getConsumerPid()).isEqualTo("processId");
+        assertThat(result.getProviderPid()).isEqualTo("processId");
+        assertThat(result.getCallbackAddress()).isEqualTo(CALLBACK_ADDRESS);
+
+        var contractOffer = result.getContractOffer();
+        assertThat(contractOffer).isNotNull();
+        assertThat(contractOffer.getId()).isEqualTo(CONTRACT_OFFER_ID);
+        assertThat(contractOffer.getPolicy()).isEqualTo(policy);
+        assertThat(contractOffer.getAssetId()).isEqualTo(ASSET_ID);
+
         verify(context, never()).reportProblem(anyString());
     }
     
@@ -113,7 +149,8 @@ class JsonObjectToContractOfferMessageTransformerTest {
         var message = jsonFactory.createObjectBuilder()
                 .add(ID, MESSAGE_ID)
                 .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_OFFER_MESSAGE)
-                .add(DSPACE_PROPERTY_PROCESS_ID, PROCESS_ID)
+                .add(DSPACE_PROPERTY_CONSUMER_PID, "consumerPid")
+                .add(DSPACE_PROPERTY_PROVIDER_PID, "providerPid")
                 .add(DSPACE_PROPERTY_CALLBACK_ADDRESS, CALLBACK_ADDRESS)
                 .build();
         
@@ -128,7 +165,8 @@ class JsonObjectToContractOfferMessageTransformerTest {
         var message = jsonFactory.createObjectBuilder()
                 .add(ID, MESSAGE_ID)
                 .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_OFFER_MESSAGE)
-                .add(DSPACE_PROPERTY_PROCESS_ID, PROCESS_ID)
+                .add(DSPACE_PROPERTY_CONSUMER_PID, "consumerPid")
+                .add(DSPACE_PROPERTY_PROVIDER_PID, "providerPid")
                 .add(DSPACE_PROPERTY_CALLBACK_ADDRESS, CALLBACK_ADDRESS)
                 .add(DSPACE_PROPERTY_OFFER, jsonFactory.createObjectBuilder().build())
                 .build();
@@ -147,7 +185,8 @@ class JsonObjectToContractOfferMessageTransformerTest {
         var message = jsonFactory.createObjectBuilder()
                 .add(ID, MESSAGE_ID)
                 .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_OFFER_MESSAGE)
-                .add(DSPACE_PROPERTY_PROCESS_ID, PROCESS_ID)
+                .add(DSPACE_PROPERTY_CONSUMER_PID, "consumerPid")
+                .add(DSPACE_PROPERTY_PROVIDER_PID, "providerPid")
                 .add(DSPACE_PROPERTY_CALLBACK_ADDRESS, CALLBACK_ADDRESS)
                 .add(DSPACE_PROPERTY_OFFER, jsonFactory.createObjectBuilder()
                         .add(ID, CONTRACT_OFFER_ID)

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractRequestMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractRequestMessageTransformerTest.java
@@ -34,12 +34,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_OFFER;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.to.TestInput.getExpanded;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_DATASET;
-import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_DATA_SET;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER_ID;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -50,7 +51,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class JsonObjectToContractRequestMessageTransformerTest {
-    private static final String PROCESS_ID = "processId";
+
     private static final String DATASET_ID = "datasetId";
     private static final String CALLBACK = "https://test.com";
     private static final String OBJECT_ID = "id1";
@@ -72,7 +73,8 @@ class JsonObjectToContractRequestMessageTransformerTest {
         var message = jsonFactory.createObjectBuilder()
                 .add(JsonLdKeywords.ID, OBJECT_ID)
                 .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE)
-                .add(DSPACE_PROPERTY_PROCESS_ID, PROCESS_ID)
+                .add(DSPACE_PROPERTY_CONSUMER_PID, "consumerPid")
+                .add(DSPACE_PROPERTY_PROVIDER_PID, "providerPid")
                 .add(DSPACE_PROPERTY_DATASET, DATASET_ID)
                 .add(DSPACE_PROPERTY_CALLBACK_ADDRESS, CALLBACK)
                 .add(DSPACE_PROPERTY_OFFER, contractOffer())
@@ -84,7 +86,8 @@ class JsonObjectToContractRequestMessageTransformerTest {
 
         assertThat(result).isNotNull();
         assertThat(result.getProtocol()).isNotEmpty();
-        assertThat(result.getProcessId()).isEqualTo(PROCESS_ID);
+        assertThat(result.getConsumerPid()).isEqualTo("consumerPid");
+        assertThat(result.getProviderPid()).isEqualTo("providerPid");
         assertThat(result.getCallbackAddress()).isEqualTo(CALLBACK);
         assertThat(result.getDataset()).isEqualTo(DATASET_ID);
 
@@ -98,30 +101,12 @@ class JsonObjectToContractRequestMessageTransformerTest {
     }
 
     @Test
-    void shouldDeserialize_whenDatasetIsWrittenWithTheWrongCase_deprecated() {
-        var message = jsonFactory.createObjectBuilder()
-                .add(JsonLdKeywords.ID, OBJECT_ID)
-                .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE)
-                .add(DSPACE_PROPERTY_PROCESS_ID, PROCESS_ID)
-                .add(DSPACE_PROPERTY_DATA_SET, DATASET_ID)
-                .add(DSPACE_PROPERTY_CALLBACK_ADDRESS, CALLBACK)
-                .add(DSPACE_PROPERTY_OFFER, contractOffer())
-                .build();
-
-        when(context.transform(any(JsonObject.class), eq(Policy.class))).thenReturn(policy());
-
-        var result = transformer.transform(getExpanded(message), context);
-
-        assertThat(result).isNotNull();
-        assertThat(result.getDataset()).isEqualTo(DATASET_ID);
-    }
-
-    @Test
     void verify_usingOfferId() {
         var message = jsonFactory.createObjectBuilder()
                 .add(JsonLdKeywords.ID, OBJECT_ID)
                 .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE)
-                .add(DSPACE_PROPERTY_PROCESS_ID, PROCESS_ID)
+                .add(DSPACE_PROPERTY_CONSUMER_PID, "consumerPid")
+                .add(DSPACE_PROPERTY_PROVIDER_PID, "providerPid")
                 .add(DSPACE_PROPERTY_DATASET, DATASET_ID)
                 .add(DSPACE_PROPERTY_CALLBACK_ADDRESS, CALLBACK)
                 .add(DSPACE_PROPERTY_OFFER_ID, CONTRACT_OFFER_ID)
@@ -131,11 +116,43 @@ class JsonObjectToContractRequestMessageTransformerTest {
 
         assertThat(result).isNotNull();
         assertThat(result.getProtocol()).isNotEmpty();
-        assertThat(result.getProcessId()).isEqualTo(PROCESS_ID);
+        assertThat(result.getConsumerPid()).isEqualTo("consumerPid");
+        assertThat(result.getProviderPid()).isEqualTo("providerPid");
         assertThat(result.getCallbackAddress()).isEqualTo(CALLBACK);
         assertThat(result.getDataset()).isEqualTo(DATASET_ID);
 
         assertThat(result.getContractOfferId()).isNotNull();
+
+        verify(context, never()).reportProblem(anyString());
+    }
+
+    @Deprecated(since = "0.4.1")
+    @Test
+    void verify_processId() {
+        var message = jsonFactory.createObjectBuilder()
+                .add(JsonLdKeywords.ID, OBJECT_ID)
+                .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE)
+                .add(DSPACE_PROPERTY_PROCESS_ID, "processId")
+                .add(DSPACE_PROPERTY_DATASET, DATASET_ID)
+                .add(DSPACE_PROPERTY_CALLBACK_ADDRESS, CALLBACK)
+                .add(DSPACE_PROPERTY_OFFER, contractOffer())
+                .build();
+
+        when(context.transform(any(JsonObject.class), eq(Policy.class))).thenReturn(policy());
+
+        var result = transformer.transform(getExpanded(message), context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getProtocol()).isNotEmpty();
+        assertThat(result.getConsumerPid()).isEqualTo("processId");
+        assertThat(result.getCallbackAddress()).isEqualTo(CALLBACK);
+        assertThat(result.getDataset()).isEqualTo(DATASET_ID);
+
+        var contractOffer = result.getContractOffer();
+        assertThat(contractOffer).isNotNull();
+        assertThat(contractOffer.getId()).isNotNull();
+        assertThat(contractOffer.getPolicy()).isNotNull();
+        assertThat(contractOffer.getAssetId()).isEqualTo("target");
 
         verify(context, never()).reportProblem(anyString());
     }
@@ -145,7 +162,8 @@ class JsonObjectToContractRequestMessageTransformerTest {
         var message = jsonFactory.createObjectBuilder()
                 .add(JsonLdKeywords.ID, OBJECT_ID)
                 .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE)
-                .add(DSPACE_PROPERTY_PROCESS_ID, PROCESS_ID)
+                .add(DSPACE_PROPERTY_CONSUMER_PID, "consumerPid")
+                .add(DSPACE_PROPERTY_PROVIDER_PID, "providerPid")
                 .add(DSPACE_PROPERTY_OFFER, contractOffer())
                 .build();
 
@@ -166,7 +184,8 @@ class JsonObjectToContractRequestMessageTransformerTest {
         var message = jsonFactory.createObjectBuilder()
                 .add(JsonLdKeywords.ID, OBJECT_ID)
                 .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE)
-                .add(DSPACE_PROPERTY_PROCESS_ID, PROCESS_ID)
+                .add(DSPACE_PROPERTY_CONSUMER_PID, "consumerPid")
+                .add(DSPACE_PROPERTY_PROVIDER_PID, "providerPid")
                 .add(DSPACE_PROPERTY_OFFER, offer)
                 .build();
 
@@ -184,7 +203,8 @@ class JsonObjectToContractRequestMessageTransformerTest {
         var message = jsonFactory.createObjectBuilder()
                 .add(JsonLdKeywords.ID, OBJECT_ID)
                 .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE)
-                .add(DSPACE_PROPERTY_PROCESS_ID, PROCESS_ID)
+                .add(DSPACE_PROPERTY_CONSUMER_PID, "consumerPid")
+                .add(DSPACE_PROPERTY_PROVIDER_PID, "providerPid")
                 .add(DSPACE_PROPERTY_DATASET, DATASET_ID)
                 .add(DSPACE_PROPERTY_CALLBACK_ADDRESS, CALLBACK)
                 .add(DSPACE_PROPERTY_OFFER, contractOffer())

--- a/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/type/DspNegotiationPropertyAndTypeNames.java
+++ b/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/type/DspNegotiationPropertyAndTypeNames.java
@@ -39,8 +39,6 @@ public interface DspNegotiationPropertyAndTypeNames {
     String DSPACE_PROPERTY_OFFER = DSPACE_SCHEMA + "offer";
     String DSPACE_PROPERTY_OFFER_ID = DSPACE_SCHEMA + "offerId";
     String DSPACE_PROPERTY_DATASET = DSPACE_SCHEMA + "dataset";
-    @Deprecated(since = "0.2.0")
-    String DSPACE_PROPERTY_DATA_SET = DSPACE_SCHEMA + "dataSet";
     String DSPACE_PROPERTY_TIMESTAMP = DSPACE_SCHEMA + "timestamp";
     String DSPACE_PROPERTY_CONSUMER_ID = DSPACE_SCHEMA + "consumerId";
     String DSPACE_PROPERTY_PROVIDER_ID = DSPACE_SCHEMA + "providerId";

--- a/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/type/DspPropertyAndTypeNames.java
+++ b/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/type/DspPropertyAndTypeNames.java
@@ -23,6 +23,9 @@ public interface DspPropertyAndTypeNames {
 
     String DSPACE_PROPERTY_CODE = DSPACE_SCHEMA + "code";
     String DSPACE_PROPERTY_REASON = DSPACE_SCHEMA + "reason";
+    String DSPACE_PROPERTY_CONSUMER_PID = DSPACE_SCHEMA + "consumerPid";
+    String DSPACE_PROPERTY_PROVIDER_PID = DSPACE_SCHEMA + "providerPid";
+    @Deprecated(since = "0.4.1")
     String DSPACE_PROPERTY_PROCESS_ID = DSPACE_SCHEMA + "processId";
     String DSPACE_PROPERTY_CALLBACK_ADDRESS = DSPACE_SCHEMA + "callbackAddress";
     String DSPACE_PROPERTY_STATE = DSPACE_SCHEMA + "state";

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/docs/schema.sql
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/docs/schema.sql
@@ -61,8 +61,7 @@ CREATE TABLE IF NOT EXISTS edc_contract_negotiation
     lease_id             VARCHAR
         CONSTRAINT contract_negotiation_lease_lease_id_fk
             REFERENCES edc_lease
-            ON DELETE SET NULL,
-    CONSTRAINT provider_correlation_id CHECK (type = '0' OR correlation_id IS NOT NULL)
+            ON DELETE SET NULL
 );
 
 COMMENT ON COLUMN edc_contract_negotiation.agreement_id IS 'ContractAgreement serialized as JSON';

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/SqlContractNegotiationStore.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/SqlContractNegotiationStore.java
@@ -269,6 +269,7 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
                 ofNullable(updatedValues.getContractAgreement()).map(ContractAgreement::getId).orElse(null),
                 updatedValues.getUpdatedAt(),
                 updatedValues.isPending(),
+                updatedValues.getCorrelationId(),
                 negotiationId);
     }
 

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/schema/BaseSqlDialectStatements.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/schema/BaseSqlDialectStatements.java
@@ -50,6 +50,7 @@ public class BaseSqlDialectStatements implements ContractNegotiationStatements {
                 .column(getContractAgreementIdFkColumn())
                 .column(getUpdatedAtColumn())
                 .column(getPendingColumn())
+                .column(getCorrelationIdColumn())
                 .update(getContractNegotiationTable(), getIdColumn());
     }
 

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/message/ProcessRemoteMessage.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/message/ProcessRemoteMessage.java
@@ -30,11 +30,10 @@ public interface ProcessRemoteMessage extends RemoteMessage {
     String getId();
 
     /**
-     * Returns the process id.
+     * Returns the process id for this instance, that could be consumerPid or providerPid.
      *
      * @return the processId.
      */
-    @NotNull
     String getProcessId();
 
     void setProtocol(String protocol);

--- a/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/transformer/AbstractJsonLdTransformer.java
+++ b/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/transformer/AbstractJsonLdTransformer.java
@@ -475,4 +475,17 @@ public abstract class AbstractJsonLdTransformer<INPUT, OUTPUT> implements JsonLd
             return null;
         }
     }
+
+    /**
+     * Add a key-value pair to the builder only if the value is not null, to avoid NPE.
+     *
+     * @param value the value.
+     * @param key the key.
+     * @param builder the builder.
+     */
+    protected void addIfNotNull(String value, String key, JsonObjectBuilder builder) {
+        if (value != null) {
+            builder.add(key, value);
+        }
+    }
 }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/negotiation/store/ContractNegotiationStore.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/negotiation/store/ContractNegotiationStore.java
@@ -83,6 +83,8 @@ public interface ContractNegotiationStore extends StateEntityStore<ContractNegot
      *
      * @param correlationId the entity correlation id.
      * @return success if the entity is unleased, failure otherwise.
+     * @deprecated not used anymore, it can be removed.
      */
+    @Deprecated(since = "0.4.1")
     StoreResult<ContractNegotiation> findByCorrelationIdAndLease(String correlationId);
 }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractAgreementMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractAgreementMessage.java
@@ -17,46 +17,12 @@ package org.eclipse.edc.connector.contract.spi.types.agreement;
 import org.eclipse.edc.connector.contract.spi.types.protocol.ContractRemoteMessage;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.types.domain.agreement.ContractAgreement;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
-import static java.util.UUID.randomUUID;
+public class ContractAgreementMessage extends ContractRemoteMessage {
 
-public class ContractAgreementMessage implements ContractRemoteMessage {
-
-    private String id;
-    private String protocol = "unknown";
-    private String counterPartyAddress;
-    private String processId;
     private ContractAgreement contractAgreement;
-
-    @Override
-    @NotNull
-    public String getId() {
-        return id;
-    }
-
-    @Override
-    public String getProtocol() {
-        return protocol;
-    }
-
-    @Override
-    public void setProtocol(String protocol) {
-        Objects.requireNonNull(protocol);
-        this.protocol = protocol;
-    }
-
-    @Override
-    public String getCounterPartyAddress() {
-        return counterPartyAddress;
-    }
-
-    @Override
-    public @NotNull String getProcessId() {
-        return processId;
-    }
 
     public ContractAgreement getContractAgreement() {
         return contractAgreement;
@@ -66,49 +32,24 @@ public class ContractAgreementMessage implements ContractRemoteMessage {
         return contractAgreement.getPolicy();
     }
 
-    public static class Builder {
-        private final ContractAgreementMessage contractAgreementMessage;
+    public static class Builder extends ContractRemoteMessage.Builder<ContractAgreementMessage, Builder> {
 
         private Builder() {
-            this.contractAgreementMessage = new ContractAgreementMessage();
+            super(new ContractAgreementMessage());
         }
 
         public static Builder newInstance() {
             return new Builder();
         }
 
-        public Builder id(String id) {
-            this.contractAgreementMessage.id = id;
-            return this;
-        }
-
-        public Builder protocol(String protocol) {
-            this.contractAgreementMessage.protocol = protocol;
-            return this;
-        }
-
-        public Builder counterPartyAddress(String counterPartyAddress) {
-            this.contractAgreementMessage.counterPartyAddress = counterPartyAddress;
-            return this;
-        }
-
-        public Builder processId(String processId) {
-            this.contractAgreementMessage.processId = processId;
-            return this;
-        }
-
         public Builder contractAgreement(ContractAgreement contractAgreement) {
-            this.contractAgreementMessage.contractAgreement = contractAgreement;
+            this.message.contractAgreement = contractAgreement;
             return this;
         }
 
         public ContractAgreementMessage build() {
-            if (contractAgreementMessage.id == null) {
-                contractAgreementMessage.id = randomUUID().toString();
-            }
-            Objects.requireNonNull(contractAgreementMessage.contractAgreement, "contractAgreement");
-            Objects.requireNonNull(contractAgreementMessage.processId, "processId");
-            return contractAgreementMessage;
+            Objects.requireNonNull(message.contractAgreement, "contractAgreement");
+            return super.build();
         }
     }
 }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractAgreementVerificationMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractAgreementVerificationMessage.java
@@ -16,25 +16,14 @@ package org.eclipse.edc.connector.contract.spi.types.agreement;
 
 import org.eclipse.edc.connector.contract.spi.types.protocol.ContractRemoteMessage;
 import org.eclipse.edc.policy.model.Policy;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
-import static java.util.UUID.randomUUID;
+public class ContractAgreementVerificationMessage extends ContractRemoteMessage {
 
-public class ContractAgreementVerificationMessage implements ContractRemoteMessage {
-
-    private String id;
     private String protocol = "unknown";
     private String counterPartyAddress;
-    private String processId;
     private Policy policy;
-
-    @NotNull
-    @Override
-    public String getId() {
-        return id;
-    }
 
     @Override
     public String getProtocol() {
@@ -53,30 +42,18 @@ public class ContractAgreementVerificationMessage implements ContractRemoteMessa
     }
 
     @Override
-    @NotNull
-    public String getProcessId() {
-        return processId;
-    }
-
-    @Override
     public Policy getPolicy() {
         return policy;
     }
 
-    public static class Builder {
-        private final ContractAgreementVerificationMessage message;
+    public static class Builder extends ContractRemoteMessage.Builder<ContractAgreementVerificationMessage, Builder> {
 
         private Builder() {
-            message = new ContractAgreementVerificationMessage();
+            super(new ContractAgreementVerificationMessage());
         }
 
         public static Builder newInstance() {
             return new Builder();
-        }
-
-        public Builder id(String id) {
-            message.id = id;
-            return this;
         }
 
         public Builder protocol(String protocol) {
@@ -89,23 +66,13 @@ public class ContractAgreementVerificationMessage implements ContractRemoteMessa
             return this;
         }
 
-        public Builder processId(String processId) {
-            message.processId = processId;
-            return this;
-        }
-
         public Builder policy(Policy policy) {
             message.policy = policy;
             return this;
         }
 
         public ContractAgreementVerificationMessage build() {
-            if (message.id == null) {
-                message.id = randomUUID().toString();
-            }
-
-            Objects.requireNonNull(message.processId, "processId");
-            return message;
+            return super.build();
         }
     }
 }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractNegotiationEventMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractNegotiationEventMessage.java
@@ -20,43 +20,9 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
-import static java.util.UUID.randomUUID;
-
-public class ContractNegotiationEventMessage implements ContractRemoteMessage {
-    private String id;
-    private String protocol = "unknown";
-    private String counterPartyAddress;
-    private String processId;
+public class ContractNegotiationEventMessage extends ContractRemoteMessage {
     private Type type;
     private Policy policy;
-
-    @Override
-    @NotNull
-    public String getId() {
-        return id;
-    }
-
-    @Override
-    public String getProtocol() {
-        return protocol;
-    }
-
-    @Override
-    public void setProtocol(String protocol) {
-        Objects.requireNonNull(protocol);
-        this.protocol = protocol;
-    }
-
-    @Override
-    public String getCounterPartyAddress() {
-        return counterPartyAddress;
-    }
-
-    @Override
-    @NotNull
-    public String getProcessId() {
-        return processId;
-    }
 
     @NotNull
     public Type getType() {
@@ -68,35 +34,14 @@ public class ContractNegotiationEventMessage implements ContractRemoteMessage {
         return policy;
     }
 
-    public static class Builder {
-        private final ContractNegotiationEventMessage message;
+    public static class Builder extends ContractRemoteMessage.Builder<ContractNegotiationEventMessage, Builder> {
 
         private Builder() {
-            message = new ContractNegotiationEventMessage();
+            super(new ContractNegotiationEventMessage());
         }
 
         public static Builder newInstance() {
             return new Builder();
-        }
-
-        public Builder id(String id) {
-            message.id = id;
-            return this;
-        }
-
-        public Builder protocol(String protocol) {
-            message.protocol = protocol;
-            return this;
-        }
-
-        public Builder counterPartyAddress(String counterPartyAddress) {
-            message.counterPartyAddress = counterPartyAddress;
-            return this;
-        }
-
-        public Builder processId(String processId) {
-            message.processId = processId;
-            return this;
         }
 
         public Builder type(Type type) {
@@ -110,12 +55,8 @@ public class ContractNegotiationEventMessage implements ContractRemoteMessage {
         }
 
         public ContractNegotiationEventMessage build() {
-            if (message.id == null) {
-                message.id = randomUUID().toString();
-            }
-            Objects.requireNonNull(message.processId, "processId");
             Objects.requireNonNull(message.type, "type");
-            return message;
+            return super.build();
         }
     }
 

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractNegotiation.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractNegotiation.java
@@ -400,6 +400,16 @@ public class ContractNegotiation extends StatefulEntity<ContractNegotiation> {
         transitionTo(end.code());
     }
 
+    /**
+     * Set the correlationId, operation that's needed on the consumer side when it receives the first message with the
+     * provider process id.
+     *
+     * @param correlationId the correlation id.
+     */
+    public void setCorrelationId(String correlationId) {
+        this.correlationId = correlationId;
+    }
+
     public enum Type {
         CONSUMER, PROVIDER
     }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractNegotiationTerminationMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractNegotiationTerminationMessage.java
@@ -16,50 +16,13 @@ package org.eclipse.edc.connector.contract.spi.types.negotiation;
 
 import org.eclipse.edc.connector.contract.spi.types.protocol.ContractRemoteMessage;
 import org.eclipse.edc.policy.model.Policy;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Objects;
+public class ContractNegotiationTerminationMessage extends ContractRemoteMessage {
 
-import static java.util.UUID.randomUUID;
-
-public class ContractNegotiationTerminationMessage implements ContractRemoteMessage {
-
-    private String id;
-    private String protocol = "unknown";
-    private String counterPartyAddress;
-    private String processId;
-    private String rejectionReason; // TODO change to list https://github.com/eclipse-edc/Connector/issues/2729
+    private String rejectionReason;
     private String code;
     private Policy policy;
-
-    @NotNull
-    @Override
-    public String getId() {
-        return id;
-    }
-
-    @Override
-    public String getProtocol() {
-        return protocol;
-    }
-
-    @Override
-    public void setProtocol(String protocol) {
-        Objects.requireNonNull(protocol);
-        this.protocol = protocol;
-    }
-
-    @Override
-    public String getCounterPartyAddress() {
-        return counterPartyAddress;
-    }
-
-    @Override
-    @NotNull
-    public String getProcessId() {
-        return processId;
-    }
 
     @Nullable
     public String getRejectionReason() {
@@ -76,35 +39,14 @@ public class ContractNegotiationTerminationMessage implements ContractRemoteMess
         return policy;
     }
 
-    public static class Builder {
-        private final ContractNegotiationTerminationMessage message;
+    public static class Builder extends ContractRemoteMessage.Builder<ContractNegotiationTerminationMessage, Builder> {
 
         private Builder() {
-            message = new ContractNegotiationTerminationMessage();
+            super(new ContractNegotiationTerminationMessage());
         }
 
         public static Builder newInstance() {
             return new Builder();
-        }
-
-        public Builder id(String id) {
-            message.id = id;
-            return this;
-        }
-
-        public Builder protocol(String protocol) {
-            message.protocol = protocol;
-            return this;
-        }
-
-        public Builder counterPartyAddress(String counterPartyAddress) {
-            message.counterPartyAddress = counterPartyAddress;
-            return this;
-        }
-
-        public Builder processId(String processId) {
-            message.processId = processId;
-            return this;
         }
 
         public Builder rejectionReason(String rejectionReason) {
@@ -123,12 +65,7 @@ public class ContractNegotiationTerminationMessage implements ContractRemoteMess
         }
 
         public ContractNegotiationTerminationMessage build() {
-            if (message.id == null) {
-                message.id = randomUUID().toString();
-            }
-
-            Objects.requireNonNull(message.processId, "processId");
-            return message;
+            return super.build();
         }
     }
 }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractOfferMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractOfferMessage.java
@@ -17,54 +17,20 @@ package org.eclipse.edc.connector.contract.spi.types.negotiation;
 import org.eclipse.edc.connector.contract.spi.types.protocol.ContractRemoteMessage;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
-import org.jetbrains.annotations.NotNull;
-
-import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
-import static java.util.UUID.randomUUID;
 
 /**
  * Object that wraps the contract offer and provides additional information about e.g. protocol and recipient.
  * Sent by the provider.
  */
-public class ContractOfferMessage implements ContractRemoteMessage {
+public class ContractOfferMessage extends ContractRemoteMessage {
 
-    private String id;
-    private String protocol = "unknown";
-    private String counterPartyAddress;
     private String callbackAddress;
-    private String processId;
     private ContractOffer contractOffer;
-
-    @Override
-    public @NotNull String getId() {
-        return id;
-    }
-
-    @Override
-    public @NotNull String getProcessId() {
-        return processId;
-    }
-
-    @Override
-    public void setProtocol(String protocol) {
-        Objects.requireNonNull(protocol);
-        this.protocol = protocol;
-    }
-
-    @Override
-    public String getProtocol() {
-        return protocol;
-    }
 
     public String getCallbackAddress() {
         return callbackAddress;
-    }
-
-    @Override
-    public String getCounterPartyAddress() {
-        return counterPartyAddress;
     }
 
     public ContractOffer getContractOffer() {
@@ -76,39 +42,18 @@ public class ContractOfferMessage implements ContractRemoteMessage {
         return contractOffer.getPolicy();
     }
 
-    public static class Builder {
-        private final ContractOfferMessage message;
+    public static class Builder extends ContractRemoteMessage.Builder<ContractOfferMessage, Builder> {
 
         private Builder() {
-            message = new ContractOfferMessage();
+            super(new ContractOfferMessage());
         }
 
         public static Builder newInstance() {
             return new Builder();
         }
 
-        public Builder id(String id) {
-            message.id = id;
-            return this;
-        }
-
-        public Builder protocol(String protocol) {
-            message.protocol = protocol;
-            return this;
-        }
-
         public Builder callbackAddress(String callbackAddress) {
             message.callbackAddress = callbackAddress;
-            return this;
-        }
-
-        public Builder counterPartyAddress(String counterPartyAddress) {
-            message.counterPartyAddress = counterPartyAddress;
-            return this;
-        }
-
-        public Builder processId(String processId) {
-            message.processId = processId;
             return this;
         }
 
@@ -118,12 +63,8 @@ public class ContractOfferMessage implements ContractRemoteMessage {
         }
 
         public ContractOfferMessage build() {
-            if (message.id == null) {
-                message.id = randomUUID().toString();
-            }
-            requireNonNull(message.processId, "processId");
             requireNonNull(message.contractOffer, "contractOffer");
-            return message;
+            return super.build();
         }
     }
 }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessage.java
@@ -17,57 +17,22 @@ package org.eclipse.edc.connector.contract.spi.types.negotiation;
 import org.eclipse.edc.connector.contract.spi.types.protocol.ContractRemoteMessage;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Objects;
-
 import static java.util.Objects.requireNonNull;
-import static java.util.UUID.randomUUID;
 
 /**
  * Object that wraps the contract offer and provides additional information about e.g. protocol and recipient.
  * Sent by the consumer.
  */
-public class ContractRequestMessage implements ContractRemoteMessage {
+public class ContractRequestMessage extends ContractRemoteMessage {
 
-    private String id;
     private Type type = Type.COUNTER_OFFER;
-    private String protocol = "unknown";
-    private String counterPartyAddress;
     private String callbackAddress;
-    private String processId;
+
     private ContractOffer contractOffer;
     private String contractOfferId;
     private String dataset;
-
-    @NotNull
-    @Override
-    public String getId() {
-        return id;
-    }
-
-    @Override
-    public String getProtocol() {
-        return protocol;
-    }
-
-    @Override
-    public void setProtocol(String protocol) {
-        Objects.requireNonNull(protocol);
-        this.protocol = protocol;
-    }
-
-    @Override
-    public String getCounterPartyAddress() {
-        return counterPartyAddress;
-    }
-
-    @Override
-    @NotNull
-    public String getProcessId() {
-        return processId;
-    }
 
     public Type getType() {
         return type;
@@ -101,39 +66,18 @@ public class ContractRequestMessage implements ContractRemoteMessage {
         COUNTER_OFFER
     }
 
-    public static class Builder {
-        private final ContractRequestMessage message;
+    public static class Builder extends ContractRemoteMessage.Builder<ContractRequestMessage, Builder> {
 
         private Builder() {
-            message = new ContractRequestMessage();
+            super(new ContractRequestMessage());
         }
 
         public static Builder newInstance() {
             return new Builder();
         }
 
-        public Builder id(String id) {
-            this.message.id = id;
-            return this;
-        }
-
-        public Builder protocol(String protocol) {
-            message.protocol = protocol;
-            return this;
-        }
-
         public Builder callbackAddress(String callbackAddress) {
             message.callbackAddress = callbackAddress;
-            return this;
-        }
-
-        public Builder counterPartyAddress(String counterPartyAddress) {
-            message.counterPartyAddress = counterPartyAddress;
-            return this;
-        }
-
-        public Builder processId(String processId) {
-            message.processId = processId;
             return this;
         }
 
@@ -158,16 +102,12 @@ public class ContractRequestMessage implements ContractRemoteMessage {
         }
 
         public ContractRequestMessage build() {
-            if (message.id == null) {
-                message.id = randomUUID().toString();
-            }
-            requireNonNull(message.processId, "processId");
             if (message.contractOfferId == null) {
                 requireNonNull(message.contractOffer, "contractOffer");
             } else {
                 requireNonNull(message.contractOfferId, "contractOfferId");
             }
-            return message;
+            return super.build();
         }
     }
 }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/protocol/ContractRemoteMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/protocol/ContractRemoteMessage.java
@@ -15,18 +15,125 @@
 package org.eclipse.edc.connector.contract.spi.types.protocol;
 
 import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.message.ProcessRemoteMessage;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+import static java.util.UUID.randomUUID;
 
 /**
- * A remote message related to the ContractNegotiation context
+ * A remote message related to the ContractNegotiation context.
+ *
+ * The {@link #processId} represent the ID of the process on the recipient part.
  */
-public interface ContractRemoteMessage extends ProcessRemoteMessage {
+public abstract class ContractRemoteMessage implements ProcessRemoteMessage {
+
+    protected String id;
+    protected String processId;
+    protected String consumerPid;
+    protected String providerPid;
+    protected String protocol = "unknown";
+    protected String counterPartyAddress;
+
+    @Override
+    public @NotNull String getId() {
+        return id;
+    }
+
+    public abstract Policy getPolicy();
+
+    public String getConsumerPid() {
+        return consumerPid;
+    }
+
+    public String getProviderPid() {
+        return providerPid;
+    }
+
+    @Override
+    public String getProtocol() {
+        return protocol;
+    }
+
+    @Override
+    public void setProtocol(String protocol) {
+        Objects.requireNonNull(protocol);
+        this.protocol = protocol;
+    }
+
+    @Override
+    public String getProcessId() {
+        return processId;
+    }
+
+    public void setProcessId(String processId) {
+        Objects.requireNonNull(processId);
+        this.processId = processId;
+    }
+
+    @Override
+    public String getCounterPartyAddress() {
+        return counterPartyAddress;
+    }
 
     /**
-     * Returns the {@link Policy} associated with the Contract.
+     * Verifies if the passed processId can be considered a valid one.
      *
-     * @return the contract {@link Policy}.
+     * @param processId the processId.
+     * @return succees if it is valid, failure otherwise.
      */
-    Policy getPolicy();
+    public Result<Void> isValidProcessId(String processId) {
+        if (processId.equals(consumerPid) || processId.equals(providerPid)) {
+            return Result.success();
+        } else {
+            return Result.failure("Expected processId to be one of [%s, %s] but it was %s".formatted(consumerPid, providerPid, processId));
+        }
+    }
 
+    protected static class Builder<M extends ContractRemoteMessage, B extends Builder<M, B>> {
+        protected final M message;
+
+        protected Builder(M message) {
+            this.message = message;
+        }
+
+        public B id(String id) {
+            message.id = id;
+            return (B) this;
+        }
+
+        public B consumerPid(String consumerPid) {
+            message.consumerPid = consumerPid;
+            return (B) this;
+        }
+
+        public B providerPid(String providerPid) {
+            message.providerPid = providerPid;
+            return (B) this;
+        }
+
+        public B protocol(String protocol) {
+            this.message.protocol = protocol;
+            return (B) this;
+        }
+
+        public B processId(String processId) {
+            this.message.processId = processId;
+            return (B) this;
+        }
+
+        public B counterPartyAddress(String counterPartyAddress) {
+            this.message.counterPartyAddress = counterPartyAddress;
+            return (B) this;
+        }
+
+        public M build() {
+            if (message.id == null) {
+                message.id = randomUUID().toString();
+            }
+            return message;
+        }
+    }
 }

--- a/spi/control-plane/contract-spi/src/test/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessageTest.java
+++ b/spi/control-plane/contract-spi/src/test/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessageTest.java
@@ -25,7 +25,6 @@ import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractR
 class ContractRequestMessageTest {
     public static final String CALLBACK_ADDRESS = "http://test.com";
     public static final String OFFER_ID = "offerId";
-    public static final String PROCESS_ID = "123";
     public static final String DATASET = "dataset1";
     public static final String ID = "id1";
     public static final String ASSET_ID = "asset1";
@@ -35,37 +34,20 @@ class ContractRequestMessageTest {
     void verify_noCallbackNeededForCounterOffer() {
         ContractRequestMessage.Builder.newInstance()
                 .type(COUNTER_OFFER)
-                .processId(PROCESS_ID)
+                .consumerPid("consumerPid")
+                .providerPid("providerPid")
                 .protocol(PROTOCOL)
                 .contractOfferId(OFFER_ID)
                 .dataset(DATASET)
                 .build();
-    }
-
-    @Test
-    void verify_noProcessIdSet() {
-        assertThatThrownBy(() -> ContractRequestMessage.Builder.newInstance()
-                .type(INITIAL)
-                .protocol(PROTOCOL)
-                .dataset(DATASET)
-                .counterPartyAddress(CALLBACK_ADDRESS)
-                .build()).isInstanceOf(NullPointerException.class).hasMessageContaining("processId");
-
-        // verify process id must be included if type is counter offer
-        assertThatThrownBy(() -> ContractRequestMessage.Builder.newInstance()
-                .type(COUNTER_OFFER)
-                .protocol(PROTOCOL)
-                .contractOfferId(OFFER_ID)
-                .dataset(DATASET)
-                .counterPartyAddress(CALLBACK_ADDRESS)
-                .build()).isInstanceOf(NullPointerException.class).hasMessageContaining("processId");
     }
 
     @Test
     void verify_contractOfferIdOrContractOffer() {
         ContractRequestMessage.Builder.newInstance()
                 .type(INITIAL)
-                .processId(PROCESS_ID)
+                .consumerPid("consumerPid")
+                .providerPid("providerPid")
                 .protocol(PROTOCOL)
                 .contractOfferId(OFFER_ID)
                 .dataset(DATASET)
@@ -74,7 +56,8 @@ class ContractRequestMessageTest {
 
         ContractRequestMessage.Builder.newInstance()
                 .type(INITIAL)
-                .processId(PROCESS_ID)
+                .consumerPid("consumerPid")
+                .providerPid("providerPid")
                 .protocol(PROTOCOL)
                 .contractOffer(ContractOffer.Builder.newInstance()
                         .id(ID)
@@ -88,7 +71,8 @@ class ContractRequestMessageTest {
         // verify no contract offer or contract offer id set
         assertThatThrownBy(() -> ContractRequestMessage.Builder.newInstance()
                 .type(INITIAL)
-                .processId(PROCESS_ID)
+                .consumerPid("consumerPid")
+                .providerPid("providerPid")
                 .protocol(PROTOCOL)
                 .dataset(DATASET)
                 .counterPartyAddress(CALLBACK_ADDRESS)

--- a/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/negotiation/store/ContractNegotiationStoreTestBase.java
+++ b/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/negotiation/store/ContractNegotiationStoreTestBase.java
@@ -214,7 +214,7 @@ public abstract class ContractNegotiationStoreTestBase {
                     .id(id)
                     .stateCount(420) //modified
                     .state(800) //modified
-                    .correlationId("corr-test-id1")
+                    .correlationId("corr-test-id2")
                     .counterPartyAddress("consumer")
                     .counterPartyId("consumerId")
                     .protocol("protocol")
@@ -224,6 +224,7 @@ public abstract class ContractNegotiationStoreTestBase {
 
             var actual = getContractNegotiationStore().findById(negotiation.getId());
             assertThat(actual).isNotNull();
+            assertThat(actual.getCorrelationId()).isEqualTo("corr-test-id2");
             assertThat(actual.getStateCount()).isEqualTo(420);
             assertThat(actual.getState()).isEqualTo(800);
         }
@@ -834,6 +835,7 @@ public abstract class ContractNegotiationStoreTestBase {
         }
     }
 
+    @Deprecated(since = "0.4.1")
     @Nested
     class FindByCorrelationIdAndLease {
         @Test


### PR DESCRIPTION
## What this PR changes/adds

Supports new DSP fields `consumerId` and `providerId` as specified in the [dataspace protocol specs](https://docs.internationaldataspaces.org/ids-knowledgebase/v/dataspace-protocol/contract-negotiation/contract.negotiation.protocol)

## Why it does that

dsp protocol

## Further notes

- transfer process implementation will come in a subsequent PR
- every message will contain both `consumerPid`, `providerPid` and `processId`, the latter will be the same as the `consumerPid`
- the functionality has been implemented in a way that it will maintain backward compatibility with previous versions connectors. Interoperability cases:

#### NEW consumer -> OLD provider
on contract request:
- consumer:
  - generate negotiation with new id and null correlation id
  - create and dispatch request message with:
    - consumerPid valued with its own id.
    - processId is valued with the same id because correlation id is null
- provider:
  - receives the message:
    - it is on an old version so it get the processId and it stores it as correlationId,
    - sends a message back with the `processId` valued with the correlationId
- consumer receives, fetches the negotiation by the processId in the URL that's its own id (correct)
  - it saves the received processId as correlationId (see ContractNegotiationProtocolServiceImpl)
  - on the next message, it will sent it using that correlationId.
- provider will fetch negotiation correctly because it used the `findByCorrelationId`, and that's the id it received.

#### OLD consumer  -> NEW provider
on contract request:
- consumer:
  - generate negotiation with id and correlation id of the same value
  - create and dispatch request message with:
    - processId valued with the id/correlationId value
- provider:
  - receives the message:
    - it is on a new version so it values both consumerPid and providerPid with the processId value
    - create a negotiation with its own id and the correlationId equal to the consumerPid/processId
    - sends a message back putting the correlationId as processId so it will be used for every communication
- consumer:
  - receives the message:
    - it will use the processId to fetch the negotiation
    - the next message will contain the `processId` that will be used by the provider to successfully fetch the negotiation by correlationIs (as fallback)


## Linked Issue(s)

Part of #3455

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
