### PR TITLE
feat: supports verification method id as URL

### DIFF
--- a/extensions/common/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/edc/iam/did/resolution/DidPublicKeyResolverImplTest.java
+++ b/extensions/common/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/edc/iam/did/resolution/DidPublicKeyResolverImplTest.java
@@ -48,7 +48,6 @@ class DidPublicKeyResolverImplTest {
     private final DidResolverRegistry resolverRegistry = mock();
     private final KeyParserRegistry keyParserRegistry = mock();
     private final DidPublicKeyResolverImpl resolver = new DidPublicKeyResolverImpl(keyParserRegistry, resolverRegistry, mock(), mock());
-    private DidDocument didDocument;
 
     public static String readFile(String filename) throws IOException {
         try (var is = Thread.currentThread().getContextClassLoader().getResourceAsStream(filename)) {
@@ -58,25 +57,58 @@ class DidPublicKeyResolverImplTest {
     }
 
     @BeforeEach
-    public void setUp() throws JOSEException, IOException {
-        var eckey = (ECKey) ECKey.parseFromPEMEncodedObjects(readFile("public_secp256k1.pem"));
-
-        var vm = VerificationMethod.Builder.newInstance()
-                .id(KEYID)
-                .type(DidConstants.ECDSA_SECP_256_K_1_VERIFICATION_KEY_2019)
-                .publicKeyJwk(eckey.toPublicJWK().toJSONObject())
-                .build();
-
-        didDocument = DidDocument.Builder.newInstance()
-                .verificationMethod(List.of(vm))
-                .service(Collections.singletonList(new Service("#my-service1", "MyService", "http://doesnotexi.st")))
-                .build();
+    public void setUp() throws JOSEException {
 
         when(keyParserRegistry.parse(anyString())).thenReturn(Result.success(new ECKeyGenerator(Curve.P_256).generate().toPublicKey()));
     }
 
+    private DidDocument createDidDocument(String verificationMethodId) {
+        return createDidDocumentBuilder(verificationMethodId).build();
+    }
+
+    private DidDocument createDidDocument() {
+        return createDidDocumentBuilder(KEYID).build();
+    }
+
+    private VerificationMethod createVerificationMethod(String verificationMethodId, ECKey eckey) {
+        return VerificationMethod.Builder.newInstance()
+                .id(verificationMethodId)
+                .type(DidConstants.ECDSA_SECP_256_K_1_VERIFICATION_KEY_2019)
+                .publicKeyJwk(eckey.toPublicJWK().toJSONObject())
+                .build();
+    }
+
+    private VerificationMethod createVerificationMethod(String verificationMethodId) {
+        try {
+            var eckey = (ECKey) ECKey.parseFromPEMEncodedObjects(readFile("public_secp256k1.pem"));
+            return createVerificationMethod(verificationMethodId, eckey);
+        } catch (JOSEException | IOException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    private DidDocument.Builder createDidDocumentBuilder(String verificationMethodId) {
+        var vm = createVerificationMethod(verificationMethodId);
+        return DidDocument.Builder.newInstance()
+                .verificationMethod(List.of(vm))
+                .service(Collections.singletonList(new Service("#my-service1", "MyService", "http://doesnotexi.st")));
+    }
+
     @Test
     void resolve() {
+        var didDocument = createDidDocument();
+        when(resolverRegistry.resolve(DID_URL)).thenReturn(Result.success(didDocument));
+
+        var result = resolver.resolveKey(DID_URL + KEYID);
+
+        assertThat(result).isSucceeded().isNotNull();
+        verify(resolverRegistry).resolve(DID_URL);
+    }
+
+    @Test
+    void resolve_withVerificationMethodUrlAsId() throws IOException, JOSEException {
+        var didDocument = createDidDocument(DID_URL + KEYID);
         when(resolverRegistry.resolve(DID_URL)).thenReturn(Result.success(didDocument));
 
         var result = resolver.resolveKey(DID_URL + KEYID);
@@ -97,6 +129,7 @@ class DidPublicKeyResolverImplTest {
 
     @Test
     void resolve_didDoesNotContainPublicKey() {
+        var didDocument = createDidDocument();
         didDocument.getVerificationMethod().clear();
         when(resolverRegistry.resolve(DID_URL)).thenReturn(Result.success(didDocument));
 
@@ -108,11 +141,24 @@ class DidPublicKeyResolverImplTest {
 
     @Test
     void resolve_didContainsMultipleKeysWithSameKeyId() throws JOSEException, IOException {
-        var publicKey = (ECKey) ECKey.parseFromPEMEncodedObjects(readFile("public_secp256k1.pem"));
-        var vm = VerificationMethod.Builder.newInstance().id(KEYID).type(DidConstants.JSON_WEB_KEY_2020).controller("")
-                .publicKeyJwk(publicKey.toJSONObject())
-                .build();
-        didDocument.getVerificationMethod().add(vm);
+        var vm = createVerificationMethod(KEYID);
+        var vm1 = createVerificationMethod(KEYID);
+        var didDocument = createDidDocumentBuilder(KEYID).verificationMethod(List.of(vm, vm1)).build();
+        when(resolverRegistry.resolve(DID_URL)).thenReturn(Result.success(didDocument));
+
+        var result = resolver.resolveKey(DID_URL + KEYID);
+
+        assertThat(result).isFailed()
+                .detail().contains("Every verification method must have a unique ID");
+        verify(resolverRegistry).resolve(DID_URL);
+    }
+
+    @Test
+    void resolve_didContainsMultipleKeysWithSameKeyId_withRelativeAndFullUrl() {
+        var vm = createVerificationMethod(DID_URL + KEYID);
+        var vm1 = createVerificationMethod(KEYID);
+
+        var didDocument = createDidDocumentBuilder(KEYID).verificationMethod(List.of(vm, vm1)).build();
         when(resolverRegistry.resolve(DID_URL)).thenReturn(Result.success(didDocument));
 
         var result = resolver.resolveKey(DID_URL + KEYID);
@@ -124,15 +170,17 @@ class DidPublicKeyResolverImplTest {
 
     @Test
     void resolve_publicKeyNotInPemFormat() {
-        didDocument.getVerificationMethod().clear();
-        var vm = VerificationMethod.Builder.newInstance().id("second-key").type(DidConstants.ECDSA_SECP_256_K_1_VERIFICATION_KEY_2019).controller("")
+        var secondKeyId = "#second-key";
+        var vm = VerificationMethod.Builder.newInstance().id(secondKeyId).type(DidConstants.ECDSA_SECP_256_K_1_VERIFICATION_KEY_2019).controller("")
                 .publicKeyJwk(Map.of("kty", "EC"))
                 .build();
-        didDocument.getVerificationMethod().add(vm);
+        var vm1 = createVerificationMethod(KEYID);
+
+        var didDocument = createDidDocumentBuilder(KEYID).verificationMethod(List.of(vm, vm1)).build();
 
         when(resolverRegistry.resolve(DID_URL)).thenReturn(Result.success(didDocument));
 
-        var result = resolver.resolveKey(DID_URL + KEYID);
+        var result = resolver.resolveKey(DID_URL + secondKeyId);
 
         assertThat(result).isFailed();
         verify(resolverRegistry).resolve(DID_URL);
@@ -140,6 +188,7 @@ class DidPublicKeyResolverImplTest {
 
     @Test
     void resolve_keyIdNullMultipleKeys() throws JOSEException, IOException {
+        var didDocument = createDidDocument();
         var publicKey = (ECKey) ECKey.parseFromPEMEncodedObjects(readFile("public_secp256k1.pem"));
         var vm = VerificationMethod.Builder.newInstance().id("#my-key2").type(DidConstants.JSON_WEB_KEY_2020).controller("")
                 .publicKeyJwk(publicKey.toJSONObject())
@@ -154,6 +203,7 @@ class DidPublicKeyResolverImplTest {
 
     @Test
     void resolve_keyIdIsNull_onlyOneVerificationMethod() {
+        var didDocument = createDidDocument();
         when(resolverRegistry.resolve(DID_URL)).thenReturn(Result.success(didDocument));
 
         var result = resolver.resolveKey(DID_URL);


### PR DESCRIPTION
## What this PR changes/adds

Supports verification method id to be both full URL (didUrl + keyId) and relative URL (keyId)

## Linked Issue(s)

Closes #3794 

