### PR TITLE
feat: policy scope extractors for contract negotiation ingress calls

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -57,18 +57,20 @@ maven/mavencentral/com.github.stephenc.jcip/jcip-annotations/1.0-1, Apache-2.0, 
 maven/mavencentral/com.google.code.findbugs/jsr305/2.0.1, BSD-3-Clause AND CC-BY-2.5 AND LGPL-2.1+, approved, CQ13390
 maven/mavencentral/com.google.code.findbugs/jsr305/3.0.2, Apache-2.0, approved, #20
 maven/mavencentral/com.google.code.gson/gson/2.10.1, Apache-2.0, approved, #6159
+maven/mavencentral/com.google.collections/google-collections/1.0, Apache-2.0, approved, CQ3285
 maven/mavencentral/com.google.crypto.tink/tink/1.12.0, Apache-2.0, approved, #12041
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.11.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.google.errorprone/error_prone_annotations/2.18.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.22.0, Apache-2.0, approved, #10661
-maven/mavencentral/com.google.errorprone/error_prone_annotations/2.7.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.guava/failureaccess/1.0.1, Apache-2.0, approved, CQ22654
 maven/mavencentral/com.google.guava/guava/28.1-android, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.guava/guava/28.2-android, Apache-2.0 AND LicenseRef-Public-Domain, approved, CQ22437
 maven/mavencentral/com.google.guava/guava/31.0.1-android, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.guava/guava/31.0.1-jre, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.guava/guava/31.1-jre, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.google.guava/guava/32.0.1-jre, Apache-2.0 AND CC0-1.0 AND CC-PDDC, approved, #8772
 maven/mavencentral/com.google.guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava, Apache-2.0, approved, CQ22657
 maven/mavencentral/com.google.j2objc/j2objc-annotations/1.3, Apache-2.0, approved, CQ21195
+maven/mavencentral/com.google.j2objc/j2objc-annotations/2.8, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.protobuf/protobuf-java/3.23.4, BSD-3-Clause, approved, #8634
 maven/mavencentral/com.google.protobuf/protobuf-java/3.24.3, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/com.googlecode.libphonenumber/libphonenumber/8.11.1, Apache-2.0, approved, clearlydefined
@@ -79,7 +81,7 @@ maven/mavencentral/com.lmax/disruptor/3.4.4, Apache-2.0, approved, clearlydefine
 maven/mavencentral/com.networknt/json-schema-validator/1.0.76, Apache-2.0, approved, CQ22638
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.28, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.37.3, Apache-2.0, approved, #11701
-maven/mavencentral/com.puppycrawl.tools/checkstyle/10.0, LGPL-2.1-or-later, approved, #7936
+maven/mavencentral/com.puppycrawl.tools/checkstyle/10.12.3, LGPL-2.1+, restricted, clearlydefined
 maven/mavencentral/com.samskivert/jmustache/1.15, BSD-2-Clause, approved, clearlydefined
 maven/mavencentral/com.squareup.okhttp3/okhttp-dnsoverhttps/4.12.0, Apache-2.0, approved, #11159
 maven/mavencentral/com.squareup.okhttp3/okhttp/4.12.0, Apache-2.0, approved, #11156
@@ -101,7 +103,7 @@ maven/mavencentral/commons-logging/commons-logging/1.1.1, Apache-2.0, approved, 
 maven/mavencentral/commons-logging/commons-logging/1.2, Apache-2.0, approved, CQ10162
 maven/mavencentral/dev.failsafe/failsafe-okhttp/3.3.2, Apache-2.0, approved, #9178
 maven/mavencentral/dev.failsafe/failsafe/3.3.2, Apache-2.0, approved, #9268
-maven/mavencentral/info.picocli/picocli/4.6.3, Apache-2.0, approved, clearlydefined
+maven/mavencentral/info.picocli/picocli/4.7.4, Apache-2.0, approved, #4365
 maven/mavencentral/io.cloudevents/cloudevents-api/2.5.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.cloudevents/cloudevents-core/2.5.0, Apache-2.0, approved, #9328
 maven/mavencentral/io.cloudevents/cloudevents-http-basic/2.5.0, Apache-2.0, approved, #9329
@@ -188,26 +190,38 @@ maven/mavencentral/net.javacrumbs.json-unit/json-unit-core/2.36.0, Apache-2.0, a
 maven/mavencentral/net.minidev/accessors-smart/2.4.7, Apache-2.0, approved, #7515
 maven/mavencentral/net.minidev/json-smart/2.4.7, Apache-2.0, approved, #3288
 maven/mavencentral/net.sf.jopt-simple/jopt-simple/5.0.4, MIT, approved, CQ13174
-maven/mavencentral/net.sf.saxon/Saxon-HE/10.6, MPL-2.0 AND W3C, approved, #7945
-maven/mavencentral/org.antlr/antlr4-runtime/4.9.3, BSD-3-Clause, approved, #322
+maven/mavencentral/net.sf.saxon/Saxon-HE/12.3, NOASSERTION, restricted, clearlydefined
+maven/mavencentral/org.antlr/antlr4-runtime/4.11.1, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-compress/1.25.0, Apache-2.0, approved, #11600
 maven/mavencentral/org.apache.commons/commons-digester3/3.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-lang3/3.10, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-lang3/3.11, Apache-2.0, approved, CQ22642
 maven/mavencentral/org.apache.commons/commons-lang3/3.12.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.commons/commons-lang3/3.7, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.commons/commons-lang3/3.8.1, Apache-2.0, approved, #815
 maven/mavencentral/org.apache.commons/commons-pool2/2.12.0, Apache-2.0 AND LicenseRef-Public-Domain, approved, #10843
 maven/mavencentral/org.apache.commons/commons-text/1.10.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.commons/commons-text/1.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.groovy/groovy-bom/4.0.16, Apache-2.0, approved, #9266
 maven/mavencentral/org.apache.groovy/groovy-json/4.0.16, Apache-2.0, approved, #7411
 maven/mavencentral/org.apache.groovy/groovy-xml/4.0.16, Apache-2.0, approved, #10179
 maven/mavencentral/org.apache.groovy/groovy/4.0.16, Apache-2.0 AND BSD-3-Clause AND MIT, approved, #1742
+maven/mavencentral/org.apache.httpcomponents.client5/httpclient5/5.1.3, Apache-2.0, approved, #6276
+maven/mavencentral/org.apache.httpcomponents.core5/httpcore5-h2/5.1.3, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.httpcomponents.core5/httpcore5/5.1.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.httpcomponents/httpclient/4.5.13, Apache-2.0 AND LicenseRef-Public-Domain, approved, CQ23527
 maven/mavencentral/org.apache.httpcomponents/httpcore/4.4.13, Apache-2.0, approved, CQ23528
+maven/mavencentral/org.apache.httpcomponents/httpcore/4.4.14, Apache-2.0, approved, CQ23528
 maven/mavencentral/org.apache.httpcomponents/httpmime/4.5.13, Apache-2.0, approved, CQ11718
 maven/mavencentral/org.apache.kafka/kafka-clients/3.6.1, Apache-2.0 AND (Apache-2.0 AND MIT) AND (Apache-2.0 AND BSD-3-Clause), approved, #11084
+maven/mavencentral/org.apache.maven.doxia/doxia-core/1.12.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.maven.doxia/doxia-logging-api/1.12.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.maven.doxia/doxia-module-xdoc/1.12.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.maven.doxia/doxia-sink-api/1.12.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.velocity.tools/velocity-tools-generic/3.1, Apache-2.0, approved, #9331
 maven/mavencentral/org.apache.velocity/velocity-engine-core/2.3, Apache-2.0, approved, #2478
 maven/mavencentral/org.apache.velocity/velocity-engine-scripting/2.3, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.xbean/xbean-reflect/3.7, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.assertj/assertj-core/3.25.1, Apache-2.0, approved, #12585
 maven/mavencentral/org.assertj/assertj-core/3.25.3, Apache-2.0, approved, #12585
@@ -220,7 +234,13 @@ maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.72, MIT, approved, #3790
 maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.77, MIT, approved, #11596
 maven/mavencentral/org.ccil.cowan.tagsoup/tagsoup/1.2.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.checkerframework/checker-qual/3.12.0, MIT, approved, clearlydefined
+maven/mavencentral/org.checkerframework/checker-qual/3.27.0, MIT, approved, clearlydefined
 maven/mavencentral/org.checkerframework/checker-qual/3.41.0, MIT, approved, #12032
+maven/mavencentral/org.codehaus.plexus/plexus-classworlds/2.6.0, Apache-2.0 AND Plexus, approved, CQ22821
+maven/mavencentral/org.codehaus.plexus/plexus-component-annotations/2.1.0, Apache-2.0, approved, #809
+maven/mavencentral/org.codehaus.plexus/plexus-container-default/2.1.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.codehaus.plexus/plexus-utils/3.1.1, , approved, CQ16492
+maven/mavencentral/org.codehaus.plexus/plexus-utils/3.3.0, , approved, CQ21066
 maven/mavencentral/org.eclipse.angus/angus-activation/1.0.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.angus
 maven/mavencentral/org.eclipse.edc/autodoc-processor/0.5.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/runtime-metamodel/0.5.1-SNAPSHOT, Apache-2.0, approved, technology.edc
@@ -333,6 +353,7 @@ maven/mavencentral/org.testcontainers/postgresql/1.19.4, MIT, approved, #10350
 maven/mavencentral/org.testcontainers/testcontainers/1.19.4, Apache-2.0 AND MIT, approved, #10347
 maven/mavencentral/org.testcontainers/vault/1.19.4, MIT, approved, #10852
 maven/mavencentral/org.xerial.snappy/snappy-java/1.1.10.5, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #9098
+maven/mavencentral/org.xmlresolver/xmlresolver/5.2.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.xmlunit/xmlunit-core/2.9.1, Apache-2.0, approved, #6272
 maven/mavencentral/org.xmlunit/xmlunit-placeholders/2.9.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.yaml/snakeyaml/1.33, Apache-2.0, approved, clearlydefined

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/ContractCoreExtension.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/ContractCoreExtension.java
@@ -27,7 +27,6 @@ import org.eclipse.edc.connector.contract.spi.negotiation.NegotiationWaitStrateg
 import org.eclipse.edc.connector.contract.spi.negotiation.ProviderContractNegotiationManager;
 import org.eclipse.edc.connector.contract.spi.negotiation.observe.ContractNegotiationObservable;
 import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
-import org.eclipse.edc.connector.contract.spi.offer.ContractDefinitionResolver;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.validation.ContractValidationService;
 import org.eclipse.edc.connector.contract.validation.ContractValidationServiceImpl;
@@ -141,9 +140,6 @@ public class ContractCoreExtension implements ServiceExtension {
     private ProtocolWebhook protocolWebhook;
 
     @Inject
-    private ContractDefinitionResolver contractDefinitionResolver;
-
-    @Inject
     private ContractNegotiationObservable observable;
 
     @Inject
@@ -184,7 +180,7 @@ public class ContractCoreExtension implements ServiceExtension {
         var participantId = context.getParticipantId();
 
         var policyEquality = new PolicyEquality(typeManager);
-        var validationService = new ContractValidationServiceImpl(agentService, contractDefinitionResolver, assetIndex, policyStore, policyEngine, policyEquality);
+        var validationService = new ContractValidationServiceImpl(agentService, assetIndex, policyEngine, policyEquality);
         context.registerService(ContractValidationService.class, validationService);
 
         // bind/register rule to evaluate contract expiry

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/ContractNegotiationDefaultServicesExtension.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/ContractNegotiationDefaultServicesExtension.java
@@ -15,11 +15,13 @@
 package org.eclipse.edc.connector.contract;
 
 import org.eclipse.edc.connector.contract.observe.ContractNegotiationObservableImpl;
+import org.eclipse.edc.connector.contract.offer.ConsumerOfferResolverImpl;
 import org.eclipse.edc.connector.contract.offer.ContractDefinitionResolverImpl;
 import org.eclipse.edc.connector.contract.policy.PolicyArchiveImpl;
 import org.eclipse.edc.connector.contract.spi.negotiation.ContractNegotiationPendingGuard;
 import org.eclipse.edc.connector.contract.spi.negotiation.observe.ContractNegotiationObservable;
 import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
+import org.eclipse.edc.connector.contract.spi.offer.ConsumerOfferResolver;
 import org.eclipse.edc.connector.contract.spi.offer.ContractDefinitionResolver;
 import org.eclipse.edc.connector.contract.spi.offer.store.ContractDefinitionStore;
 import org.eclipse.edc.connector.policy.spi.store.PolicyArchive;
@@ -54,6 +56,11 @@ public class ContractNegotiationDefaultServicesExtension implements ServiceExten
     @Provider
     public ContractDefinitionResolver contractDefinitionResolver(ServiceExtensionContext context) {
         return new ContractDefinitionResolverImpl(context.getMonitor(), contractDefinitionStore, policyEngine, policyStore);
+    }
+
+    @Provider
+    public ConsumerOfferResolver consumerOfferResolver() {
+        return new ConsumerOfferResolverImpl(contractDefinitionStore, policyStore);
     }
 
     @Provider

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/offer/ConsumerOfferResolverImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/offer/ConsumerOfferResolverImpl.java
@@ -20,7 +20,6 @@ import org.eclipse.edc.connector.contract.spi.offer.store.ContractDefinitionStor
 import org.eclipse.edc.connector.contract.spi.validation.ValidatableConsumerOffer;
 import org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore;
 import org.eclipse.edc.spi.result.ServiceResult;
-import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 import org.jetbrains.annotations.NotNull;
 
 import static java.lang.String.format;
@@ -34,11 +33,6 @@ public class ConsumerOfferResolverImpl implements ConsumerOfferResolver {
     public ConsumerOfferResolverImpl(ContractDefinitionStore contractDefinitionStore, PolicyDefinitionStore policyDefinitionStore) {
         this.contractDefinitionStore = contractDefinitionStore;
         this.policyDefinitionStore = policyDefinitionStore;
-    }
-
-    @Override
-    public @NotNull ServiceResult<ValidatableConsumerOffer> resolveOffer(ContractOffer offer) {
-        return resolveOffer(offer.getId());
     }
 
     @Override
@@ -73,5 +67,5 @@ public class ConsumerOfferResolverImpl implements ConsumerOfferResolver {
 
         }
     }
-    
+
 }

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/offer/ConsumerOfferResolverImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/offer/ConsumerOfferResolverImpl.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.contract.offer;
+
+import org.eclipse.edc.connector.contract.spi.ContractOfferId;
+import org.eclipse.edc.connector.contract.spi.offer.ConsumerOfferResolver;
+import org.eclipse.edc.connector.contract.spi.offer.store.ContractDefinitionStore;
+import org.eclipse.edc.connector.contract.spi.validation.ValidatableConsumerOffer;
+import org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
+import org.jetbrains.annotations.NotNull;
+
+import static java.lang.String.format;
+
+public class ConsumerOfferResolverImpl implements ConsumerOfferResolver {
+
+    private final ContractDefinitionStore contractDefinitionStore;
+    private final PolicyDefinitionStore policyDefinitionStore;
+
+
+    public ConsumerOfferResolverImpl(ContractDefinitionStore contractDefinitionStore, PolicyDefinitionStore policyDefinitionStore) {
+        this.contractDefinitionStore = contractDefinitionStore;
+        this.policyDefinitionStore = policyDefinitionStore;
+    }
+
+    @Override
+    public @NotNull ServiceResult<ValidatableConsumerOffer> resolveOffer(ContractOffer offer) {
+        return resolveOffer(offer.getId());
+    }
+
+    @Override
+    public @NotNull ServiceResult<ValidatableConsumerOffer> resolveOffer(String offerId) {
+        var parsedResult = ContractOfferId.parseId(offerId);
+
+        if (parsedResult.failed()) {
+            return ServiceResult.badRequest(parsedResult.getFailureMessages());
+        } else {
+            var definitionId = parsedResult.getContent().definitionPart();
+            var contractDefinition = contractDefinitionStore.findById(definitionId);
+            if (contractDefinition == null) {
+                return ServiceResult.notFound(format("Contract definition with id %s not found", definitionId));
+            }
+
+            var accessPolicy = policyDefinitionStore.findById(contractDefinition.getAccessPolicyId());
+            if (accessPolicy == null) {
+                return ServiceResult.notFound(format("Policy with id %s not found", contractDefinition.getAccessPolicyId()));
+            }
+
+            var contractPolicy = policyDefinitionStore.findById(contractDefinition.getContractPolicyId());
+            if (contractPolicy == null) {
+                return ServiceResult.notFound(format("Policy with id %s not found", contractDefinition.getContractPolicyId()));
+            }
+
+            return ServiceResult.success(ValidatableConsumerOffer.Builder.newInstance()
+                    .contractDefinition(contractDefinition)
+                    .accessPolicy(accessPolicy.getPolicy())
+                    .contractPolicy(contractPolicy.getPolicy())
+                    .offerId(parsedResult.getContent())
+                    .build());
+
+        }
+    }
+    
+}

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -175,7 +175,7 @@ class ContractNegotiationIntegrationTest {
         var validatableOffer = mock(ValidatableConsumerOffer.class);
 
         when(validatableOffer.getContractPolicy()).thenReturn(Policy.Builder.newInstance().build());
-        when(offerResolver.resolveOffer(isA(ContractOffer.class))).thenReturn(ServiceResult.success(validatableOffer));
+        when(offerResolver.resolveOffer(any())).thenReturn(ServiceResult.success(validatableOffer));
         when(validationService.validateInitialOffer(token, validatableOffer)).thenReturn(Result.success(new ValidatedConsumerOffer(CONSUMER_ID, offer)));
         when(validationService.validateConfirmed(eq(token), any(ContractAgreement.class), any(ContractOffer.class))).thenReturn(Result.success());
         when(validationService.validateRequest(eq(token), any(ContractNegotiation.class))).thenReturn(Result.success());
@@ -228,7 +228,7 @@ class ContractNegotiationIntegrationTest {
         var validatableOffer = mock(ValidatableConsumerOffer.class);
 
         when(validatableOffer.getContractPolicy()).thenReturn(Policy.Builder.newInstance().build());
-        when(offerResolver.resolveOffer(isA(ContractOffer.class))).thenReturn(ServiceResult.success(validatableOffer));
+        when(offerResolver.resolveOffer(any())).thenReturn(ServiceResult.success(validatableOffer));
         when(validationService.validateInitialOffer(token, validatableOffer)).thenReturn(Result.failure("must be declined"));
 
         // Start provider and consumer negotiation managers
@@ -260,7 +260,7 @@ class ContractNegotiationIntegrationTest {
         var validatableOffer = mock(ValidatableConsumerOffer.class);
 
         when(validatableOffer.getContractPolicy()).thenReturn(Policy.Builder.newInstance().build());
-        when(offerResolver.resolveOffer(isA(ContractOffer.class))).thenReturn(ServiceResult.success(validatableOffer));
+        when(offerResolver.resolveOffer(any())).thenReturn(ServiceResult.success(validatableOffer));
         when(validationService.validateInitialOffer(token, validatableOffer)).thenReturn(Result.success(new ValidatedConsumerOffer(CONSUMER_ID, offer)));
         when(validationService.validateConfirmed(eq(token), any(ContractAgreement.class), any(ContractOffer.class))).thenReturn(Result.failure("error"));
 

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/offer/ConsumerOfferResolverImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/offer/ConsumerOfferResolverImplTest.java
@@ -1,0 +1,174 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
+ *
+ */
+
+package org.eclipse.edc.connector.contract.offer;
+
+import org.eclipse.edc.connector.contract.spi.ContractOfferId;
+import org.eclipse.edc.connector.contract.spi.offer.store.ContractDefinitionStore;
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractDefinition;
+import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
+import org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.result.ServiceFailure;
+import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.spi.result.ServiceFailure.Reason.BAD_REQUEST;
+import static org.eclipse.edc.spi.result.ServiceFailure.Reason.NOT_FOUND;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+class ConsumerOfferResolverImplTest {
+
+    private final PolicyDefinitionStore policyStore = mock(PolicyDefinitionStore.class);
+    private final ContractDefinitionStore definitionStore = mock(ContractDefinitionStore.class);
+    private ConsumerOfferResolverImpl validatableConsumerOfferResolver;
+
+    @BeforeEach
+    void setUp() {
+        validatableConsumerOfferResolver = new ConsumerOfferResolverImpl(definitionStore, policyStore);
+    }
+
+    @Test
+    void resolveOffer_withId() {
+        var contractDefinition = createContractDefinition();
+
+        var offerId = ContractOfferId.create(contractDefinition.getId(), "1");
+        var accessPolicy = Policy.Builder.newInstance().build();
+        var accessPolicyDef = PolicyDefinition.Builder.newInstance().policy(accessPolicy).build();
+        var contractPolicy = Policy.Builder.newInstance().build();
+        var contractPolicyDef = PolicyDefinition.Builder.newInstance().policy(contractPolicy).build();
+
+        when(policyStore.findById(contractDefinition.getAccessPolicyId())).thenReturn(accessPolicyDef);
+        when(policyStore.findById(contractDefinition.getContractPolicyId())).thenReturn(contractPolicyDef);
+        when(definitionStore.findById(contractDefinition.getId())).thenReturn(contractDefinition);
+
+        var validatableOfferResult = validatableConsumerOfferResolver.resolveOffer(offerId.toString());
+
+        assertThat(validatableOfferResult).isSucceeded().satisfies(consumerOffer -> {
+            assertThat(consumerOffer.getOfferId()).usingRecursiveComparison().isEqualTo(offerId);
+            assertThat(consumerOffer.getContractDefinition()).isEqualTo(contractDefinition);
+            assertThat(consumerOffer.getAccessPolicy()).isSameAs(accessPolicy);
+            assertThat(consumerOffer.getContractPolicy()).isSameAs(contractPolicy);
+        });
+
+        verify(policyStore).findById(contractDefinition.getAccessPolicyId());
+        verify(policyStore).findById(contractDefinition.getContractPolicyId());
+        verify(definitionStore).findById(any());
+    }
+
+
+    @Test
+    void resolveOffer_withOffer() {
+
+        var offer = ContractOffer.Builder.newInstance()
+                .id(ContractOfferId.create("1", "1").toString())
+                .assetId("1")
+                .policy(Policy.Builder.newInstance().build())
+                .build();
+
+        var contractDefinition = createContractDefinition();
+        var accessPolicy = Policy.Builder.newInstance().build();
+        var accessPolicyDef = PolicyDefinition.Builder.newInstance().policy(accessPolicy).build();
+        var contractPolicy = Policy.Builder.newInstance().build();
+        var contractPolicyDef = PolicyDefinition.Builder.newInstance().policy(contractPolicy).build();
+
+        when(policyStore.findById(contractDefinition.getAccessPolicyId())).thenReturn(accessPolicyDef);
+        when(policyStore.findById(contractDefinition.getContractPolicyId())).thenReturn(contractPolicyDef);
+        when(definitionStore.findById(any())).thenReturn(contractDefinition);
+
+        var validatableOfferResult = validatableConsumerOfferResolver.resolveOffer(offer);
+
+        assertThat(validatableOfferResult).isSucceeded().satisfies(consumerOffer -> {
+            assertThat(consumerOffer.getOfferId().toString()).isEqualTo(offer.getId());
+            assertThat(consumerOffer.getContractDefinition()).isEqualTo(contractDefinition);
+            assertThat(consumerOffer.getAccessPolicy()).isSameAs(accessPolicy);
+            assertThat(consumerOffer.getContractPolicy()).isSameAs(contractPolicy);
+        });
+
+        verify(policyStore).findById(contractDefinition.getAccessPolicyId());
+        verify(policyStore).findById(contractDefinition.getContractPolicyId());
+        verify(definitionStore).findById(any());
+    }
+
+    @Test
+    void resolveOffer_shouldReturnNotFound_whenContractDefinitionNotFound() {
+        var offerId = ContractOfferId.create("1", "1");
+
+        when(definitionStore.findById(any())).thenReturn(null);
+
+        var validatableOfferResult = validatableConsumerOfferResolver.resolveOffer(offerId.toString());
+
+        assertThat(validatableOfferResult).isFailed().extracting(ServiceFailure::getReason).isEqualTo(NOT_FOUND);
+
+        verify(definitionStore).findById(any());
+    }
+
+    @Test
+    void resolveOffer_shouldReturnNotFound_whenAccessPolicyNotFound() {
+        var contractDefinition = createContractDefinition();
+        var offerId = ContractOfferId.create(contractDefinition.getId(), "1");
+        var accessPolicy = Policy.Builder.newInstance().build();
+        var accessPolicyDef = PolicyDefinition.Builder.newInstance().policy(accessPolicy).build();
+
+        when(definitionStore.findById(contractDefinition.getId())).thenReturn(contractDefinition);
+        when(policyStore.findById(contractDefinition.getAccessPolicyId())).thenReturn(accessPolicyDef);
+        when(policyStore.findById(contractDefinition.getContractPolicyId())).thenReturn(null);
+
+        var validatableOfferResult = validatableConsumerOfferResolver.resolveOffer(offerId.toString());
+
+        assertThat(validatableOfferResult).isFailed().extracting(ServiceFailure::getReason).isEqualTo(NOT_FOUND);
+
+        verify(definitionStore).findById(any());
+    }
+
+    @Test
+    void resolveOffer_shouldReturnNotFound_whenContractPolicyNotFound() {
+        var contractDefinition = createContractDefinition();
+        var offerId = ContractOfferId.create(contractDefinition.getId(), "1");
+
+        when(definitionStore.findById(contractDefinition.getId())).thenReturn(contractDefinition);
+        when(policyStore.findById(contractDefinition.getAccessPolicyId())).thenReturn(null);
+
+        var validatableOfferResult = validatableConsumerOfferResolver.resolveOffer(offerId.toString());
+
+        assertThat(validatableOfferResult).isFailed().extracting(ServiceFailure::getReason).isEqualTo(NOT_FOUND);
+
+        verify(definitionStore).findById(any());
+    }
+
+    @Test
+    void resolveOffer_shouldReturnBadRequest_whenOfferIdParseFails() {
+
+        var validatableOfferResult = validatableConsumerOfferResolver.resolveOffer("malformed");
+
+        assertThat(validatableOfferResult).isFailed().extracting(ServiceFailure::getReason).isEqualTo(BAD_REQUEST);
+
+    }
+
+    private ContractDefinition createContractDefinition() {
+        return ContractDefinition.Builder.newInstance()
+                .id("1")
+                .accessPolicyId("access")
+                .contractPolicyId("contract")
+                .build();
+    }
+}

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/offer/ConsumerOfferResolverImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/offer/ConsumerOfferResolverImplTest.java
@@ -22,7 +22,6 @@ import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
 import org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.result.ServiceFailure;
-import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -48,7 +47,7 @@ class ConsumerOfferResolverImplTest {
     }
 
     @Test
-    void resolveOffer_withId() {
+    void resolveOffer() {
         var contractDefinition = createContractDefinition();
 
         var offerId = ContractOfferId.create(contractDefinition.getId(), "1");
@@ -65,40 +64,6 @@ class ConsumerOfferResolverImplTest {
 
         assertThat(validatableOfferResult).isSucceeded().satisfies(consumerOffer -> {
             assertThat(consumerOffer.getOfferId()).usingRecursiveComparison().isEqualTo(offerId);
-            assertThat(consumerOffer.getContractDefinition()).isEqualTo(contractDefinition);
-            assertThat(consumerOffer.getAccessPolicy()).isSameAs(accessPolicy);
-            assertThat(consumerOffer.getContractPolicy()).isSameAs(contractPolicy);
-        });
-
-        verify(policyStore).findById(contractDefinition.getAccessPolicyId());
-        verify(policyStore).findById(contractDefinition.getContractPolicyId());
-        verify(definitionStore).findById(any());
-    }
-
-
-    @Test
-    void resolveOffer_withOffer() {
-
-        var offer = ContractOffer.Builder.newInstance()
-                .id(ContractOfferId.create("1", "1").toString())
-                .assetId("1")
-                .policy(Policy.Builder.newInstance().build())
-                .build();
-
-        var contractDefinition = createContractDefinition();
-        var accessPolicy = Policy.Builder.newInstance().build();
-        var accessPolicyDef = PolicyDefinition.Builder.newInstance().policy(accessPolicy).build();
-        var contractPolicy = Policy.Builder.newInstance().build();
-        var contractPolicyDef = PolicyDefinition.Builder.newInstance().policy(contractPolicy).build();
-
-        when(policyStore.findById(contractDefinition.getAccessPolicyId())).thenReturn(accessPolicyDef);
-        when(policyStore.findById(contractDefinition.getContractPolicyId())).thenReturn(contractPolicyDef);
-        when(definitionStore.findById(any())).thenReturn(contractDefinition);
-
-        var validatableOfferResult = validatableConsumerOfferResolver.resolveOffer(offer);
-
-        assertThat(validatableOfferResult).isSucceeded().satisfies(consumerOffer -> {
-            assertThat(consumerOffer.getOfferId().toString()).isEqualTo(offer.getId());
             assertThat(consumerOffer.getContractDefinition()).isEqualTo(contractDefinition);
             assertThat(consumerOffer.getAccessPolicy()).isSameAs(accessPolicy);
             assertThat(consumerOffer.getContractPolicy()).isSameAs(contractPolicy);

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImplTest.java
@@ -19,14 +19,11 @@ package org.eclipse.edc.connector.contract.validation;
 
 import org.eclipse.edc.connector.contract.policy.PolicyEquality;
 import org.eclipse.edc.connector.contract.spi.ContractOfferId;
-import org.eclipse.edc.connector.contract.spi.offer.ContractDefinitionResolver;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractDefinition;
-import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
-import org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore;
+import org.eclipse.edc.connector.contract.spi.validation.ValidatableConsumerOffer;
 import org.eclipse.edc.policy.engine.spi.PolicyContext;
 import org.eclipse.edc.policy.engine.spi.PolicyEngine;
-import org.eclipse.edc.policy.model.AtomicConstraint;
 import org.eclipse.edc.policy.model.Permission;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.agent.ParticipantAgent;
@@ -46,18 +43,17 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 
 import java.time.Instant;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
 import static java.time.Instant.MIN;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.connector.contract.spi.offer.ContractDefinitionResolver.CATALOGING_SCOPE;
 import static org.eclipse.edc.connector.contract.spi.validation.ContractValidationService.NEGOTIATION_SCOPE;
 import static org.eclipse.edc.connector.contract.spi.validation.ContractValidationService.TRANSFER_SCOPE;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.spi.agent.ParticipantAgent.PARTICIPANT_IDENTITY;
-import static org.eclipse.edc.spi.query.Criterion.criterion;
 import static org.mockito.AdditionalMatchers.and;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -78,9 +74,7 @@ class ContractValidationServiceImplTest {
     private final Instant now = Instant.now();
 
     private final ParticipantAgentService agentService = mock(ParticipantAgentService.class);
-    private final ContractDefinitionResolver definitionResolver = mock(ContractDefinitionResolver.class);
     private final AssetIndex assetIndex = mock(AssetIndex.class);
-    private final PolicyDefinitionStore policyStore = mock(PolicyDefinitionStore.class);
     private final PolicyEngine policyEngine = mock(PolicyEngine.class);
     private final PolicyEquality policyEquality = mock(PolicyEquality.class);
     private ContractValidationServiceImpl validationService;
@@ -94,31 +88,26 @@ class ContractValidationServiceImplTest {
 
     @BeforeEach
     void setUp() {
-        validationService = new ContractValidationServiceImpl(agentService, definitionResolver, assetIndex, policyStore, policyEngine, policyEquality);
+        validationService = new ContractValidationServiceImpl(agentService, assetIndex, policyEngine, policyEquality);
         when(assetIndex.countAssets(anyList())).thenReturn(1L);
     }
 
-    @ParameterizedTest
-    @ValueSource(booleans = { true, false })
-    void verifyContractOfferValidation(boolean verifyById) {
+    @Test
+    void verifyContractOfferValidation() {
         var participantAgent = new ParticipantAgent(emptyMap(), Map.of(PARTICIPANT_IDENTITY, CONSUMER_ID));
         var originalPolicy = Policy.Builder.newInstance().target("1").build();
         var newPolicy = Policy.Builder.newInstance().target("1").build();
         var asset = Asset.Builder.newInstance().id("1").build();
-        var contractDefinition = createContractDefinition();
 
         when(agentService.createFor(isA(ClaimToken.class))).thenReturn(participantAgent);
-        when(definitionResolver.definitionFor(isA(ParticipantAgent.class), eq("1"))).thenReturn(contractDefinition);
-        when(policyStore.findById("access")).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
-        when(policyStore.findById("contract")).thenReturn(PolicyDefinition.Builder.newInstance().policy(newPolicy).build());
         when(assetIndex.findById("1")).thenReturn(asset);
-        when(policyEngine.evaluate(any(), any(), isA(PolicyContext.class))).thenReturn(Result.success());
-        when(policyEquality.test(any(), any())).thenReturn(true);
+        when(policyEngine.evaluate(eq(CATALOGING_SCOPE), any(), isA(PolicyContext.class))).thenReturn(Result.success());
+        when(policyEngine.evaluate(eq(NEGOTIATION_SCOPE), any(), isA(PolicyContext.class))).thenReturn(Result.success());
 
         var claimToken = ClaimToken.Builder.newInstance().build();
-        var offer = createContractOffer(asset, originalPolicy);
+        var validatableOffer = createValidatableConsumerOffer(asset, originalPolicy);
 
-        var result = verifyById ? validationService.validateInitialOffer(claimToken, offer) : validationService.validateInitialOffer(claimToken, offer.getId());
+        var result = validationService.validateInitialOffer(claimToken, validatableOffer);
 
         assertThat(result.succeeded()).isTrue();
         var validatedOffer = result.getContent().getOffer();
@@ -127,8 +116,12 @@ class ContractValidationServiceImplTest {
         assertThat(result.getContent().getConsumerIdentity()).isEqualTo(CONSUMER_ID); // verify the returned policy has the consumer id set, essential for later validation checks
 
         verify(agentService).createFor(isA(ClaimToken.class));
-        verify(definitionResolver).definitionFor(isA(ParticipantAgent.class), eq("1"));
         verify(assetIndex).findById("1");
+        verify(policyEngine).evaluate(
+                eq(CATALOGING_SCOPE),
+                eq(newPolicy),
+                and(isA(PolicyContext.class), argThat(c -> c.getContextData(ParticipantAgent.class).equals(participantAgent)))
+        );
         verify(policyEngine).evaluate(
                 eq(NEGOTIATION_SCOPE),
                 eq(newPolicy),
@@ -145,9 +138,9 @@ class ContractValidationServiceImplTest {
         when(agentService.createFor(isA(ClaimToken.class))).thenReturn(participantAgent);
 
         var claimToken = ClaimToken.Builder.newInstance().build();
-        var offer = createContractOffer(asset, originalPolicy);
+        var validatableOffer = createValidatableConsumerOffer(asset, originalPolicy);
 
-        var result = validationService.validateInitialOffer(claimToken, offer);
+        var result = validationService.validateInitialOffer(claimToken, validatableOffer);
 
         assertThat(result).isFailed().detail().isEqualTo("Invalid consumer identity");
 
@@ -157,41 +150,16 @@ class ContractValidationServiceImplTest {
     @Test
     void validate_failsIfValidityDiscrepancy() {
         var originalPolicy = Policy.Builder.newInstance().target("a").build();
-        var newPolicy = Policy.Builder.newInstance().target("b").build();
         var asset = Asset.Builder.newInstance().id("1").build();
-        var contractDefinition = createContractDefinition();
 
         when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
-        when(definitionResolver.definitionFor(isA(ParticipantAgent.class), eq("1"))).thenReturn(contractDefinition);
-        when(policyStore.findById("access")).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
-        when(policyStore.findById("contract")).thenReturn(PolicyDefinition.Builder.newInstance().policy(newPolicy).build());
         when(assetIndex.findById("1")).thenReturn(asset);
         when(policyEquality.test(any(), any())).thenReturn(true);
 
         var claimToken = ClaimToken.Builder.newInstance().build();
-        var offer = createContractOffer(asset, originalPolicy);
+        var validatableOffer = createValidatableConsumerOffer(asset, originalPolicy);
 
-        var result = validationService.validateInitialOffer(claimToken, offer);
-
-        assertThat(result).isFailed().detail().isEqualTo("Invalid consumer identity");
-        verifyNoInteractions(policyEngine);
-    }
-
-    @Test
-    void validate_failsIfPolicyNotFound() {
-        var originalPolicy = Policy.Builder.newInstance().build();
-        var asset = Asset.Builder.newInstance().id("1").build();
-        var contractDefinition = createContractDefinition();
-
-        when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
-        when(definitionResolver.definitionFor(isA(ParticipantAgent.class), eq("1"))).thenReturn(contractDefinition);
-        when(policyStore.findById(any())).thenReturn(null);
-        when(assetIndex.findById("1")).thenReturn(asset);
-
-        var claimToken = ClaimToken.Builder.newInstance().build();
-        var offer = createContractOffer(asset, originalPolicy);
-
-        var result = validationService.validateInitialOffer(claimToken, offer);
+        var result = validationService.validateInitialOffer(claimToken, validatableOffer);
 
         assertThat(result).isFailed().detail().isEqualTo("Invalid consumer identity");
         verifyNoInteractions(policyEngine);
@@ -200,22 +168,16 @@ class ContractValidationServiceImplTest {
     @Test
     void validate_failsIfOfferedPolicyIsNotTheEqualToTheStoredOne() {
         var offeredPolicy = Policy.Builder.newInstance().permission(Permission.Builder.newInstance().build()).build();
-        var storedPolicy = Policy.Builder.newInstance().permission(Permission.Builder.newInstance()
-                        .constraint(AtomicConstraint.Builder.newInstance().build()).build())
-                .build();
         var asset = Asset.Builder.newInstance().id("1").build();
-        var contractDefinition = createContractDefinition();
 
         when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
-        when(definitionResolver.definitionFor(isA(ParticipantAgent.class), eq("1"))).thenReturn(contractDefinition);
-        when(policyStore.findById(any())).thenReturn(PolicyDefinition.Builder.newInstance().policy(storedPolicy).build());
         when(assetIndex.findById("1")).thenReturn(asset);
         when(policyEquality.test(any(), any())).thenReturn(false);
 
         var claimToken = ClaimToken.Builder.newInstance().build();
-        var offer = createContractOffer(asset, offeredPolicy);
+        var validatableOffer = createValidatableConsumerOffer(asset, offeredPolicy);
 
-        var result = validationService.validateInitialOffer(claimToken, offer);
+        var result = validationService.validateInitialOffer(claimToken, validatableOffer);
 
         assertThat(result.failed()).isTrue();
         verifyNoInteractions(policyEngine);
@@ -228,9 +190,6 @@ class ContractValidationServiceImplTest {
         var captor = ArgumentCaptor.forClass(PolicyContext.class);
 
         when(agentService.createFor(isA(ClaimToken.class))).thenReturn(participantAgent);
-
-        when(policyStore.findById("access")).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
-        when(policyStore.findById("contract")).thenReturn(PolicyDefinition.Builder.newInstance().policy(newPolicy).build());
         when(policyEngine.evaluate(any(), any(), isA(PolicyContext.class))).thenReturn(Result.success());
 
         var claimToken = ClaimToken.Builder.newInstance().build();
@@ -254,13 +213,9 @@ class ContractValidationServiceImplTest {
     @ValueSource(strings = { "malicious-actor" })
     @NullSource
     void verifyContractAgreementValidation_failedIfInvalidCredentials(String counterPartyId) {
-        var newPolicy = Policy.Builder.newInstance().build();
         var participantAgent = new ParticipantAgent(emptyMap(), counterPartyId != null ? Map.of(PARTICIPANT_IDENTITY, counterPartyId) : Map.of());
 
         when(agentService.createFor(isA(ClaimToken.class))).thenReturn(participantAgent);
-
-        when(policyStore.findById("access")).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
-        when(policyStore.findById("contract")).thenReturn(PolicyDefinition.Builder.newInstance().policy(newPolicy).build());
 
         var claimToken = ClaimToken.Builder.newInstance().build();
         var agreement = createContractAgreement()
@@ -410,20 +365,18 @@ class ContractValidationServiceImplTest {
     @Test
     void validateInitialOffer_assetInOfferNotReferencedByDefinition_shouldFail() {
 
-        var offer = createContractOffer();
+        var validatableOffer = createValidatableConsumerOffer();
         var participantAgent = new ParticipantAgent(emptyMap(), Map.of(PARTICIPANT_IDENTITY, CONSUMER_ID));
         var claimToken = ClaimToken.Builder.newInstance().build();
-        var expr = List.of(criterion(Asset.PROPERTY_ID, "like", "%someAssetId%"));
-        var contractDef = createContractDefinitionBuilder().assetsSelector(expr).build();
 
         //prepare mocks
         when(agentService.createFor(eq(claimToken))).thenReturn(participantAgent);
-        when(definitionResolver.definitionFor(eq(participantAgent), anyString())).thenReturn(contractDef);
+        when(policyEngine.evaluate(eq(CATALOGING_SCOPE), any(), isA(PolicyContext.class))).thenReturn(Result.success());
         when(assetIndex.findById(anyString())).thenReturn(Asset.Builder.newInstance().build());
         when(assetIndex.countAssets(anyList())).thenReturn(0L);
 
         //act
-        var result = validationService.validateInitialOffer(claimToken, offer);
+        var result = validationService.validateInitialOffer(claimToken, validatableOffer);
 
         //assert
         assertThat(result).isFailed().detail().isEqualTo("Asset ID from the ContractOffer is not included in the ContractDefinition");
@@ -455,7 +408,6 @@ class ContractValidationServiceImplTest {
     void validateAgreement_failWhenOutsideInForcePeriod_fixed() {
         var participantAgent = new ParticipantAgent(emptyMap(), Map.of(PARTICIPANT_IDENTITY, CONSUMER_ID));
         when(agentService.createFor(isA(ClaimToken.class))).thenReturn(participantAgent);
-        when(definitionResolver.definitionFor(isA(ParticipantAgent.class), eq("1"))).thenReturn(createContractDefinition());
         when(policyEngine.evaluate(any(), any(), isA(PolicyContext.class))).thenReturn(Result.failure("test-failure"));
 
         var claimToken = ClaimToken.Builder.newInstance().build();
@@ -470,7 +422,6 @@ class ContractValidationServiceImplTest {
 
     private Result<ContractAgreement> validateAgreementDate(long signingDate) {
         when(agentService.createFor(isA(ClaimToken.class))).thenReturn(new ParticipantAgent(emptyMap(), emptyMap()));
-        when(definitionResolver.definitionFor(isA(ParticipantAgent.class), eq("1"))).thenReturn(createContractDefinition());
         when(policyEngine.evaluate(eq(NEGOTIATION_SCOPE), isA(Policy.class), isA(PolicyContext.class))).thenReturn(Result.success());
 
         var claimToken = ClaimToken.Builder.newInstance().build();
@@ -490,6 +441,24 @@ class ContractValidationServiceImplTest {
                 .build();
     }
 
+    private ValidatableConsumerOffer createValidatableConsumerOffer(Asset asset, Policy policy) {
+        return createValidatableConsumerOffer(asset, policy, policy);
+    }
+
+    private ValidatableConsumerOffer createValidatableConsumerOffer() {
+        return createValidatableConsumerOffer(Asset.Builder.newInstance().build(), createPolicy());
+    }
+
+    private ValidatableConsumerOffer createValidatableConsumerOffer(Asset asset, Policy accessPolicy, Policy contractPolicy) {
+        var offerId = ContractOfferId.create("1", asset.getId());
+        return ValidatableConsumerOffer.Builder.newInstance()
+                .offerId(offerId)
+                .contractDefinition(createContractDefinition())
+                .accessPolicy(accessPolicy)
+                .contractPolicy(contractPolicy)
+                .build();
+    }
+
     @NotNull
     private ContractOffer createContractOffer() {
         return createContractOffer(Asset.Builder.newInstance().build(), Policy.Builder.newInstance().build());
@@ -498,6 +467,10 @@ class ContractValidationServiceImplTest {
     private ContractDefinition createContractDefinition() {
         return createContractDefinitionBuilder()
                 .build();
+    }
+
+    private Policy createPolicy() {
+        return Policy.Builder.newInstance().build();
     }
 
     private ContractAgreement.Builder createContractAgreement() {

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/ControlPlaneServicesExtension.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/ControlPlaneServicesExtension.java
@@ -21,6 +21,7 @@ import org.eclipse.edc.connector.contract.spi.definition.observe.ContractDefinit
 import org.eclipse.edc.connector.contract.spi.negotiation.ConsumerContractNegotiationManager;
 import org.eclipse.edc.connector.contract.spi.negotiation.observe.ContractNegotiationObservable;
 import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
+import org.eclipse.edc.connector.contract.spi.offer.ConsumerOfferResolver;
 import org.eclipse.edc.connector.contract.spi.offer.store.ContractDefinitionStore;
 import org.eclipse.edc.connector.contract.spi.validation.ContractValidationService;
 import org.eclipse.edc.connector.policy.spi.observe.PolicyDefinitionObservableImpl;
@@ -115,6 +116,9 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     private ContractValidationService contractValidationService;
 
     @Inject
+    private ConsumerOfferResolver consumerOfferResolver;
+
+    @Inject
     private ContractNegotiationObservable contractNegotiationObservable;
 
     @Inject
@@ -187,7 +191,7 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     @Provider
     public ContractNegotiationProtocolService contractNegotiationProtocolService() {
         return new ContractNegotiationProtocolServiceImpl(contractNegotiationStore,
-                transactionContext, contractValidationService, identityService, policyEngine, contractNegotiationObservable,
+                transactionContext, contractValidationService, consumerOfferResolver, identityService, policyEngine, contractNegotiationObservable,
                 monitor, telemetry);
     }
 

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
@@ -124,7 +124,7 @@ class ContractNegotiationProtocolServiceImplTest {
         var validatableOffer = mock(ValidatableConsumerOffer.class);
 
         when(validatableOffer.getContractPolicy()).thenReturn(createPolicy());
-        when(consumerOfferResolver.resolveOffer(contractOffer)).thenReturn(ServiceResult.success(validatableOffer));
+        when(consumerOfferResolver.resolveOffer(contractOffer.getId())).thenReturn(ServiceResult.success(validatableOffer));
         when(identityService.verifyJwtToken(eq(tokenRepresentation), isA(VerificationContext.class))).thenReturn(Result.success(claimToken));
         when(store.findByIdAndLease(any())).thenReturn(StoreResult.notFound("not found"));
         when(validationService.validateInitialOffer(claimToken, validatableOffer)).thenReturn(Result.success(validatedOffer));
@@ -167,7 +167,7 @@ class ContractNegotiationProtocolServiceImplTest {
         var validatableOffer = mock(ValidatableConsumerOffer.class);
 
         when(validatableOffer.getContractPolicy()).thenReturn(createPolicy());
-        when(consumerOfferResolver.resolveOffer(contractOffer)).thenReturn(ServiceResult.success(validatableOffer));
+        when(consumerOfferResolver.resolveOffer(contractOffer.getId())).thenReturn(ServiceResult.success(validatableOffer));
         when(identityService.verifyJwtToken(eq(tokenRepresentation), isA(VerificationContext.class))).thenReturn(Result.success(claimToken));
         when(store.findById(any())).thenReturn(negotiation);
         when(store.findByIdAndLease(any())).thenReturn(StoreResult.success(negotiation));
@@ -206,7 +206,7 @@ class ContractNegotiationProtocolServiceImplTest {
         var validatableOffer = mock(ValidatableConsumerOffer.class);
 
         when(validatableOffer.getContractPolicy()).thenReturn(createPolicy());
-        when(consumerOfferResolver.resolveOffer(contractOffer)).thenReturn(ServiceResult.notFound(""));
+        when(consumerOfferResolver.resolveOffer(contractOffer.getId())).thenReturn(ServiceResult.notFound(""));
 
         var result = service.notifyRequested(message, tokenRepresentation);
 
@@ -415,7 +415,8 @@ class ContractNegotiationProtocolServiceImplTest {
         var id = "negotiationId";
         var claimToken = claimToken();
         var tokenRepresentation = tokenRepresentation();
-        var negotiation = contractNegotiationBuilder().id(id).type(PROVIDER).state(VERIFIED.code()).build();
+        var contractOffer = contractOffer();
+        var negotiation = contractNegotiationBuilder().id(id).type(PROVIDER).contractOffer(contractOffer).state(VERIFIED.code()).build();
 
         when(identityService.verifyJwtToken(eq(tokenRepresentation), isA(VerificationContext.class))).thenReturn(Result.success(claimToken));
         when(store.findById(id)).thenReturn(negotiation);
@@ -449,9 +450,11 @@ class ContractNegotiationProtocolServiceImplTest {
         var id = "negotiationId";
         var claimToken = claimToken();
         var tokenRepresentation = tokenRepresentation();
+        var contractOffer = contractOffer();
+
         when(identityService.verifyJwtToken(eq(tokenRepresentation), isA(VerificationContext.class))).thenReturn(Result.success(claimToken));
 
-        var negotiation = contractNegotiationBuilder().id(id).type(PROVIDER).state(VERIFIED.code()).build();
+        var negotiation = contractNegotiationBuilder().id(id).type(PROVIDER).contractOffer(contractOffer).state(VERIFIED.code()).build();
 
         when(store.findById(id)).thenReturn(negotiation);
         when(validationService.validateRequest(claimToken, negotiation)).thenReturn(Result.failure("validation error"));
@@ -491,7 +494,7 @@ class ContractNegotiationProtocolServiceImplTest {
         var validatableOffer = mock(ValidatableConsumerOffer.class);
 
         when(validatableOffer.getContractPolicy()).thenReturn(createPolicy());
-        when(consumerOfferResolver.resolveOffer(any(ContractOffer.class))).thenReturn(ServiceResult.success(validatableOffer));
+        when(consumerOfferResolver.resolveOffer(any())).thenReturn(ServiceResult.success(validatableOffer));
         when(identityService.verifyJwtToken(eq(tokenRepresentation), isA(VerificationContext.class))).thenReturn(Result.success(claimToken));
         when(store.findById(any())).thenReturn(createContractNegotiationOffered());
         when(store.findByIdAndLease(any())).thenReturn(StoreResult.success(createContractNegotiationOffered()));
@@ -513,7 +516,7 @@ class ContractNegotiationProtocolServiceImplTest {
         var validatableOffer = mock(ValidatableConsumerOffer.class);
 
         when(validatableOffer.getContractPolicy()).thenReturn(createPolicy());
-        when(consumerOfferResolver.resolveOffer(any(ContractOffer.class))).thenReturn(ServiceResult.success(validatableOffer));
+        when(consumerOfferResolver.resolveOffer(any())).thenReturn(ServiceResult.success(validatableOffer));
         when(store.findById(any())).thenReturn(createContractNegotiationOffered());
         when(identityService.verifyJwtToken(eq(tokenRepresentation), isA(VerificationContext.class))).thenReturn(Result.failure("unauthorized"));
 
@@ -662,7 +665,7 @@ class ContractNegotiationProtocolServiceImplTest {
             var validatableOffer = mock(ValidatableConsumerOffer.class);
 
             when(validatableOffer.getContractPolicy()).thenReturn(createPolicy());
-            when(consumerOfferResolver.resolveOffer(any(ContractOffer.class))).thenReturn(ServiceResult.success(validatableOffer));
+            when(consumerOfferResolver.resolveOffer(any())).thenReturn(ServiceResult.success(validatableOffer));
             when(identityService.verifyJwtToken(any(), isA(VerificationContext.class)))
                     .thenReturn(Result.success(claimToken()));
             when(store.findById(any())).thenReturn(negotiation);
@@ -692,7 +695,7 @@ class ContractNegotiationProtocolServiceImplTest {
             var validatableOffer = mock(ValidatableConsumerOffer.class);
 
             when(validatableOffer.getContractPolicy()).thenReturn(createPolicy());
-            when(consumerOfferResolver.resolveOffer(any(ContractOffer.class))).thenReturn(ServiceResult.success(validatableOffer));
+            when(consumerOfferResolver.resolveOffer(any())).thenReturn(ServiceResult.success(validatableOffer));
             when(identityService.verifyJwtToken(any(), isA(VerificationContext.class)))
                     .thenReturn(Result.success(claimToken()));
             when(store.findById(any())).thenReturn(negotiation);
@@ -718,7 +721,7 @@ class ContractNegotiationProtocolServiceImplTest {
             var validatableOffer = mock(ValidatableConsumerOffer.class);
 
             when(validatableOffer.getContractPolicy()).thenReturn(createPolicy());
-            when(consumerOfferResolver.resolveOffer(any(ContractOffer.class))).thenReturn(ServiceResult.success(validatableOffer));
+            when(consumerOfferResolver.resolveOffer(any())).thenReturn(ServiceResult.success(validatableOffer));
             when(identityService.verifyJwtToken(any(), isA(VerificationContext.class)))
                     .thenReturn(Result.success(claimToken()));
             when(store.findById(any())).thenReturn(negotiation);

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/offer/ConsumerOfferResolver.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/offer/ConsumerOfferResolver.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.contract.spi.offer;
+
+import org.eclipse.edc.connector.contract.spi.validation.ContractValidationService;
+import org.eclipse.edc.connector.contract.spi.validation.ValidatableConsumerOffer;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Resolve the consumer offer into a {@link ValidatableConsumerOffer} which can be used
+ * to validate incoming offer through {@link ContractValidationService#validateInitialOffer}
+ */
+public interface ConsumerOfferResolver {
+
+    @NotNull
+    ServiceResult<ValidatableConsumerOffer> resolveOffer(ContractOffer offer);
+
+    @NotNull
+    ServiceResult<ValidatableConsumerOffer> resolveOffer(String offerId);
+
+}

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/offer/ConsumerOfferResolver.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/offer/ConsumerOfferResolver.java
@@ -17,7 +17,6 @@ package org.eclipse.edc.connector.contract.spi.offer;
 import org.eclipse.edc.connector.contract.spi.validation.ContractValidationService;
 import org.eclipse.edc.connector.contract.spi.validation.ValidatableConsumerOffer;
 import org.eclipse.edc.spi.result.ServiceResult;
-import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -25,9 +24,6 @@ import org.jetbrains.annotations.NotNull;
  * to validate incoming offer through {@link ContractValidationService#validateInitialOffer}
  */
 public interface ConsumerOfferResolver {
-
-    @NotNull
-    ServiceResult<ValidatableConsumerOffer> resolveOffer(ContractOffer offer);
 
     @NotNull
     ServiceResult<ValidatableConsumerOffer> resolveOffer(String offerId);

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/validation/ContractValidationService.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/validation/ContractValidationService.java
@@ -36,29 +36,16 @@ public interface ContractValidationService {
     @PolicyScope
     String TRANSFER_SCOPE = "transfer.process";
 
-    /**
-     * Validates and sanitizes the contract offer for the consumer represented by the given claims.
-     * <p>
-     * The original offer must be validated and sanitized to avoid policy and asset injection attacks by malicious consumers.
-     *
-     * @param token The {@link ClaimToken} of the consumer
-     * @param offer The initial {@link ContractOffer} to validate
-     * @return The sanitized version {@link ContractOffer}. The input {@link ContractOffer} could contain some fields or value on policy or asset that differs from the original
-     *     policy and asset defined by the provider, which could cause injection attacks. The provider validation should return a new {@link ContractOffer} that contains the
-     *     original policy and asset defined by the provider.
-     */
-    @NotNull
-    Result<ValidatedConsumerOffer> validateInitialOffer(ClaimToken token, ContractOffer offer);
-
+    
     /**
      * Validates the contract offer for the consumer represented by the given claims.
      *
-     * @param token   The {@link ClaimToken} of the consumer
-     * @param offerId The initial {@link ContractOffer} id to validate
-     * @return The referenced {@link ContractOffer}.
+     * @param token         The {@link ClaimToken} of the consumer
+     * @param consumerOffer The initial {@link ValidatableConsumerOffer} id to validate
+     * @return The referenced {@link ValidatedConsumerOffer}.
      */
     @NotNull
-    Result<ValidatedConsumerOffer> validateInitialOffer(ClaimToken token, String offerId);
+    Result<ValidatedConsumerOffer> validateInitialOffer(ClaimToken token, ValidatableConsumerOffer consumerOffer);
 
     /**
      * Validates the contract agreement that the consumer referenced in its transfer request.

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/validation/ValidatableConsumerOffer.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/validation/ValidatableConsumerOffer.java
@@ -1,0 +1,95 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.contract.spi.validation;
+
+import org.eclipse.edc.connector.contract.spi.ContractOfferId;
+import org.eclipse.edc.connector.contract.spi.types.offer.ContractDefinition;
+import org.eclipse.edc.policy.model.Policy;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Enriched consumer offer which contains all information for validating the offer with
+ * {@link ContractValidationService#validateInitialOffer}
+ */
+public class ValidatableConsumerOffer {
+
+    private ContractOfferId offerId;
+    private ContractDefinition contractDefinition;
+    private Policy accessPolicy;
+    private Policy contractPolicy;
+
+    private ValidatableConsumerOffer() {
+    }
+
+    public Policy getContractPolicy() {
+        return contractPolicy;
+    }
+
+    public ContractOfferId getOfferId() {
+        return offerId;
+    }
+
+    public Policy getAccessPolicy() {
+        return accessPolicy;
+    }
+
+    public ContractDefinition getContractDefinition() {
+        return contractDefinition;
+    }
+
+    public static final class Builder {
+
+        private final ValidatableConsumerOffer consumerOffer;
+
+        private Builder(ValidatableConsumerOffer consumerOffer) {
+            this.consumerOffer = consumerOffer;
+        }
+
+        public static Builder newInstance() {
+            return new Builder(new ValidatableConsumerOffer());
+        }
+
+
+        public Builder offerId(ContractOfferId offerId) {
+            consumerOffer.offerId = offerId;
+            return this;
+        }
+
+        public Builder contractDefinition(ContractDefinition contractDefinition) {
+            consumerOffer.contractDefinition = contractDefinition;
+            return this;
+        }
+
+        public Builder accessPolicy(Policy accessPolicy) {
+            consumerOffer.accessPolicy = accessPolicy;
+            return this;
+        }
+
+        public Builder contractPolicy(Policy contractPolicy) {
+            consumerOffer.contractPolicy = contractPolicy;
+            return this;
+        }
+
+        public ValidatableConsumerOffer build() {
+            requireNonNull(consumerOffer.offerId, "offerId");
+            requireNonNull(consumerOffer.contractDefinition, "contractDefinition");
+            requireNonNull(consumerOffer.accessPolicy, "accessPolicy");
+            requireNonNull(consumerOffer.contractPolicy, "contractPolicy");
+
+            return consumerOffer;
+        }
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

Introduces the policy scopes extractor in contract negotiation messages at protocol layers:

- in all contract negotiation messages, `ContractRequestMessage` excluded, we first load the contract negotiation in read mode based on the message, then we extract the policy and verify the token with the scope attached running the policy engine. Same as in #3822,  if the contract negotiation is not found or the token verification fails the returned error is `404`
- When dealing with `ContractRequestMessage` we changed a bit how the sequence of fetching stuff from the database for validation is done. We first fetch all the information what we need in order to validate the `ContractRequestMessage`  through the new core service `ConsumerOfferResolver`. Then we verify the token with the extracted scopes, if successful we run the validation of the `ValidatableConsumerOffer` with the `ContractValidationService` 
- The default implementation of `ContractValidationService` has been modified in order to validate `ValidatableConsumerOffer`. Additional data like `Policy` or `ContractDefinition` from the database are not fetched anymore here since they are already contained  in the input `ValidatableConsumerOffer`

## Linked Issue(s)

Closes #2819 

