### PR TITLE
feat(dsp): remove `offerId` property

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
@@ -41,7 +41,6 @@ import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.telemetry.Telemetry;
-import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 import org.jetbrains.annotations.NotNull;
 
@@ -218,9 +217,7 @@ public class ContractNegotiationProtocolServiceImpl extends BaseProtocolService 
 
     @NotNull
     private ServiceResult<ValidatableConsumerOffer> fetchValidatableOffer(ContractRequestMessage message) {
-        var offerId = Optional.ofNullable(message.getContractOffer())
-                .map(ContractOffer::getId)
-                .orElseGet(message::getContractOfferId);
+        var offerId = message.getContractOffer().getId();
 
         var result = consumerOfferResolver.resolveOffer(offerId);
         if (result.failed()) {

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractRequestMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractRequestMessageTransformer.java
@@ -27,7 +27,6 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_DATASET;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER;
-import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER_ID;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
@@ -75,9 +74,6 @@ public class JsonObjectFromContractRequestMessageTransformer extends AbstractJso
                     .build();
             builder.add(DSPACE_PROPERTY_OFFER, enrichedPolicy);
 
-        } else {
-            builder.add(DSPACE_PROPERTY_OFFER_ID, requestMessage.getContractOfferId());
-            addIfNotNull(requestMessage.getDataset(), DSPACE_PROPERTY_DATASET, builder);
         }
 
         return builder.build();

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractRequestMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractRequestMessageTransformer.java
@@ -26,7 +26,6 @@ import org.jetbrains.annotations.Nullable;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_DATASET;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER;
-import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER_ID;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
@@ -100,14 +99,12 @@ public class JsonObjectToContractRequestMessageTransformer extends AbstractJsonL
         } else if (context.hasProblems()) {
             return null;
         } else {
-            if (!transformMandatoryString(requestObject.get(DSPACE_PROPERTY_OFFER_ID), builder::contractOfferId, context)) {
-                context.problem()
-                        .missingProperty()
-                        .type(DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE)
-                        .property(DSPACE_PROPERTY_OFFER)
-                        .report();
-                return null;
-            }
+            context.problem()
+                    .missingProperty()
+                    .type(DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE)
+                    .property(DSPACE_PROPERTY_OFFER)
+                    .report();
+            return null;
         }
         return builder.build();
     }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractRequestMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractRequestMessageTransformerTest.java
@@ -32,7 +32,6 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_DATASET;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER;
-import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER_ID;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
@@ -94,25 +93,7 @@ class JsonObjectFromContractRequestMessageTransformerTest {
     }
 
     @Test
-    void verify_contractOfferId() {
-        var message = contractRequestMessageBuilder()
-                .processId("processId")
-                .consumerPid(CONSUMER_PID)
-                .contractOfferId(CONTRACT_OFFER_ID)
-                .build();
-
-        var result = transformer.transform(message, context);
-
-        assertThat(result).isNotNull();
-        assertThat(result.getJsonString(ID).getString()).isNotEmpty();
-        assertThat(result.getJsonString(TYPE).getString()).isEqualTo(DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE);
-        assertThat(result.getString(DSPACE_PROPERTY_OFFER_ID)).isEqualTo(CONTRACT_OFFER_ID);
-
-        verify(context, never()).reportProblem(anyString());
-    }
-
-    @Test
-    void verify_nullPolicyFails() {
+    void shouldFail_whenPolicyCannotBeTransformed() {
         var message = contractRequestMessageBuilder()
                 .processId("processId")
                 .consumerPid(CONSUMER_PID)

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractRequestMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractRequestMessageTransformerTest.java
@@ -35,7 +35,6 @@ import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_O
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.to.TestInput.getExpanded;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_DATASET;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER;
-import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER_ID;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID;
@@ -96,32 +95,6 @@ class JsonObjectToContractRequestMessageTransformerTest {
         assertThat(contractOffer.getId()).isNotNull();
         assertThat(contractOffer.getPolicy()).isNotNull();
         assertThat(contractOffer.getAssetId()).isEqualTo("target");
-
-        verify(context, never()).reportProblem(anyString());
-    }
-
-    @Test
-    void verify_usingOfferId() {
-        var message = jsonFactory.createObjectBuilder()
-                .add(JsonLdKeywords.ID, OBJECT_ID)
-                .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE)
-                .add(DSPACE_PROPERTY_CONSUMER_PID, "consumerPid")
-                .add(DSPACE_PROPERTY_PROVIDER_PID, "providerPid")
-                .add(DSPACE_PROPERTY_DATASET, DATASET_ID)
-                .add(DSPACE_PROPERTY_CALLBACK_ADDRESS, CALLBACK)
-                .add(DSPACE_PROPERTY_OFFER_ID, CONTRACT_OFFER_ID)
-                .build();
-
-        var result = transformer.transform(getExpanded(message), context);
-
-        assertThat(result).isNotNull();
-        assertThat(result.getProtocol()).isNotEmpty();
-        assertThat(result.getConsumerPid()).isEqualTo("consumerPid");
-        assertThat(result.getProviderPid()).isEqualTo("providerPid");
-        assertThat(result.getCallbackAddress()).isEqualTo(CALLBACK);
-        assertThat(result.getDataset()).isEqualTo(DATASET_ID);
-
-        assertThat(result.getContractOfferId()).isNotNull();
 
         verify(context, never()).reportProblem(anyString());
     }

--- a/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/type/DspNegotiationPropertyAndTypeNames.java
+++ b/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/type/DspNegotiationPropertyAndTypeNames.java
@@ -37,7 +37,6 @@ public interface DspNegotiationPropertyAndTypeNames {
     String DSPACE_PROPERTY_EVENT_TYPE = DSPACE_SCHEMA + "eventType";
     String DSPACE_PROPERTY_AGREEMENT = DSPACE_SCHEMA + "agreement";
     String DSPACE_PROPERTY_OFFER = DSPACE_SCHEMA + "offer";
-    String DSPACE_PROPERTY_OFFER_ID = DSPACE_SCHEMA + "offerId";
     String DSPACE_PROPERTY_DATASET = DSPACE_SCHEMA + "dataset";
     String DSPACE_PROPERTY_TIMESTAMP = DSPACE_SCHEMA + "timestamp";
     String DSPACE_PROPERTY_CONSUMER_ID = DSPACE_SCHEMA + "consumerId";

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessage.java
@@ -18,7 +18,7 @@ import org.eclipse.edc.connector.contract.spi.types.protocol.ContractRemoteMessa
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.types.domain.message.ProcessRemoteMessage;
 import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
-import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.NotNull;
 
 import static java.util.Objects.requireNonNull;
 
@@ -32,21 +32,15 @@ public class ContractRequestMessage extends ContractRemoteMessage {
     private String callbackAddress;
 
     private ContractOffer contractOffer;
-    private String contractOfferId;
     private String dataset;
 
     public Type getType() {
         return type;
     }
 
-    @Nullable
+    @NotNull
     public ContractOffer getContractOffer() {
         return contractOffer;
-    }
-
-    @Nullable
-    public String getContractOfferId() {
-        return contractOfferId;
     }
 
     public String getDataset() {
@@ -87,11 +81,6 @@ public class ContractRequestMessage extends ContractRemoteMessage {
             return this;
         }
 
-        public Builder contractOfferId(String id) {
-            message.contractOfferId = id;
-            return this;
-        }
-
         public Builder type(Type type) {
             message.type = type;
             return this;
@@ -103,11 +92,7 @@ public class ContractRequestMessage extends ContractRemoteMessage {
         }
 
         public ContractRequestMessage build() {
-            if (message.contractOfferId == null) {
-                requireNonNull(message.contractOffer, "contractOffer");
-            } else {
-                requireNonNull(message.contractOfferId, "contractOfferId");
-            }
+            requireNonNull(message.contractOffer, "contractOffer");
             return super.build();
         }
     }

--- a/spi/control-plane/contract-spi/src/test/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessageTest.java
+++ b/spi/control-plane/contract-spi/src/test/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessageTest.java
@@ -37,23 +37,17 @@ class ContractRequestMessageTest {
                 .consumerPid("consumerPid")
                 .providerPid("providerPid")
                 .protocol(PROTOCOL)
-                .contractOfferId(OFFER_ID)
+                .contractOffer(ContractOffer.Builder.newInstance()
+                        .id(ID)
+                        .assetId(ASSET_ID)
+                        .policy(Policy.Builder.newInstance().build())
+                        .build())
                 .dataset(DATASET)
                 .build();
     }
 
     @Test
     void verify_contractOfferIdOrContractOffer() {
-        ContractRequestMessage.Builder.newInstance()
-                .type(INITIAL)
-                .consumerPid("consumerPid")
-                .providerPid("providerPid")
-                .protocol(PROTOCOL)
-                .contractOfferId(OFFER_ID)
-                .dataset(DATASET)
-                .counterPartyAddress(CALLBACK_ADDRESS)
-                .build();
-
         ContractRequestMessage.Builder.newInstance()
                 .type(INITIAL)
                 .consumerPid("consumerPid")
@@ -68,7 +62,7 @@ class ContractRequestMessageTest {
                 .counterPartyAddress(CALLBACK_ADDRESS)
                 .build();
 
-        // verify no contract offer or contract offer id set
+        // verify no contract offer is set
         assertThatThrownBy(() -> ContractRequestMessage.Builder.newInstance()
                 .type(INITIAL)
                 .consumerPid("consumerPid")


### PR DESCRIPTION
## What this PR changes/adds

The `offerId` property is not defined in the DSP spec, so let's get rid of it. 

## Why it does that

dsp compliance

## Further notes

## Linked Issue(s)

Closes #3846 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
