### PR TITLE
feat: adapt VP client to support multi-tenant `PresentationApi`

### DIFF
--- a/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/defaults/DefaultCredentialServiceClient.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/defaults/DefaultCredentialServiceClient.java
@@ -18,6 +18,10 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import okhttp3.MediaType;
 import okhttp3.Request;
 import okhttp3.RequestBody;
@@ -36,16 +40,12 @@ import org.eclipse.edc.spi.result.AbstractResult;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
+import static java.lang.String.format;
 import static org.eclipse.edc.spi.result.Result.failure;
 import static org.eclipse.edc.spi.result.Result.success;
 
 public class DefaultCredentialServiceClient implements CredentialServiceClient {
-    public static final String PRESENTATION_ENDPOINT = "/presentation/query";
+    public static final String PRESENTATION_ENDPOINT_TEMPLATE = "/participants/%s/presentation/query";
     private final EdcHttpClient httpClient;
     private final JsonBuilderFactory jsonFactory;
     private final ObjectMapper objectMapper;
@@ -63,10 +63,10 @@ public class DefaultCredentialServiceClient implements CredentialServiceClient {
     }
 
     @Override
-    public Result<List<VerifiablePresentationContainer>> requestPresentation(String credentialServiceBaseUrl, String selfIssuedTokenJwt, List<String> scopes) {
+    public Result<List<VerifiablePresentationContainer>> requestPresentation(String credentialServiceBaseUrl, String participantId, String selfIssuedTokenJwt, List<String> scopes) {
         var query = createPresentationQuery(scopes);
 
-        var url = credentialServiceBaseUrl + PRESENTATION_ENDPOINT;
+        var url = credentialServiceBaseUrl + format(PRESENTATION_ENDPOINT_TEMPLATE, participantId);
 
         try {
             var requestJson = objectMapper.writeValueAsString(query);

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/IdentityAndTrustService.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/IdentityAndTrustService.java
@@ -15,6 +15,17 @@
 package org.eclipse.edc.iam.identitytrust;
 
 import com.nimbusds.jwt.SignedJWT;
+import java.text.ParseException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Stream;
 import org.eclipse.edc.iam.identitytrust.validation.rules.HasValidIssuer;
 import org.eclipse.edc.iam.identitytrust.validation.rules.HasValidSubjectIds;
 import org.eclipse.edc.iam.identitytrust.validation.rules.IsNotExpired;
@@ -37,18 +48,6 @@ import org.eclipse.edc.spi.iam.VerificationContext;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.util.string.StringUtils;
 import org.jetbrains.annotations.NotNull;
-
-import java.text.ParseException;
-import java.time.Clock;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Stream;
 
 import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_ACCESS_TOKEN_CLAIM;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.AUDIENCE;
@@ -170,7 +169,7 @@ public class IdentityAndTrustService implements IdentityService {
 
         // get CS Url, execute VP request
         var vpResponse = credentialServiceUrlResolver.resolve(issuer)
-                .compose(url -> credentialServiceClient.requestPresentation(url, siTokenString, scopes));
+                .compose(url -> credentialServiceClient.requestPresentation(url, issuer, siTokenString, scopes));
 
         if (vpResponse.failed()) {
             return vpResponse.mapTo();

--- a/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/CredentialServiceClient.java
+++ b/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/CredentialServiceClient.java
@@ -14,10 +14,9 @@
 
 package org.eclipse.edc.identitytrust;
 
+import java.util.List;
 import org.eclipse.edc.identitytrust.model.VerifiablePresentationContainer;
 import org.eclipse.edc.spi.result.Result;
-
-import java.util.List;
 
 /**
  * This interface gives access to the REST API of a CredentialService
@@ -33,10 +32,11 @@ public interface CredentialServiceClient {
      *
      * @param credentialServiceUrl The URL of the credentialService from which the VP is to be requested
      * @param siTokenJwt           A Self-Issued ID token in JWT format, that contains the access_token
+     * @param participantId        Context ID of the participant from which the VP is to be requested
      * @param scopes               A list of strings, each containing a <a href="https://github.com/eclipse-tractusx/identity-trust/blob/main/specifications/M1/verifiable.presentation.protocol.md#31-access-scopes">scope definition</a>
      * @return A list of {@link VerifiablePresentationContainer} objects, or a failure if the request was unsuccessful.
      */
-    Result<List<VerifiablePresentationContainer>> requestPresentation(String credentialServiceUrl, String siTokenJwt, List<String> scopes);
+    Result<List<VerifiablePresentationContainer>> requestPresentation(String credentialServiceUrl, String participantId, String siTokenJwt, List<String> scopes);
 
     //todo: add write api?
 }


### PR DESCRIPTION
## What this PR changes/adds

Adapt VP client to support multi-tenant PresentationApi implemented as part of https://github.com/eclipse-edc/IdentityHub/pull/263

## Why it does that

Support of multi-tenancy in Credentials Service.

## Linked Issue(s)

https://github.com/eclipse-edc/IdentityHub/pull/263

