### PR TITLE
fix: remove request logging in FallbackFactories

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -57,7 +57,7 @@ maven/mavencentral/com.github.stephenc.jcip/jcip-annotations/1.0-1, Apache-2.0, 
 maven/mavencentral/com.google.code.findbugs/jsr305/2.0.1, BSD-3-Clause AND CC-BY-2.5 AND LGPL-2.1+, approved, CQ13390
 maven/mavencentral/com.google.code.findbugs/jsr305/3.0.2, Apache-2.0, approved, #20
 maven/mavencentral/com.google.code.gson/gson/2.10.1, Apache-2.0, approved, #6159
-maven/mavencentral/com.google.crypto.tink/tink/1.12.0, , restricted, clearlydefined
+maven/mavencentral/com.google.crypto.tink/tink/1.12.0, Apache-2.0, approved, #12041
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.11.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.22.0, Apache-2.0, approved, #10661
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.7.1, Apache-2.0, approved, clearlydefined
@@ -132,10 +132,10 @@ maven/mavencentral/io.prometheus/simpleclient_httpserver/0.16.0, Apache-2.0, app
 maven/mavencentral/io.prometheus/simpleclient_tracer_common/0.16.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.prometheus/simpleclient_tracer_otel/0.16.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.prometheus/simpleclient_tracer_otel_agent/0.16.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.rest-assured/json-path/5.4.0, , restricted, clearlydefined
-maven/mavencentral/io.rest-assured/rest-assured-common/5.4.0, , restricted, clearlydefined
-maven/mavencentral/io.rest-assured/rest-assured/5.4.0, , restricted, clearlydefined
-maven/mavencentral/io.rest-assured/xml-path/5.4.0, , restricted, clearlydefined
+maven/mavencentral/io.rest-assured/json-path/5.4.0, Apache-2.0, approved, #12042
+maven/mavencentral/io.rest-assured/rest-assured-common/5.4.0, Apache-2.0, approved, #12039
+maven/mavencentral/io.rest-assured/rest-assured/5.4.0, Apache-2.0, approved, #12040
+maven/mavencentral/io.rest-assured/xml-path/5.4.0, Apache-2.0, approved, #12038
 maven/mavencentral/io.setl/rdf-urdna/1.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.15, Apache-2.0, approved, #5947
 maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.19, Apache-2.0, approved, #5947

--- a/spi/common/http-spi/src/main/java/org/eclipse/edc/spi/http/FallbackFactories.java
+++ b/spi/common/http-spi/src/main/java/org/eclipse/edc/spi/http/FallbackFactories.java
@@ -41,7 +41,7 @@ public interface FallbackFactories {
                 if (response == null) {
                     return new EdcHttpClientException(event.getLastException().getMessage());
                 } else {
-                    return new EdcHttpClientException(format("Server response to %s was not successful but was %s: %s", request, response.code(), response.body().string()));
+                    return new EdcHttpClientException(format("Server response to [%s, %s] was not successful but was %s: %s", request.method(), request.url(), response.code(), response.body().string()));
                 }
             };
             return Fallback.builderOfException(exceptionSupplier)
@@ -72,7 +72,7 @@ public interface FallbackFactories {
                 if (response == null) {
                     return new EdcHttpClientException(event.getLastException().getMessage());
                 } else {
-                    return new EdcHttpClientException(format("Server response to %s was not one of %s but was %s: %s", request, Arrays.toString(status), response.code(), response.body().string()));
+                    return new EdcHttpClientException(format("Server response to [%s, %s] was not one of %s but was %s: %s", request.method(), request.url(), Arrays.toString(status), response.code(), response.body().string()));
                 }
             };
             return Fallback.builderOfException(exceptionSupplier)


### PR DESCRIPTION
## What this PR changes/adds

Removes request logging on `FallbackFactories`

## Linked Issue(s)

Closes #3709 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
