### PR TITLE
feat: remove `target` from contract offer

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -57,7 +57,7 @@ maven/mavencentral/com.github.stephenc.jcip/jcip-annotations/1.0-1, Apache-2.0, 
 maven/mavencentral/com.google.code.findbugs/jsr305/2.0.1, BSD-3-Clause AND CC-BY-2.5 AND LGPL-2.1+, approved, CQ13390
 maven/mavencentral/com.google.code.findbugs/jsr305/3.0.2, Apache-2.0, approved, #20
 maven/mavencentral/com.google.code.gson/gson/2.10.1, Apache-2.0, approved, #6159
-maven/mavencentral/com.google.crypto.tink/tink/1.12.0, , restricted, clearlydefined
+maven/mavencentral/com.google.crypto.tink/tink/1.12.0, Apache-2.0, approved, #12041
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.11.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.22.0, Apache-2.0, approved, #10661
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.7.1, Apache-2.0, approved, clearlydefined
@@ -132,10 +132,10 @@ maven/mavencentral/io.prometheus/simpleclient_httpserver/0.16.0, Apache-2.0, app
 maven/mavencentral/io.prometheus/simpleclient_tracer_common/0.16.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.prometheus/simpleclient_tracer_otel/0.16.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.prometheus/simpleclient_tracer_otel_agent/0.16.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.rest-assured/json-path/5.4.0, , restricted, clearlydefined
-maven/mavencentral/io.rest-assured/rest-assured-common/5.4.0, , restricted, clearlydefined
-maven/mavencentral/io.rest-assured/rest-assured/5.4.0, , restricted, clearlydefined
-maven/mavencentral/io.rest-assured/xml-path/5.4.0, , restricted, clearlydefined
+maven/mavencentral/io.rest-assured/json-path/5.4.0, Apache-2.0, approved, #12042
+maven/mavencentral/io.rest-assured/rest-assured-common/5.4.0, Apache-2.0, approved, #12039
+maven/mavencentral/io.rest-assured/rest-assured/5.4.0, Apache-2.0, approved, #12040
+maven/mavencentral/io.rest-assured/xml-path/5.4.0, Apache-2.0, approved, #12038
 maven/mavencentral/io.setl/rdf-urdna/1.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.15, Apache-2.0, approved, #5947
 maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.19, Apache-2.0, approved, #5947

--- a/core/control-plane/catalog-core/src/main/java/org/eclipse/edc/connector/catalog/DatasetResolverImpl.java
+++ b/core/control-plane/catalog-core/src/main/java/org/eclipse/edc/connector/catalog/DatasetResolverImpl.java
@@ -92,7 +92,7 @@ public class DatasetResolverImpl implements DatasetResolver {
                     var policyDefinition = policyDefinitionStore.findById(contractDefinition.getContractPolicyId());
                     if (policyDefinition != null) {
                         var contractId = ContractOfferId.create(contractDefinition.getId(), asset.getId());
-                        datasetBuilder.offer(contractId.toString(), policyDefinition.getPolicy().withTarget(asset.getId()));
+                        datasetBuilder.offer(contractId.toString(), policyDefinition.getPolicy());
                     }
                 });
 

--- a/core/control-plane/catalog-core/src/test/java/org/eclipse/edc/connector/catalog/DatasetResolverImplTest.java
+++ b/core/control-plane/catalog-core/src/test/java/org/eclipse/edc/connector/catalog/DatasetResolverImplTest.java
@@ -90,7 +90,7 @@ class DatasetResolverImplTest {
             assertThat(dataset.getDistributions()).hasSize(1).first().isEqualTo(distribution);
             assertThat(dataset.getOffers()).hasSize(1).allSatisfy((id, policy) -> {
                 assertThat(ContractOfferId.parseId(id)).isSucceeded().extracting(ContractOfferId::definitionPart).asString().isEqualTo("definitionId");
-                assertThat(policy.getTarget()).isEqualTo("assetId");
+                assertThat(policy.getTarget()).isEqualTo(null);
             });
             assertThat(dataset.getProperties()).contains(entry("key", "value"));
         });

--- a/core/control-plane/catalog-core/src/test/java/org/eclipse/edc/connector/catalog/DatasetResolverImplTest.java
+++ b/core/control-plane/catalog-core/src/test/java/org/eclipse/edc/connector/catalog/DatasetResolverImplTest.java
@@ -90,7 +90,7 @@ class DatasetResolverImplTest {
             assertThat(dataset.getDistributions()).hasSize(1).first().isEqualTo(distribution);
             assertThat(dataset.getOffers()).hasSize(1).allSatisfy((id, policy) -> {
                 assertThat(ContractOfferId.parseId(id)).isSucceeded().extracting(ContractOfferId::definitionPart).asString().isEqualTo("definitionId");
-                assertThat(policy.getTarget()).isEqualTo(null);
+                assertThat(policy.getTarget()).isNull();
             });
             assertThat(dataset.getProperties()).contains(entry("key", "value"));
         });

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -130,7 +130,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
                     .contractSigningDate(clock.instant().getEpochSecond())
                     .providerId(participantId)
                     .consumerId(negotiation.getCounterPartyId())
-                    .policy(lastOffer.getPolicy())
+                    .policy(lastOffer.getPolicy().withTarget(lastOffer.getAssetId()))
                     .assetId(lastOffer.getAssetId())
                     .build();
         } else {

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
@@ -24,6 +24,7 @@ import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiat
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.EdcException;
@@ -35,7 +36,6 @@ import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.retry.ExponentialWaitStrategy;
 import org.eclipse.edc.spi.types.domain.agreement.ContractAgreement;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
-import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 import org.eclipse.edc.statemachine.retry.EntityRetryProcessConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -293,7 +293,6 @@ class ConsumerContractNegotiationManagerImplTest {
     private ContractOffer contractOffer() {
         return ContractOffer.Builder.newInstance().id("id:assetId:random")
                 .policy(Policy.Builder.newInstance().build())
-                .assetId("assetId")
                 .build();
     }
 
@@ -346,7 +345,6 @@ class ConsumerContractNegotiationManagerImplTest {
         private ContractOffer contractOffer() {
             return ContractOffer.Builder.newInstance().id("id:assetId:random")
                     .policy(Policy.Builder.newInstance().build())
-                    .assetId("assetId")
                     .build();
         }
     }

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -25,6 +25,7 @@ import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiat
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationTerminationMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.contract.spi.validation.ContractValidationService;
 import org.eclipse.edc.connector.contract.spi.validation.ValidatedConsumerOffer;
 import org.eclipse.edc.connector.defaults.storage.contractnegotiation.InMemoryContractNegotiationStore;
@@ -49,7 +50,6 @@ import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.telemetry.Telemetry;
 import org.eclipse.edc.spi.types.domain.agreement.ContractAgreement;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
-import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 import org.eclipse.edc.transaction.spi.NoopTransactionContext;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
@@ -62,7 +62,6 @@ import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-import static java.util.UUID.randomUUID;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.CompletableFuture.failedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -334,7 +333,6 @@ class ContractNegotiationIntegrationTest {
     private ContractOffer getContractOffer() {
         return ContractOffer.Builder.newInstance()
                 .id(ContractOfferId.create("1", "test-asset-id").toString())
-                .assetId(randomUUID().toString())
                 .policy(Policy.Builder.newInstance()
                         .type(PolicyType.CONTRACT)
                         .assigner("assigner")

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
@@ -25,6 +25,7 @@ import org.eclipse.edc.connector.contract.spi.types.agreement.ContractNegotiatio
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferMessage;
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
 import org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore;
 import org.eclipse.edc.policy.model.Policy;
@@ -35,7 +36,6 @@ import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.retry.ExponentialWaitStrategy;
 import org.eclipse.edc.spi.types.domain.agreement.ContractAgreement;
-import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 import org.eclipse.edc.statemachine.retry.EntityRetryProcessConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -285,7 +285,6 @@ class ProviderContractNegotiationManagerImplTest {
         return ContractOffer.Builder.newInstance()
                 .id(ContractOfferId.create("1", "test-asset-id").toString())
                 .policy(Policy.Builder.newInstance().build())
-                .assetId("assetId")
                 .build();
     }
 
@@ -322,7 +321,6 @@ class ProviderContractNegotiationManagerImplTest {
         private ContractOffer contractOffer() {
             return ContractOffer.Builder.newInstance().id("id:assetId:random")
                     .policy(Policy.Builder.newInstance().build())
-                    .assetId("assetId")
                     .build();
         }
 

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImplTest.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.connector.contract.spi.ContractOfferId;
 import org.eclipse.edc.connector.contract.spi.offer.ContractDefinitionResolver;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractDefinition;
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
 import org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore;
 import org.eclipse.edc.policy.engine.spi.PolicyContext;
@@ -36,7 +37,6 @@ import org.eclipse.edc.spi.iam.ClaimToken;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.agreement.ContractAgreement;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
-import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -77,12 +77,12 @@ class ContractValidationServiceImplTest {
 
     private final Instant now = Instant.now();
 
-    private final ParticipantAgentService agentService = mock(ParticipantAgentService.class);
-    private final ContractDefinitionResolver definitionResolver = mock(ContractDefinitionResolver.class);
-    private final AssetIndex assetIndex = mock(AssetIndex.class);
-    private final PolicyDefinitionStore policyStore = mock(PolicyDefinitionStore.class);
-    private final PolicyEngine policyEngine = mock(PolicyEngine.class);
-    private final PolicyEquality policyEquality = mock(PolicyEquality.class);
+    private final ParticipantAgentService agentService = mock();
+    private final ContractDefinitionResolver definitionResolver = mock();
+    private final AssetIndex assetIndex = mock();
+    private final PolicyDefinitionStore policyStore = mock();
+    private final PolicyEngine policyEngine = mock();
+    private final PolicyEquality policyEquality = mock();
     private ContractValidationServiceImpl validationService;
 
     private static ContractDefinition.Builder createContractDefinitionBuilder() {
@@ -485,7 +485,6 @@ class ContractValidationServiceImplTest {
     private ContractOffer createContractOffer(Asset asset, Policy policy) {
         return ContractOffer.Builder.newInstance()
                 .id(ContractOfferId.create("1", asset.getId()).toString())
-                .assetId(asset.getId())
                 .policy(policy)
                 .build();
     }

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationEventDispatchTest.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.connector.contract.spi.negotiation.NegotiationWaitStrateg
 import org.eclipse.edc.connector.contract.spi.offer.store.ContractDefinitionStore;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractDefinition;
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.dataplane.selector.spi.store.DataPlaneInstanceStore;
 import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
 import org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore;
@@ -43,7 +44,6 @@ import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
-import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -123,7 +123,6 @@ class ContractNegotiationEventDispatchTest {
     private ContractRequestMessage createContractOfferRequest(Policy policy, String assetId) {
         var contractOffer = ContractOffer.Builder.newInstance()
                 .id(ContractOfferId.create("contractDefinitionId", assetId).toString())
-                .assetId("assetId")
                 .policy(policy)
                 .build();
 

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
@@ -25,6 +25,7 @@ import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiat
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationTerminationMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferMessage;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.contract.spi.validation.ContractValidationService;
 import org.eclipse.edc.connector.contract.spi.validation.ValidatedConsumerOffer;
 import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationProtocolService;
@@ -39,7 +40,6 @@ import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.result.StoreResult;
 import org.eclipse.edc.spi.types.domain.agreement.ContractAgreement;
 import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
-import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 import org.eclipse.edc.transaction.spi.NoopTransactionContext;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 import org.junit.jupiter.api.BeforeEach;
@@ -547,7 +547,6 @@ class ContractNegotiationProtocolServiceImplTest {
             return ContractOffer.Builder.newInstance()
                     .id(ContractOfferId.create("1", "test-asset-id").toString())
                     .policy(createPolicy())
-                    .assetId("assetId")
                     .build();
         }
 

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationServiceImplTest.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiat
 import org.eclipse.edc.connector.contract.spi.types.command.TerminateNegotiationCommand;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest;
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationService;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.command.CommandHandlerRegistry;
@@ -28,7 +29,6 @@ import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.result.ServiceFailure;
 import org.eclipse.edc.spi.types.domain.agreement.ContractAgreement;
-import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 import org.eclipse.edc.transaction.spi.NoopTransactionContext;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 import org.junit.jupiter.api.Test;
@@ -273,7 +273,6 @@ class ContractNegotiationServiceImplTest {
         return ContractOffer.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
                 .policy(Policy.Builder.newInstance().build())
-                .assetId("test-asset")
                 .build();
     }
 }

--- a/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/contractnegotiation/TestFunctions.java
+++ b/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/defaults/storage/contractnegotiation/TestFunctions.java
@@ -16,9 +16,9 @@
 package org.eclipse.edc.connector.defaults.storage.contractnegotiation;
 
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.types.domain.agreement.ContractAgreement;
-import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 
 import java.time.Instant;
 import java.util.List;
@@ -38,7 +38,6 @@ public class TestFunctions {
                 .type(ContractNegotiation.Type.CONSUMER)
                 .contractOffers(List.of(ContractOffer.Builder.newInstance().id("contractId")
                         .policy(Policy.Builder.newInstance().build())
-                        .assetId("test-asset")
                         .build()))
                 .counterPartyAddress("consumer")
                 .counterPartyId("consumerId")

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractOfferMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractOfferMessageTransformer.java
@@ -16,9 +16,9 @@ package org.eclipse.edc.protocol.dsp.negotiation.transform.to;
 
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferMessage;
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
 import org.eclipse.edc.policy.model.Policy;
-import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -65,7 +65,6 @@ public class JsonObjectToContractOfferMessageTransformer extends AbstractJsonLdT
             }
             var offer = ContractOffer.Builder.newInstance()
                     .id(id)
-                    .assetId(policy.getTarget())
                     .policy(policy)
                     .build();
             builder.contractOffer(offer);

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractRequestMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractRequestMessageTransformer.java
@@ -16,9 +16,9 @@ package org.eclipse.edc.protocol.dsp.negotiation.transform.to;
 
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
 import org.eclipse.edc.policy.model.Policy;
-import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -88,7 +88,7 @@ public class JsonObjectToContractRequestMessageTransformer extends AbstractJsonL
                         .report();
                 return null;
             }
-            var offer = ContractOffer.Builder.newInstance().id(id).assetId(policy.getTarget()).policy(policy).build();
+            var offer = ContractOffer.Builder.newInstance().id(id).policy(policy).build();
             builder.contractOffer(offer);
         } else if (context.hasProblems()) {
             return null;

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractOfferMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractOfferMessageTransformerTest.java
@@ -18,8 +18,8 @@ import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferMessage;
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.policy.model.Policy;
-import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 import org.eclipse.edc.transform.spi.ProblemBuilder;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.junit.jupiter.api.BeforeEach;
@@ -108,7 +108,6 @@ class JsonObjectFromContractOfferMessageTransformerTest {
     private ContractOffer contractOffer() {
         return ContractOffer.Builder.newInstance()
                 .id(CONTRACT_OFFER_ID)
-                .assetId("assetId")
                 .policy(Policy.Builder.newInstance().build())
                 .build();
     }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractRequestMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractRequestMessageTransformerTest.java
@@ -17,9 +17,10 @@ package org.eclipse.edc.protocol.dsp.negotiation.transform.from;
 import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.contract.spi.ContractOfferId;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.policy.model.Policy;
-import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 import org.eclipse.edc.transform.spi.ProblemBuilder;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,7 +52,7 @@ class JsonObjectFromContractRequestMessageTransformerTest {
     private static final String PROCESS_ID = "processId";
     private static final String PROTOCOL = "DSP";
     private static final String DATASET_ID = "datasetId";
-    private static final String CONTRACT_OFFER_ID = "contractOffer1";
+    private static final String CONTRACT_OFFER_ID = ContractOfferId.create("definitionId", "assetId").toString();
 
     private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
     private final TransformerContext context = mock(TransformerContext.class);
@@ -76,7 +77,7 @@ class JsonObjectFromContractRequestMessageTransformerTest {
         assertThat(result.getJsonString(ID).getString()).isNotEmpty();
         assertThat(result.getJsonString(TYPE).getString()).isEqualTo(DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE);
         assertThat(result.getJsonString(DSPACE_PROPERTY_PROCESS_ID).getString()).isEqualTo(PROCESS_ID);
-        assertThat(result.getJsonString(DSPACE_PROPERTY_DATASET).getString()).isEqualTo(DATASET_ID);
+        assertThat(result.getJsonString(DSPACE_PROPERTY_DATASET).getString()).isEqualTo("assetId");
         assertThat(result.getJsonString(DSPACE_PROPERTY_CALLBACK_ADDRESS).getString()).isEqualTo(CALLBACK_ADDRESS);
         assertThat(result.getJsonObject(DSPACE_PROPERTY_OFFER)).isNotNull();
         assertThat(result.getJsonObject(DSPACE_PROPERTY_OFFER).getString(ID)).isEqualTo(CONTRACT_OFFER_ID);
@@ -131,7 +132,6 @@ class JsonObjectFromContractRequestMessageTransformerTest {
     private ContractOffer contractOffer() {
         return ContractOffer.Builder.newInstance()
                 .id(CONTRACT_OFFER_ID)
-                .assetId(DATASET_ID)
                 .policy(Policy.Builder.newInstance().build())
                 .build();
     }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractOfferMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractOfferMessageTransformerTest.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.protocol.dsp.negotiation.transform.to;
 import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.contract.spi.ContractOfferId;
 import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.transform.spi.ProblemBuilder;
@@ -47,7 +48,7 @@ class JsonObjectToContractOfferMessageTransformerTest {
     private static final String CALLBACK_ADDRESS = "https://test.com";
     private static final String MESSAGE_ID = "messageId";
     private static final String ASSET_ID = "assetId";
-    private static final String CONTRACT_OFFER_ID = "assetId";
+    private static final String CONTRACT_OFFER_ID = ContractOfferId.create("definitionId", "assetId").toString();
     
     private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
     private final TransformerContext context = mock(TransformerContext.class);

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractRequestMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractRequestMessageTransformerTest.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.protocol.dsp.negotiation.transform.to;
 import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.contract.spi.ContractOfferId;
 import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
 import org.eclipse.edc.policy.model.Action;
 import org.eclipse.edc.policy.model.Duty;
@@ -54,7 +55,8 @@ class JsonObjectToContractRequestMessageTransformerTest {
     private static final String DATASET_ID = "datasetId";
     private static final String CALLBACK = "https://test.com";
     private static final String OBJECT_ID = "id1";
-    private static final String CONTRACT_OFFER_ID = "contractOfferId";
+    private static final String ASSET_ID = "assetId";
+    private static final String CONTRACT_OFFER_ID = ContractOfferId.create("definitionId", ASSET_ID).toString();
 
     private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
     private final TransformerContext context = mock();
@@ -92,7 +94,7 @@ class JsonObjectToContractRequestMessageTransformerTest {
         assertThat(contractOffer).isNotNull();
         assertThat(contractOffer.getId()).isNotNull();
         assertThat(contractOffer.getPolicy()).isNotNull();
-        assertThat(contractOffer.getAssetId()).isEqualTo("target");
+        assertThat(contractOffer.getAssetId()).isEqualTo(ASSET_ID);
 
         verify(context, never()).reportProblem(anyString());
     }

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectToContractOfferTransformer.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectToContractOfferTransformer.java
@@ -15,9 +15,9 @@
 package org.eclipse.edc.connector.api.management.contractnegotiation.transform;
 
 import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
 import org.eclipse.edc.policy.model.Policy;
-import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -37,7 +37,6 @@ public class JsonObjectToContractOfferTransformer extends AbstractJsonLdTransfor
         var id = nodeId(jsonObject);
         return ContractOffer.Builder.newInstance()
                 .id(id)
-                .assetId(policy.getTarget())
                 .policy(policy)
                 .build();
     }

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectToContractRequestTransformer.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectToContractRequestTransformer.java
@@ -17,9 +17,9 @@ package org.eclipse.edc.connector.api.management.contractnegotiation.transform;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractOfferDescription;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest;
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
-import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -66,7 +66,6 @@ public class JsonObjectToContractRequestTransformer extends AbstractJsonLdTransf
             var contractOfferDescription = transformObject(jsonObject.get(OFFER), ContractOfferDescription.class, context);
             return ContractOffer.Builder.newInstance()
                     .id(contractOfferDescription.getOfferId())
-                    .assetId(contractOfferDescription.getAssetId())
                     .policy(contractOfferDescription.getPolicy())
                     .build();
         }

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/validation/ContractRequestValidator.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/validation/ContractRequestValidator.java
@@ -34,7 +34,6 @@ import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractR
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.OFFER;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.POLICY;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.PROTOCOL;
-import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIBUTE;
 
 public class ContractRequestValidator {
 
@@ -65,8 +64,7 @@ public class ContractRequestValidator {
                     .verify(POLICY, MandatoryObject::new)
                     .verifyObject(POLICY, builder -> builder
                             .verifyId(MandatoryIdNotBlank::new)
-                            .verify(ODRL_TARGET_ATTRIBUTE, MandatoryObject::new)
-                            .verifyObject(ODRL_TARGET_ATTRIBUTE, b -> b.verifyId(MandatoryIdNotBlank::new)))
+                    )
                     .build();
 
             return validator.validate(input);

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerTest.java
@@ -24,6 +24,7 @@ import org.eclipse.edc.connector.api.management.contractnegotiation.model.Negoti
 import org.eclipse.edc.connector.contract.spi.types.command.TerminateNegotiationCommand;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest;
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationService;
 import org.eclipse.edc.junit.annotations.ApiTest;
 import org.eclipse.edc.policy.model.Policy;
@@ -32,7 +33,6 @@ import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.types.domain.agreement.ContractAgreement;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
-import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 import org.eclipse.edc.validator.spi.ValidationResult;
@@ -338,7 +338,6 @@ class ContractNegotiationApiControllerTest extends RestControllerTestBase {
                         .counterPartyAddress("test-cb")
                         .contractOffer(ContractOffer.Builder.newInstance()
                                 .id("test-offer-id")
-                                .assetId(randomUUID().toString())
                                 .policy(Policy.Builder.newInstance().build())
                                 .build())
                         .build()));

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectToContractOfferTransformerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectToContractOfferTransformerTest.java
@@ -16,10 +16,10 @@ package org.eclipse.edc.connector.api.management.contractnegotiation.transform;
 
 import jakarta.json.JsonObject;
 import jakarta.json.JsonValue;
+import org.eclipse.edc.connector.contract.spi.ContractOfferId;
 import org.eclipse.edc.jsonld.TitaniumJsonLd;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.policy.model.Policy;
-import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,7 +32,6 @@ import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_OBLIGATION_AT
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_PERMISSION_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_SET;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_PROHIBITION_ATTRIBUTE;
-import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIBUTE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -40,7 +39,7 @@ import static org.mockito.Mockito.when;
 
 class JsonObjectToContractOfferTransformerTest {
 
-    private final JsonLd jsonLd = new TitaniumJsonLd(mock(Monitor.class));
+    private final JsonLd jsonLd = new TitaniumJsonLd(mock());
     private final TransformerContext context = mock();
     private JsonObjectToContractOfferTransformer transformer;
 
@@ -51,10 +50,10 @@ class JsonObjectToContractOfferTransformerTest {
 
     @Test
     void transform() {
+        var contractId = ContractOfferId.create("definitionId", "assetId").toString();
         var offerPolicy = createObjectBuilder()
                 .add(TYPE, ODRL_POLICY_TYPE_SET)
-                .add(ID, "test-offer-id")
-                .add(ODRL_TARGET_ATTRIBUTE, "test-asset")
+                .add(ID, contractId)
                 .add(ODRL_PERMISSION_ATTRIBUTE, getJsonObject("permission"))
                 .add(ODRL_PROHIBITION_ATTRIBUTE, getJsonObject("prohibition"))
                 .add(ODRL_OBLIGATION_ATTRIBUTE, getJsonObject("duty"))
@@ -66,8 +65,8 @@ class JsonObjectToContractOfferTransformerTest {
         var result = transformer.transform(jsonLd.expand(offerPolicy).getContent(), context);
 
         assertThat(result).isNotNull();
-        assertThat(result.getId()).isEqualTo("test-offer-id");
-        assertThat(result.getAssetId()).isEqualTo("test-asset");
+        assertThat(result.getId()).isEqualTo(contractId);
+        assertThat(result.getAssetId()).isEqualTo("assetId");
     }
 
     @Test

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/validation/ContractRequestValidatorTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/validation/ContractRequestValidatorTest.java
@@ -37,7 +37,6 @@ import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractR
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.PROVIDER_ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
-import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIBUTE;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -55,8 +54,8 @@ class ContractRequestValidatorTest {
                 .add(PROTOCOL, value("protocol"))
                 .add(PROVIDER_ID, value("connector-id"))
                 .add(POLICY, createArrayBuilder().add(createObjectBuilder()
-                        .add(ID, "offer-id")
-                        .add(ODRL_TARGET_ATTRIBUTE, createArrayBuilder().add(createObjectBuilder().add(ID, "target")))))
+                        .add(ID, "offer-id"))
+                )
                 .build();
 
         var result = validator.validate(input);
@@ -78,22 +77,6 @@ class ContractRequestValidatorTest {
         assertThat(result).isFailed().extracting(ValidationFailure::getViolations).asInstanceOf(list(Violation.class))
                 .isNotEmpty()
                 .anySatisfy(violation -> assertThat(violation.message()).contains(ID));
-    }
-
-    @Test
-    void shouldFail_whenPolicyMissesTarget() {
-        var input = Json.createObjectBuilder()
-                .add(CONTRACT_REQUEST_COUNTER_PARTY_ADDRESS, value("http://connector-address"))
-                .add(PROTOCOL, value("protocol"))
-                .add(PROVIDER_ID, value("connector-id"))
-                .add(POLICY, createArrayBuilder().add(createObjectBuilder().add(ID, "offer-id")))
-                .build();
-
-        var result = validator.validate(input);
-
-        assertThat(result).isFailed().extracting(ValidationFailure::getViolations).asInstanceOf(list(Violation.class))
-                .isNotEmpty()
-                .anySatisfy(violation -> assertThat(violation.message()).contains(ODRL_TARGET_ATTRIBUTE));
     }
 
     @Test
@@ -169,8 +152,8 @@ class ContractRequestValidatorTest {
                 .add(PROTOCOL, value("protocol"))
                 .add(PROVIDER_ID, value("connector-id"))
                 .add(POLICY, createArrayBuilder().add(createObjectBuilder()
-                        .add(ID, "offer-id")
-                        .add(ODRL_TARGET_ATTRIBUTE, createArrayBuilder().add(createObjectBuilder().add(ID, "target")))))
+                        .add(ID, "offer-id"))
+                )
                 .build();
 
         var result = validator.validate(input);

--- a/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
+++ b/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.connector.provision.http.impl;
 import okhttp3.Interceptor;
 import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.contract.spi.validation.ContractValidationService;
 import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
 import org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore;
@@ -44,7 +45,6 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.agreement.ContractAgreement;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
-import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 import org.eclipse.edc.validator.spi.DataAddressValidatorRegistry;
 import org.eclipse.edc.validator.spi.ValidationResult;
 import org.jetbrains.annotations.NotNull;
@@ -155,7 +155,6 @@ public class HttpProvisionerExtensionEndToEndTest {
 
         var contractOffer = ContractOffer.Builder.newInstance()
                 .id(randomUUID().toString())
-                .assetId(randomUUID().toString())
                 .policy(policy)
                 .build();
         return ContractNegotiation.Builder.newInstance()

--- a/spi/common/catalog-spi/build.gradle.kts
+++ b/spi/common/catalog-spi/build.gradle.kts
@@ -19,6 +19,7 @@ plugins {
 
 dependencies {
     api(project(":spi:common:core-spi"))
+    api(project(":spi:control-plane:contract-spi"))
 }
 
 

--- a/spi/common/catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/Catalog.java
+++ b/spi/common/catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/Catalog.java
@@ -17,7 +17,7 @@ package org.eclipse.edc.catalog.spi;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/event/contractnegotiation/ContractNegotiationEvent.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/event/contractnegotiation/ContractNegotiationEvent.java
@@ -14,9 +14,9 @@
 
 package org.eclipse.edc.connector.contract.spi.event.contractnegotiation;
 
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.spi.event.Event;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
-import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractNegotiation.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractNegotiation.java
@@ -20,10 +20,10 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.spi.entity.StatefulEntity;
 import org.eclipse.edc.spi.types.domain.agreement.ContractAgreement;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
-import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractOfferMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractOfferMessage.java
@@ -14,9 +14,9 @@
 
 package org.eclipse.edc.connector.contract.spi.types.negotiation;
 
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.contract.spi.types.protocol.ContractRemoteMessage;
 import org.eclipse.edc.policy.model.Policy;
-import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequest.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequest.java
@@ -14,8 +14,8 @@
 
 package org.eclipse.edc.connector.contract.spi.types.negotiation;
 
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
-import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessage.java
@@ -14,9 +14,9 @@
 
 package org.eclipse.edc.connector.contract.spi.types.negotiation;
 
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.contract.spi.types.protocol.ContractRemoteMessage;
 import org.eclipse.edc.policy.model.Policy;
-import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/offer/ContractOffer.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/offer/ContractOffer.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021 Daimler TSS GmbH
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,15 +8,16 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Daimler TSS GmbH - Initial API and Implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
  *
  */
 
-package org.eclipse.edc.spi.types.domain.offer;
+package org.eclipse.edc.connector.contract.spi.types.offer;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.connector.contract.spi.ContractOfferId;
 import org.eclipse.edc.policy.model.Policy;
 import org.jetbrains.annotations.NotNull;
 
@@ -35,11 +36,6 @@ public class ContractOffer {
      */
     private Policy policy;
 
-    /**
-     * The offered asset
-     */
-    private String assetId;
-
     @NotNull
     public String getId() {
         return id;
@@ -47,7 +43,8 @@ public class ContractOffer {
 
     @NotNull
     public String getAssetId() {
-        return assetId;
+        return ContractOfferId.parseId(id).map(ContractOfferId::assetIdPart)
+                .orElseThrow(it -> new IllegalArgumentException("Cannot get assetId from the contract offer id"));
     }
 
     @NotNull
@@ -57,7 +54,7 @@ public class ContractOffer {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, policy, assetId);
+        return Objects.hash(id, policy);
     }
 
     @Override
@@ -69,7 +66,7 @@ public class ContractOffer {
             return false;
         }
         ContractOffer that = (ContractOffer) o;
-        return Objects.equals(id, that.id) && Objects.equals(policy, that.policy) && Objects.equals(assetId, that.assetId);
+        return Objects.equals(id, that.id) && Objects.equals(policy, that.policy);
     }
 
     @JsonPOJOBuilder(withPrefix = "")
@@ -91,11 +88,6 @@ public class ContractOffer {
             return this;
         }
 
-        public Builder assetId(String assetId) {
-            contractOffer.assetId = assetId;
-            return this;
-        }
-
         public Builder policy(Policy policy) {
             contractOffer.policy = policy;
             return this;
@@ -103,7 +95,6 @@ public class ContractOffer {
 
         public ContractOffer build() {
             Objects.requireNonNull(contractOffer.id, "Id must not be null");
-            Objects.requireNonNull(contractOffer.assetId, "Asset id must not be null");
             Objects.requireNonNull(contractOffer.policy, "Policy must not be null");
             return contractOffer;
         }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/validation/ContractValidationService.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/validation/ContractValidationService.java
@@ -16,12 +16,12 @@
 package org.eclipse.edc.connector.contract.spi.validation;
 
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.policy.engine.spi.PolicyScope;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import org.eclipse.edc.spi.iam.ClaimToken;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.agreement.ContractAgreement;
-import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 import org.jetbrains.annotations.NotNull;
 
 /**

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/validation/ValidatedConsumerOffer.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/validation/ValidatedConsumerOffer.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.edc.connector.contract.spi.validation;
 
-import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 
 import static java.util.Objects.requireNonNull;
 

--- a/spi/control-plane/contract-spi/src/test/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessageTest.java
+++ b/spi/control-plane/contract-spi/src/test/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessageTest.java
@@ -14,8 +14,8 @@
 
 package org.eclipse.edc.connector.contract.spi.types.negotiation;
 
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.policy.model.Policy;
-import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -28,7 +28,6 @@ class ContractRequestMessageTest {
     public static final String PROCESS_ID = "123";
     public static final String DATASET = "dataset1";
     public static final String ID = "id1";
-    public static final String ASSET_ID = "asset1";
     public static final String PROTOCOL = "DPS";
 
     @Test
@@ -78,7 +77,6 @@ class ContractRequestMessageTest {
                 .protocol(PROTOCOL)
                 .contractOffer(ContractOffer.Builder.newInstance()
                         .id(ID)
-                        .assetId(ASSET_ID)
                         .policy(Policy.Builder.newInstance().build())
                         .build())
                 .dataset(DATASET)

--- a/spi/control-plane/contract-spi/src/test/java/org/eclipse/edc/connector/contract/spi/types/offer/ContractOfferTest.java
+++ b/spi/control-plane/contract-spi/src/test/java/org/eclipse/edc/connector/contract/spi/types/offer/ContractOfferTest.java
@@ -14,8 +14,6 @@
 
 package org.eclipse.edc.connector.contract.spi.types.offer;
 
-import org.eclipse.edc.policy.model.Policy;
-import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -29,20 +27,8 @@ class ContractOfferTest {
 
     @Test
     void verifyPolicyNotNull() {
-        assertThatThrownBy(() -> ContractOffer.Builder.newInstance().id("some-id")
-                .assetId("test-assetId")
-                .build())
+        assertThatThrownBy(() -> ContractOffer.Builder.newInstance().id("some-id").build())
                 .isInstanceOf(NullPointerException.class)
                 .hasMessage("Policy must not be null");
-    }
-
-    @Test
-    void verifyAssetNotNull() {
-        assertThatThrownBy(() -> ContractOffer.Builder.newInstance()
-                .id("some-id")
-                .policy(Policy.Builder.newInstance().build())
-                .build())
-                .isInstanceOf(NullPointerException.class)
-                .hasMessage("Asset id must not be null");
     }
 }

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractAgreementApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractAgreementApiEndToEndTest.java
@@ -16,11 +16,11 @@ package org.eclipse.edc.test.e2e.managementapi;
 
 import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.types.domain.agreement.ContractAgreement;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
-import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -109,7 +109,6 @@ public class ContractAgreementApiEndToEndTest extends BaseManagementApiEndToEndT
     private ContractOffer.Builder contractOfferBuilder() {
         return ContractOffer.Builder.newInstance()
                 .id("test-offer-id")
-                .assetId("test-asset-id")
                 .policy(Policy.Builder.newInstance().build());
     }
 

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractNegotiationApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractNegotiationApiEndToEndTest.java
@@ -20,11 +20,11 @@ import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates;
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.types.domain.agreement.ContractAgreement;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
-import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -225,7 +225,6 @@ public class ContractNegotiationApiEndToEndTest extends BaseManagementApiEndToEn
     private ContractOffer.Builder contractOfferBuilder() {
         return ContractOffer.Builder.newInstance()
                 .id("test-offer-id")
-                .assetId(randomUUID().toString())
                 .policy(Policy.Builder.newInstance().build());
     }
 


### PR DESCRIPTION
## What this PR changes/adds

Remove `target` from contract offer.

## Why it does that

DSP compliance

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #3718 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
