### PR TITLE
feat: improves reported error in ContractValidationServiceImpl

### DIFF
--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImpl.java
@@ -170,7 +170,7 @@ public class ContractValidationServiceImpl implements ContractValidationService 
         var policyContext = PolicyContextImpl.Builder.newInstance().additional(ParticipantAgent.class, agent).build();
         var policyResult = policyEngine.evaluate(scope, policy, policyContext);
         if (policyResult.failed()) {
-            return failure(format("Policy in scope %s not fulfilled for offer %s", scope, offerId.toString()));
+            return failure(format("Policy in scope %s not fulfilled for offer %s, policy evaluation %s", scope, offerId.toString(), policyResult.getFailureDetail()));
         }
         return Result.success(policy);
     }


### PR DESCRIPTION
## What this PR changes/adds

Improves the failure message in `ContractValidationServiceImpl#validateInitialOffer` by including the failure details of the policy evaluation 


## Linked Issue(s)

Closes #3864 

