### PR TITLE
feat: support contains operator for postgresql

### DIFF
--- a/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/CriterionToWhereClauseConverterImpl.java
+++ b/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/CriterionToWhereClauseConverterImpl.java
@@ -15,81 +15,35 @@
 package org.eclipse.edc.sql.translation;
 
 import org.eclipse.edc.spi.query.Criterion;
-import org.eclipse.edc.spi.result.Result;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-
-import static java.lang.String.format;
-import static java.util.Collections.emptyList;
-import static java.util.Collections.nCopies;
-import static java.util.Collections.unmodifiableCollection;
 
 public class CriterionToWhereClauseConverterImpl implements CriterionToWhereClauseConverter {
 
-    private static final String IN_OPERATOR = "in";
-    private static final String LIKE_OPERATOR = "like";
-    private static final String EQUALS_OPERATOR = "=";
-    private static final List<String> SUPPORTED_PREPARED_STATEMENT_OPERATORS = List.of(EQUALS_OPERATOR, LIKE_OPERATOR, IN_OPERATOR);
-    private static final String PREPARED_STATEMENT_PLACEHOLDER = "?";
-
     private final TranslationMapping translationMapping;
-    private final boolean validateOperator;
+    private final SqlOperatorTranslator operatorTranslator;
 
-    public CriterionToWhereClauseConverterImpl(TranslationMapping translationMapping, boolean validateOperator) {
+    public CriterionToWhereClauseConverterImpl(TranslationMapping translationMapping, SqlOperatorTranslator operatorTranslator) {
         this.translationMapping = translationMapping;
-        this.validateOperator = validateOperator;
+        this.operatorTranslator = operatorTranslator;
     }
 
     @Override
     public WhereClause convert(Criterion criterion) {
-        var rightOperandClass = Optional.ofNullable(criterion.getOperandRight()).map(Object::getClass).orElse(null);
-        var newCriterion = Optional.ofNullable(criterion.getOperandLeft())
-                .map(Object::toString)
-                .flatMap(fieldPath -> Optional.ofNullable(translationMapping.getFieldTranslator(fieldPath))
-                        .map(translator -> translator.apply(rightOperandClass)))
-                .map(criterion::withLeftOperand)
-                .orElseGet(() -> Criterion.criterion("0", "=", 1));
-
-        if (validateOperator) {
-            isValidExpression(criterion)
-                    .orElseThrow(f -> new IllegalArgumentException("This expression is not valid: " + f.getFailureDetail()));
+        var operator = operatorTranslator.translate(criterion.getOperator().toLowerCase());
+        if (operator == null) {
+            throw new IllegalArgumentException("The operator '%s' is not supported".formatted(criterion.getOperator()));
         }
 
-        var sql = format("%s %s %s", newCriterion.getOperandLeft(), newCriterion.getOperator(), toValuePlaceholder(newCriterion));
-        return new WhereClause(sql, toParameters(newCriterion));
-    }
-
-    public Result<Void> isValidExpression(Criterion criterion) {
-        var isSupportedOperator = SUPPORTED_PREPARED_STATEMENT_OPERATORS.contains(criterion.getOperator().toLowerCase());
-        if (!isSupportedOperator) {
-            return Result.failure("unsupported operator " + criterion.getOperator());
+        if (!operator.rightOperandClass().isAssignableFrom(criterion.getOperandRight().getClass())) {
+            throw new IllegalArgumentException("The operator '%s' requires the right-hand operand to be of type %s"
+                    .formatted(criterion.getOperator(), operator.rightOperandClass().getSimpleName()));
         }
 
-        if (Objects.equals(IN_OPERATOR, criterion.getOperator()) && !(criterion.getOperandRight() instanceof Iterable)) {
-            return Result.failure(format("The \"%s\" operator requires the right-hand operand to be of type %s", IN_OPERATOR, Iterable.class));
+        var whereClause = translationMapping.getWhereClause(criterion, operator);
+        if (whereClause == null) {
+            return new WhereClause("0 = ?", 1);
         }
-        return Result.success();
-    }
 
-    public String toValuePlaceholder(Criterion criterion) {
-        if (criterion.getOperandRight() instanceof Collection<?> collection) {
-            return format("(%s)", String.join(",", nCopies(collection.size(), PREPARED_STATEMENT_PLACEHOLDER)));
-        }
-        return PREPARED_STATEMENT_PLACEHOLDER;
-    }
-
-    public Collection<Object> toParameters(Criterion criterion) {
-        var operandRight = criterion.getOperandRight();
-        if (operandRight == null) {
-            return emptyList();
-        } else if (operandRight instanceof Collection<?> collection) {
-            return unmodifiableCollection(collection);
-        } else {
-            return List.of(operandRight);
-        }
+        return whereClause;
     }
 
 }

--- a/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/FieldTranslator.java
+++ b/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/FieldTranslator.java
@@ -14,23 +14,58 @@
 
 package org.eclipse.edc.sql.translation;
 
+import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.types.PathItem;
 
+import java.util.Collection;
 import java.util.List;
+
+import static java.lang.String.format;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.nCopies;
+import static java.util.Collections.unmodifiableCollection;
 
 /**
  * Component that can translate a canonical field path into a sql column name or path.
  */
-@FunctionalInterface
 public interface FieldTranslator {
+
+    String PREPARED_STATEMENT_PLACEHOLDER = "?";
 
     /**
      * Get left operand for a SQL query given the canonical path name and the type
      *
      * @param path the path.
-     * @param type the type.
      * @return the left operand.
      */
-    String getLeftOperand(List<PathItem> path, Class<?> type);
+    String getLeftOperand(List<PathItem> path, Class<?> rightOperandType);
+
+    /**
+     * Translate the {@link Criterion} into a {@link WhereClause}.
+     *
+     * @param path the path.
+     * @param criterion the criterion.
+     * @param operator the sql operator.
+     * @return the {@link WhereClause}.
+     */
+    WhereClause toWhereClause(List<PathItem> path, Criterion criterion, SqlOperator operator);
+
+    static String toValuePlaceholder(Criterion criterion) {
+        if (criterion.getOperandRight() instanceof Collection<?> collection) {
+            return format("(%s)", String.join(",", nCopies(collection.size(), PREPARED_STATEMENT_PLACEHOLDER)));
+        }
+        return PREPARED_STATEMENT_PLACEHOLDER;
+    }
+
+    static Collection<Object> toParameters(Criterion criterion) {
+        var operandRight = criterion.getOperandRight();
+        if (operandRight == null) {
+            return emptyList();
+        } else if (operandRight instanceof Collection<?> collection) {
+            return unmodifiableCollection(collection);
+        } else {
+            return List.of(operandRight);
+        }
+    }
 
 }

--- a/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/PlainColumnFieldTranslator.java
+++ b/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/PlainColumnFieldTranslator.java
@@ -14,9 +14,13 @@
 
 package org.eclipse.edc.sql.translation;
 
+import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.types.PathItem;
 
 import java.util.List;
+
+import static org.eclipse.edc.sql.translation.FieldTranslator.toParameters;
+import static org.eclipse.edc.sql.translation.FieldTranslator.toValuePlaceholder;
 
 public class PlainColumnFieldTranslator implements FieldTranslator {
 
@@ -29,5 +33,13 @@ public class PlainColumnFieldTranslator implements FieldTranslator {
     @Override
     public String getLeftOperand(List<PathItem> path, Class<?> type) {
         return columnName;
+    }
+
+    @Override
+    public WhereClause toWhereClause(List<PathItem> path, Criterion criterion, SqlOperator operator) {
+        return new WhereClause(
+                "%s %s %s".formatted(columnName, operator.representation(), toValuePlaceholder(criterion)),
+                toParameters(criterion)
+        );
     }
 }

--- a/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/PostgresqlOperatorTranslator.java
+++ b/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/PostgresqlOperatorTranslator.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.sql.translation;
+
+import java.util.Collection;
+
+/**
+ * Postgresql's implementation of the operator translator
+ */
+public class PostgresqlOperatorTranslator implements SqlOperatorTranslator {
+
+    @Override
+    public SqlOperator translate(String operator) {
+        return switch (operator) {
+            case "=" -> new SqlOperator("=", Object.class);
+            case "like" -> new SqlOperator("like", String.class);
+            case "in" -> new SqlOperator("in", Collection.class);
+            case "contains" -> new SqlOperator("??", Object.class);
+            default -> null;
+        };
+    }
+}

--- a/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/SqlOperator.java
+++ b/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/SqlOperator.java
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.sql.translation;
+
+/**
+ * Represent a SQL operator
+ */
+public record SqlOperator(String representation, Class<?> rightOperandClass) {
+}

--- a/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/SqlOperatorTranslator.java
+++ b/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/SqlOperatorTranslator.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.sql.translation;
+
+/**
+ * Translate domain representation of an operator into its SQL representation
+ */
+public interface SqlOperatorTranslator {
+
+    /**
+     * Give the SQL representation of the operator.
+     *
+     * @param operator operator.
+     * @return the SQL representation.
+     */
+    SqlOperator translate(String operator);
+}

--- a/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/SqlQueryStatement.java
+++ b/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/SqlQueryStatement.java
@@ -46,29 +46,16 @@ public class SqlQueryStatement {
     private String orderByClause = "";
 
     /**
-     * Initializes this SQL Query Statement with a SELECT clause, a {@link QuerySpec} and a translation mapping.
+     * Initializes this SQL Query Statement.
      *
-     * @param selectStatement The SELECT clause, e.g. {@code SELECT * FROM your_table}
-     * @param query           a {@link QuerySpec} that contains a query in the canonical format
-     * @param rootModel       A {@link TranslationMapping} that enables mapping from canonical to the SQL-specific
-     *                        model/format
+     * @param selectStatement    The SELECT clause, e.g. {@code SELECT * FROM your_table}
+     * @param query              a {@link QuerySpec} that contains a query in the canonical format
+     * @param rootModel          A {@link TranslationMapping} that enables mapping from canonical to the SQL-specific
+     *                           model/format
+     * @param operatorTranslator the {@link SqlOperatorTranslator} instance.
      */
-    public SqlQueryStatement(String selectStatement, QuerySpec query, TranslationMapping rootModel) {
-        this(selectStatement, query, rootModel, true);
-    }
-
-    /**
-     * Initializes this SQL Query Statement with a SELECT clause, a {@link QuerySpec} and a translation mapping.
-     *
-     * @param selectStatement  The SELECT clause, e.g. {@code SELECT * FROM your_table}
-     * @param query            a {@link QuerySpec} that contains a query in the canonical format
-     * @param rootModel        A {@link TranslationMapping} that enables mapping from canonical to the SQL-specific
-     *                         model/format
-     * @param validateOperator Determines whether the operator should be validated, and an {@link IllegalArgumentException}
-     *                         raised when an unknown/unsupported operator is found.
-     */
-    public SqlQueryStatement(String selectStatement, QuerySpec query, TranslationMapping rootModel, boolean validateOperator) {
-        this(selectStatement, query, rootModel, new CriterionToWhereClauseConverterImpl(rootModel, validateOperator));
+    public SqlQueryStatement(String selectStatement, QuerySpec query, TranslationMapping rootModel, SqlOperatorTranslator operatorTranslator) {
+        this(selectStatement, query, rootModel, new CriterionToWhereClauseConverterImpl(rootModel, operatorTranslator));
     }
 
     /**

--- a/extensions/common/sql/sql-core/src/test/java/org/eclipse/edc/sql/translation/JsonFieldTranslatorTest.java
+++ b/extensions/common/sql/sql-core/src/test/java/org/eclipse/edc/sql/translation/JsonFieldTranslatorTest.java
@@ -1,0 +1,102 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.sql.translation;
+
+import org.eclipse.edc.spi.types.PathItem;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.spi.query.Criterion.criterion;
+
+class JsonFieldTranslatorTest {
+
+    private final JsonFieldTranslator translator = new JsonFieldTranslator("column_name");
+
+    @Nested
+    class GetLeftOperand {
+
+        @Test
+        void shouldReturnLeftOperand_whenPathHasSingleEntry() {
+            var result = translator.getLeftOperand(PathItem.parse("field"), Object.class);
+
+            assertThat(result).isEqualTo("column_name ->> 'field'");
+        }
+
+        @Test
+        void shouldReturnLeftOperand_whenPathHasMultipleEntries() {
+            var result = translator.getLeftOperand(PathItem.parse("nested.field"), Object.class);
+
+            assertThat(result).isEqualTo("column_name -> 'nested' ->> 'field'");
+        }
+
+        @Test
+        void shouldParseLeftOperand_whenRightOperandIsBoolean() {
+            var result = translator.getLeftOperand(PathItem.parse("field"), Boolean.class);
+
+            assertThat(result).isEqualTo("(column_name ->> 'field')::boolean");
+        }
+    }
+
+    @Nested
+    class ToWhereClause {
+
+        @Test
+        void shouldReturnWhereClause_whenPathHasSingleEntry() {
+            var operator = new SqlOperator("=", Object.class);
+            var criterion = criterion("json.field", "=", "value");
+
+            var result = translator.toWhereClause(PathItem.parse("field"), criterion, operator);
+
+            assertThat(result.sql()).isEqualTo("column_name ->> 'field' = ?");
+            assertThat(result.parameters()).containsExactly("value");
+        }
+
+        @Test
+        void shouldReturnWhereClause_whenPathHasMultipleEntries() {
+            var operator = new SqlOperator("=", Object.class);
+            var criterion = criterion("json.nested.field", "=", "value");
+
+            var result = translator.toWhereClause(PathItem.parse("nested.field"), criterion, operator);
+
+            assertThat(result.sql()).isEqualTo("column_name -> 'nested' ->> 'field' = ?");
+            assertThat(result.parameters()).containsExactly("value");
+        }
+
+        @Test
+        void shouldParseWhereClause_whenRightOperandIsBoolean() {
+            var operator = new SqlOperator("=", Object.class);
+            var criterion = criterion("json.field", "=", true);
+
+            var result = translator.toWhereClause(PathItem.parse("field"), criterion, operator);
+
+            assertThat(result.sql()).isEqualTo("(column_name ->> 'field')::boolean = ?");
+            assertThat(result.parameters()).containsExactly(true);
+        }
+
+        @Test
+        void shouldConvertToJsonB_whenOperatorIsContains() {
+            var operator = new SqlOperator("??", Object.class);
+            var criterion = criterion("json.array", "contains", "value");
+
+            var result = translator.toWhereClause(PathItem.parse("array"), criterion, operator);
+
+            assertThat(result.sql()).isEqualTo("(column_name -> 'array')::jsonb ?? ?");
+            assertThat(result.parameters()).containsExactly("value");
+        }
+
+    }
+
+}

--- a/extensions/common/sql/sql-core/src/test/java/org/eclipse/edc/sql/translation/PlainColumnFieldTranslatorTest.java
+++ b/extensions/common/sql/sql-core/src/test/java/org/eclipse/edc/sql/translation/PlainColumnFieldTranslatorTest.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.sql.translation;
+
+import org.eclipse.edc.spi.types.PathItem;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.spi.query.Criterion.criterion;
+
+class PlainColumnFieldTranslatorTest {
+
+    private final PlainColumnFieldTranslator translator = new PlainColumnFieldTranslator("column_name");
+
+    @Test
+    void shouldReturnWhereClause_whenOperatorSpecified() {
+        var path = PathItem.parse("any");
+
+        var result = translator.toWhereClause(path, criterion("field", "=", "value"), createOperator());
+
+        assertThat(result.sql()).isEqualTo("column_name any ?");
+        assertThat(result.parameters()).containsExactly("value");
+    }
+
+    @Test
+    void shouldMapMultipleParameters_whenRightOperandIsCollection() {
+        var path = PathItem.parse("any");
+
+        var result = translator.toWhereClause(path, criterion("field", "in", List.of("value", "another")), createOperator());
+
+        assertThat(result.sql()).isEqualTo("column_name any (?,?)");
+        assertThat(result.parameters()).containsExactly("value", "another");
+    }
+
+    @NotNull
+    private static SqlOperator createOperator() {
+        return new SqlOperator("any", Object.class);
+    }
+}

--- a/extensions/common/sql/sql-core/src/test/java/org/eclipse/edc/sql/translation/PostgresqlOperatorTranslatorTest.java
+++ b/extensions/common/sql/sql-core/src/test/java/org/eclipse/edc/sql/translation/PostgresqlOperatorTranslatorTest.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.sql.translation;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PostgresqlOperatorTranslatorTest {
+
+    private final PostgresqlOperatorTranslator translator = new PostgresqlOperatorTranslator();
+
+    @Test
+    void shouldTranslate_equal() {
+        var operator = translator.translate("=");
+
+        assertThat(operator.representation()).isEqualTo("=");
+        assertThat(operator.rightOperandClass()).isEqualTo(Object.class);
+    }
+
+    @Test
+    void shouldTranslate_like() {
+        var operator = translator.translate("like");
+
+        assertThat(operator.representation()).isEqualTo("like");
+        assertThat(operator.rightOperandClass()).isEqualTo(String.class);
+    }
+
+    @Test
+    void shouldTranslate_in() {
+        var operator = translator.translate("in");
+
+        assertThat(operator.representation()).isEqualTo("in");
+        assertThat(operator.rightOperandClass()).isEqualTo(Collection.class);
+    }
+
+    @Test
+    void shouldTranslate_contains() {
+        var operator = translator.translate("contains");
+
+        assertThat(operator.representation()).isEqualTo("??");
+        assertThat(operator.rightOperandClass()).isEqualTo(Object.class);
+    }
+
+    @Test
+    void shouldReturnNull_whenOperatorNotSupported() {
+        var operator = translator.translate("not-supported");
+
+        assertThat(operator).isNull();
+    }
+}

--- a/extensions/common/sql/sql-core/src/test/java/org/eclipse/edc/sql/translation/TranslationMappingTest.java
+++ b/extensions/common/sql/sql-core/src/test/java/org/eclipse/edc/sql/translation/TranslationMappingTest.java
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.sql.translation;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.spi.query.Criterion.criterion;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class TranslationMappingTest {
+
+    private final FieldTranslator fieldTranslator = mock();
+    private final FieldTranslator nestedFieldTranslator = mock();
+    private final TranslationMapping mapping = new TestMapping(fieldTranslator, nestedFieldTranslator);
+
+    @Test
+    void shouldInvokeTranslatorAndReturnWhereClause() {
+        var expected = new WhereClause("column = ?", "value");
+        when(fieldTranslator.toWhereClause(any(), any(), any())).thenReturn(expected);
+        var criterion = criterion("field", "=", "value");
+
+        var whereClause = mapping.getWhereClause(criterion, dummyOperator());
+
+        assertThat(whereClause).isSameAs(expected);
+        verify(fieldTranslator).toWhereClause(argThat(List::isEmpty), same(criterion), any());
+    }
+
+    @Test
+    void shouldReturnNull_whenFieldDoesNotExist() {
+        var whereClause = mapping.getWhereClause(criterion("notExistentField", "=", "value"), dummyOperator());
+
+        assertThat(whereClause).isNull();
+        verifyNoInteractions(fieldTranslator);
+    }
+
+    @Test
+    void shouldInvokeNestedTranslatorAndReturnWhereClause() {
+        var expected = new WhereClause("nested -> column = ?", "value");
+        when(nestedFieldTranslator.toWhereClause(any(), any(), any())).thenReturn(expected);
+        var criterion = criterion("nested.field", "=", "value");
+
+        var whereClause = mapping.getWhereClause(criterion, dummyOperator());
+
+        assertThat(whereClause).isSameAs(expected);
+        verify(nestedFieldTranslator).toWhereClause(argThat(List::isEmpty), same(criterion), any());
+    }
+
+    @NotNull
+    private SqlOperator dummyOperator() {
+        return new SqlOperator("=", Object.class);
+    }
+
+    private static class TestMapping extends TranslationMapping {
+
+        TestMapping(FieldTranslator fieldTranslator, FieldTranslator nestedFieldTranslator) {
+            add("field", fieldTranslator);
+            if (nestedFieldTranslator != null) {
+                add("nested", new TestMapping(nestedFieldTranslator, null));
+            }
+        }
+    }
+}

--- a/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/assetindex/schema/BaseSqlDialectStatements.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/assetindex/schema/BaseSqlDialectStatements.java
@@ -19,6 +19,7 @@ package org.eclipse.edc.connector.store.sql.assetindex.schema;
 import org.eclipse.edc.connector.store.sql.assetindex.schema.postgres.AssetMapping;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.sql.translation.SqlOperatorTranslator;
 import org.eclipse.edc.sql.translation.SqlQueryStatement;
 
 import java.util.List;
@@ -26,6 +27,12 @@ import java.util.List;
 import static java.lang.String.format;
 
 public class BaseSqlDialectStatements implements AssetStatements {
+
+    protected final SqlOperatorTranslator operatorTranslator;
+
+    public BaseSqlDialectStatements(SqlOperatorTranslator operatorTranslator) {
+        this.operatorTranslator = operatorTranslator;
+    }
 
     @Override
     public String getInsertAssetTemplate() {
@@ -73,7 +80,7 @@ public class BaseSqlDialectStatements implements AssetStatements {
 
     @Override
     public SqlQueryStatement createQuery(QuerySpec querySpec) {
-        return new SqlQueryStatement(getSelectAssetTemplate(), querySpec, new AssetMapping(this));
+        return new SqlQueryStatement(getSelectAssetTemplate(), querySpec, new AssetMapping(this), operatorTranslator);
     }
 
     @Override

--- a/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/assetindex/schema/postgres/PostgresDialectStatements.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/assetindex/schema/postgres/PostgresDialectStatements.java
@@ -16,8 +16,14 @@ package org.eclipse.edc.connector.store.sql.assetindex.schema.postgres;
 
 import org.eclipse.edc.connector.store.sql.assetindex.schema.BaseSqlDialectStatements;
 import org.eclipse.edc.sql.dialect.PostgresDialect;
+import org.eclipse.edc.sql.translation.PostgresqlOperatorTranslator;
 
 public class PostgresDialectStatements extends BaseSqlDialectStatements {
+
+    public PostgresDialectStatements() {
+        super(new PostgresqlOperatorTranslator());
+    }
+
     @Override
     public String getFormatAsJsonOperator() {
         return PostgresDialect.getJsonCastOperator();

--- a/extensions/control-plane/store/sql/contract-definition-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractdefinition/schema/BaseSqlDialectStatements.java
+++ b/extensions/control-plane/store/sql/contract-definition-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractdefinition/schema/BaseSqlDialectStatements.java
@@ -16,11 +16,18 @@ package org.eclipse.edc.connector.store.sql.contractdefinition.schema;
 
 import org.eclipse.edc.connector.store.sql.contractdefinition.schema.postgres.ContractDefinitionMapping;
 import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.sql.translation.SqlOperatorTranslator;
 import org.eclipse.edc.sql.translation.SqlQueryStatement;
 
 import static java.lang.String.format;
 
 public class BaseSqlDialectStatements implements ContractDefinitionStatements {
+
+    protected final SqlOperatorTranslator operatorTranslator;
+
+    public BaseSqlDialectStatements(SqlOperatorTranslator operatorTranslator) {
+        this.operatorTranslator = operatorTranslator;
+    }
 
     @Override
     public String getDeleteByIdTemplate() {
@@ -68,7 +75,7 @@ public class BaseSqlDialectStatements implements ContractDefinitionStatements {
     @Override
     public SqlQueryStatement createQuery(QuerySpec querySpec) {
         var select = format("SELECT * FROM %s", getContractDefinitionTable());
-        return new SqlQueryStatement(select, querySpec, new ContractDefinitionMapping(this));
+        return new SqlQueryStatement(select, querySpec, new ContractDefinitionMapping(this), operatorTranslator);
     }
 
     protected String getSelectStatement() {

--- a/extensions/control-plane/store/sql/contract-definition-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractdefinition/schema/postgres/PostgresDialectStatements.java
+++ b/extensions/control-plane/store/sql/contract-definition-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractdefinition/schema/postgres/PostgresDialectStatements.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.connector.store.sql.contractdefinition.schema.postgres;
 import org.eclipse.edc.connector.store.sql.contractdefinition.schema.BaseSqlDialectStatements;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.sql.dialect.PostgresDialect;
+import org.eclipse.edc.sql.translation.PostgresqlOperatorTranslator;
 import org.eclipse.edc.sql.translation.SqlQueryStatement;
 
 import static java.lang.String.format;
@@ -26,6 +27,10 @@ import static org.eclipse.edc.sql.dialect.PostgresDialect.getSelectFromJsonArray
  * Contains Postgres-specific SQL statements
  */
 public class PostgresDialectStatements extends BaseSqlDialectStatements {
+
+    public PostgresDialectStatements() {
+        super(new PostgresqlOperatorTranslator());
+    }
 
     @Override
     public String getFormatAsJsonOperator() {
@@ -37,11 +42,11 @@ public class PostgresDialectStatements extends BaseSqlDialectStatements {
         // if any criterion targets a JSON array field, we need to slightly adapt the FROM clause
         if (querySpec.containsAnyLeftOperand("assetsSelector.")) {
             var select = getSelectFromJsonArrayTemplate(getSelectStatement(), getAssetsSelectorColumn(), getAssetsSelectorAlias());
-            return new SqlQueryStatement(select, querySpec, new ContractDefinitionMapping(this));
+            return new SqlQueryStatement(select, querySpec, new ContractDefinitionMapping(this), operatorTranslator);
         }
         if (querySpec.containsAnyLeftOperand("privateProperties.")) {
             var select = format("SELECT * FROM %s", getContractDefinitionTable());
-            return new SqlQueryStatement(select, querySpec, new ContractDefinitionMapping(this));
+            return new SqlQueryStatement(select, querySpec, new ContractDefinitionMapping(this), operatorTranslator);
         }
         return super.createQuery(querySpec);
     }

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/schema/BaseSqlDialectStatements.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/schema/BaseSqlDialectStatements.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.connector.store.sql.contractnegotiation.store.schema;
 
 import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.sql.translation.SqlOperatorTranslator;
 import org.eclipse.edc.sql.translation.SqlQueryStatement;
 
 import static java.lang.String.format;
@@ -26,6 +27,13 @@ import static org.eclipse.edc.sql.statement.SqlExecuteStatement.isNull;
  * database. This class is abstract, because there are some statements that cannot be expressed in a generic way.
  */
 public class BaseSqlDialectStatements implements ContractNegotiationStatements {
+
+    protected final SqlOperatorTranslator operatorTranslator;
+
+    public BaseSqlDialectStatements(SqlOperatorTranslator operatorTranslator) {
+        this.operatorTranslator = operatorTranslator;
+    }
+
     @Override
     public String getFindTemplate() {
         return format("SELECT * FROM %s LEFT OUTER JOIN %s ON %s.%s = %s.%s WHERE %s.%s = ?;", getContractNegotiationTable(), getContractAgreementTable(),

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/schema/postgres/PostgresDialectStatements.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/schema/postgres/PostgresDialectStatements.java
@@ -18,6 +18,7 @@ import org.eclipse.edc.connector.store.sql.contractnegotiation.store.schema.Base
 import org.eclipse.edc.connector.store.sql.contractnegotiation.store.schema.ContractNegotiationStatements;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.sql.dialect.PostgresDialect;
+import org.eclipse.edc.sql.translation.PostgresqlOperatorTranslator;
 import org.eclipse.edc.sql.translation.SqlQueryStatement;
 import org.eclipse.edc.sql.translation.TranslationMapping;
 
@@ -30,16 +31,20 @@ import org.eclipse.edc.sql.translation.TranslationMapping;
  */
 public class PostgresDialectStatements extends BaseSqlDialectStatements {
 
+    public PostgresDialectStatements() {
+        super(new PostgresqlOperatorTranslator());
+    }
+
     @Override
     public SqlQueryStatement createNegotiationsQuery(QuerySpec querySpec) {
         var selectStmt = getSelectNegotiationsTemplate();
-        return new SqlQueryStatement(selectStmt, querySpec, new ContractNegotiationMapping(this));
+        return new SqlQueryStatement(selectStmt, querySpec, new ContractNegotiationMapping(this), operatorTranslator);
     }
 
     @Override
     public SqlQueryStatement createAgreementsQuery(QuerySpec querySpec) {
         var selectStmt = getSelectFromAgreementsTemplate();
-        return new SqlQueryStatement(selectStmt, querySpec, new ContractAgreementMapping(this));
+        return new SqlQueryStatement(selectStmt, querySpec, new ContractAgreementMapping(this), operatorTranslator);
     }
 
     /**

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/schema/postgres/ContractNegotiationSqlQueryStatementTest.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/schema/postgres/ContractNegotiationSqlQueryStatementTest.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.connector.store.sql.contractnegotiation.store.schema.pos
 import org.eclipse.edc.connector.store.sql.contractnegotiation.store.schema.ContractNegotiationStatements;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.sql.translation.PostgresqlOperatorTranslator;
 import org.eclipse.edc.sql.translation.SqlQueryStatement;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +33,7 @@ class ContractNegotiationSqlQueryStatementTest {
     @Test
     void singleExpression_equalsOperator() {
         var criterion = new Criterion("counterPartyId", "=", "testid1");
-        var t = new SqlQueryStatement(SELECT_STATEMENT, query(criterion), new ContractNegotiationMapping(postresStatements));
+        var t = new SqlQueryStatement(SELECT_STATEMENT, query(criterion), new ContractNegotiationMapping(postresStatements), new PostgresqlOperatorTranslator());
 
 
         assertThat(t.getQueryAsString()).isEqualToIgnoringCase(SELECT_STATEMENT + " WHERE counterparty_id = ? LIMIT ? OFFSET ?;");
@@ -42,7 +43,7 @@ class ContractNegotiationSqlQueryStatementTest {
     @Test
     void singleExpression_inOperator() {
         var criterion = new Criterion("counterPartyId", "in", List.of("id1", "id2", "id3"));
-        var t = new SqlQueryStatement(SELECT_STATEMENT, query(criterion), new ContractNegotiationMapping(postresStatements));
+        var t = new SqlQueryStatement(SELECT_STATEMENT, query(criterion), new ContractNegotiationMapping(postresStatements), new PostgresqlOperatorTranslator());
 
 
         assertThat(t.getQueryAsString()).isEqualToIgnoringCase(SELECT_STATEMENT + " WHERE counterparty_id IN (?,?,?) LIMIT ? OFFSET ?;");
@@ -53,7 +54,7 @@ class ContractNegotiationSqlQueryStatementTest {
     void multipleExpressions() {
         var criterion1 = new Criterion("counterPartyId", "in", List.of("id1", "id2", "id3"));
         var criterion2 = new Criterion("stateCount", "=", "4");
-        var t = new SqlQueryStatement(SELECT_STATEMENT, query(criterion1, criterion2), new ContractNegotiationMapping(postresStatements));
+        var t = new SqlQueryStatement(SELECT_STATEMENT, query(criterion1, criterion2), new ContractNegotiationMapping(postresStatements), new PostgresqlOperatorTranslator());
 
         assertThat(t.getQueryAsString()).isEqualToIgnoringCase(SELECT_STATEMENT + " WHERE counterparty_id IN (?,?,?) AND state_count = ? LIMIT ? OFFSET ?;");
         assertThat(t.getParameters()).containsExactlyInAnyOrder("id1", "id2", "id3", "4", 50, 0);
@@ -62,7 +63,7 @@ class ContractNegotiationSqlQueryStatementTest {
     @Test
     void nestedFieldAccess_inOperator() {
         var criterion = new Criterion("contractAgreement.providerId", "in", List.of("id1", "id2", "id3"));
-        var t = new SqlQueryStatement(SELECT_STATEMENT, query(criterion), new ContractNegotiationMapping(postresStatements));
+        var t = new SqlQueryStatement(SELECT_STATEMENT, query(criterion), new ContractNegotiationMapping(postresStatements), new PostgresqlOperatorTranslator());
 
         assertThat(t.getQueryAsString()).isEqualToIgnoringCase(SELECT_STATEMENT + " WHERE provider_agent_id IN (?,?,?) LIMIT ? OFFSET ?;");
         assertThat(t.getParameters()).containsExactlyInAnyOrder("id1", "id2", "id3", 50, 0);
@@ -71,7 +72,7 @@ class ContractNegotiationSqlQueryStatementTest {
     @Test
     void multiNestedFieldAccess_equalsOperator() {
         var criterion = new Criterion("contractAgreement.policy.assignee", "=", "testassignee");
-        var t = new SqlQueryStatement(SELECT_STATEMENT, query(criterion), new ContractNegotiationMapping(postresStatements));
+        var t = new SqlQueryStatement(SELECT_STATEMENT, query(criterion), new ContractNegotiationMapping(postresStatements), new PostgresqlOperatorTranslator());
 
         assertThat(t.getQueryAsString()).isEqualToIgnoringCase(SELECT_STATEMENT + " WHERE policy ->> 'assignee' = ? LIMIT ? OFFSET ?;");
         assertThat(t.getParameters()).containsOnly("testassignee", 50, 0);
@@ -80,7 +81,7 @@ class ContractNegotiationSqlQueryStatementTest {
     @Test
     void multiNestedFieldAccess_withPath_inOperator() {
         var criterion = new Criterion("contractAgreement.policy.prohibitions.constraints", "in", List.of("yomama"));
-        var t = new SqlQueryStatement(SELECT_STATEMENT, query(criterion), new ContractNegotiationMapping(postresStatements));
+        var t = new SqlQueryStatement(SELECT_STATEMENT, query(criterion), new ContractNegotiationMapping(postresStatements), new PostgresqlOperatorTranslator());
 
         assertThat(t.getQueryAsString()).isEqualToIgnoringCase(SELECT_STATEMENT + " WHERE policy -> 'prohibitions' ->> 'constraints' in (?) LIMIT ? OFFSET ?;");
         assertThat(t.getParameters()).containsOnly("yomama", 50, 0);

--- a/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/policydefinition/store/schema/BaseSqlDialectStatements.java
+++ b/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/policydefinition/store/schema/BaseSqlDialectStatements.java
@@ -16,9 +16,16 @@ package org.eclipse.edc.connector.store.sql.policydefinition.store.schema;
 
 import org.eclipse.edc.connector.store.sql.policydefinition.store.schema.postgres.PolicyDefinitionMapping;
 import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.sql.translation.SqlOperatorTranslator;
 import org.eclipse.edc.sql.translation.SqlQueryStatement;
 
 public class BaseSqlDialectStatements implements SqlPolicyStoreStatements {
+
+    protected final SqlOperatorTranslator operatorTranslator;
+
+    public BaseSqlDialectStatements(SqlOperatorTranslator operatorTranslator) {
+        this.operatorTranslator = operatorTranslator;
+    }
 
     @Override
     public String getSelectTemplate() {
@@ -68,6 +75,6 @@ public class BaseSqlDialectStatements implements SqlPolicyStoreStatements {
 
     @Override
     public SqlQueryStatement createQuery(QuerySpec querySpec) {
-        return new SqlQueryStatement(getSelectTemplate(), querySpec, new PolicyDefinitionMapping(this));
+        return new SqlQueryStatement(getSelectTemplate(), querySpec, new PolicyDefinitionMapping(this), operatorTranslator);
     }
 }

--- a/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/policydefinition/store/schema/postgres/PostgresDialectStatements.java
+++ b/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/policydefinition/store/schema/postgres/PostgresDialectStatements.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.connector.store.sql.policydefinition.store.schema.postgr
 import org.eclipse.edc.connector.store.sql.policydefinition.store.schema.BaseSqlDialectStatements;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.sql.dialect.PostgresDialect;
+import org.eclipse.edc.sql.translation.PostgresqlOperatorTranslator;
 import org.eclipse.edc.sql.translation.SqlQueryStatement;
 
 import static java.lang.String.format;
@@ -34,6 +35,10 @@ public class PostgresDialectStatements extends BaseSqlDialectStatements {
     private static final String PRIVATE_PROPERTIES = "privateProperties.";
     private static final String SELECT_QUERY = "SELECT * FROM %s";
 
+    public PostgresDialectStatements() {
+        super(new PostgresqlOperatorTranslator());
+    }
+
     @Override
     public String getFormatAsJsonOperator() {
         return PostgresDialect.getJsonCastOperator();
@@ -43,19 +48,19 @@ public class PostgresDialectStatements extends BaseSqlDialectStatements {
     public SqlQueryStatement createQuery(QuerySpec querySpec) {
         if (querySpec.containsAnyLeftOperand("policy.prohibitions")) {
             var select = getSelectFromJsonArrayTemplate(getSelectTemplate(), getProhibitionsColumn(), PROHIBITIONS_ALIAS);
-            return new SqlQueryStatement(select, querySpec, new PolicyDefinitionMapping(this));
+            return new SqlQueryStatement(select, querySpec, new PolicyDefinitionMapping(this), operatorTranslator);
         } else if (querySpec.containsAnyLeftOperand("policy.permissions")) {
             var select = getSelectFromJsonArrayTemplate(getSelectTemplate(), getPermissionsColumn(), PERMISSIONS_ALIAS);
-            return new SqlQueryStatement(select, querySpec, new PolicyDefinitionMapping(this));
+            return new SqlQueryStatement(select, querySpec, new PolicyDefinitionMapping(this), operatorTranslator);
         } else if (querySpec.containsAnyLeftOperand("policy.obligations")) {
             var select = getSelectFromJsonArrayTemplate(getSelectTemplate(), getDutiesColumn(), OBLIGATIONS_ALIAS);
-            return new SqlQueryStatement(select, querySpec, new PolicyDefinitionMapping(this));
+            return new SqlQueryStatement(select, querySpec, new PolicyDefinitionMapping(this), operatorTranslator);
         } else if (querySpec.containsAnyLeftOperand("policy.extensibleProperties")) {
             var select = getSelectFromJsonArrayTemplate(getSelectTemplate(), getExtensiblePropertiesColumn(), EXT_PROPERTIES_ALIAS);
-            return new SqlQueryStatement(select, querySpec, new PolicyDefinitionMapping(this));
+            return new SqlQueryStatement(select, querySpec, new PolicyDefinitionMapping(this), operatorTranslator);
         } else if (querySpec.containsAnyLeftOperand(PRIVATE_PROPERTIES)) {
             var select = format(SELECT_QUERY, getPolicyTable());
-            return new SqlQueryStatement(select, querySpec, new PolicyDefinitionMapping(this));
+            return new SqlQueryStatement(select, querySpec, new PolicyDefinitionMapping(this), operatorTranslator);
         } else {
             return super.createQuery(querySpec);
         }

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/BaseSqlDialectStatements.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/BaseSqlDialectStatements.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.connector.store.sql.transferprocess.store.schema;
 
 import org.eclipse.edc.connector.store.sql.transferprocess.store.schema.postgres.TransferProcessMapping;
 import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.sql.translation.SqlOperatorTranslator;
 import org.eclipse.edc.sql.translation.SqlQueryStatement;
 
 import static java.lang.String.format;
@@ -25,6 +26,12 @@ import static java.lang.String.format;
  * Postgres-specific variants and implementations of the statements required for the TransferProcessStore
  */
 public abstract class BaseSqlDialectStatements implements TransferProcessStoreStatements {
+
+    protected final SqlOperatorTranslator operatorTranslator;
+
+    protected BaseSqlDialectStatements(SqlOperatorTranslator operatorTranslator) {
+        this.operatorTranslator = operatorTranslator;
+    }
 
     @Override
     public String getDeleteLeaseTemplate() {
@@ -138,7 +145,7 @@ public abstract class BaseSqlDialectStatements implements TransferProcessStoreSt
 
     @Override
     public SqlQueryStatement createQuery(QuerySpec querySpec) {
-        return new SqlQueryStatement(getSelectTemplate(), querySpec, new TransferProcessMapping(this));
+        return new SqlQueryStatement(getSelectTemplate(), querySpec, new TransferProcessMapping(this), operatorTranslator);
     }
 
 }

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/postgres/PostgresDialectStatements.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/transferprocess/store/schema/postgres/PostgresDialectStatements.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.connector.store.sql.transferprocess.store.schema.postgre
 import org.eclipse.edc.connector.store.sql.transferprocess.store.schema.BaseSqlDialectStatements;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.sql.dialect.PostgresDialect;
+import org.eclipse.edc.sql.translation.PostgresqlOperatorTranslator;
 import org.eclipse.edc.sql.translation.SqlQueryStatement;
 
 import static java.lang.String.format;
@@ -31,6 +32,10 @@ public class PostgresDialectStatements extends BaseSqlDialectStatements {
     private static final String RESOURCES_ALIAS = "resources";
     private static final String DEFINITIONS_ALIAS = "definitions";
 
+    public PostgresDialectStatements() {
+        super(new PostgresqlOperatorTranslator());
+    }
+
     @Override
     public String getFormatAsJsonOperator() {
         return PostgresDialect.getJsonCastOperator();
@@ -41,13 +46,13 @@ public class PostgresDialectStatements extends BaseSqlDialectStatements {
         // if any criterion targets a JSON array field, we need to slightly adapt the FROM clause
         if (querySpec.containsAnyLeftOperand("resourceManifest.definitions")) {
             var select = getSelectFromJsonArrayTemplate(getSelectTemplate(), format("%s -> '%s'", getResourceManifestColumn(), "definitions"), DEFINITIONS_ALIAS);
-            return new SqlQueryStatement(select, querySpec, new TransferProcessMapping(this));
+            return new SqlQueryStatement(select, querySpec, new TransferProcessMapping(this), operatorTranslator);
         } else if (querySpec.containsAnyLeftOperand("provisionedResourceSet.resources")) {
             var select = getSelectFromJsonArrayTemplate(getSelectTemplate(), format("%s -> '%s'", getProvisionedResourceSetColumn(), "resources"), RESOURCES_ALIAS);
-            return new SqlQueryStatement(select, querySpec, new TransferProcessMapping(this));
+            return new SqlQueryStatement(select, querySpec, new TransferProcessMapping(this), operatorTranslator);
         } else if (querySpec.containsAnyLeftOperand("deprovisionedResources")) {
             var select = getSelectFromJsonArrayTemplate(getSelectTemplate(), format("%s", getDeprovisionedResourcesColumn()), DEPROVISIONED_RESOURCES_ALIAS);
-            return new SqlQueryStatement(select, querySpec, new TransferProcessMapping(this));
+            return new SqlQueryStatement(select, querySpec, new TransferProcessMapping(this), operatorTranslator);
         }
         return super.createQuery(querySpec);
     }

--- a/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/schema/BaseSqlDataPlaneStatements.java
+++ b/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/schema/BaseSqlDataPlaneStatements.java
@@ -16,11 +16,18 @@ package org.eclipse.edc.connector.dataplane.store.sql.schema;
 
 import org.eclipse.edc.connector.dataplane.store.sql.schema.postgres.DataPlaneMapping;
 import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.sql.translation.SqlOperatorTranslator;
 import org.eclipse.edc.sql.translation.SqlQueryStatement;
 
 import static java.lang.String.format;
 
 public class BaseSqlDataPlaneStatements implements DataPlaneStatements {
+
+    protected final SqlOperatorTranslator operatorTranslator;
+
+    public BaseSqlDataPlaneStatements(SqlOperatorTranslator operatorTranslator) {
+        this.operatorTranslator = operatorTranslator;
+    }
 
     @Override
     public String getInsertTemplate() {
@@ -65,7 +72,7 @@ public class BaseSqlDataPlaneStatements implements DataPlaneStatements {
 
     @Override
     public SqlQueryStatement createQuery(QuerySpec querySpec) {
-        return new SqlQueryStatement(getSelectTemplate(), querySpec, new DataPlaneMapping(this));
+        return new SqlQueryStatement(getSelectTemplate(), querySpec, new DataPlaneMapping(this), operatorTranslator);
     }
 
     @Override

--- a/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/schema/postgres/PostgresDataPlaneStatements.java
+++ b/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/schema/postgres/PostgresDataPlaneStatements.java
@@ -16,9 +16,13 @@ package org.eclipse.edc.connector.dataplane.store.sql.schema.postgres;
 
 import org.eclipse.edc.connector.dataplane.store.sql.schema.BaseSqlDataPlaneStatements;
 import org.eclipse.edc.sql.dialect.PostgresDialect;
+import org.eclipse.edc.sql.translation.PostgresqlOperatorTranslator;
 
 public class PostgresDataPlaneStatements extends BaseSqlDataPlaneStatements {
 
+    public PostgresDataPlaneStatements() {
+        super(new PostgresqlOperatorTranslator());
+    }
 
     @Override
     public String getFormatAsJsonOperator() {

--- a/extensions/policy-monitor/store/sql/policy-monitor-store-sql/src/main/java/org/eclipse/edc/connector/policy/monitor/store/sql/schema/BaseSqlPolicyMonitorStatements.java
+++ b/extensions/policy-monitor/store/sql/policy-monitor-store-sql/src/main/java/org/eclipse/edc/connector/policy/monitor/store/sql/schema/BaseSqlPolicyMonitorStatements.java
@@ -15,11 +15,18 @@
 package org.eclipse.edc.connector.policy.monitor.store.sql.schema;
 
 import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.sql.translation.SqlOperatorTranslator;
 import org.eclipse.edc.sql.translation.SqlQueryStatement;
 
 import static java.lang.String.format;
 
 public class BaseSqlPolicyMonitorStatements implements PolicyMonitorStatements {
+
+    protected final SqlOperatorTranslator operatorTranslator;
+
+    public BaseSqlPolicyMonitorStatements(SqlOperatorTranslator operatorTranslator) {
+        this.operatorTranslator = operatorTranslator;
+    }
 
     @Override
     public String getInsertTemplate() {
@@ -56,7 +63,7 @@ public class BaseSqlPolicyMonitorStatements implements PolicyMonitorStatements {
 
     @Override
     public SqlQueryStatement createQuery(QuerySpec querySpec) {
-        return new SqlQueryStatement(getSelectTemplate(), querySpec, new PolicyMonitorMapping(this));
+        return new SqlQueryStatement(getSelectTemplate(), querySpec, new PolicyMonitorMapping(this), operatorTranslator);
     }
 
     @Override

--- a/extensions/policy-monitor/store/sql/policy-monitor-store-sql/src/main/java/org/eclipse/edc/connector/policy/monitor/store/sql/schema/PostgresPolicyMonitorStatements.java
+++ b/extensions/policy-monitor/store/sql/policy-monitor-store-sql/src/main/java/org/eclipse/edc/connector/policy/monitor/store/sql/schema/PostgresPolicyMonitorStatements.java
@@ -15,8 +15,13 @@
 package org.eclipse.edc.connector.policy.monitor.store.sql.schema;
 
 import org.eclipse.edc.sql.dialect.PostgresDialect;
+import org.eclipse.edc.sql.translation.PostgresqlOperatorTranslator;
 
 public class PostgresPolicyMonitorStatements extends BaseSqlPolicyMonitorStatements {
+
+    public PostgresPolicyMonitorStatements() {
+        super(new PostgresqlOperatorTranslator());
+    }
 
     @Override
     public String getFormatAsJsonOperator() {

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/Criterion.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/Criterion.java
@@ -74,6 +74,7 @@ public class Criterion {
         return new Criterion(operandLeft, operator, getOperandRight());
     }
 
+    @Deprecated(since = "0.5.0")
     public Criterion withLeftOperand(Function<Object, Object> function) {
         return new Criterion(function.apply(operandLeft), operator, getOperandRight());
     }

--- a/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/negotiation/store/ContractNegotiationStoreTestBase.java
+++ b/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/negotiation/store/ContractNegotiationStoreTestBase.java
@@ -416,6 +416,7 @@ public abstract class ContractNegotiationStoreTestBase {
 
     @Nested
     class QueryNegotiations {
+
         @Test
         void shouldPaginateResults() {
             var querySpec = QuerySpec.Builder.newInstance()

--- a/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/offer/store/ContractDefinitionStoreTestBase.java
+++ b/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/offer/store/ContractDefinitionStoreTestBase.java
@@ -460,6 +460,24 @@ public abstract class ContractDefinitionStoreTestBase {
         }
 
         @Test
+        void shouldFilterUsingContainsOperator() {
+            var definitionsExpected = createContractDefinitions(10);
+            definitionsExpected.get(3).getPrivateProperties().put("test", List.of("id1", "id3"));
+            definitionsExpected.get(5).getPrivateProperties().put("test", List.of("id1", "id2"));
+            saveContractDefinitions(definitionsExpected);
+
+            var spec = QuerySpec.Builder.newInstance()
+                    .filter(criterion("privateProperties.test", "contains", "id2"))
+                    .build();
+
+            var definitionsRetrieved = getContractDefinitionStore().findAll(spec);
+
+            assertThat(definitionsRetrieved).hasSize(1)
+                    .usingRecursiveFieldByFieldElementComparator()
+                    .containsOnly(definitionsExpected.get(5));
+        }
+
+        @Test
         void queryMultiple() {
             var definitionsExpected = createContractDefinitions(20);
             definitionsExpected.forEach(d -> d.getAssetsSelector().add(new Criterion(Asset.PROPERTY_ID, "=", "test-asset")));


### PR DESCRIPTION
## What this PR changes/adds

Adds support for `contains` operator in SQL as it was done for in-memory store.
Adds flexibility, defining a `SqlOperatorTranslator` interface that permits to specify how the operator is defined in the specific SQL implementation.

## Why it does that

stores feature consistence

## Further notes

- I noticed that we have some things tangled between "sql" and "postgresql" specific, e.g. the `JsonFieldTranslator` is postgresql specific but it's located in the `sql-core`, same for the `PostgresOperatorTranslator`, maybe we should extract a `postgresql` extension that takes care of registering common postgresql-related services, "refactoring never ends" :)
- removed the `validateOperator` from the `SqlQueryStatement` constructor, because now that's implicit in the `SqlOperatorTranslator` component: if the operator gets translated is valid, otherwise it's not.

## Linked Issue(s)

Closes #3736

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
