### PR TITLE
feat: attach entire VC to claimtoken

### DIFF
--- a/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtension.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtension.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.iam.identitytrust.DidCredentialServiceUrlResolver;
 import org.eclipse.edc.iam.identitytrust.IdentityAndTrustService;
 import org.eclipse.edc.iam.identitytrust.core.defaults.DefaultCredentialServiceClient;
 import org.eclipse.edc.iam.identitytrust.verification.MultiFormatPresentationVerifier;
+import org.eclipse.edc.identitytrust.ClaimTokenCreatorFunction;
 import org.eclipse.edc.identitytrust.CredentialServiceClient;
 import org.eclipse.edc.identitytrust.SecureTokenService;
 import org.eclipse.edc.identitytrust.TrustedIssuerRegistry;
@@ -105,6 +106,8 @@ public class IdentityAndTrustExtension implements ServiceExtension {
     private TokenValidationRulesRegistry rulesRegistry;
     @Inject
     private DidPublicKeyResolver didPublicKeyResolver;
+    @Inject
+    private ClaimTokenCreatorFunction claimTokenFunction;
 
     private PresentationVerifier presentationVerifier;
     private CredentialServiceClient credentialServiceClient;
@@ -141,7 +144,7 @@ public class IdentityAndTrustExtension implements ServiceExtension {
         var validationAction = tokenValidationAction();
 
         return new IdentityAndTrustService(secureTokenService, getOwnDid(context), getPresentationVerifier(context),
-                getCredentialServiceClient(context), validationAction, registry, clock, credentialServiceUrlResolver);
+                getCredentialServiceClient(context), validationAction, registry, clock, credentialServiceUrlResolver, claimTokenFunction);
     }
 
     @Provider

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/IdentityAndTrustService.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/IdentityAndTrustService.java
@@ -196,11 +196,9 @@ public class IdentityAndTrustService implements IdentityService {
         if (credentials.isEmpty()) {
             return failure("No VerifiableCredentials were found on VP");
         }
-        var b = ClaimToken.Builder.newInstance();
-        credentials.stream().flatMap(vc -> vc.getCredentialSubject().stream())
-                .map(CredentialSubject::getClaims)
-                .forEach(claimSet -> claimSet.forEach(b::claim));
-
+        var key = "vc";
+        var b = ClaimToken.Builder.newInstance()
+                .claims(Map.of(key, credentials));
         return success(b.build());
     }
 

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/test/java/org/eclipse/edc/iam/identitytrust/service/IdentityAndTrustServiceTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/test/java/org/eclipse/edc/iam/identitytrust/service/IdentityAndTrustServiceTest.java
@@ -25,6 +25,7 @@ import org.eclipse.edc.identitytrust.TrustedIssuerRegistry;
 import org.eclipse.edc.identitytrust.model.CredentialFormat;
 import org.eclipse.edc.identitytrust.model.CredentialSubject;
 import org.eclipse.edc.identitytrust.model.Issuer;
+import org.eclipse.edc.identitytrust.model.VerifiableCredential;
 import org.eclipse.edc.identitytrust.model.VerifiablePresentationContainer;
 import org.eclipse.edc.identitytrust.validation.TokenValidationAction;
 import org.eclipse.edc.identitytrust.verification.PresentationVerifier;
@@ -149,6 +150,7 @@ class IdentityAndTrustServiceTest {
     }
 
 
+    @SuppressWarnings("unchecked")
     @Nested
     class VerifyJwtToken {
 
@@ -286,7 +288,11 @@ class IdentityAndTrustServiceTest {
             var token = createJwt(CONSUMER_DID, EXPECTED_OWN_DID);
             var result = service.verifyJwtToken(token, verificationContext());
             assertThat(result).isSucceeded()
-                    .satisfies(ct -> Assertions.assertThat(ct.getClaims()).containsEntry("some-claim", "some-val"));
+                    .satisfies(ct -> {
+                        var vc = (List<VerifiableCredential>) ct.getListClaim("vc");
+                        Assertions.assertThat(vc).hasSize(1);
+                        Assertions.assertThat(vc.get(0).getCredentialSubject().get(0).getClaims()).containsEntry("some-claim", "some-val");
+                    });
         }
 
         @Test
@@ -313,9 +319,12 @@ class IdentityAndTrustServiceTest {
             var token = createJwt(CONSUMER_DID, EXPECTED_OWN_DID);
             var result = service.verifyJwtToken(token, verificationContext());
             assertThat(result).isSucceeded()
-                    .satisfies(ct -> Assertions.assertThat(ct.getClaims())
-                            .containsEntry("some-claim", "some-val")
-                            .containsEntry("some-other-claim", "some-other-val"));
+                    .satisfies(ct -> {
+                        var credentials = (List<VerifiableCredential>) ct.getClaims().get("vc");
+                        Assertions.assertThat(credentials).hasSize(2);
+                        Assertions.assertThat(credentials.get(0).getCredentialSubject().get(0).getClaims()).containsEntry("some-claim", "some-val");
+                        Assertions.assertThat(credentials.get(1).getCredentialSubject().get(0).getClaims()).containsEntry("some-other-claim", "some-other-val");
+                    });
         }
 
         @Test
@@ -362,11 +371,14 @@ class IdentityAndTrustServiceTest {
             var token = createJwt(CONSUMER_DID, EXPECTED_OWN_DID);
             var result = service.verifyJwtToken(token, verificationContext());
             assertThat(result).isSucceeded()
-                    .satisfies(ct -> Assertions.assertThat(ct.getClaims())
-                            .containsEntry("some-claim", "some-val")
-                            .containsEntry("some-other-claim", "some-other-val")
-                            .containsEntry("some-claim-2", "some-val-2")
-                            .containsEntry("some-other-claim-2", "some-other-val-2"));
+                    .satisfies(ct -> {
+                        var credentials = (List<VerifiableCredential>) ct.getListClaim("vc");
+                        Assertions.assertThat(credentials).hasSize(4);
+                        Assertions.assertThat(credentials).anySatisfy(vc -> Assertions.assertThat(vc.getCredentialSubject().get(0).getClaims()).containsEntry("some-claim", "some-val"));
+                        Assertions.assertThat(credentials).anySatisfy(vc -> Assertions.assertThat(vc.getCredentialSubject().get(0).getClaims()).containsEntry("some-other-claim", "some-other-val"));
+                        Assertions.assertThat(credentials).anySatisfy(vc -> Assertions.assertThat(vc.getCredentialSubject().get(0).getClaims()).containsEntry("some-claim-2", "some-val-2"));
+                        Assertions.assertThat(credentials).anySatisfy(vc -> Assertions.assertThat(vc.getCredentialSubject().get(0).getClaims()).containsEntry("some-other-claim-2", "some-other-val-2"));
+                    });
         }
     }
 }

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/test/java/org/eclipse/edc/iam/identitytrust/service/IdentityAndTrustServiceTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/test/java/org/eclipse/edc/iam/identitytrust/service/IdentityAndTrustServiceTest.java
@@ -81,7 +81,7 @@ class IdentityAndTrustServiceTest {
     private final CredentialServiceUrlResolver credentialServiceUrlResolverMock = mock();
     private final TokenValidationAction actionMock = mock();
     private final IdentityAndTrustService service = new IdentityAndTrustService(mockedSts, EXPECTED_OWN_DID, mockedVerifier, mockedClient,
-            actionMock, trustedIssuerRegistryMock, Clock.systemUTC(), credentialServiceUrlResolverMock);
+            actionMock, trustedIssuerRegistryMock, Clock.systemUTC(), credentialServiceUrlResolverMock, vcs -> Result.success(ClaimToken.Builder.newInstance().claim("vc", vcs).build()));
 
     @BeforeEach
     void setup() {

--- a/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/ClaimTokenCreatorFunction.java
+++ b/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/ClaimTokenCreatorFunction.java
@@ -1,0 +1,17 @@
+package org.eclipse.edc.identitytrust;
+
+import org.eclipse.edc.identitytrust.model.VerifiableCredential;
+import org.eclipse.edc.spi.iam.ClaimToken;
+import org.eclipse.edc.spi.result.Result;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * This is a marker interface for functions that convert a {@link List<VerifiableCredential>} to a ClaimToken.
+ * Implementors decide which information should be extracted from a {@link VerifiableCredential} and how it should be represented
+ * inside the {@link ClaimToken}.
+ * For example, an implementor could choose to simply attach the list of credentials to the ClaimToken using a reasonable key.
+ */
+public interface ClaimTokenCreatorFunction extends Function<List<VerifiableCredential>, Result<ClaimToken>> {
+}

--- a/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/ClaimTokenCreatorFunction.java
+++ b/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/ClaimTokenCreatorFunction.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
 package org.eclipse.edc.identitytrust;
 
 import org.eclipse.edc.identitytrust.model.VerifiableCredential;
@@ -8,10 +22,10 @@ import java.util.List;
 import java.util.function.Function;
 
 /**
- * This is a marker interface for functions that convert a {@link List<VerifiableCredential>} to a ClaimToken.
+ * This is a marker interface for functions that convert a {@link List} of {@link VerifiableCredential}s to a ClaimToken.
  * Implementors decide which information should be extracted from a {@link VerifiableCredential} and how it should be represented
  * inside the {@link ClaimToken}.
- * For example, an implementor could choose to simply attach the list of credentials to the ClaimToken using a reasonable key.
+ * For example, an implementor could choose to simply attach the entire list of credentials to the ClaimToken using a reasonable key.
  */
 public interface ClaimTokenCreatorFunction extends Function<List<VerifiableCredential>, Result<ClaimToken>> {
 }


### PR DESCRIPTION
## What this PR changes/adds

This PR changes, what the `ClaimtToken` contains when the `IdentityAndTrustService` creates it.
Before, it only contained the `credentialSubject` of each VC, where now it contains the actual list of VCs.

This is also pluggable, with a default implementation.

## Why it does that

More versatile ways to evaluate the `ClaimToken` in policy evaluation functions.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #3855

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
