### PR TITLE
fix: multiple fix in `Iatp` modules

### DIFF
--- a/core/common/token-core/src/main/java/org/eclipse/edc/token/TokenValidationRulesRegistryImpl.java
+++ b/core/common/token-core/src/main/java/org/eclipse/edc/token/TokenValidationRulesRegistryImpl.java
@@ -23,6 +23,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static java.util.Collections.emptyList;
+
 /**
  * In-memory implementation of {@link TokenValidationRulesRegistry}
  */
@@ -38,6 +40,6 @@ public class TokenValidationRulesRegistryImpl implements TokenValidationRulesReg
 
     @Override
     public List<TokenValidationRule> getRules(String context) {
-        return Collections.unmodifiableList(rules.get(context));
+        return Collections.unmodifiableList(rules.getOrDefault(context, emptyList()));
     }
 }

--- a/extensions/common/crypto/jwt-verifiable-credentials/src/main/java/org/eclipse/edc/verifiablecredentials/jwt/JwtPresentationVerifier.java
+++ b/extensions/common/crypto/jwt-verifiable-credentials/src/main/java/org/eclipse/edc/verifiablecredentials/jwt/JwtPresentationVerifier.java
@@ -60,6 +60,9 @@ import java.util.Map;
  * <em>Note: VP-JWTs may only contain VCs also represented in JWT format. Mixing formats is not allowed.</em>
  */
 public class JwtPresentationVerifier implements CredentialVerifier {
+
+    public static final String JWT_VC_TOKEN_CONTEXT = "iatp-vc";
+    public static final String JWT_VP_TOKEN_CONTEXT = "iatp-vp";
     public static final String VERIFIABLE_CREDENTIAL_JSON_KEY = "verifiableCredential";
     public static final String VP_CLAIM = "vp";
     public static final String VC_CLAIM = "vc";
@@ -99,7 +102,7 @@ public class JwtPresentationVerifier implements CredentialVerifier {
     public Result<Void> verify(String serializedJwt, VerifierContext context) {
 
         // verify the "outer" JWT, i.e. the VP JWT
-        var audience = context.getAudience();
+
         Result<ClaimToken> verificationResult;
 
         // verify all "inner" VC JWTs
@@ -107,20 +110,16 @@ public class JwtPresentationVerifier implements CredentialVerifier {
             // obtain the actual JSON structure
             var signedJwt = SignedJWT.parse(serializedJwt);
             if (isCredential(signedJwt)) {
-                verificationResult = tokenValidationService.validate(serializedJwt, publicKeyResolver, getCredentialRules(audience, "iatp-vc"));
-                if (verificationResult.failed()) {
-                    return verificationResult.mapTo();
-                }
-                return verificationResult.mapTo();
+                return tokenValidationService.validate(serializedJwt, publicKeyResolver, tokenValidationRulesRegistry.getRules(JWT_VC_TOKEN_CONTEXT))
+                        .mapTo();
             }
 
             if (!isPresentation(signedJwt)) {
                 return Result.failure("Either '%s' or '%s' claim must be present in JWT.".formatted(VP_CLAIM, VC_CLAIM));
             }
 
-
             //we can be sure to have a presentation token
-            verificationResult = tokenValidationService.validate(serializedJwt, publicKeyResolver, getCredentialRules(audience, "iatp-vp"));
+            verificationResult = tokenValidationService.validate(serializedJwt, publicKeyResolver, vpValidationRules(context.getAudience()));
 
             var vpClaim = signedJwt.getJWTClaimsSet().getClaim(VP_CLAIM);
             var vpJson = vpClaim.toString();
@@ -138,8 +137,8 @@ public class JwtPresentationVerifier implements CredentialVerifier {
             }
 
             // every VC is represented as another JWT, so we verify all of them
-            for (String token : rawCredentials) {
-                verificationResult = verificationResult.merge(context.withAudience(signedJwt.getJWTClaimsSet().getIssuer()).verify(token));
+            for (var token : rawCredentials) {
+                verificationResult = verificationResult.merge(context.toBuilder().audience(signedJwt.getJWTClaimsSet().getIssuer()).build().verify(token));
             }
 
         } catch (ParseException | JsonProcessingException e) {
@@ -148,10 +147,9 @@ public class JwtPresentationVerifier implements CredentialVerifier {
         return verificationResult.mapTo();
     }
 
-
-    private List<TokenValidationRule> getCredentialRules(String audience, String ruleContext) {
+    private List<TokenValidationRule> vpValidationRules(String audience) {
         var audRule = new AudienceValidationRule(audience);
-        var rules = new ArrayList<>(tokenValidationRulesRegistry.getRules(ruleContext));
+        var rules = new ArrayList<>(tokenValidationRulesRegistry.getRules(JWT_VP_TOKEN_CONTEXT));
         rules.add(audRule);
         return rules;
     }

--- a/extensions/common/crypto/jwt-verifiable-credentials/src/main/java/org/eclipse/edc/verifiablecredentials/jwt/rules/HasSubjectRule.java
+++ b/extensions/common/crypto/jwt-verifiable-credentials/src/main/java/org/eclipse/edc/verifiablecredentials/jwt/rules/HasSubjectRule.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (c) 2024 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.verifiablecredentials.jwt.rules;
+
+import com.nimbusds.jwt.JWTClaimNames;
+import org.eclipse.edc.spi.iam.ClaimToken;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.token.spi.TokenValidationRule;
+import org.eclipse.edc.util.string.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
+
+/**
+ * Checks that the 'sub' claim contains a non-empty value.
+ */
+public class HasSubjectRule implements TokenValidationRule {
+
+    @Override
+    public Result<Void> checkRule(@NotNull ClaimToken toVerify, @Nullable Map<String, Object> additional) {
+        return StringUtils.isNullOrEmpty(toVerify.getStringClaim(JWTClaimNames.SUBJECT)) ?
+                Result.failure("The '%s' claim is mandatory and must not be null.".formatted(JWTClaimNames.SUBJECT)) :
+                Result.success();
+    }
+}

--- a/extensions/common/crypto/jwt-verifiable-credentials/src/test/java/org/eclipse/edc/verifiablecredentials/jwt/JwtPresentationVerifierTest.java
+++ b/extensions/common/crypto/jwt-verifiable-credentials/src/test/java/org/eclipse/edc/verifiablecredentials/jwt/JwtPresentationVerifierTest.java
@@ -19,26 +19,25 @@ import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
-import com.nimbusds.jwt.JWTClaimNames;
 import org.eclipse.edc.identitytrust.verification.VerifierContext;
 import org.eclipse.edc.jsonld.util.JacksonJsonLd;
 import org.eclipse.edc.junit.annotations.ComponentTest;
-import org.eclipse.edc.junit.assertions.AbstractResultAssert;
 import org.eclipse.edc.spi.iam.PublicKeyResolver;
-import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.token.TokenValidationRulesRegistryImpl;
 import org.eclipse.edc.token.TokenValidationServiceImpl;
 import org.eclipse.edc.token.spi.TokenValidationRulesRegistry;
 import org.eclipse.edc.token.spi.TokenValidationService;
+import org.eclipse.edc.verifiablecredentials.jwt.rules.HasSubjectRule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
-import java.util.Optional;
 
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.spi.result.Result.success;
 import static org.eclipse.edc.verifiablecredentials.TestFunctions.createPublicKey;
+import static org.eclipse.edc.verifiablecredentials.jwt.JwtPresentationVerifier.JWT_VP_TOKEN_CONTEXT;
 import static org.eclipse.edc.verifiablecredentials.jwt.TestConstants.CENTRAL_ISSUER_DID;
 import static org.eclipse.edc.verifiablecredentials.jwt.TestConstants.CENTRAL_ISSUER_KEY_ID;
 import static org.eclipse.edc.verifiablecredentials.jwt.TestConstants.MY_OWN_DID;
@@ -82,11 +81,7 @@ class JwtPresentationVerifierTest {
 
 
         // those rules would normally get registered in an extension
-        ruleRegistry.addRule("iatp-vc", (toVerify, additional) -> Optional.ofNullable(toVerify.getStringClaim(JWTClaimNames.SUBJECT)).map(s ->
-                Result.success()).orElseGet(() -> Result.failure("Token could not be verified: Claim verification failed. JWT missing required claims: [sub]")).mapTo());
-
-        ruleRegistry.addRule("iatp-vp", (toVerify, additional) -> Optional.ofNullable(toVerify.getStringClaim(JWTClaimNames.SUBJECT)).map(s ->
-                Result.success()).orElseGet(() -> Result.failure("Token could not be verified: Claim verification failed. JWT missing required claims: [sub]")).mapTo());
+        ruleRegistry.addRule(JWT_VP_TOKEN_CONTEXT, new HasSubjectRule());
     }
 
     @Test
@@ -100,7 +95,7 @@ class JwtPresentationVerifierTest {
                 .audience(MY_OWN_DID)
                 .build();
         var result = verifier.verify(vpJwt, context);
-        AbstractResultAssert.assertThat(result).isFailed().detail().contains("Either 'vp' or 'vc' claim must be present in JWT.");
+        assertThat(result).isFailed().detail().contains("Either 'vp' or 'vc' claim must be present in JWT.");
     }
 
     @DisplayName("VP-JWT does not contain any credential")
@@ -114,7 +109,7 @@ class JwtPresentationVerifierTest {
                 .audience(MY_OWN_DID)
                 .build();
         var result = verifier.verify(vpJwt, context);
-        AbstractResultAssert.assertThat(result).isSucceeded();
+        assertThat(result).isSucceeded();
     }
 
     @DisplayName("VP-JWT does not contain \"verifiablePresentation\" object")
@@ -132,7 +127,7 @@ class JwtPresentationVerifierTest {
                 .audience(MY_OWN_DID)
                 .build();
         var result = verifier.verify(vpJwt, context);
-        AbstractResultAssert.assertThat(result).isFailed().detail().contains("Presentation object did not contain mandatory object: verifiableCredential");
+        assertThat(result).isFailed().detail().contains("Presentation object did not contain mandatory object: verifiableCredential");
     }
 
     @DisplayName("VP-JWT with a single VC-JWT - both are successfully verified")
@@ -149,7 +144,7 @@ class JwtPresentationVerifierTest {
                 .audience(MY_OWN_DID)
                 .build();
         var result = verifier.verify(vpJwt, context);
-        AbstractResultAssert.assertThat(result).isSucceeded();
+        assertThat(result).isSucceeded();
     }
 
     @DisplayName("VP-JWT with a multiple VC-JWTs - all are successfully verified")
@@ -170,7 +165,7 @@ class JwtPresentationVerifierTest {
                 .audience(MY_OWN_DID)
                 .build();
         var result = verifier.verify(vpJwt, context);
-        AbstractResultAssert.assertThat(result).isSucceeded();
+        assertThat(result).isSucceeded();
     }
 
     @DisplayName("VP-JWT with one spoofed VC-JWT - expect a failure")
@@ -191,7 +186,7 @@ class JwtPresentationVerifierTest {
                 .audience(MY_OWN_DID)
                 .build();
         var result = verifier.verify(vpJwt, context);
-        AbstractResultAssert.assertThat(result).isFailed().detail().contains("Token verification failed");
+        assertThat(result).isFailed().detail().contains("Token verification failed");
     }
 
     @DisplayName("VP-JWT with a spoofed signature - expect a failure")
@@ -211,7 +206,7 @@ class JwtPresentationVerifierTest {
                 .audience(MY_OWN_DID)
                 .build();
         var result = verifier.verify(vpJwt, context);
-        AbstractResultAssert.assertThat(result).isFailed().detail().contains("Token verification failed");
+        assertThat(result).isFailed().detail().contains("Token verification failed");
     }
 
     @DisplayName("VP-JWT with a missing claim - expect a failure")
@@ -228,24 +223,7 @@ class JwtPresentationVerifierTest {
                 .audience(MY_OWN_DID)
                 .build();
         var result = verifier.verify(vpJwt, context);
-        AbstractResultAssert.assertThat(result).isFailed().detail().contains("Token could not be verified: Claim verification failed. JWT missing required claims: [sub]");
-    }
-
-    @DisplayName("VP-JWT with a VC-JWT, which misses a claim - expect a failure")
-    @Test
-    void verifyPresentation_vcJwt_invalidClaims() {
-        // create VC-JWT (signed by the central issuer)
-        var vcJwt1 = JwtCreationUtils.createJwt(vcSigningKey, CENTRAL_ISSUER_DID, null, VP_HOLDER_ID, Map.of("vc", VC_CONTENT_DEGREE_EXAMPLE));
-
-        // create VP-JWT (signed by the presenter) that contains the VP as a claim
-        var vpJwt = JwtCreationUtils.createJwt(vpSigningKey, VP_HOLDER_ID, "test-subject", MY_OWN_DID, Map.of("vp", VP_CONTENT_TEMPLATE.formatted("\"" + vcJwt1 + "\"")));
-
-        var context = VerifierContext.Builder.newInstance()
-                .verifier(verifier)
-                .audience(MY_OWN_DID)
-                .build();
-        var result = verifier.verify(vpJwt, context);
-        AbstractResultAssert.assertThat(result).isFailed().detail().contains("Token could not be verified: Claim verification failed. JWT missing required claims: [sub]");
+        assertThat(result).isFailed().detail().contains("The 'sub' claim is mandatory and must not be null.");
     }
 
     @DisplayName("VP-JWT with a wrong audience")
@@ -262,30 +240,7 @@ class JwtPresentationVerifierTest {
                 .audience(MY_OWN_DID)
                 .build();
         var result = verifier.verify(vpJwt, context);
-        AbstractResultAssert.assertThat(result).isFailed().detail().contains("Token audience claim (aud -> [invalid-vp-audience]) did not contain expected audience: did:web:myself");
+        assertThat(result).isFailed().detail().contains("Token audience claim (aud -> [invalid-vp-audience]) did not contain expected audience: did:web:myself");
     }
 
-    @DisplayName("VP-JWT containing a VC-JWT, where the VC-audience does not match the VP-issuer")
-    @Test
-    void verifyPresentation_vcJwt_wrongAudience() {
-        // create first VC-JWT (signed by the central issuer)
-        var vcJwt1 = JwtCreationUtils.createJwt(vcSigningKey, CENTRAL_ISSUER_DID, "degreeSub", VP_HOLDER_ID, Map.of("vc", VC_CONTENT_DEGREE_EXAMPLE));
-
-        // create first VC-JWT (signed by the central issuer)
-        var vcJwt2 = JwtCreationUtils.createJwt(vcSigningKey, CENTRAL_ISSUER_DID, "isoCred", "invalid-vc-audience", Map.of("vc", VC_CONTENT_CERTIFICATE_EXAMPLE));
-
-        // create VP-JWT (signed by the presenter) that contains the VP as a claim
-        var vpContent = "\"%s\", \"%s\"".formatted(vcJwt1, vcJwt2);
-        var vpJwt = JwtCreationUtils.createJwt(vpSigningKey, VP_HOLDER_ID, "testSub", MY_OWN_DID, Map.of("vp", VP_CONTENT_TEMPLATE.formatted(vpContent)));
-
-        var context = VerifierContext.Builder.newInstance()
-                .verifier(verifier)
-                .audience(MY_OWN_DID)
-                .build();
-        var result = verifier.verify(vpJwt, context);
-        AbstractResultAssert.assertThat(result)
-                .isFailed()
-                .detail()
-                .isEqualTo("Token audience claim (aud -> [invalid-vc-audience]) did not contain expected audience: did:web:test-issuer");
-    }
 }

--- a/extensions/common/crypto/jwt-verifiable-credentials/src/test/java/org/eclipse/edc/verifiablecredentials/jwt/rules/HasSubjectRuleTest.java
+++ b/extensions/common/crypto/jwt-verifiable-credentials/src/test/java/org/eclipse/edc/verifiablecredentials/jwt/rules/HasSubjectRuleTest.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2024 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.verifiablecredentials.jwt.rules;
+
+import org.eclipse.edc.spi.iam.ClaimToken;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+
+class HasSubjectRuleTest {
+
+    private final HasSubjectRule rule = new HasSubjectRule();
+
+    @Test
+    void subjectClaimPresent() {
+        assertThat(rule.checkRule(ClaimToken.Builder.newInstance().claim("sub", "subject-test").build(), Map.of()))
+                .isSucceeded();
+    }
+
+    @Test
+    void subjectClaimEmpty() {
+        assertThat(rule.checkRule(ClaimToken.Builder.newInstance().claim("sub", "").build(), Map.of()))
+                .isFailed()
+                .detail()
+                .isEqualTo("The 'sub' claim is mandatory and must not be null.");
+    }
+
+    @Test
+    void subjectClaimNotPresent() {
+        assertThat(rule.checkRule(ClaimToken.Builder.newInstance().build(), Map.of()))
+                .isFailed()
+                .detail()
+                .isEqualTo("The 'sub' claim is mandatory and must not be null.");
+    }
+}

--- a/extensions/common/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/edc/iam/did/resolution/DidPublicKeyResolverImpl.java
+++ b/extensions/common/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/edc/iam/did/resolution/DidPublicKeyResolverImpl.java
@@ -54,6 +54,10 @@ public class DidPublicKeyResolverImpl extends AbstractPublicKeyResolver implemen
 
     @Override
     protected Result<String> resolveInternal(String id) {
+        if (id == null) {
+            return Result.failure("The provided DID is null");
+        }
+
         var matcher = PATTERN_DID_WITH_OPTIONAL_FRAGMENT.matcher(id);
         if (!matcher.matches()) {
             throw new IllegalArgumentException("The given ID must conform to 'did:method:identifier[:fragment]' but did not"); //todo: use Result?

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/IdentityAndTrustService.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/IdentityAndTrustService.java
@@ -132,7 +132,6 @@ public class IdentityAndTrustService implements IdentityService {
 
     @Override
     public Result<ClaimToken> verifyJwtToken(TokenRepresentation tokenRepresentation, VerificationContext context) {
-
         var claimTokenResult = tokenValidationAction.apply(tokenRepresentation);
 
         if (claimTokenResult.failed()) {

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/validation/rules/HasValidSubjectIds.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/validation/rules/HasValidSubjectIds.java
@@ -37,7 +37,8 @@ public class HasValidSubjectIds implements CredentialValidationRule {
 
     @Override
     public Result<Void> apply(VerifiableCredential credential) {
-        return credential.getCredentialSubject().stream().allMatch(sub -> expectedSubjectId.equals(sub.getId())) ?
+        return credential.getCredentialSubjects().stream()
+                .allMatch(sub -> expectedSubjectId.equals(sub.getId())) ?
                 success() : failure("Not all subject IDs match the expected subject ID %s".formatted(expectedSubjectId));
     }
 }

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/verification/MultiFormatPresentationVerifier.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/verification/MultiFormatPresentationVerifier.java
@@ -20,6 +20,8 @@ import org.eclipse.edc.identitytrust.verification.PresentationVerifier;
 import org.eclipse.edc.identitytrust.verification.VerifierContext;
 import org.eclipse.edc.spi.result.Result;
 
+import java.util.List;
+
 public class MultiFormatPresentationVerifier implements PresentationVerifier {
 
     private final VerifierContext context;
@@ -27,7 +29,7 @@ public class MultiFormatPresentationVerifier implements PresentationVerifier {
     public MultiFormatPresentationVerifier(String audience, CredentialVerifier... verifiers) {
 
         this.context = VerifierContext.Builder.newInstance()
-                .verifiers(verifiers)
+                .verifiers(List.of(verifiers))
                 .audience(audience).build();
     }
 

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/test/java/org/eclipse/edc/iam/identitytrust/service/IdentityAndTrustServiceTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/test/java/org/eclipse/edc/iam/identitytrust/service/IdentityAndTrustServiceTest.java
@@ -104,8 +104,8 @@ class IdentityAndTrustServiceTest {
     @Nested
     class ObtainClientCredentials {
         @ParameterizedTest(name = "{0}")
-        @ValueSource(strings = { "org.eclipse.edc:TestCredential:modify", "org.eclipse.edc:TestCredential:", "org.eclipse.edc:TestCredential: ", "org.eclipse.edc:TestCredential:write*", ":TestCredential:read",
-                "org.eclipse.edc:fooCredential:+" })
+        @ValueSource(strings = {"org.eclipse.edc:TestCredential:modify", "org.eclipse.edc:TestCredential:", "org.eclipse.edc:TestCredential: ", "org.eclipse.edc:TestCredential:write*", ":TestCredential:read",
+                "org.eclipse.edc:fooCredential:+"})
         void obtainClientCredentials_invalidScopeString(String scope) {
             var tp = TokenParameters.Builder.newInstance()
                     .claims(SCOPE, scope)
@@ -118,8 +118,8 @@ class IdentityAndTrustServiceTest {
         }
 
         @ParameterizedTest(name = "Scope: {0}")
-        @ValueSource(strings = { "org.eclipse.edc:TestCredential:modify", "org.eclipse.edc:TestCredential:", "org.eclipse.edc:TestCredential: ", "org.eclipse.edc:TestCredential:write*", ":TestCredential:read",
-                "org.eclipse.edc:fooCredential:+" })
+        @ValueSource(strings = {"org.eclipse.edc:TestCredential:modify", "org.eclipse.edc:TestCredential:", "org.eclipse.edc:TestCredential: ", "org.eclipse.edc:TestCredential:write*", ":TestCredential:read",
+                "org.eclipse.edc:fooCredential:+"})
         @NullSource
         @EmptySource
         void obtainClientCredentials_validScopeString(String scope) {
@@ -291,7 +291,7 @@ class IdentityAndTrustServiceTest {
                     .satisfies(ct -> {
                         var vc = (List<VerifiableCredential>) ct.getListClaim("vc");
                         Assertions.assertThat(vc).hasSize(1);
-                        Assertions.assertThat(vc.get(0).getCredentialSubject().get(0).getClaims()).containsEntry("some-claim", "some-val");
+                        Assertions.assertThat(vc.get(0).getCredentialSubjects().get(0).getClaims()).containsEntry("some-claim", "some-val");
                     });
         }
 
@@ -322,8 +322,8 @@ class IdentityAndTrustServiceTest {
                     .satisfies(ct -> {
                         var credentials = (List<VerifiableCredential>) ct.getClaims().get("vc");
                         Assertions.assertThat(credentials).hasSize(2);
-                        Assertions.assertThat(credentials.get(0).getCredentialSubject().get(0).getClaims()).containsEntry("some-claim", "some-val");
-                        Assertions.assertThat(credentials.get(1).getCredentialSubject().get(0).getClaims()).containsEntry("some-other-claim", "some-other-val");
+                        Assertions.assertThat(credentials.get(0).getCredentialSubjects().get(0).getClaims()).containsEntry("some-claim", "some-val");
+                        Assertions.assertThat(credentials.get(1).getCredentialSubjects().get(0).getClaims()).containsEntry("some-other-claim", "some-other-val");
                     });
         }
 
@@ -374,10 +374,10 @@ class IdentityAndTrustServiceTest {
                     .satisfies(ct -> {
                         var credentials = (List<VerifiableCredential>) ct.getListClaim("vc");
                         Assertions.assertThat(credentials).hasSize(4);
-                        Assertions.assertThat(credentials).anySatisfy(vc -> Assertions.assertThat(vc.getCredentialSubject().get(0).getClaims()).containsEntry("some-claim", "some-val"));
-                        Assertions.assertThat(credentials).anySatisfy(vc -> Assertions.assertThat(vc.getCredentialSubject().get(0).getClaims()).containsEntry("some-other-claim", "some-other-val"));
-                        Assertions.assertThat(credentials).anySatisfy(vc -> Assertions.assertThat(vc.getCredentialSubject().get(0).getClaims()).containsEntry("some-claim-2", "some-val-2"));
-                        Assertions.assertThat(credentials).anySatisfy(vc -> Assertions.assertThat(vc.getCredentialSubject().get(0).getClaims()).containsEntry("some-other-claim-2", "some-other-val-2"));
+                        Assertions.assertThat(credentials).anySatisfy(vc -> Assertions.assertThat(vc.getCredentialSubjects().get(0).getClaims()).containsEntry("some-claim", "some-val"));
+                        Assertions.assertThat(credentials).anySatisfy(vc -> Assertions.assertThat(vc.getCredentialSubjects().get(0).getClaims()).containsEntry("some-other-claim", "some-other-val"));
+                        Assertions.assertThat(credentials).anySatisfy(vc -> Assertions.assertThat(vc.getCredentialSubjects().get(0).getClaims()).containsEntry("some-claim-2", "some-val-2"));
+                        Assertions.assertThat(credentials).anySatisfy(vc -> Assertions.assertThat(vc.getCredentialSubjects().get(0).getClaims()).containsEntry("some-other-claim-2", "some-other-val-2"));
                     });
         }
     }

--- a/extensions/common/iam/identity-trust/identity-trust-transform/src/main/java/org/eclipse/edc/iam/identitytrust/IdentityTrustTransformExtension.java
+++ b/extensions/common/iam/identity-trust/identity-trust-transform/src/main/java/org/eclipse/edc/iam/identitytrust/IdentityTrustTransformExtension.java
@@ -43,7 +43,7 @@ import static java.lang.String.format;
 import static org.eclipse.edc.identitytrust.VcConstants.IATP_CONTEXT_URL;
 import static org.eclipse.edc.spi.CoreConstants.JSON_LD;
 
-@Extension(value = IdentityTrustTransformExtension.NAME, categories = { "iam", "transform", "jsonld" })
+@Extension(value = IdentityTrustTransformExtension.NAME, categories = {"iam", "transform", "jsonld"})
 public class IdentityTrustTransformExtension implements ServiceExtension {
     public static final String NAME = "Identity And Trust Transform Extension";
 

--- a/extensions/common/iam/identity-trust/identity-trust-transform/src/main/java/org/eclipse/edc/iam/identitytrust/transform/to/AbstractJwtTransformer.java
+++ b/extensions/common/iam/identity-trust/identity-trust-transform/src/main/java/org/eclipse/edc/iam/identitytrust/transform/to/AbstractJwtTransformer.java
@@ -1,0 +1,81 @@
+/*
+ *  Copyright (c) 2024 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.iam.identitytrust.transform.to;
+
+import org.eclipse.edc.transform.spi.TypeTransformer;
+
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+
+import static java.util.Collections.emptyList;
+
+abstract class AbstractJwtTransformer<OUTPUT> implements TypeTransformer<String, OUTPUT> {
+
+
+    protected static final String TYPE_PROPERTY = "type";
+
+
+    private static final String VALUE_PROPERTY = "value";
+
+    private final Class<OUTPUT> output;
+
+
+    protected AbstractJwtTransformer(Class<OUTPUT> output) {
+        this.output = output;
+    }
+
+    @Override
+    public Class<String> getInputType() {
+        return String.class;
+    }
+
+    @Override
+    public Class<OUTPUT> getOutputType() {
+        return output;
+    }
+
+    /**
+     * If provided object is a {@link Collection} then apply the transformation
+     * method on every object composing the collection. Otherwise, apply the mapping
+     * function on the input object directly.
+     */
+    protected <T> List<T> listOrReturn(Object o, Function<Object, T> mapping) {
+        if (o == null) {
+            return emptyList();
+        } else if (o instanceof Collection<?>) {
+            return ((Collection<?>) o).stream()
+                    .map(mapping)
+                    .filter(Objects::nonNull)
+                    .toList();
+        }
+        return List.of(mapping.apply(o));
+    }
+
+    /**
+     * Convert the provided object into an {@link Instant}.
+     * Handle the case where the instance if provided as a map.
+     */
+    protected Instant toInstant(Object o) {
+        var str = o.toString();
+        if (o instanceof Map) {
+            str = ((Map) o).get(VALUE_PROPERTY).toString();
+        }
+        return Instant.parse(str);
+    }
+}

--- a/extensions/common/iam/identity-trust/identity-trust-transform/src/test/java/org/eclipse/edc/iam/identitytrust/transform/to/AbstractJwtTransformerTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-transform/src/test/java/org/eclipse/edc/iam/identitytrust/transform/to/AbstractJwtTransformerTest.java
@@ -1,0 +1,88 @@
+/*
+ *  Copyright (c) 2024 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.iam.identitytrust.transform.to;
+
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AbstractJwtTransformerTest {
+
+    private AbstractJwtTransformer<Object> transformer;
+
+    @BeforeEach
+    void setUp() {
+        transformer = new AbstractJwtTransformer<>(Object.class) {
+            @Override
+            public @Nullable Object transform(@NotNull String s, @NotNull TransformerContext context) {
+                return null;
+            }
+        };
+    }
+
+
+    @Test
+    void listOrReturn_null() {
+        assertThat(transformer.listOrReturn(null, null)).isEmpty();
+    }
+
+
+    @Test
+    void listOrReturn_list() {
+        List<Object> obj = List.of("1", "2", "3");
+
+        var result = transformer.listOrReturn(obj, o -> Integer.valueOf(o.toString()));
+
+        assertThat(result).isNotNull().hasSize(3)
+                .contains(1, 2, 3);
+    }
+
+    @Test
+    void listOrReturn_return() {
+        Object obj = "2";
+
+        var result = transformer.listOrReturn(obj, o -> Integer.valueOf(o.toString()));
+
+        assertThat(result).isNotNull().hasSize(1)
+                .contains(2);
+    }
+
+    @Test
+    void toInstant_string() {
+        Object obj = Instant.now();
+
+        var result = transformer.toInstant(obj.toString());
+
+        assertThat(result).isEqualTo(obj);
+    }
+
+    @Test
+    void toInstant_map() {
+        var now = Instant.now();
+        var obj = Map.of("value", now.toString());
+
+        var result = transformer.toInstant(obj);
+
+        assertThat(result).isEqualTo(now);
+    }
+}

--- a/extensions/common/iam/identity-trust/identity-trust-transform/src/test/java/org/eclipse/edc/iam/identitytrust/transform/to/JsonObjectToVerifiableCredentialTransformerTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-transform/src/test/java/org/eclipse/edc/iam/identitytrust/transform/to/JsonObjectToVerifiableCredentialTransformerTest.java
@@ -66,7 +66,7 @@ class JsonObjectToVerifiableCredentialTransformerTest {
         var vc = transformer.transform(jsonLdService.expand(jsonObj).getContent(), context);
 
         assertThat(vc).isNotNull();
-        assertThat(vc.getCredentialSubject()).isNotNull().hasSize(1);
+        assertThat(vc.getCredentialSubjects()).isNotNull().hasSize(1);
         assertThat(vc.getTypes()).hasSize(2);
         assertThat(vc.getDescription()).isNotNull();
         assertThat(vc.getName()).isNotNull();
@@ -82,7 +82,7 @@ class JsonObjectToVerifiableCredentialTransformerTest {
         var vc = transformer.transform(jsonLdService.expand(jsonObj).getContent(), context);
 
         assertThat(vc).isNotNull();
-        assertThat(vc.getCredentialSubject()).isNotNull().hasSize(1);
+        assertThat(vc.getCredentialSubjects()).isNotNull().hasSize(1);
         assertThat(vc.getTypes()).hasSize(2);
         assertThat(vc.getDescription()).isNotNull();
         assertThat(vc.getName()).isNotNull();

--- a/extensions/common/iam/identity-trust/identity-trust-transform/src/test/java/org/eclipse/edc/iam/identitytrust/transform/to/JwtToVerifiableCredentialTransformerTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-transform/src/test/java/org/eclipse/edc/iam/identitytrust/transform/to/JwtToVerifiableCredentialTransformerTest.java
@@ -35,7 +35,8 @@ class JwtToVerifiableCredentialTransformerTest {
         assertThat(vc).isNotNull();
         assertThat(vc.getTypes()).doesNotContainNull().isNotEmpty();
         assertThat(vc.getCredentialStatus()).isNotNull();
-        assertThat(vc.getCredentialSubject()).doesNotContainNull().isNotEmpty();
+        assertThat(vc.getCredentialSubjects()).doesNotContainNull().isNotEmpty();
+        assertThat(vc.getCredentialSubjects().stream().findFirst().orElseThrow().getId()).isNotNull();
 
         verifyNoInteractions(context);
     }

--- a/extensions/common/iam/identity-trust/identity-trust-transform/src/test/java/org/eclipse/edc/iam/identitytrust/transform/to/JwtToVerifiablePresentationTransformerTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-transform/src/test/java/org/eclipse/edc/iam/identitytrust/transform/to/JwtToVerifiablePresentationTransformerTest.java
@@ -69,7 +69,7 @@ class JwtToVerifiablePresentationTransformerTest {
         assertThat(vp).isNotNull();
         assertThat(vp.getTypes()).containsExactlyInAnyOrder("VerifiablePresentation", "CredentialManagerPresentation");
         assertThat(vp.getCredentials()).hasSize(1).allSatisfy(vc -> {
-            assertThat(vc.getCredentialSubject()).isNotEmpty();
+            assertThat(vc.getCredentialSubjects()).isNotEmpty();
             assertThat(vc.getTypes()).isNotEmpty();
         });
     }
@@ -83,7 +83,7 @@ class JwtToVerifiablePresentationTransformerTest {
         assertThat(vp.getCredentials()).hasSize(1)
                 .doesNotContainNull()
                 .allSatisfy(vc -> {
-                    assertThat(vc.getCredentialSubject()).isNotEmpty();
+                    assertThat(vc.getCredentialSubjects()).isNotEmpty();
                     assertThat(vc.getTypes()).isNotEmpty();
                 });
     }
@@ -127,7 +127,7 @@ class JwtToVerifiablePresentationTransformerTest {
         assertThat(vp.getCredentials()).hasSize(1)
                 .doesNotContainNull()
                 .allSatisfy(vc -> {
-                    assertThat(vc.getCredentialSubject()).isNotEmpty();
+                    assertThat(vc.getCredentialSubjects()).isNotEmpty();
                     assertThat(vc.getTypes()).isNotEmpty();
                 });
         verify(context, never()).reportProblem(anyString());

--- a/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/model/VerifiableCredential.java
+++ b/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/model/VerifiableCredential.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.identitytrust.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.jetbrains.annotations.NotNull;
 
 import java.time.Instant;
@@ -39,8 +40,12 @@ public class VerifiableCredential {
     public static final String VERIFIABLE_CREDENTIAL_NAME_PROPERTY = SCHEMA_ORG_NAMESPACE + "name";
     public static final String VERIFIABLE_CREDENTIAL_DESCRIPTION_PROPERTY = SCHEMA_ORG_NAMESPACE + "description";
     public static final String VERIFIABLE_CREDENTIAL_PROOF_PROPERTY = "https://w3id.org/security#proof";
-    private List<CredentialSubject> credentialSubject = new ArrayList<>();
+
+    @JsonProperty("credentialSubject")
+    private List<CredentialSubject> credentialSubjects = new ArrayList<>();
     private String id; // must be URI, but URI is less efficient at runtime
+
+    @JsonProperty("type")
     private List<String> types = new ArrayList<>();
     private Issuer issuer; // can be URI or an object containing an ID
     private Instant issuanceDate; // v2 of the spec renames this to "validFrom"
@@ -52,8 +57,8 @@ public class VerifiableCredential {
     private VerifiableCredential() {
     }
 
-    public List<CredentialSubject> getCredentialSubject() {
-        return credentialSubject;
+    public List<CredentialSubject> getCredentialSubjects() {
+        return credentialSubjects;
     }
 
     public String getId() {
@@ -101,12 +106,12 @@ public class VerifiableCredential {
         }
 
         public Builder credentialSubjects(List<CredentialSubject> credentialSubject) {
-            this.instance.credentialSubject = credentialSubject;
+            this.instance.credentialSubjects = credentialSubject;
             return this;
         }
 
         public Builder credentialSubject(CredentialSubject subject) {
-            this.instance.credentialSubject.add(subject);
+            this.instance.credentialSubjects.add(subject);
             return this;
         }
 
@@ -162,7 +167,7 @@ public class VerifiableCredential {
             if (instance.types.isEmpty()) {
                 throw new IllegalArgumentException("VerifiableCredentials MUST have at least one 'type' value.");
             }
-            if (instance.credentialSubject == null || instance.credentialSubject.isEmpty()) {
+            if (instance.credentialSubjects == null || instance.credentialSubjects.isEmpty()) {
                 throw new IllegalArgumentException("VerifiableCredential must have a non-null, non-empty 'credentialSubject' property.");
             }
             Objects.requireNonNull(instance.issuer, "VerifiableCredential must have an 'issuer' property.");

--- a/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/verification/VerifierContext.java
+++ b/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/verification/VerifierContext.java
@@ -18,15 +18,14 @@ package org.eclipse.edc.identitytrust.verification;
 import org.eclipse.edc.spi.result.Result;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
+import java.util.List;
 
 public class VerifierContext {
 
-    private Collection<CredentialVerifier> verifiers = new ArrayList<>();
+    private final List<CredentialVerifier> verifiers = new ArrayList<>();
     private String audience;
 
-    public Collection<CredentialVerifier> getVerifiers() {
+    public List<CredentialVerifier> getVerifiers() {
         return verifiers;
     }
 
@@ -41,13 +40,10 @@ public class VerifierContext {
         return audience;
     }
 
-    public VerifierContext withAudience(String audience) {
-        this.audience = audience;
-        return this;
-    }
-
     public Builder toBuilder() {
-        return new Builder(this);
+        return new Builder()
+                .verifiers(verifiers)
+                .audience(audience);
     }
 
     public static class Builder {
@@ -55,10 +51,6 @@ public class VerifierContext {
 
         private Builder() {
             context = new VerifierContext();
-        }
-
-        private Builder(VerifierContext verifierContext) {
-            this.context = verifierContext;
         }
 
         public static Builder newInstance() {
@@ -70,8 +62,8 @@ public class VerifierContext {
             return this;
         }
 
-        public Builder verifiers(CredentialVerifier... verifiers) {
-            this.context.verifiers = new ArrayList<>(Arrays.asList(verifiers));
+        public Builder verifiers(List<CredentialVerifier> verifiers) {
+            this.context.verifiers.addAll(verifiers);
             return this;
         }
 

--- a/spi/common/identity-trust-spi/src/test/java/org/eclipse/edc/identitytrust/model/VerifiableCredentialTest.java
+++ b/spi/common/identity-trust-spi/src/test/java/org/eclipse/edc/identitytrust/model/VerifiableCredentialTest.java
@@ -14,20 +14,36 @@
 
 package org.eclipse.edc.identitytrust.model;
 
-import org.junit.jupiter.api.BeforeEach;
+import org.eclipse.edc.spi.types.TypeManager;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Map;
 
 import static java.time.Instant.now;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class VerifiableCredentialTest {
 
-    @BeforeEach
-    void setUp() {
+    @Test
+    void serDeser() {
+        var typeManager = new TypeManager();
+        var vc = VerifiableCredential.Builder.newInstance()
+                .credentialSubject(new CredentialSubject())
+                .issuer(new Issuer("http://test.issuer", Map.of()))
+                .issuanceDate(now())
+                .type("test-type")
+                .build();
+
+        var serialized = typeManager.writeValueAsString(vc);
+        assertThat(serialized).contains("\"type\"");
+        assertThat(serialized).contains("\"credentialSubject\"");
+
+        var deserialized = typeManager.readValue(serialized, VerifiableCredential.class);
+
+        assertThat(deserialized).usingRecursiveComparison().isEqualTo(vc);
     }
 
     @Test
@@ -38,16 +54,6 @@ class VerifiableCredentialTest {
                 .issuanceDate(now())
                 .type("test-type")
                 .build());
-    }
-
-    @Test
-    void assertDefaultValues() {
-        var vc = VerifiableCredential.Builder.newInstance()
-                .credentialSubject(new CredentialSubject())
-                .issuer(new Issuer("http://test.issuer", Map.of()))
-                .issuanceDate(now())
-                .type("test-type")
-                .build();
     }
 
     @Test


### PR DESCRIPTION
## What this PR changes/adds

 - Avoid `NullPointerException` in `TokenValidationRulesRegistryImpl` if there is no rules registered for a given context
 - In `JwtPresentationVerifier`:
 - do not validate VC `aud` claim, as they don't have one
 - do not validate VP `sub` claim, as they don't have one
 - **MAKE VERIFIER CONTEXT IMMUTABLE**: this was causing very dubious behavior as `JwtPresentationVerifier.verify` was modifying the `audience` in the `VerificationContext` in the 
recursive call but it was never restored to the initial and expected value for the subsequent presentation verifications! So basically, first presentation verification was fine, but all consecutives were failing because the context audience was changed at the end of the first execution!
 - In `DidPublicKeyResolverImpl`: improve error logging when the provided did is null (happens when the validated token does not have the `kid` claim)
 - Make `JwtToVerifiableCredentialTransformer` and `JwtToVerifiablePresentationTransformer` more robust by also handling the cases where `credentialSubject` and `credentialStatus` are list!
 - Fix missing `credentialSubject.id` mapping in `JwtToVerifiableCredentialTransformer`
 - Fix the serialization of `VerifiableCredential` `type` field: current implem was giving `types` instead of `type` (see spec: https://www.w3.org/TR/vc-data-model-2.0/#example-a-simple-example-of-a-verifiable-presentation)
 
## Why it does that

Fix.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
