### PR TITLE
feat: policy scope extractors for transfer process ingress calls

### DIFF
--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -148,8 +148,8 @@ class ContractNegotiationIntegrationTest {
                 .build();
 
         when(identityService.verifyJwtToken(eq(tokenRepresentation), isA(VerificationContext.class))).thenReturn(Result.success(token));
-        consumerService = new ContractNegotiationProtocolServiceImpl(consumerStore, new NoopTransactionContext(), validationService, identityService, new ContractNegotiationObservableImpl(), monitor, mock());
-        providerService = new ContractNegotiationProtocolServiceImpl(providerStore, new NoopTransactionContext(), validationService, identityService, new ContractNegotiationObservableImpl(), monitor, mock());
+        consumerService = new ContractNegotiationProtocolServiceImpl(consumerStore, new NoopTransactionContext(), validationService, identityService, mock(), new ContractNegotiationObservableImpl(), monitor, mock());
+        providerService = new ContractNegotiationProtocolServiceImpl(providerStore, new NoopTransactionContext(), validationService, identityService, mock(), new ContractNegotiationObservableImpl(), monitor, mock());
     }
 
     @AfterEach
@@ -292,7 +292,7 @@ class ContractNegotiationIntegrationTest {
         @ParameterizedTest
         @ArgumentsSource(EgressMessages.class)
         void shouldSendMessageWithTheSameId_whenFirstDispatchFailed(ContractNegotiation.Type type, ContractNegotiationStates state,
-                                                                  Class<? extends ContractRemoteMessage> messageType) {
+                                                                    Class<? extends ContractRemoteMessage> messageType) {
             var dispatcherRegistry = type == CONSUMER ? consumerDispatcherRegistry : providerDispatcherRegistry;
             var store = type == CONSUMER ? consumerStore : providerStore;
             var manager = type == CONSUMER ? consumerManager : providerManager;

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/ControlPlaneServicesExtension.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/ControlPlaneServicesExtension.java
@@ -51,6 +51,7 @@ import org.eclipse.edc.connector.spi.transferprocess.TransferProcessService;
 import org.eclipse.edc.connector.transfer.spi.TransferProcessManager;
 import org.eclipse.edc.connector.transfer.spi.observe.TransferProcessObservable;
 import org.eclipse.edc.connector.transfer.spi.store.TransferProcessStore;
+import org.eclipse.edc.policy.engine.spi.PolicyEngine;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
@@ -140,6 +141,9 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     @Inject
     private IdentityService identityService;
 
+    @Inject
+    private PolicyEngine policyEngine;
+
     @Override
     public String name() {
         return NAME;
@@ -160,7 +164,7 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     @Provider
     public CatalogProtocolService catalogProtocolService(ServiceExtensionContext context) {
         return new CatalogProtocolServiceImpl(datasetResolver, participantAgentService, dataServiceRegistry,
-                identityService, monitor, context.getParticipantId(), transactionContext);
+                identityService, policyEngine, monitor, context.getParticipantId(), transactionContext);
     }
 
     @Provider
@@ -183,7 +187,7 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     @Provider
     public ContractNegotiationProtocolService contractNegotiationProtocolService() {
         return new ContractNegotiationProtocolServiceImpl(contractNegotiationStore,
-                transactionContext, contractValidationService, identityService, contractNegotiationObservable,
+                transactionContext, contractValidationService, identityService, policyEngine, contractNegotiationObservable,
                 monitor, telemetry);
     }
 
@@ -203,6 +207,6 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     @Provider
     public TransferProcessProtocolService transferProcessProtocolService() {
         return new TransferProcessProtocolServiceImpl(transferProcessStore, transactionContext, contractNegotiationStore,
-                contractValidationService, identityService, dataAddressValidator, transferProcessObservable, clock, monitor, telemetry);
+                contractValidationService, identityService, policyEngine, dataAddressValidator, transferProcessObservable, clock, monitor, telemetry);
     }
 }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/catalog/CatalogProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/catalog/CatalogProtocolServiceImpl.java
@@ -21,6 +21,7 @@ import org.eclipse.edc.catalog.spi.Dataset;
 import org.eclipse.edc.catalog.spi.DatasetResolver;
 import org.eclipse.edc.connector.service.protocol.BaseProtocolService;
 import org.eclipse.edc.connector.spi.catalog.CatalogProtocolService;
+import org.eclipse.edc.policy.engine.spi.PolicyEngine;
 import org.eclipse.edc.spi.agent.ParticipantAgentService;
 import org.eclipse.edc.spi.iam.IdentityService;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
@@ -42,14 +43,17 @@ public class CatalogProtocolServiceImpl extends BaseProtocolService implements C
     private final String participantId;
     private final TransactionContext transactionContext;
 
+    private PolicyEngine policyEngine;
+
     public CatalogProtocolServiceImpl(DatasetResolver datasetResolver,
                                       ParticipantAgentService participantAgentService,
                                       DataServiceRegistry dataServiceRegistry,
                                       IdentityService identityService,
+                                      PolicyEngine policyEngine,
                                       Monitor monitor,
                                       String participantId,
                                       TransactionContext transactionContext) {
-        super(identityService, monitor);
+        super(identityService, policyEngine, monitor);
         this.datasetResolver = datasetResolver;
         this.participantAgentService = participantAgentService;
         this.dataServiceRegistry = dataServiceRegistry;

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
@@ -29,6 +29,7 @@ import org.eclipse.edc.connector.contract.spi.validation.ContractValidationServi
 import org.eclipse.edc.connector.contract.spi.validation.ValidatedConsumerOffer;
 import org.eclipse.edc.connector.service.protocol.BaseProtocolService;
 import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationProtocolService;
+import org.eclipse.edc.policy.engine.spi.PolicyEngine;
 import org.eclipse.edc.spi.iam.ClaimToken;
 import org.eclipse.edc.spi.iam.IdentityService;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
@@ -56,9 +57,10 @@ public class ContractNegotiationProtocolServiceImpl extends BaseProtocolService 
                                                   TransactionContext transactionContext,
                                                   ContractValidationService validationService,
                                                   IdentityService identityService,
+                                                  PolicyEngine policyEngine,
                                                   ContractNegotiationObservable observable,
                                                   Monitor monitor, Telemetry telemetry) {
-        super(identityService, monitor);
+        super(identityService, policyEngine, monitor);
         this.store = store;
         this.transactionContext = transactionContext;
         this.validationService = validationService;
@@ -137,7 +139,7 @@ public class ContractNegotiationProtocolServiceImpl extends BaseProtocolService 
     public ServiceResult<ContractNegotiation> notifyAgreed(ContractAgreementMessage message, TokenRepresentation tokenRepresentation) {
         return transactionContext.execute(() -> verifyToken(tokenRepresentation)
                 .compose(claimToken -> getNegotiation(message.getProcessId())
-                    .compose(negotiation -> validateAgreed(message, claimToken, negotiation))
+                        .compose(negotiation -> validateAgreed(message, claimToken, negotiation))
                 )
                 .onSuccess(negotiation -> {
                     if (negotiation.shouldIgnoreIncomingMessage(message.getId())) {

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/protocol/BaseProtocolService.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/protocol/BaseProtocolService.java
@@ -14,13 +14,18 @@
 
 package org.eclipse.edc.connector.service.protocol;
 
+import org.eclipse.edc.policy.engine.spi.PolicyContextImpl;
+import org.eclipse.edc.policy.engine.spi.PolicyEngine;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.iam.ClaimToken;
 import org.eclipse.edc.spi.iam.IdentityService;
+import org.eclipse.edc.spi.iam.RequestScope;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.iam.VerificationContext;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.ServiceResult;
+
+import java.util.List;
 
 /**
  * Base class for all protocol service implementation. This will contain common logic such as validating the JWT token
@@ -30,11 +35,14 @@ public abstract class BaseProtocolService {
 
     private final IdentityService identityService;
 
+    private final PolicyEngine policyEngine;
+
     private final Monitor monitor;
 
-    protected BaseProtocolService(IdentityService identityService, Monitor monitor) {
+    protected BaseProtocolService(IdentityService identityService, PolicyEngine policyEngine, Monitor monitor) {
         this.identityService = identityService;
         this.monitor = monitor;
+        this.policyEngine = policyEngine;
     }
 
     /**
@@ -43,7 +51,8 @@ public abstract class BaseProtocolService {
      * @param tokenRepresentation The input {@link TokenRepresentation}
      * @return The {@link ClaimToken} if success, failure otherwise
      */
-    public ServiceResult<ClaimToken> verifyToken(TokenRepresentation tokenRepresentation) {
+    //TODO remove once this lands https://github.com/eclipse-edc/Connector/issues/3819
+    protected ServiceResult<ClaimToken> verifyToken(TokenRepresentation tokenRepresentation) {
         // TODO: since we are pushing here the invocation of the IdentityService we don't know the audience here
         //  The audience removal will be tackle next. IdentityService that relies on this parameter would not work
         //  for the time being.
@@ -51,8 +60,13 @@ public abstract class BaseProtocolService {
         // TODO: policy extractors will be handled next
         var verificationContext = VerificationContext.Builder.newInstance()
                 .policy(Policy.Builder.newInstance().build())
+                .scopes(List.of())
                 .build();
 
+        return verifyToken(tokenRepresentation, verificationContext);
+    }
+
+    protected ServiceResult<ClaimToken> verifyToken(TokenRepresentation tokenRepresentation, VerificationContext verificationContext) {
         var result = identityService.verifyJwtToken(tokenRepresentation, verificationContext);
 
         if (result.failed()) {
@@ -61,4 +75,30 @@ public abstract class BaseProtocolService {
         }
         return ServiceResult.success(result.getContent());
     }
+
+
+    /**
+     * Validate and extract the {@link ClaimToken} from the input {@link TokenRepresentation} by using the {@link IdentityService}
+     *
+     * @param tokenRepresentation The input {@link TokenRepresentation}
+     * @param scope               The policy scope
+     * @param policy              The {@link Policy}
+     * @return The {@link ClaimToken} if success, failure otherwise
+     */
+    protected ServiceResult<ClaimToken> verifyToken(TokenRepresentation tokenRepresentation, String scope, Policy policy) {
+        return verifyToken(tokenRepresentation, createVerificationContext(scope, policy));
+    }
+
+    private VerificationContext createVerificationContext(String scope, Policy policy) {
+        var requestScopeBuilder = RequestScope.Builder.newInstance();
+        var policyContext = PolicyContextImpl.Builder.newInstance()
+                .additional(RequestScope.Builder.class, requestScopeBuilder)
+                .build();
+        policyEngine.evaluate(scope, policy, policyContext);
+        return VerificationContext.Builder.newInstance()
+                .policy(policy)
+                .scopes(requestScopeBuilder.build().getScopes())
+                .build();
+    }
+
 }

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/catalog/CatalogProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/catalog/CatalogProtocolServiceImplTest.java
@@ -60,7 +60,7 @@ class CatalogProtocolServiceImplTest {
     private final TransactionContext transactionContext = spy(new NoopTransactionContext());
 
     private final CatalogProtocolServiceImpl service = new CatalogProtocolServiceImpl(datasetResolver,
-            participantAgentService, dataServiceRegistry, identityService, mock(), "participantId",
+            participantAgentService, dataServiceRegistry, identityService, mock(), mock(), "participantId",
             transactionContext);
 
     @Test

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
@@ -101,7 +101,7 @@ class ContractNegotiationProtocolServiceImplTest {
     void setUp() {
         var observable = new ContractNegotiationObservableImpl();
         observable.registerListener(listener);
-        service = new ContractNegotiationProtocolServiceImpl(store, transactionContext, validationService, identityService,
+        service = new ContractNegotiationProtocolServiceImpl(store, transactionContext, validationService, identityService, mock(),
                 observable, mock(), mock());
     }
 
@@ -266,7 +266,7 @@ class ContractNegotiationProtocolServiceImplTest {
         verify(store).findByIdAndLease("processId");
         verify(store).save(argThat(negotiation ->
                 negotiation.getState() == AGREED.code() &&
-                negotiation.getContractAgreement() == contractAgreement
+                        negotiation.getContractAgreement() == contractAgreement
         ));
         verify(store).findByIdAndLease("processId");
         verify(validationService).validateConfirmed(eq(claimToken), eq(contractAgreement), any(ContractOffer.class));

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessEventDispatchTest.java
@@ -140,6 +140,7 @@ public class TransferProcessEventDispatchTest {
         var providerId = "ProviderId";
 
         when(agreement.getProviderId()).thenReturn(providerId);
+        when(agreement.getPolicy()).thenReturn(Policy.Builder.newInstance().build());
         when(agent.getIdentity()).thenReturn(providerId);
 
         dispatcherRegistry.register(getTestDispatcher());

--- a/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtension.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtension.java
@@ -140,7 +140,7 @@ public class IdentityAndTrustExtension implements ServiceExtension {
 
         var validationAction = tokenValidationAction();
 
-        return new IdentityAndTrustService(secureTokenService, getOwnDid(context), context.getParticipantId(), getPresentationVerifier(context),
+        return new IdentityAndTrustService(secureTokenService, getOwnDid(context), getPresentationVerifier(context),
                 getCredentialServiceClient(context), validationAction, registry, clock, credentialServiceUrlResolver);
     }
 

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/IdentityAndTrustService.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/IdentityAndTrustService.java
@@ -75,7 +75,6 @@ public class IdentityAndTrustService implements IdentityService {
     private static final String SCOPE_STRING_REGEX = "(.+):(.+):(read|write|\\*)";
     private final SecureTokenService secureTokenService;
     private final String myOwnDid;
-    private final String participantId;
     private final PresentationVerifier presentationVerifier;
     private final CredentialServiceClient credentialServiceClient;
     private final Function<TokenRepresentation, Result<ClaimToken>> tokenValidationAction;
@@ -89,13 +88,12 @@ public class IdentityAndTrustService implements IdentityService {
      * @param secureTokenService Instance of an STS, which can create SI tokens
      * @param myOwnDid           The DID which belongs to "this connector"
      */
-    public IdentityAndTrustService(SecureTokenService secureTokenService, String myOwnDid, String participantId,
+    public IdentityAndTrustService(SecureTokenService secureTokenService, String myOwnDid,
                                    PresentationVerifier presentationVerifier, CredentialServiceClient credentialServiceClient,
                                    TokenValidationAction tokenValidationAction,
                                    TrustedIssuerRegistry trustedIssuerRegistry, Clock clock, CredentialServiceUrlResolver csUrlResolver) {
         this.secureTokenService = secureTokenService;
         this.myOwnDid = myOwnDid;
-        this.participantId = participantId;
         this.presentationVerifier = presentationVerifier;
         this.credentialServiceClient = credentialServiceClient;
         this.tokenValidationAction = tokenValidationAction;
@@ -147,6 +145,7 @@ public class IdentityAndTrustService implements IdentityService {
         var issuer = claimToken.getStringClaim(ISSUER);
 
         /* TODO: DEMO the scopes should be extracted elsewhere. replace this section!!############################*/
+        //TODO remove once this lands https://github.com/eclipse-edc/Connector/issues/3819
         var scopes = new ArrayList<String>();
         try {
             var scope = SignedJWT.parse(accessToken).getJWTClaimsSet().getStringClaim("scope");
@@ -154,7 +153,6 @@ public class IdentityAndTrustService implements IdentityService {
         } catch (ParseException e) {
             throw new RuntimeException(e);
         }
-        /* TODO: END DEMO ########################################################################################*/
 
         var siTokenClaims = Map.of(PRESENTATION_ACCESS_TOKEN_CLAIM, accessToken,
                 ISSUED_AT, Instant.now().toString(),

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/test/java/org/eclipse/edc/iam/identitytrust/service/IdentityAndTrustServiceTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/test/java/org/eclipse/edc/iam/identitytrust/service/IdentityAndTrustServiceTest.java
@@ -71,9 +71,7 @@ import static org.mockito.Mockito.when;
 
 class IdentityAndTrustServiceTest {
     public static final String EXPECTED_OWN_DID = "did:web:test";
-
-    public static final String EXPECTED_PARTICIPANT_ID = "participantId";
-
+    
     public static final String CONSUMER_DID = "did:web:consumer";
     private final SecureTokenService mockedSts = mock();
     private final PresentationVerifier mockedVerifier = mock();
@@ -81,7 +79,7 @@ class IdentityAndTrustServiceTest {
     private final TrustedIssuerRegistry trustedIssuerRegistryMock = mock();
     private final CredentialServiceUrlResolver credentialServiceUrlResolverMock = mock();
     private final TokenValidationAction actionMock = mock();
-    private final IdentityAndTrustService service = new IdentityAndTrustService(mockedSts, EXPECTED_OWN_DID, EXPECTED_PARTICIPANT_ID, mockedVerifier, mockedClient,
+    private final IdentityAndTrustService service = new IdentityAndTrustService(mockedSts, EXPECTED_OWN_DID, mockedVerifier, mockedClient,
             actionMock, trustedIssuerRegistryMock, Clock.systemUTC(), credentialServiceUrlResolverMock);
 
     @BeforeEach

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/iam/RequestScope.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/iam/RequestScope.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.spi.iam;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Gets injected in the policy context on ingress/egress protocol calls to be able to append scopes needed
+ * for the protocol request.
+ */
+public class RequestScope {
+
+    private RequestScope() {
+    }
+
+    private Set<String> scopes = new HashSet<>();
+
+
+    public Set<String> getScopes() {
+        return scopes;
+    }
+
+    public static class Builder {
+        private final RequestScope requestScope;
+
+        private Builder() {
+            requestScope = new RequestScope();
+        }
+
+        public static RequestScope.Builder newInstance() {
+            return new RequestScope.Builder();
+        }
+
+        public Builder scope(String scope) {
+            requestScope.scopes.add(scope);
+            return this;
+        }
+
+        public Builder scopes(Collection<String> scopes) {
+            requestScope.scopes = new HashSet<>(scopes);
+            return this;
+        }
+
+        public RequestScope build() {
+            return requestScope;
+        }
+    }
+}

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/iam/VerificationContext.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/iam/VerificationContext.java
@@ -16,9 +16,12 @@ package org.eclipse.edc.spi.iam;
 
 import org.eclipse.edc.policy.model.Policy;
 
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Provides additional context for {@link IdentityService} verifiers.
@@ -30,6 +33,7 @@ public class VerificationContext {
     private String audience;
     private Policy policy;
 
+    private Set<String> scopes = new HashSet<>();
     private final Map<Class<?>, Object> additional;
 
     private VerificationContext() {
@@ -51,12 +55,23 @@ public class VerificationContext {
     }
 
     /**
+     * Return the scopes associated with the verification context
+     *
+     * @return The scope
+     */
+    public Set<String> getScopes() {
+        return scopes;
+    }
+
+    /**
      * Gets additional data from the context by type.
      *
      * @param type the type class.
      * @param <T>  the type of data.
      * @return the object associated with the type, or null.
      */
+
+
     @SuppressWarnings("unchecked")
     public <T> T getContextData(Class<T> type) {
         return (T) additional.get(type);
@@ -88,7 +103,13 @@ public class VerificationContext {
             return this;
         }
 
+        public Builder scopes(Collection<String> scopes) {
+            context.scopes = new HashSet<>(scopes);
+            return this;
+        }
+
         public VerificationContext build() {
+
             Objects.requireNonNull(this.context.policy, "Policy cannot be null");
             return context;
         }


### PR DESCRIPTION
## What this PR changes/adds

Introduces the policy scopes extractor in transfer process messages at protocol layers:

- Injected in all `*ProtocolService` the `policy` engine for scope extraction
- When evaluating the `policy` for the request scope the in context object has been changed from `TokenParameters.Builder`  to `RequestScope.Builder` for ingress/egress symmetry
- Now we need to fetch some additional data before verifying the actual token. To prevent possible leakage of resource presence to unauthenticated calls, all the transfer process apis returns `404` not found, in case of resource (transferprocess/contract negotiation) not present in the database and in the case token verification failure as outlined in the [spec](https://docs.internationaldataspaces.org/ids-knowledgebase/v/dataspace-protocol/transfer-process/transfer.process.binding.https#id-2.4.1-get).
- In order to prevent unwanted writes on transfer process lease in the database before the token verification, on all `TransferRemoteMessage` with the exception of `TransferRequestMessage`, the transfer process will be fetched two times, the first time in read-only mode for getting the associated policy and the second one after the token has been verified with the lease attached.

## Linked Issue(s)

Closes #3818 


