### PR TITLE
fix: provide InMemoryPolicyMonitorStore as default

### DIFF
--- a/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/PolicyMonitorDefaultServicesExtension.java
+++ b/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/PolicyMonitorDefaultServicesExtension.java
@@ -38,7 +38,7 @@ public class PolicyMonitorDefaultServicesExtension implements ServiceExtension {
     @Inject
     private Clock clock;
 
-    @Provider
+    @Provider(isDefault = true)
     public PolicyMonitorStore policyMonitorStore() {
         return new InMemoryPolicyMonitorStore(clock);
     }


### PR DESCRIPTION
## What this PR changes/adds

provide InMemoryPolicyMonitorStore as default

## Why it does that

permits other implementations to be used

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #3722 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
