### PR TITLE
feat: add @type validation on policy definition api

### DIFF
--- a/core/common/validator-core/src/main/java/org/eclipse/edc/validator/jsonobject/validators/TypeIs.java
+++ b/core/common/validator-core/src/main/java/org/eclipse/edc/validator/jsonobject/validators/TypeIs.java
@@ -57,7 +57,7 @@ public class TypeIs implements Validator<JsonObject> {
             var newPath = path.append(TYPE);
 
             var violation = violation(
-                    "%s was expected to be %s but it was not".formatted(newPath, types),
+                    "%s was expected to be %s but it was not".formatted(newPath, expectedType),
                     newPath.toString(), types
             );
             return ValidationResult.failure(violation);

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/validation/PolicyDefinitionValidator.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/validation/PolicyDefinitionValidator.java
@@ -18,15 +18,18 @@ import jakarta.json.JsonObject;
 import org.eclipse.edc.validator.jsonobject.JsonObjectValidator;
 import org.eclipse.edc.validator.jsonobject.validators.MandatoryObject;
 import org.eclipse.edc.validator.jsonobject.validators.OptionalIdNotBlank;
+import org.eclipse.edc.validator.jsonobject.validators.TypeIs;
 import org.eclipse.edc.validator.spi.Validator;
 
 import static org.eclipse.edc.connector.policy.spi.PolicyDefinition.EDC_POLICY_DEFINITION_POLICY;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_SET;
 
 public class PolicyDefinitionValidator {
     public static Validator<JsonObject> instance() {
         return JsonObjectValidator.newValidator()
                 .verifyId(OptionalIdNotBlank::new)
                 .verify(EDC_POLICY_DEFINITION_POLICY, MandatoryObject::new)
+                .verifyObject(EDC_POLICY_DEFINITION_POLICY, builder -> builder.verify(path -> new TypeIs(path, ODRL_POLICY_TYPE_SET)))
                 .build();
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

add @type validation on policy definition api

## Why it does that

preventing NPE when posting a policy definition without `@type`

## Linked Issue(s)

Closes #3876 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
