### PR TITLE
feat(dsp): remove target from offer policy in catalog

### DIFF
--- a/core/common/transform-core/src/main/java/org/eclipse/edc/core/transform/transformer/from/JsonObjectFromPolicyTransformer.java
+++ b/core/common/transform-core/src/main/java/org/eclipse/edc/core/transform/transformer/from/JsonObjectFromPolicyTransformer.java
@@ -28,7 +28,6 @@ import org.eclipse.edc.policy.model.Duty;
 import org.eclipse.edc.policy.model.Expression;
 import org.eclipse.edc.policy.model.LiteralExpression;
 import org.eclipse.edc.policy.model.MultiplicityConstraint;
-import org.eclipse.edc.policy.model.OdrlNamespace;
 import org.eclipse.edc.policy.model.OrConstraint;
 import org.eclipse.edc.policy.model.Permission;
 import org.eclipse.edc.policy.model.Policy;
@@ -58,6 +57,9 @@ import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_OBLIGATION_AT
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_OPERATOR_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_OR_CONSTRAINT_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_PERMISSION_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_AGREEMENT;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_OFFER;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_SET;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_PROHIBITION_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_REFINEMENT_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_RIGHT_OPERAND_ATTRIBUTE;
@@ -77,18 +79,16 @@ public class JsonObjectFromPolicyTransformer extends AbstractJsonLdTransformer<P
 
     @Override
     public @Nullable JsonObject transform(@NotNull Policy policy, @NotNull TransformerContext context) {
-        return policy.accept(new Visitor(context, jsonFactory));
+        return policy.accept(new Visitor(jsonFactory));
     }
 
     /**
      * Walks the policy object model, transforming it to a JsonObject.
      */
     private static class Visitor implements Policy.Visitor<JsonObject>, Rule.Visitor<JsonObject>, Constraint.Visitor<JsonObject>, Expression.Visitor<JsonObject> {
-        private final TransformerContext context;
         private final JsonBuilderFactory jsonFactory;
 
-        Visitor(TransformerContext context, JsonBuilderFactory jsonFactory) {
-            this.context = context;
+        Visitor(JsonBuilderFactory jsonFactory) {
             this.jsonFactory = jsonFactory;
         }
 
@@ -152,7 +152,7 @@ public class JsonObjectFromPolicyTransformer extends AbstractJsonLdTransformer<P
 
             var builder = jsonFactory.createObjectBuilder()
                     .add(ID, randomUUID().toString())
-                    .add(TYPE, OdrlNamespace.ODRL_SCHEMA + getTypeAsString(policy.getType()))
+                    .add(TYPE, getTypeAsString(policy.getType()))
                     .add(ODRL_PERMISSION_ATTRIBUTE, permissionsBuilder)
                     .add(ODRL_PROHIBITION_ATTRIBUTE, prohibitionsBuilder)
                     .add(ODRL_OBLIGATION_ATTRIBUTE, obligationsBuilder);
@@ -237,12 +237,11 @@ public class JsonObjectFromPolicyTransformer extends AbstractJsonLdTransformer<P
             return actionBuilder.build();
         }
 
-        // Hint: can be removed if internal type "contract" was changed to "agreement"
         private String getTypeAsString(PolicyType type) {
             return switch (type) {
-                default -> "Set";
-                case OFFER -> "Offer";
-                case CONTRACT -> "Agreement";
+                case SET -> ODRL_POLICY_TYPE_SET;
+                case OFFER -> ODRL_POLICY_TYPE_OFFER;
+                case CONTRACT -> ODRL_POLICY_TYPE_AGREEMENT;
             };
         }
     }

--- a/core/common/transform-core/src/test/java/org/eclipse/edc/core/transform/transformer/to/JsonObjectToPolicyTransformerTest.java
+++ b/core/common/transform-core/src/test/java/org/eclipse/edc/core/transform/transformer/to/JsonObjectToPolicyTransformerTest.java
@@ -18,22 +18,27 @@ import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonValue;
-import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
 import org.eclipse.edc.policy.model.Duty;
 import org.eclipse.edc.policy.model.Permission;
+import org.eclipse.edc.policy.model.PolicyType;
 import org.eclipse.edc.policy.model.Prohibition;
+import org.eclipse.edc.transform.spi.ProblemBuilder;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.core.transform.transformer.TestInput.getExpanded;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_OBLIGATION_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_PERMISSION_ATTRIBUTE;
@@ -42,6 +47,10 @@ import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_O
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_SET;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_PROHIBITION_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIBUTE;
+import static org.eclipse.edc.policy.model.PolicyType.CONTRACT;
+import static org.eclipse.edc.policy.model.PolicyType.OFFER;
+import static org.eclipse.edc.policy.model.PolicyType.SET;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -56,9 +65,7 @@ class JsonObjectToPolicyTransformerTest {
     private static final String TARGET = "target";
 
     private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
-    private final TransformerContext context = mock(TransformerContext.class);
-
-
+    private final TransformerContext context = mock();
     private final Permission permission = Permission.Builder.newInstance().build();
     private final Prohibition prohibition = Prohibition.Builder.newInstance().build();
     private final Duty duty = Duty.Builder.newInstance().build();
@@ -120,20 +127,17 @@ class JsonObjectToPolicyTransformerTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {
-            ODRL_POLICY_TYPE_SET,
-            ODRL_POLICY_TYPE_OFFER,
-            ODRL_POLICY_TYPE_AGREEMENT
-    })
-    void transform_differentPolicyTypes_returnPolicy(String type) {
+    @ArgumentsSource(PolicyTypeArguments.class)
+    void transform_differentPolicyTypes_returnPolicy(String type, PolicyType policyType) {
         var policy = jsonFactory.createObjectBuilder()
-                .add(JsonLdKeywords.CONTEXT, JsonObject.EMPTY_JSON_OBJECT)
+                .add(CONTEXT, JsonObject.EMPTY_JSON_OBJECT)
                 .add(TYPE, type)
                 .build();
 
         var result = transformer.transform(getExpanded(policy), context);
 
         assertThat(result).isNotNull();
+        assertThat(result.getType()).isEqualTo(policyType);
         verify(context, never()).reportProblem(anyString());
     }
 
@@ -142,10 +146,24 @@ class JsonObjectToPolicyTransformerTest {
         var policy = jsonFactory.createObjectBuilder()
                 .add(TYPE, "not-a-policy")
                 .build();
+        when(context.problem()).thenReturn(new ProblemBuilder(context));
 
-        transformer.transform(getExpanded(policy), context);
+        var result = transformer.transform(getExpanded(policy), context);
 
-        verify(context, never()).reportProblem(anyString());
+        assertThat(result).isNull();
+        verify(context).reportProblem(anyString());
+    }
+
+    private static class PolicyTypeArguments implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) throws Exception {
+            return Stream.of(
+                    arguments(ODRL_POLICY_TYPE_SET, SET),
+                    arguments(ODRL_POLICY_TYPE_OFFER, OFFER),
+                    arguments(ODRL_POLICY_TYPE_AGREEMENT, CONTRACT)
+            );
+        }
     }
 
 

--- a/core/common/validator-core/src/main/java/org/eclipse/edc/validator/jsonobject/validators/TypeIs.java
+++ b/core/common/validator-core/src/main/java/org/eclipse/edc/validator/jsonobject/validators/TypeIs.java
@@ -42,24 +42,23 @@ public class TypeIs implements Validator<JsonObject> {
 
     @Override
     public ValidationResult validate(JsonObject input) {
-        var newPath = path.append(TYPE);
-        var typeStream = Optional.of(input)
+        var types = Optional.of(input)
                 .map(it -> it.getJsonArray(TYPE))
-                .stream().flatMap(Collection::stream);
-
-        var result = typeStream
+                .stream().flatMap(Collection::stream)
                 .filter(it -> it.getValueType() == JsonValue.ValueType.STRING)
                 .map(JsonString.class::cast)
                 .map(JsonString::getString)
-                .filter(it -> it.equals(expectedType))
-                .findFirst();
+                .toList();
 
-        if (result.isPresent()) {
+
+        if (types.contains(expectedType)) {
             return ValidationResult.success();
         } else {
+            var newPath = path.append(TYPE);
+
             var violation = violation(
-                    "%s was expected to be %s but it was not".formatted(newPath, expectedType),
-                    newPath.toString(), typeStream
+                    "%s was expected to be %s but it was not".formatted(newPath, types),
+                    newPath.toString(), types
             );
             return ValidationResult.failure(violation);
         }

--- a/core/control-plane/catalog-core/src/main/java/org/eclipse/edc/connector/catalog/DatasetResolverImpl.java
+++ b/core/control-plane/catalog-core/src/main/java/org/eclipse/edc/connector/catalog/DatasetResolverImpl.java
@@ -21,6 +21,7 @@ import org.eclipse.edc.connector.contract.spi.ContractOfferId;
 import org.eclipse.edc.connector.contract.spi.offer.ContractDefinitionResolver;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractDefinition;
 import org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore;
+import org.eclipse.edc.policy.model.PolicyType;
 import org.eclipse.edc.spi.agent.ParticipantAgent;
 import org.eclipse.edc.spi.asset.AssetIndex;
 import org.eclipse.edc.spi.query.CriterionOperatorRegistry;
@@ -92,7 +93,8 @@ public class DatasetResolverImpl implements DatasetResolver {
                     var policyDefinition = policyDefinitionStore.findById(contractDefinition.getContractPolicyId());
                     if (policyDefinition != null) {
                         var contractId = ContractOfferId.create(contractDefinition.getId(), asset.getId());
-                        datasetBuilder.offer(contractId.toString(), policyDefinition.getPolicy().withTarget(asset.getId()));
+                        var offerPolicy = policyDefinition.getPolicy().toBuilder().type(PolicyType.OFFER).build();
+                        datasetBuilder.offer(contractId.toString(), offerPolicy);
                     }
                 });
 

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -25,6 +25,7 @@ import org.eclipse.edc.connector.contract.spi.types.agreement.ContractNegotiatio
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferMessage;
 import org.eclipse.edc.connector.contract.spi.types.protocol.ContractNegotiationAck;
+import org.eclipse.edc.policy.model.PolicyType;
 import org.eclipse.edc.spi.types.domain.agreement.ContractAgreement;
 import org.eclipse.edc.statemachine.StateMachineManager;
 
@@ -123,7 +124,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
                             .contractSigningDate(clock.instant().getEpochSecond())
                             .providerId(participantId)
                             .consumerId(negotiation.getCounterPartyId())
-                            .policy(lastOffer.getPolicy())
+                            .policy(lastOffer.getPolicy().toBuilder().type(PolicyType.CONTRACT).build())
                             .assetId(lastOffer.getAssetId())
                             .build();
                 });

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/policy/PolicyEquality.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/policy/PolicyEquality.java
@@ -33,7 +33,8 @@ public class PolicyEquality implements BiPredicate<Policy, Policy> {
     public boolean test(Policy one, Policy two) {
         var oneTree = mapper.<ObjectNode>valueToTree(one);
         var twoTree = mapper.<ObjectNode>valueToTree(two);
-        // TODO: target is excluded from the equality as it's not possible to map it to the current IDS implementation: https://github.com/eclipse-edc/Connector/issues/1791
+        oneTree.remove("@type");
+        twoTree.remove("@type");
         oneTree.remove("target");
         twoTree.remove("target");
         return oneTree.equals(twoTree);

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
@@ -31,7 +31,6 @@ import org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
-import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.retry.ExponentialWaitStrategy;
@@ -70,6 +69,7 @@ import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractN
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.TERMINATED;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.TERMINATING;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.VERIFIED;
+import static org.eclipse.edc.policy.model.PolicyType.CONTRACT;
 import static org.eclipse.edc.spi.persistence.StateEntityStore.hasState;
 import static org.eclipse.edc.spi.persistence.StateEntityStore.isNotPending;
 import static org.eclipse.edc.spi.response.ResponseStatus.FATAL_ERROR;
@@ -89,10 +89,10 @@ class ProviderContractNegotiationManagerImplTest {
 
     private static final String PROVIDER_ID = "provider";
     private static final int RETRY_LIMIT = 1;
-    private final ContractNegotiationStore store = mock(ContractNegotiationStore.class);
-    private final RemoteMessageDispatcherRegistry dispatcherRegistry = mock(RemoteMessageDispatcherRegistry.class);
-    private final PolicyDefinitionStore policyStore = mock(PolicyDefinitionStore.class);
-    private final ContractNegotiationListener listener = mock(ContractNegotiationListener.class);
+    private final ContractNegotiationStore store = mock();
+    private final RemoteMessageDispatcherRegistry dispatcherRegistry = mock();
+    private final PolicyDefinitionStore policyStore = mock();
+    private final ContractNegotiationListener listener = mock();
     private final ContractNegotiationPendingGuard pendingGuard = mock();
     private ProviderContractNegotiationManagerImpl manager;
 
@@ -103,7 +103,7 @@ class ProviderContractNegotiationManagerImplTest {
         manager = ProviderContractNegotiationManagerImpl.Builder.newInstance()
                 .participantId(PROVIDER_ID)
                 .dispatcherRegistry(dispatcherRegistry)
-                .monitor(mock(Monitor.class))
+                .monitor(mock())
                 .observable(observable)
                 .store(store)
                 .policyStore(policyStore)
@@ -180,7 +180,6 @@ class ProviderContractNegotiationManagerImplTest {
         var negotiation = contractNegotiationBuilder()
                 .state(AGREEING.code())
                 .contractOffer(contractOffer())
-                .contractAgreement(contractAgreementBuilder().policy(Policy.Builder.newInstance().build()).build())
                 .build();
         when(store.nextNotLeased(anyInt(), stateIs(AGREEING.code()))).thenReturn(List.of(negotiation)).thenReturn(emptyList());
         when(dispatcherRegistry.dispatch(any(), any())).thenReturn(completedFuture(StatusResult.success("any")));
@@ -190,8 +189,14 @@ class ProviderContractNegotiationManagerImplTest {
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(store).save(argThat(p -> p.getState() == AGREED.code()));
-            verify(dispatcherRegistry, only()).dispatch(any(), isA(ContractAgreementMessage.class));
+            var messageCaptor = ArgumentCaptor.forClass(ContractAgreementMessage.class);
+            verify(dispatcherRegistry, only()).dispatch(any(), messageCaptor.capture());
+            assertThat(messageCaptor.getValue().getPolicy().getType()).isEqualTo(CONTRACT);
+            var storedCaptor = ArgumentCaptor.forClass(ContractNegotiation.class);
+            verify(store).save(storedCaptor.capture());
+            var stored = storedCaptor.getValue();
+            assertThat(stored.getState()).isEqualTo(AGREED.code());
+            assertThat(stored.getContractAgreement().getPolicy().getType()).isEqualTo(CONTRACT);
             verify(listener).agreed(any());
         });
     }

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/policy/PolicyEqualityTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/policy/PolicyEqualityTest.java
@@ -20,6 +20,8 @@ import org.eclipse.edc.spi.types.TypeManager;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.policy.model.PolicyType.CONTRACT;
+import static org.eclipse.edc.policy.model.PolicyType.OFFER;
 
 class PolicyEqualityTest {
 
@@ -46,9 +48,9 @@ class PolicyEqualityTest {
     }
 
     @Test
-    void targetIsExcludedFromTheComparison() {
-        var one = Policy.Builder.newInstance().target("a").build();
-        var two = Policy.Builder.newInstance().target("b").build();
+    void policyTypeIsExcludedFromTheComparison() {
+        var one = Policy.Builder.newInstance().type(OFFER).build();
+        var two = Policy.Builder.newInstance().type(CONTRACT).build();
 
         var result = comparator.test(one, two);
 

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/api/validation/ContractOfferMessageValidator.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/api/validation/ContractOfferMessageValidator.java
@@ -17,9 +17,13 @@ package org.eclipse.edc.protocol.dsp.negotiation.api.validation;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferMessage;
 import org.eclipse.edc.validator.jsonobject.JsonObjectValidator;
+import org.eclipse.edc.validator.jsonobject.validators.MandatoryIdNotBlank;
+import org.eclipse.edc.validator.jsonobject.validators.MandatoryObject;
 import org.eclipse.edc.validator.jsonobject.validators.TypeIs;
 import org.eclipse.edc.validator.spi.Validator;
 
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIBUTE;
+import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_OFFER_MESSAGE;
 
 /**
@@ -29,6 +33,11 @@ public class ContractOfferMessageValidator {
     public static Validator<JsonObject> instance() {
         return JsonObjectValidator.newValidator()
                 .verify(path -> new TypeIs(path, DSPACE_TYPE_CONTRACT_OFFER_MESSAGE))
+                .verifyObject(DSPACE_PROPERTY_OFFER, v -> v
+                        .verifyId(MandatoryIdNotBlank::new)
+                        .verify(ODRL_TARGET_ATTRIBUTE, MandatoryObject::new)
+                        .verifyObject(ODRL_TARGET_ATTRIBUTE, b -> b.verifyId(MandatoryIdNotBlank::new))
+                )
                 .build();
     }
 }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/api/validation/ContractRequestMessageValidator.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/api/validation/ContractRequestMessageValidator.java
@@ -17,9 +17,13 @@ package org.eclipse.edc.protocol.dsp.negotiation.api.validation;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequestMessage;
 import org.eclipse.edc.validator.jsonobject.JsonObjectValidator;
+import org.eclipse.edc.validator.jsonobject.validators.MandatoryIdNotBlank;
+import org.eclipse.edc.validator.jsonobject.validators.MandatoryObject;
 import org.eclipse.edc.validator.jsonobject.validators.TypeIs;
 import org.eclipse.edc.validator.spi.Validator;
 
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIBUTE;
+import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE;
 
 /**
@@ -29,6 +33,11 @@ public class ContractRequestMessageValidator {
     public static Validator<JsonObject> instance() {
         return JsonObjectValidator.newValidator()
                 .verify(path -> new TypeIs(path, DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE))
+                .verifyObject(DSPACE_PROPERTY_OFFER, v -> v
+                        .verifyId(MandatoryIdNotBlank::new)
+                        .verify(ODRL_TARGET_ATTRIBUTE, MandatoryObject::new)
+                        .verifyObject(ODRL_TARGET_ATTRIBUTE, b -> b.verifyId(MandatoryIdNotBlank::new))
+                )
                 .build();
     }
 }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/api/validation/ContractOfferMessageValidatorTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/api/validation/ContractOfferMessageValidatorTest.java
@@ -15,16 +15,25 @@
 package org.eclipse.edc.protocol.dsp.negotiation.api.validation;
 
 import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.validator.spi.ValidationFailure;
 import org.eclipse.edc.validator.spi.Validator;
 import org.eclipse.edc.validator.spi.Violation;
 import org.junit.jupiter.api.Test;
 
+import java.util.UUID;
+
+import static jakarta.json.Json.createArrayBuilder;
+import static jakarta.json.Json.createObjectBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.list;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_OFFER;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIBUTE;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_OFFER_MESSAGE;
 
 class ContractOfferMessageValidatorTest {
@@ -35,6 +44,11 @@ class ContractOfferMessageValidatorTest {
     void shouldSucceed_whenObjectIsValid() {
         var input = Json.createObjectBuilder()
                 .add(TYPE, Json.createArrayBuilder().add(DSPACE_TYPE_CONTRACT_OFFER_MESSAGE))
+                .add(DSPACE_PROPERTY_OFFER, createArrayBuilder()
+                        .add(createObjectBuilder()
+                                .add(TYPE, ODRL_POLICY_TYPE_OFFER)
+                                .add(ID, UUID.randomUUID().toString())
+                                .add(ODRL_TARGET_ATTRIBUTE, id("target"))))
                 .build();
 
         var result = validator.validate(input);
@@ -53,4 +67,25 @@ class ContractOfferMessageValidatorTest {
                 .hasSize(1)
                 .anySatisfy(violation -> assertThat(violation.path()).isEqualTo(TYPE));
     }
+
+    @Test
+    void shouldFail_whenOfferMissesIdAndTarget() {
+        var input = createObjectBuilder()
+                .add(TYPE, createArrayBuilder().add(DSPACE_TYPE_CONTRACT_OFFER_MESSAGE))
+                .add(DSPACE_PROPERTY_OFFER, createArrayBuilder().add(createObjectBuilder()))
+                .build();
+
+        var result = validator.validate(input);
+
+        assertThat(result).isFailed().extracting(ValidationFailure::getViolations).asInstanceOf(list(Violation.class))
+                .hasSize(2)
+                .allSatisfy(violation -> assertThat(violation.path()).startsWith(DSPACE_PROPERTY_OFFER))
+                .anySatisfy(violation -> assertThat(violation.path()).endsWith(ID))
+                .anySatisfy(violation -> assertThat(violation.path()).endsWith(ODRL_TARGET_ATTRIBUTE));
+    }
+
+    private JsonArrayBuilder id(String id) {
+        return createArrayBuilder().add(createObjectBuilder().add(ID, id));
+    }
+
 }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/api/validation/ContractRequestMessageValidatorTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/api/validation/ContractRequestMessageValidatorTest.java
@@ -14,17 +14,25 @@
 
 package org.eclipse.edc.protocol.dsp.negotiation.api.validation;
 
-import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.validator.spi.ValidationFailure;
 import org.eclipse.edc.validator.spi.Validator;
 import org.eclipse.edc.validator.spi.Violation;
 import org.junit.jupiter.api.Test;
 
+import java.util.UUID;
+
+import static jakarta.json.Json.createArrayBuilder;
+import static jakarta.json.Json.createObjectBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.list;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_OFFER;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIBUTE;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE;
 
 class ContractRequestMessageValidatorTest {
@@ -33,8 +41,13 @@ class ContractRequestMessageValidatorTest {
 
     @Test
     void shouldSucceed_whenObjectIsValid() {
-        var input = Json.createObjectBuilder()
-                .add(TYPE, Json.createArrayBuilder().add(DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE))
+        var input = createObjectBuilder()
+                .add(TYPE, createArrayBuilder().add(DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE))
+                .add(DSPACE_PROPERTY_OFFER, createArrayBuilder()
+                        .add(createObjectBuilder()
+                                .add(TYPE, ODRL_POLICY_TYPE_OFFER)
+                                .add(ID, UUID.randomUUID().toString())
+                                .add(ODRL_TARGET_ATTRIBUTE, id("target"))))
                 .build();
 
         var result = validator.validate(input);
@@ -44,7 +57,7 @@ class ContractRequestMessageValidatorTest {
 
     @Test
     void shouldFail_whenMandatoryFieldsAreMissing() {
-        var input = Json.createObjectBuilder()
+        var input = createObjectBuilder()
                 .build();
 
         var result = validator.validate(input);
@@ -53,4 +66,25 @@ class ContractRequestMessageValidatorTest {
                 .hasSize(1)
                 .anySatisfy(violation -> assertThat(violation.path()).isEqualTo(TYPE));
     }
+
+    @Test
+    void shouldFail_whenOfferMissesIdAndTarget() {
+        var input = createObjectBuilder()
+                .add(TYPE, createArrayBuilder().add(DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE))
+                .add(DSPACE_PROPERTY_OFFER, createArrayBuilder().add(createObjectBuilder()))
+                .build();
+
+        var result = validator.validate(input);
+
+        assertThat(result).isFailed().extracting(ValidationFailure::getViolations).asInstanceOf(list(Violation.class))
+                .hasSize(2)
+                .allSatisfy(violation -> assertThat(violation.path()).startsWith(DSPACE_PROPERTY_OFFER))
+                .anySatisfy(violation -> assertThat(violation.path()).endsWith(ID))
+                .anySatisfy(violation -> assertThat(violation.path()).endsWith(ODRL_TARGET_ATTRIBUTE));
+    }
+
+    private JsonArrayBuilder id(String id) {
+        return createArrayBuilder().add(createObjectBuilder().add(ID, id));
+    }
+
 }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractRequestMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractRequestMessageTransformer.java
@@ -25,7 +25,6 @@ import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_DATASET;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS;
@@ -57,24 +56,20 @@ public class JsonObjectFromContractRequestMessageTransformer extends AbstractJso
         addIfNotNull(requestMessage.getProviderPid(), DSPACE_PROPERTY_PROVIDER_PID, builder);
         addIfNotNull(requestMessage.getCallbackAddress(), DSPACE_PROPERTY_CALLBACK_ADDRESS, builder);
 
-        if (requestMessage.getContractOffer() != null) {
-            builder.add(DSPACE_PROPERTY_DATASET, requestMessage.getContractOffer().getAssetId());
-            var policy = context.transform(requestMessage.getContractOffer().getPolicy(), JsonObject.class);
-            if (policy == null) {
-                context.problem()
-                        .nullProperty()
-                        .type(ContractRequestMessage.class)
-                        .property("contractOffer")
-                        .report();
-                return null;
-            }
-
-            var enrichedPolicy = Json.createObjectBuilder(policy)
-                    .add(ID, requestMessage.getContractOffer().getId())
-                    .build();
-            builder.add(DSPACE_PROPERTY_OFFER, enrichedPolicy);
-
+        var policy = context.transform(requestMessage.getContractOffer().getPolicy(), JsonObject.class);
+        if (policy == null) {
+            context.problem()
+                    .nullProperty()
+                    .type(ContractRequestMessage.class)
+                    .property("contractOffer")
+                    .report();
+            return null;
         }
+
+        var enrichedPolicy = Json.createObjectBuilder(policy)
+                .add(ID, requestMessage.getContractOffer().getId())
+                .build();
+        builder.add(DSPACE_PROPERTY_OFFER, enrichedPolicy);
 
         return builder.build();
     }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractRequestMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractRequestMessageTransformer.java
@@ -24,7 +24,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
-import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_DATASET;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS;
@@ -67,11 +66,6 @@ public class JsonObjectToContractRequestMessageTransformer extends AbstractJsonL
         var callback = requestObject.get(DSPACE_PROPERTY_CALLBACK_ADDRESS);
         if (callback != null) {
             builder.callbackAddress(transformString(callback, context));
-        }
-
-        var dataset = requestObject.get(DSPACE_PROPERTY_DATASET);
-        if (dataset != null) {
-            builder.dataset(transformString(dataset, context));
         }
 
         var contractOffer = returnJsonObject(requestObject.get(DSPACE_PROPERTY_OFFER), context, DSPACE_PROPERTY_OFFER, false);

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractRequestMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractRequestMessageTransformerTest.java
@@ -30,7 +30,6 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_DATASET;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS;
@@ -81,7 +80,6 @@ class JsonObjectFromContractRequestMessageTransformerTest {
         assertThat(result).isNotNull();
         assertThat(result.getJsonString(ID).getString()).isNotEmpty();
         assertThat(result.getJsonString(TYPE).getString()).isEqualTo(DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE);
-        assertThat(result.getJsonString(DSPACE_PROPERTY_DATASET).getString()).isEqualTo(DATASET_ID);
         assertThat(result.getJsonString(DSPACE_PROPERTY_CALLBACK_ADDRESS).getString()).isEqualTo(CALLBACK_ADDRESS);
         assertThat(result.getJsonObject(DSPACE_PROPERTY_OFFER)).isNotNull();
         assertThat(result.getJsonObject(DSPACE_PROPERTY_OFFER).getString(ID)).isEqualTo(CONTRACT_OFFER_ID);
@@ -110,8 +108,7 @@ class JsonObjectFromContractRequestMessageTransformerTest {
     private ContractRequestMessage.Builder contractRequestMessageBuilder() {
         return ContractRequestMessage.Builder.newInstance()
                 .protocol(PROTOCOL)
-                .callbackAddress(CALLBACK_ADDRESS)
-                .dataset(DATASET_ID);
+                .callbackAddress(CALLBACK_ADDRESS);
     }
 
     private ContractOffer contractOffer() {

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractRequestMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractRequestMessageTransformerTest.java
@@ -33,7 +33,6 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_OFFER;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.to.TestInput.getExpanded;
-import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_DATASET;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS;
@@ -51,7 +50,6 @@ import static org.mockito.Mockito.when;
 
 class JsonObjectToContractRequestMessageTransformerTest {
 
-    private static final String DATASET_ID = "datasetId";
     private static final String CALLBACK = "https://test.com";
     private static final String OBJECT_ID = "id1";
     private static final String CONTRACT_OFFER_ID = "contractOfferId";
@@ -74,7 +72,6 @@ class JsonObjectToContractRequestMessageTransformerTest {
                 .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE)
                 .add(DSPACE_PROPERTY_CONSUMER_PID, "consumerPid")
                 .add(DSPACE_PROPERTY_PROVIDER_PID, "providerPid")
-                .add(DSPACE_PROPERTY_DATASET, DATASET_ID)
                 .add(DSPACE_PROPERTY_CALLBACK_ADDRESS, CALLBACK)
                 .add(DSPACE_PROPERTY_OFFER, contractOffer())
                 .build();
@@ -88,7 +85,6 @@ class JsonObjectToContractRequestMessageTransformerTest {
         assertThat(result.getConsumerPid()).isEqualTo("consumerPid");
         assertThat(result.getProviderPid()).isEqualTo("providerPid");
         assertThat(result.getCallbackAddress()).isEqualTo(CALLBACK);
-        assertThat(result.getDataset()).isEqualTo(DATASET_ID);
 
         var contractOffer = result.getContractOffer();
         assertThat(contractOffer).isNotNull();
@@ -106,7 +102,6 @@ class JsonObjectToContractRequestMessageTransformerTest {
                 .add(JsonLdKeywords.ID, OBJECT_ID)
                 .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE)
                 .add(DSPACE_PROPERTY_PROCESS_ID, "processId")
-                .add(DSPACE_PROPERTY_DATASET, DATASET_ID)
                 .add(DSPACE_PROPERTY_CALLBACK_ADDRESS, CALLBACK)
                 .add(DSPACE_PROPERTY_OFFER, contractOffer())
                 .build();
@@ -119,7 +114,6 @@ class JsonObjectToContractRequestMessageTransformerTest {
         assertThat(result.getProtocol()).isNotEmpty();
         assertThat(result.getConsumerPid()).isEqualTo("processId");
         assertThat(result.getCallbackAddress()).isEqualTo(CALLBACK);
-        assertThat(result.getDataset()).isEqualTo(DATASET_ID);
 
         var contractOffer = result.getContractOffer();
         assertThat(contractOffer).isNotNull();
@@ -178,7 +172,6 @@ class JsonObjectToContractRequestMessageTransformerTest {
                 .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE)
                 .add(DSPACE_PROPERTY_CONSUMER_PID, "consumerPid")
                 .add(DSPACE_PROPERTY_PROVIDER_PID, "providerPid")
-                .add(DSPACE_PROPERTY_DATASET, DATASET_ID)
                 .add(DSPACE_PROPERTY_CALLBACK_ADDRESS, CALLBACK)
                 .add(DSPACE_PROPERTY_OFFER, contractOffer())
                 .build();

--- a/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/type/DspNegotiationPropertyAndTypeNames.java
+++ b/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/type/DspNegotiationPropertyAndTypeNames.java
@@ -37,7 +37,6 @@ public interface DspNegotiationPropertyAndTypeNames {
     String DSPACE_PROPERTY_EVENT_TYPE = DSPACE_SCHEMA + "eventType";
     String DSPACE_PROPERTY_AGREEMENT = DSPACE_SCHEMA + "agreement";
     String DSPACE_PROPERTY_OFFER = DSPACE_SCHEMA + "offer";
-    String DSPACE_PROPERTY_DATASET = DSPACE_SCHEMA + "dataset";
     String DSPACE_PROPERTY_TIMESTAMP = DSPACE_SCHEMA + "timestamp";
     String DSPACE_PROPERTY_CONSUMER_ID = DSPACE_SCHEMA + "consumerId";
     String DSPACE_PROPERTY_PROVIDER_ID = DSPACE_SCHEMA + "providerId";

--- a/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/api/management/catalog/CatalogApi.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/api/management/catalog/CatalogApi.java
@@ -153,8 +153,7 @@ public interface CatalogApi {
                                 }
                             },
                             "odrl:prohibition": [],
-                            "odrl:obligation": [],
-                            "odrl:target": "bcca61be-e82e-4da6-bfec-9716a56cef35"
+                            "odrl:obligation": []
                         },
                         "dcat:distribution": [
                             {
@@ -174,7 +173,7 @@ public interface CatalogApi {
                         "dct:terms": "connector",
                         "dct:endpointUrl": "http://localhost:16806/protocol"
                     },
-                    "participantId": "urn:connector:provider",
+                    "dspace:participantId": "urn:connector:provider",
                     "@context": {
                         "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
                         "dct": "https://purl.org/dc/terms/",

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApi.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApi.java
@@ -150,7 +150,7 @@ public interface ContractNegotiationApi {
                     "providerId": "provider-id",
                     "policy": {
                         "@context": "http://www.w3.org/ns/odrl.jsonld",
-                        "@type": "Set",
+                        "@type": "odrl:Offer",
                         "@id": "policy-id",
                         "permission": [],
                         "prohibition": [],

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/validation/ContractRequestValidator.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/validation/ContractRequestValidator.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.validator.jsonobject.JsonObjectValidator;
 import org.eclipse.edc.validator.jsonobject.validators.MandatoryIdNotBlank;
 import org.eclipse.edc.validator.jsonobject.validators.MandatoryObject;
 import org.eclipse.edc.validator.jsonobject.validators.MandatoryValue;
+import org.eclipse.edc.validator.jsonobject.validators.TypeIs;
 import org.eclipse.edc.validator.spi.ValidationResult;
 import org.eclipse.edc.validator.spi.Validator;
 
@@ -34,6 +35,7 @@ import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractR
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.OFFER;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.POLICY;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.PROTOCOL;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_OFFER;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIBUTE;
 
 public class ContractRequestValidator {
@@ -65,6 +67,7 @@ public class ContractRequestValidator {
                     .verify(POLICY, MandatoryObject::new)
                     .verifyObject(POLICY, builder -> builder
                             .verifyId(MandatoryIdNotBlank::new)
+                            .verify(path -> new TypeIs(path, ODRL_POLICY_TYPE_OFFER))
                             .verify(ODRL_TARGET_ATTRIBUTE, MandatoryObject::new)
                             .verifyObject(ODRL_TARGET_ATTRIBUTE, b -> b.verifyId(MandatoryIdNotBlank::new)))
                     .build();

--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/test/system/utils/Participant.java
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/test/system/utils/Participant.java
@@ -45,6 +45,7 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DATASET_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIBUTE;
 import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 
 /**
@@ -133,6 +134,7 @@ public class Participant {
                 .when()
                 .post("/v2/policydefinitions")
                 .then()
+                .log().ifError()
                 .statusCode(200)
                 .contentType(JSON)
                 .extract().jsonPath().getString(ID);
@@ -446,7 +448,8 @@ public class Participant {
     public String requestAsset(Participant provider, String assetId, JsonObject privateProperties, JsonObject destination, String transferType) {
         var dataset = getDatasetForAsset(provider, assetId);
         var policy = dataset.getJsonArray(ODRL_POLICY_ATTRIBUTE).get(0).asJsonObject();
-        var contractAgreementId = negotiateContract(provider, policy);
+        var policyWithTarget = createObjectBuilder(policy).add(ODRL_TARGET_ATTRIBUTE, createObjectBuilder().add(ID, dataset.get(ID))).build();
+        var contractAgreementId = negotiateContract(provider, policyWithTarget);
         var transferProcessId = initiateTransfer(provider, contractAgreementId, assetId, privateProperties, destination, transferType);
         assertThat(transferProcessId).isNotNull();
         return transferProcessId;

--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/test/system/utils/PolicyFixtures.java
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/test/system/utils/PolicyFixtures.java
@@ -22,6 +22,7 @@ import static jakarta.json.Json.createArrayBuilder;
 import static jakarta.json.Json.createObjectBuilder;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_SET;
 import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 
 /**
@@ -38,13 +39,14 @@ public class PolicyFixtures {
     public static JsonObject noConstraintPolicy() {
         return createObjectBuilder()
                 .add(CONTEXT, ODRL_JSONLD)
-                .add(TYPE, "use")
+                .add(TYPE, ODRL_POLICY_TYPE_SET)
                 .build();
     }
 
     public static JsonObject policy(List<JsonObject> permissions) {
         return createObjectBuilder()
                 .add(CONTEXT, ODRL_JSONLD)
+                .add(TYPE, ODRL_POLICY_TYPE_SET)
                 .add("permission", createArrayBuilder(permissions))
                 .build();
     }

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/transform/JsonObjectToPolicyDefinitionTransformer.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/transform/JsonObjectToPolicyDefinitionTransformer.java
@@ -15,13 +15,14 @@
 package org.eclipse.edc.connector.api.management.policy.transform;
 
 import jakarta.json.JsonObject;
-import jakarta.json.JsonValue;
 import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
 
 import static org.eclipse.edc.connector.policy.spi.PolicyDefinition.EDC_POLICY_DEFINITION_POLICY;
 import static org.eclipse.edc.connector.policy.spi.PolicyDefinition.EDC_POLICY_DEFINITION_PRIVATE_PROPERTIES;
@@ -36,22 +37,25 @@ public class JsonObjectToPolicyDefinitionTransformer extends AbstractJsonLdTrans
     public @Nullable PolicyDefinition transform(@NotNull JsonObject input, @NotNull TransformerContext context) {
         var builder = PolicyDefinition.Builder.newInstance();
         builder.id(nodeId(input));
-        visitProperties(input, (key, value) -> transformProperties(key, value, builder, context));
+
+        var policy = Optional.of(EDC_POLICY_DEFINITION_POLICY)
+                .map(input::get)
+                .map(it -> transformObject(it, Policy.class, context))
+                .orElse(null);
+
+        if (policy == null) {
+            return null;
+        } else {
+            builder.policy(policy);
+        }
+
+        var privateProperties = input.get(EDC_POLICY_DEFINITION_PRIVATE_PROPERTIES);
+        if (privateProperties != null) {
+            var props = privateProperties.asJsonArray().getJsonObject(0);
+            visitProperties(props, (key, value) -> builder.privateProperty(key, transformGenericProperty(value, context)));
+        }
+
         return builder.build();
     }
 
-    private void transformProperties(String key, JsonValue jsonValue, PolicyDefinition.Builder builder, TransformerContext context) {
-        switch (key) {
-            case EDC_POLICY_DEFINITION_POLICY ->
-                    transformArrayOrObject(jsonValue, Policy.class, builder::policy, context);
-            case EDC_POLICY_DEFINITION_PRIVATE_PROPERTIES -> {
-                var props = jsonValue.asJsonArray().getJsonObject(0);
-                visitProperties(props, (k, val) -> transformProperties(k, val, builder, context));
-            }
-            default -> {
-                builder.privateProperty(key, transformGenericProperty(jsonValue, context));
-            }
-        }
-
-    }
 }

--- a/spi/common/policy-model/src/main/java/org/eclipse/edc/policy/model/Policy.java
+++ b/spi/common/policy-model/src/main/java/org/eclipse/edc/policy/model/Policy.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * A collection of permissions, prohibitions, and obligations. Subtypes are defined by
@@ -107,7 +106,6 @@ public class Policy {
                 Objects.equals(inheritsFrom, policy.inheritsFrom) && Objects.equals(assigner, policy.assigner) && Objects.equals(assignee, policy.assignee) && Objects.equals(target, policy.target) && type == policy.type;
     }
 
-
     /**
      * Returns a copy of this policy with the specified target.
      *
@@ -116,9 +114,9 @@ public class Policy {
      */
     public Policy withTarget(String target) {
         return Builder.newInstance()
-                .prohibitions(prohibitions.stream().map(p -> p.withTarget(target)).collect(Collectors.toList()))
-                .permissions(permissions.stream().map(p -> p.withTarget(target)).collect(Collectors.toList()))
-                .duties(obligations.stream().map(o -> o.withTarget(target)).collect(Collectors.toList()))
+                .prohibitions(prohibitions)
+                .permissions(permissions)
+                .duties(obligations)
                 .assigner(assigner)
                 .assignee(assignee)
                 .inheritsFrom(inheritsFrom)
@@ -133,9 +131,9 @@ public class Policy {
      */
     public Builder toBuilder() {
         return Builder.newInstance()
-                .prohibitions(prohibitions.stream().map(p -> p.withTarget(target)).collect(Collectors.toList()))
-                .permissions(permissions.stream().map(p -> p.withTarget(target)).collect(Collectors.toList()))
-                .duties(obligations.stream().map(o -> o.withTarget(target)).collect(Collectors.toList()))
+                .prohibitions(prohibitions)
+                .permissions(permissions)
+                .duties(obligations)
                 .assigner(assigner)
                 .assignee(assignee)
                 .inheritsFrom(inheritsFrom)
@@ -188,11 +186,6 @@ public class Policy {
         @JsonProperty("obligations")
         public Builder duties(List<Duty> duties) {
             policy.obligations.addAll(duties);
-            return this;
-        }
-
-        public Builder duty(String inheritsFrom) {
-            policy.inheritsFrom = inheritsFrom;
             return this;
         }
 

--- a/spi/common/policy-model/src/test/java/org/eclipse/edc/policy/model/PolicyTest.java
+++ b/spi/common/policy-model/src/test/java/org/eclipse/edc/policy/model/PolicyTest.java
@@ -56,9 +56,6 @@ class PolicyTest {
         var copy = policy.withTarget(target);
 
         assertThat(copy.getPermissions().size()).isEqualTo(policy.getPermissions().size());
-        copy.getPermissions().forEach(p -> assertThat(p.getTarget()).isEqualTo(target));
-        copy.getProhibitions().forEach(p -> assertThat(p.getTarget()).isEqualTo(target));
-        copy.getObligations().forEach(o -> assertThat(o.getTarget()).isEqualTo(target));
         assertThat(copy.getAssigner()).isEqualTo(policy.getAssigner());
         assertThat(copy.getAssignee()).isEqualTo(policy.getAssignee());
         assertThat(copy.getInheritsFrom()).isEqualTo(policy.getInheritsFrom());

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessage.java
@@ -32,7 +32,6 @@ public class ContractRequestMessage extends ContractRemoteMessage {
     private String callbackAddress;
 
     private ContractOffer contractOffer;
-    private String dataset;
 
     public Type getType() {
         return type;
@@ -41,10 +40,6 @@ public class ContractRequestMessage extends ContractRemoteMessage {
     @NotNull
     public ContractOffer getContractOffer() {
         return contractOffer;
-    }
-
-    public String getDataset() {
-        return dataset;
     }
 
     public String getCallbackAddress() {
@@ -83,11 +78,6 @@ public class ContractRequestMessage extends ContractRemoteMessage {
 
         public Builder type(Type type) {
             message.type = type;
-            return this;
-        }
-
-        public Builder dataset(String dataset) {
-            message.dataset = dataset;
             return this;
         }
 

--- a/spi/control-plane/contract-spi/src/test/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessageTest.java
+++ b/spi/control-plane/contract-spi/src/test/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequestMessageTest.java
@@ -24,8 +24,6 @@ import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractR
 
 class ContractRequestMessageTest {
     public static final String CALLBACK_ADDRESS = "http://test.com";
-    public static final String OFFER_ID = "offerId";
-    public static final String DATASET = "dataset1";
     public static final String ID = "id1";
     public static final String ASSET_ID = "asset1";
     public static final String PROTOCOL = "DPS";
@@ -42,7 +40,6 @@ class ContractRequestMessageTest {
                         .assetId(ASSET_ID)
                         .policy(Policy.Builder.newInstance().build())
                         .build())
-                .dataset(DATASET)
                 .build();
     }
 
@@ -58,7 +55,6 @@ class ContractRequestMessageTest {
                         .assetId(ASSET_ID)
                         .policy(Policy.Builder.newInstance().build())
                         .build())
-                .dataset(DATASET)
                 .counterPartyAddress(CALLBACK_ADDRESS)
                 .build();
 
@@ -68,7 +64,6 @@ class ContractRequestMessageTest {
                 .consumerPid("consumerPid")
                 .providerPid("providerPid")
                 .protocol(PROTOCOL)
-                .dataset(DATASET)
                 .counterPartyAddress(CALLBACK_ADDRESS)
                 .build()).isInstanceOf(NullPointerException.class).hasMessageContaining("contractOffer");
 

--- a/system-tests/telemetry/telemetry-test-runner/src/test/java/org/eclipse/edc/test/e2e/tracing/TracingEndToEndTest.java
+++ b/system-tests/telemetry/telemetry-test-runner/src/test/java/org/eclipse/edc/test/e2e/tracing/TracingEndToEndTest.java
@@ -81,7 +81,7 @@ public class TracingEndToEndTest extends BaseTelemetryEndToEndTest {
                 .add("consumerId", "test-consumer-id")
                 .add("policy", Json.createObjectBuilder()
                         .add(CONTEXT, "http://www.w3.org/ns/odrl.jsonld")
-                        .add(TYPE, "use")
+                        .add(TYPE, "Offer")
                         .add(ID, "offer-id")
                         .add("target", "test-asset")
                         .build())


### PR DESCRIPTION
## What this PR changes/adds

Remove the `odrl:target` in the policies contained in the catalog dataset.
Other related improvements:
- correclty mapping `PolicyType` to ODRL `@type`, ingress and egress
- set `Offer` type for policies in the dataset
- set `Agreement` type for generated `ContractAgreement`
- add policy validation on `ContractRequestMessage` and `ContractOfferMessage`

**BREAKING CHANGES**:
- catalog policies won't contain the `odrl:target` anymore, the client will need to add it before calling the contract request endpoint. 
- the `POST /contractnegotiations` management-api call will require the `policy` to have the type `Offer`

## Why it does that

dsp compliance 

## Further notes

- changed `Policy.withTarget` to avoid setting target on included rules, that will be anyway removed in #3872 

## Linked Issue(s)

Closes #3843

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
