### PR TITLE
feat: implement DataPlaneAccessControlService

### DIFF
--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/DataPlaneDefaultServicesExtension.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/DataPlaneDefaultServicesExtension.java
@@ -18,6 +18,7 @@ import org.eclipse.edc.connector.dataplane.framework.pipeline.PipelineServiceImp
 import org.eclipse.edc.connector.dataplane.framework.registry.TransferServiceSelectionStrategy;
 import org.eclipse.edc.connector.dataplane.framework.store.InMemoryAccessTokenDataStore;
 import org.eclipse.edc.connector.dataplane.framework.store.InMemoryDataPlaneStore;
+import org.eclipse.edc.connector.dataplane.spi.iam.DataPlaneAccessControlService;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.PipelineService;
 import org.eclipse.edc.connector.dataplane.spi.store.AccessTokenDataStore;
 import org.eclipse.edc.connector.dataplane.spi.store.DataPlaneStore;
@@ -25,6 +26,7 @@ import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.spi.query.CriterionOperatorRegistry;
+import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 
@@ -62,5 +64,11 @@ public class DataPlaneDefaultServicesExtension implements ServiceExtension {
     @Provider(isDefault = true)
     public PipelineService pipelineService(ServiceExtensionContext context) {
         return new PipelineServiceImpl(context.getMonitor());
+    }
+
+    @Provider(isDefault = true)
+    public DataPlaneAccessControlService defaultAccessControlService(ServiceExtensionContext context) {
+        context.getMonitor().debug("DataPlane Access Control: default implementation is used, will always return Result.success()");
+        return (claimToken, address, requestData) -> Result.success();
     }
 }

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/iam/DataPlaneAccessControlService.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/iam/DataPlaneAccessControlService.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.spi.iam;
+
+import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
+import org.eclipse.edc.spi.iam.ClaimToken;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+
+import java.util.Map;
+
+/**
+ * This service is used to grant or deny a request for data based on the token attached to the request, and some request data.
+ * For example, an implementation could make that decision based on the URL pattern of the data request.
+ * <p>
+ * The default implementation provided by EDC always returns {@link Result#success()}.
+ */
+@ExtensionPoint
+@FunctionalInterface
+public interface DataPlaneAccessControlService {
+
+    /**
+     * Grants or denies access to a particular resource (DataAddress) based on the supplied credential (ClaimToken) and
+     * additional request information (requestData).
+     * <p>
+     * Note that if access is denied ({@link Result#failed()}), it is advised <strong>not</strong> to forward the failure
+     * detail to the requestor for security reasons.
+     * <p>
+     *
+     * @param claimToken  The credential that was attached to the data request received by the data plane
+     * @param address     The resource address of the data that is being requested
+     * @param requestData Additional information about the request, e.g. URL pattern, additional headers, query params, etc.
+     * @return success if access to the resource is granted, a failure otherwise.
+     */
+    Result<Void> checkAccess(ClaimToken claimToken, DataAddress address, Map<String, Object> requestData);
+}


### PR DESCRIPTION
## What this PR changes/adds

This PR adds the `DataPlaneAccessControlService` plus a default allow-all implementation.

## Why it does that

data plane signaling.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #3894

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
