### PR TITLE
chore: move observability api docs to default api docs

### DIFF
--- a/.github/workflows/apidoc.yaml
+++ b/.github/workflows/apidoc.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        apiGroup: [ 'default-api', 'public-api', 'management-api', 'control-api' ]
+        apiGroup: [ 'observability-api', 'public-api', 'management-api', 'control-api' ]
     env:
       rootDir: resources/openapi/yaml/${{ matrix.apiGroup }}
       SWAGGERHUB_API_KEY: ${{ secrets.SWAGGERHUB_TOKEN }}

--- a/.github/workflows/apidoc.yaml
+++ b/.github/workflows/apidoc.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        apiGroup: [ 'public-api', 'management-api', 'control-api' ]
+        apiGroup: [ 'default-api', 'public-api', 'management-api', 'control-api' ]
     env:
       rootDir: resources/openapi/yaml/${{ matrix.apiGroup }}
       SWAGGERHUB_API_KEY: ${{ secrets.SWAGGERHUB_TOKEN }}

--- a/extensions/common/api/api-observability/build.gradle.kts
+++ b/extensions/common/api/api-observability/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("management-api")
+        apiGroup.set("default-api")
     }
 }
 

--- a/extensions/common/api/api-observability/build.gradle.kts
+++ b/extensions/common/api/api-observability/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("default-api")
+        apiGroup.set("observability-api")
     }
 }
 


### PR DESCRIPTION
## What this PR changes/adds

Moves move observability api docs to default api documentations.

## Why it does that

Currently the observability endpoints are listed under the [management-api swaggerhub documentation](https://app.swaggerhub.com/apis/eclipse-edc-bot/management-api/0.5.1#/Application%20Observability/checkHealth), but in fact they are exposed in the default api context.

## Further notes

## Linked Issue(s)

Closes #3759

