### PR TITLE
fix: use correct Regex when parsing DID

### DIFF
--- a/extensions/common/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/edc/iam/did/resolution/DidPublicKeyResolverImpl.java
+++ b/extensions/common/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/edc/iam/did/resolution/DidPublicKeyResolverImpl.java
@@ -37,7 +37,7 @@ public class DidPublicKeyResolverImpl extends AbstractPublicKeyResolver implemen
      * Group 1 ("did")      = the did:method:identifier portion
      * Group 2 ("fragment") = the #fragment portion
      */
-    private static final Pattern PATTERN_DID_WITH_OPTIONAL_FRAGMENT = Pattern.compile("(?<did>did:.*:[^#]*)(?<fragment>#.*)?");
+    private static final Pattern PATTERN_DID_WITH_OPTIONAL_FRAGMENT = Pattern.compile("(?<did>did:.*:[^#]*)((#)(?<fragment>.*))?");
     private static final String GROUP_DID = "did";
     private static final String GROUP_FRAGMENT = "fragment";
     private final DidResolverRegistry resolverRegistry;

--- a/extensions/common/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/edc/iam/did/resolution/DidPublicKeyResolverImplTest.java
+++ b/extensions/common/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/edc/iam/did/resolution/DidPublicKeyResolverImplTest.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.when;
 
 class DidPublicKeyResolverImplTest {
 
-    public static final String KEYID = "#my-key1";
+    public static final String KEYID = "my-key1";
     private static final String DID_URL = "did:web:example.com";
     private final DidResolverRegistry resolverRegistry = mock();
     private final KeyParserRegistry keyParserRegistry = mock();
@@ -100,18 +100,18 @@ class DidPublicKeyResolverImplTest {
         var didDocument = createDidDocument();
         when(resolverRegistry.resolve(DID_URL)).thenReturn(Result.success(didDocument));
 
-        var result = resolver.resolveKey(DID_URL + KEYID);
+        var result = resolver.resolveKey(DID_URL + "#" + KEYID);
 
         assertThat(result).isSucceeded().isNotNull();
         verify(resolverRegistry).resolve(DID_URL);
     }
 
     @Test
-    void resolve_withVerificationMethodUrlAsId() throws IOException, JOSEException {
-        var didDocument = createDidDocument(DID_URL + KEYID);
+    void resolve_withVerificationMethodUrlAsId() {
+        var didDocument = createDidDocument(DID_URL + "#" + KEYID);
         when(resolverRegistry.resolve(DID_URL)).thenReturn(Result.success(didDocument));
 
-        var result = resolver.resolveKey(DID_URL + KEYID);
+        var result = resolver.resolveKey(DID_URL + "#" + KEYID);
 
         assertThat(result).isSucceeded().isNotNull();
         verify(resolverRegistry).resolve(DID_URL);
@@ -121,7 +121,7 @@ class DidPublicKeyResolverImplTest {
     void resolve_didNotFound() {
         when(resolverRegistry.resolve(DID_URL)).thenReturn(Result.failure("Not found"));
 
-        var result = resolver.resolveKey(DID_URL + KEYID);
+        var result = resolver.resolveKey(DID_URL + "#" + KEYID);
 
         assertThat(result).isFailed();
         verify(resolverRegistry).resolve(DID_URL);
@@ -133,20 +133,20 @@ class DidPublicKeyResolverImplTest {
         didDocument.getVerificationMethod().clear();
         when(resolverRegistry.resolve(DID_URL)).thenReturn(Result.success(didDocument));
 
-        var result = resolver.resolveKey(DID_URL + KEYID);
+        var result = resolver.resolveKey(DID_URL + "#" + KEYID);
 
         assertThat(result).isFailed();
         verify(resolverRegistry).resolve(DID_URL);
     }
 
     @Test
-    void resolve_didContainsMultipleKeysWithSameKeyId() throws JOSEException, IOException {
+    void resolve_didContainsMultipleKeysWithSameKeyId() {
         var vm = createVerificationMethod(KEYID);
         var vm1 = createVerificationMethod(KEYID);
         var didDocument = createDidDocumentBuilder(KEYID).verificationMethod(List.of(vm, vm1)).build();
         when(resolverRegistry.resolve(DID_URL)).thenReturn(Result.success(didDocument));
 
-        var result = resolver.resolveKey(DID_URL + KEYID);
+        var result = resolver.resolveKey(DID_URL + "#" + KEYID);
 
         assertThat(result).isFailed()
                 .detail().contains("Every verification method must have a unique ID");
@@ -155,13 +155,13 @@ class DidPublicKeyResolverImplTest {
 
     @Test
     void resolve_didContainsMultipleKeysWithSameKeyId_withRelativeAndFullUrl() {
-        var vm = createVerificationMethod(DID_URL + KEYID);
+        var vm = createVerificationMethod(DID_URL + "#" + KEYID);
         var vm1 = createVerificationMethod(KEYID);
 
         var didDocument = createDidDocumentBuilder(KEYID).verificationMethod(List.of(vm, vm1)).build();
         when(resolverRegistry.resolve(DID_URL)).thenReturn(Result.success(didDocument));
 
-        var result = resolver.resolveKey(DID_URL + KEYID);
+        var result = resolver.resolveKey(DID_URL + "#" + KEYID);
 
         assertThat(result).isFailed()
                 .detail().contains("Every verification method must have a unique ID");


### PR DESCRIPTION
## What this PR changes/adds

This PR fixes the Regex we use to parse DIDs. Previously, in a DID `"did:web:foobar#key-1"`the key-id would have been extracted as`""#key-1"`, where now it is `"key-1"` without the pound sign.

## Why it does that

Would have caused a bug when matching verification methods

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
