### PR TITLE
refactor: minor improvements in Iatp and Did modules

### DIFF
--- a/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/IatpDefaultServicesExtension.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/IatpDefaultServicesExtension.java
@@ -44,18 +44,15 @@ public class IatpDefaultServicesExtension implements ServiceExtension {
 
     @Setting(value = "Alias of private key used for signing tokens, retrieved from private key resolver", defaultValue = "A random EC private key")
     public static final String STS_PRIVATE_KEY_ALIAS = "edc.iam.sts.privatekey.alias";
-    @Setting(value = "Alias of public key used for verifying the tokens, retrieved from the vault", defaultValue = "A random EC public key")
-    public static final String STS_PUBLIC_KEY_ALIAS = "edc.iam.sts.publickey.alias";
+    @Setting(value = "Id used by the counterparty to resolve the public key for token validation, e.g. did:example:123#public-key-0", defaultValue = "A random EC public key")
+    public static final String STS_PUBLIC_KEY_ID = "edc.iam.sts.publickey.id";
     // not a setting, it's defined in Oauth2ServiceExtension
     private static final String OAUTH_TOKENURL_PROPERTY = "edc.oauth.token.url";
     @Setting(value = "Self-issued ID Token expiration in minutes. By default is 5 minutes", defaultValue = "" + IatpDefaultServicesExtension.DEFAULT_STS_TOKEN_EXPIRATION_MIN)
     private static final String STS_TOKEN_EXPIRATION = "edc.iam.sts.token.expiration"; // in minutes
     private static final int DEFAULT_STS_TOKEN_EXPIRATION_MIN = 5;
-
-
     @Inject
     private Clock clock;
-
     @Inject
     private PrivateKeyResolver privateKeyResolver;
 
@@ -71,7 +68,7 @@ public class IatpDefaultServicesExtension implements ServiceExtension {
         }
 
 
-        var publicKeyId = context.getSetting(STS_PUBLIC_KEY_ALIAS, null);
+        var publicKeyId = context.getSetting(STS_PUBLIC_KEY_ID, null);
         var privKeyAlias = context.getSetting(STS_PRIVATE_KEY_ALIAS, null);
 
         Supplier<PrivateKey> supplier = () -> privateKeyResolver.resolvePrivateKey(privKeyAlias).orElseThrow(f -> new EdcException("This EDC instance is not operational due to the following error: %s".formatted(f.getFailureDetail())));

--- a/extensions/common/iam/identity-trust/identity-trust-core/src/test/java/org/eclipse/edc/iam/identitytrust/core/IatpDefaultServicesExtensionTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/test/java/org/eclipse/edc/iam/identitytrust/core/IatpDefaultServicesExtensionTest.java
@@ -36,7 +36,7 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.iam.identitytrust.core.IatpDefaultServicesExtension.STS_PRIVATE_KEY_ALIAS;
-import static org.eclipse.edc.iam.identitytrust.core.IatpDefaultServicesExtension.STS_PUBLIC_KEY_ALIAS;
+import static org.eclipse.edc.iam.identitytrust.core.IatpDefaultServicesExtension.STS_PUBLIC_KEY_ID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -65,12 +65,12 @@ class IatpDefaultServicesExtensionTest {
 
     @Test
     void verify_defaultService(ServiceExtensionContext context, IatpDefaultServicesExtension ext) {
-        var publicAlias = "public";
-        var privateAlias = "private";
+        var publicKeyId = "did:web:" + UUID.randomUUID() + "#key-id";
+        var privateKeyAlias = "private";
         Monitor mockedMonitor = mock();
         context.registerService(Monitor.class, mockedMonitor);
-        when(context.getSetting(STS_PUBLIC_KEY_ALIAS, null)).thenReturn(publicAlias);
-        when(context.getSetting(STS_PRIVATE_KEY_ALIAS, null)).thenReturn(privateAlias);
+        when(context.getSetting(STS_PUBLIC_KEY_ID, null)).thenReturn(publicKeyId);
+        when(context.getSetting(STS_PRIVATE_KEY_ALIAS, null)).thenReturn(privateKeyAlias);
         var sts = ext.createDefaultTokenService(context);
 
         assertThat(sts).isInstanceOf(EmbeddedSecureTokenService.class);

--- a/spi/common/identity-did-spi/src/main/java/org/eclipse/edc/iam/did/spi/document/DidConstants.java
+++ b/spi/common/identity-did-spi/src/main/java/org/eclipse/edc/iam/did/spi/document/DidConstants.java
@@ -14,21 +14,16 @@
 
 package org.eclipse.edc.iam.did.spi.document;
 
-import org.eclipse.edc.runtime.metamodel.annotation.Setting;
-
-import java.util.Arrays;
-import java.util.List;
+import java.util.Set;
 
 public interface DidConstants {
     String ECDSA_SECP_256_K_1_VERIFICATION_KEY_2019 = "EcdsaSecp256k1VerificationKey2019";
     String JSON_WEB_KEY_2020 = "JsonWebKey2020";
     String RSA_VERIFICATION_KEY_2018 = "RsaVerificationKey2018";
     String ED_25519_VERIFICATION_KEY_2018 = "Ed25519VerificationKey2018";
-    List<String> ALLOWED_VERIFICATION_TYPES = Arrays.asList(DidConstants.ECDSA_SECP_256_K_1_VERIFICATION_KEY_2019,
+    Set<String> ALLOWED_VERIFICATION_TYPES = Set.of(DidConstants.ECDSA_SECP_256_K_1_VERIFICATION_KEY_2019,
             DidConstants.JSON_WEB_KEY_2020,
             DidConstants.RSA_VERIFICATION_KEY_2018,
             DidConstants.ED_25519_VERIFICATION_KEY_2018);
-    @Setting
-    String DID_URL_SETTING = "edc.identity.did.url";
 
 }


### PR DESCRIPTION
## What this PR changes/adds

- improve error message when no Verification Method with supported type is found in DID document
- improve naming and documentation of STS setting for the public key: current documentation indicates this setting refers to public key alias in the Vault, while it actually corresponds to the public ID resolves by the counterparty.

## Why it does that

Easier investigations

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
