### PR TITLE
chore: add BouncyCastle provider to JWSSigner and JWSVerifier

### DIFF
--- a/extensions/common/crypto/crypto-common/src/test/java/org/eclipse/edc/security/token/jwt/CryptoConverterTest.java
+++ b/extensions/common/crypto/crypto-common/src/test/java/org/eclipse/edc/security/token/jwt/CryptoConverterTest.java
@@ -23,6 +23,7 @@ import com.nimbusds.jose.crypto.Ed25519Signer;
 import com.nimbusds.jose.crypto.Ed25519Verifier;
 import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jose.crypto.RSASSAVerifier;
+import com.nimbusds.jose.crypto.bc.BouncyCastleProviderSingleton;
 import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.JWK;
@@ -95,7 +96,9 @@ class CryptoConverterTest {
     void createSignerFor_ecKey() throws NoSuchAlgorithmException, InvalidAlgorithmParameterException {
         var pk = createEc();
 
-        assertThat(CryptoConverter.createSignerFor(pk.getPrivate())).isInstanceOf(ECDSASigner.class);
+        var signer = CryptoConverter.createSignerFor(pk.getPrivate());
+        assertThat(signer).isInstanceOf(ECDSASigner.class);
+        assertThat(signer.getJCAContext().getProvider()).isEqualTo(BouncyCastleProviderSingleton.getInstance());
     }
 
     @Test
@@ -119,7 +122,9 @@ class CryptoConverterTest {
     @Test
     void createVerifierFor_ecKey() throws NoSuchAlgorithmException, InvalidAlgorithmParameterException {
         var pk = createEc().getPublic();
-        assertThat(CryptoConverter.createVerifierFor(pk)).isInstanceOf(ECDSAVerifier.class);
+        var verifier = CryptoConverter.createVerifierFor(pk);
+        assertThat(verifier).isInstanceOf(ECDSAVerifier.class);
+        assertThat(verifier.getJCAContext().getProvider()).isEqualTo(BouncyCastleProviderSingleton.getInstance());
     }
 
     @Test


### PR DESCRIPTION
## What this PR changes/adds

Adds the `BouncyCastleProvider` to the JCA context when creating JWS signers and JWS verifiers.

## Why it does that

Some curves (e.g. `secp256k1`) are not supported natively in the JDK, check https://connect2id.com/products/nimbus-jose-jwt/examples/jwt-with-es256k-signature

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
