### PR TITLE
chore: remove redundant builder API call

### DIFF
--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
@@ -139,7 +139,6 @@ public class TransferProcessManagerImpl extends AbstractStateEntityManager<Trans
                 .contractId(transferRequest.getContractId())
                 .destinationType(transferRequest.getDataDestination().getType())
                 .protocol(transferRequest.getProtocol())
-                .dataDestination(transferRequest.getDataDestination())
                 .build();
 
         var process = TransferProcess.Builder.newInstance()


### PR DESCRIPTION
## What this PR changes/adds

Removes one unnecessary DataRequest builder API call.

## Why it does that

Cleaning up the code