### PR TITLE
fix: edr dynamic http receiver

### DIFF
--- a/extensions/control-plane/transfer/transfer-pull-http-dynamic-receiver/src/main/java/org/eclipse/edc/connector/receiver/http/dynamic/HttpDynamicEndpointDataReferenceReceiver.java
+++ b/extensions/control-plane/transfer/transfer-pull-http-dynamic-receiver/src/main/java/org/eclipse/edc/connector/receiver/http/dynamic/HttpDynamicEndpointDataReferenceReceiver.java
@@ -28,6 +28,7 @@ import org.eclipse.edc.spi.types.domain.edr.EndpointDataReference;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import static dev.failsafe.Failsafe.with;
@@ -60,7 +61,8 @@ public class HttpDynamicEndpointDataReferenceReceiver implements EndpointDataRef
 
     @Override
     public CompletableFuture<Result<Void>> send(@NotNull EndpointDataReference edr) {
-        var transferProcess = transferProcessStore.findForCorrelationId(edr.getId());
+        var transferProcess = Optional.ofNullable(transferProcessStore.findById(edr.getId()))
+                .orElseGet(() -> transferProcessStore.findForCorrelationId(edr.getId()));
 
         if (transferProcess == null) {
             return completedFuture(Result.failure(format("Failed to found transfer process for correlation id %s", edr.getId())));

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/AbstractEndToEndTransfer.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/AbstractEndToEndTransfer.java
@@ -78,7 +78,8 @@ public abstract class AbstractEndToEndTransfer {
         var msg = UUID.randomUUID().toString();
         await().atMost(timeout).untilAsserted(() -> CONSUMER.pullData(edr, Map.of("message", msg), equalTo(msg)));
 
-        assertThat(CONSUMER.getAllDataReferences(transferProcessId)).hasSize(1);
+        // We expect two EDR because in the test runtime we have two receiver extensions static and dynamic one
+        assertThat(CONSUMER.getAllDataReferences(transferProcessId)).hasSize(2);
     }
 
     @Test
@@ -104,7 +105,8 @@ public abstract class AbstractEndToEndTransfer {
         var msg = UUID.randomUUID().toString();
         await().atMost(timeout).untilAsserted(() -> CONSUMER.pullData(edr, Map.of("message", msg), equalTo(msg)));
 
-        assertThat(CONSUMER.getAllDataReferences(transferProcessId)).hasSize(1);
+        // We expect two EDR because in the test runtime we have two receiver extensions static and dynamic one
+        assertThat(CONSUMER.getAllDataReferences(transferProcessId)).hasSize(2);
     }
 
     @Test


### PR DESCRIPTION
## What this PR changes/adds

Fixes the `HttpDynamicEndpointDataReferenceReceiver` for receiving the EDR

## Why it does that

bugfix

## Linked Issue(s)

Closes #3788 

