### PR TITLE
fix: use `type` and `credentialSubject` properties in `VerifiableCredential`

### DIFF
--- a/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/validation/rules/HasValidSubjectIds.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/validation/rules/HasValidSubjectIds.java
@@ -37,7 +37,7 @@ public class HasValidSubjectIds implements CredentialValidationRule {
 
     @Override
     public Result<Void> apply(VerifiableCredential credential) {
-        return credential.getCredentialSubjects().stream()
+        return credential.getCredentialSubject().stream()
                 .allMatch(sub -> expectedSubjectId.equals(sub.getId())) ?
                 success() : failure("Not all subject IDs match the expected subject ID %s".formatted(expectedSubjectId));
     }

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/test/java/org/eclipse/edc/iam/identitytrust/service/IdentityAndTrustServiceTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/test/java/org/eclipse/edc/iam/identitytrust/service/IdentityAndTrustServiceTest.java
@@ -291,7 +291,7 @@ class IdentityAndTrustServiceTest {
                     .satisfies(ct -> {
                         var vc = (List<VerifiableCredential>) ct.getListClaim("vc");
                         Assertions.assertThat(vc).hasSize(1);
-                        Assertions.assertThat(vc.get(0).getCredentialSubjects().get(0).getClaims()).containsEntry("some-claim", "some-val");
+                        Assertions.assertThat(vc.get(0).getCredentialSubject().get(0).getClaims()).containsEntry("some-claim", "some-val");
                     });
         }
 
@@ -322,8 +322,8 @@ class IdentityAndTrustServiceTest {
                     .satisfies(ct -> {
                         var credentials = (List<VerifiableCredential>) ct.getClaims().get("vc");
                         Assertions.assertThat(credentials).hasSize(2);
-                        Assertions.assertThat(credentials.get(0).getCredentialSubjects().get(0).getClaims()).containsEntry("some-claim", "some-val");
-                        Assertions.assertThat(credentials.get(1).getCredentialSubjects().get(0).getClaims()).containsEntry("some-other-claim", "some-other-val");
+                        Assertions.assertThat(credentials.get(0).getCredentialSubject().get(0).getClaims()).containsEntry("some-claim", "some-val");
+                        Assertions.assertThat(credentials.get(1).getCredentialSubject().get(0).getClaims()).containsEntry("some-other-claim", "some-other-val");
                     });
         }
 
@@ -374,10 +374,10 @@ class IdentityAndTrustServiceTest {
                     .satisfies(ct -> {
                         var credentials = (List<VerifiableCredential>) ct.getListClaim("vc");
                         Assertions.assertThat(credentials).hasSize(4);
-                        Assertions.assertThat(credentials).anySatisfy(vc -> Assertions.assertThat(vc.getCredentialSubjects().get(0).getClaims()).containsEntry("some-claim", "some-val"));
-                        Assertions.assertThat(credentials).anySatisfy(vc -> Assertions.assertThat(vc.getCredentialSubjects().get(0).getClaims()).containsEntry("some-other-claim", "some-other-val"));
-                        Assertions.assertThat(credentials).anySatisfy(vc -> Assertions.assertThat(vc.getCredentialSubjects().get(0).getClaims()).containsEntry("some-claim-2", "some-val-2"));
-                        Assertions.assertThat(credentials).anySatisfy(vc -> Assertions.assertThat(vc.getCredentialSubjects().get(0).getClaims()).containsEntry("some-other-claim-2", "some-other-val-2"));
+                        Assertions.assertThat(credentials).anySatisfy(vc -> Assertions.assertThat(vc.getCredentialSubject().get(0).getClaims()).containsEntry("some-claim", "some-val"));
+                        Assertions.assertThat(credentials).anySatisfy(vc -> Assertions.assertThat(vc.getCredentialSubject().get(0).getClaims()).containsEntry("some-other-claim", "some-other-val"));
+                        Assertions.assertThat(credentials).anySatisfy(vc -> Assertions.assertThat(vc.getCredentialSubject().get(0).getClaims()).containsEntry("some-claim-2", "some-val-2"));
+                        Assertions.assertThat(credentials).anySatisfy(vc -> Assertions.assertThat(vc.getCredentialSubject().get(0).getClaims()).containsEntry("some-other-claim-2", "some-other-val-2"));
                     });
         }
     }

--- a/extensions/common/iam/identity-trust/identity-trust-transform/src/test/java/org/eclipse/edc/iam/identitytrust/transform/to/JsonObjectToVerifiableCredentialTransformerTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-transform/src/test/java/org/eclipse/edc/iam/identitytrust/transform/to/JsonObjectToVerifiableCredentialTransformerTest.java
@@ -66,8 +66,8 @@ class JsonObjectToVerifiableCredentialTransformerTest {
         var vc = transformer.transform(jsonLdService.expand(jsonObj).getContent(), context);
 
         assertThat(vc).isNotNull();
-        assertThat(vc.getCredentialSubjects()).isNotNull().hasSize(1);
-        assertThat(vc.getTypes()).hasSize(2);
+        assertThat(vc.getCredentialSubject()).isNotNull().hasSize(1);
+        assertThat(vc.getType()).hasSize(2);
         assertThat(vc.getDescription()).isNotNull();
         assertThat(vc.getName()).isNotNull();
         assertThat(vc.getCredentialStatus()).isNotNull();
@@ -82,8 +82,8 @@ class JsonObjectToVerifiableCredentialTransformerTest {
         var vc = transformer.transform(jsonLdService.expand(jsonObj).getContent(), context);
 
         assertThat(vc).isNotNull();
-        assertThat(vc.getCredentialSubjects()).isNotNull().hasSize(1);
-        assertThat(vc.getTypes()).hasSize(2);
+        assertThat(vc.getCredentialSubject()).isNotNull().hasSize(1);
+        assertThat(vc.getType()).hasSize(2);
         assertThat(vc.getDescription()).isNotNull();
         assertThat(vc.getName()).isNotNull();
         assertThat(vc.getCredentialStatus()).isNotNull();

--- a/extensions/common/iam/identity-trust/identity-trust-transform/src/test/java/org/eclipse/edc/iam/identitytrust/transform/to/JwtToVerifiableCredentialTransformerTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-transform/src/test/java/org/eclipse/edc/iam/identitytrust/transform/to/JwtToVerifiableCredentialTransformerTest.java
@@ -33,10 +33,10 @@ class JwtToVerifiableCredentialTransformerTest {
         var vc = transformer.transform(EXAMPLE_JWT_VC, context);
 
         assertThat(vc).isNotNull();
-        assertThat(vc.getTypes()).doesNotContainNull().isNotEmpty();
+        assertThat(vc.getType()).doesNotContainNull().isNotEmpty();
         assertThat(vc.getCredentialStatus()).isNotNull();
-        assertThat(vc.getCredentialSubjects()).doesNotContainNull().isNotEmpty();
-        assertThat(vc.getCredentialSubjects().stream().findFirst().orElseThrow().getId()).isNotNull();
+        assertThat(vc.getCredentialSubject()).doesNotContainNull().isNotEmpty();
+        assertThat(vc.getCredentialSubject().stream().findFirst().orElseThrow().getId()).isNotNull();
 
         verifyNoInteractions(context);
     }

--- a/extensions/common/iam/identity-trust/identity-trust-transform/src/test/java/org/eclipse/edc/iam/identitytrust/transform/to/JwtToVerifiablePresentationTransformerTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-transform/src/test/java/org/eclipse/edc/iam/identitytrust/transform/to/JwtToVerifiablePresentationTransformerTest.java
@@ -69,8 +69,8 @@ class JwtToVerifiablePresentationTransformerTest {
         assertThat(vp).isNotNull();
         assertThat(vp.getTypes()).containsExactlyInAnyOrder("VerifiablePresentation", "CredentialManagerPresentation");
         assertThat(vp.getCredentials()).hasSize(1).allSatisfy(vc -> {
-            assertThat(vc.getCredentialSubjects()).isNotEmpty();
-            assertThat(vc.getTypes()).isNotEmpty();
+            assertThat(vc.getCredentialSubject()).isNotEmpty();
+            assertThat(vc.getType()).isNotEmpty();
         });
     }
 
@@ -83,8 +83,8 @@ class JwtToVerifiablePresentationTransformerTest {
         assertThat(vp.getCredentials()).hasSize(1)
                 .doesNotContainNull()
                 .allSatisfy(vc -> {
-                    assertThat(vc.getCredentialSubjects()).isNotEmpty();
-                    assertThat(vc.getTypes()).isNotEmpty();
+                    assertThat(vc.getCredentialSubject()).isNotEmpty();
+                    assertThat(vc.getType()).isNotEmpty();
                 });
     }
 
@@ -127,8 +127,8 @@ class JwtToVerifiablePresentationTransformerTest {
         assertThat(vp.getCredentials()).hasSize(1)
                 .doesNotContainNull()
                 .allSatisfy(vc -> {
-                    assertThat(vc.getCredentialSubjects()).isNotEmpty();
-                    assertThat(vc.getTypes()).isNotEmpty();
+                    assertThat(vc.getCredentialSubject()).isNotEmpty();
+                    assertThat(vc.getType()).isNotEmpty();
                 });
         verify(context, never()).reportProblem(anyString());
     }

--- a/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/model/VerifiableCredential.java
+++ b/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/model/VerifiableCredential.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.identitytrust.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import org.jetbrains.annotations.NotNull;
 
 import java.time.Instant;
@@ -41,12 +40,10 @@ public class VerifiableCredential {
     public static final String VERIFIABLE_CREDENTIAL_DESCRIPTION_PROPERTY = SCHEMA_ORG_NAMESPACE + "description";
     public static final String VERIFIABLE_CREDENTIAL_PROOF_PROPERTY = "https://w3id.org/security#proof";
 
-    @JsonProperty("credentialSubject")
-    private List<CredentialSubject> credentialSubjects = new ArrayList<>();
+    private List<CredentialSubject> credentialSubject = new ArrayList<>();
     private String id; // must be URI, but URI is less efficient at runtime
 
-    @JsonProperty("type")
-    private List<String> types = new ArrayList<>();
+    private List<String> type = new ArrayList<>();
     private Issuer issuer; // can be URI or an object containing an ID
     private Instant issuanceDate; // v2 of the spec renames this to "validFrom"
     private Instant expirationDate; // v2 of the spec renames this to "validUntil"
@@ -57,16 +54,16 @@ public class VerifiableCredential {
     private VerifiableCredential() {
     }
 
-    public List<CredentialSubject> getCredentialSubjects() {
-        return credentialSubjects;
+    public List<CredentialSubject> getCredentialSubject() {
+        return credentialSubject;
     }
 
     public String getId() {
         return id;
     }
 
-    public List<String> getTypes() {
-        return types;
+    public List<String> getType() {
+        return type;
     }
 
     public Issuer getIssuer() {
@@ -106,12 +103,12 @@ public class VerifiableCredential {
         }
 
         public Builder credentialSubjects(List<CredentialSubject> credentialSubject) {
-            this.instance.credentialSubjects = credentialSubject;
+            this.instance.credentialSubject = credentialSubject;
             return this;
         }
 
         public Builder credentialSubject(CredentialSubject subject) {
-            this.instance.credentialSubjects.add(subject);
+            this.instance.credentialSubject.add(subject);
             return this;
         }
 
@@ -121,12 +118,12 @@ public class VerifiableCredential {
         }
 
         public Builder types(List<String> type) {
-            this.instance.types = type;
+            this.instance.type = type;
             return this;
         }
 
         public Builder type(String type) {
-            this.instance.types.add(type);
+            this.instance.type.add(type);
             return this;
         }
 
@@ -164,10 +161,10 @@ public class VerifiableCredential {
         }
 
         public VerifiableCredential build() {
-            if (instance.types.isEmpty()) {
+            if (instance.type.isEmpty()) {
                 throw new IllegalArgumentException("VerifiableCredentials MUST have at least one 'type' value.");
             }
-            if (instance.credentialSubjects == null || instance.credentialSubjects.isEmpty()) {
+            if (instance.credentialSubject == null || instance.credentialSubject.isEmpty()) {
                 throw new IllegalArgumentException("VerifiableCredential must have a non-null, non-empty 'credentialSubject' property.");
             }
             Objects.requireNonNull(instance.issuer, "VerifiableCredential must have an 'issuer' property.");


### PR DESCRIPTION
## What this PR changes/adds

Use class argument name and serialized name for the `type` and `credentialSubject` properties of the `VerifiableCredential` object.

## Why it does that

This is required to have a consistent way to query for a VC independently on the type of VC store (in-mem store uses reflection while PostgreSQL store will work on the serialized json structure.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
