### PR TITLE
chore: remove useless function in `JwtToVerifiableCredentialTransformer`

### DIFF
--- a/extensions/common/iam/identity-trust/identity-trust-transform/src/main/java/org/eclipse/edc/iam/identitytrust/transform/to/AbstractJwtTransformer.java
+++ b/extensions/common/iam/identity-trust/identity-trust-transform/src/main/java/org/eclipse/edc/iam/identitytrust/transform/to/AbstractJwtTransformer.java
@@ -16,10 +16,8 @@ package org.eclipse.edc.iam.identitytrust.transform.to;
 
 import org.eclipse.edc.transform.spi.TypeTransformer;
 
-import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 
@@ -29,9 +27,7 @@ abstract class AbstractJwtTransformer<OUTPUT> implements TypeTransformer<String,
 
 
     protected static final String TYPE_PROPERTY = "type";
-
-
-    private static final String VALUE_PROPERTY = "value";
+    
 
     private final Class<OUTPUT> output;
 
@@ -67,15 +63,4 @@ abstract class AbstractJwtTransformer<OUTPUT> implements TypeTransformer<String,
         return List.of(mapping.apply(o));
     }
 
-    /**
-     * Convert the provided object into an {@link Instant}.
-     * Handle the case where the instance if provided as a map.
-     */
-    protected Instant toInstant(Object o) {
-        var str = o.toString();
-        if (o instanceof Map) {
-            str = ((Map) o).get(VALUE_PROPERTY).toString();
-        }
-        return Instant.parse(str);
-    }
 }

--- a/extensions/common/iam/identity-trust/identity-trust-transform/src/main/java/org/eclipse/edc/iam/identitytrust/transform/to/JwtToVerifiableCredentialTransformer.java
+++ b/extensions/common/iam/identity-trust/identity-trust-transform/src/main/java/org/eclipse/edc/iam/identitytrust/transform/to/JwtToVerifiableCredentialTransformer.java
@@ -89,7 +89,8 @@ public class JwtToVerifiableCredentialTransformer extends AbstractJwtTransformer
 
     private Optional<Instant> extractDate(@Nullable Object dateObject, Date fallback) {
         return ofNullable(dateObject)
-                .map(this::toInstant)
+                .map(Object::toString)
+                .map(Instant::parse)
                 .or(() -> ofNullable(fallback).map(Date::toInstant));
     }
 

--- a/extensions/common/iam/identity-trust/identity-trust-transform/src/test/java/org/eclipse/edc/iam/identitytrust/transform/to/AbstractJwtTransformerTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-transform/src/test/java/org/eclipse/edc/iam/identitytrust/transform/to/AbstractJwtTransformerTest.java
@@ -20,9 +20,7 @@ import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.time.Instant;
 import java.util.List;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -67,22 +65,4 @@ class AbstractJwtTransformerTest {
                 .contains(2);
     }
 
-    @Test
-    void toInstant_string() {
-        Object obj = Instant.now();
-
-        var result = transformer.toInstant(obj.toString());
-
-        assertThat(result).isEqualTo(obj);
-    }
-
-    @Test
-    void toInstant_map() {
-        var now = Instant.now();
-        var obj = Map.of("value", now.toString());
-
-        var result = transformer.toInstant(obj);
-
-        assertThat(result).isEqualTo(now);
-    }
 }


### PR DESCRIPTION
## What this PR changes/adds

Remove useless function `toInstant` in `JwtToVerifiableCredentialTransformer`.

## Why it does that

Clean up.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
