### PR TITLE
fix: issuedAt now validated with leeway in Oauth2ExpirationIssuedAtValidationRule

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -138,7 +138,7 @@ maven/mavencentral/io.rest-assured/rest-assured/5.4.0, Apache-2.0, approved, #12
 maven/mavencentral/io.rest-assured/xml-path/5.4.0, Apache-2.0, approved, #12038
 maven/mavencentral/io.setl/rdf-urdna/1.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.15, Apache-2.0, approved, #5947
-maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.19, Apache-2.0, approved, #5947
+maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.20, Apache-2.0, approved, #5947
 maven/mavencentral/io.swagger.core.v3/swagger-annotations/2.2.15, Apache-2.0, approved, #11362
 maven/mavencentral/io.swagger.core.v3/swagger-annotations/2.2.8, Apache-2.0, approved, #11362
 maven/mavencentral/io.swagger.core.v3/swagger-core-jakarta/2.2.15, Apache-2.0, approved, #5929
@@ -226,26 +226,26 @@ maven/mavencentral/org.eclipse.edc/autodoc-processor/0.4.2-SNAPSHOT, Apache-2.0,
 maven/mavencentral/org.eclipse.edc/runtime-metamodel/0.4.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.jetty.toolchain/jetty-jakarta-servlet-api/5.0.2, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty.toolchain/jetty-jakarta-websocket-api/2.0.0, EPL-2.0 OR Apache-2.0, approved, rt.jetty
-maven/mavencentral/org.eclipse.jetty.websocket/websocket-core-client/11.0.18, EPL-2.0 OR Apache-2.0, approved, rt.jetty
-maven/mavencentral/org.eclipse.jetty.websocket/websocket-core-common/11.0.18, EPL-2.0 OR Apache-2.0, approved, rt.jetty
-maven/mavencentral/org.eclipse.jetty.websocket/websocket-core-server/11.0.18, EPL-2.0 OR Apache-2.0, approved, rt.jetty
-maven/mavencentral/org.eclipse.jetty.websocket/websocket-jakarta-client/11.0.18, EPL-2.0 OR Apache-2.0, approved, rt.jetty
-maven/mavencentral/org.eclipse.jetty.websocket/websocket-jakarta-common/11.0.18, EPL-2.0 OR Apache-2.0, approved, rt.jetty
-maven/mavencentral/org.eclipse.jetty.websocket/websocket-jakarta-server/11.0.18, EPL-2.0 OR Apache-2.0, approved, rt.jetty
-maven/mavencentral/org.eclipse.jetty.websocket/websocket-servlet/11.0.18, EPL-2.0 OR Apache-2.0, approved, rt.jetty
-maven/mavencentral/org.eclipse.jetty/jetty-alpn-client/11.0.18, EPL-2.0 OR Apache-2.0, approved, rt.jetty
-maven/mavencentral/org.eclipse.jetty/jetty-annotations/11.0.18, EPL-2.0 OR Apache-2.0, approved, rt.jetty
-maven/mavencentral/org.eclipse.jetty/jetty-client/11.0.18, EPL-2.0 OR Apache-2.0, approved, rt.jetty
-maven/mavencentral/org.eclipse.jetty/jetty-http/11.0.18, EPL-2.0 OR Apache-2.0, approved, rt.jetty
-maven/mavencentral/org.eclipse.jetty/jetty-io/11.0.18, EPL-2.0 OR Apache-2.0, approved, rt.jetty
-maven/mavencentral/org.eclipse.jetty/jetty-jndi/11.0.18, EPL-2.0 OR Apache-2.0, approved, rt.jetty
-maven/mavencentral/org.eclipse.jetty/jetty-plus/11.0.18, EPL-2.0 OR Apache-2.0, approved, rt.jetty
-maven/mavencentral/org.eclipse.jetty/jetty-security/11.0.18, EPL-2.0 OR Apache-2.0, approved, rt.jetty
-maven/mavencentral/org.eclipse.jetty/jetty-server/11.0.18, EPL-2.0 OR Apache-2.0, approved, rt.jetty
-maven/mavencentral/org.eclipse.jetty/jetty-servlet/11.0.18, EPL-2.0 OR Apache-2.0, approved, rt.jetty
-maven/mavencentral/org.eclipse.jetty/jetty-util/11.0.18, EPL-2.0 OR Apache-2.0, approved, rt.jetty
-maven/mavencentral/org.eclipse.jetty/jetty-webapp/11.0.18, EPL-2.0 OR Apache-2.0, approved, rt.jetty
-maven/mavencentral/org.eclipse.jetty/jetty-xml/11.0.18, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty.websocket/websocket-core-client/11.0.19, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty.websocket/websocket-core-common/11.0.19, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty.websocket/websocket-core-server/11.0.19, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty.websocket/websocket-jakarta-client/11.0.19, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty.websocket/websocket-jakarta-common/11.0.19, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty.websocket/websocket-jakarta-server/11.0.19, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty.websocket/websocket-servlet/11.0.19, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty/jetty-alpn-client/11.0.19, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty/jetty-annotations/11.0.19, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty/jetty-client/11.0.19, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty/jetty-http/11.0.19, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty/jetty-io/11.0.19, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty/jetty-jndi/11.0.19, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty/jetty-plus/11.0.19, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty/jetty-security/11.0.19, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty/jetty-server/11.0.19, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty/jetty-servlet/11.0.19, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty/jetty-util/11.0.19, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty/jetty-webapp/11.0.19, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty/jetty-xml/11.0.19, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.glassfish.hk2.external/aopalliance-repackaged/3.0.5, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/hk2-api/3.0.5, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/hk2-locator/3.0.5, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceConfiguration.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceConfiguration.java
@@ -33,6 +33,7 @@ public class Oauth2ServiceConfiguration {
     private String publicCertificateAlias;
     private String providerAudience;
     private int notBeforeValidationLeeway;
+    private int issuedAtValidationLeeway;
     private String endpointAudience;
 
     private Long tokenExpiration;
@@ -75,6 +76,10 @@ public class Oauth2ServiceConfiguration {
 
     public int getNotBeforeValidationLeeway() {
         return notBeforeValidationLeeway;
+    }
+
+    public int getIssuedAtValidationLeeway() {
+        return issuedAtValidationLeeway;
     }
 
     public String getEndpointAudience() {
@@ -143,6 +148,11 @@ public class Oauth2ServiceConfiguration {
 
         public Builder notBeforeValidationLeeway(int notBeforeValidationLeeway) {
             configuration.notBeforeValidationLeeway = notBeforeValidationLeeway;
+            return this;
+        }
+
+        public Builder issuedAtValidationLeeway(int issuedAtValidationLeeway) {
+            configuration.issuedAtValidationLeeway = issuedAtValidationLeeway;
             return this;
         }
 

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceConfiguration.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceConfiguration.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       sovity GmbH - added issuedAt leeway
  *
  */
 

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceConfiguration.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceConfiguration.java
@@ -33,7 +33,7 @@ public class Oauth2ServiceConfiguration {
     private String publicCertificateAlias;
     private String providerAudience;
     private int notBeforeValidationLeeway;
-    private int issuedAtValidationLeeway;
+    private int issuedAtLeeway;
     private String endpointAudience;
 
     private Long tokenExpiration;
@@ -78,8 +78,8 @@ public class Oauth2ServiceConfiguration {
         return notBeforeValidationLeeway;
     }
 
-    public int getIssuedAtValidationLeeway() {
-        return issuedAtValidationLeeway;
+    public int getIssuedAtLeeway() {
+        return issuedAtLeeway;
     }
 
     public String getEndpointAudience() {
@@ -151,8 +151,8 @@ public class Oauth2ServiceConfiguration {
             return this;
         }
 
-        public Builder issuedAtValidationLeeway(int issuedAtValidationLeeway) {
-            configuration.issuedAtValidationLeeway = issuedAtValidationLeeway;
+        public Builder issuedAtLeeway(int issuedAtLeeway) {
+            configuration.issuedAtLeeway = issuedAtLeeway;
             return this;
         }
 

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceExtension.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceExtension.java
@@ -10,6 +10,7 @@
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
  *       Fraunhofer Institute for Software and Systems Engineering - Improvements
+ *       sovity GmbH - added issuedAt leeway
  *
  */
 

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceExtension.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceExtension.java
@@ -169,9 +169,22 @@ public class Oauth2ServiceExtension implements ServiceExtension {
                 .privateKeyResolver(privateKeyResolver)
                 .certificateResolver(certificateResolver)
                 .notBeforeValidationLeeway(context.getSetting(NOT_BEFORE_LEEWAY, 10))
-                .issuedAtValidationLeeway(context.getSetting(ISSUED_AT_LEEWAY, 0))
+                .issuedAtValidationLeeway(getIssuedAtValidationLeeway(context))
                 .tokenExpiration(TimeUnit.MINUTES.toSeconds(tokenExpiration))
                 .build();
+    }
+
+    private int getIssuedAtValidationLeeway(ServiceExtensionContext context) {
+        if (!context.getConfig().hasKey(ISSUED_AT_LEEWAY)) {
+            String message = "No value was configured for '%s'.".formatted(ISSUED_AT_LEEWAY) +
+                    " Please consider configuring a leeway of 2-5s. The check 'iat <= now' can" +
+                    " cause errors in production due to the comparison of second-rounded and" +
+                    " nanosecond-precise dates, because the rounding and rounding direction are" +
+                    " implementation specific, platform specific, but also within spec for JWT.";
+            context.getMonitor().info(message);
+        }
+
+        return context.getSetting(ISSUED_AT_LEEWAY, 0);
     }
 
 }

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceExtension.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceExtension.java
@@ -74,8 +74,10 @@ public class Oauth2ServiceExtension implements ServiceExtension {
     private static final String TOKEN_EXPIRATION = "edc.oauth.token.expiration"; // in minutes
     @Setting
     private static final String CLIENT_ID = "edc.oauth.client.id";
-    @Setting
+    @Setting(value = "Leeway in seconds for validating the not before (nbf) claim in the token")
     private static final String NOT_BEFORE_LEEWAY = "edc.oauth.validation.nbf.leeway";
+    @Setting(value = "Leeway in seconds for validating the issuedAt claim in the token")
+    private static final String ISSUED_AT_LEEWAY = "edc.oauth.validation.issued.at.leeway";
     private IdentityProviderKeyResolver providerKeyResolver;
 
     @Inject
@@ -167,6 +169,7 @@ public class Oauth2ServiceExtension implements ServiceExtension {
                 .privateKeyResolver(privateKeyResolver)
                 .certificateResolver(certificateResolver)
                 .notBeforeValidationLeeway(context.getSetting(NOT_BEFORE_LEEWAY, 10))
+                .issuedAtValidationLeeway(context.getSetting(ISSUED_AT_LEEWAY, 10))
                 .tokenExpiration(TimeUnit.MINUTES.toSeconds(tokenExpiration))
                 .build();
     }

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceExtension.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceExtension.java
@@ -171,12 +171,12 @@ public class Oauth2ServiceExtension implements ServiceExtension {
                 .privateKeyResolver(privateKeyResolver)
                 .certificateResolver(certificateResolver)
                 .notBeforeValidationLeeway(context.getSetting(NOT_BEFORE_LEEWAY, 10))
-                .issuedAtValidationLeeway(getIssuedAtValidationLeeway(context))
+                .issuedAtLeeway(getIssuedAtLeeway(context))
                 .tokenExpiration(TimeUnit.MINUTES.toSeconds(tokenExpiration))
                 .build();
     }
 
-    private int getIssuedAtValidationLeeway(ServiceExtensionContext context) {
+    private int getIssuedAtLeeway(ServiceExtensionContext context) {
         if (!context.getConfig().hasKey(ISSUED_AT_LEEWAY)) {
             var message = format(
                     "No value was configured for '%s'. Consider setting a leeway of 2-5s in production to avoid problems with clock skew.",

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceExtension.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceExtension.java
@@ -77,9 +77,9 @@ public class Oauth2ServiceExtension implements ServiceExtension {
     private static final String TOKEN_EXPIRATION = "edc.oauth.token.expiration"; // in minutes
     @Setting
     private static final String CLIENT_ID = "edc.oauth.client.id";
-    @Setting(value = "Leeway in seconds for validating the not before (nbf) claim in the token")
+    @Setting(value = "Leeway in seconds for validating the not before (nbf) claim in the token.", defaultValue = "10", type = "int")
     private static final String NOT_BEFORE_LEEWAY = "edc.oauth.validation.nbf.leeway";
-    @Setting(value = "Leeway in seconds for validating the issuedAt claim in the token")
+    @Setting(value = "Leeway in seconds for validating the issuedAt claim in the token. By default it is 0 seconds.", defaultValue = "0", type = "int")
     private static final String ISSUED_AT_LEEWAY = "edc.oauth.validation.issued.at.leeway";
     private IdentityProviderKeyResolver providerKeyResolver;
 

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceExtension.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceExtension.java
@@ -46,6 +46,8 @@ import java.time.Clock;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
+import static java.lang.String.format;
+
 /**
  * Provides OAuth2 client credentials flow support.
  */
@@ -176,11 +178,8 @@ public class Oauth2ServiceExtension implements ServiceExtension {
 
     private int getIssuedAtValidationLeeway(ServiceExtensionContext context) {
         if (!context.getConfig().hasKey(ISSUED_AT_LEEWAY)) {
-            String message = "No value was configured for '%s'.".formatted(ISSUED_AT_LEEWAY) +
-                    " Please consider configuring a leeway of 2-5s. The check 'iat <= now' can" +
-                    " cause errors in production due to the comparison of second-rounded and" +
-                    " nanosecond-precise dates, because the rounding and rounding direction are" +
-                    " implementation specific, platform specific, but also within spec for JWT.";
+            var message = format("No value was configured for '%s'. Consider setting a leeway " +
+                    "of 2-5s in production to avoid problems with clock skew.", ISSUED_AT_LEEWAY);
             context.getMonitor().info(message);
         }
 

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceExtension.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceExtension.java
@@ -178,8 +178,10 @@ public class Oauth2ServiceExtension implements ServiceExtension {
 
     private int getIssuedAtValidationLeeway(ServiceExtensionContext context) {
         if (!context.getConfig().hasKey(ISSUED_AT_LEEWAY)) {
-            var message = format("No value was configured for '%s'. Consider setting a leeway " +
-                    "of 2-5s in production to avoid problems with clock skew.", ISSUED_AT_LEEWAY);
+            var message = format(
+                    "No value was configured for '%s'. Consider setting a leeway of 2-5s in production to avoid problems with clock skew.",
+                    ISSUED_AT_LEEWAY
+            );
             context.getMonitor().info(message);
         }
 

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceExtension.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceExtension.java
@@ -169,7 +169,7 @@ public class Oauth2ServiceExtension implements ServiceExtension {
                 .privateKeyResolver(privateKeyResolver)
                 .certificateResolver(certificateResolver)
                 .notBeforeValidationLeeway(context.getSetting(NOT_BEFORE_LEEWAY, 10))
-                .issuedAtValidationLeeway(context.getSetting(ISSUED_AT_LEEWAY, 10))
+                .issuedAtValidationLeeway(context.getSetting(ISSUED_AT_LEEWAY, 0))
                 .tokenExpiration(TimeUnit.MINUTES.toSeconds(tokenExpiration))
                 .build();
     }

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/rule/Oauth2ExpirationIssuedAtValidationRule.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/rule/Oauth2ExpirationIssuedAtValidationRule.java
@@ -32,9 +32,11 @@ import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.ISSUED_AT;
 public class Oauth2ExpirationIssuedAtValidationRule implements TokenValidationRule {
 
     private final Clock clock;
+    private final int issuedAtValidationLeeway;
 
-    public Oauth2ExpirationIssuedAtValidationRule(Clock clock) {
+    public Oauth2ExpirationIssuedAtValidationRule(Clock clock, int issuedAtValidationLeeway) {
         this.clock = clock;
+        this.issuedAtValidationLeeway = issuedAtValidationLeeway;
     }
 
     @Override
@@ -51,7 +53,7 @@ public class Oauth2ExpirationIssuedAtValidationRule implements TokenValidationRu
         if (issuedAt != null) {
             if (issuedAt.isAfter(expires)) {
                 return Result.failure("Issued at (iat) claim is after expiration time (exp) claim in token");
-            } else if (now.isBefore(issuedAt)) {
+            } else if (now.plusSeconds(issuedAtValidationLeeway).isBefore(issuedAt)) {
                 return Result.failure("Current date/time before issued at (iat) claim in token");
             }
         }

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/rule/Oauth2ExpirationIssuedAtValidationRule.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/rule/Oauth2ExpirationIssuedAtValidationRule.java
@@ -32,11 +32,11 @@ import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.ISSUED_AT;
 public class Oauth2ExpirationIssuedAtValidationRule implements TokenValidationRule {
 
     private final Clock clock;
-    private final int issuedAtValidationLeeway;
+    private final int issuedAtLeeway;
 
-    public Oauth2ExpirationIssuedAtValidationRule(Clock clock, int issuedAtValidationLeeway) {
+    public Oauth2ExpirationIssuedAtValidationRule(Clock clock, int issuedAtLeeway) {
         this.clock = clock;
-        this.issuedAtValidationLeeway = issuedAtValidationLeeway;
+        this.issuedAtLeeway = issuedAtLeeway;
     }
 
     @Override
@@ -53,7 +53,7 @@ public class Oauth2ExpirationIssuedAtValidationRule implements TokenValidationRu
         if (issuedAt != null) {
             if (issuedAt.isAfter(expires)) {
                 return Result.failure("Issued at (iat) claim is after expiration time (exp) claim in token");
-            } else if (now.plusSeconds(issuedAtValidationLeeway).isBefore(issuedAt)) {
+            } else if (now.plusSeconds(issuedAtLeeway).isBefore(issuedAt)) {
                 return Result.failure("Current date/time before issued at (iat) claim in token");
             }
         }

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/rule/Oauth2ExpirationIssuedAtValidationRule.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/rule/Oauth2ExpirationIssuedAtValidationRule.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       sovity GmbH - added issuedAt leeway
  *
  */
 

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/rule/Oauth2ValidationRulesRegistryImpl.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/rule/Oauth2ValidationRulesRegistryImpl.java
@@ -28,6 +28,6 @@ public class Oauth2ValidationRulesRegistryImpl extends TokenValidationRulesRegis
     public Oauth2ValidationRulesRegistryImpl(Oauth2ServiceConfiguration configuration, Clock clock) {
         this.addRule(new Oauth2AudienceValidationRule(configuration.getEndpointAudience()));
         this.addRule(new Oauth2NotBeforeValidationRule(clock, configuration.getNotBeforeValidationLeeway()));
-        this.addRule(new Oauth2ExpirationIssuedAtValidationRule(clock));
+        this.addRule(new Oauth2ExpirationIssuedAtValidationRule(clock, configuration.getIssuedAtValidationLeeway()));
     }
 }

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/rule/Oauth2ValidationRulesRegistryImpl.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/rule/Oauth2ValidationRulesRegistryImpl.java
@@ -28,6 +28,6 @@ public class Oauth2ValidationRulesRegistryImpl extends TokenValidationRulesRegis
     public Oauth2ValidationRulesRegistryImpl(Oauth2ServiceConfiguration configuration, Clock clock) {
         this.addRule(new Oauth2AudienceValidationRule(configuration.getEndpointAudience()));
         this.addRule(new Oauth2NotBeforeValidationRule(clock, configuration.getNotBeforeValidationLeeway()));
-        this.addRule(new Oauth2ExpirationIssuedAtValidationRule(clock, configuration.getIssuedAtValidationLeeway()));
+        this.addRule(new Oauth2ExpirationIssuedAtValidationRule(clock, configuration.getIssuedAtLeeway()));
     }
 }

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/rule/Oauth2ValidationRulesRegistryImpl.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/rule/Oauth2ValidationRulesRegistryImpl.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Amadeus - Initial implementation
+ *       sovity GmbH - added issuedAt leeway
  *
  */
 

--- a/extensions/common/iam/oauth2/oauth2-core/src/test/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceExtensionTest.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/test/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceExtensionTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.iam.oauth2;
 
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.security.CertificateResolver;
 import org.eclipse.edc.spi.security.PrivateKeyResolver;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
@@ -29,6 +30,7 @@ import java.security.cert.X509Certificate;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -49,24 +51,75 @@ class Oauth2ServiceExtensionTest {
     }
 
     @Test
-    void verifyExtensionWithCertificateAlias(Oauth2ServiceExtension extension, ServiceExtensionContext context) throws CertificateEncodingException {
+    void verifyExtensionWithCertificateAlias(Oauth2ServiceExtension extension, ServiceExtensionContext context) {
         var config = spy(ConfigFactory.fromMap(Map.of(
                 "edc.oauth.client.id", "id",
                 "edc.oauth.token.url", "url",
                 "edc.oauth.certificate.alias", "alias",
                 "edc.oauth.private.key.alias", "p_alias")));
-        when(context.getConfig(any())).thenReturn(config);
-        var certificate = mock(X509Certificate.class);
-        var privateKey = mock(PrivateKey.class);
-        when(privateKey.getAlgorithm()).thenReturn("RSA");
-        when(certificate.getEncoded()).thenReturn(new byte[] {});
-        when(certificateResolver.resolveCertificate("alias")).thenReturn(certificate);
-        when(privateKeyResolver.resolvePrivateKey("p_alias", PrivateKey.class)).thenReturn(privateKey);
+        mockCertificate("alias");
+        mockRsaPrivateKey("p_alias");
 
+        when(context.getConfig(any())).thenReturn(config);
         extension.initialize(context);
 
         verify(config, times(1)).getString("edc.oauth.certificate.alias");
         verify(config, never()).getString("edc.oauth.public.key.alias");
     }
 
+    @Test
+    void leewayWarningLoggedWhenLeewayUnconfigured(Oauth2ServiceExtension extension, ServiceExtensionContext context) {
+        var config = spy(ConfigFactory.fromMap(Map.of(
+                "edc.oauth.client.id", "id",
+                "edc.oauth.token.url", "url",
+                "edc.oauth.certificate.alias", "alias",
+                "edc.oauth.private.key.alias", "p_alias")));
+        mockCertificate("alias");
+        mockRsaPrivateKey("p_alias");
+
+        var monitor = mock(Monitor.class);
+        when(context.getMonitor()).thenReturn(monitor);
+        when(context.getConfig(any())).thenReturn(config);
+        extension.initialize(context);
+
+        var message = "No value was configured for 'edc.oauth.validation.issued.at.leeway'.";
+        verify(monitor, times(1)).info(contains(message));
+    }
+
+    @Test
+    void leewayNoWarningWhenLeewayConfigured(Oauth2ServiceExtension extension, ServiceExtensionContext context) {
+        var config = spy(ConfigFactory.fromMap(Map.of(
+                "edc.oauth.client.id", "id",
+                "edc.oauth.token.url", "url",
+                "edc.oauth.certificate.alias", "alias",
+                "edc.oauth.private.key.alias", "p_alias",
+                "edc.oauth.validation.issued.at.leeway", "5")));
+        mockCertificate("alias");
+        mockRsaPrivateKey("p_alias");
+
+        var monitor = mock(Monitor.class);
+        when(context.getMonitor()).thenReturn(monitor);
+        when(context.getConfig(any())).thenReturn(config);
+        extension.initialize(context);
+
+        var message = "No value was configured for 'edc.oauth.validation.issued.at.leeway'.";
+        verify(monitor, never()).info(contains(message));
+    }
+
+    private void mockRsaPrivateKey(String alias) {
+        var privateKey = mock(PrivateKey.class);
+        when(privateKey.getAlgorithm()).thenReturn("RSA");
+        when(privateKeyResolver.resolvePrivateKey(alias, PrivateKey.class)).thenReturn(privateKey);
+    }
+
+    private void mockCertificate(String alias) {
+        try {
+            var certificate = mock(X509Certificate.class);
+            when(certificate.getEncoded()).thenReturn(new byte[] {});
+            when(certificateResolver.resolveCertificate(alias)).thenReturn(certificate);
+        } catch (CertificateEncodingException e) {
+            // Should never happen, it's a checked exception in the way of mocking
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/extensions/common/iam/oauth2/oauth2-core/src/test/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceExtensionTest.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/test/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceExtensionTest.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       sovity GmbH - added issuedAt leeway
  *
  */
 

--- a/extensions/common/iam/oauth2/oauth2-core/src/test/java/org/eclipse/edc/iam/oauth2/rule/Oauth2ExpirationIssuedAtValidationRuleTest.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/test/java/org/eclipse/edc/iam/oauth2/rule/Oauth2ExpirationIssuedAtValidationRuleTest.java
@@ -33,52 +33,12 @@ class Oauth2ExpirationIssuedAtValidationRuleTest {
 
     private final Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
     private final Clock clock = Clock.fixed(now, UTC);
-    private final int issuedAtValidationLeeway = 5;
-    private final TokenValidationRule rule = new Oauth2ExpirationIssuedAtValidationRule(clock, issuedAtValidationLeeway);
+    private final TokenValidationRule rule = new Oauth2ExpirationIssuedAtValidationRule(clock,  0);
 
     @Test
     void validationOk() {
         var token = ClaimToken.Builder.newInstance()
                 .claim(EXPIRATION_TIME, Date.from(now.plusSeconds(600)))
-                .build();
-
-        var result = rule.checkRule(token, emptyMap());
-
-        assertThat(result.succeeded()).isTrue();
-    }
-
-    @Test
-    void validationOkBecauseIssuedAtInFutureButWithinLeeway() {
-        var token = ClaimToken.Builder.newInstance()
-                .claim(EXPIRATION_TIME, Date.from(now.plusSeconds(60)))
-                .claim(ISSUED_AT, Date.from(now.plusSeconds(2)))
-                .build();
-
-        var result = rule.checkRule(token, emptyMap());
-
-        assertThat(result.succeeded()).isTrue();
-    }
-
-    /**
-     * Regression test against clock skew and platform-dependant rounding of dates, solved with a 2s leeway.
-     * <br>
-     * Rounding of dates in JWT is within spec and the direction of rounding is platform-dependant.
-     */
-    @Test
-    void validationOkWithRoundedIssuedAtAndMinimalLeeway() {
-        // time skew: tokens have dates rounded up to the second
-        var issuedAt = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        var expiresAt = issuedAt.plusSeconds(60);
-
-        // time skew: the connector is still in the previous second, with unrounded dates
-        var now = issuedAt.minus(250, ChronoUnit.MILLIS);
-
-        var clock = Clock.fixed(now, UTC);
-        var rule = new Oauth2ExpirationIssuedAtValidationRule(clock, 2);
-
-        var token = ClaimToken.Builder.newInstance()
-                .claim(EXPIRATION_TIME, Date.from(expiresAt))
-                .claim(ISSUED_AT, Date.from(issuedAt))
                 .build();
 
         var result = rule.checkRule(token, emptyMap());
@@ -134,5 +94,89 @@ class Oauth2ExpirationIssuedAtValidationRuleTest {
 
         assertThat(result.succeeded()).isFalse();
         assertThat(result.getFailureMessages()).hasSize(1).contains("Current date/time before issued at (iat) claim in token");
+    }
+
+    @Test
+    void validationKoBecauseIssuedAtInFutureOutsideLeeway() {
+        var rule = new Oauth2ExpirationIssuedAtValidationRule(clock, 5);
+
+        var token = ClaimToken.Builder.newInstance()
+                .claim(EXPIRATION_TIME, Date.from(now.plusSeconds(60)))
+                .claim(ISSUED_AT, Date.from(now.plusSeconds(10)))
+                .build();
+
+        var result = rule.checkRule(token, emptyMap());
+
+        assertThat(result.succeeded()).isFalse();
+        assertThat(result.getFailureMessages()).hasSize(1).contains("Current date/time before issued at (iat) claim in token");
+    }
+
+    @Test
+    void validationOkBecauseIssuedAtInFutureButWithinLeeway() {
+        var rule = new Oauth2ExpirationIssuedAtValidationRule(clock, 20);
+
+        var token = ClaimToken.Builder.newInstance()
+                .claim(EXPIRATION_TIME, Date.from(now.plusSeconds(60)))
+                .claim(ISSUED_AT, Date.from(now.plusSeconds(10)))
+                .build();
+
+        var result = rule.checkRule(token, emptyMap());
+
+        assertThat(result.succeeded()).isTrue();
+    }
+
+    /**
+     * Demonstrates situation where rounded dates in the JWT token cause validation failures
+     * <br>
+     * Rounding of dates in JWT is within spec and the direction of rounding is platform-dependant.
+     */
+    @Test
+    void validationKoWithRoundedIssuedAtAndNoLeeway() {
+        // time skew: tokens have dates rounded up to the second
+        var issuedAt = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+        var expiresAt = issuedAt.plusSeconds(60);
+
+        // time skew: the connector is still in the previous second, with unrounded dates
+        var now = issuedAt.minus(250, ChronoUnit.MILLIS);
+
+        var clock = Clock.fixed(now, UTC);
+        var rule = new Oauth2ExpirationIssuedAtValidationRule(clock, 0);
+
+        var token = ClaimToken.Builder.newInstance()
+                .claim(EXPIRATION_TIME, Date.from(expiresAt))
+                .claim(ISSUED_AT, Date.from(issuedAt))
+                .build();
+
+        var result = rule.checkRule(token, emptyMap());
+
+        assertThat(result.succeeded()).isFalse();
+        assertThat(result.getFailureMessages()).hasSize(1).contains("Current date/time before issued at (iat) claim in token");
+    }
+
+    /**
+     * Regression test against clock skew and platform-dependant rounding of dates, solved with a 2s leeway.
+     * <br>
+     * Rounding of dates in JWT is within spec and the direction of rounding is platform-dependant.
+     */
+    @Test
+    void validationOkWithRoundedIssuedAtAndMinimalLeeway() {
+        // time skew: tokens have dates rounded up to the second
+        var issuedAt = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+        var expiresAt = issuedAt.plusSeconds(60);
+
+        // time skew: the connector is still in the previous second, with unrounded dates
+        var now = issuedAt.minus(250, ChronoUnit.MILLIS);
+
+        var clock = Clock.fixed(now, UTC);
+        var rule = new Oauth2ExpirationIssuedAtValidationRule(clock, 2);
+
+        var token = ClaimToken.Builder.newInstance()
+                .claim(EXPIRATION_TIME, Date.from(expiresAt))
+                .claim(ISSUED_AT, Date.from(issuedAt))
+                .build();
+
+        var result = rule.checkRule(token, emptyMap());
+
+        assertThat(result.succeeded()).isTrue();
     }
 }

--- a/extensions/common/iam/oauth2/oauth2-core/src/test/java/org/eclipse/edc/iam/oauth2/rule/Oauth2ExpirationIssuedAtValidationRuleTest.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/test/java/org/eclipse/edc/iam/oauth2/rule/Oauth2ExpirationIssuedAtValidationRuleTest.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       sovity GmbH - added issuedAt leeway
  *
  */
 


### PR DESCRIPTION
## What this PR changes/adds

As discussed [here](https://github.com/eclipse-edc/Connector/issues/3692#issuecomment-1846767475), added a configurable leeway to the validation of the `issuedAt` claim in `oauth2-core`.

## Why it does that

The validation was added due to the sensitivity to clock skew of the aforementioned `issuedAt` claim.

See the https://github.com/eclipse-edc/Connector/issues/3692 for more detail.

## Further notes

- Added no validation for the `expiresAt` claim as it is less sensitive to clock skew.

## Linked Issue(s)

Closes https://github.com/eclipse-edc/Connector/issues/3692
