### PR TITLE
fix: add 'keyId' param to methods of the CryptoConverter

### DIFF
--- a/extensions/common/crypto/crypto-common/src/test/java/org/eclipse/edc/security/token/jwt/CryptoConverterTest.java
+++ b/extensions/common/crypto/crypto-common/src/test/java/org/eclipse/edc/security/token/jwt/CryptoConverterTest.java
@@ -140,7 +140,7 @@ class CryptoConverterTest {
     }
 
     @Test
-    void convertToJwk_rsaKey() throws NoSuchAlgorithmException {
+    void createJwk_rsaKey() throws NoSuchAlgorithmException {
         var pk = createRsa();
         var jwk = CryptoConverter.createJwk(pk);
         assertThat(jwk).isInstanceOf(RSAKey.class);
@@ -149,7 +149,16 @@ class CryptoConverterTest {
     }
 
     @Test
-    void convertToJwk_ecKey_fromPublic() throws NoSuchAlgorithmException, InvalidAlgorithmParameterException {
+    void createJwk_rsaKey_withKeyId() throws NoSuchAlgorithmException {
+        var pk = createRsa();
+        var jwk = CryptoConverter.createJwk(pk, "test-key-id");
+        assertThat(jwk).isInstanceOf(RSAKey.class);
+        assertThat(jwk.isPrivate()).isTrue();
+        assertThat(jwk.getKeyID()).isEqualTo("test-key-id");
+    }
+
+    @Test
+    void createJwk_ecKey_fromPublic() throws NoSuchAlgorithmException, InvalidAlgorithmParameterException {
         var pk = createEc();
         var jwk = CryptoConverter.createJwk(new KeyPair(pk.getPublic(), null));
         assertThat(jwk).isInstanceOf(ECKey.class);
@@ -159,7 +168,7 @@ class CryptoConverterTest {
     }
 
     @Test
-    void convertToJwk_ecKey_fromPrivate() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException {
+    void createJwk_ecKey_fromPrivate() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException {
         var pk = createEc();
 
         var jwk2 = CryptoConverter.createJwk(new KeyPair(null, pk.getPrivate()));
@@ -170,7 +179,7 @@ class CryptoConverterTest {
     }
 
     @Test
-    void convertToJwk_ecKey_fromKeyPair() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException {
+    void createJwk_ecKey_fromKeyPair() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException {
         var pk = createEc();
         var jwk3 = CryptoConverter.createJwk(new KeyPair(pk.getPublic(), pk.getPrivate()));
         assertThat(jwk3).isInstanceOf(ECKey.class);
@@ -181,7 +190,18 @@ class CryptoConverterTest {
     }
 
     @Test
-    void convertToJwk_edDsaKey_fromPrivate_sunProvider() throws NoSuchAlgorithmException {
+    void createJwk_ecKey_fromKeyPair_withKeyId() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException {
+        var pk = createEc();
+        var jwk3 = CryptoConverter.createJwk(new KeyPair(pk.getPublic(), pk.getPrivate()), "test-kid");
+        assertThat(jwk3).isInstanceOf(ECKey.class);
+        assertThat(jwk3.isPrivate()).isTrue();
+        assertThat(jwk3.getKeyID()).isEqualTo("test-kid");
+        assertThat(KeyConverter.toJavaKeys(List.of(jwk3))).containsExactlyInAnyOrder(pk.getPublic(), pk.getPrivate());
+
+    }
+
+    @Test
+    void createJwk_edDsaKey_fromPrivate_sunProvider() throws NoSuchAlgorithmException {
         var kp = createEd25519(null);
         var jwk = CryptoConverter.createJwk(new KeyPair(null, kp.getPrivate()));
         assertThat(jwk).isInstanceOf(OctetKeyPair.class);
@@ -191,7 +211,7 @@ class CryptoConverterTest {
     }
 
     @Test
-    void convertToJwk_edDsaKey_fromPublic_sunProvider() throws NoSuchAlgorithmException {
+    void createJwk_edDsaKey_fromPublic_sunProvider() throws NoSuchAlgorithmException {
         var kp = createEd25519(null);
         var jwk = CryptoConverter.createJwk(new KeyPair(kp.getPublic(), null));
 
@@ -204,7 +224,7 @@ class CryptoConverterTest {
     }
 
     @Test
-    void convertToJwk_edDsaKey_sunProvider() throws NoSuchAlgorithmException {
+    void createJwk_edDsaKey_sunProvider() throws NoSuchAlgorithmException {
         var kp = createEd25519(null);
         var jwk = CryptoConverter.createJwk(new KeyPair(kp.getPublic(), kp.getPrivate()));
 
@@ -215,7 +235,7 @@ class CryptoConverterTest {
     }
 
     @Test
-    void convertToJwk_edDsaKey_fromPrivate_bouncyCastleProvider() throws NoSuchAlgorithmException {
+    void createJwk_edDsaKey_fromPrivate_bouncyCastleProvider() throws NoSuchAlgorithmException {
         var kp = createEd25519(new BouncyCastleProvider());
         var jwk = CryptoConverter.createJwk(new KeyPair(null, kp.getPrivate()));
         assertThat(jwk).isInstanceOf(OctetKeyPair.class);
@@ -225,7 +245,7 @@ class CryptoConverterTest {
     }
 
     @Test
-    void convertToJwk_edDsaKey_fromPublic_bouncyCastleProvider() throws NoSuchAlgorithmException {
+    void createJwk_edDsaKey_fromPublic_bouncyCastleProvider() throws NoSuchAlgorithmException {
         var kp = createEd25519(new BouncyCastleProvider());
         var jwk = CryptoConverter.createJwk(new KeyPair(kp.getPublic(), null));
 
@@ -238,7 +258,7 @@ class CryptoConverterTest {
     }
 
     @Test
-    void convertToJwk_edDsaKey_bouncyCastleProvider() throws NoSuchAlgorithmException {
+    void createJwk_edDsaKey_bouncyCastleProvider() throws NoSuchAlgorithmException {
         var kp = createEd25519(new BouncyCastleProvider());
         var jwk = CryptoConverter.createJwk(new KeyPair(kp.getPublic(), kp.getPrivate()));
 
@@ -248,6 +268,16 @@ class CryptoConverterTest {
         assertThat(jwk.getKeyID()).isNull();
     }
 
+    @Test
+    void createJwk_edDsaKey_withKeyId() throws NoSuchAlgorithmException {
+        var kp = createEd25519(null);
+        var jwk = CryptoConverter.createJwk(new KeyPair(kp.getPublic(), kp.getPrivate()), "test-key-id");
+
+        assertThat(jwk).isInstanceOf(OctetKeyPair.class);
+        assertThat(jwk.isPrivate()).isTrue();
+        assertThat(jwk.toPublicJWK()).isNotNull();
+        assertThat(jwk.getKeyID()).isEqualTo("test-key-id");
+    }
 
     @ParameterizedTest
     @ArgumentsSource(KeyProvider.class)


### PR DESCRIPTION
## What this PR changes/adds

This PR an overload taking a `keyId` parameter to the `CryptoConverter#createJwk()` method

## Why it does that

Usually, the resulting JWK should have a `kid` property, to make it identifiable, e.g. in DID documents.

## Further notes

- I also reordered some methods in `CryptoConverter` to have publics first, and privates further down in the file.
- 
## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
