### PR TITLE
feat(dsp): add `negotiations/offer` endpoint

### DIFF
--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -75,7 +75,9 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
      */
     @WithSpan
     private boolean processOffering(ContractNegotiation negotiation) {
-        var messageBuilder = ContractOfferMessage.Builder.newInstance().contractOffer(negotiation.getLastContractOffer());
+        var messageBuilder = ContractOfferMessage.Builder.newInstance()
+                .contractOffer(negotiation.getLastContractOffer())
+                .callbackAddress(protocolWebhook.url());
 
         return dispatch(messageBuilder, negotiation, ContractNegotiationAck.class)
                 .onSuccessResult(this::transitionToOffered)

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/ControlPlaneServicesExtension.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/ControlPlaneServicesExtension.java
@@ -222,7 +222,7 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     @Provider
     public ProtocolTokenValidator protocolTokenValidator() {
         if (protocolTokenValidator == null) {
-            protocolTokenValidator = new ProtocolTokenValidatorImpl(identityService, policyEngine, monitor);
+            protocolTokenValidator = new ProtocolTokenValidatorImpl(identityService, policyEngine, monitor, participantAgentService);
         }
         return protocolTokenValidator;
     }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
@@ -46,12 +46,14 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
 
+import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation.Type.CONSUMER;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation.Type.PROVIDER;
 
 public class ContractNegotiationProtocolServiceImpl implements ContractNegotiationProtocolService {
 
     @PolicyScope
     public static final String CONTRACT_NEGOTIATION_REQUEST_SCOPE = "request.contract.negotiation";
+
     private final ContractNegotiationStore store;
     private final TransactionContext transactionContext;
     private final ContractValidationService validationService;
@@ -84,10 +86,10 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
     public ServiceResult<ContractNegotiation> notifyRequested(ContractRequestMessage message, TokenRepresentation tokenRepresentation) {
         return transactionContext.execute(() -> fetchValidatableOffer(message)
                 .compose(validatableOffer -> verifyRequest(tokenRepresentation, validatableOffer.getContractPolicy())
-                        .compose(context -> validateOffer(context.claimToken(), validatableOffer))
+                        .compose(claimToken -> validateOffer(claimToken, validatableOffer))
                         .compose(validatedOffer -> {
                             var result = message.getProviderPid() == null
-                                    ? createNegotiation(message, validatedOffer)
+                                    ? createNegotiation(message, validatedOffer.getConsumerIdentity(), PROVIDER, message.getCallbackAddress())
                                     : getAndLeaseNegotiation(message.getProviderPid());
 
                             return result.onSuccess(negotiation -> {
@@ -108,19 +110,34 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
     @WithSpan
     @NotNull
     public ServiceResult<ContractNegotiation> notifyOffered(ContractOfferMessage message, TokenRepresentation tokenRepresentation) {
-        return transactionContext.execute(() -> getNegotiation(message)
-                .compose(contractNegotiation -> verifyRequest(tokenRepresentation, contractNegotiation))
-                .compose(context -> validateRequest(context.claimToken(), context.negotiation()))
-                .compose(cn -> onMessageDo(message, contractNegotiation -> offeredAction(message, contractNegotiation))));
+        return transactionContext.execute(() -> verifyRequest(tokenRepresentation, message.getContractOffer().getPolicy())
+                .compose(claimToken -> {
+                    ServiceResult<ContractNegotiation> result = message.getConsumerPid() == null
+                            // TODO: counter party identity should be obtained from somewhere
+                            ? createNegotiation(message, "any", CONSUMER, message.getCallbackAddress())
+                            : getAndLeaseNegotiation(message.getProviderPid())
+                                .compose(negotiation -> validateRequest(claimToken, negotiation).map(it -> negotiation));
+
+                    return result.onSuccess(negotiation -> {
+                        if (negotiation.shouldIgnoreIncomingMessage(message.getId())) {
+                            return;
+                        }
+                        negotiation.protocolMessageReceived(message.getId());
+                        negotiation.addContractOffer(message.getContractOffer());
+                        negotiation.transitionOffered();
+                        update(negotiation);
+                        observable.invokeForEach(l -> l.offered(negotiation));
+                    });
+                }));
     }
 
     @Override
     @WithSpan
     @NotNull
     public ServiceResult<ContractNegotiation> notifyAccepted(ContractNegotiationEventMessage message, TokenRepresentation tokenRepresentation) {
-        return transactionContext.execute(() -> getNegotiation(message)
-                .compose(contractNegotiation -> verifyRequest(tokenRepresentation, contractNegotiation))
-                .compose(context -> validateRequest(context.claimToken(), context.negotiation()))
+        return transactionContext.execute(() -> getNegotiation(message.getProcessId())
+                .compose(contractNegotiation -> verifyRequest(tokenRepresentation, contractNegotiation.getLastContractOffer().getPolicy())
+                        .compose(claimToken -> validateRequest(claimToken, contractNegotiation)))
                 .compose(cn -> onMessageDo(message, contractNegotiation -> acceptedAction(message, contractNegotiation))));
 
     }
@@ -129,9 +146,9 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
     @WithSpan
     @NotNull
     public ServiceResult<ContractNegotiation> notifyAgreed(ContractAgreementMessage message, TokenRepresentation tokenRepresentation) {
-        return transactionContext.execute(() -> getNegotiation(message)
-                .compose(contractNegotiation -> verifyRequest(tokenRepresentation, contractNegotiation))
-                .compose(context -> validateAgreed(message, context.claimToken(), context.negotiation()))
+        return transactionContext.execute(() -> getNegotiation(message.getProcessId())
+                .compose(contractNegotiation -> verifyRequest(tokenRepresentation, contractNegotiation.getLastContractOffer().getPolicy())
+                        .compose(claimToken -> validateAgreed(message, claimToken, contractNegotiation)))
                 .compose(cn -> onMessageDo(message, contractNegotiation -> agreedAction(message, contractNegotiation))));
     }
 
@@ -139,9 +156,9 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
     @WithSpan
     @NotNull
     public ServiceResult<ContractNegotiation> notifyVerified(ContractAgreementVerificationMessage message, TokenRepresentation tokenRepresentation) {
-        return transactionContext.execute(() -> getNegotiation(message)
-                .compose(contractNegotiation -> verifyRequest(tokenRepresentation, contractNegotiation))
-                .compose(context -> validateRequest(context.claimToken(), context.negotiation()))
+        return transactionContext.execute(() -> getNegotiation(message.getProcessId())
+                .compose(contractNegotiation -> verifyRequest(tokenRepresentation, contractNegotiation.getLastContractOffer().getPolicy())
+                        .compose(claimToken -> validateRequest(claimToken, contractNegotiation)))
                 .compose(cn -> onMessageDo(message, contractNegotiation -> verifiedAction(message, contractNegotiation))));
     }
 
@@ -149,9 +166,9 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
     @WithSpan
     @NotNull
     public ServiceResult<ContractNegotiation> notifyFinalized(ContractNegotiationEventMessage message, TokenRepresentation tokenRepresentation) {
-        return transactionContext.execute(() -> getNegotiation(message)
-                .compose(contractNegotiation -> verifyRequest(tokenRepresentation, contractNegotiation))
-                .compose(context -> validateRequest(context.claimToken(), context.negotiation()))
+        return transactionContext.execute(() -> getNegotiation(message.getProcessId())
+                .compose(contractNegotiation -> verifyRequest(tokenRepresentation, contractNegotiation.getLastContractOffer().getPolicy())
+                        .compose(claimToken -> validateRequest(claimToken, contractNegotiation)))
                 .compose(cn -> onMessageDo(message, contractNegotiation -> finalizedAction(message, contractNegotiation))));
     }
 
@@ -159,9 +176,9 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
     @WithSpan
     @NotNull
     public ServiceResult<ContractNegotiation> notifyTerminated(ContractNegotiationTerminationMessage message, TokenRepresentation tokenRepresentation) {
-        return transactionContext.execute(() -> getNegotiation(message)
-                .compose(contractNegotiation -> verifyRequest(tokenRepresentation, contractNegotiation))
-                .compose(context -> validateRequest(context.claimToken(), context.negotiation()))
+        return transactionContext.execute(() -> getNegotiation(message.getProcessId())
+                .compose(contractNegotiation -> verifyRequest(tokenRepresentation, contractNegotiation.getLastContractOffer().getPolicy())
+                        .compose(claimToken -> validateRequest(claimToken, contractNegotiation)))
                 .compose(cn -> onMessageDo(message, contractNegotiation -> terminatedAction(message, contractNegotiation))));
     }
 
@@ -170,8 +187,9 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
     @NotNull
     public ServiceResult<ContractNegotiation> findById(String id, TokenRepresentation tokenRepresentation) {
         return transactionContext.execute(() -> getNegotiation(id)
-                .compose(contractNegotiation -> verifyRequest(tokenRepresentation, contractNegotiation))
-                .compose(context -> validateRequest(context.claimToken(), context.negotiation())));
+                .compose(contractNegotiation -> verifyRequest(tokenRepresentation, contractNegotiation.getLastContractOffer().getPolicy())
+                        .compose(claimToken -> validateRequest(claimToken, contractNegotiation)
+                                .map(it -> contractNegotiation))));
     }
 
     @NotNull
@@ -187,15 +205,15 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
     }
 
     @NotNull
-    private ServiceResult<ContractNegotiation> createNegotiation(ContractRequestMessage message, ValidatedConsumerOffer validatedOffer) {
+    private ServiceResult<ContractNegotiation> createNegotiation(ContractRemoteMessage message, String counterPartyIdentity, ContractNegotiation.Type type, String callbackAddress) {
         var negotiation = ContractNegotiation.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
                 .correlationId(message.getConsumerPid())
-                .counterPartyId(validatedOffer.getConsumerIdentity())
-                .counterPartyAddress(message.getCallbackAddress())
+                .counterPartyId(counterPartyIdentity)
+                .counterPartyAddress(callbackAddress)
                 .protocol(message.getProtocol())
                 .traceContext(telemetry.getCurrentTraceContext())
-                .type(PROVIDER)
+                .type(type)
                 .build();
 
         return ServiceResult.success(negotiation);
@@ -239,12 +257,12 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
     }
 
     @NotNull
-    private ServiceResult<ContractNegotiation> validateRequest(ClaimToken claimToken, ContractNegotiation negotiation) {
+    private ServiceResult<Void> validateRequest(ClaimToken claimToken, ContractNegotiation negotiation) {
         var result = validationService.validateRequest(claimToken, negotiation);
         if (result.failed()) {
             return ServiceResult.badRequest("Invalid client credentials: " + result.getFailureDetail());
         } else {
-            return ServiceResult.success(negotiation);
+            return ServiceResult.success();
         }
     }
 
@@ -286,16 +304,6 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
     }
 
     @NotNull
-    private ServiceResult<ContractNegotiation> offeredAction(ContractOfferMessage message, ContractNegotiation negotiation) {
-        negotiation.protocolMessageReceived(message.getId());
-        negotiation.addContractOffer(message.getContractOffer());
-        negotiation.transitionOffered();
-        update(negotiation);
-        observable.invokeForEach(l -> l.offered(negotiation));
-        return ServiceResult.success(negotiation);
-    }
-
-    @NotNull
     private ServiceResult<ContractNegotiation> terminatedAction(ContractNegotiationTerminationMessage message, ContractNegotiation negotiation) {
         negotiation.protocolMessageReceived(message.getId());
         negotiation.transitionTerminated();
@@ -311,26 +319,9 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
                 .flatMap(ServiceResult::from);
     }
 
-    private ServiceResult<ClaimTokenContext> verifyRequest(TokenRepresentation tokenRepresentation, ContractNegotiation contractNegotiation) {
-        return verifyRequest(tokenRepresentation, contractNegotiation.getLastContractOffer().getPolicy(), contractNegotiation);
-    }
-
-    private ServiceResult<ClaimTokenContext> verifyRequest(TokenRepresentation tokenRepresentation, Policy policy) {
-        return verifyRequest(tokenRepresentation, policy, null);
-    }
-
-    private ServiceResult<ClaimTokenContext> verifyRequest(TokenRepresentation tokenRepresentation, Policy policy, ContractNegotiation contractNegotiation) {
-        var result = protocolTokenValidator.verifyToken(tokenRepresentation, CONTRACT_NEGOTIATION_REQUEST_SCOPE, policy);
-        if (result.failed()) {
-            monitor.debug(() -> "Verification Failed: %s".formatted(result.getFailureDetail()));
-            return ServiceResult.notFound("Not found");
-        } else {
-            return ServiceResult.success(new ClaimTokenContext(result.getContent(), contractNegotiation));
-        }
-    }
-
-    private ServiceResult<ContractNegotiation> getNegotiation(ContractRemoteMessage message) {
-        return getNegotiation(message.getProcessId());
+    private ServiceResult<ClaimToken> verifyRequest(TokenRepresentation tokenRepresentation, Policy policy) {
+        return protocolTokenValidator.verifyToken(tokenRepresentation, CONTRACT_NEGOTIATION_REQUEST_SCOPE, policy)
+                .onFailure(failure -> monitor.debug(() -> "Verification Failed: %s".formatted(failure.getFailureDetail())));
     }
 
     private ServiceResult<ContractNegotiation> getNegotiation(String negotiationId) {
@@ -347,6 +338,4 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
                 .formatted(negotiation.getType(), negotiation.getId(), negotiation.stateAsString()));
     }
 
-    private record ClaimTokenContext(ClaimToken claimToken, ContractNegotiation negotiation) {
-    }
 }

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
@@ -33,7 +33,7 @@ import org.eclipse.edc.connector.contract.spi.validation.ValidatedConsumerOffer;
 import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationProtocolService;
 import org.eclipse.edc.connector.spi.protocol.ProtocolTokenValidator;
 import org.eclipse.edc.policy.model.Policy;
-import org.eclipse.edc.spi.iam.ClaimToken;
+import org.eclipse.edc.spi.agent.ParticipantAgent;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.ServiceFailure;
@@ -56,6 +56,8 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.mockito.ArgumentCaptor;
 
 import java.time.Instant;
+import java.util.Collections;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -74,6 +76,7 @@ import static org.eclipse.edc.connector.service.contractnegotiation.ContractNego
 import static org.eclipse.edc.connector.service.contractnegotiation.ContractNegotiationProtocolServiceImplTest.TestFunctions.contractOffer;
 import static org.eclipse.edc.connector.service.contractnegotiation.ContractNegotiationProtocolServiceImplTest.TestFunctions.createPolicy;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.spi.agent.ParticipantAgent.PARTICIPANT_IDENTITY;
 import static org.eclipse.edc.spi.result.ServiceFailure.Reason.BAD_REQUEST;
 import static org.eclipse.edc.spi.result.ServiceFailure.Reason.NOT_FOUND;
 import static org.eclipse.edc.spi.result.ServiceFailure.Reason.UNAUTHORIZED;
@@ -81,6 +84,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -113,7 +117,7 @@ class ContractNegotiationProtocolServiceImplTest {
     class NotifyRequested {
         @Test
         void shouldInitiateNegotiation_whenNegotiationDoesNotExist() {
-            var claimToken = ClaimToken.Builder.newInstance().build();
+            var participantAgent = participantAgent();
             var tokenRepresentation = tokenRepresentation();
             var contractOffer = contractOffer();
             var validatedOffer = new ValidatedConsumerOffer(CONSUMER_ID, contractOffer);
@@ -127,9 +131,9 @@ class ContractNegotiationProtocolServiceImplTest {
 
             when(validatableOffer.getContractPolicy()).thenReturn(createPolicy());
             when(consumerOfferResolver.resolveOffer(contractOffer.getId())).thenReturn(ServiceResult.success(validatableOffer));
-            when(protocolTokenValidator.verifyToken(eq(tokenRepresentation), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any())).thenReturn(ServiceResult.success(claimToken));
+            when(protocolTokenValidator.verify(eq(tokenRepresentation), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any())).thenReturn(ServiceResult.success(participantAgent));
             when(store.findByIdAndLease(any())).thenReturn(StoreResult.notFound("not found"));
-            when(validationService.validateInitialOffer(claimToken, validatableOffer)).thenReturn(Result.success(validatedOffer));
+            when(validationService.validateInitialOffer(participantAgent, validatableOffer)).thenReturn(Result.success(validatedOffer));
 
             var result = service.notifyRequested(message, tokenRepresentation);
 
@@ -146,13 +150,13 @@ class ContractNegotiationProtocolServiceImplTest {
                 assertThat(n.getLastContractOffer()).isEqualTo(contractOffer);
             });
             verify(listener).requested(any());
-            verify(validationService).validateInitialOffer(claimToken, validatableOffer);
+            verify(validationService).validateInitialOffer(participantAgent, validatableOffer);
             verify(transactionContext, atLeastOnce()).execute(any(TransactionContext.ResultTransactionBlock.class));
         }
 
         @Test
         void shouldTransitionToRequested_whenNegotiationFound() {
-            var claimToken = claimToken();
+            var participantAgent = participantAgent();
             var tokenRepresentation = tokenRepresentation();
             var contractOffer = contractOffer();
             var validatedOffer = new ValidatedConsumerOffer(CONSUMER_ID, contractOffer);
@@ -170,10 +174,10 @@ class ContractNegotiationProtocolServiceImplTest {
 
             when(validatableOffer.getContractPolicy()).thenReturn(createPolicy());
             when(consumerOfferResolver.resolveOffer(contractOffer.getId())).thenReturn(ServiceResult.success(validatableOffer));
-            when(protocolTokenValidator.verifyToken(eq(tokenRepresentation), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any())).thenReturn(ServiceResult.success(claimToken));
+            when(protocolTokenValidator.verify(eq(tokenRepresentation), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any())).thenReturn(ServiceResult.success(participantAgent));
             when(store.findById(any())).thenReturn(negotiation);
             when(store.findByIdAndLease(any())).thenReturn(StoreResult.success(negotiation));
-            when(validationService.validateInitialOffer(claimToken, validatableOffer)).thenReturn(Result.success(validatedOffer));
+            when(validationService.validateInitialOffer(participantAgent, validatableOffer)).thenReturn(Result.success(validatedOffer));
 
 
             var result = service.notifyRequested(message, tokenRepresentation);
@@ -190,7 +194,7 @@ class ContractNegotiationProtocolServiceImplTest {
             });
             verify(listener).requested(any());
             verify(store).findByIdAndLease("providerPid");
-            verify(validationService).validateInitialOffer(claimToken, validatableOffer);
+            verify(validationService).validateInitialOffer(participantAgent, validatableOffer);
             verify(transactionContext, atLeastOnce()).execute(any(TransactionContext.ResultTransactionBlock.class));
         }
 
@@ -223,7 +227,6 @@ class ContractNegotiationProtocolServiceImplTest {
 
         @Test
         void shouldInitiateNegotiation_whenNegotiationDoesNotExist() {
-            var claimToken = ClaimToken.Builder.newInstance().build();
             var tokenRepresentation = tokenRepresentation();
             var contractOffer = contractOffer();
             var message = ContractOfferMessage.Builder.newInstance()
@@ -232,8 +235,8 @@ class ContractNegotiationProtocolServiceImplTest {
                     .contractOffer(contractOffer)
                     .providerPid("providerPid")
                     .build();
-            when(protocolTokenValidator.verifyToken(eq(tokenRepresentation), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any()))
-                    .thenReturn(ServiceResult.success(claimToken));
+            when(protocolTokenValidator.verify(eq(tokenRepresentation), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any()))
+                    .thenReturn(ServiceResult.success(participantAgent()));
 
             var result = service.notifyOffered(message, tokenRepresentation);
 
@@ -244,6 +247,7 @@ class ContractNegotiationProtocolServiceImplTest {
             assertThat(calls.getAllValues()).anySatisfy(n -> {
                 assertThat(n.getState()).isEqualTo(OFFERED.code());
                 assertThat(n.getType()).isEqualTo(CONSUMER);
+                assertThat(n.getCounterPartyId()).isEqualTo("counterPartyId");
                 assertThat(n.getCounterPartyAddress()).isEqualTo(message.getCallbackAddress());
                 assertThat(n.getProtocol()).isEqualTo(message.getProtocol());
                 assertThat(n.getCorrelationId()).isEqualTo(message.getConsumerPid());
@@ -258,7 +262,7 @@ class ContractNegotiationProtocolServiceImplTest {
         @Test
         void shouldTransitionToOffered_whenNegotiationAlreadyExist() {
             var processId = "processId";
-            var claimToken = claimToken();
+            var participantAgent = participantAgent();
             var tokenRepresentation = tokenRepresentation();
             var contractOffer = contractOffer();
             var message = ContractOfferMessage.Builder.newInstance()
@@ -271,11 +275,11 @@ class ContractNegotiationProtocolServiceImplTest {
                     .build();
             var negotiation = createContractNegotiationRequested();
 
-            when(protocolTokenValidator.verifyToken(eq(tokenRepresentation), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any()))
-                    .thenReturn(ServiceResult.success(claimToken));
+            when(protocolTokenValidator.verify(eq(tokenRepresentation), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any()))
+                    .thenReturn(ServiceResult.success(participantAgent));
             when(store.findById(processId)).thenReturn(negotiation);
             when(store.findByIdAndLease(any())).thenReturn(StoreResult.success(negotiation));
-            when(validationService.validateRequest(claimToken, negotiation)).thenReturn(Result.success());
+            when(validationService.validateRequest(participantAgent, negotiation)).thenReturn(Result.success());
 
             var result = service.notifyOffered(message, tokenRepresentation);
 
@@ -299,8 +303,8 @@ class ContractNegotiationProtocolServiceImplTest {
                     .consumerPid("consumerPid")
                     .providerPid("providerPid")
                     .build();
-            when(protocolTokenValidator.verifyToken(eq(tokenRepresentation), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any()))
-                    .thenReturn(ServiceResult.success(claimToken()));
+            when(protocolTokenValidator.verify(eq(tokenRepresentation), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any()))
+                    .thenReturn(ServiceResult.success(participantAgent()));
             when(store.findByIdAndLease(any())).thenReturn(StoreResult.notFound("not found"));
             when(store.findByCorrelationIdAndLease(any())).thenReturn(StoreResult.notFound("not found"));
 
@@ -316,7 +320,7 @@ class ContractNegotiationProtocolServiceImplTest {
     @Test
     void notifyAccepted_shouldTransitionToAccepted() {
         var contractNegotiation = createContractNegotiationOffered();
-        var claimToken = claimToken();
+        var participantAgent = participantAgent();
         var tokenRepresentation = tokenRepresentation();
         var message = ContractNegotiationEventMessage.Builder.newInstance()
                 .protocol("protocol")
@@ -327,10 +331,11 @@ class ContractNegotiationProtocolServiceImplTest {
                 .type(ContractNegotiationEventMessage.Type.ACCEPTED)
                 .policy(Policy.Builder.newInstance().build())
                 .build();
-        when(protocolTokenValidator.verifyToken(eq(tokenRepresentation), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any())).thenReturn(ServiceResult.success(claimToken));
+        when(protocolTokenValidator.verify(eq(tokenRepresentation), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any()))
+                .thenReturn(ServiceResult.success(participantAgent));
         when(store.findById(any())).thenReturn(contractNegotiation);
         when(store.findByIdAndLease(any())).thenReturn(StoreResult.success(contractNegotiation));
-        when(validationService.validateRequest(eq(claimToken), any(ContractNegotiation.class))).thenReturn(Result.success());
+        when(validationService.validateRequest(eq(participantAgent), any(ContractNegotiation.class))).thenReturn(Result.success());
 
         var result = service.notifyAccepted(message, tokenRepresentation);
 
@@ -338,7 +343,7 @@ class ContractNegotiationProtocolServiceImplTest {
         verify(store).findById("processId");
         verify(store).findByIdAndLease("processId");
         verify(store).save(argThat(negotiation -> negotiation.getState() == ACCEPTED.code()));
-        verify(validationService).validateRequest(claimToken, contractNegotiation);
+        verify(validationService).validateRequest(participantAgent, contractNegotiation);
         verify(listener).accepted(any());
         verify(transactionContext, atLeastOnce()).execute(any(TransactionContext.ResultTransactionBlock.class));
     }
@@ -346,7 +351,7 @@ class ContractNegotiationProtocolServiceImplTest {
     @Test
     void notifyAgreed_shouldTransitionToAgreed() {
         var negotiationConsumerRequested = createContractNegotiationRequested();
-        var claimToken = claimToken();
+        var participantAgent = participantAgent();
         var tokenRepresentation = tokenRepresentation();
 
         var contractAgreement = mock(ContractAgreement.class);
@@ -359,10 +364,10 @@ class ContractNegotiationProtocolServiceImplTest {
                 .contractAgreement(contractAgreement)
                 .build();
 
-        when(protocolTokenValidator.verifyToken(eq(tokenRepresentation), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any())).thenReturn(ServiceResult.success(claimToken));
+        when(protocolTokenValidator.verify(eq(tokenRepresentation), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any())).thenReturn(ServiceResult.success(participantAgent));
         when(store.findById(any())).thenReturn(negotiationConsumerRequested);
         when(store.findByIdAndLease(any())).thenReturn(StoreResult.success(negotiationConsumerRequested));
-        when(validationService.validateConfirmed(eq(claimToken), eq(contractAgreement), any(ContractOffer.class))).thenReturn(Result.success());
+        when(validationService.validateConfirmed(eq(participantAgent), eq(contractAgreement), any(ContractOffer.class))).thenReturn(Result.success());
 
         var result = service.notifyAgreed(message, tokenRepresentation);
 
@@ -373,19 +378,19 @@ class ContractNegotiationProtocolServiceImplTest {
                 negotiation.getState() == AGREED.code() &&
                         negotiation.getContractAgreement() == contractAgreement
         ));
-        verify(validationService).validateConfirmed(eq(claimToken), eq(contractAgreement), any(ContractOffer.class));
+        verify(validationService).validateConfirmed(eq(participantAgent), eq(contractAgreement), any(ContractOffer.class));
         verify(listener).agreed(any());
         verify(transactionContext, atLeastOnce()).execute(any(TransactionContext.ResultTransactionBlock.class));
     }
 
     @Test
     void notifyVerified_shouldTransitionToVerified() {
-        var claimToken = claimToken();
+        var participantAgent = participantAgent();
         var tokenRepresentation = tokenRepresentation();
         var contractOffer = contractOffer();
         var negotiation = contractNegotiationBuilder().id("negotiationId").type(PROVIDER).state(AGREED.code()).contractOffer(contractOffer).build();
         when(store.findByIdAndLease(any())).thenReturn(StoreResult.success(negotiation));
-        when(validationService.validateRequest(any(), any(ContractNegotiation.class))).thenReturn(Result.success());
+        when(validationService.validateRequest(any(ParticipantAgent.class), any(ContractNegotiation.class))).thenReturn(Result.success());
         var message = ContractAgreementVerificationMessage.Builder.newInstance()
                 .protocol("protocol")
                 .counterPartyAddress("http://any")
@@ -394,10 +399,10 @@ class ContractNegotiationProtocolServiceImplTest {
                 .providerPid("providerPid")
                 .build();
 
-        when(protocolTokenValidator.verifyToken(eq(tokenRepresentation), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any())).thenReturn(ServiceResult.success(claimToken));
+        when(protocolTokenValidator.verify(eq(tokenRepresentation), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any())).thenReturn(ServiceResult.success(participantAgent));
         when(store.findById(any())).thenReturn(negotiation);
         when(store.findByIdAndLease(any())).thenReturn(StoreResult.success(negotiation));
-        when(validationService.validateRequest(any(), any(ContractNegotiation.class))).thenReturn(Result.success());
+        when(validationService.validateRequest(any(ParticipantAgent.class), any(ContractNegotiation.class))).thenReturn(Result.success());
 
         var result = service.notifyVerified(message, tokenRepresentation);
 
@@ -406,7 +411,7 @@ class ContractNegotiationProtocolServiceImplTest {
         verify(store).findByIdAndLease("processId");
         verify(store).save(argThat(n -> n.getState() == VERIFIED.code()));
         verify(listener).verified(negotiation);
-        verify(validationService).validateRequest(any(), any(ContractNegotiation.class));
+        verify(validationService).validateRequest(same(participantAgent), any(ContractNegotiation.class));
         verify(transactionContext, atLeastOnce()).execute(any(TransactionContext.ResultTransactionBlock.class));
     }
 
@@ -423,13 +428,13 @@ class ContractNegotiationProtocolServiceImplTest {
                 .consumerPid("consumerPid")
                 .providerPid("providerPid")
                 .build();
-        var claimToken = ClaimToken.Builder.newInstance().build();
         var tokenRepresentation = tokenRepresentation();
 
-        when(protocolTokenValidator.verifyToken(eq(tokenRepresentation), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any())).thenReturn(ServiceResult.success(claimToken));
+        when(protocolTokenValidator.verify(eq(tokenRepresentation), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any()))
+                .thenReturn(ServiceResult.success(participantAgent()));
         when(store.findById(any())).thenReturn(negotiation);
         when(store.findByIdAndLease(any())).thenReturn(StoreResult.success(negotiation));
-        when(validationService.validateRequest(any(), any(ContractNegotiation.class))).thenReturn(Result.success());
+        when(validationService.validateRequest(any(ParticipantAgent.class), any(ContractNegotiation.class))).thenReturn(Result.success());
 
         var result = service.notifyFinalized(message, tokenRepresentation);
 
@@ -438,7 +443,7 @@ class ContractNegotiationProtocolServiceImplTest {
         verify(store).findByIdAndLease("processId");
         verify(store).save(argThat(n -> n.getState() == FINALIZED.code()));
         verify(listener).finalized(negotiation);
-        verify(validationService).validateRequest(any(), any(ContractNegotiation.class));
+        verify(validationService).validateRequest(any(ParticipantAgent.class), any(ContractNegotiation.class));
         verify(transactionContext, atLeastOnce()).execute(any(TransactionContext.ResultTransactionBlock.class));
     }
 
@@ -454,13 +459,13 @@ class ContractNegotiationProtocolServiceImplTest {
                 .counterPartyAddress("http://any")
                 .rejectionReason("any")
                 .build();
-        var claimToken = claimToken();
         var tokenRepresentation = tokenRepresentation();
 
-        when(protocolTokenValidator.verifyToken(eq(tokenRepresentation), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any())).thenReturn(ServiceResult.success(claimToken));
+        when(protocolTokenValidator.verify(eq(tokenRepresentation), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any()))
+                .thenReturn(ServiceResult.success(participantAgent()));
         when(store.findById(any())).thenReturn(negotiation);
         when(store.findByIdAndLease(any())).thenReturn(StoreResult.success(negotiation));
-        when(validationService.validateRequest(any(), any(ContractNegotiation.class))).thenReturn(Result.success());
+        when(validationService.validateRequest(any(ParticipantAgent.class), any(ContractNegotiation.class))).thenReturn(Result.success());
 
         var result = service.notifyTerminated(message, tokenRepresentation);
 
@@ -469,21 +474,22 @@ class ContractNegotiationProtocolServiceImplTest {
         verify(store).findByIdAndLease("processId");
         verify(store).save(argThat(n -> n.getState() == TERMINATED.code()));
         verify(listener).terminated(negotiation);
-        verify(validationService).validateRequest(any(), any(ContractNegotiation.class));
+        verify(validationService).validateRequest(any(ParticipantAgent.class), any(ContractNegotiation.class));
         verify(transactionContext, atLeastOnce()).execute(any(TransactionContext.ResultTransactionBlock.class));
     }
 
     @Test
     void findById_shouldReturnNegotiation_whenValidCounterParty() {
         var id = "negotiationId";
-        var claimToken = claimToken();
+        var participantAgent = participantAgent();
         var tokenRepresentation = tokenRepresentation();
         var contractOffer = contractOffer();
         var negotiation = contractNegotiationBuilder().id(id).type(PROVIDER).contractOffer(contractOffer).state(VERIFIED.code()).build();
 
-        when(protocolTokenValidator.verifyToken(eq(tokenRepresentation), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any())).thenReturn(ServiceResult.success(claimToken));
+        when(protocolTokenValidator.verify(eq(tokenRepresentation), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any()))
+                .thenReturn(ServiceResult.success(participantAgent));
         when(store.findById(id)).thenReturn(negotiation);
-        when(validationService.validateRequest(claimToken, negotiation)).thenReturn(Result.success());
+        when(validationService.validateRequest(participantAgent, negotiation)).thenReturn(Result.success());
 
         var result = service.findById(id, tokenRepresentation);
 
@@ -494,10 +500,9 @@ class ContractNegotiationProtocolServiceImplTest {
 
     @Test
     void findById_shouldReturnNotFound_whenNegotiationNotFound() {
-        var claimToken = claimToken();
         var tokenRepresentation = tokenRepresentation();
-
-        when(protocolTokenValidator.verifyToken(eq(tokenRepresentation), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any())).thenReturn(ServiceResult.success(claimToken));
+        when(protocolTokenValidator.verify(eq(tokenRepresentation), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any()))
+                .thenReturn(ServiceResult.success(participantAgent()));
         when(store.findById(any())).thenReturn(null);
 
         var result = service.findById("invalidId", tokenRepresentation);
@@ -511,16 +516,16 @@ class ContractNegotiationProtocolServiceImplTest {
     @Test
     void findById_shouldReturnBadRequest_whenCounterPartyUnauthorized() {
         var id = "negotiationId";
-        var claimToken = claimToken();
+        var participantAgent = participantAgent();
         var tokenRepresentation = tokenRepresentation();
         var contractOffer = contractOffer();
 
-        when(protocolTokenValidator.verifyToken(eq(tokenRepresentation), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any())).thenReturn(ServiceResult.success(claimToken));
+        when(protocolTokenValidator.verify(eq(tokenRepresentation), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any())).thenReturn(ServiceResult.success(participantAgent));
 
         var negotiation = contractNegotiationBuilder().id(id).type(PROVIDER).contractOffer(contractOffer).state(VERIFIED.code()).build();
 
         when(store.findById(id)).thenReturn(negotiation);
-        when(validationService.validateRequest(claimToken, negotiation)).thenReturn(Result.failure("validation error"));
+        when(validationService.validateRequest(participantAgent, negotiation)).thenReturn(Result.failure("validation error"));
 
         var result = service.findById(id, tokenRepresentation);
 
@@ -533,9 +538,9 @@ class ContractNegotiationProtocolServiceImplTest {
     @ParameterizedTest
     @ArgumentsSource(NotifyArguments.class)
     <M extends RemoteMessage> void notify_shouldReturnNotFound_whenNotFound(MethodCall<M> methodCall, M message) {
-        var claimToken = claimToken();
         var tokenRepresentation = tokenRepresentation();
-        when(protocolTokenValidator.verifyToken(eq(tokenRepresentation), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any())).thenReturn(ServiceResult.success(claimToken));
+        when(protocolTokenValidator.verify(eq(tokenRepresentation), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any()))
+                .thenReturn(ServiceResult.success(participantAgent()));
         when(store.findByIdAndLease(any())).thenReturn(StoreResult.notFound("not found"));
         when(store.findByCorrelationIdAndLease(any())).thenReturn(StoreResult.notFound("not found"));
 
@@ -552,18 +557,18 @@ class ContractNegotiationProtocolServiceImplTest {
     @ParameterizedTest
     @ArgumentsSource(NotifyArguments.class)
     <M extends RemoteMessage> void notify_shouldReturnBadRequest_whenValidationFails(MethodCall<M> methodCall, M message) {
-        var claimToken = claimToken();
         var tokenRepresentation = tokenRepresentation();
         var validatableOffer = mock(ValidatableConsumerOffer.class);
 
         when(validatableOffer.getContractPolicy()).thenReturn(createPolicy());
         when(consumerOfferResolver.resolveOffer(any())).thenReturn(ServiceResult.success(validatableOffer));
-        when(protocolTokenValidator.verifyToken(eq(tokenRepresentation), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any())).thenReturn(ServiceResult.success(claimToken));
+        when(protocolTokenValidator.verify(eq(tokenRepresentation), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any()))
+                .thenReturn(ServiceResult.success(participantAgent()));
         when(store.findById(any())).thenReturn(createContractNegotiationOffered());
         when(store.findByIdAndLease(any())).thenReturn(StoreResult.success(createContractNegotiationOffered()));
-        when(validationService.validateRequest(any(), any(ContractNegotiation.class))).thenReturn(Result.failure("validation error"));
-        when(validationService.validateInitialOffer(any(), isA(ValidatableConsumerOffer.class))).thenReturn(Result.failure("error"));
-        when(validationService.validateConfirmed(any(), any(), any(ContractOffer.class))).thenReturn(Result.failure("failure"));
+        when(validationService.validateRequest(any(ParticipantAgent.class), any(ContractNegotiation.class))).thenReturn(Result.failure("validation error"));
+        when(validationService.validateInitialOffer(any(ParticipantAgent.class), isA(ValidatableConsumerOffer.class))).thenReturn(Result.failure("error"));
+        when(validationService.validateConfirmed(any(ParticipantAgent.class), any(), any(ContractOffer.class))).thenReturn(Result.failure("failure"));
 
         var result = methodCall.call(service, message, tokenRepresentation);
 
@@ -581,7 +586,7 @@ class ContractNegotiationProtocolServiceImplTest {
         when(validatableOffer.getContractPolicy()).thenReturn(createPolicy());
         when(consumerOfferResolver.resolveOffer(any())).thenReturn(ServiceResult.success(validatableOffer));
         when(store.findById(any())).thenReturn(createContractNegotiationOffered());
-        when(protocolTokenValidator.verifyToken(eq(tokenRepresentation), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any())).thenReturn(ServiceResult.unauthorized("unauthorized"));
+        when(protocolTokenValidator.verify(eq(tokenRepresentation), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any())).thenReturn(ServiceResult.unauthorized("unauthorized"));
 
         var result = methodCall.call(service, message, tokenRepresentation);
 
@@ -590,10 +595,8 @@ class ContractNegotiationProtocolServiceImplTest {
         verifyNoInteractions(listener);
     }
 
-    private ClaimToken claimToken() {
-        return ClaimToken.Builder.newInstance()
-                .claim("key", "value")
-                .build();
+    private ParticipantAgent participantAgent() {
+        return new ParticipantAgent(Collections.emptyMap(), Map.of(PARTICIPANT_IDENTITY, "counterPartyId"));
     }
 
     private ContractNegotiation createContractNegotiationRequested() {
@@ -729,13 +732,14 @@ class ContractNegotiationProtocolServiceImplTest {
 
             when(validatableOffer.getContractPolicy()).thenReturn(createPolicy());
             when(consumerOfferResolver.resolveOffer(any())).thenReturn(ServiceResult.success(validatableOffer));
-            when(protocolTokenValidator.verifyToken(any(), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any())).thenReturn(ServiceResult.success(claimToken()));
+            when(protocolTokenValidator.verify(any(), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any()))
+                    .thenReturn(ServiceResult.success(participantAgent()));
             when(store.findById(any())).thenReturn(negotiation);
             when(store.findByIdAndLease(any())).thenReturn(StoreResult.success(negotiation));
-            when(validationService.validateRequest(any(), any(ContractNegotiation.class))).thenReturn(Result.success());
-            when(validationService.validateInitialOffer(any(), isA(ValidatableConsumerOffer.class)))
+            when(validationService.validateRequest(any(ParticipantAgent.class), any(ContractNegotiation.class))).thenReturn(Result.success());
+            when(validationService.validateInitialOffer(any(ParticipantAgent.class), isA(ValidatableConsumerOffer.class)))
                     .thenAnswer(i -> Result.success(new ValidatedConsumerOffer("any", offer)));
-            when(validationService.validateConfirmed(any(), any(), any())).thenAnswer(i -> Result.success(negotiation));
+            when(validationService.validateConfirmed(any(ParticipantAgent.class), any(), any())).thenAnswer(i -> Result.success(negotiation));
 
             var result = methodCall.call(service, message, tokenRepresentation());
 
@@ -758,13 +762,14 @@ class ContractNegotiationProtocolServiceImplTest {
 
             when(validatableOffer.getContractPolicy()).thenReturn(createPolicy());
             when(consumerOfferResolver.resolveOffer(any())).thenReturn(ServiceResult.success(validatableOffer));
-            when(protocolTokenValidator.verifyToken(any(), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any())).thenReturn(ServiceResult.success(claimToken()));
+            when(protocolTokenValidator.verify(any(), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any()))
+                    .thenReturn(ServiceResult.success(participantAgent()));
             when(store.findById(any())).thenReturn(negotiation);
             when(store.findByIdAndLease(any())).thenReturn(StoreResult.success(negotiation));
-            when(validationService.validateRequest(any(), any(ContractNegotiation.class))).thenReturn(Result.success());
-            when(validationService.validateInitialOffer(any(), any(ValidatableConsumerOffer.class)))
+            when(validationService.validateRequest(any(ParticipantAgent.class), any(ContractNegotiation.class))).thenReturn(Result.success());
+            when(validationService.validateInitialOffer(any(ParticipantAgent.class), any(ValidatableConsumerOffer.class)))
                     .thenAnswer(i -> Result.success(new ValidatedConsumerOffer("any", offer)));
-            when(validationService.validateConfirmed(any(), any(), any())).thenAnswer(i -> Result.success(negotiation));
+            when(validationService.validateConfirmed(any(ParticipantAgent.class), any(), any())).thenAnswer(i -> Result.success(negotiation));
 
             var result = methodCall.call(service, message, tokenRepresentation());
 
@@ -783,13 +788,14 @@ class ContractNegotiationProtocolServiceImplTest {
 
             when(validatableOffer.getContractPolicy()).thenReturn(createPolicy());
             when(consumerOfferResolver.resolveOffer(any())).thenReturn(ServiceResult.success(validatableOffer));
-            when(protocolTokenValidator.verifyToken(any(), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any())).thenReturn(ServiceResult.success(claimToken()));
+            when(protocolTokenValidator.verify(any(), eq(CONTRACT_NEGOTIATION_REQUEST_SCOPE), any()))
+                    .thenReturn(ServiceResult.success(participantAgent()));
             when(store.findById(any())).thenReturn(negotiation);
             when(store.findByIdAndLease(any())).thenReturn(StoreResult.success(negotiation));
-            when(validationService.validateRequest(any(), any(ContractNegotiation.class))).thenReturn(Result.success());
-            when(validationService.validateInitialOffer(any(ClaimToken.class), any(ValidatableConsumerOffer.class)))
+            when(validationService.validateRequest(any(ParticipantAgent.class), any(ContractNegotiation.class))).thenReturn(Result.success());
+            when(validationService.validateInitialOffer(any(ParticipantAgent.class), any(ValidatableConsumerOffer.class)))
                     .thenAnswer(i -> Result.success(new ValidatedConsumerOffer("any", offer)));
-            when(validationService.validateConfirmed(any(), any(), any())).thenAnswer(i -> Result.success(negotiation));
+            when(validationService.validateConfirmed(any(ParticipantAgent.class), any(), any())).thenAnswer(i -> Result.success(negotiation));
 
             var result = methodCall.call(service, message, tokenRepresentation());
 

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/protocol/ProtocolTokenValidatorImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/protocol/ProtocolTokenValidatorImplTest.java
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.service.protocol;
+
+import org.eclipse.edc.policy.engine.spi.PolicyEngine;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.agent.ParticipantAgent;
+import org.eclipse.edc.spi.agent.ParticipantAgentService;
+import org.eclipse.edc.spi.iam.ClaimToken;
+import org.eclipse.edc.spi.iam.IdentityService;
+import org.eclipse.edc.spi.iam.TokenRepresentation;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.result.ServiceFailure;
+import org.junit.jupiter.api.Test;
+
+import static java.util.Collections.emptyMap;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.spi.result.ServiceFailure.Reason.UNAUTHORIZED;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ProtocolTokenValidatorImplTest {
+
+    private final ParticipantAgentService agentService = mock();
+    private final IdentityService identityService = mock();
+    private final PolicyEngine policyEngine = mock();
+    private final ProtocolTokenValidatorImpl validator = new ProtocolTokenValidatorImpl(identityService, policyEngine, mock(), agentService);
+
+    @Test
+    void shouldVerifyToken() {
+        var participantAgent = new ParticipantAgent(emptyMap(), emptyMap());
+        var claimToken = ClaimToken.Builder.newInstance().build();
+        var policy = Policy.Builder.newInstance().build();
+        var tokenRepresentation = TokenRepresentation.Builder.newInstance().build();
+        when(identityService.verifyJwtToken(any(), any())).thenReturn(Result.success(claimToken));
+        when(agentService.createFor(any())).thenReturn(participantAgent);
+
+        var result = validator.verify(tokenRepresentation, "scope", policy);
+
+        assertThat(result).isSucceeded().isSameAs(participantAgent);
+        verify(agentService).createFor(claimToken);
+        verify(policyEngine).evaluate(eq("scope"), same(policy), any());
+        verify(identityService).verifyJwtToken(same(tokenRepresentation), any());
+    }
+
+    @Test
+    void shouldReturnUnauthorized_whenTokenIsNotValid() {
+        when(identityService.verifyJwtToken(any(), any())).thenReturn(Result.failure("failure"));
+
+        var result = validator.verify(TokenRepresentation.Builder.newInstance().build(), "scope", Policy.Builder.newInstance().build());
+
+        assertThat(result).isFailed().extracting(ServiceFailure::getReason).isEqualTo(UNAUTHORIZED);
+    }
+}

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/transferprocess/TransferProcessProtocolServiceImplTest.java
@@ -126,7 +126,7 @@ class TransferProcessProtocolServiceImplTest {
 
         when(protocolTokenValidator.verifyToken(eq(tokenRepresentation), eq(TRANSFER_PROCESS_REQUEST_SCOPE), any())).thenReturn(ServiceResult.success(claimToken));
         when(negotiationStore.findContractAgreement(any())).thenReturn(contractAgreement());
-        when(validationService.validateAgreement(any(), any())).thenReturn(Result.success(null));
+        when(validationService.validateAgreement(any(ClaimToken.class), any())).thenReturn(Result.success(null));
         when(dataAddressValidator.validateDestination(any())).thenReturn(ValidationResult.success());
 
         var result = service.notifyRequested(message, tokenRepresentation);
@@ -157,7 +157,7 @@ class TransferProcessProtocolServiceImplTest {
 
         when(protocolTokenValidator.verifyToken(eq(tokenRepresentation), eq(TRANSFER_PROCESS_REQUEST_SCOPE), any())).thenReturn(ServiceResult.success(claimToken));
         when(negotiationStore.findContractAgreement(any())).thenReturn(contractAgreement());
-        when(validationService.validateAgreement(any(), any())).thenReturn(Result.success(null));
+        when(validationService.validateAgreement(any(ClaimToken.class), any())).thenReturn(Result.success(null));
         when(dataAddressValidator.validateDestination(any())).thenReturn(ValidationResult.success());
         when(store.findForCorrelationId(any())).thenReturn(transferProcess(REQUESTED, "transferProcessId"));
 
@@ -182,7 +182,7 @@ class TransferProcessProtocolServiceImplTest {
 
         when(protocolTokenValidator.verifyToken(eq(tokenRepresentation), eq(TRANSFER_PROCESS_REQUEST_SCOPE), any())).thenReturn(ServiceResult.success(claimToken));
         when(negotiationStore.findContractAgreement(any())).thenReturn(contractAgreement());
-        when(validationService.validateAgreement(any(), any())).thenReturn(Result.failure("error"));
+        when(validationService.validateAgreement(any(ClaimToken.class), any())).thenReturn(Result.failure("error"));
         when(dataAddressValidator.validateDestination(any())).thenReturn(ValidationResult.success());
 
         var result = service.notifyRequested(message, tokenRepresentation);
@@ -229,7 +229,7 @@ class TransferProcessProtocolServiceImplTest {
 
         when(protocolTokenValidator.verifyToken(eq(tokenRepresentation), eq(TRANSFER_PROCESS_REQUEST_SCOPE), any())).thenReturn(ServiceResult.success(claimToken));
         when(negotiationStore.findContractAgreement(any())).thenReturn(contractAgreement());
-        when(validationService.validateAgreement(any(), any())).thenReturn(Result.success(null));
+        when(validationService.validateAgreement(any(ClaimToken.class), any())).thenReturn(Result.success(null));
 
         var result = service.notifyRequested(message, tokenRepresentation);
 
@@ -699,8 +699,8 @@ class TransferProcessProtocolServiceImplTest {
             when(store.findById(any())).thenReturn(transferProcess);
             when(store.findByIdAndLease(any())).thenReturn(StoreResult.success(transferProcess));
             when(negotiationStore.findContractAgreement(any())).thenReturn(contractAgreement());
-            when(validationService.validateAgreement(any(), any())).thenAnswer(i -> Result.success(i.getArgument(1)));
-            when(validationService.validateRequest(any(), isA(ContractAgreement.class))).thenReturn(Result.success());
+            when(validationService.validateAgreement(any(ClaimToken.class), any())).thenAnswer(i -> Result.success(i.getArgument(1)));
+            when(validationService.validateRequest(any(ClaimToken.class), isA(ContractAgreement.class))).thenReturn(Result.success());
 
             var result = methodCall.call(service, message, tokenRepresentation());
 
@@ -722,8 +722,8 @@ class TransferProcessProtocolServiceImplTest {
             when(store.findById(any())).thenReturn(transferProcess);
             when(store.findByIdAndLease(any())).thenReturn(StoreResult.success(transferProcess));
             when(negotiationStore.findContractAgreement(any())).thenReturn(contractAgreement());
-            when(validationService.validateAgreement(any(), any())).thenAnswer(i -> Result.success(i.getArgument(1)));
-            when(validationService.validateRequest(any(), isA(ContractAgreement.class))).thenReturn(Result.success());
+            when(validationService.validateAgreement(any(ClaimToken.class), any())).thenAnswer(i -> Result.success(i.getArgument(1)));
+            when(validationService.validateRequest(any(ClaimToken.class), isA(ContractAgreement.class))).thenReturn(Result.success());
 
             var result = methodCall.call(service, message, tokenRepresentation());
 
@@ -741,8 +741,8 @@ class TransferProcessProtocolServiceImplTest {
             when(store.findById(any())).thenReturn(transferProcess);
             when(store.findByIdAndLease(any())).thenReturn(StoreResult.success(transferProcess));
             when(negotiationStore.findContractAgreement(any())).thenReturn(contractAgreement());
-            when(validationService.validateAgreement(any(), any())).thenAnswer(i -> Result.success(i.getArgument(1)));
-            when(validationService.validateRequest(any(), isA(ContractAgreement.class))).thenReturn(Result.success());
+            when(validationService.validateAgreement(any(ClaimToken.class), any())).thenAnswer(i -> Result.success(i.getArgument(1)));
+            when(validationService.validateRequest(any(ClaimToken.class), isA(ContractAgreement.class))).thenReturn(Result.success());
 
             var result = methodCall.call(service, message, tokenRepresentation());
 

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/api/DspNegotiationApiExtension.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/api/DspNegotiationApiExtension.java
@@ -26,10 +26,8 @@ import org.eclipse.edc.protocol.dsp.negotiation.api.validation.ContractRequestMe
 import org.eclipse.edc.protocol.dsp.spi.message.DspRequestHandler;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
-import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
-import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 import org.eclipse.edc.web.spi.WebService;
 
@@ -46,16 +44,12 @@ import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNam
 @Extension(value = DspNegotiationApiExtension.NAME)
 public class DspNegotiationApiExtension implements ServiceExtension {
 
-    public static final String NAME = "Dataspace Protocol Negotiation Api Extension";
+    public static final String NAME = "Dataspace Protocol Negotiation Api";
 
     @Inject
     private WebService webService;
     @Inject
     private DspApiConfiguration apiConfiguration;
-    @Inject
-    private TypeTransformerRegistry transformerRegistry;
-    @Inject
-    private Monitor monitor;
     @Inject
     private ContractNegotiationProtocolService protocolService;
     @Inject
@@ -77,8 +71,7 @@ public class DspNegotiationApiExtension implements ServiceExtension {
         validatorRegistry.register(DSPACE_TYPE_CONTRACT_AGREEMENT_VERIFICATION_MESSAGE, ContractAgreementVerificationMessageValidator.instance());
         validatorRegistry.register(DSPACE_TYPE_CONTRACT_NEGOTIATION_TERMINATION_MESSAGE, ContractNegotiationTerminationMessageValidator.instance());
 
-        var controller = new DspNegotiationApiController(transformerRegistry,
-                protocolService, monitor, dspRequestHandler);
+        var controller = new DspNegotiationApiController(protocolService, dspRequestHandler);
 
         webService.registerResource(apiConfiguration.getContextAlias(), controller);
     }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/api/NegotiationApiPaths.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/api/NegotiationApiPaths.java
@@ -21,8 +21,9 @@ public interface NegotiationApiPaths {
 
     String BASE_PATH = "/negotiations/";
     String INITIAL_CONTRACT_REQUEST = "request";
-    String CONTRACT_REQUEST = "/request";
-    String CONTRACT_OFFER = "/offers";
+    String INITIAL_CONTRACT_OFFER = "offer";
+    String CONTRACT_REQUEST = "/" + INITIAL_CONTRACT_REQUEST;
+    String CONTRACT_OFFER = "/" + INITIAL_CONTRACT_OFFER;
     String EVENT = "/events";
     String AGREEMENT = "/agreement";
     String VERIFICATION = "/verification";

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/api/validation/ContractOfferMessageValidator.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/api/validation/ContractOfferMessageValidator.java
@@ -19,12 +19,14 @@ import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferMes
 import org.eclipse.edc.validator.jsonobject.JsonObjectValidator;
 import org.eclipse.edc.validator.jsonobject.validators.MandatoryIdNotBlank;
 import org.eclipse.edc.validator.jsonobject.validators.MandatoryObject;
+import org.eclipse.edc.validator.jsonobject.validators.MandatoryValue;
 import org.eclipse.edc.validator.jsonobject.validators.TypeIs;
 import org.eclipse.edc.validator.spi.Validator;
 
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIBUTE;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_OFFER_MESSAGE;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS;
 
 /**
  * Validator for {@link ContractOfferMessage} Json-LD representation
@@ -38,6 +40,7 @@ public class ContractOfferMessageValidator {
                         .verify(ODRL_TARGET_ATTRIBUTE, MandatoryObject::new)
                         .verifyObject(ODRL_TARGET_ATTRIBUTE, b -> b.verifyId(MandatoryIdNotBlank::new))
                 )
+                .verify(DSPACE_PROPERTY_CALLBACK_ADDRESS, MandatoryValue::new)
                 .build();
     }
 }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/api/validation/ContractRequestMessageValidator.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/api/validation/ContractRequestMessageValidator.java
@@ -19,12 +19,14 @@ import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestM
 import org.eclipse.edc.validator.jsonobject.JsonObjectValidator;
 import org.eclipse.edc.validator.jsonobject.validators.MandatoryIdNotBlank;
 import org.eclipse.edc.validator.jsonobject.validators.MandatoryObject;
+import org.eclipse.edc.validator.jsonobject.validators.MandatoryValue;
 import org.eclipse.edc.validator.jsonobject.validators.TypeIs;
 import org.eclipse.edc.validator.spi.Validator;
 
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIBUTE;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS;
 
 /**
  * Validator for {@link ContractRequestMessage} Json-LD representation
@@ -38,6 +40,7 @@ public class ContractRequestMessageValidator {
                         .verify(ODRL_TARGET_ATTRIBUTE, MandatoryObject::new)
                         .verifyObject(ODRL_TARGET_ATTRIBUTE, b -> b.verifyId(MandatoryIdNotBlank::new))
                 )
+                .verify(DSPACE_PROPERTY_CALLBACK_ADDRESS, MandatoryValue::new)
                 .build();
     }
 }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/api/validation/ContractOfferMessageValidatorTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/api/validation/ContractOfferMessageValidatorTest.java
@@ -30,11 +30,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.list;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_OFFER;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIBUTE;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_OFFER_MESSAGE;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS;
 
 class ContractOfferMessageValidatorTest {
 
@@ -49,6 +51,7 @@ class ContractOfferMessageValidatorTest {
                                 .add(TYPE, ODRL_POLICY_TYPE_OFFER)
                                 .add(ID, UUID.randomUUID().toString())
                                 .add(ODRL_TARGET_ATTRIBUTE, id("target"))))
+                .add(DSPACE_PROPERTY_CALLBACK_ADDRESS, value("http://any/address"))
                 .build();
 
         var result = validator.validate(input);
@@ -65,7 +68,8 @@ class ContractOfferMessageValidatorTest {
 
         assertThat(result).isFailed().extracting(ValidationFailure::getViolations).asInstanceOf(list(Violation.class))
                 .hasSize(1)
-                .anySatisfy(violation -> assertThat(violation.path()).isEqualTo(TYPE));
+                .anySatisfy(violation -> assertThat(violation.path()).isEqualTo(TYPE))
+                .anySatisfy(violation -> assertThat(violation.path()).isEqualTo(DSPACE_PROPERTY_CALLBACK_ADDRESS));
     }
 
     @Test
@@ -82,6 +86,10 @@ class ContractOfferMessageValidatorTest {
                 .allSatisfy(violation -> assertThat(violation.path()).startsWith(DSPACE_PROPERTY_OFFER))
                 .anySatisfy(violation -> assertThat(violation.path()).endsWith(ID))
                 .anySatisfy(violation -> assertThat(violation.path()).endsWith(ODRL_TARGET_ATTRIBUTE));
+    }
+
+    private JsonArrayBuilder value(String value) {
+        return createArrayBuilder().add(createObjectBuilder().add(VALUE, value));
     }
 
     private JsonArrayBuilder id(String id) {

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/api/validation/ContractOfferMessageValidatorTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/api/validation/ContractOfferMessageValidatorTest.java
@@ -67,7 +67,7 @@ class ContractOfferMessageValidatorTest {
         var result = validator.validate(input);
 
         assertThat(result).isFailed().extracting(ValidationFailure::getViolations).asInstanceOf(list(Violation.class))
-                .hasSize(1)
+                .hasSize(2)
                 .anySatisfy(violation -> assertThat(violation.path()).isEqualTo(TYPE))
                 .anySatisfy(violation -> assertThat(violation.path()).isEqualTo(DSPACE_PROPERTY_CALLBACK_ADDRESS));
     }
@@ -77,6 +77,7 @@ class ContractOfferMessageValidatorTest {
         var input = createObjectBuilder()
                 .add(TYPE, createArrayBuilder().add(DSPACE_TYPE_CONTRACT_OFFER_MESSAGE))
                 .add(DSPACE_PROPERTY_OFFER, createArrayBuilder().add(createObjectBuilder()))
+                .add(DSPACE_PROPERTY_CALLBACK_ADDRESS, value("http://any/address"))
                 .build();
 
         var result = validator.validate(input);

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/api/validation/ContractRequestMessageValidatorTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/api/validation/ContractRequestMessageValidatorTest.java
@@ -80,6 +80,7 @@ class ContractRequestMessageValidatorTest {
         var input = createObjectBuilder()
                 .add(TYPE, createArrayBuilder().add(DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE))
                 .add(DSPACE_PROPERTY_OFFER, createArrayBuilder().add(createObjectBuilder()))
+                .add(DSPACE_PROPERTY_CALLBACK_ADDRESS, value("http://any/address"))
                 .build();
 
         var result = validator.validate(input);

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/api/validation/ContractRequestMessageValidatorTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/api/validation/ContractRequestMessageValidatorTest.java
@@ -29,11 +29,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.list;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_OFFER;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIBUTE;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE;
+import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS;
 
 class ContractRequestMessageValidatorTest {
 
@@ -48,6 +50,7 @@ class ContractRequestMessageValidatorTest {
                                 .add(TYPE, ODRL_POLICY_TYPE_OFFER)
                                 .add(ID, UUID.randomUUID().toString())
                                 .add(ODRL_TARGET_ATTRIBUTE, id("target"))))
+                .add(DSPACE_PROPERTY_CALLBACK_ADDRESS, value("http://any/address"))
                 .build();
 
         var result = validator.validate(input);
@@ -63,8 +66,13 @@ class ContractRequestMessageValidatorTest {
         var result = validator.validate(input);
 
         assertThat(result).isFailed().extracting(ValidationFailure::getViolations).asInstanceOf(list(Violation.class))
-                .hasSize(1)
-                .anySatisfy(violation -> assertThat(violation.path()).isEqualTo(TYPE));
+                .hasSize(2)
+                .anySatisfy(violation -> assertThat(violation.path()).isEqualTo(TYPE))
+                .anySatisfy(violation -> assertThat(violation.path()).isEqualTo(DSPACE_PROPERTY_CALLBACK_ADDRESS));
+    }
+
+    private JsonArrayBuilder value(String value) {
+        return createArrayBuilder().add(createObjectBuilder().add(VALUE, value));
     }
 
     @Test

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractOfferMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractOfferMessageTransformerTest.java
@@ -96,6 +96,7 @@ class JsonObjectFromContractOfferMessageTransformerTest {
     @Test
     void transform_shouldReportProblem_whenPolicyTransformationFails() {
         var message = ContractOfferMessage.Builder.newInstance()
+                .callbackAddress("callbackAddress")
                 .id(MESSAGE_ID)
                 .processId("processId")
                 .providerPid("providerPid")

--- a/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
+++ b/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
@@ -118,7 +118,7 @@ public class HttpProvisionerExtensionEndToEndTest {
                                      ContractNegotiationStore negotiationStore,
                                      AssetIndex assetIndex,
                                      TransferProcessStore store, PolicyDefinitionStore policyStore) throws Exception {
-        when(contractValidationService.validateAgreement(any(), any())).thenReturn(Result.success(null));
+        when(contractValidationService.validateAgreement(any(ClaimToken.class), any())).thenReturn(Result.success(null));
         negotiationStore.save(createContractNegotiation());
         policyStore.create(createPolicyDefinition());
         assetIndex.create(createAssetEntry());

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractNegotiation.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractNegotiation.java
@@ -235,7 +235,7 @@ public class ContractNegotiation extends StatefulEntity<ContractNegotiation> {
      */
     public void transitionOffered() {
         if (CONSUMER == type) {
-            transition(OFFERED, OFFERED, REQUESTED);
+            transition(OFFERED, OFFERED, REQUESTED, INITIAL);
         } else {
             transition(OFFERED, OFFERED, OFFERING);
         }
@@ -521,9 +521,7 @@ public class ContractNegotiation extends StatefulEntity<ContractNegotiation> {
             Objects.requireNonNull(entity.counterPartyId);
             Objects.requireNonNull(entity.counterPartyAddress);
             Objects.requireNonNull(entity.protocol);
-            if (Type.PROVIDER == entity.type) {
-                Objects.requireNonNull(entity.correlationId);
-            }
+
             if (entity.state == 0) {
                 entity.transitionTo(INITIAL.code());
             }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractOfferMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractOfferMessage.java
@@ -64,6 +64,7 @@ public class ContractOfferMessage extends ContractRemoteMessage {
         }
 
         public ContractOfferMessage build() {
+            requireNonNull(message.callbackAddress, "callbackAddress");
             requireNonNull(message.contractOffer, "contractOffer");
             return super.build();
         }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessage.java
@@ -82,6 +82,9 @@ public class ContractRequestMessage extends ContractRemoteMessage {
         }
 
         public ContractRequestMessage build() {
+            if (message.type == Type.INITIAL) {
+                requireNonNull(message.callbackAddress, "callbackAddress");
+            }
             requireNonNull(message.contractOffer, "contractOffer");
             return super.build();
         }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/validation/ContractValidationService.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/validation/ContractValidationService.java
@@ -18,6 +18,7 @@ package org.eclipse.edc.connector.contract.spi.validation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.policy.engine.spi.PolicyScope;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
+import org.eclipse.edc.spi.agent.ParticipantAgent;
 import org.eclipse.edc.spi.iam.ClaimToken;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.agreement.ContractAgreement;
@@ -36,15 +37,68 @@ public interface ContractValidationService {
     @PolicyScope
     String TRANSFER_SCOPE = "transfer.process";
 
-    
+    /**
+     * Validates the contract offer for the consumer represented by the given claims.
+     *
+     * @param agent         The {@link ParticipantAgent} of the consumer
+     * @param consumerOffer The initial {@link ValidatableConsumerOffer} id to validate
+     * @return The referenced {@link ValidatedConsumerOffer}.
+     */
+    @NotNull
+    Result<ValidatedConsumerOffer> validateInitialOffer(ParticipantAgent agent, ValidatableConsumerOffer consumerOffer);
+
+    /**
+     * Validates the contract agreement that the consumer referenced in its transfer request.
+     * The {@code ParticipantAgent} must represent the counter-party that is referenced in the contract agreement.
+     *
+     * @param agent     The {@link ParticipantAgent} of the consumer
+     * @param agreement The {@link ContractAgreement} between consumer and provider to validate
+     * @return The result of the validation
+     */
+    @NotNull
+    Result<ContractAgreement> validateAgreement(ParticipantAgent agent, ContractAgreement agreement);
+
+    /**
+     * Validates the request for a contract agreement. Verifies that the requesting party is involved
+     * in the contract agreement, but does not perform policy evaluation.
+     *
+     * @param agent     The {@link ParticipantAgent} of the counter-party
+     * @param agreement The agreement
+     * @return The result of the validation
+     */
+    @NotNull
+    Result<Void> validateRequest(ParticipantAgent agent, ContractAgreement agreement);
+
+    /**
+     * Validates the request for a contract negotiation.
+     *
+     * @param agent       The {@link ParticipantAgent} of the consumer
+     * @param negotiation The negotiation
+     * @return The result of the validation
+     */
+    @NotNull
+    Result<Void> validateRequest(ParticipantAgent agent, ContractNegotiation negotiation);
+
+    /**
+     * When the negotiation has been confirmed by the provider, the consumer must validate it ensuring that it is the same that was sent in the last offer.
+     *
+     * @param agent       The {@link ParticipantAgent} the provider agent
+     * @param agreement   The {@link ContractAgreement} between consumer and provider
+     * @param latestOffer The last {@link ContractOffer}
+     */
+    @NotNull
+    Result<Void> validateConfirmed(ParticipantAgent agent, ContractAgreement agreement, ContractOffer latestOffer);
+
     /**
      * Validates the contract offer for the consumer represented by the given claims.
      *
      * @param token         The {@link ClaimToken} of the consumer
      * @param consumerOffer The initial {@link ValidatableConsumerOffer} id to validate
      * @return The referenced {@link ValidatedConsumerOffer}.
+     * @deprecated please use the same method that accepts {@link ParticipantAgent}
      */
     @NotNull
+    @Deprecated(since = "0.5.1")
     Result<ValidatedConsumerOffer> validateInitialOffer(ClaimToken token, ValidatableConsumerOffer consumerOffer);
 
     /**
@@ -54,8 +108,10 @@ public interface ContractValidationService {
      * @param token     The {@link ClaimToken} of the consumer
      * @param agreement The {@link ContractAgreement} between consumer and provider to validate
      * @return The result of the validation
+     * @deprecated please use the same method that accepts {@link ParticipantAgent}
      */
     @NotNull
+    @Deprecated(since = "0.5.1")
     Result<ContractAgreement> validateAgreement(ClaimToken token, ContractAgreement agreement);
 
     /**
@@ -65,8 +121,10 @@ public interface ContractValidationService {
      * @param token     The {@link ClaimToken} of the counter-party
      * @param agreement The agreement
      * @return The result of the validation
+     * @deprecated please use the same method that accepts {@link ParticipantAgent}
      */
     @NotNull
+    @Deprecated(since = "0.5.1")
     Result<Void> validateRequest(ClaimToken token, ContractAgreement agreement);
 
     /**
@@ -75,8 +133,10 @@ public interface ContractValidationService {
      * @param token       The {@link ClaimToken} of the consumer
      * @param negotiation The negotiation
      * @return The result of the validation
+     * @deprecated please use the same method that accepts {@link ParticipantAgent}
      */
     @NotNull
+    @Deprecated(since = "0.5.1")
     Result<Void> validateRequest(ClaimToken token, ContractNegotiation negotiation);
 
     /**
@@ -85,8 +145,10 @@ public interface ContractValidationService {
      * @param token       The {@link ClaimToken} the provider token
      * @param agreement   The {@link ContractAgreement} between consumer and provider
      * @param latestOffer The last {@link ContractOffer}
+     * @deprecated please use the same method that accepts {@link ParticipantAgent}
      */
     @NotNull
+    @Deprecated(since = "0.5.1")
     Result<Void> validateConfirmed(ClaimToken token, ContractAgreement agreement, ContractOffer latestOffer);
 
 }

--- a/spi/control-plane/contract-spi/src/test/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessageTest.java
+++ b/spi/control-plane/contract-spi/src/test/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessageTest.java
@@ -24,6 +24,10 @@ import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractR
 
 class ContractRequestMessageTest {
     public static final String CALLBACK_ADDRESS = "http://test.com";
+<<<<<<< HEAD
+=======
+    public static final String DATASET = "dataset1";
+>>>>>>> 2190e5ada (feat(dsp): add negotiation/offers endpoint)
     public static final String ID = "id1";
     public static final String ASSET_ID = "asset1";
     public static final String PROTOCOL = "DPS";
@@ -47,6 +51,7 @@ class ContractRequestMessageTest {
     void verify_contractOfferIdOrContractOffer() {
         ContractRequestMessage.Builder.newInstance()
                 .type(INITIAL)
+                .callbackAddress("any")
                 .consumerPid("consumerPid")
                 .providerPid("providerPid")
                 .protocol(PROTOCOL)
@@ -61,6 +66,7 @@ class ContractRequestMessageTest {
         // verify no contract offer is set
         assertThatThrownBy(() -> ContractRequestMessage.Builder.newInstance()
                 .type(INITIAL)
+                .callbackAddress("any")
                 .consumerPid("consumerPid")
                 .providerPid("providerPid")
                 .protocol(PROTOCOL)

--- a/spi/control-plane/contract-spi/src/test/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessageTest.java
+++ b/spi/control-plane/contract-spi/src/test/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessageTest.java
@@ -23,11 +23,8 @@ import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractR
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage.Type.INITIAL;
 
 class ContractRequestMessageTest {
+
     public static final String CALLBACK_ADDRESS = "http://test.com";
-<<<<<<< HEAD
-=======
-    public static final String DATASET = "dataset1";
->>>>>>> 2190e5ada (feat(dsp): add negotiation/offers endpoint)
     public static final String ID = "id1";
     public static final String ASSET_ID = "asset1";
     public static final String PROTOCOL = "DPS";
@@ -35,6 +32,7 @@ class ContractRequestMessageTest {
     @Test
     void verify_noCallbackNeededForCounterOffer() {
         ContractRequestMessage.Builder.newInstance()
+                .callbackAddress("http://any")
                 .type(COUNTER_OFFER)
                 .consumerPid("consumerPid")
                 .providerPid("providerPid")
@@ -50,6 +48,7 @@ class ContractRequestMessageTest {
     @Test
     void verify_contractOfferIdOrContractOffer() {
         ContractRequestMessage.Builder.newInstance()
+                .callbackAddress("http://any")
                 .type(INITIAL)
                 .callbackAddress("any")
                 .consumerPid("consumerPid")
@@ -65,6 +64,7 @@ class ContractRequestMessageTest {
 
         // verify no contract offer is set
         assertThatThrownBy(() -> ContractRequestMessage.Builder.newInstance()
+                .callbackAddress("http://any")
                 .type(INITIAL)
                 .callbackAddress("any")
                 .consumerPid("consumerPid")
@@ -73,5 +73,13 @@ class ContractRequestMessageTest {
                 .counterPartyAddress(CALLBACK_ADDRESS)
                 .build()).isInstanceOf(NullPointerException.class).hasMessageContaining("contractOffer");
 
+    }
+
+    private ContractOffer contractOffer() {
+        return ContractOffer.Builder.newInstance()
+                .id(ID)
+                .assetId(ASSET_ID)
+                .policy(Policy.Builder.newInstance().build())
+                .build();
     }
 }

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/protocol/ProtocolTokenValidator.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/protocol/ProtocolTokenValidator.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.spi.protocol;
 
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
+import org.eclipse.edc.spi.agent.ParticipantAgent;
 import org.eclipse.edc.spi.iam.ClaimToken;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.result.ServiceResult;
@@ -34,6 +35,18 @@ public interface ProtocolTokenValidator {
      * @param policyScope         The policy scope
      * @param policy              The policy
      * @return Returns the extracted {@link ClaimToken} if successful, failure otherwise
+     * @deprecated please use {@link #verify(TokenRepresentation, String, Policy)}
      */
+    @Deprecated(since = "0.5.1")
     ServiceResult<ClaimToken> verifyToken(TokenRepresentation tokenRepresentation, String policyScope, Policy policy);
+
+    /**
+     * Verify the {@link TokenRepresentation} in the context of a policy
+     *
+     * @param tokenRepresentation The token
+     * @param policyScope         The policy scope
+     * @param policy              The policy
+     * @return Returns the extracted {@link ParticipantAgent} if successful, failure otherwise
+     */
+    ServiceResult<ParticipantAgent> verify(TokenRepresentation tokenRepresentation, String policyScope, Policy policy);
 }


### PR DESCRIPTION
## What this PR changes/adds

Add the `negotiations/offer` endpoint, that can be used by a provider to start a negotiation.

## Why it does that

dsp compliance

## Further notes

- to create a new negotiation from a `ContractOfferMessage` I had to move the extraction of the counter party id from the contract validator to the `ProtocolTokenValidator`, that returns a `ServiceResult<ParticipantAgent>` now. I left the old methods and I will align the missing services (transfer process and catalog) to the new behavior in a subsequent PR.
- moved the validation on the `ContractRequestMessage` for the `callbackAddress` property to the JsonLdValidator instance, because it didn't make much sense in the controller (and it wasn't properly tested too).

## Linked Issue(s)

Closes #3840 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
