### PR TITLE
refactor: extract the translation logic from the TranslationMapping class

### DIFF
--- a/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/CriterionToWhereClauseConverterImpl.java
+++ b/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/CriterionToWhereClauseConverterImpl.java
@@ -48,7 +48,8 @@ public class CriterionToWhereClauseConverterImpl implements CriterionToWhereClau
         var rightOperandClass = Optional.ofNullable(criterion.getOperandRight()).map(Object::getClass).orElse(null);
         var newCriterion = Optional.ofNullable(criterion.getOperandLeft())
                 .map(Object::toString)
-                .map(it -> translationMapping.getStatement(it, rightOperandClass))
+                .flatMap(fieldPath -> Optional.ofNullable(translationMapping.getFieldTranslator(fieldPath))
+                        .map(translator -> translator.apply(rightOperandClass)))
                 .map(criterion::withLeftOperand)
                 .orElseGet(() -> Criterion.criterion("0", "=", 1));
 

--- a/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/FieldTranslator.java
+++ b/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/FieldTranslator.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -21,12 +21,13 @@ import java.util.List;
 /**
  * Component that can translate a canonical field path into a sql column name or path.
  */
+@FunctionalInterface
 public interface FieldTranslator {
 
     /**
      * Get left operand for a SQL query given the canonical path name and the type
      *
-     * @param pathName the path name.
+     * @param path the path.
      * @param type the type.
      * @return the left operand.
      */

--- a/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/FieldTranslator.java
+++ b/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/FieldTranslator.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.sql.translation;
+
+import org.eclipse.edc.spi.types.PathItem;
+
+import java.util.List;
+
+/**
+ * Component that can translate a canonical field path into a sql column name or path.
+ */
+public interface FieldTranslator {
+
+    /**
+     * Get left operand for a SQL query given the canonical path name and the type
+     *
+     * @param pathName the path name.
+     * @param type the type.
+     * @return the left operand.
+     */
+    String getLeftOperand(List<PathItem> path, Class<?> type);
+
+}

--- a/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/JsonFieldTranslator.java
+++ b/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/JsonFieldTranslator.java
@@ -21,15 +21,15 @@ import java.util.List;
 import static java.lang.String.format;
 import static java.util.stream.IntStream.range;
 
-public class JsonFieldMapping extends TranslationMapping {
+public class JsonFieldTranslator implements FieldTranslator {
     protected final String columnName;
 
-    public JsonFieldMapping(String columnName) {
+    public JsonFieldTranslator(String columnName) {
         this.columnName = columnName;
     }
 
     @Override
-    public String getStatement(List<PathItem> path, Class<?> type) {
+    public String getLeftOperand(List<PathItem> path, Class<?> type) {
         var statementBuilder = new StringBuilder(columnName);
 
         var length = path.size();

--- a/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/PlainColumnFieldTranslator.java
+++ b/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/PlainColumnFieldTranslator.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at

--- a/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/PlainColumnFieldTranslator.java
+++ b/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/PlainColumnFieldTranslator.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.sql.translation;
+
+import org.eclipse.edc.spi.types.PathItem;
+
+import java.util.List;
+
+public class PlainColumnFieldTranslator implements FieldTranslator {
+
+    private final String columnName;
+
+    public PlainColumnFieldTranslator(String columnName) {
+        this.columnName = columnName;
+    }
+
+    @Override
+    public String getLeftOperand(List<PathItem> path, Class<?> type) {
+        return columnName;
+    }
+}

--- a/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/SortFieldConverter.java
+++ b/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/SortFieldConverter.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -17,6 +17,7 @@ package org.eclipse.edc.sql.translation;
 /**
  * Converts a sort field in the canonical format to the sql representation.
  */
+@FunctionalInterface
 interface SortFieldConverter {
 
     /**

--- a/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/SortFieldConverter.java
+++ b/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/SortFieldConverter.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.sql.translation;
+
+/**
+ * Converts a sort field in the canonical format to the sql representation.
+ */
+interface SortFieldConverter {
+
+    /**
+     * Converts the sort field into the SQL representation.
+     *
+     * @param sortField the sort field.
+     * @return the SQL representation.
+     */
+    String convert(String sortField);
+}

--- a/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/SortFieldConverterImpl.java
+++ b/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/SortFieldConverterImpl.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at

--- a/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/SortFieldConverterImpl.java
+++ b/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/SortFieldConverterImpl.java
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.sql.translation;
+
+import java.util.Optional;
+
+/**
+ * Implementation of the {@link SortFieldConverter}.
+ */
+public class SortFieldConverterImpl implements SortFieldConverter {
+
+    private final TranslationMapping rootModel;
+
+    public SortFieldConverterImpl(TranslationMapping rootModel) {
+        this.rootModel = rootModel;
+    }
+
+    @Override
+    public String convert(String sortField) {
+        return Optional.ofNullable(rootModel.getFieldTranslator(sortField))
+                .map(it -> it.apply(String.class))
+                .orElse(null);
+    }
+}

--- a/extensions/common/sql/sql-lease/src/main/java/org/eclipse/edc/sql/lease/StatefulEntityMapping.java
+++ b/extensions/common/sql/sql-lease/src/main/java/org/eclipse/edc/sql/lease/StatefulEntityMapping.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.edc.sql.lease;
 
-import org.eclipse.edc.sql.translation.JsonFieldMapping;
+import org.eclipse.edc.sql.translation.JsonFieldTranslator;
 import org.eclipse.edc.sql.translation.TranslationMapping;
 
 /**
@@ -28,7 +28,7 @@ public class StatefulEntityMapping extends TranslationMapping {
         add("state", statements.getStateColumn());
         add("stateCount", statements.getStateCountColumn());
         add("createdAt", statements.getCreatedAtColumn());
-        add("traceContext", new JsonFieldMapping(statements.getTraceContextColumn()));
+        add("traceContext", new JsonFieldTranslator(statements.getTraceContextColumn()));
         add("errorDetail", statements.getErrorDetailColumn());
     }
 }

--- a/extensions/control-plane/store/sql/contract-definition-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractdefinition/schema/postgres/ContractDefinitionMapping.java
+++ b/extensions/control-plane/store/sql/contract-definition-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractdefinition/schema/postgres/ContractDefinitionMapping.java
@@ -16,7 +16,7 @@ package org.eclipse.edc.connector.store.sql.contractdefinition.schema.postgres;
 
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractDefinition;
 import org.eclipse.edc.connector.store.sql.contractdefinition.schema.ContractDefinitionStatements;
-import org.eclipse.edc.sql.translation.JsonFieldMapping;
+import org.eclipse.edc.sql.translation.JsonFieldTranslator;
 import org.eclipse.edc.sql.translation.TranslationMapping;
 
 /**
@@ -30,7 +30,7 @@ public class ContractDefinitionMapping extends TranslationMapping {
         add("accessPolicy", statements.getAccessPolicyIdColumn());
         add("contractPolicyId", statements.getContractPolicyIdColumn());
         add("contractPolicy", statements.getContractPolicyIdColumn());
-        add("assetsSelector", new JsonFieldMapping(statements.getAssetsSelectorAlias()));
-        add("privateProperties", new JsonFieldMapping(statements.getPrivatePropertiesColumn()));
+        add("assetsSelector", new JsonFieldTranslator(statements.getAssetsSelectorAlias()));
+        add("privateProperties", new JsonFieldTranslator(statements.getPrivatePropertiesColumn()));
     }
 }

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/schema/postgres/ContractAgreementMapping.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/schema/postgres/ContractAgreementMapping.java
@@ -16,7 +16,7 @@ package org.eclipse.edc.connector.store.sql.contractnegotiation.store.schema.pos
 
 import org.eclipse.edc.connector.store.sql.contractnegotiation.store.schema.ContractNegotiationStatements;
 import org.eclipse.edc.spi.types.domain.agreement.ContractAgreement;
-import org.eclipse.edc.sql.translation.JsonFieldMapping;
+import org.eclipse.edc.sql.translation.JsonFieldTranslator;
 import org.eclipse.edc.sql.translation.TranslationMapping;
 
 /**
@@ -39,6 +39,6 @@ class ContractAgreementMapping extends TranslationMapping {
         add(FIELD_CONSUMER_AGENT_ID, statements.getConsumerAgentColumn());
         add(FIELD_CONTRACT_SIGNING_DATE, statements.getSigningDateColumn());
         add(FIELD_ASSET_ID, statements.getAssetIdColumn());
-        add(FIELD_POLICY, new JsonFieldMapping("policy"));
+        add(FIELD_POLICY, new JsonFieldTranslator("policy"));
     }
 }

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/schema/postgres/ContractNegotiationMapping.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/schema/postgres/ContractNegotiationMapping.java
@@ -32,7 +32,6 @@ class ContractNegotiationMapping extends StatefulEntityMapping {
     private static final String FIELD_TRACECONTEXT = "traceContext";
     private static final String FIELD_PENDING = "pending";
 
-
     ContractNegotiationMapping(ContractNegotiationStatements statements) {
         super(statements);
         add(FIELD_CORRELATION_ID, statements.getCorrelationIdColumn());
@@ -41,8 +40,7 @@ class ContractNegotiationMapping extends StatefulEntityMapping {
         add(FIELD_PROTOCOL, statements.getProtocolColumn());
         add(FIELD_TYPE, statements.getTypeColumn());
         add(FIELD_PENDING, statements.getPendingColumn());
-
-        fieldMap.put(FIELD_CONTRACT_AGREEMENT, new ContractAgreementMapping(statements));
+        add(FIELD_CONTRACT_AGREEMENT, new ContractAgreementMapping(statements));
         add(FIELD_TRACECONTEXT, statements.getTraceContextColumn());
     }
 

--- a/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/policydefinition/store/schema/postgres/PolicyDefinitionMapping.java
+++ b/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/policydefinition/store/schema/postgres/PolicyDefinitionMapping.java
@@ -16,7 +16,7 @@ package org.eclipse.edc.connector.store.sql.policydefinition.store.schema.postgr
 
 import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
 import org.eclipse.edc.connector.store.sql.policydefinition.store.schema.SqlPolicyStoreStatements;
-import org.eclipse.edc.sql.translation.JsonFieldMapping;
+import org.eclipse.edc.sql.translation.JsonFieldTranslator;
 import org.eclipse.edc.sql.translation.TranslationMapping;
 
 /**
@@ -29,6 +29,6 @@ public class PolicyDefinitionMapping extends TranslationMapping {
         add("id", statements.getPolicyIdColumn());
         add("createdAt", statements.getCreatedAtColumn());
         add("policy", new PolicyMapping(statements));
-        add("privateProperties", new JsonFieldMapping(statements.getPrivatePropertiesColumn()));
+        add("privateProperties", new JsonFieldTranslator(statements.getPrivatePropertiesColumn()));
     }
 }

--- a/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/policydefinition/store/schema/postgres/PolicyMapping.java
+++ b/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/policydefinition/store/schema/postgres/PolicyMapping.java
@@ -15,15 +15,15 @@
 package org.eclipse.edc.connector.store.sql.policydefinition.store.schema.postgres;
 
 import org.eclipse.edc.connector.store.sql.policydefinition.store.schema.SqlPolicyStoreStatements;
-import org.eclipse.edc.sql.translation.JsonFieldMapping;
+import org.eclipse.edc.sql.translation.JsonFieldTranslator;
 import org.eclipse.edc.sql.translation.TranslationMapping;
 
 public class PolicyMapping extends TranslationMapping {
     public PolicyMapping(SqlPolicyStoreStatements statements) {
-        add("permissions", new JsonFieldMapping(PostgresDialectStatements.PERMISSIONS_ALIAS));
-        add("prohibitions", new JsonFieldMapping(PostgresDialectStatements.PROHIBITIONS_ALIAS));
-        add("obligations", new JsonFieldMapping(PostgresDialectStatements.OBLIGATIONS_ALIAS));
-        add("extensibleProperties", new JsonFieldMapping(PostgresDialectStatements.EXT_PROPERTIES_ALIAS));
+        add("permissions", new JsonFieldTranslator(PostgresDialectStatements.PERMISSIONS_ALIAS));
+        add("prohibitions", new JsonFieldTranslator(PostgresDialectStatements.PROHIBITIONS_ALIAS));
+        add("obligations", new JsonFieldTranslator(PostgresDialectStatements.OBLIGATIONS_ALIAS));
+        add("extensibleProperties", new JsonFieldTranslator(PostgresDialectStatements.EXT_PROPERTIES_ALIAS));
         add("inheritsFrom", statements.getInheritsFromColumn());
         add("assigner", statements.getAssignerColumn());
         add("assignee", statements.getAssigneeColumn());

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/postgres/DataRequestMapping.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/postgres/DataRequestMapping.java
@@ -17,7 +17,7 @@ package org.eclipse.edc.connector.store.sql.transferprocess.store.schema.postgre
 
 import org.eclipse.edc.connector.store.sql.transferprocess.store.schema.TransferProcessStoreStatements;
 import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
-import org.eclipse.edc.sql.translation.JsonFieldMapping;
+import org.eclipse.edc.sql.translation.JsonFieldTranslator;
 import org.eclipse.edc.sql.translation.TranslationMapping;
 
 /**
@@ -42,7 +42,7 @@ class DataRequestMapping extends TranslationMapping {
         add(FIELD_PROTOCOL, statements.getProtocolColumn());
         add(FIELD_ASSET_ID, statements.getAssetIdColumn());
         add(FIELD_CONTRACT_ID, statements.getContractIdColumn());
-        add(FIELD_DATA_DESTINATION, new JsonFieldMapping(statements.getDataDestinationColumn()));
+        add(FIELD_DATA_DESTINATION, new JsonFieldTranslator(statements.getDataDestinationColumn()));
         add(FIELD_TRANSFER_PROCESS_ID, statements.getTransferProcessIdFkColumn());
     }
 }

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/postgres/ProvisionedResourceSetMapping.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/postgres/ProvisionedResourceSetMapping.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.edc.connector.store.sql.transferprocess.store.schema.postgres;
 
-import org.eclipse.edc.sql.translation.JsonFieldMapping;
+import org.eclipse.edc.sql.translation.JsonFieldTranslator;
 import org.eclipse.edc.sql.translation.TranslationMapping;
 
 /**
@@ -25,6 +25,6 @@ class ProvisionedResourceSetMapping extends TranslationMapping {
     private static final String FIELD_RESOURCES = "resources";
 
     ProvisionedResourceSetMapping() {
-        add(FIELD_RESOURCES, new JsonFieldMapping("resources"));
+        add(FIELD_RESOURCES, new JsonFieldTranslator("resources"));
     }
 }

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/postgres/ResourceManifestMapping.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/postgres/ResourceManifestMapping.java
@@ -15,7 +15,7 @@
 package org.eclipse.edc.connector.store.sql.transferprocess.store.schema.postgres;
 
 import org.eclipse.edc.connector.transfer.spi.types.ResourceManifest;
-import org.eclipse.edc.sql.translation.JsonFieldMapping;
+import org.eclipse.edc.sql.translation.JsonFieldTranslator;
 import org.eclipse.edc.sql.translation.TranslationMapping;
 
 /**
@@ -27,6 +27,6 @@ class ResourceManifestMapping extends TranslationMapping {
     private static final String FIELD_DEFINITIONS = "definitions";
 
     ResourceManifestMapping() {
-        add(FIELD_DEFINITIONS, new JsonFieldMapping("definitions"));
+        add(FIELD_DEFINITIONS, new JsonFieldTranslator("definitions"));
     }
 }

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/postgres/TransferProcessMapping.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/postgres/TransferProcessMapping.java
@@ -17,7 +17,7 @@ package org.eclipse.edc.connector.store.sql.transferprocess.store.schema.postgre
 import org.eclipse.edc.connector.store.sql.transferprocess.store.schema.TransferProcessStoreStatements;
 import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.sql.lease.StatefulEntityMapping;
-import org.eclipse.edc.sql.translation.JsonFieldMapping;
+import org.eclipse.edc.sql.translation.JsonFieldTranslator;
 
 /**
  * Maps fields of a {@link TransferProcess} onto the
@@ -45,13 +45,13 @@ public class TransferProcessMapping extends StatefulEntityMapping {
         add(FIELD_TYPE, statements.getTypeColumn());
         add(FIELD_CREATED_TIMESTAMP, statements.getCreatedAtColumn());
         add(FIELD_DATAREQUEST, new DataRequestMapping(statements));
-        add(FIELD_DATAADDRESS, new JsonFieldMapping(statements.getContentDataAddressColumn()));
-        add(FIELD_CONTENTDATAADDRESS, new JsonFieldMapping(statements.getContentDataAddressColumn()));
+        add(FIELD_DATAADDRESS, new JsonFieldTranslator(statements.getContentDataAddressColumn()));
+        add(FIELD_CONTENTDATAADDRESS, new JsonFieldTranslator(statements.getContentDataAddressColumn()));
         add(FIELD_RESOURCE_MANIFEST, new ResourceManifestMapping());
-        add(FIELD_PRIVATE_PROPERTIES, new JsonFieldMapping(statements.getPrivatePropertiesColumn()));
+        add(FIELD_PRIVATE_PROPERTIES, new JsonFieldTranslator(statements.getPrivatePropertiesColumn()));
         add(FIELD_PROVISIONED_RESOURCE_SET, new ProvisionedResourceSetMapping());
         // using the alias instead of the actual column name to avoid name clashes.
-        add(FIELD_DEPROVISIONED_RESOURCES, new JsonFieldMapping(PostgresDialectStatements.DEPROVISIONED_RESOURCES_ALIAS));
+        add(FIELD_DEPROVISIONED_RESOURCES, new JsonFieldTranslator(PostgresDialectStatements.DEPROVISIONED_RESOURCES_ALIAS));
         add(FIELD_PENDING, statements.getPendingColumn());
         add(FIELD_TRANSFER_TYPE, statements.getTransferTypeColumn());
     }


### PR DESCRIPTION
## What this PR changes/adds

second refactoring toward the solution of #3736 

in this PR the "translation" logic that was implemented in the `TranslationMapping` hierarchy has been extracted to a new interface `FieldTranslator` and its hierarchy, while `TranslationMapping` remains a simple tree data structure that can provide the `FieldTranslator` to the caller (we could find a better name for it, suggestions welcome)

## Why it does that

now that we have the `FieldTranslator` we can add a method there that can return a `WhereClause` directly, giving the possibility to translate the whole criteria following the specific SQL implementation

## Further notes


## Linked Issue(s)

Part of #3736 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
