### PR TITLE
fix: use delimited scope

### DIFF
--- a/core/common/policy-engine/src/main/java/org/eclipse/edc/policy/engine/PolicyEngineImpl.java
+++ b/core/common/policy-engine/src/main/java/org/eclipse/edc/policy/engine/PolicyEngineImpl.java
@@ -98,7 +98,7 @@ public class PolicyEngineImpl implements PolicyEngine {
             }
         });
 
-        dynamicConstraintFunctions.stream().filter(entry -> scopeFilter(entry.scope, scope)).forEach(entry -> {
+        dynamicConstraintFunctions.stream().filter(entry -> scopeFilter(entry.scope, delimitedScope)).forEach(entry -> {
             if (Duty.class.isAssignableFrom(entry.type)) {
                 evalBuilder.dynamicDutyFunction(entry.function::canHandle, (key, operator, value, duty) -> entry.function.evaluate(key, operator, value, duty, context));
             } else if (Permission.class.isAssignableFrom(entry.type)) {

--- a/core/common/policy-engine/src/test/java/org/eclipse/edc/policy/engine/PolicyEngineImplTest.java
+++ b/core/common/policy-engine/src/test/java/org/eclipse/edc/policy/engine/PolicyEngineImplTest.java
@@ -310,12 +310,32 @@ class PolicyEngineImplTest {
 
     @ParameterizedTest
     @ArgumentsSource(PolicyProvider.class)
-    void shouldTriggerDynamicFunction(Policy policy, Class<Rule> ruleClass, boolean evaluateReturn) {
+    void shouldTriggerDynamicFunction_whenWildcardScope(Policy policy, Class<Rule> ruleClass, boolean evaluateReturn) {
         bindingRegistry.dynamicBind((key) -> Set.of(TEST_SCOPE));
 
         var context = PolicyContextImpl.Builder.newInstance().build();
         DynamicAtomicConstraintFunction<Rule> function = mock(DynamicAtomicConstraintFunction.class);
         policyEngine.registerFunction(ALL_SCOPES, ruleClass, function);
+
+        when(function.canHandle(any())).thenReturn(true);
+        when(function.evaluate(any(), any(), any(), any(), eq(context))).thenReturn(evaluateReturn);
+
+        var result = policyEngine.evaluate(TEST_SCOPE, policy, context);
+
+        assertThat(result.succeeded()).isTrue();
+
+        verify(function).canHandle(any());
+        verify(function).evaluate(any(), any(), any(), any(), eq(context));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(PolicyProvider.class)
+    void shouldTriggerDynamicFunction_whenExplicitScope(Policy policy, Class<Rule> ruleClass, boolean evaluateReturn) {
+        bindingRegistry.dynamicBind((key) -> Set.of(TEST_SCOPE));
+
+        var context = PolicyContextImpl.Builder.newInstance().build();
+        DynamicAtomicConstraintFunction<Rule> function = mock(DynamicAtomicConstraintFunction.class);
+        policyEngine.registerFunction(TEST_SCOPE, ruleClass, function);
 
         when(function.canHandle(any())).thenReturn(true);
         when(function.evaluate(any(), any(), any(), any(), eq(context))).thenReturn(evaluateReturn);


### PR DESCRIPTION
## What this PR changes/adds

this PR fixes the scope, that dynamically bound eval functions are evaluated against. They should use the _delimited_ scope, not the raw one.

## Why it does that

Dynamically bound functions did not get evaluated on any scope other than `".*"`

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
