### PR TITLE
fix: applies transactional context in getAll

### DIFF
--- a/core/data-plane-selector/data-plane-selector-core/src/test/java/org/eclipse/edc/connector/dataplane/selector/service/EmbeddedDataPlaneSelectorServiceTest.java
+++ b/core/data-plane-selector/data-plane-selector-core/src/test/java/org/eclipse/edc/connector/dataplane/selector/service/EmbeddedDataPlaneSelectorServiceTest.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstan
 import org.eclipse.edc.connector.dataplane.selector.spi.store.DataPlaneInstanceStore;
 import org.eclipse.edc.connector.dataplane.selector.spi.strategy.SelectionStrategy;
 import org.eclipse.edc.connector.dataplane.selector.spi.strategy.SelectionStrategyRegistry;
+import org.eclipse.edc.transaction.spi.NoopTransactionContext;
 import org.junit.jupiter.api.Test;
 
 import java.util.stream.IntStream;
@@ -35,7 +36,7 @@ public class EmbeddedDataPlaneSelectorServiceTest {
 
     private final DataPlaneInstanceStore store = mock();
     private final SelectionStrategyRegistry selectionStrategyRegistry = mock();
-    private final DataPlaneSelectorService selector = new EmbeddedDataPlaneSelectorService(store, selectionStrategyRegistry, mock());
+    private final DataPlaneSelectorService selector = new EmbeddedDataPlaneSelectorService(store, selectionStrategyRegistry, new NoopTransactionContext());
 
     @Test
     void select_shouldUseChosenSelector() {

--- a/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/selector/store/sql/SqlDataPlaneInstanceStore.java
+++ b/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/selector/store/sql/SqlDataPlaneInstanceStore.java
@@ -100,12 +100,14 @@ public class SqlDataPlaneInstanceStore extends AbstractSqlStore implements DataP
 
     @Override
     public Stream<DataPlaneInstance> getAll() {
-        try {
-            var sql = statements.getAllTemplate();
-            return queryExecutor.query(getConnection(), true, this::mapResultSet, sql);
-        } catch (SQLException exception) {
-            throw new EdcPersistenceException(exception);
-        }
+        return transactionContext.execute(() -> {
+            try {
+                var sql = statements.getAllTemplate();
+                return queryExecutor.query(getConnection(), true, this::mapResultSet, sql);
+            } catch (SQLException exception) {
+                throw new EdcPersistenceException(exception);
+            }
+        });
     }
 
     private DataPlaneInstance findByIdInternal(Connection connection, String id) {


### PR DESCRIPTION
## What this PR changes/adds

Applies the transactional context in the getAll on the `SqlDataPlaneInstanceStore` and in the caller when consuming the streaming.

## Why it does that

bug fix

## Linked Issue(s)

Closes #3887 


