### PR TITLE
refactor: introduction of ProtocolTokenValidator

### DIFF
--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -37,15 +37,14 @@ import org.eclipse.edc.connector.defaults.storage.contractnegotiation.InMemoryCo
 import org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore;
 import org.eclipse.edc.connector.service.contractnegotiation.ContractNegotiationProtocolServiceImpl;
 import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationProtocolService;
+import org.eclipse.edc.connector.spi.protocol.ProtocolTokenValidator;
 import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.policy.model.Action;
 import org.eclipse.edc.policy.model.Duty;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.policy.model.PolicyType;
 import org.eclipse.edc.spi.iam.ClaimToken;
-import org.eclipse.edc.spi.iam.IdentityService;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
-import org.eclipse.edc.spi.iam.VerificationContext;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.monitor.ConsoleMonitor;
 import org.eclipse.edc.spi.protocol.ProtocolWebhook;
@@ -117,7 +116,7 @@ class ContractNegotiationIntegrationTest {
     private final ConsumerOfferResolver offerResolver = mock();
     private final RemoteMessageDispatcherRegistry providerDispatcherRegistry = mock();
     private final RemoteMessageDispatcherRegistry consumerDispatcherRegistry = mock();
-    private final IdentityService identityService = mock();
+    private final ProtocolTokenValidator protocolTokenValidator = mock();
     private final ProtocolWebhook protocolWebhook = () -> "http://dummy";
     protected ClaimToken token = ClaimToken.Builder.newInstance().build();
     protected TokenRepresentation tokenRepresentation = TokenRepresentation.Builder.newInstance().build();
@@ -153,9 +152,9 @@ class ContractNegotiationIntegrationTest {
                 .protocolWebhook(protocolWebhook)
                 .build();
 
-        when(identityService.verifyJwtToken(eq(tokenRepresentation), isA(VerificationContext.class))).thenReturn(Result.success(token));
-        consumerService = new ContractNegotiationProtocolServiceImpl(consumerStore, new NoopTransactionContext(), validationService, offerResolver, identityService, mock(), new ContractNegotiationObservableImpl(), monitor, mock());
-        providerService = new ContractNegotiationProtocolServiceImpl(providerStore, new NoopTransactionContext(), validationService, offerResolver, identityService, mock(), new ContractNegotiationObservableImpl(), monitor, mock());
+        when(protocolTokenValidator.verifyToken(eq(tokenRepresentation), any(), any())).thenReturn(ServiceResult.success(token));
+        consumerService = new ContractNegotiationProtocolServiceImpl(consumerStore, new NoopTransactionContext(), validationService, offerResolver, protocolTokenValidator, new ContractNegotiationObservableImpl(), monitor, mock());
+        providerService = new ContractNegotiationProtocolServiceImpl(providerStore, new NoopTransactionContext(), validationService, offerResolver, protocolTokenValidator, new ContractNegotiationObservableImpl(), monitor, mock());
     }
 
     @AfterEach

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/test/java/org/eclipse/edc/iam/identitytrust/service/IdentityAndTrustServiceTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/test/java/org/eclipse/edc/iam/identitytrust/service/IdentityAndTrustServiceTest.java
@@ -71,7 +71,7 @@ import static org.mockito.Mockito.when;
 
 class IdentityAndTrustServiceTest {
     public static final String EXPECTED_OWN_DID = "did:web:test";
-    
+
     public static final String CONSUMER_DID = "did:web:consumer";
     private final SecureTokenService mockedSts = mock();
     private final PresentationVerifier mockedVerifier = mock();
@@ -96,7 +96,6 @@ class IdentityAndTrustServiceTest {
 
     private VerificationContext verificationContext() {
         return VerificationContext.Builder.newInstance()
-                .audience("test-audience")
                 .policy(Policy.Builder.newInstance().build())
                 .build();
     }

--- a/extensions/common/iam/oauth2/oauth2-core/src/test/java/org/eclipse/edc/iam/oauth2/identity/Oauth2ServiceImplTest.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/test/java/org/eclipse/edc/iam/oauth2/identity/Oauth2ServiceImplTest.java
@@ -76,7 +76,6 @@ class Oauth2ServiceImplTest {
     private static final String ENDPOINT_AUDIENCE = "endpoint-audience-test";
 
     private static final VerificationContext VERIFICATION_CONTEXT = VerificationContext.Builder.newInstance()
-            .audience(ENDPOINT_AUDIENCE)
             .policy(Policy.Builder.newInstance().build())
             .build();
     private static final String OAUTH2_SERVER_URL = "http://oauth2-server.com";

--- a/extensions/common/iam/oauth2/oauth2-daps/src/test/java/org/eclipse/edc/iam/oauth2/daps/DapsIntegrationTest.java
+++ b/extensions/common/iam/oauth2/oauth2-daps/src/test/java/org/eclipse/edc/iam/oauth2/daps/DapsIntegrationTest.java
@@ -63,7 +63,6 @@ class DapsIntegrationTest {
         assertThat(tokenResult.succeeded()).withFailMessage(tokenResult::getFailureDetail).isTrue();
 
         var verificationContext = VerificationContext.Builder.newInstance()
-                .audience("audience")
                 .policy(Policy.Builder.newInstance().build())
                 .build();
 

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/iam/IdentityService.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/iam/IdentityService.java
@@ -16,7 +16,6 @@
 
 package org.eclipse.edc.spi.iam;
 
-import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import org.eclipse.edc.spi.result.Result;
 
@@ -44,21 +43,4 @@ public interface IdentityService {
      */
     Result<ClaimToken> verifyJwtToken(TokenRepresentation tokenRepresentation, VerificationContext context);
 
-    /**
-     * Verifies a JWT bearer token.
-     *
-     * @param tokenRepresentation A token representation including the token to verify.
-     * @param audience            The audience.
-     * @return Result of the validation.
-     * @deprecated please use {@link #verifyJwtToken(TokenRepresentation, VerificationContext)}
-     */
-
-    @Deprecated(since = "0.4.2", forRemoval = true)
-    default Result<ClaimToken> verifyJwtToken(TokenRepresentation tokenRepresentation, String audience) {
-        var context = VerificationContext.Builder.newInstance()
-                .audience(audience)
-                .policy(Policy.Builder.newInstance().build())
-                .build();
-        return verifyJwtToken(tokenRepresentation, context);
-    }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/iam/VerificationContext.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/iam/VerificationContext.java
@@ -28,24 +28,14 @@ import java.util.Set;
  */
 public class VerificationContext {
 
-    // TODO it will be removed with the TokenGenerator/Verification refactor
-    @Deprecated
-    private String audience;
-    private Policy policy;
-
-    private Set<String> scopes = new HashSet<>();
     private final Map<Class<?>, Object> additional;
+    private Policy policy;
+    private Set<String> scopes = new HashSet<>();
 
     private VerificationContext() {
         additional = new HashMap<>();
     }
 
-    /**
-     * Returns the audience or null if not available.
-     */
-    public String getAudience() {
-        return audience;
-    }
 
     /**
      * Returns the {@link Policy} associated with the verification context
@@ -86,11 +76,6 @@ public class VerificationContext {
 
         public static Builder newInstance() {
             return new Builder();
-        }
-
-        public Builder audience(String audience) {
-            context.audience = audience;
-            return this;
         }
 
         public Builder data(Class<?> clazz, Object object) {

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/protocol/ProtocolTokenValidator.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/protocol/ProtocolTokenValidator.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.spi.protocol;
+
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
+import org.eclipse.edc.spi.iam.ClaimToken;
+import org.eclipse.edc.spi.iam.TokenRepresentation;
+import org.eclipse.edc.spi.result.ServiceResult;
+
+/**
+ * Token validator to be used in protocol layer for verifying the token according the
+ * input policy and policy scope
+ */
+@ExtensionPoint
+public interface ProtocolTokenValidator {
+    
+    /**
+     * Verify the {@link TokenRepresentation} in the context of a policy
+     *
+     * @param tokenRepresentation The token
+     * @param policyScope         The policy scope
+     * @param policy              The policy
+     * @return Returns the extracted {@link ClaimToken} if successful, failure otherwise
+     */
+    ServiceResult<ClaimToken> verifyToken(TokenRepresentation tokenRepresentation, String policyScope, Policy policy);
+}


### PR DESCRIPTION
## What this PR changes/adds

- Extracts `BaseProtocolService` into `ProtocolTokenValidator`
- Removes the parsing of `access_token` for fetching the scopes
- Removes the deprecated `VerificationContext#audience` field

## Why it does that

refactoring

## Linked Issue(s)

Closes #3832 

