### PR TITLE
feat: disable consumer pull transfers if key settings are missing

### DIFF
--- a/core/common/token-core/src/main/java/org/eclipse/edc/token/JwtGenerationService.java
+++ b/core/common/token-core/src/main/java/org/eclipse/edc/token/JwtGenerationService.java
@@ -43,10 +43,12 @@ public class JwtGenerationService implements TokenGenerationService {
     public Result<TokenRepresentation> generate(Supplier<PrivateKey> privateKeySupplier, @NotNull TokenDecorator... decorators) {
 
         var privateKey = privateKeySupplier.get();
+        if (privateKey == null) {
+            return Result.failure("PrivateKey cannot be resolved.");
+        }
 
         var tokenSigner = CryptoConverter.createSignerFor(privateKey);
         var jwsAlgorithm = CryptoConverter.getRecommendedAlgorithm(tokenSigner);
-
 
         var bldr = TokenParameters.Builder.newInstance();
         var allDecorators = new ArrayList<>(Arrays.asList(decorators));

--- a/core/common/token-core/src/test/java/org/eclipse/edc/token/JwtGenerationServiceTest.java
+++ b/core/common/token-core/src/test/java/org/eclipse/edc/token/JwtGenerationServiceTest.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.jwt;
+package org.eclipse.edc.token;
 
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSHeader;
@@ -23,7 +23,6 @@ import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
 import com.nimbusds.jose.util.Base64URL;
 import com.nimbusds.jwt.SignedJWT;
-import org.eclipse.edc.token.JwtGenerationService;
 import org.eclipse.edc.token.spi.TokenDecorator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,13 +41,6 @@ class JwtGenerationServiceTest {
 
     private RSAKey keys;
     private JwtGenerationService tokenGenerationService;
-
-    private static RSAKey testKey() throws JOSEException {
-        return new RSAKeyGenerator(2048)
-                .keyUse(KeyUse.SIGNATURE) // indicate the intended use of the key
-                .keyID(UUID.randomUUID().toString()) // give the key a unique ID
-                .generate();
-    }
 
     @BeforeEach
     void setUp() throws JOSEException {
@@ -88,8 +80,24 @@ class JwtGenerationServiceTest {
         });
     }
 
+    @Test
+    void shouldFail_whenPrivateKeyCannotBeResolved() {
+        var decorator = testDecorator();
+
+        var result = tokenGenerationService.generate(() -> null, decorator);
+
+        assertThat(result.failed()).isTrue();
+    }
+
     private JWSVerifier createVerifier(JWSHeader header, Key publicKey) throws JOSEException {
         return new DefaultJWSVerifierFactory().createJWSVerifier(header, publicKey);
+    }
+
+    private RSAKey testKey() throws JOSEException {
+        return new RSAKeyGenerator(2048)
+                .keyUse(KeyUse.SIGNATURE) // indicate the intended use of the key
+                .keyID(UUID.randomUUID().toString()) // give the key a unique ID
+                .generate();
     }
 
     private TokenDecorator testDecorator() {

--- a/extensions/control-plane/transfer/transfer-data-plane/src/main/java/org/eclipse/edc/connector/transfer/dataplane/TransferDataPlaneConfig.java
+++ b/extensions/control-plane/transfer/transfer-data-plane/src/main/java/org/eclipse/edc/connector/transfer/dataplane/TransferDataPlaneConfig.java
@@ -19,18 +19,14 @@ import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 
 public interface TransferDataPlaneConfig {
 
-
     long DEFAULT_TOKEN_VALIDITY_SECONDS = 600; // 10min
     @Setting(value = "Validity (in seconds) of tokens issued by the Control Plane for targeting the Data Plane public API. Default value: " + DEFAULT_TOKEN_VALIDITY_SECONDS, type = "long")
     String TOKEN_VALIDITY_SECONDS = "edc.transfer.proxy.token.validity.seconds";
 
-    @Setting(value = "Alias of private key used for signing tokens, retrieved from private key resolver", defaultValue = "A random EC private key")
+    @Setting(value = "Alias of private key used for signing tokens, retrieved from private key resolver")
     String TOKEN_SIGNER_PRIVATE_KEY_ALIAS = "edc.transfer.proxy.token.signer.privatekey.alias";
 
-    @Setting(value = "Alias of public key used for verifying the tokens, retrieved from the vault", defaultValue = "A random EC public key")
+    @Setting(value = "Alias of public key used for verifying the tokens, retrieved from the vault")
     String TOKEN_VERIFIER_PUBLIC_KEY_ALIAS = "edc.transfer.proxy.token.verifier.publickey.alias";
 
-    String DEFAULT_DPF_SELECTOR_STRATEGY = "random";
-    @Setting(value = "Strategy for Data Plane instance selection", defaultValue = DEFAULT_DPF_SELECTOR_STRATEGY)
-    String DPF_SELECTOR_STRATEGY = "edc.transfer.client.selector.strategy";
 }

--- a/extensions/control-plane/transfer/transfer-data-plane/src/main/java/org/eclipse/edc/connector/transfer/dataplane/TransferDataPlaneCoreExtension.java
+++ b/extensions/control-plane/transfer/transfer-data-plane/src/main/java/org/eclipse/edc/connector/transfer/dataplane/TransferDataPlaneCoreExtension.java
@@ -111,27 +111,31 @@ public class TransferDataPlaneCoreExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
+        var publicKeyAlias = context.getSetting(TOKEN_VERIFIER_PUBLIC_KEY_ALIAS, null);
+        var privateKeyAlias = context.getSetting(TOKEN_SIGNER_PRIVATE_KEY_ALIAS, null);
 
-        var pubKeyAlias = context.getSetting(TOKEN_VERIFIER_PUBLIC_KEY_ALIAS, null);
-        var privKeyAlias = context.getSetting(TOKEN_SIGNER_PRIVATE_KEY_ALIAS, null);
+        if (publicKeyAlias != null && privateKeyAlias != null) {
+            context.getMonitor().info("One of these settings is not configured, so the connector won't be able to provide 'consumer-pull' transfers: [%s, %s]"
+                            .formatted(TOKEN_VERIFIER_PUBLIC_KEY_ALIAS, TOKEN_SIGNER_PRIVATE_KEY_ALIAS));
+
+            var controller = new ConsumerPullTransferTokenValidationApiController(tokenValidationService, dataEncrypter, typeManager, (i) -> publicKeyService.resolveKey(publicKeyAlias));
+            webService.registerResource(controlApiConfiguration.getContextAlias(), controller);
+
+            var resolver = new ConsumerPullDataPlaneProxyResolver(dataEncrypter, typeManager, new JwtGenerationService(), getPrivateKeySupplier(context, privateKeyAlias), () -> publicKeyAlias, tokenExpirationDateFunction);
+            dataFlowManager.register(new ConsumerPullTransferDataFlowController(selectorService, resolver));
+        }
 
         tokenValidationRulesRegistry.addRule(TRANSFER_DATAPLANE_TOKEN_CONTEXT, new ExpirationDateValidationRule(clock));
 
-        var controller = new ConsumerPullTransferTokenValidationApiController(tokenValidationService, dataEncrypter, typeManager, (i) -> publicKeyService.resolveKey(pubKeyAlias));
-        webService.registerResource(controlApiConfiguration.getContextAlias(), controller);
-
-        var resolver = new ConsumerPullDataPlaneProxyResolver(dataEncrypter, typeManager, new JwtGenerationService(), getPrivateKeySupplier(context, privKeyAlias), () -> pubKeyAlias, tokenExpirationDateFunction);
-        dataFlowManager.register(new ConsumerPullTransferDataFlowController(selectorService, resolver));
         dataFlowManager.register(new ProviderPushTransferDataFlowController(callbackUrl, selectorService, clientFactory));
-
         dataAddressValidatorRegistry.registerDestinationValidator("HttpProxy", dataAddress -> ValidationResult.success());
     }
 
     @NotNull
-    private Supplier<PrivateKey> getPrivateKeySupplier(ServiceExtensionContext context, String privKeyAlias) {
-        return () -> privateKeyResolver.resolvePrivateKey(privKeyAlias)
+    private Supplier<PrivateKey> getPrivateKeySupplier(ServiceExtensionContext context, String privateKeyAlias) {
+        return () -> privateKeyResolver.resolvePrivateKey(privateKeyAlias)
                 .orElse(f -> {
-                    context.getMonitor().warning(f.getFailureDetail());
+                    context.getMonitor().warning("Cannot resolve private key: " + f.getFailureDetail());
                     return null;
                 });
     }

--- a/extensions/control-plane/transfer/transfer-data-plane/src/test/java/org/eclipse/edc/connector/transfer/dataplane/TransferDataPlaneCoreExtensionTest.java
+++ b/extensions/control-plane/transfer/transfer-data-plane/src/test/java/org/eclipse/edc/connector/transfer/dataplane/TransferDataPlaneCoreExtensionTest.java
@@ -14,41 +14,33 @@
 
 package org.eclipse.edc.connector.transfer.dataplane;
 
-import com.nimbusds.jose.JOSEException;
-import com.nimbusds.jose.jwk.KeyUse;
-import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
 import org.eclipse.edc.connector.api.control.configuration.ControlApiConfiguration;
-import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
-import org.eclipse.edc.connector.dataplane.selector.spi.client.DataPlaneClient;
 import org.eclipse.edc.connector.transfer.dataplane.api.ConsumerPullTransferTokenValidationApiController;
 import org.eclipse.edc.connector.transfer.dataplane.flow.ConsumerPullTransferDataFlowController;
 import org.eclipse.edc.connector.transfer.dataplane.flow.ProviderPushTransferDataFlowController;
-import org.eclipse.edc.connector.transfer.dataplane.spi.security.DataEncrypter;
 import org.eclipse.edc.connector.transfer.spi.flow.DataFlowManager;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
-import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.monitor.Monitor;
-import org.eclipse.edc.spi.security.PrivateKeyResolver;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.configuration.Config;
-import org.eclipse.edc.spi.system.injection.ObjectFactory;
 import org.eclipse.edc.web.spi.WebService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
-import java.security.KeyPair;
 import java.util.Objects;
-import java.util.UUID;
 
 import static org.eclipse.edc.connector.transfer.dataplane.TransferDataPlaneConfig.TOKEN_SIGNER_PRIVATE_KEY_ALIAS;
 import static org.eclipse.edc.connector.transfer.dataplane.TransferDataPlaneConfig.TOKEN_VERIFIER_PUBLIC_KEY_ALIAS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(DependencyInjectionExtension.class)
@@ -56,50 +48,26 @@ class TransferDataPlaneCoreExtensionTest {
 
     private static final String CONTROL_PLANE_API_CONTEXT = "control";
 
-    private final Vault vault = mock(Vault.class);
-    private final WebService webService = mock(WebService.class);
-    private final DataFlowManager dataFlowManager = mock(DataFlowManager.class);
-    private KeyPair keypair;
-    private TransferDataPlaneCoreExtension extension;
-
-    private static KeyPair keyPair() throws JOSEException {
-        return new RSAKeyGenerator(2048)
-                .keyUse(KeyUse.SIGNATURE) // indicate the intended use of the key
-                .keyID(UUID.randomUUID().toString()) // give the key a unique ID
-                .generate()
-                .toKeyPair();
-    }
-
-    private static String publicKeyPem() throws IOException {
-        return new String(Objects.requireNonNull(TransferDataPlaneCoreExtensionTest.class.getClassLoader().getResourceAsStream("rsa-pubkey.pem"))
-                .readAllBytes());
-    }
+    private final Vault vault = mock();
+    private final WebService webService = mock();
+    private final DataFlowManager dataFlowManager = mock();
 
     @BeforeEach
-    public void setUp(ServiceExtensionContext context, ObjectFactory factory) throws JOSEException {
-        keypair = keyPair();
+    public void setUp(ServiceExtensionContext context) {
         var monitor = mock(Monitor.class);
         var controlApiConfigurationMock = mock(ControlApiConfiguration.class);
         when(controlApiConfigurationMock.getContextAlias()).thenReturn(CONTROL_PLANE_API_CONTEXT);
 
-        context.registerService(PrivateKeyResolver.class, mock(PrivateKeyResolver.class));
-        context.registerService(Vault.class, mock(Vault.class));
         context.registerService(WebService.class, webService);
-        context.registerService(ContractNegotiationStore.class, mock(ContractNegotiationStore.class));
-        context.registerService(RemoteMessageDispatcherRegistry.class, mock(RemoteMessageDispatcherRegistry.class));
         context.registerService(DataFlowManager.class, dataFlowManager);
-        context.registerService(DataEncrypter.class, mock(DataEncrypter.class));
         context.registerService(ControlApiConfiguration.class, controlApiConfigurationMock);
-        context.registerService(DataPlaneClient.class, mock(DataPlaneClient.class));
         context.registerService(Vault.class, vault);
 
         when(context.getMonitor()).thenReturn(monitor);
-
-        extension = factory.constructInstance(TransferDataPlaneCoreExtension.class);
     }
 
     @Test
-    void verifyInitializeSuccess(ServiceExtensionContext context) throws IOException {
+    void verifyInitializeSuccess(TransferDataPlaneCoreExtension extension, ServiceExtensionContext context) throws IOException {
         var publicKeyAlias = "publicKey";
         var privateKeyAlias = "privateKey";
         var config = mock(Config.class);
@@ -113,5 +81,24 @@ class TransferDataPlaneCoreExtensionTest {
         verify(dataFlowManager).register(any(ConsumerPullTransferDataFlowController.class));
         verify(dataFlowManager).register(any(ProviderPushTransferDataFlowController.class));
         verify(webService).registerResource(eq(CONTROL_PLANE_API_CONTEXT), any(ConsumerPullTransferTokenValidationApiController.class));
+    }
+
+    @Test
+    void shouldNotRegisterConsumerPullControllers_whenSettingsAreMissing(TransferDataPlaneCoreExtension extension, ServiceExtensionContext context) {
+        var config = mock(Config.class);
+        when(context.getConfig()).thenReturn(config);
+        when(config.getString(TOKEN_VERIFIER_PUBLIC_KEY_ALIAS, null)).thenReturn(null);
+        when(config.getString(TOKEN_SIGNER_PRIVATE_KEY_ALIAS, null)).thenReturn(null);
+
+        extension.initialize(context);
+
+        verify(dataFlowManager, never()).register(isA(ConsumerPullTransferDataFlowController.class));
+        verifyNoInteractions(webService);
+    }
+
+    private String publicKeyPem() throws IOException {
+        try (var resource = TransferDataPlaneCoreExtensionTest.class.getClassLoader().getResourceAsStream("rsa-pubkey.pem")) {
+            return new String(Objects.requireNonNull(resource).readAllBytes());
+        }
     }
 }

--- a/extensions/control-plane/transfer/transfer-data-plane/src/test/java/org/eclipse/edc/connector/transfer/dataplane/TransferDataPlaneCoreExtensionTest.java
+++ b/extensions/control-plane/transfer/transfer-data-plane/src/test/java/org/eclipse/edc/connector/transfer/dataplane/TransferDataPlaneCoreExtensionTest.java
@@ -51,10 +51,10 @@ class TransferDataPlaneCoreExtensionTest {
     private final Vault vault = mock();
     private final WebService webService = mock();
     private final DataFlowManager dataFlowManager = mock();
+    private final Monitor monitor = mock();
 
     @BeforeEach
     public void setUp(ServiceExtensionContext context) {
-        var monitor = mock(Monitor.class);
         var controlApiConfigurationMock = mock(ControlApiConfiguration.class);
         when(controlApiConfigurationMock.getContextAlias()).thenReturn(CONTROL_PLANE_API_CONTEXT);
 
@@ -94,6 +94,7 @@ class TransferDataPlaneCoreExtensionTest {
 
         verify(dataFlowManager, never()).register(isA(ConsumerPullTransferDataFlowController.class));
         verifyNoInteractions(webService);
+        verify(monitor).info(any(String.class));
     }
 
     private String publicKeyPem() throws IOException {


### PR DESCRIPTION
## What this PR changes/adds

Add settings check to `TransferDataPlaneCoreExtension`, if the ones related to the private/public keys are missing, then the "consumer-pull" transfer won't be enabled.

## Why it does that

avoid weird exceptions when settings are missing

## Further notes

- added a check also in the `JwtGenerationService` to avoid null pointer exceptions there in the case the key is not available.

## Linked Issue(s)

Closes #3810

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
