### PR TITLE
feat(kafka_extension): make partitionSize configurable

### DIFF
--- a/extensions/data-plane/data-plane-kafka/src/main/java/org/eclipse/edc/dataplane/kafka/DataPlaneKafkaExtension.java
+++ b/extensions/data-plane/data-plane-kafka/src/main/java/org/eclipse/edc/dataplane/kafka/DataPlaneKafkaExtension.java
@@ -32,9 +32,9 @@ public class DataPlaneKafkaExtension implements ServiceExtension {
 
     public static final String NAME = "Data Plane Kafka";
 
-    private static final int DEFAULT_PART_SIZE = 5;
+    private static final int DEFAULT_PARTITION_SIZE = 5;
 
-    @Setting
+    @Setting(value="The partitionSize used by the KafkaDataSink", type="int", defaultValue="5", min=1)
     private static final String EDC_DATAPLANE_KAFKA_SINK_PARTITION_SIZE = "edc.dataplane.kafka.sink.partition.size";
 
     @Inject
@@ -55,8 +55,8 @@ public class DataPlaneKafkaExtension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
         var monitor = context.getMonitor();
         var propertiesFactory = new KafkaPropertiesFactory();
-
-        var sinkPartitionSize = context.getSetting(EDC_DATAPLANE_KAFKA_SINK_PARTITION_SIZE, DEFAULT_PART_SIZE);
+        
+        var sinkPartitionSize = context.getSetting(EDC_DATAPLANE_KAFKA_SINK_PARTITION_SIZE, DEFAULT_PARTITION_SIZE);
 
         pipelineService.registerFactory(new KafkaDataSourceFactory(monitor, propertiesFactory, clock));
         pipelineService.registerFactory(new KafkaDataSinkFactory(executorContainer.getExecutorService(), monitor, propertiesFactory, sinkPartitionSize));

--- a/extensions/data-plane/data-plane-kafka/src/main/java/org/eclipse/edc/dataplane/kafka/DataPlaneKafkaExtension.java
+++ b/extensions/data-plane/data-plane-kafka/src/main/java/org/eclipse/edc/dataplane/kafka/DataPlaneKafkaExtension.java
@@ -21,6 +21,7 @@ import org.eclipse.edc.dataplane.kafka.pipeline.KafkaDataSinkFactory;
 import org.eclipse.edc.dataplane.kafka.pipeline.KafkaDataSourceFactory;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 
@@ -30,6 +31,11 @@ import java.time.Clock;
 public class DataPlaneKafkaExtension implements ServiceExtension {
 
     public static final String NAME = "Data Plane Kafka";
+
+    private static final int DEFAULT_PART_SIZE = 5;
+
+    @Setting
+    private static final String EDC_DATAPLANE_KAFKA_SINK_PARTITION_SIZE = "edc.dataplane.kafka.sink.partition.size";
 
     @Inject
     private DataTransferExecutorServiceContainer executorContainer;
@@ -50,7 +56,9 @@ public class DataPlaneKafkaExtension implements ServiceExtension {
         var monitor = context.getMonitor();
         var propertiesFactory = new KafkaPropertiesFactory();
 
+        var sinkPartitionSize = context.getSetting(EDC_DATAPLANE_KAFKA_SINK_PARTITION_SIZE, DEFAULT_PART_SIZE);
+
         pipelineService.registerFactory(new KafkaDataSourceFactory(monitor, propertiesFactory, clock));
-        pipelineService.registerFactory(new KafkaDataSinkFactory(executorContainer.getExecutorService(), monitor, propertiesFactory));
+        pipelineService.registerFactory(new KafkaDataSinkFactory(executorContainer.getExecutorService(), monitor, propertiesFactory, sinkPartitionSize));
     }
 }

--- a/extensions/data-plane/data-plane-kafka/src/main/java/org/eclipse/edc/dataplane/kafka/DataPlaneKafkaExtension.java
+++ b/extensions/data-plane/data-plane-kafka/src/main/java/org/eclipse/edc/dataplane/kafka/DataPlaneKafkaExtension.java
@@ -34,7 +34,7 @@ public class DataPlaneKafkaExtension implements ServiceExtension {
 
     private static final int DEFAULT_PARTITION_SIZE = 5;
 
-    @Setting(value="The partitionSize used by the KafkaDataSink", type="int", defaultValue="5", min=1)
+    @Setting(value = "The partitionSize used by the kafka data sink", type = "int", defaultValue = "5", min = 1)
     private static final String EDC_DATAPLANE_KAFKA_SINK_PARTITION_SIZE = "edc.dataplane.kafka.sink.partition.size";
 
     @Inject

--- a/extensions/data-plane/data-plane-kafka/src/main/java/org/eclipse/edc/dataplane/kafka/pipeline/KafkaDataSinkFactory.java
+++ b/extensions/data-plane/data-plane-kafka/src/main/java/org/eclipse/edc/dataplane/kafka/pipeline/KafkaDataSinkFactory.java
@@ -38,12 +38,14 @@ public class KafkaDataSinkFactory implements DataSinkFactory {
     private final Monitor monitor;
     private final KafkaPropertiesFactory propertiesFactory;
     private final Validator<DataAddress> validation;
+    private final int partitionSize;
 
-    public KafkaDataSinkFactory(ExecutorService executorService, Monitor monitor, KafkaPropertiesFactory propertiesFactory) {
+    public KafkaDataSinkFactory(ExecutorService executorService, Monitor monitor, KafkaPropertiesFactory propertiesFactory, int partitionSize) {
         this.executorService = executorService;
         this.monitor = monitor;
         this.propertiesFactory = propertiesFactory;
         this.validation = new KafkaDataAddressValidator();
+        this.partitionSize = partitionSize;
     }
 
     @Override
@@ -73,6 +75,7 @@ public class KafkaDataSinkFactory implements DataSinkFactory {
                 .requestId(request.getId())
                 .topic(destination.getStringProperty(TOPIC))
                 .producerProperties(producerProps)
+                .partitionSize(partitionSize)
                 .executorService(executorService)
                 .build();
     }

--- a/extensions/data-plane/data-plane-kafka/src/test/java/org/eclipse/edc/dataplane/kafka/pipeline/KafkaDataSinkFactoryTest.java
+++ b/extensions/data-plane/data-plane-kafka/src/test/java/org/eclipse/edc/dataplane/kafka/pipeline/KafkaDataSinkFactoryTest.java
@@ -44,7 +44,7 @@ class KafkaDataSinkFactoryTest {
 
     @BeforeEach
     public void setUp() {
-        factory = new KafkaDataSinkFactory(mock(ExecutorService.class), mock(Monitor.class), propertiesFactory);
+        factory = new KafkaDataSinkFactory(mock(ExecutorService.class), mock(Monitor.class), propertiesFactory, 1);
     }
 
     @Test


### PR DESCRIPTION
## What this PR changes/adds

Adds the possibility to configure the `partitionSize` of the `KafkaDataSink` via the `.properties` file.

## Why it does that

Enhances the usability of the extension.

## Linked Issue(s)

Closes #3849
