### PR TITLE
fix: align DCAT namespace IRI to the correct one

### DIFF
--- a/docs/developer/ids-dataspace-protocol/ids-endpoints-services-architecture.md
+++ b/docs/developer/ids-dataspace-protocol/ids-endpoints-services-architecture.md
@@ -162,10 +162,10 @@ Similarly, a `ToCatalogTransformer` can convert from a JSON=LD structure to the 
 
 ```
 public class ToCatalogTransformer extends AbstractJsonLdTransformer<JsonObject, Catalog> {
-    private static final String DCAT_CATALOG = "http://www.w3.org/ns/dcat/Catalog";
-    private static final String DCAT_DATASET = "http://www.w3.org/ns/dcat/dataset";
-    private static final String DCAT_DISTRIBUTION = "http://www.w3.org/ns/dcat/distribution";
-    private static final String DCAT_DATA_SERVICE = "http://www.w3.org/ns/dcat/DataService";
+    private static final String DCAT_CATALOG = "http://www.w3.org/ns/dcat#Catalog";
+    private static final String DCAT_DATASET = "http://www.w3.org/ns/dcat#dataset";
+    private static final String DCAT_DISTRIBUTION = "http://www.w3.org/ns/dcat#distribution";
+    private static final String DCAT_DATA_SERVICE = "http://www.w3.org/ns/dcat#DataService";
 
     public ToCatalogTransformer() {
         super(JsonObject.class, Catalog.class);

--- a/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/api/management/catalog/CatalogApi.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/api/management/catalog/CatalogApi.java
@@ -172,7 +172,7 @@ public interface CatalogApi {
                         "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
                         "dct": "https://purl.org/dc/terms/",
                         "edc": "https://w3id.org/edc/v0.0.1/ns/",
-                        "dcat": "https://www.w3.org/ns/dcat/",
+                        "dcat": "http://www.w3.org/ns/dcat#",
                         "odrl": "http://www.w3.org/ns/odrl/2/",
                         "dspace": "https://w3id.org/dspace/v0.8/"
                     }
@@ -233,7 +233,7 @@ public interface CatalogApi {
                         "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
                         "dct": "https://purl.org/dc/terms/",
                         "edc": "https://w3id.org/edc/v0.0.1/ns/",
-                        "dcat": "https://www.w3.org/ns/dcat/",
+                        "dcat": "http://www.w3.org/ns/dcat#",
                         "odrl": "http://www.w3.org/ns/odrl/2/",
                         "dspace": "https://w3id.org/dspace/v0.8/"
                     }

--- a/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/Namespaces.java
+++ b/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/Namespaces.java
@@ -19,8 +19,9 @@ package org.eclipse.edc.jsonld.spi;
  */
 public interface Namespaces {
 
+    // ref. https://www.w3.org/TR/vocab-dcat-3/#normative-namespaces
     String DCAT_PREFIX = "dcat";
-    String DCAT_SCHEMA = "https://www.w3.org/ns/dcat/";
+    String DCAT_SCHEMA = "http://www.w3.org/ns/dcat#";
 
     String DCT_PREFIX = "dct";
     String DCT_SCHEMA = "https://purl.org/dc/terms/";


### PR DESCRIPTION
## What this PR changes/adds

Fix the DCAT namespace IRI according to the documentation (https://www.w3.org/TR/vocab-dcat-3/#normative-namespaces)

## Why it does that

dcat compliance

## Further notes

- this is a breaking change because the Catalog will be expanded in a different way than before. No issue on persistance because we don't store anything related to DCAT.

## Linked Issue(s)

Closes #3458

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
