### PR TITLE
feat: support consumerPid and providerPid for transfer process messages

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,6 @@ val javaVersion: String by project
 val edcScmUrl: String by project
 val edcScmConnection: String by project
 val annotationProcessorVersion: String by project
-val metaModelVersion: String by project
 
 buildscript {
     dependencies {
@@ -36,14 +35,10 @@ allprojects {
     // configure which version of the annotation processor to use. defaults to the same version as the plugin
     configure<org.eclipse.edc.plugins.autodoc.AutodocExtension> {
         processorVersion.set(annotationProcessorVersion)
-        outputDirectory.set(project.buildDir)
+        outputDirectory.set(project.layout.buildDirectory.asFile)
     }
 
     configure<org.eclipse.edc.plugins.edcbuild.extensions.BuildExtension> {
-        versions {
-            // override default dependency versions here
-            metaModel.set(metaModelVersion)
-        }
         pom {
             scmUrl.set(edcScmUrl)
             scmConnection.set(edcScmConnection)

--- a/core/common/validator-core/src/main/java/org/eclipse/edc/validator/jsonobject/validators/TypeIs.java
+++ b/core/common/validator-core/src/main/java/org/eclipse/edc/validator/jsonobject/validators/TypeIs.java
@@ -28,7 +28,7 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.validator.spi.Violation.violation;
 
 /**
- * Verify that the @value node has a certain value
+ * Verify that the @type node has a certain value
  */
 public class TypeIs implements Validator<JsonObject> {
 

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
@@ -238,7 +238,8 @@ public class ContractNegotiationProtocolServiceImpl extends BaseProtocolService 
 
     private ServiceResult<ContractNegotiation> getNegotiation(String negotiationId) {
         return store.findByIdAndLease(negotiationId)
-                .recover(it -> store.findByCorrelationIdAndLease(negotiationId)) // this is to maintain backward compatibility with the processId
+                // recover needed to maintain backward compatibility when there was no distinction between providerPid and consumerPid
+                .recover(it -> store.findByCorrelationIdAndLease(negotiationId))
                 .flatMap(ServiceResult::from);
     }
 

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImpl.java
@@ -140,7 +140,7 @@ public class TransferProcessProtocolServiceImpl extends BaseProtocolService impl
         var destination = message.getDataDestination() != null ? message.getDataDestination() :
                 DataAddress.Builder.newInstance().type(HTTP_PROXY).build();
         var dataRequest = DataRequest.Builder.newInstance()
-                .id(message.getProcessId())
+                .id(message.getConsumerPid())
                 .protocol(message.getProtocol())
                 .connectorAddress(message.getCallbackAddress())
                 .dataDestination(destination)
@@ -173,6 +173,7 @@ public class TransferProcessProtocolServiceImpl extends BaseProtocolService impl
         if (transferProcess.getType() == CONSUMER && transferProcess.canBeStartedConsumer()) {
             observable.invokeForEach(l -> l.preStarted(transferProcess));
             transferProcess.transitionStarted();
+            transferProcess.setCorrelationId(message.getProviderPid());
             update(transferProcess);
             var transferStartedData = TransferProcessStartedData.Builder.newInstance()
                     .dataAddress(message.getDataAddress())
@@ -212,7 +213,9 @@ public class TransferProcessProtocolServiceImpl extends BaseProtocolService impl
 
     private ServiceResult<TransferProcess> onMessageDo(TransferRemoteMessage message, ClaimToken claimToken, Function<TransferProcess, ServiceResult<TransferProcess>> action) {
         return transactionContext.execute(() -> transferProcessStore
-                .findByCorrelationIdAndLease(message.getProcessId())
+                .findByIdAndLease(message.getProcessId())
+                // recover needed to maintain backward compatibility when there was no distinction between providerPid and consumerPid
+                .recover(it -> transferProcessStore.findByCorrelationIdAndLease(message.getProcessId()))
                 .flatMap(ServiceResult::from)
                 .compose(transferProcess -> validateCounterParty(claimToken, transferProcess)
                         .compose(action)

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImplTest.java
@@ -91,16 +91,16 @@ class TransferProcessProtocolServiceImplTest {
     private final ContractValidationService validationService = mock();
     private final DataAddressValidatorRegistry dataAddressValidator = mock();
     private final TransferProcessListener listener = mock();
-
     private final IdentityService identityService = mock();
+
     private TransferProcessProtocolService service;
 
     @BeforeEach
     void setUp() {
         var observable = new TransferProcessObservableImpl();
         observable.registerListener(listener);
-        service = new TransferProcessProtocolServiceImpl(store, transactionContext, negotiationStore, validationService, identityService,
-                dataAddressValidator, observable, mock(), mock(), mock());
+        service = new TransferProcessProtocolServiceImpl(store, transactionContext, negotiationStore, validationService,
+                identityService, dataAddressValidator, observable, mock(), mock(), mock());
     }
 
     @Test
@@ -108,7 +108,8 @@ class TransferProcessProtocolServiceImplTest {
         var claimToken = claimToken();
         var tokenRepresentation = tokenRepresentation();
         var message = TransferRequestMessage.Builder.newInstance()
-                .processId("transferProcessId")
+                .consumerPid("consumerPid")
+                .processId("consumerPid")
                 .contractId("agreementId")
                 .protocol("protocol")
                 .callbackAddress("http://any")
@@ -123,7 +124,7 @@ class TransferProcessProtocolServiceImplTest {
         var result = service.notifyRequested(message, tokenRepresentation);
 
         assertThat(result).isSucceeded().satisfies(tp -> {
-            assertThat(tp.getCorrelationId()).isEqualTo("transferProcessId");
+            assertThat(tp.getCorrelationId()).isEqualTo("consumerPid");
             assertThat(tp.getConnectorAddress()).isEqualTo("http://any");
             assertThat(tp.getAssetId()).isEqualTo("assetId");
         });
@@ -137,6 +138,7 @@ class TransferProcessProtocolServiceImplTest {
     void notifyRequested_doNothingIfProcessAlreadyExist() {
         var message = TransferRequestMessage.Builder.newInstance()
                 .processId("correlationId")
+                .consumerPid("consumerPid")
                 .contractId("agreementId")
                 .protocol("protocol")
                 .callbackAddress("http://any")
@@ -161,6 +163,7 @@ class TransferProcessProtocolServiceImplTest {
     @Test
     void notifyRequested_invalidAgreement_shouldNotInitiateTransfer() {
         var message = TransferRequestMessage.Builder.newInstance()
+                .consumerPid("consumerPid")
                 .protocol("protocol")
                 .callbackAddress("http://any")
                 .contractId("agreementId")
@@ -186,6 +189,7 @@ class TransferProcessProtocolServiceImplTest {
         var claimToken = claimToken();
         var tokenRepresentation = tokenRepresentation();
         var message = TransferRequestMessage.Builder.newInstance()
+                .consumerPid("consumerPid")
                 .protocol("protocol")
                 .contractId("agreementId")
                 .callbackAddress("http://any")
@@ -194,7 +198,6 @@ class TransferProcessProtocolServiceImplTest {
 
         when(identityService.verifyJwtToken(eq(tokenRepresentation), isA(VerificationContext.class))).thenReturn(Result.success(claimToken));
         when(dataAddressValidator.validateDestination(any())).thenReturn(ValidationResult.failure(violation("invalid data address", "path")));
-
 
         var result = service.notifyRequested(message, tokenRepresentation);
 
@@ -208,7 +211,8 @@ class TransferProcessProtocolServiceImplTest {
         var claimToken = claimToken();
         var tokenRepresentation = tokenRepresentation();
         var message = TransferRequestMessage.Builder.newInstance()
-                .processId("transferProcessId")
+                .consumerPid("consumerPid")
+                .processId("consumerPid")
                 .protocol("protocol")
                 .contractId("agreementId")
                 .callbackAddress("http://any")
@@ -220,11 +224,11 @@ class TransferProcessProtocolServiceImplTest {
 
         var result = service.notifyRequested(message, tokenRepresentation);
 
-        assertThat(result).isSucceeded().satisfies(tokenParams -> {
-            assertThat(tokenParams.getCorrelationId()).isEqualTo("transferProcessId");
-            assertThat(tokenParams.getConnectorAddress()).isEqualTo("http://any");
-            assertThat(tokenParams.getAssetId()).isEqualTo("assetId");
-            assertThat(tokenParams.getDataDestination().getType()).isEqualTo(HTTP_PROXY);
+        assertThat(result).isSucceeded().satisfies(transferProcess -> {
+            assertThat(transferProcess.getCorrelationId()).isEqualTo("consumerPid");
+            assertThat(transferProcess.getConnectorAddress()).isEqualTo("http://any");
+            assertThat(transferProcess.getAssetId()).isEqualTo("assetId");
+            assertThat(transferProcess.getDataDestination().getType()).isEqualTo(HTTP_PROXY);
         });
         verify(listener).preCreated(any());
         verify(store).save(argThat(t -> t.getState() == INITIAL.code()));
@@ -238,6 +242,8 @@ class TransferProcessProtocolServiceImplTest {
         var tokenRepresentation = tokenRepresentation();
         var message = TransferStartMessage.Builder.newInstance()
                 .protocol("protocol")
+                .consumerPid("consumerPid")
+                .providerPid("providerPid")
                 .counterPartyAddress("http://any")
                 .processId("correlationId")
                 .dataAddress(DataAddress.Builder.newInstance().type("test").build())
@@ -245,21 +251,23 @@ class TransferProcessProtocolServiceImplTest {
         var agreement = contractAgreement();
 
         when(identityService.verifyJwtToken(eq(tokenRepresentation), isA(VerificationContext.class))).thenReturn(Result.success(claimToken));
-        when(store.findByCorrelationIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess(REQUESTED, "transferProcessId")));
+        when(store.findByIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess(REQUESTED, "transferProcessId")));
         when(negotiationStore.findContractAgreement(any())).thenReturn(agreement);
         when(validationService.validateRequest(claimToken, agreement)).thenReturn(Result.success());
 
         var result = service.notifyStarted(message, tokenRepresentation);
 
-        var captor = ArgumentCaptor.forClass(TransferProcessStartedData.class);
-
+        var startedDataCaptor = ArgumentCaptor.forClass(TransferProcessStartedData.class);
+        var transferProcessCaptor = ArgumentCaptor.forClass(TransferProcess.class);
         assertThat(result).isSucceeded();
         verify(listener).preStarted(any());
+        verify(store).save(transferProcessCaptor.capture());
         verify(store).save(argThat(t -> t.getState() == STARTED.code()));
-        verify(listener).started(any(), captor.capture());
+        verify(listener).started(any(), startedDataCaptor.capture());
         verify(transactionContext, atLeastOnce()).execute(any(TransactionContext.ResultTransactionBlock.class));
-
-        assertThat(captor.getValue().getDataAddress()).usingRecursiveComparison().isEqualTo(message.getDataAddress());
+        var transferProcess = transferProcessCaptor.getValue();
+        assertThat(transferProcess.getCorrelationId()).isEqualTo(message.getProviderPid());
+        assertThat(startedDataCaptor.getValue().getDataAddress()).usingRecursiveComparison().isEqualTo(message.getDataAddress());
     }
 
     @Test
@@ -269,13 +277,15 @@ class TransferProcessProtocolServiceImplTest {
         var transferProcess = transferProcess(COMPLETED, UUID.randomUUID().toString());
         var message = TransferStartMessage.Builder.newInstance()
                 .protocol("protocol")
+                .consumerPid("consumerPid")
+                .providerPid("providerPid")
                 .counterPartyAddress("http://any")
                 .processId("correlationId")
                 .build();
         var agreement = contractAgreement();
 
         when(identityService.verifyJwtToken(eq(tokenRepresentation), isA(VerificationContext.class))).thenReturn(Result.success(claimToken));
-        when(store.findByCorrelationIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess));
+        when(store.findByIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess));
         when(negotiationStore.findContractAgreement(any())).thenReturn(agreement);
         when(validationService.validateRequest(claimToken, agreement)).thenReturn(Result.success());
 
@@ -293,6 +303,8 @@ class TransferProcessProtocolServiceImplTest {
         var tokenRepresentation = tokenRepresentation();
         var message = TransferStartMessage.Builder.newInstance()
                 .protocol("protocol")
+                .consumerPid("consumerPid")
+                .providerPid("providerPid")
                 .counterPartyAddress("http://any")
                 .processId("correlationId")
                 .dataAddress(DataAddress.Builder.newInstance().type("test").build())
@@ -300,7 +312,7 @@ class TransferProcessProtocolServiceImplTest {
         var agreement = contractAgreement();
 
         when(identityService.verifyJwtToken(eq(tokenRepresentation), isA(VerificationContext.class))).thenReturn(Result.success(claimToken));
-        when(store.findByCorrelationIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess(REQUESTED, "transferProcessId")));
+        when(store.findByIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess(REQUESTED, "transferProcessId")));
         when(negotiationStore.findContractAgreement(any())).thenReturn(agreement);
         when(validationService.validateRequest(claimToken, agreement)).thenReturn(Result.failure("error"));
 
@@ -321,13 +333,15 @@ class TransferProcessProtocolServiceImplTest {
         var tokenRepresentation = tokenRepresentation();
         var message = TransferCompletionMessage.Builder.newInstance()
                 .protocol("protocol")
+                .consumerPid("consumerPid")
+                .providerPid("providerPid")
                 .counterPartyAddress("http://any")
                 .processId("correlationId")
                 .build();
         var agreement = contractAgreement();
 
         when(identityService.verifyJwtToken(eq(tokenRepresentation), isA(VerificationContext.class))).thenReturn(Result.success(claimToken));
-        when(store.findByCorrelationIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess(STARTED, "transferProcessId")));
+        when(store.findByIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess(STARTED, "transferProcessId")));
         when(negotiationStore.findContractAgreement(any())).thenReturn(agreement);
         when(validationService.validateRequest(claimToken, agreement)).thenReturn(Result.success());
 
@@ -347,13 +361,15 @@ class TransferProcessProtocolServiceImplTest {
         var transferProcess = transferProcess(REQUESTED, UUID.randomUUID().toString());
         var message = TransferCompletionMessage.Builder.newInstance()
                 .protocol("protocol")
+                .consumerPid("consumerPid")
+                .providerPid("providerPid")
                 .counterPartyAddress("http://any")
                 .processId("correlationId")
                 .build();
         var agreement = contractAgreement();
 
         when(identityService.verifyJwtToken(eq(tokenRepresentation), isA(VerificationContext.class))).thenReturn(Result.success(claimToken));
-        when(store.findByCorrelationIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess));
+        when(store.findByIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess));
         when(negotiationStore.findContractAgreement(any())).thenReturn(agreement);
         when(validationService.validateRequest(claimToken, agreement)).thenReturn(Result.success());
 
@@ -371,6 +387,8 @@ class TransferProcessProtocolServiceImplTest {
         var tokenRepresentation = tokenRepresentation();
         var message = TransferCompletionMessage.Builder.newInstance()
                 .protocol("protocol")
+                .consumerPid("consumerPid")
+                .providerPid("providerPid")
                 .counterPartyAddress("http://any")
                 .processId("correlationId")
                 .build();
@@ -378,7 +396,7 @@ class TransferProcessProtocolServiceImplTest {
         var agreement = contractAgreement();
 
         when(identityService.verifyJwtToken(eq(tokenRepresentation), isA(VerificationContext.class))).thenReturn(Result.success(claimToken));
-        when(store.findByCorrelationIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess(STARTED, "transferProcessId")));
+        when(store.findByIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess(STARTED, "transferProcessId")));
         when(negotiationStore.findContractAgreement(any())).thenReturn(agreement);
         when(validationService.validateRequest(claimToken, agreement)).thenReturn(Result.failure("error"));
 
@@ -399,6 +417,8 @@ class TransferProcessProtocolServiceImplTest {
         var tokenRepresentation = tokenRepresentation();
         var message = TransferTerminationMessage.Builder.newInstance()
                 .protocol("protocol")
+                .consumerPid("consumerPid")
+                .providerPid("providerPid")
                 .counterPartyAddress("http://any")
                 .processId("correlationId")
                 .code("TestCode")
@@ -407,7 +427,7 @@ class TransferProcessProtocolServiceImplTest {
         var agreement = contractAgreement();
 
         when(identityService.verifyJwtToken(eq(tokenRepresentation), isA(VerificationContext.class))).thenReturn(Result.success(claimToken));
-        when(store.findByCorrelationIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess(STARTED, "transferProcessId")));
+        when(store.findByIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess(STARTED, "transferProcessId")));
         when(negotiationStore.findContractAgreement(any())).thenReturn(agreement);
         when(validationService.validateRequest(claimToken, agreement)).thenReturn(Result.success());
         var result = service.notifyTerminated(message, tokenRepresentation);
@@ -427,6 +447,8 @@ class TransferProcessProtocolServiceImplTest {
         var agreement = contractAgreement();
         var message = TransferTerminationMessage.Builder.newInstance()
                 .protocol("protocol")
+                .consumerPid("consumerPid")
+                .providerPid("providerPid")
                 .counterPartyAddress("http://any")
                 .processId("correlationId")
                 .code("TestCode")
@@ -434,7 +456,7 @@ class TransferProcessProtocolServiceImplTest {
                 .build();
 
         when(identityService.verifyJwtToken(eq(tokenRepresentation), isA(VerificationContext.class))).thenReturn(Result.success(claimToken));
-        when(store.findByCorrelationIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess));
+        when(store.findByIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess));
         when(negotiationStore.findContractAgreement(any())).thenReturn(agreement);
         when(validationService.validateRequest(claimToken, agreement)).thenReturn(Result.success());
 
@@ -454,6 +476,8 @@ class TransferProcessProtocolServiceImplTest {
         var transferProcess = transferProcess(TERMINATED, UUID.randomUUID().toString());
         var message = TransferTerminationMessage.Builder.newInstance()
                 .protocol("protocol")
+                .consumerPid("consumerPid")
+                .providerPid("providerPid")
                 .counterPartyAddress("http://any")
                 .processId("correlationId")
                 .code("TestCode")
@@ -461,7 +485,7 @@ class TransferProcessProtocolServiceImplTest {
                 .build();
 
         when(identityService.verifyJwtToken(eq(tokenRepresentation), isA(VerificationContext.class))).thenReturn(Result.success(claimToken));
-        when(store.findByCorrelationIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess));
+        when(store.findByIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess));
         when(negotiationStore.findContractAgreement(any())).thenReturn(agreement);
         when(validationService.validateRequest(claimToken, agreement)).thenReturn(Result.failure("error"));
 
@@ -540,6 +564,7 @@ class TransferProcessProtocolServiceImplTest {
         var tokenRepresentation = tokenRepresentation();
 
         when(identityService.verifyJwtToken(eq(tokenRepresentation), isA(VerificationContext.class))).thenReturn(Result.success(claimToken));
+        when(store.findByIdAndLease(any())).thenReturn(StoreResult.notFound("not found"));
         when(store.findByCorrelationIdAndLease(any())).thenReturn(StoreResult.notFound("not found"));
 
         var result = methodCall.call(service, message, tokenRepresentation);

--- a/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/type/DspPropertyAndTypeNames.java
+++ b/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/type/DspPropertyAndTypeNames.java
@@ -25,7 +25,6 @@ public interface DspPropertyAndTypeNames {
     String DSPACE_PROPERTY_REASON = DSPACE_SCHEMA + "reason";
     String DSPACE_PROPERTY_CONSUMER_PID = DSPACE_SCHEMA + "consumerPid";
     String DSPACE_PROPERTY_PROVIDER_PID = DSPACE_SCHEMA + "providerPid";
-    @Deprecated(since = "0.4.1")
     String DSPACE_PROPERTY_PROCESS_ID = DSPACE_SCHEMA + "processId";
     String DSPACE_PROPERTY_CALLBACK_ADDRESS = DSPACE_SCHEMA + "callbackAddress";
     String DSPACE_PROPERTY_STATE = DSPACE_SCHEMA + "state";

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/from/JsonObjectFromTransferCompletionMessageTransformer.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/from/JsonObjectFromTransferCompletionMessageTransformer.java
@@ -24,7 +24,9 @@ import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE;
 
 
@@ -39,12 +41,12 @@ public class JsonObjectFromTransferCompletionMessageTransformer extends Abstract
 
     @Override
     public @Nullable JsonObject transform(@NotNull TransferCompletionMessage transferCompletionMessage, @NotNull TransformerContext context) {
-        var builder = jsonBuilderFactory.createObjectBuilder();
-
-        builder.add(ID, transferCompletionMessage.getId());
-        builder.add(TYPE, DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE);
-        builder.add(DSPACE_PROPERTY_PROCESS_ID, transferCompletionMessage.getProcessId());
-
-        return builder.build();
+        return jsonBuilderFactory.createObjectBuilder()
+                .add(ID, transferCompletionMessage.getId())
+                .add(TYPE, DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE)
+                .add(DSPACE_PROPERTY_CONSUMER_PID, transferCompletionMessage.getConsumerPid())
+                .add(DSPACE_PROPERTY_PROVIDER_PID, transferCompletionMessage.getProviderPid())
+                .add(DSPACE_PROPERTY_PROCESS_ID, transferCompletionMessage.getProcessId())
+                .build();
     }
 }

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/from/JsonObjectFromTransferRequestMessageTransformer.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/from/JsonObjectFromTransferRequestMessageTransformer.java
@@ -17,7 +17,6 @@ package org.eclipse.edc.protocol.dsp.transferprocess.transformer.type.from;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.transfer.spi.types.protocol.TransferRequestMessage;
-import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
@@ -25,8 +24,11 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
 
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCT_FORMAT_ATTRIBUTE;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
 import static org.eclipse.edc.protocol.dsp.type.DspTransferProcessPropertyAndTypeNames.DSPACE_PROPERTY_CONTRACT_AGREEMENT_ID;
 import static org.eclipse.edc.protocol.dsp.type.DspTransferProcessPropertyAndTypeNames.DSPACE_PROPERTY_DATA_ADDRESS;
@@ -42,20 +44,19 @@ public class JsonObjectFromTransferRequestMessageTransformer extends AbstractJso
         this.jsonBuilderFactory = jsonBuilderFactory;
     }
 
-
     @Override
     public @Nullable JsonObject transform(@NotNull TransferRequestMessage transferRequestMessage, @NotNull TransformerContext context) {
-        var builder = jsonBuilderFactory.createObjectBuilder();
+        var format = Optional.ofNullable(transferRequestMessage.getTransferType())
+                .orElseGet(() -> transferRequestMessage.getDataDestination().getType());
 
-        builder.add(JsonLdKeywords.ID, transferRequestMessage.getId());
-        builder.add(JsonLdKeywords.TYPE, DSPACE_TYPE_TRANSFER_REQUEST_MESSAGE);
-
-        var transferType = Optional.ofNullable(transferRequestMessage.getTransferType()).orElseGet(() -> transferRequestMessage.getDataDestination().getType());
-
-        builder.add(DSPACE_PROPERTY_CONTRACT_AGREEMENT_ID, transferRequestMessage.getContractId());
-        builder.add(DCT_FORMAT_ATTRIBUTE, transferType);
-        builder.add(DSPACE_PROPERTY_CALLBACK_ADDRESS, transferRequestMessage.getCallbackAddress());
-        builder.add(DSPACE_PROPERTY_PROCESS_ID, transferRequestMessage.getProcessId());
+        var builder = jsonBuilderFactory.createObjectBuilder()
+                .add(ID, transferRequestMessage.getId())
+                .add(TYPE, DSPACE_TYPE_TRANSFER_REQUEST_MESSAGE)
+                .add(DSPACE_PROPERTY_CONTRACT_AGREEMENT_ID, transferRequestMessage.getContractId())
+                .add(DCT_FORMAT_ATTRIBUTE, format)
+                .add(DSPACE_PROPERTY_CALLBACK_ADDRESS, transferRequestMessage.getCallbackAddress())
+                .add(DSPACE_PROPERTY_CONSUMER_PID, transferRequestMessage.getConsumerPid())
+                .add(DSPACE_PROPERTY_PROCESS_ID, transferRequestMessage.getProcessId());
 
         if (transferRequestMessage.getDataDestination() != null && transferRequestMessage.getDataDestination().getProperties().size() > 1) {
             builder.add(DSPACE_PROPERTY_DATA_ADDRESS, context.transform(transferRequestMessage.getDataDestination(), JsonObject.class));

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/from/JsonObjectFromTransferStartMessageTransformer.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/from/JsonObjectFromTransferStartMessageTransformer.java
@@ -24,7 +24,9 @@ import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspTransferProcessPropertyAndTypeNames.DSPACE_PROPERTY_DATA_ADDRESS;
 import static org.eclipse.edc.protocol.dsp.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_START_MESSAGE;
 
@@ -39,11 +41,13 @@ public class JsonObjectFromTransferStartMessageTransformer extends AbstractJsonL
 
     @Override
     public @Nullable JsonObject transform(@NotNull TransferStartMessage transferStartMessage, @NotNull TransformerContext context) {
-        var builder = jsonBuilderFactory.createObjectBuilder();
+        var builder = jsonBuilderFactory.createObjectBuilder()
+                .add(ID, transferStartMessage.getId())
+                .add(TYPE, DSPACE_TYPE_TRANSFER_START_MESSAGE)
+                .add(DSPACE_PROPERTY_PROVIDER_PID, transferStartMessage.getProviderPid())
+                .add(DSPACE_PROPERTY_CONSUMER_PID, transferStartMessage.getConsumerPid())
+                .add(DSPACE_PROPERTY_PROCESS_ID, transferStartMessage.getProcessId());
 
-        builder.add(ID, transferStartMessage.getId());
-        builder.add(TYPE, DSPACE_TYPE_TRANSFER_START_MESSAGE);
-        builder.add(DSPACE_PROPERTY_PROCESS_ID, transferStartMessage.getProcessId());
         if (transferStartMessage.getDataAddress() != null) {
             builder.add(DSPACE_PROPERTY_DATA_ADDRESS, context.transform(transferStartMessage.getDataAddress(), JsonObject.class));
         }

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/from/JsonObjectFromTransferTerminationMessageTransformer.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/from/JsonObjectFromTransferTerminationMessageTransformer.java
@@ -25,7 +25,9 @@ import org.jetbrains.annotations.Nullable;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CODE;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_REASON;
 import static org.eclipse.edc.protocol.dsp.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_TERMINATION_MESSAGE;
 
@@ -40,17 +42,15 @@ public class JsonObjectFromTransferTerminationMessageTransformer extends Abstrac
 
     @Override
     public @Nullable JsonObject transform(@NotNull TransferTerminationMessage transferTerminationMessage, @NotNull TransformerContext context) {
-        var builder = jsonBuilderFactory.createObjectBuilder();
+        var builder = jsonBuilderFactory.createObjectBuilder()
+                .add(ID, transferTerminationMessage.getId())
+                .add(TYPE, DSPACE_TYPE_TRANSFER_TERMINATION_MESSAGE)
+                .add(DSPACE_PROPERTY_CONSUMER_PID, transferTerminationMessage.getConsumerPid())
+                .add(DSPACE_PROPERTY_PROVIDER_PID, transferTerminationMessage.getProviderPid())
+                .add(DSPACE_PROPERTY_PROCESS_ID, transferTerminationMessage.getProcessId());
 
-        builder.add(ID, transferTerminationMessage.getId());
-        builder.add(TYPE, DSPACE_TYPE_TRANSFER_TERMINATION_MESSAGE);
-        builder.add(DSPACE_PROPERTY_PROCESS_ID, transferTerminationMessage.getProcessId());
-        if (transferTerminationMessage.getCode() != null) {
-            builder.add(DSPACE_PROPERTY_CODE, transferTerminationMessage.getCode());
-        }
-        if (transferTerminationMessage.getReason() != null) {
-            builder.add(DSPACE_PROPERTY_REASON, transferTerminationMessage.getReason());
-        }
+        addIfNotNull(transferTerminationMessage.getCode(), DSPACE_PROPERTY_CODE, builder);
+        addIfNotNull(transferTerminationMessage.getReason(), DSPACE_PROPERTY_REASON, builder);
 
         return builder.build();
 

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/to/JsonObjectToTransferCompletionMessageTransformer.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/to/JsonObjectToTransferCompletionMessageTransformer.java
@@ -21,7 +21,9 @@ import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE;
 
 public class JsonObjectToTransferCompletionMessageTransformer extends AbstractJsonLdTransformer<JsonObject, TransferCompletionMessage> {
@@ -32,18 +34,37 @@ public class JsonObjectToTransferCompletionMessageTransformer extends AbstractJs
 
     @Override
     public @Nullable TransferCompletionMessage transform(@NotNull JsonObject messageObject, @NotNull TransformerContext context) {
-        var transferCompletionMessageBuilder = TransferCompletionMessage.Builder.newInstance();
+        var builder = TransferCompletionMessage.Builder.newInstance();
 
-        if (!transformMandatoryString(messageObject.get(DSPACE_PROPERTY_PROCESS_ID), transferCompletionMessageBuilder::processId, context)) {
-            context.problem()
-                    .missingProperty()
-                    .type(DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE)
-                    .property(DSPACE_PROPERTY_PROCESS_ID)
-                    .report();
-            return null;
+        var processId = transformString(messageObject.get(DSPACE_PROPERTY_PROCESS_ID), context);
+
+        if (!transformMandatoryString(messageObject.get(DSPACE_PROPERTY_CONSUMER_PID), builder::consumerPid, context)) {
+            if (processId == null) {
+                context.problem()
+                        .missingProperty()
+                        .type(DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE)
+                        .property(DSPACE_PROPERTY_CONSUMER_PID)
+                        .report();
+                return null;
+            } else {
+                builder.consumerPid(processId);
+            }
         }
 
-        return transferCompletionMessageBuilder.build();
+        if (!transformMandatoryString(messageObject.get(DSPACE_PROPERTY_PROVIDER_PID), builder::providerPid, context)) {
+            if (processId == null) {
+                context.problem()
+                        .missingProperty()
+                        .type(DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE)
+                        .property(DSPACE_PROPERTY_PROVIDER_PID)
+                        .report();
+                return null;
+            } else {
+                builder.providerPid(processId);
+            }
+        }
+
+        return builder.build();
 
     }
 }

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/to/JsonObjectToTransferTerminationMessageTransformer.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/type/to/JsonObjectToTransferTerminationMessageTransformer.java
@@ -24,8 +24,11 @@ import org.jetbrains.annotations.Nullable;
 
 import static jakarta.json.JsonValue.ValueType.ARRAY;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CODE;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_REASON;
+import static org.eclipse.edc.protocol.dsp.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_START_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_TERMINATION_MESSAGE;
 
 public class JsonObjectToTransferTerminationMessageTransformer extends AbstractJsonLdTransformer<JsonObject, TransferTerminationMessage> {
@@ -36,14 +39,38 @@ public class JsonObjectToTransferTerminationMessageTransformer extends AbstractJ
 
     @Override
     public @Nullable TransferTerminationMessage transform(@NotNull JsonObject messageObject, @NotNull TransformerContext context) {
-        var transferTerminationMessageBuilder = TransferTerminationMessage.Builder.newInstance();
+        var builder = TransferTerminationMessage.Builder.newInstance();
 
-        if (!transformMandatoryString(messageObject.get(DSPACE_PROPERTY_PROCESS_ID), transferTerminationMessageBuilder::processId, context)) {
-            return null;
+        var processId = transformString(messageObject.get(DSPACE_PROPERTY_PROCESS_ID), context);
+
+        if (!transformMandatoryString(messageObject.get(DSPACE_PROPERTY_CONSUMER_PID), builder::consumerPid, context)) {
+            if (processId == null) {
+                context.problem()
+                        .missingProperty()
+                        .type(DSPACE_TYPE_TRANSFER_START_MESSAGE)
+                        .property(DSPACE_PROPERTY_CONSUMER_PID)
+                        .report();
+                return null;
+            } else {
+                builder.consumerPid(processId);
+            }
+        }
+
+        if (!transformMandatoryString(messageObject.get(DSPACE_PROPERTY_PROVIDER_PID), builder::providerPid, context)) {
+            if (processId == null) {
+                context.problem()
+                        .missingProperty()
+                        .type(DSPACE_TYPE_TRANSFER_START_MESSAGE)
+                        .property(DSPACE_PROPERTY_PROVIDER_PID)
+                        .report();
+                return null;
+            } else {
+                builder.providerPid(processId);
+            }
         }
 
         if (messageObject.containsKey(DSPACE_PROPERTY_CODE)) {
-            transformString(messageObject.get(DSPACE_PROPERTY_CODE), transferTerminationMessageBuilder::code, context);
+            transformString(messageObject.get(DSPACE_PROPERTY_CODE), builder::code, context);
         }
 
         var reasons = messageObject.get(DSPACE_PROPERTY_REASON);
@@ -59,12 +86,12 @@ public class JsonObjectToTransferTerminationMessageTransformer extends AbstractJ
             } else {
                 var array = (JsonArray) reasons;
                 if (array.size() > 0) {
-                    transferTerminationMessageBuilder.reason(array.toString());
+                    builder.reason(array.toString());
                 }
             }
         }
 
-        return transferTerminationMessageBuilder.build();
+        return builder.build();
 
     }
 }

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/from/JsonObjectFromTransferCompletionMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/from/JsonObjectFromTransferCompletionMessageTransformerTest.java
@@ -20,13 +20,14 @@ import org.eclipse.edc.connector.transfer.spi.types.protocol.TransferCompletionM
 import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
 import org.eclipse.edc.protocol.dsp.transferprocess.transformer.type.from.JsonObjectFromTransferCompletionMessageTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -37,27 +38,27 @@ import static org.mockito.Mockito.verify;
 class JsonObjectFromTransferCompletionMessageTransformerTest {
 
     private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
-    private final TransformerContext context = mock(TransformerContext.class);
+    private final TransformerContext context = mock();
 
-    private JsonObjectFromTransferCompletionMessageTransformer transformer;
-
-    @BeforeEach
-    void setUp() {
-        transformer = new JsonObjectFromTransferCompletionMessageTransformer(jsonFactory);
-    }
+    private final JsonObjectFromTransferCompletionMessageTransformer transformer =
+            new JsonObjectFromTransferCompletionMessageTransformer(jsonFactory);
 
     @Test
     void transformTransferCompletionMessage() {
         var message = TransferCompletionMessage.Builder.newInstance()
-                .processId("TestID")
+                .processId("processId")
+                .consumerPid("consumerPid")
+                .providerPid("providerPid")
                 .protocol("dsp")
                 .build();
 
         var result = transformer.transform(message, context);
 
         assertThat(result).isNotNull();
-        assertThat(result.getJsonString(JsonLdKeywords.TYPE).getString()).isEqualTo(DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE);
-        assertThat(result.getJsonString(DSPACE_PROPERTY_PROCESS_ID).getString()).isEqualTo("TestID");
+        assertThat(result.getString(JsonLdKeywords.TYPE)).isEqualTo(DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE);
+        assertThat(result.getString(DSPACE_PROPERTY_CONSUMER_PID)).isEqualTo("consumerPid");
+        assertThat(result.getString(DSPACE_PROPERTY_PROVIDER_PID)).isEqualTo("providerPid");
+        assertThat(result.getString(DSPACE_PROPERTY_PROCESS_ID)).isEqualTo("processId");
 
         verify(context, never()).reportProblem(anyString());
     }

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/from/JsonObjectFromTransferRequestMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/from/JsonObjectFromTransferRequestMessageTransformerTest.java
@@ -22,7 +22,6 @@ import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
 import org.eclipse.edc.protocol.dsp.transferprocess.transformer.type.from.JsonObjectFromTransferRequestMessageTransformer;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.transform.spi.TransformerContext;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,6 +30,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCT_FORMAT_ATTRIBUTE;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
 import static org.eclipse.edc.protocol.dsp.type.DspTransferProcessPropertyAndTypeNames.DSPACE_PROPERTY_CONTRACT_AGREEMENT_ID;
 import static org.eclipse.edc.protocol.dsp.type.DspTransferProcessPropertyAndTypeNames.DSPACE_PROPERTY_DATA_ADDRESS;
@@ -47,21 +47,16 @@ import static org.mockito.Mockito.when;
 class JsonObjectFromTransferRequestMessageTransformerTest {
 
     private final String dataAddressKey = "testDataAddressKey";
-
     private final String dataAddressType = "testDataAddressType";
-
     private final String protocol = "testProtocol";
-
     private final String contractId = "testContractId";
-
     private final String callbackAddress = "http://testcallback";
 
-    private final String id = "testId";
-
     private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
-    private final TransformerContext context = mock(TransformerContext.class);
+    private final TransformerContext context = mock();
 
-    private JsonObjectFromTransferRequestMessageTransformer transformer;
+    private final JsonObjectFromTransferRequestMessageTransformer transformer =
+            new JsonObjectFromTransferRequestMessageTransformer(jsonFactory);
 
     @BeforeEach
     void setUp() {
@@ -70,16 +65,14 @@ class JsonObjectFromTransferRequestMessageTransformerTest {
                 .add("type", dataAddressType)
                 .build();
 
-        transformer = new JsonObjectFromTransferRequestMessageTransformer(jsonFactory);
-
         when(context.transform(isA(DataAddress.class), eq(JsonObject.class))).thenReturn(dataAddressJson);
     }
-
 
     @Test
     void transformTransferRequestMessageWithDataAddress() {
         var message = TransferRequestMessage.Builder.newInstance()
-                .processId(id)
+                .processId("processId")
+                .consumerPid("consumerPid")
                 .callbackAddress(callbackAddress)
                 .contractId(contractId)
                 .protocol(protocol)
@@ -88,12 +81,13 @@ class JsonObjectFromTransferRequestMessageTransformerTest {
 
         var result = transformer.transform(message, context);
 
-        Assertions.assertNotNull(result);
+        assertThat(result).isNotNull();
         assertThat(result.getJsonString(JsonLdKeywords.TYPE).getString()).isEqualTo(DSPACE_TYPE_TRANSFER_REQUEST_MESSAGE);
         assertThat(result.getJsonString(DSPACE_PROPERTY_CONTRACT_AGREEMENT_ID).getString()).isEqualTo(contractId);
         assertThat(result.getJsonString(DCT_FORMAT_ATTRIBUTE).getString()).isEqualTo(dataAddressType);
         assertThat(result.getJsonString(DSPACE_PROPERTY_CALLBACK_ADDRESS).getString()).isEqualTo(callbackAddress);
-        assertThat(result.getJsonString(DSPACE_PROPERTY_PROCESS_ID).getString()).isEqualTo(id);
+        assertThat(result.getJsonString(DSPACE_PROPERTY_PROCESS_ID).getString()).isEqualTo("processId");
+        assertThat(result.getJsonString(DSPACE_PROPERTY_CONSUMER_PID).getString()).isEqualTo("consumerPid");
         assertThat(result.getJsonObject(DSPACE_PROPERTY_DATA_ADDRESS).getString("keyName")).isEqualTo(dataAddressKey);
 
         verify(context, never()).reportProblem(anyString());
@@ -102,7 +96,8 @@ class JsonObjectFromTransferRequestMessageTransformerTest {
     @Test
     void transformTransferRequestMessageWithoutDataAddress() {
         var message = TransferRequestMessage.Builder.newInstance()
-                .processId(id)
+                .processId("processId")
+                .consumerPid("consumerPid")
                 .callbackAddress(callbackAddress)
                 .contractId(contractId)
                 .protocol(protocol)
@@ -116,7 +111,6 @@ class JsonObjectFromTransferRequestMessageTransformerTest {
         assertThat(result.getJsonString(DSPACE_PROPERTY_CONTRACT_AGREEMENT_ID).getString()).isEqualTo(contractId);
         assertThat(result.getJsonString(DCT_FORMAT_ATTRIBUTE).getString()).isEqualTo(dataAddressType);
         assertThat(result.getJsonString(DSPACE_PROPERTY_CALLBACK_ADDRESS).getString()).isEqualTo(callbackAddress);
-        assertThat(result.getJsonString(DSPACE_PROPERTY_PROCESS_ID).getString()).isEqualTo(id);
         assertThat(result.getJsonObject(DSPACE_PROPERTY_DATA_ADDRESS)).isEqualTo(null);
 
         verify(context, never()).reportProblem(anyString());
@@ -126,7 +120,8 @@ class JsonObjectFromTransferRequestMessageTransformerTest {
     void transformTransferRequestMessageWithTransferType() {
         var transferType = "Http-Pull";
         var message = TransferRequestMessage.Builder.newInstance()
-                .processId(id)
+                .processId("processId")
+                .consumerPid("consumerPid")
                 .callbackAddress(callbackAddress)
                 .contractId(contractId)
                 .protocol(protocol)
@@ -140,7 +135,6 @@ class JsonObjectFromTransferRequestMessageTransformerTest {
         assertThat(result.getJsonString(DSPACE_PROPERTY_CONTRACT_AGREEMENT_ID).getString()).isEqualTo(contractId);
         assertThat(result.getJsonString(DCT_FORMAT_ATTRIBUTE).getString()).isEqualTo(transferType);
         assertThat(result.getJsonString(DSPACE_PROPERTY_CALLBACK_ADDRESS).getString()).isEqualTo(callbackAddress);
-        assertThat(result.getJsonString(DSPACE_PROPERTY_PROCESS_ID).getString()).isEqualTo(id);
         assertThat(result.getJsonObject(DSPACE_PROPERTY_DATA_ADDRESS)).isEqualTo(null);
 
         verify(context, never()).reportProblem(anyString());

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/from/JsonObjectFromTransferStartMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/from/JsonObjectFromTransferStartMessageTransformerTest.java
@@ -22,13 +22,14 @@ import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
 import org.eclipse.edc.protocol.dsp.transferprocess.transformer.type.from.JsonObjectFromTransferStartMessageTransformer;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.transform.spi.TransformerContext;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspTransferProcessPropertyAndTypeNames.DSPACE_PROPERTY_DATA_ADDRESS;
 import static org.eclipse.edc.protocol.dsp.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_START_MESSAGE;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -40,26 +41,20 @@ import static org.mockito.Mockito.when;
 
 class JsonObjectFromTransferStartMessageTransformerTest {
 
-    private final String processId = "testId";
-
-    private final String protocol = "testProtocol";
-
     private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
-    private final TransformerContext context = mock(TransformerContext.class);
+    private final TransformerContext context = mock();
 
-    private JsonObjectFromTransferStartMessageTransformer transformer;
-
-    @BeforeEach
-    void setUp() {
-        transformer = new JsonObjectFromTransferStartMessageTransformer(jsonFactory);
-    }
+    private final JsonObjectFromTransferStartMessageTransformer transformer =
+            new JsonObjectFromTransferStartMessageTransformer(jsonFactory);
 
     @Test
     void transformTransferStartMessage() {
         var dataAddress = DataAddress.Builder.newInstance().type("type").build();
         var message = TransferStartMessage.Builder.newInstance()
-                .processId(processId)
-                .protocol(protocol)
+                .processId("processId")
+                .consumerPid("consumerPid")
+                .providerPid("providerPid")
+                .protocol("testProtocol")
                 .dataAddress(dataAddress)
                 .build();
 
@@ -69,8 +64,10 @@ class JsonObjectFromTransferStartMessageTransformerTest {
         var result = transformer.transform(message, context);
 
         assertThat(result).isNotNull();
-        assertThat(result.getJsonString(JsonLdKeywords.TYPE).getString()).isEqualTo(DSPACE_TYPE_TRANSFER_START_MESSAGE);
-        assertThat(result.getJsonString(DSPACE_PROPERTY_PROCESS_ID).getString()).isEqualTo(processId);
+        assertThat(result.getString(JsonLdKeywords.TYPE)).isEqualTo(DSPACE_TYPE_TRANSFER_START_MESSAGE);
+        assertThat(result.getString(DSPACE_PROPERTY_PROCESS_ID)).isEqualTo("processId");
+        assertThat(result.getString(DSPACE_PROPERTY_PROVIDER_PID)).isEqualTo("providerPid");
+        assertThat(result.getString(DSPACE_PROPERTY_CONSUMER_PID)).isEqualTo("consumerPid");
         assertThat(result.getJsonObject(DSPACE_PROPERTY_DATA_ADDRESS)).isEqualTo(dataAddressJson);
 
         verify(context, times(1)).transform(dataAddress, JsonObject.class);

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/from/JsonObjectFromTransferTerminationMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/from/JsonObjectFromTransferTerminationMessageTransformerTest.java
@@ -20,14 +20,15 @@ import org.eclipse.edc.connector.transfer.spi.types.protocol.TransferTermination
 import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
 import org.eclipse.edc.protocol.dsp.transferprocess.transformer.type.from.JsonObjectFromTransferTerminationMessageTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CODE;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_REASON;
 import static org.eclipse.edc.protocol.dsp.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_TERMINATION_MESSAGE;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -39,19 +40,17 @@ import static org.mockito.Mockito.verify;
 class JsonObjectFromTransferTerminationMessageTransformerTest {
 
     private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
-    private final TransformerContext context = mock(TransformerContext.class);
+    private final TransformerContext context = mock();
 
-    private JsonObjectFromTransferTerminationMessageTransformer transformer;
-
-    @BeforeEach
-    void setUp() {
-        transformer = new JsonObjectFromTransferTerminationMessageTransformer(jsonFactory);
-    }
+    private final JsonObjectFromTransferTerminationMessageTransformer transformer =
+            new JsonObjectFromTransferTerminationMessageTransformer(jsonFactory);
 
     @Test
     void transformTransferTerminationMessage() {
         var message = TransferTerminationMessage.Builder.newInstance()
-                .processId("TestID")
+                .processId("processId")
+                .consumerPid("consumerPid")
+                .providerPid("providerPid")
                 .protocol("dsp")
                 .code("testCode")
                 .reason("testReason")
@@ -61,7 +60,9 @@ class JsonObjectFromTransferTerminationMessageTransformerTest {
 
         assertThat(result).isNotNull();
         assertThat(result.getJsonString(JsonLdKeywords.TYPE).getString()).isEqualTo(DSPACE_TYPE_TRANSFER_TERMINATION_MESSAGE);
-        assertThat(result.getJsonString(DSPACE_PROPERTY_PROCESS_ID).getString()).isEqualTo("TestID");
+        assertThat(result.getJsonString(DSPACE_PROPERTY_CONSUMER_PID).getString()).isEqualTo("consumerPid");
+        assertThat(result.getJsonString(DSPACE_PROPERTY_PROVIDER_PID).getString()).isEqualTo("providerPid");
+        assertThat(result.getJsonString(DSPACE_PROPERTY_PROCESS_ID).getString()).isEqualTo("processId");
         assertThat(result.getJsonString(DSPACE_PROPERTY_CODE).getString()).isEqualTo("testCode");
         assertThat(result.getJsonString(DSPACE_PROPERTY_REASON).getString()).isEqualTo("testReason");
 

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/to/JsonObjectToTransferCompletionMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/to/JsonObjectToTransferCompletionMessageTransformerTest.java
@@ -16,46 +16,74 @@ package org.eclipse.edc.protocol.dsp.transferprocess.transformer.to;
 
 import jakarta.json.Json;
 import org.eclipse.edc.protocol.dsp.transferprocess.transformer.type.to.JsonObjectToTransferCompletionMessageTransformer;
+import org.eclipse.edc.transform.spi.ProblemBuilder;
 import org.eclipse.edc.transform.spi.TransformerContext;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.to.TestInput.getExpanded;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class JsonObjectToTransferCompletionMessageTransformerTest {
 
-    private final String processId = "TestProcessId";
+    private final TransformerContext context = mock();
 
-    private TransformerContext context = mock(TransformerContext.class);
-
-    private JsonObjectToTransferCompletionMessageTransformer transformer;
-
-    @BeforeEach
-    void setUp() {
-        transformer = new JsonObjectToTransferCompletionMessageTransformer();
-    }
+    private final JsonObjectToTransferCompletionMessageTransformer transformer =
+            new JsonObjectToTransferCompletionMessageTransformer();
 
     @Test
-    void jsonObjectToTransferCompletionMessage() {
-
+    void shouldTransform() {
         var json = Json.createObjectBuilder()
                 .add(TYPE, DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE)
-                .add(DSPACE_PROPERTY_PROCESS_ID, processId)
+                .add(DSPACE_PROPERTY_PROVIDER_PID, "providerPid")
+                .add(DSPACE_PROPERTY_CONSUMER_PID, "consumerPid")
                 .build();
 
         var result = transformer.transform(getExpanded(json), context);
 
         assertThat(result).isNotNull();
+        assertThat(result.getProviderPid()).isEqualTo("providerPid");
+        assertThat(result.getConsumerPid()).isEqualTo("consumerPid");
 
-        assertThat(result.getProcessId()).isEqualTo(processId);
+        verify(context, never()).reportProblem(anyString());
+    }
+
+    @Test
+    void shouldReportError_whenConsumerPidAndProviderPidNotSet() {
+        when(context.problem()).thenReturn(new ProblemBuilder(context));
+        var json = Json.createObjectBuilder()
+                .add(TYPE, DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE)
+                .build();
+
+        var result = transformer.transform(getExpanded(json), context);
+
+        assertThat(result).isNull();
+
+        verify(context).reportProblem(anyString());
+    }
+
+    @Deprecated(since = "0.4.1")
+    @Test
+    void shouldSetProcessIdAsConsumerAndProviderPid_whenProcessIdIsSet() {
+        var json = Json.createObjectBuilder()
+                .add(TYPE, DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE)
+                .add(DSPACE_PROPERTY_PROCESS_ID, "TestProcessId")
+                .build();
+
+        var result = transformer.transform(getExpanded(json), context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getConsumerPid()).isEqualTo("TestProcessId");
+        assertThat(result.getProviderPid()).isEqualTo("TestProcessId");
 
         verify(context, never()).reportProblem(anyString());
     }

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/to/JsonObjectToTransferRequestMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transformer/to/JsonObjectToTransferRequestMessageTransformerTest.java
@@ -17,8 +17,8 @@ package org.eclipse.edc.protocol.dsp.transferprocess.transformer.to;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.protocol.dsp.transferprocess.transformer.type.to.JsonObjectToTransferRequestMessageTransformer;
+import org.eclipse.edc.transform.spi.ProblemBuilder;
 import org.eclipse.edc.transform.spi.TransformerContext;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,6 +26,7 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCT_FORMAT_ATTRIBUTE;
 import static org.eclipse.edc.protocol.dsp.transferprocess.transformer.to.TestInput.getExpanded;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROCESS_ID;
 import static org.eclipse.edc.protocol.dsp.type.DspTransferProcessPropertyAndTypeNames.DSPACE_PROPERTY_CONTRACT_AGREEMENT_ID;
 import static org.eclipse.edc.protocol.dsp.type.DspTransferProcessPropertyAndTypeNames.DSPACE_PROPERTY_DATA_ADDRESS;
@@ -35,6 +36,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class JsonObjectToTransferRequestMessageTransformerTest {
 
@@ -42,17 +44,76 @@ class JsonObjectToTransferRequestMessageTransformerTest {
     private final String contractId = "TestContreactID";
     private final String destinationType = "dspace:s3+push";
 
-    private final TransformerContext context = mock(TransformerContext.class);
+    private final TransformerContext context = mock();
 
-    private JsonObjectToTransferRequestMessageTransformer transformer;
-
-    @BeforeEach
-    void setUp() {
-        transformer = new JsonObjectToTransferRequestMessageTransformer();
-    }
+    private final JsonObjectToTransferRequestMessageTransformer transformer =
+            new JsonObjectToTransferRequestMessageTransformer();
 
     @Test
     void jsonObjectToTransferRequestWithoutDataAddress() {
+        var json = Json.createObjectBuilder()
+                .add(TYPE, DSPACE_TYPE_TRANSFER_REQUEST_MESSAGE)
+                .add(DSPACE_PROPERTY_CONTRACT_AGREEMENT_ID, contractId)
+                .add(DCT_FORMAT_ATTRIBUTE, destinationType)
+                .add(DSPACE_PROPERTY_DATA_ADDRESS, Json.createObjectBuilder().build())
+                .add(DSPACE_PROPERTY_CALLBACK_ADDRESS, callbackAddress)
+                .add(DSPACE_PROPERTY_CONSUMER_PID, "processId")
+                .build();
+
+        var result = transformer.transform(getExpanded(json), context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getContractId()).isEqualTo(contractId);
+        assertThat(result.getDataDestination().getType()).isEqualTo(destinationType);
+        assertThat(result.getCallbackAddress()).isEqualTo(callbackAddress);
+        assertThat(result.getConsumerPid()).isEqualTo("processId");
+
+        verify(context, never()).reportProblem(anyString());
+    }
+
+    @Test
+    void jsonObjectToTransferRequestWithDataAddress() {
+        var json = Json.createObjectBuilder()
+                .add(TYPE, DSPACE_TYPE_TRANSFER_REQUEST_MESSAGE)
+                .add(DSPACE_PROPERTY_CONTRACT_AGREEMENT_ID, contractId)
+                .add(DCT_FORMAT_ATTRIBUTE, destinationType)
+                .add(DSPACE_PROPERTY_DATA_ADDRESS, createDataAddress())
+                .add(DSPACE_PROPERTY_CALLBACK_ADDRESS, callbackAddress)
+                .add(DSPACE_PROPERTY_CONSUMER_PID, "processId")
+                .build();
+
+        var result = transformer.transform(getExpanded(json), context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getContractId()).isEqualTo(contractId);
+        assertThat(result.getDataDestination().getType()).isEqualTo(destinationType);
+        assertThat(result.getCallbackAddress()).isEqualTo(callbackAddress);
+        assertThat(result.getDataDestination().getStringProperty("accessKeyId")).isEqualTo("TESTID");
+        assertThat(result.getDataDestination().getStringProperty("region")).isEqualTo("eu-central-1");
+
+        verify(context, never()).reportProblem(anyString());
+    }
+
+    @Test
+    void shouldReturnNullAndReportError_whenConsumerPidNotSet() {
+        when(context.problem()).thenReturn(new ProblemBuilder(context));
+        var json = Json.createObjectBuilder()
+                .add(TYPE, DSPACE_TYPE_TRANSFER_REQUEST_MESSAGE)
+                .add(DSPACE_PROPERTY_CONTRACT_AGREEMENT_ID, contractId)
+                .add(DCT_FORMAT_ATTRIBUTE, destinationType)
+                .add(DSPACE_PROPERTY_DATA_ADDRESS, Json.createObjectBuilder().build())
+                .add(DSPACE_PROPERTY_CALLBACK_ADDRESS, callbackAddress)
+                .build();
+
+        var result = transformer.transform(getExpanded(json), context);
+
+        assertThat(result).isNull();
+        verify(context).reportProblem(anyString());
+    }
+
+    @Deprecated(since = "0.4.1")
+    @Test
+    void shouldGetConsumerPidFromProcessId_whenFormerIsNotSet() {
         var json = Json.createObjectBuilder()
                 .add(TYPE, DSPACE_TYPE_TRANSFER_REQUEST_MESSAGE)
                 .add(DSPACE_PROPERTY_CONTRACT_AGREEMENT_ID, contractId)
@@ -68,30 +129,7 @@ class JsonObjectToTransferRequestMessageTransformerTest {
         assertThat(result.getContractId()).isEqualTo(contractId);
         assertThat(result.getDataDestination().getType()).isEqualTo(destinationType);
         assertThat(result.getCallbackAddress()).isEqualTo(callbackAddress);
-        assertThat(result.getProcessId()).isEqualTo("processId");
-
-        verify(context, never()).reportProblem(anyString());
-    }
-
-    @Test
-    void jsonObjectToTransferRequestWithDataAddress() {
-        var json = Json.createObjectBuilder()
-                .add(TYPE, DSPACE_TYPE_TRANSFER_REQUEST_MESSAGE)
-                .add(DSPACE_PROPERTY_CONTRACT_AGREEMENT_ID, contractId)
-                .add(DCT_FORMAT_ATTRIBUTE, destinationType)
-                .add(DSPACE_PROPERTY_DATA_ADDRESS, createDataAddress())
-                .add(DSPACE_PROPERTY_CALLBACK_ADDRESS, callbackAddress)
-                .add(DSPACE_PROPERTY_PROCESS_ID, "processId")
-                .build();
-
-        var result = transformer.transform(getExpanded(json), context);
-
-        assertThat(result).isNotNull();
-        assertThat(result.getContractId()).isEqualTo(contractId);
-        assertThat(result.getDataDestination().getType()).isEqualTo(destinationType);
-        assertThat(result.getCallbackAddress()).isEqualTo(callbackAddress);
-        assertThat(result.getDataDestination().getStringProperty("accessKeyId")).isEqualTo("TESTID");
-        assertThat(result.getDataDestination().getStringProperty("region")).isEqualTo("eu-central-1");
+        assertThat(result.getConsumerPid()).isEqualTo("processId");
 
         verify(context, never()).reportProblem(anyString());
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,7 @@
 group=org.eclipse.edc
 version=0.4.2-SNAPSHOT
-# for now, we're using the same version for the autodoc plugin, the processor and the runtime-metamodel lib, but that could
-# change in the future
+# for now, we're using the same version for the autodoc plugin and the processor, but that could change in the future
 annotationProcessorVersion=0.4.2-SNAPSHOT
 edcGradlePluginsVersion=0.4.2-SNAPSHOT
-metaModelVersion=0.4.2-SNAPSHOT
 edcScmUrl=https://github.com/eclipse-edc/Connector.git
 edcScmConnection=scm:git:git@github.com:eclipse-edc/Connector.git

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/message/ProcessRemoteMessage.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/message/ProcessRemoteMessage.java
@@ -14,27 +14,143 @@
 
 package org.eclipse.edc.spi.types.domain.message;
 
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.result.Result;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+import static java.util.UUID.randomUUID;
 
 /**
  * A remote message that conveys state modifications of a process. These messages are idempotent.
+ * <p>
+ * The {@link #processId} represent the ID of the process on the recipient part.
  */
-public interface ProcessRemoteMessage extends RemoteMessage {
+public abstract class ProcessRemoteMessage implements RemoteMessage {
+
+    protected String id;
+    protected String processId;
+    protected String consumerPid;
+    protected String providerPid;
+    protected String protocol = "unknown";
+    protected String counterPartyAddress;
+
+    /**
+     * Returns the {@link Policy} associated with the process.
+     *
+     * @return the process {@link Policy}.
+     */
+    public abstract Policy getPolicy();
 
     /**
      * Returns the unique message id.
      *
      * @return the id;
      */
-    @NotNull
-    String getId();
+    public @NotNull String getId() {
+        return id;
+    }
+
+    @Override
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        Objects.requireNonNull(protocol);
+        this.protocol = protocol;
+    }
 
     /**
      * Returns the process id for this instance, that could be consumerPid or providerPid.
      *
      * @return the processId.
      */
-    String getProcessId();
+    public String getProcessId() {
+        return processId;
+    }
 
-    void setProtocol(String protocol);
+    public void setProcessId(String processId) {
+        Objects.requireNonNull(processId);
+        this.processId = processId;
+    }
+
+    public String getConsumerPid() {
+        return consumerPid;
+    }
+
+    public String getProviderPid() {
+        return providerPid;
+    }
+
+    @Override
+    public String getCounterPartyAddress() {
+        return counterPartyAddress;
+    }
+
+    /**
+     * Verifies if the passed processId can be considered a valid one.
+     *
+     * @param processId the processId.
+     * @return success if it is valid, failure otherwise.
+     */
+    public Result<Void> isValidProcessId(String processId) {
+        if (processId.equals(consumerPid) || processId.equals(providerPid)) {
+            return Result.success();
+        } else {
+            return Result.failure("Expected processId to be one of [%s, %s] but it was %s".formatted(consumerPid, providerPid, processId));
+        }
+    }
+
+    protected static class Builder<M extends ProcessRemoteMessage, B extends Builder<M, B>> {
+        protected final M message;
+
+        protected Builder(M message) {
+            this.message = message;
+        }
+
+        public B id(String id) {
+            message.id = id;
+            return (B) this;
+        }
+
+        public B consumerPid(String consumerPid) {
+            message.consumerPid = consumerPid;
+            return (B) this;
+        }
+
+        public B providerPid(String providerPid) {
+            message.providerPid = providerPid;
+            return (B) this;
+        }
+
+        public B protocol(String protocol) {
+            this.message.protocol = protocol;
+            return (B) this;
+        }
+
+        /**
+         * Represent the processId of the recipient
+         *
+         * @param processId the processId.
+         * @return the builder.
+         */
+        public B processId(String processId) {
+            this.message.processId = processId;
+            return (B) this;
+        }
+
+        public B counterPartyAddress(String counterPartyAddress) {
+            this.message.counterPartyAddress = counterPartyAddress;
+            return (B) this;
+        }
+
+        public M build() {
+            if (message.id == null) {
+                message.id = randomUUID().toString();
+            }
+            return message;
+        }
+    }
 }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/negotiation/store/ContractNegotiationStore.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/negotiation/store/ContractNegotiationStore.java
@@ -83,7 +83,7 @@ public interface ContractNegotiationStore extends StateEntityStore<ContractNegot
      *
      * @param correlationId the entity correlation id.
      * @return success if the entity is unleased, failure otherwise.
-     * @deprecated not used anymore, it can be removed.
+     * @deprecated it will be deleted in the future
      */
     @Deprecated(since = "0.4.1")
     StoreResult<ContractNegotiation> findByCorrelationIdAndLease(String correlationId);

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractAgreementMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractAgreementMessage.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.connector.contract.spi.types.agreement;
 import org.eclipse.edc.connector.contract.spi.types.protocol.ContractRemoteMessage;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.types.domain.agreement.ContractAgreement;
+import org.eclipse.edc.spi.types.domain.message.ProcessRemoteMessage;
 
 import java.util.Objects;
 
@@ -32,7 +33,7 @@ public class ContractAgreementMessage extends ContractRemoteMessage {
         return contractAgreement.getPolicy();
     }
 
-    public static class Builder extends ContractRemoteMessage.Builder<ContractAgreementMessage, Builder> {
+    public static class Builder extends ProcessRemoteMessage.Builder<ContractAgreementMessage, Builder> {
 
         private Builder() {
             super(new ContractAgreementMessage());

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractAgreementVerificationMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractAgreementVerificationMessage.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.contract.spi.types.agreement;
 
 import org.eclipse.edc.connector.contract.spi.types.protocol.ContractRemoteMessage;
 import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.types.domain.message.ProcessRemoteMessage;
 
 import java.util.Objects;
 
@@ -46,7 +47,7 @@ public class ContractAgreementVerificationMessage extends ContractRemoteMessage 
         return policy;
     }
 
-    public static class Builder extends ContractRemoteMessage.Builder<ContractAgreementVerificationMessage, Builder> {
+    public static class Builder extends ProcessRemoteMessage.Builder<ContractAgreementVerificationMessage, Builder> {
 
         private Builder() {
             super(new ContractAgreementVerificationMessage());

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractNegotiationEventMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/agreement/ContractNegotiationEventMessage.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.contract.spi.types.agreement;
 
 import org.eclipse.edc.connector.contract.spi.types.protocol.ContractRemoteMessage;
 import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.types.domain.message.ProcessRemoteMessage;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
@@ -34,7 +35,7 @@ public class ContractNegotiationEventMessage extends ContractRemoteMessage {
         return policy;
     }
 
-    public static class Builder extends ContractRemoteMessage.Builder<ContractNegotiationEventMessage, Builder> {
+    public static class Builder extends ProcessRemoteMessage.Builder<ContractNegotiationEventMessage, Builder> {
 
         private Builder() {
             super(new ContractNegotiationEventMessage());

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractNegotiationTerminationMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractNegotiationTerminationMessage.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.contract.spi.types.negotiation;
 
 import org.eclipse.edc.connector.contract.spi.types.protocol.ContractRemoteMessage;
 import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.types.domain.message.ProcessRemoteMessage;
 import org.jetbrains.annotations.Nullable;
 
 public class ContractNegotiationTerminationMessage extends ContractRemoteMessage {
@@ -39,7 +40,7 @@ public class ContractNegotiationTerminationMessage extends ContractRemoteMessage
         return policy;
     }
 
-    public static class Builder extends ContractRemoteMessage.Builder<ContractNegotiationTerminationMessage, Builder> {
+    public static class Builder extends ProcessRemoteMessage.Builder<ContractNegotiationTerminationMessage, Builder> {
 
         private Builder() {
             super(new ContractNegotiationTerminationMessage());

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractOfferMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractOfferMessage.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.contract.spi.types.negotiation;
 
 import org.eclipse.edc.connector.contract.spi.types.protocol.ContractRemoteMessage;
 import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.types.domain.message.ProcessRemoteMessage;
 import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 
 import static java.util.Objects.requireNonNull;
@@ -42,7 +43,7 @@ public class ContractOfferMessage extends ContractRemoteMessage {
         return contractOffer.getPolicy();
     }
 
-    public static class Builder extends ContractRemoteMessage.Builder<ContractOfferMessage, Builder> {
+    public static class Builder extends ProcessRemoteMessage.Builder<ContractOfferMessage, Builder> {
 
         private Builder() {
             super(new ContractOfferMessage());

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessage.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.contract.spi.types.negotiation;
 
 import org.eclipse.edc.connector.contract.spi.types.protocol.ContractRemoteMessage;
 import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.types.domain.message.ProcessRemoteMessage;
 import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 import org.jetbrains.annotations.Nullable;
 
@@ -66,7 +67,7 @@ public class ContractRequestMessage extends ContractRemoteMessage {
         COUNTER_OFFER
     }
 
-    public static class Builder extends ContractRemoteMessage.Builder<ContractRequestMessage, Builder> {
+    public static class Builder extends ProcessRemoteMessage.Builder<ContractRequestMessage, Builder> {
 
         private Builder() {
             super(new ContractRequestMessage());

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/protocol/ContractRemoteMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/protocol/ContractRemoteMessage.java
@@ -15,125 +15,13 @@
 package org.eclipse.edc.connector.contract.spi.types.protocol;
 
 import org.eclipse.edc.policy.model.Policy;
-import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.message.ProcessRemoteMessage;
-import org.jetbrains.annotations.NotNull;
-
-import java.util.Objects;
-
-import static java.util.UUID.randomUUID;
 
 /**
  * A remote message related to the ContractNegotiation context.
- *
- * The {@link #processId} represent the ID of the process on the recipient part.
  */
-public abstract class ContractRemoteMessage implements ProcessRemoteMessage {
-
-    protected String id;
-    protected String processId;
-    protected String consumerPid;
-    protected String providerPid;
-    protected String protocol = "unknown";
-    protected String counterPartyAddress;
-
-    @Override
-    public @NotNull String getId() {
-        return id;
-    }
+public abstract class ContractRemoteMessage extends ProcessRemoteMessage {
 
     public abstract Policy getPolicy();
 
-    public String getConsumerPid() {
-        return consumerPid;
-    }
-
-    public String getProviderPid() {
-        return providerPid;
-    }
-
-    @Override
-    public String getProtocol() {
-        return protocol;
-    }
-
-    @Override
-    public void setProtocol(String protocol) {
-        Objects.requireNonNull(protocol);
-        this.protocol = protocol;
-    }
-
-    @Override
-    public String getProcessId() {
-        return processId;
-    }
-
-    public void setProcessId(String processId) {
-        Objects.requireNonNull(processId);
-        this.processId = processId;
-    }
-
-    @Override
-    public String getCounterPartyAddress() {
-        return counterPartyAddress;
-    }
-
-    /**
-     * Verifies if the passed processId can be considered a valid one.
-     *
-     * @param processId the processId.
-     * @return succees if it is valid, failure otherwise.
-     */
-    public Result<Void> isValidProcessId(String processId) {
-        if (processId.equals(consumerPid) || processId.equals(providerPid)) {
-            return Result.success();
-        } else {
-            return Result.failure("Expected processId to be one of [%s, %s] but it was %s".formatted(consumerPid, providerPid, processId));
-        }
-    }
-
-    protected static class Builder<M extends ContractRemoteMessage, B extends Builder<M, B>> {
-        protected final M message;
-
-        protected Builder(M message) {
-            this.message = message;
-        }
-
-        public B id(String id) {
-            message.id = id;
-            return (B) this;
-        }
-
-        public B consumerPid(String consumerPid) {
-            message.consumerPid = consumerPid;
-            return (B) this;
-        }
-
-        public B providerPid(String providerPid) {
-            message.providerPid = providerPid;
-            return (B) this;
-        }
-
-        public B protocol(String protocol) {
-            this.message.protocol = protocol;
-            return (B) this;
-        }
-
-        public B processId(String processId) {
-            this.message.processId = processId;
-            return (B) this;
-        }
-
-        public B counterPartyAddress(String counterPartyAddress) {
-            this.message.counterPartyAddress = counterPartyAddress;
-            return (B) this;
-        }
-
-        public M build() {
-            if (message.id == null) {
-                message.id = randomUUID().toString();
-            }
-            return message;
-        }
-    }
 }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/store/TransferProcessStore.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/store/TransferProcessStore.java
@@ -54,6 +54,8 @@ public interface TransferProcessStore extends StateEntityStore<TransferProcess> 
      *
      * @param correlationId the entity correlation id.
      * @return success if the entity is unleased, failure otherwise.
+     * @deprecated it will be deleted in the future
      */
+    @Deprecated(since = "0.4.1")
     StoreResult<TransferProcess> findByCorrelationIdAndLease(String correlationId);
 }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/DataRequest.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/DataRequest.java
@@ -103,6 +103,10 @@ public class DataRequest implements Polymorphic {
         dataDestination = dataAddress;
     }
 
+    public void setId(String id) {
+        this.id = id;
+    }
+
     @JsonPOJOBuilder(withPrefix = "")
     public static class Builder {
         private final DataRequest request;

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/TransferProcess.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/TransferProcess.java
@@ -458,6 +458,16 @@ public class TransferProcess extends StatefulEntity<TransferProcess> {
         transitionTo(end.code());
     }
 
+    /**
+     * Set the correlationId, operation that's needed on the consumer side when it receives the first message with the
+     * provider process id.
+     *
+     * @param correlationId the correlation id.
+     */
+    public void setCorrelationId(String correlationId) {
+        dataRequest.setId(correlationId);
+    }
+
     public enum Type {
         CONSUMER, PROVIDER
     }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferCompletionMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferCompletionMessage.java
@@ -16,104 +16,24 @@ package org.eclipse.edc.connector.transfer.spi.types.protocol;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-import org.eclipse.edc.policy.model.Policy;
-import org.jetbrains.annotations.NotNull;
-
-import java.util.Objects;
-
-import static java.util.UUID.randomUUID;
 
 /**
  * The {@link TransferCompletionMessage} is sent by the provider or consumer when asset transfer has completed. Note
  * that some data plane implementations may optimize completion notification by performing it as part of its wire
  * protocol. In those cases, a {@link TransferCompletionMessage} message does not need to be sent.
  */
-public class TransferCompletionMessage implements TransferRemoteMessage {
-    private String id;
-    private String counterPartyAddress;
-    private String protocol = "unknown";
-    private String processId;
-    private Policy policy;
-
-    @NotNull
-    @Override
-    public String getId() {
-        return id;
-    }
-
-    @Override
-    public String getProtocol() {
-        return protocol;
-    }
-
-    @Override
-    public void setProtocol(String protocol) {
-        Objects.requireNonNull(protocol);
-        this.protocol = protocol;
-    }
-
-    @Override
-    public String getCounterPartyAddress() {
-        return counterPartyAddress;
-    }
-
-    @Override
-    @NotNull
-    public String getProcessId() {
-        return processId;
-    }
-
-    @Override
-    public Policy getPolicy() {
-        return policy;
-    }
+public class TransferCompletionMessage extends TransferRemoteMessage {
 
     @JsonPOJOBuilder(withPrefix = "")
-    public static class Builder {
-        private final TransferCompletionMessage message;
+    public static class Builder extends TransferRemoteMessage.Builder<TransferCompletionMessage, Builder> {
 
         private Builder() {
-            message = new TransferCompletionMessage();
+            super(new TransferCompletionMessage());
         }
 
         @JsonCreator
         public static Builder newInstance() {
             return new Builder();
-        }
-
-        public Builder id(String id) {
-            this.message.id = id;
-            return this;
-        }
-
-        public Builder counterPartyAddress(String address) {
-            message.counterPartyAddress = address;
-            return this;
-        }
-
-        public Builder policy(Policy policy) {
-            message.policy = policy;
-            return this;
-        }
-
-        public Builder protocol(String protocol) {
-            message.protocol = protocol;
-            return this;
-        }
-
-        public Builder processId(String processId) {
-            message.processId = processId;
-            return this;
-        }
-
-        public TransferCompletionMessage build() {
-            if (message.id == null) {
-                message.id = randomUUID().toString();
-            }
-
-            Objects.requireNonNull(message.protocol, "The protocol must be specified");
-            Objects.requireNonNull(message.processId, "The processId must be specified");
-            return message;
         }
 
     }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferRemoteMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferRemoteMessage.java
@@ -16,26 +16,29 @@ package org.eclipse.edc.connector.transfer.spi.types.protocol;
 
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.types.domain.message.ProcessRemoteMessage;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A remote message related to the TransferProcess context
  */
-public interface TransferRemoteMessage extends ProcessRemoteMessage {
+public abstract class TransferRemoteMessage extends ProcessRemoteMessage {
 
-    /**
-     * Returns the process id.
-     *
-     * @return the processId property.
-     */
+    protected Policy policy;
+
     @Override
-    @NotNull
-    String getProcessId();
+    public Policy getPolicy() {
+        return policy;
+    }
 
-    /**
-     * Returns the {@link Policy} associated with the Transfer Process.
-     *
-     * @return the transfer process {@link Policy}.
-     */
-    Policy getPolicy();
+    public static class Builder<M extends TransferRemoteMessage, B extends TransferRemoteMessage.Builder<M, B>> extends ProcessRemoteMessage.Builder<M, B> {
+
+        protected Builder(M message) {
+            super(message);
+        }
+
+        public B policy(Policy policy) {
+            message.policy = policy;
+            return (B) this;
+        }
+    }
+
 }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferRequestMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferRequestMessage.java
@@ -16,61 +16,19 @@ package org.eclipse.edc.connector.transfer.spi.types.protocol;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
-
-import static java.util.UUID.randomUUID;
 
 /**
  * The {@link TransferRequestMessage} is sent by a consumer to initiate a transfer process.
  */
-public class TransferRequestMessage implements TransferRemoteMessage {
+public class TransferRequestMessage extends TransferRemoteMessage {
 
-    private String id;
-    private String counterPartyAddress;
-    private String protocol = "unknown";
-    private String processId;
     private String contractId;
     private DataAddress dataDestination;
     private String transferType;
     private String callbackAddress;
-    private Policy policy;
-
-    @NotNull
-    @Override
-    public String getId() {
-        return id;
-    }
-
-    @Override
-    public String getProtocol() {
-        return protocol;
-    }
-
-    @Override
-    public void setProtocol(String protocol) {
-        Objects.requireNonNull(protocol);
-        this.protocol = protocol;
-    }
-
-    @Override
-    public String getCounterPartyAddress() {
-        return counterPartyAddress;
-    }
-
-    @Override
-    @NotNull
-    public String getProcessId() {
-        return processId;
-    }
-
-    @Override
-    public Policy getPolicy() {
-        return policy;
-    }
 
     public String getContractId() {
         return contractId;
@@ -89,11 +47,10 @@ public class TransferRequestMessage implements TransferRemoteMessage {
     }
 
     @JsonPOJOBuilder(withPrefix = "")
-    public static class Builder {
-        private final TransferRequestMessage message;
+    public static class Builder extends TransferRemoteMessage.Builder<TransferRequestMessage, Builder> {
 
         private Builder() {
-            message = new TransferRequestMessage();
+            super(new TransferRequestMessage());
         }
 
         @JsonCreator
@@ -101,33 +58,8 @@ public class TransferRequestMessage implements TransferRemoteMessage {
             return new Builder();
         }
 
-        public Builder id(String id) {
-            message.id = id;
-            return this;
-        }
-
-        public Builder policy(Policy policy) {
-            message.policy = policy;
-            return this;
-        }
-
-        public Builder processId(String processId) {
-            message.processId = processId;
-            return this;
-        }
-
-        public Builder counterPartyAddress(String callbackAddress) {
-            message.counterPartyAddress = callbackAddress;
-            return this;
-        }
-
         public Builder callbackAddress(String callbackAddress) {
             message.callbackAddress = callbackAddress;
-            return this;
-        }
-
-        public Builder protocol(String protocol) {
-            message.protocol = protocol;
             return this;
         }
 
@@ -146,13 +78,10 @@ public class TransferRequestMessage implements TransferRemoteMessage {
             return this;
         }
 
+        @Override
         public TransferRequestMessage build() {
-            if (message.id == null) {
-                message.id = randomUUID().toString();
-            }
-
             Objects.requireNonNull(message.callbackAddress, "The callbackAddress must be specified");
-            return message;
+            return super.build();
         }
     }
 }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferStartMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferStartMessage.java
@@ -16,70 +16,24 @@ package org.eclipse.edc.connector.transfer.spi.types.protocol;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.jetbrains.annotations.NotNull;
-
-import java.util.Objects;
-
-import static java.util.UUID.randomUUID;
 
 /**
  * The {@link TransferStartMessage} is sent by the provider to indicate the asset transfer has been initiated.
  */
-public class TransferStartMessage implements TransferRemoteMessage {
-
-    private String id;
-    private String counterPartyAddress;
-    private String protocol = "unknown";
-    private String processId;
-    private Policy policy;
+public class TransferStartMessage extends TransferRemoteMessage {
 
     private DataAddress dataAddress;
-
-    @NotNull
-    @Override
-    public String getId() {
-        return id;
-    }
-
-    @Override
-    public String getProtocol() {
-        return protocol;
-    }
-
-    @Override
-    public void setProtocol(String protocol) {
-        Objects.requireNonNull(protocol);
-        this.protocol = protocol;
-    }
-
-    @Override
-    public String getCounterPartyAddress() {
-        return counterPartyAddress;
-    }
-
-    @Override
-    @NotNull
-    public String getProcessId() {
-        return processId;
-    }
-
-    @Override
-    public Policy getPolicy() {
-        return policy;
-    }
 
     public DataAddress getDataAddress() {
         return dataAddress;
     }
 
     @JsonPOJOBuilder(withPrefix = "")
-    public static class Builder {
-        private final TransferStartMessage message;
+    public static class Builder extends TransferRemoteMessage.Builder<TransferStartMessage, Builder> {
 
         private Builder() {
-            message = new TransferStartMessage();
+            super(new TransferStartMessage());
         }
 
         @JsonCreator
@@ -87,43 +41,9 @@ public class TransferStartMessage implements TransferRemoteMessage {
             return new Builder();
         }
 
-        public Builder id(String id) {
-            this.message.id = id;
-            return this;
-        }
-
-        public Builder counterPartyAddress(String counterPartyAddress) {
-            message.counterPartyAddress = counterPartyAddress;
-            return this;
-        }
-
-        public Builder policy(Policy policy) {
-            message.policy = policy;
-            return this;
-        }
-
-        public Builder protocol(String protocol) {
-            message.protocol = protocol;
-            return this;
-        }
-
-        public Builder processId(String processId) {
-            message.processId = processId;
-            return this;
-        }
-
         public Builder dataAddress(DataAddress dataAddress) {
             message.dataAddress = dataAddress;
             return this;
-        }
-
-        public TransferStartMessage build() {
-            if (message.id == null) {
-                message.id = randomUUID().toString();
-            }
-
-            Objects.requireNonNull(message.processId, "The processId must be specified");
-            return message;
         }
 
     }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferTerminationMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/types/protocol/TransferTerminationMessage.java
@@ -16,60 +16,16 @@ package org.eclipse.edc.connector.transfer.spi.types.protocol;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-import org.eclipse.edc.policy.model.Policy;
-import org.jetbrains.annotations.NotNull;
-
-import java.util.Objects;
-
-import static java.util.UUID.randomUUID;
 
 /**
  * The {@link TransferTerminationMessage} is sent by the provider or consumer at any point except a terminal state to
  * indicate the data transfer process should stop and be placed in a terminal state. If the termination was due to an
  * error, the sender may include error information.
  */
-public class TransferTerminationMessage implements TransferRemoteMessage {
+public class TransferTerminationMessage extends TransferRemoteMessage {
 
-    private String id;
-    private String counterPartyAddress;
-    private String protocol = "unknown";
-    private String processId;
     private String code;
     private String reason; //TODO change to List  https://github.com/eclipse-edc/Connector/issues/2729
-    private Policy policy;
-
-    @NotNull
-    @Override
-    public String getId() {
-        return id;
-    }
-
-    @Override
-    public String getProtocol() {
-        return protocol;
-    }
-
-    @Override
-    public void setProtocol(String protocol) {
-        Objects.requireNonNull(protocol);
-        this.protocol = protocol;
-    }
-
-    @Override
-    public String getCounterPartyAddress() {
-        return counterPartyAddress;
-    }
-
-    @Override
-    @NotNull
-    public String getProcessId() {
-        return processId;
-    }
-
-    @Override
-    public Policy getPolicy() {
-        return policy;
-    }
 
     public String getCode() {
         return code;
@@ -80,41 +36,15 @@ public class TransferTerminationMessage implements TransferRemoteMessage {
     }
 
     @JsonPOJOBuilder(withPrefix = "")
-    public static class Builder {
-        private final TransferTerminationMessage message;
+    public static class Builder extends TransferRemoteMessage.Builder<TransferTerminationMessage, Builder> {
 
         private Builder() {
-            message = new TransferTerminationMessage();
+            super(new TransferTerminationMessage());
         }
 
         @JsonCreator
         public static Builder newInstance() {
             return new Builder();
-        }
-
-        public Builder id(String id) {
-            this.message.id = id;
-            return this;
-        }
-
-        public Builder counterPartyAddress(String counterPartyAddress) {
-            message.counterPartyAddress = counterPartyAddress;
-            return this;
-        }
-
-        public Builder policy(Policy policy) {
-            message.policy = policy;
-            return this;
-        }
-
-        public Builder protocol(String protocol) {
-            message.protocol = protocol;
-            return this;
-        }
-
-        public Builder processId(String processId) {
-            message.processId = processId;
-            return this;
         }
 
         public Builder code(String code) {
@@ -127,14 +57,5 @@ public class TransferTerminationMessage implements TransferRemoteMessage {
             return this;
         }
 
-        public TransferTerminationMessage build() {
-            if (message.id == null) {
-                message.id = randomUUID().toString();
-            }
-
-            Objects.requireNonNull(message.processId, "The processId must be specified");
-            //TODO add Nullcheck for message.code Issue https://github.com/eclipse-edc/Connector/issues/2810
-            return message;
-        }
     }
 }

--- a/spi/control-plane/transfer-spi/src/testFixtures/java/org/eclipse/edc/connector/transfer/spi/testfixtures/store/TransferProcessStoreTestBase.java
+++ b/spi/control-plane/transfer-spi/src/testFixtures/java/org/eclipse/edc/connector/transfer/spi/testfixtures/store/TransferProcessStoreTestBase.java
@@ -383,32 +383,24 @@ public abstract class TransferProcessStoreTestBase {
         }
 
         @Test
-        void dataRequestWithNewId_replacesOld() {
-            var bldr = createTransferProcessBuilder("id1").state(STARTED.code());
-            var t1 = bldr.build();
-            getTransferProcessStore().save(t1);
-
-            var t2 = bldr
-                    .dataRequest(TestFunctions.createDataRequestBuilder()
-                            .id("new-dr-id")
-                            .assetId("new-asset")
-                            .contractId("new-contract")
-                            .protocol("test-protocol")
-                            .build())
+        void shouldReplaceDataRequest_whenItGetsTheIdUpdated() {
+            var builder = createTransferProcessBuilder("id1").state(STARTED.code());
+            var newDataRequest = createDataRequestBuilder()
+                    .id("new-dr-id")
+                    .assetId("new-asset")
+                    .contractId("new-contract")
+                    .protocol("test-protocol")
                     .build();
-            getTransferProcessStore().save(t2);
+            getTransferProcessStore().save(builder.build());
+            getTransferProcessStore().save(builder.dataRequest(newDataRequest).build());
 
-            var all = getTransferProcessStore().findAll(QuerySpec.none()).collect(Collectors.toList());
-            assertThat(all)
+            var result = getTransferProcessStore().findAll(QuerySpec.none());
+
+            assertThat(result)
                     .hasSize(1)
                     .usingRecursiveFieldByFieldElementComparator()
-                    .containsExactly(t2);
-
-
-            var drs = all.stream().map(TransferProcess::getDataRequest).collect(Collectors.toList());
-            assertThat(drs).hasSize(1)
-                    .usingRecursiveFieldByFieldElementComparator()
-                    .containsOnly(t2.getDataRequest());
+                    .map(TransferProcess::getDataRequest)
+                    .containsExactly(newDataRequest);
         }
     }
 

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/AbstractEndToEndTransfer.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/AbstractEndToEndTransfer.java
@@ -78,8 +78,7 @@ public abstract class AbstractEndToEndTransfer {
         var msg = UUID.randomUUID().toString();
         await().atMost(timeout).untilAsserted(() -> CONSUMER.pullData(edr, Map.of("message", msg), equalTo(msg)));
 
-        assertThat(CONSUMER.getAllDataReferences(transferProcessId))
-                .hasSize(2);
+        assertThat(CONSUMER.getAllDataReferences(transferProcessId)).hasSize(1);
     }
 
     @Test
@@ -105,8 +104,7 @@ public abstract class AbstractEndToEndTransfer {
         var msg = UUID.randomUUID().toString();
         await().atMost(timeout).untilAsserted(() -> CONSUMER.pullData(edr, Map.of("message", msg), equalTo(msg)));
 
-        assertThat(CONSUMER.getAllDataReferences(transferProcessId))
-                .hasSize(2);
+        assertThat(CONSUMER.getAllDataReferences(transferProcessId)).hasSize(1);
     }
 
     @Test


### PR DESCRIPTION
## What this PR changes/adds

Second part of #3455.
Does the same thing done by #3717 but on the Transfer Process 

## Why it does that

dsp compliance

## Further notes

- same notes posted on #3717 are valid here as well (about interoperability with old versions)
- cleaned up a little the build gradle (solving deprecation, avoiding set metamodel version as not needed)

## Linked Issue(s)

Closes #3455

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
