### PR TITLE
feat(dsp): expose version endpoint

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -223,7 +223,6 @@ maven/mavencentral/org.apache.velocity/velocity-engine-core/2.3, Apache-2.0, app
 maven/mavencentral/org.apache.velocity/velocity-engine-scripting/2.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.xbean/xbean-reflect/3.7, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.assertj/assertj-core/3.25.1, Apache-2.0, approved, #12585
 maven/mavencentral/org.assertj/assertj-core/3.25.3, Apache-2.0, approved, #12585
 maven/mavencentral/org.awaitility/awaitility/4.2.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.72, MIT, approved, #3789

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -60,17 +60,17 @@ maven/mavencentral/com.google.code.gson/gson/2.10.1, Apache-2.0, approved, #6159
 maven/mavencentral/com.google.collections/google-collections/1.0, Apache-2.0, approved, CQ3285
 maven/mavencentral/com.google.crypto.tink/tink/1.12.0, Apache-2.0, approved, #12041
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.11.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.errorprone/error_prone_annotations/2.18.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.22.0, Apache-2.0, approved, #10661
+maven/mavencentral/com.google.errorprone/error_prone_annotations/2.23.0, Apache-2.0, approved, #11083
 maven/mavencentral/com.google.guava/failureaccess/1.0.1, Apache-2.0, approved, CQ22654
+maven/mavencentral/com.google.guava/failureaccess/1.0.2, Apache-2.0, approved, CQ22654
 maven/mavencentral/com.google.guava/guava/28.1-android, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.guava/guava/28.2-android, Apache-2.0 AND LicenseRef-Public-Domain, approved, CQ22437
 maven/mavencentral/com.google.guava/guava/31.0.1-android, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.guava/guava/31.1-jre, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.guava/guava/32.0.1-jre, Apache-2.0 AND CC0-1.0 AND CC-PDDC, approved, #8772
+maven/mavencentral/com.google.guava/guava/33.0.0-jre, Apache-2.0 AND CC0-1.0, approved, #12173
 maven/mavencentral/com.google.guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava, Apache-2.0, approved, CQ22657
 maven/mavencentral/com.google.j2objc/j2objc-annotations/1.3, Apache-2.0, approved, CQ21195
-maven/mavencentral/com.google.j2objc/j2objc-annotations/2.8, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.protobuf/protobuf-java/3.23.4, BSD-3-Clause, approved, #8634
 maven/mavencentral/com.google.protobuf/protobuf-java/3.24.3, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/com.googlecode.libphonenumber/libphonenumber/8.11.1, Apache-2.0, approved, clearlydefined
@@ -81,7 +81,7 @@ maven/mavencentral/com.lmax/disruptor/3.4.4, Apache-2.0, approved, clearlydefine
 maven/mavencentral/com.networknt/json-schema-validator/1.0.76, Apache-2.0, approved, CQ22638
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.28, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.37.3, Apache-2.0, approved, #11701
-maven/mavencentral/com.puppycrawl.tools/checkstyle/10.12.3, LGPL-2.1-only AND Apache-2.0 AND LGPL-2.1-or-later AND ANTLR-PD AND GPL-2.0-or-later AND LGPL-2.0-or-later AND (Apache-2.0 AND LGPL-2.1-or-later) AND LicenseRef-scancode-proprietary-license, restricted, #13190
+maven/mavencentral/com.puppycrawl.tools/checkstyle/10.13.0, , restricted, clearlydefined
 maven/mavencentral/com.samskivert/jmustache/1.15, BSD-2-Clause, approved, clearlydefined
 maven/mavencentral/com.squareup.okhttp3/okhttp-dnsoverhttps/4.12.0, Apache-2.0, approved, #11159
 maven/mavencentral/com.squareup.okhttp3/okhttp/4.12.0, Apache-2.0, approved, #11156
@@ -103,7 +103,7 @@ maven/mavencentral/commons-logging/commons-logging/1.1.1, Apache-2.0, approved, 
 maven/mavencentral/commons-logging/commons-logging/1.2, Apache-2.0, approved, CQ10162
 maven/mavencentral/dev.failsafe/failsafe-okhttp/3.3.2, Apache-2.0, approved, #9178
 maven/mavencentral/dev.failsafe/failsafe/3.3.2, Apache-2.0, approved, #9268
-maven/mavencentral/info.picocli/picocli/4.7.4, Apache-2.0, approved, #4365
+maven/mavencentral/info.picocli/picocli/4.7.5, Apache-2.0, approved, #4365
 maven/mavencentral/io.cloudevents/cloudevents-api/2.5.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.cloudevents/cloudevents-core/2.5.0, Apache-2.0, approved, #9328
 maven/mavencentral/io.cloudevents/cloudevents-http-basic/2.5.0, Apache-2.0, approved, #9329
@@ -190,8 +190,8 @@ maven/mavencentral/net.javacrumbs.json-unit/json-unit-core/2.36.0, Apache-2.0, a
 maven/mavencentral/net.minidev/accessors-smart/2.4.7, Apache-2.0, approved, #7515
 maven/mavencentral/net.minidev/json-smart/2.4.7, Apache-2.0, approved, #3288
 maven/mavencentral/net.sf.jopt-simple/jopt-simple/5.0.4, MIT, approved, CQ13174
-maven/mavencentral/net.sf.saxon/Saxon-HE/12.3, MPL-2.0-no-copyleft-exception AND (LicenseRef-scancode-proprietary-license AND MPL-2.0-no-copyleft-exception) AND (MPL-2.0-no-copyleft-exception AND X11) AND (MIT AND MPL-2.0-no-copyleft-exception) AND (MPL-1.0 AND MPL-2.0-no-copyleft-exception) AND (Apache-2.0 AND MPL-2.0-no-copyleft-exception) AND MPL-1.0, restricted, #13191
-maven/mavencentral/org.antlr/antlr4-runtime/4.11.1, BSD-3-Clause, approved, clearlydefined
+maven/mavencentral/net.sf.saxon/Saxon-HE/12.4, MPL-2.0 AND (MPL-2.0 AND Apache-2.0) AND (MPL-2.0 AND LicenseRef-X11-style) AND MPL-1.0 AND W3C, approved, #12716
+maven/mavencentral/org.antlr/antlr4-runtime/4.13.1, BSD-3-Clause, approved, #10767
 maven/mavencentral/org.apache.commons/commons-compress/1.24.0, Apache-2.0 AND BSD-3-Clause AND bzip2-1.0.6 AND LicenseRef-Public-Domain, approved, #10368
 maven/mavencentral/org.apache.commons/commons-digester3/3.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-lang3/3.10, Apache-2.0, approved, clearlydefined
@@ -233,8 +233,8 @@ maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.72, MIT, approved, #3790
 maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.77, MIT, approved, #11596
 maven/mavencentral/org.ccil.cowan.tagsoup/tagsoup/1.2.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.checkerframework/checker-qual/3.12.0, MIT, approved, clearlydefined
-maven/mavencentral/org.checkerframework/checker-qual/3.27.0, MIT, approved, clearlydefined
 maven/mavencentral/org.checkerframework/checker-qual/3.41.0, MIT, approved, #12032
+maven/mavencentral/org.checkerframework/checker-qual/3.42.0, MIT, approved, clearlydefined
 maven/mavencentral/org.codehaus.plexus/plexus-classworlds/2.6.0, Apache-2.0 AND Plexus, approved, CQ22821
 maven/mavencentral/org.codehaus.plexus/plexus-component-annotations/2.1.0, Apache-2.0, approved, #809
 maven/mavencentral/org.codehaus.plexus/plexus-container-default/2.1.0, Apache-2.0, approved, clearlydefined
@@ -352,7 +352,7 @@ maven/mavencentral/org.testcontainers/postgresql/1.19.5, MIT, approved, #10350
 maven/mavencentral/org.testcontainers/testcontainers/1.19.5, Apache-2.0 AND MIT, approved, #10347
 maven/mavencentral/org.testcontainers/vault/1.19.5, MIT, approved, #10852
 maven/mavencentral/org.xerial.snappy/snappy-java/1.1.10.5, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #9098
-maven/mavencentral/org.xmlresolver/xmlresolver/5.2.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.xmlresolver/xmlresolver/5.2.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.xmlunit/xmlunit-core/2.9.1, Apache-2.0, approved, #6272
 maven/mavencentral/org.xmlunit/xmlunit-placeholders/2.9.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.yaml/snakeyaml/1.33, Apache-2.0, approved, clearlydefined

--- a/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/EdcExtension.java
+++ b/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/EdcExtension.java
@@ -51,7 +51,6 @@ import static org.eclipse.edc.util.types.Cast.cast;
  */
 public class EdcExtension extends BaseRuntime implements BeforeTestExecutionCallback, AfterTestExecutionCallback, ParameterResolver {
     private final LinkedHashMap<Class<?>, Object> serviceMocks = new LinkedHashMap<>();
-    private List<ServiceExtension> runningServiceExtensions;
     private DefaultServiceExtensionContext context;
 
     public EdcExtension() {
@@ -115,6 +114,10 @@ public class EdcExtension extends BaseRuntime implements BeforeTestExecutionCall
 
     public void setConfiguration(Map<String, String> configuration) {
         registerSystemExtension(ConfigurationExtension.class, (ConfigurationExtension) () -> ConfigFactory.fromMap(configuration));
+    }
+
+    public <T> T getService(Class<T> clazz) {
+        return context.getService(clazz);
     }
 
     @Override

--- a/core/control-plane/catalog-core/src/test/java/org/eclipse/edc/connector/defaults/protocol/ProtocolVersionRegistryImplTest.java
+++ b/core/control-plane/catalog-core/src/test/java/org/eclipse/edc/connector/defaults/protocol/ProtocolVersionRegistryImplTest.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.defaults.protocol;
+
+import org.eclipse.edc.connector.spi.protocol.ProtocolVersion;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProtocolVersionRegistryImplTest {
+
+    private final ProtocolVersionRegistryImpl registry = new ProtocolVersionRegistryImpl();
+
+    @Test
+    void shouldRegisterAndRetrieve() {
+        var version = new ProtocolVersion("version", "/path");
+        registry.register(version);
+
+        var result = registry.getAll();
+
+        assertThat(result.protocolVersions()).containsOnly(version);
+    }
+
+    @Test
+    void shouldNotReturnDuplicatedEntries() {
+        registry.register(new ProtocolVersion("version", "/path"));
+        registry.register(new ProtocolVersion("version", "/path"));
+
+        var result = registry.getAll();
+
+        assertThat(result.protocolVersions()).hasSize(1);
+    }
+}

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/ControlPlaneServicesExtension.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/ControlPlaneServicesExtension.java
@@ -38,6 +38,7 @@ import org.eclipse.edc.connector.service.contractnegotiation.ContractNegotiation
 import org.eclipse.edc.connector.service.policydefinition.PolicyDefinitionEventListener;
 import org.eclipse.edc.connector.service.policydefinition.PolicyDefinitionServiceImpl;
 import org.eclipse.edc.connector.service.protocol.ProtocolTokenValidatorImpl;
+import org.eclipse.edc.connector.service.protocol.VersionProtocolServiceImpl;
 import org.eclipse.edc.connector.service.transferprocess.TransferProcessProtocolServiceImpl;
 import org.eclipse.edc.connector.service.transferprocess.TransferProcessServiceImpl;
 import org.eclipse.edc.connector.spi.asset.AssetService;
@@ -49,6 +50,8 @@ import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationProt
 import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationService;
 import org.eclipse.edc.connector.spi.policydefinition.PolicyDefinitionService;
 import org.eclipse.edc.connector.spi.protocol.ProtocolTokenValidator;
+import org.eclipse.edc.connector.spi.protocol.ProtocolVersionRegistry;
+import org.eclipse.edc.connector.spi.protocol.VersionProtocolService;
 import org.eclipse.edc.connector.spi.transferprocess.TransferProcessProtocolService;
 import org.eclipse.edc.connector.spi.transferprocess.TransferProcessService;
 import org.eclipse.edc.connector.transfer.spi.TransferProcessManager;
@@ -153,6 +156,9 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     @Inject(required = false)
     private ProtocolTokenValidator protocolTokenValidator;
 
+    @Inject
+    private ProtocolVersionRegistry protocolVersionRegistry;
+
     @Override
     public String name() {
         return NAME;
@@ -226,4 +232,10 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
         }
         return protocolTokenValidator;
     }
+
+    @Provider
+    public VersionProtocolService versionProtocolService() {
+        return new VersionProtocolServiceImpl(protocolVersionRegistry, protocolTokenValidator());
+    }
+
 }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/protocol/VersionProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/protocol/VersionProtocolServiceImpl.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.service.protocol;
+
+import org.eclipse.edc.connector.spi.protocol.ProtocolTokenValidator;
+import org.eclipse.edc.connector.spi.protocol.ProtocolVersionRegistry;
+import org.eclipse.edc.connector.spi.protocol.ProtocolVersions;
+import org.eclipse.edc.connector.spi.protocol.VersionProtocolService;
+import org.eclipse.edc.policy.engine.spi.PolicyScope;
+import org.eclipse.edc.spi.iam.TokenRepresentation;
+import org.eclipse.edc.spi.result.ServiceResult;
+
+public class VersionProtocolServiceImpl implements VersionProtocolService {
+
+    @PolicyScope
+    public static final String VERSIONING_REQUEST_SCOPE = "request.version";
+
+    private final ProtocolVersionRegistry registry;
+    private final ProtocolTokenValidator tokenValidator;
+
+    public VersionProtocolServiceImpl(ProtocolVersionRegistry registry, ProtocolTokenValidator tokenValidator) {
+        this.registry = registry;
+        this.tokenValidator = tokenValidator;
+    }
+
+    @Override
+    public ServiceResult<ProtocolVersions> getAll(TokenRepresentation tokenRepresentation) {
+        return tokenValidator.verify(tokenRepresentation, VERSIONING_REQUEST_SCOPE)
+                .map(it -> registry.getAll());
+    }
+}

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/catalog/CatalogProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/catalog/CatalogProtocolServiceImplTest.java
@@ -66,7 +66,7 @@ class CatalogProtocolServiceImplTest {
         var participantAgent = createParticipantAgent();
         var dataService = DataService.Builder.newInstance().build();
 
-        when(protocolTokenValidator.verify(eq(tokenRepresentation), eq(CATALOGING_REQUEST_SCOPE), any())).thenReturn(ServiceResult.success(participantAgent));
+        when(protocolTokenValidator.verify(eq(tokenRepresentation), eq(CATALOGING_REQUEST_SCOPE))).thenReturn(ServiceResult.success(participantAgent));
         when(dataServiceRegistry.getDataServices()).thenReturn(List.of(dataService));
         when(datasetResolver.query(any(), any())).thenReturn(Stream.of(createDataset()));
 
@@ -86,7 +86,7 @@ class CatalogProtocolServiceImplTest {
         var message = CatalogRequestMessage.Builder.newInstance().protocol("protocol").querySpec(querySpec).build();
         var tokenRepresentation = createTokenRepresentation();
 
-        when(protocolTokenValidator.verify(eq(tokenRepresentation), eq(CATALOGING_REQUEST_SCOPE), any())).thenReturn(ServiceResult.unauthorized("unauthorized"));
+        when(protocolTokenValidator.verify(eq(tokenRepresentation), eq(CATALOGING_REQUEST_SCOPE))).thenReturn(ServiceResult.unauthorized("unauthorized"));
 
         var result = service.getCatalog(message, tokenRepresentation);
 
@@ -99,7 +99,7 @@ class CatalogProtocolServiceImplTest {
         var participantAgent = createParticipantAgent();
         var dataset = createDataset();
 
-        when(protocolTokenValidator.verify(eq(tokenRepresentation), eq(CATALOGING_REQUEST_SCOPE), any())).thenReturn(ServiceResult.success(participantAgent));
+        when(protocolTokenValidator.verify(eq(tokenRepresentation), eq(CATALOGING_REQUEST_SCOPE))).thenReturn(ServiceResult.success(participantAgent));
         when(datasetResolver.getById(any(), any())).thenReturn(dataset);
 
         var result = service.getDataset("datasetId", tokenRepresentation);
@@ -114,7 +114,7 @@ class CatalogProtocolServiceImplTest {
         var participantAgent = createParticipantAgent();
         var tokenRepresentation = createTokenRepresentation();
 
-        when(protocolTokenValidator.verify(eq(tokenRepresentation), eq(CATALOGING_REQUEST_SCOPE), any())).thenReturn(ServiceResult.success(participantAgent));
+        when(protocolTokenValidator.verify(eq(tokenRepresentation), eq(CATALOGING_REQUEST_SCOPE))).thenReturn(ServiceResult.success(participantAgent));
         when(datasetResolver.getById(any(), any())).thenReturn(null);
 
         var result = service.getDataset("datasetId", tokenRepresentation);
@@ -126,7 +126,7 @@ class CatalogProtocolServiceImplTest {
     void getDataset_shouldFail_whenTokenValidationFails() {
         var tokenRepresentation = createTokenRepresentation();
 
-        when(protocolTokenValidator.verify(eq(tokenRepresentation), eq(CATALOGING_REQUEST_SCOPE), any())).thenReturn(ServiceResult.unauthorized("unauthorized"));
+        when(protocolTokenValidator.verify(eq(tokenRepresentation), eq(CATALOGING_REQUEST_SCOPE))).thenReturn(ServiceResult.unauthorized("unauthorized"));
 
         var result = service.getDataset("datasetId", tokenRepresentation);
 

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/protocol/VersionProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/protocol/VersionProtocolServiceImplTest.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.service.protocol;
+
+import org.eclipse.edc.connector.spi.protocol.ProtocolTokenValidator;
+import org.eclipse.edc.connector.spi.protocol.ProtocolVersionRegistry;
+import org.eclipse.edc.connector.spi.protocol.ProtocolVersions;
+import org.eclipse.edc.spi.iam.TokenRepresentation;
+import org.eclipse.edc.spi.result.ServiceFailure;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.spi.result.ServiceFailure.Reason.UNAUTHORIZED;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class VersionProtocolServiceImplTest {
+
+    private final ProtocolVersionRegistry registry = mock();
+    private final ProtocolTokenValidator tokenValidator = mock();
+    private final VersionProtocolServiceImpl service = new VersionProtocolServiceImpl(registry, tokenValidator);
+
+    @Test
+    void shouldReturnAllProtocolVersions() {
+        when(tokenValidator.verify(any(), any())).thenReturn(ServiceResult.success());
+        var protocolVersions = new ProtocolVersions(Collections.emptyList());
+        when(registry.getAll()).thenReturn(protocolVersions);
+
+        var result = service.getAll(TokenRepresentation.Builder.newInstance().build());
+
+        assertThat(result).isSucceeded().isSameAs(protocolVersions);
+    }
+
+    @Test
+    void shouldReturnUnauthorized_whenTokenIsNotValid() {
+        when(tokenValidator.verify(any(), any())).thenReturn(ServiceResult.unauthorized("unauthorized"));
+
+        var result = service.getAll(TokenRepresentation.Builder.newInstance().build());
+
+        assertThat(result).isFailed().extracting(ServiceFailure::getReason).isEqualTo(UNAUTHORIZED);
+        verifyNoInteractions(registry);
+    }
+}

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/ControlPlaneDefaultServicesExtension.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/ControlPlaneDefaultServicesExtension.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.connector;
 import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.connector.contract.spi.offer.store.ContractDefinitionStore;
 import org.eclipse.edc.connector.defaults.callback.CallbackRegistryImpl;
+import org.eclipse.edc.connector.defaults.protocol.ProtocolVersionRegistryImpl;
 import org.eclipse.edc.connector.defaults.storage.assetindex.InMemoryAssetIndex;
 import org.eclipse.edc.connector.defaults.storage.contractdefinition.InMemoryContractDefinitionStore;
 import org.eclipse.edc.connector.defaults.storage.contractnegotiation.InMemoryContractNegotiationStore;
@@ -24,6 +25,7 @@ import org.eclipse.edc.connector.defaults.storage.policydefinition.InMemoryPolic
 import org.eclipse.edc.connector.defaults.storage.transferprocess.InMemoryTransferProcessStore;
 import org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore;
 import org.eclipse.edc.connector.spi.callback.CallbackRegistry;
+import org.eclipse.edc.connector.spi.protocol.ProtocolVersionRegistry;
 import org.eclipse.edc.connector.transfer.spi.store.TransferProcessStore;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
@@ -91,6 +93,11 @@ public class ControlPlaneDefaultServicesExtension implements ServiceExtension {
     @Provider(isDefault = true)
     public CallbackRegistry defaultCallbackRegistry() {
         return new CallbackRegistryImpl();
+    }
+
+    @Provider(isDefault = true)
+    public ProtocolVersionRegistry protocolVersionRegistry() {
+        return new ProtocolVersionRegistryImpl();
     }
 
     private ContractDefinitionStore getContractDefinitionStore() {

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/protocol/ProtocolVersionRegistryImpl.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/protocol/ProtocolVersionRegistryImpl.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.defaults.protocol;
+
+import org.eclipse.edc.connector.spi.protocol.ProtocolVersion;
+import org.eclipse.edc.connector.spi.protocol.ProtocolVersionRegistry;
+import org.eclipse.edc.connector.spi.protocol.ProtocolVersions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ProtocolVersionRegistryImpl implements ProtocolVersionRegistry {
+
+    private final List<ProtocolVersion> versions = new ArrayList<>();
+
+    @Override
+    public void register(ProtocolVersion protocolVersion) {
+        versions.add(protocolVersion);
+    }
+
+    @Override
+    public ProtocolVersions getAll() {
+        return new ProtocolVersions(versions.stream().distinct().toList());
+    }
+}

--- a/data-protocols/dsp/build.gradle.kts
+++ b/data-protocols/dsp/build.gradle.kts
@@ -24,4 +24,5 @@ dependencies {
     api(project(":data-protocols:dsp:dsp-http-spi"))
     api(project(":data-protocols:dsp:dsp-negotiation"))
     api(project(":data-protocols:dsp:dsp-transfer-process"))
+    api(project(":data-protocols:dsp:dsp-version:dsp-version-api"))
 }

--- a/data-protocols/dsp/dsp-api-configuration/src/main/java/org/eclipse/edc/protocol/dsp/api/configuration/DspApiConfigurationExtension.java
+++ b/data-protocols/dsp/dsp-api-configuration/src/main/java/org/eclipse/edc/protocol/dsp/api/configuration/DspApiConfigurationExtension.java
@@ -37,6 +37,7 @@ import org.eclipse.edc.core.transform.transformer.to.JsonValueToGenericTypeTrans
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.policy.model.AtomicConstraint;
 import org.eclipse.edc.policy.model.LiteralExpression;
+import org.eclipse.edc.protocol.dsp.spi.configuration.DspApiConfiguration;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provides;

--- a/data-protocols/dsp/dsp-api-configuration/src/test/java/org/eclipse/edc/protocol/dsp/api/configuration/DspApiConfigurationExtensionTest.java
+++ b/data-protocols/dsp/dsp-api-configuration/src/test/java/org/eclipse/edc/protocol/dsp/api/configuration/DspApiConfigurationExtensionTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.protocol.dsp.api.configuration;
 
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.protocol.dsp.spi.configuration.DspApiConfiguration;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.eclipse.edc.spi.types.TypeManager;

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-api/build.gradle.kts
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-api/build.gradle.kts
@@ -17,7 +17,6 @@ plugins {
 }
 
 dependencies {
-    api(project(":data-protocols:dsp:dsp-api-configuration"))
     api(project(":data-protocols:dsp:dsp-spi"))
     api(project(":data-protocols:dsp:dsp-http-spi"))
 

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-api/src/main/java/org/eclipse/edc/protocol/dsp/catalog/api/controller/DspCatalogApiController20241.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-api/src/main/java/org/eclipse/edc/protocol/dsp/catalog/api/controller/DspCatalogApiController20241.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (c) 2023 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.catalog.api.controller;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import org.eclipse.edc.connector.spi.catalog.CatalogProtocolService;
+import org.eclipse.edc.protocol.dsp.spi.message.DspRequestHandler;
+import org.eclipse.edc.protocol.dsp.version.DspVersions;
+
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.eclipse.edc.protocol.dsp.catalog.api.CatalogApiPaths.BASE_PATH;
+
+/**
+ * Versioned Catalog endpoint, same as {@link DspCatalogApiController} but exposed on the /2024/1 path
+ */
+@Consumes({APPLICATION_JSON})
+@Produces({APPLICATION_JSON})
+@Path(DspVersions.V_2024_1_PATH +  BASE_PATH)
+public class DspCatalogApiController20241 extends DspCatalogApiController {
+
+    public DspCatalogApiController20241(CatalogProtocolService service, DspRequestHandler dspRequestHandler) {
+        super(service, dspRequestHandler);
+    }
+}

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-api/src/test/java/org/eclipse/edc/protocol/dsp/catalog/api/DspCatalogApiExtensionTest.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-api/src/test/java/org/eclipse/edc/protocol/dsp/catalog/api/DspCatalogApiExtensionTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.edc.protocol.dsp.catalog.api;
 
+import org.eclipse.edc.connector.spi.protocol.ProtocolVersion;
+import org.eclipse.edc.connector.spi.protocol.ProtocolVersionRegistry;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
@@ -24,6 +26,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import static org.eclipse.edc.protocol.dsp.type.DspCatalogPropertyAndTypeNames.DSPACE_TYPE_CATALOG_REQUEST_MESSAGE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -31,10 +34,12 @@ import static org.mockito.Mockito.verify;
 class DspCatalogApiExtensionTest {
 
     private final JsonObjectValidatorRegistry validatorRegistry = mock();
+    private final ProtocolVersionRegistry versionRegistry = mock();
 
     @BeforeEach
     void setUp(ServiceExtensionContext context) {
         context.registerService(JsonObjectValidatorRegistry.class, validatorRegistry);
+        context.registerService(ProtocolVersionRegistry.class, versionRegistry);
     }
 
     @Test
@@ -42,5 +47,12 @@ class DspCatalogApiExtensionTest {
         extension.initialize(context);
 
         verify(validatorRegistry).register(eq(DSPACE_TYPE_CATALOG_REQUEST_MESSAGE), any());
+    }
+
+    @Test
+    void shouldRegisterDspVersion(DspCatalogApiExtension extension, ServiceExtensionContext context) {
+        extension.initialize(context);
+
+        verify(versionRegistry).register(isA(ProtocolVersion.class));
     }
 }

--- a/data-protocols/dsp/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/message/DspRequestHandlerImplTest.java
+++ b/data-protocols/dsp/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/message/DspRequestHandlerImplTest.java
@@ -76,6 +76,20 @@ class DspRequestHandlerImplTest {
         }
 
         @Test
+        void shouldReturnUnauthorized_whenTokenIsNull() {
+            var request = getDspRequestBuilder().token(null).errorType("errorType").serviceCall((m, t) -> ServiceResult.success()).build();
+
+            var result = handler.getResource(request);
+
+            assertThat(result.getStatus()).isEqualTo(401);
+            assertThat(result.getEntity()).asInstanceOf(type(JsonObject.class)).satisfies(error -> {
+                assertThat(error.getString(TYPE)).isEqualTo("errorType");
+                assertThat(error.getString(DSPACE_PROPERTY_CODE)).isEqualTo("401");
+                assertThat(error.get(DSPACE_PROPERTY_REASON)).isNotNull();
+            });
+        }
+
+        @Test
         void shouldFail_whenTokenIsNotValid() {
             var request = getDspRequestBuilder().errorType("errorType").serviceCall((m, t) -> ServiceResult.unauthorized("unauthorized")).build();
 
@@ -149,6 +163,20 @@ class DspRequestHandlerImplTest {
             verify(transformerRegistry).transform(jsonMessage, TestProcessRemoteMessage.class);
             verify(message).setProtocol(DATASPACE_PROTOCOL_HTTP);
             verify(transformerRegistry).transform(content, JsonObject.class);
+        }
+
+        @Test
+        void shouldReturnUnauthorized_whenTokenIsNull() {
+            var request = postDspRequestBuilder().token(null).errorType("errorType").serviceCall((m, t) -> ServiceResult.success()).build();
+
+            var result = handler.createResource(request);
+
+            assertThat(result.getStatus()).isEqualTo(401);
+            assertThat(result.getEntity()).asInstanceOf(type(JsonObject.class)).satisfies(error -> {
+                assertThat(error.getString(TYPE)).isEqualTo("errorType");
+                assertThat(error.getString(DSPACE_PROPERTY_CODE)).isEqualTo("401");
+                assertThat(error.get(DSPACE_PROPERTY_REASON)).isNotNull();
+            });
         }
 
         @Test
@@ -268,6 +296,28 @@ class DspRequestHandlerImplTest {
             
             when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
             when(transformerRegistry.transform(any(), eq(TestProcessRemoteMessage.class))).thenReturn(Result.success(message));
+
+            var result = handler.updateResource(request);
+
+            assertThat(result.getStatus()).isEqualTo(401);
+            assertThat(result.getEntity()).asInstanceOf(type(JsonObject.class)).satisfies(error -> {
+                assertThat(error.getString(TYPE)).isEqualTo("errorType");
+                assertThat(error.getString(DSPACE_PROPERTY_CODE)).isEqualTo("401");
+                assertThat(error.getString(DSPACE_PROPERTY_PROCESS_ID)).isEqualTo("processId");
+                assertThat(error.get(DSPACE_PROPERTY_REASON)).isNotNull();
+            });
+        }
+
+        @Test
+        void shouldReturnUnauthorized_whenTokenIsNull() {
+            var jsonMessage = Json.createObjectBuilder().build();
+            var request = postDspRequestBuilder()
+                    .token(null)
+                    .processId("processId")
+                    .errorType("errorType")
+                    .message(jsonMessage)
+                    .serviceCall((m, t) -> ServiceResult.unauthorized("unauthorized"))
+                    .build();
 
             var result = handler.updateResource(request);
 

--- a/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/spi/configuration/DspApiConfiguration.java
+++ b/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/spi/configuration/DspApiConfiguration.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2023 Fraunhofer Institute for Software and Systems Engineering
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,11 +8,11 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
  *
  */
 
-package org.eclipse.edc.protocol.dsp.api.configuration;
+package org.eclipse.edc.protocol.dsp.spi.configuration;
 
 /**
  * Holds configuration information for the Dataspace Protocol API context. This is includes the

--- a/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/spi/error/DspErrorResponse.java
+++ b/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/spi/error/DspErrorResponse.java
@@ -59,6 +59,10 @@ public class DspErrorResponse {
         return internalBuild(Response.Status.INTERNAL_SERVER_ERROR, Collections.emptyList());
     }
 
+    public Response unauthorized() {
+        return internalBuild(Response.Status.UNAUTHORIZED, List.of("Unauthorized."));
+    }
+
     public DspErrorResponse processId(String processId) {
         this.processId = processId;
         return this;

--- a/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/spi/message/DspRequest.java
+++ b/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/spi/message/DspRequest.java
@@ -78,7 +78,6 @@ public class DspRequest<I, R> {
         }
 
         public M build() {
-            requireNonNull(message.token);
             requireNonNull(message.serviceCall);
             requireNonNull(message.errorType);
             return message;

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/build.gradle.kts
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/build.gradle.kts
@@ -17,7 +17,6 @@ plugins {
 }
 
 dependencies {
-    api(project(":data-protocols:dsp:dsp-api-configuration"))
     api(project(":data-protocols:dsp:dsp-spi"))
     api(project(":data-protocols:dsp:dsp-http-spi"))
 

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/api/DspNegotiationApiExtension.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/api/DspNegotiationApiExtension.java
@@ -15,14 +15,16 @@
 package org.eclipse.edc.protocol.dsp.negotiation.api;
 
 import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationProtocolService;
-import org.eclipse.edc.protocol.dsp.api.configuration.DspApiConfiguration;
+import org.eclipse.edc.connector.spi.protocol.ProtocolVersionRegistry;
 import org.eclipse.edc.protocol.dsp.negotiation.api.controller.DspNegotiationApiController;
+import org.eclipse.edc.protocol.dsp.negotiation.api.controller.DspNegotiationApiController20241;
 import org.eclipse.edc.protocol.dsp.negotiation.api.validation.ContractAgreementMessageValidator;
 import org.eclipse.edc.protocol.dsp.negotiation.api.validation.ContractAgreementVerificationMessageValidator;
 import org.eclipse.edc.protocol.dsp.negotiation.api.validation.ContractNegotiationEventMessageValidator;
 import org.eclipse.edc.protocol.dsp.negotiation.api.validation.ContractNegotiationTerminationMessageValidator;
 import org.eclipse.edc.protocol.dsp.negotiation.api.validation.ContractOfferMessageValidator;
 import org.eclipse.edc.protocol.dsp.negotiation.api.validation.ContractRequestMessageValidator;
+import org.eclipse.edc.protocol.dsp.spi.configuration.DspApiConfiguration;
 import org.eclipse.edc.protocol.dsp.spi.message.DspRequestHandler;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
@@ -37,6 +39,7 @@ import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNam
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_TERMINATION_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_OFFER_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE;
+import static org.eclipse.edc.protocol.dsp.version.DspVersions.V_2024_1;
 
 /**
  * Creates and registers the controller for dataspace protocol negotiation requests.
@@ -56,6 +59,8 @@ public class DspNegotiationApiExtension implements ServiceExtension {
     private JsonObjectValidatorRegistry validatorRegistry;
     @Inject
     private DspRequestHandler dspRequestHandler;
+    @Inject
+    private ProtocolVersionRegistry versionRegistry;
 
     @Override
     public String name() {
@@ -71,8 +76,9 @@ public class DspNegotiationApiExtension implements ServiceExtension {
         validatorRegistry.register(DSPACE_TYPE_CONTRACT_AGREEMENT_VERIFICATION_MESSAGE, ContractAgreementVerificationMessageValidator.instance());
         validatorRegistry.register(DSPACE_TYPE_CONTRACT_NEGOTIATION_TERMINATION_MESSAGE, ContractNegotiationTerminationMessageValidator.instance());
 
-        var controller = new DspNegotiationApiController(protocolService, dspRequestHandler);
+        webService.registerResource(apiConfiguration.getContextAlias(), new DspNegotiationApiController(protocolService, dspRequestHandler));
+        webService.registerResource(apiConfiguration.getContextAlias(), new DspNegotiationApiController20241(protocolService, dspRequestHandler));
 
-        webService.registerResource(apiConfiguration.getContextAlias(), controller);
+        versionRegistry.register(V_2024_1);
     }
 }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/api/controller/DspNegotiationApiController20241.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/api/controller/DspNegotiationApiController20241.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (c) 2023 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.negotiation.api.controller;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationProtocolService;
+import org.eclipse.edc.protocol.dsp.spi.message.DspRequestHandler;
+import org.eclipse.edc.protocol.dsp.version.DspVersions;
+
+import static org.eclipse.edc.protocol.dsp.negotiation.api.NegotiationApiPaths.BASE_PATH;
+
+/**
+ * Versioned Negotiation endpoint, same as {@link DspNegotiationApiController} but exposed on the /2024/1 path
+ */
+@Consumes({ MediaType.APPLICATION_JSON })
+@Produces({ MediaType.APPLICATION_JSON })
+@Path(DspVersions.V_2024_1_PATH + BASE_PATH)
+public class DspNegotiationApiController20241 extends DspNegotiationApiController {
+
+    public DspNegotiationApiController20241(ContractNegotiationProtocolService protocolService, DspRequestHandler dspRequestHandler) {
+        super(protocolService, dspRequestHandler);
+    }
+}

--- a/data-protocols/dsp/dsp-spi/build.gradle.kts
+++ b/data-protocols/dsp/dsp-spi/build.gradle.kts
@@ -17,5 +17,7 @@ plugins {
 }
 
 dependencies {
-    api(project(":extensions:common:json-ld"))
+    api(project(":spi:control-plane:control-plane-spi"))
+
+    implementation(project(":extensions:common:json-ld"))
 }

--- a/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/type/DspVersionPropertyAndTypeNames.java
+++ b/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/type/DspVersionPropertyAndTypeNames.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.type;
+
+import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+
+/**
+ * Dataspace protocol types and attributes for version request.
+ */
+public interface DspVersionPropertyAndTypeNames {
+
+    String DSPACE_PROPERTY_PROTOCOL_VERSIONS = DSPACE_SCHEMA + "protocolVersions";
+
+    String DSPACE_TYPE_VERSIONS_ERROR = DSPACE_SCHEMA + "VersionsError";
+    String DSPACE_PROPERTY_VERSION = DSPACE_SCHEMA + "version";
+    String DSPACE_PROPERTY_PATH = DSPACE_SCHEMA + "path";
+
+}

--- a/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/version/DspVersions.java
+++ b/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/version/DspVersions.java
@@ -1,0 +1,25 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.version;
+
+import org.eclipse.edc.connector.spi.protocol.ProtocolVersion;
+
+public interface DspVersions {
+
+    String V_2024_1_VERSION = "2024/1";
+    String V_2024_1_PATH = "/" + V_2024_1_VERSION;
+    ProtocolVersion V_2024_1 = new ProtocolVersion(V_2024_1_VERSION, V_2024_1_PATH);
+
+}

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-api/build.gradle.kts
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-api/build.gradle.kts
@@ -20,7 +20,6 @@ dependencies {
     api(project(":spi:control-plane:transfer-spi"))
     api(project(":spi:control-plane:control-plane-spi"))
     api(project(":extensions:common:http"))
-    api(project(":data-protocols:dsp:dsp-api-configuration"))
     api(project(":data-protocols:dsp:dsp-spi"))
     api(project(":data-protocols:dsp:dsp-http-spi"))
 

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-api/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/api/DspTransferProcessApiExtension.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-api/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/api/DspTransferProcessApiExtension.java
@@ -14,10 +14,12 @@
 
 package org.eclipse.edc.protocol.dsp.transferprocess.api;
 
+import org.eclipse.edc.connector.spi.protocol.ProtocolVersionRegistry;
 import org.eclipse.edc.connector.spi.transferprocess.TransferProcessProtocolService;
-import org.eclipse.edc.protocol.dsp.api.configuration.DspApiConfiguration;
+import org.eclipse.edc.protocol.dsp.spi.configuration.DspApiConfiguration;
 import org.eclipse.edc.protocol.dsp.spi.message.DspRequestHandler;
 import org.eclipse.edc.protocol.dsp.transferprocess.api.controller.DspTransferProcessApiController;
+import org.eclipse.edc.protocol.dsp.transferprocess.api.controller.DspTransferProcessApiController20241;
 import org.eclipse.edc.protocol.dsp.transferprocess.api.validation.TransferCompletionMessageValidator;
 import org.eclipse.edc.protocol.dsp.transferprocess.api.validation.TransferRequestMessageValidator;
 import org.eclipse.edc.protocol.dsp.transferprocess.api.validation.TransferStartMessageValidator;
@@ -33,6 +35,7 @@ import static org.eclipse.edc.protocol.dsp.type.DspTransferProcessPropertyAndTyp
 import static org.eclipse.edc.protocol.dsp.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_REQUEST_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_START_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_TERMINATION_MESSAGE;
+import static org.eclipse.edc.protocol.dsp.version.DspVersions.V_2024_1;
 
 /**
  * Creates and registers the controller for dataspace protocol transfer process requests.
@@ -51,6 +54,8 @@ public class DspTransferProcessApiExtension implements ServiceExtension {
     private DspRequestHandler dspRequestHandler;
     @Inject
     private JsonObjectValidatorRegistry validatorRegistry;
+    @Inject
+    private ProtocolVersionRegistry versionRegistry;
 
     @Override
     public void initialize(ServiceExtensionContext context) {
@@ -59,8 +64,9 @@ public class DspTransferProcessApiExtension implements ServiceExtension {
         validatorRegistry.register(DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE, TransferCompletionMessageValidator.instance());
         validatorRegistry.register(DSPACE_TYPE_TRANSFER_TERMINATION_MESSAGE, TransferTerminationMessageValidator.instance());
 
-        var controller = new DspTransferProcessApiController(transferProcessProtocolService, dspRequestHandler);
+        webService.registerResource(config.getContextAlias(), new DspTransferProcessApiController(transferProcessProtocolService, dspRequestHandler));
+        webService.registerResource(config.getContextAlias(), new DspTransferProcessApiController20241(transferProcessProtocolService, dspRequestHandler));
 
-        webService.registerResource(config.getContextAlias(), controller);
+        versionRegistry.register(V_2024_1);
     }
 }

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-api/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/api/controller/DspTransferProcessApiController20241.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-api/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/api/controller/DspTransferProcessApiController20241.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2023 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.transferprocess.api.controller;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.edc.connector.spi.transferprocess.TransferProcessProtocolService;
+import org.eclipse.edc.protocol.dsp.spi.message.DspRequestHandler;
+import org.eclipse.edc.protocol.dsp.version.DspVersions;
+
+import static org.eclipse.edc.protocol.dsp.transferprocess.api.TransferProcessApiPaths.BASE_PATH;
+
+
+/**
+ * Versioned Transfer endpoint, same as {@link DspTransferProcessApiController} but exposed on the /2024/1 path
+ */
+@Consumes({ MediaType.APPLICATION_JSON })
+@Produces({ MediaType.APPLICATION_JSON })
+@Path(DspVersions.V_2024_1_PATH + BASE_PATH)
+public class DspTransferProcessApiController20241 extends DspTransferProcessApiController {
+
+    public DspTransferProcessApiController20241(TransferProcessProtocolService protocolService, DspRequestHandler dspRequestHandler) {
+        super(protocolService, dspRequestHandler);
+    }
+}

--- a/data-protocols/dsp/dsp-version/dsp-version-api/build.gradle.kts
+++ b/data-protocols/dsp/dsp-version/dsp-version-api/build.gradle.kts
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(project(":spi:common:core-spi"))
+    api(project(":spi:common:json-ld-spi"))
+    api(project(":spi:common:transform-spi"))
+    api(project(":spi:common:web-spi"))
+    api(project(":data-protocols:dsp:dsp-http-spi"))
+
+    testImplementation(project(":core:common:junit"))
+    testImplementation(project(":extensions:common:json-ld"))
+    testImplementation(testFixtures(project(":extensions:common:http:jersey-core")))
+    testImplementation(libs.restAssured)
+}

--- a/data-protocols/dsp/dsp-version/dsp-version-api/src/main/java/org/eclipse/edc/protocol/dsp/version/api/DspVersionApiController.java
+++ b/data-protocols/dsp/dsp-version/dsp-version-api/src/main/java/org/eclipse/edc/protocol/dsp/version/api/DspVersionApiController.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.version.api;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.edc.connector.spi.protocol.ProtocolVersions;
+import org.eclipse.edc.connector.spi.protocol.VersionProtocolService;
+import org.eclipse.edc.protocol.dsp.spi.message.DspRequestHandler;
+import org.eclipse.edc.protocol.dsp.spi.message.GetDspRequest;
+
+import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.eclipse.edc.protocol.dsp.type.DspVersionPropertyAndTypeNames.DSPACE_TYPE_VERSIONS_ERROR;
+
+@Produces(APPLICATION_JSON)
+@Path("/.well-known/dspace-version")
+public class DspVersionApiController {
+
+    private final DspRequestHandler requestHandler;
+    private final VersionProtocolService service;
+
+    public DspVersionApiController(DspRequestHandler requestHandler, VersionProtocolService service) {
+        this.requestHandler = requestHandler;
+        this.service = service;
+    }
+
+    @GET
+    public Response getProtocolVersions(@HeaderParam(AUTHORIZATION) String token) {
+        var request = GetDspRequest.Builder.newInstance(ProtocolVersions.class)
+                .token(token)
+                .errorType(DSPACE_TYPE_VERSIONS_ERROR)
+                .serviceCall((id, tokenRepresentation) -> service.getAll(tokenRepresentation))
+                .build();
+
+        return requestHandler.getResource(request);
+    }
+
+}

--- a/data-protocols/dsp/dsp-version/dsp-version-api/src/main/java/org/eclipse/edc/protocol/dsp/version/api/DspVersionApiExtension.java
+++ b/data-protocols/dsp/dsp-version/dsp-version-api/src/main/java/org/eclipse/edc/protocol/dsp/version/api/DspVersionApiExtension.java
@@ -27,6 +27,9 @@ import org.eclipse.edc.web.spi.WebService;
 
 import static org.eclipse.edc.protocol.dsp.version.api.DspVersionApiExtension.NAME;
 
+/**
+ * Provide API for the protocol versions.
+ */
 @Extension(NAME)
 public class DspVersionApiExtension implements ServiceExtension {
 

--- a/data-protocols/dsp/dsp-version/dsp-version-api/src/main/java/org/eclipse/edc/protocol/dsp/version/api/DspVersionApiExtension.java
+++ b/data-protocols/dsp/dsp-version/dsp-version-api/src/main/java/org/eclipse/edc/protocol/dsp/version/api/DspVersionApiExtension.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.version.api;
+
+import org.eclipse.edc.connector.spi.protocol.VersionProtocolService;
+import org.eclipse.edc.protocol.dsp.spi.configuration.DspApiConfiguration;
+import org.eclipse.edc.protocol.dsp.spi.message.DspRequestHandler;
+import org.eclipse.edc.protocol.dsp.version.api.transformer.JsonObjectFromProtocolVersionsTransformer;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.web.spi.WebService;
+
+import static org.eclipse.edc.protocol.dsp.version.api.DspVersionApiExtension.NAME;
+
+@Extension(NAME)
+public class DspVersionApiExtension implements ServiceExtension {
+
+    public static final String NAME = "Dataspace Protocol Version Api";
+
+    @Inject
+    private WebService webService;
+
+    @Inject
+    private DspApiConfiguration configuration;
+
+    @Inject
+    private TypeTransformerRegistry transformerRegistry;
+
+    @Inject
+    private DspRequestHandler requestHandler;
+
+    @Inject
+    private VersionProtocolService service;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        transformerRegistry.register(new JsonObjectFromProtocolVersionsTransformer());
+
+        webService.registerResource(configuration.getContextAlias(), new DspVersionApiController(requestHandler, service));
+    }
+
+}

--- a/data-protocols/dsp/dsp-version/dsp-version-api/src/main/java/org/eclipse/edc/protocol/dsp/version/api/transformer/JsonObjectFromProtocolVersionsTransformer.java
+++ b/data-protocols/dsp/dsp-version/dsp-version-api/src/main/java/org/eclipse/edc/protocol/dsp/version/api/transformer/JsonObjectFromProtocolVersionsTransformer.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.version.api.transformer;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.spi.protocol.ProtocolVersions;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static jakarta.json.stream.JsonCollectors.toJsonArray;
+import static org.eclipse.edc.protocol.dsp.type.DspVersionPropertyAndTypeNames.DSPACE_PROPERTY_PATH;
+import static org.eclipse.edc.protocol.dsp.type.DspVersionPropertyAndTypeNames.DSPACE_PROPERTY_PROTOCOL_VERSIONS;
+import static org.eclipse.edc.protocol.dsp.type.DspVersionPropertyAndTypeNames.DSPACE_PROPERTY_VERSION;
+
+public class JsonObjectFromProtocolVersionsTransformer extends AbstractJsonLdTransformer<ProtocolVersions, JsonObject> {
+
+    public JsonObjectFromProtocolVersionsTransformer() {
+        super(ProtocolVersions.class, JsonObject.class);
+    }
+
+    @Override
+    public @Nullable JsonObject transform(@NotNull ProtocolVersions protocolVersions, @NotNull TransformerContext context) {
+        var versions = protocolVersions.protocolVersions().stream()
+                .map(version -> Json.createObjectBuilder()
+                        .add(DSPACE_PROPERTY_VERSION, version.version())
+                        .add(DSPACE_PROPERTY_PATH, version.path())
+                        .build())
+                .collect(toJsonArray());
+
+        return Json.createObjectBuilder().add(DSPACE_PROPERTY_PROTOCOL_VERSIONS, versions).build();
+    }
+}

--- a/data-protocols/dsp/dsp-version/dsp-version-api/src/main/java/org/eclipse/edc/protocol/dsp/version/api/transformer/JsonObjectFromProtocolVersionsTransformer.java
+++ b/data-protocols/dsp/dsp-version/dsp-version-api/src/main/java/org/eclipse/edc/protocol/dsp/version/api/transformer/JsonObjectFromProtocolVersionsTransformer.java
@@ -27,6 +27,9 @@ import static org.eclipse.edc.protocol.dsp.type.DspVersionPropertyAndTypeNames.D
 import static org.eclipse.edc.protocol.dsp.type.DspVersionPropertyAndTypeNames.DSPACE_PROPERTY_PROTOCOL_VERSIONS;
 import static org.eclipse.edc.protocol.dsp.type.DspVersionPropertyAndTypeNames.DSPACE_PROPERTY_VERSION;
 
+/**
+ * Transform {@link ProtocolVersions} into {@link JsonObject}
+ */
 public class JsonObjectFromProtocolVersionsTransformer extends AbstractJsonLdTransformer<ProtocolVersions, JsonObject> {
 
     public JsonObjectFromProtocolVersionsTransformer() {

--- a/data-protocols/dsp/dsp-version/dsp-version-api/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/data-protocols/dsp/dsp-version/dsp-version-api/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial API and Implementation
+#
+#
+
+org.eclipse.edc.protocol.dsp.version.api.DspVersionApiExtension

--- a/data-protocols/dsp/dsp-version/dsp-version-api/src/test/java/org/eclipse/edc/protocol/dsp/version/api/DspVersionApiControllerTest.java
+++ b/data-protocols/dsp/dsp-version/dsp-version-api/src/test/java/org/eclipse/edc/protocol/dsp/version/api/DspVersionApiControllerTest.java
@@ -1,0 +1,73 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.version.api;
+
+import io.restassured.specification.RequestSpecification;
+import jakarta.json.Json;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.edc.connector.spi.protocol.VersionProtocolService;
+import org.eclipse.edc.junit.annotations.ApiTest;
+import org.eclipse.edc.protocol.dsp.spi.message.DspRequestHandler;
+import org.eclipse.edc.protocol.dsp.spi.message.GetDspRequest;
+import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static io.restassured.RestAssured.given;
+import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ApiTest
+class DspVersionApiControllerTest extends RestControllerTestBase {
+
+    private final VersionProtocolService service = mock();
+    private final DspRequestHandler requestHandler = mock();
+
+    @Test
+    void shouldInvokeRequestHandler() {
+        var output = Json.createObjectBuilder().add("protocolVersions", Json.createArrayBuilder().add(Json.createObjectBuilder().add("version", "1.0")).build()).build();
+        when(requestHandler.getResource(any())).thenReturn(Response.ok(output).build());
+
+        baseRequest()
+                .header(AUTHORIZATION, "token")
+                .get(".well-known/dspace-version")
+                .then()
+                .log().ifError()
+                .statusCode(200)
+                .contentType(APPLICATION_JSON)
+                .body("protocolVersions[0].version", is("1.0"));
+
+        var captor = ArgumentCaptor.forClass(GetDspRequest.class);
+        verify(requestHandler).getResource(captor.capture());
+        assertThat(captor.getValue().getToken()).isEqualTo("token");
+    }
+
+    @Override
+    protected Object controller() {
+        return new DspVersionApiController(requestHandler, service);
+    }
+
+    private RequestSpecification baseRequest() {
+        return given()
+                .baseUri("http://localhost:" + port)
+                .when();
+    }
+}

--- a/data-protocols/dsp/dsp-version/dsp-version-api/src/test/java/org/eclipse/edc/protocol/dsp/version/api/DspVersionApiExtensionTest.java
+++ b/data-protocols/dsp/dsp-version/dsp-version-api/src/test/java/org/eclipse/edc/protocol/dsp/version/api/DspVersionApiExtensionTest.java
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.version.api;
+
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.protocol.dsp.spi.configuration.DspApiConfiguration;
+import org.eclipse.edc.protocol.dsp.version.api.transformer.JsonObjectFromProtocolVersionsTransformer;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.web.spi.WebService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(DependencyInjectionExtension.class)
+class DspVersionApiExtensionTest {
+
+    private final WebService webService = mock();
+    private final DspApiConfiguration dspApiConfiguration = mock();
+    private final TypeTransformerRegistry transformerRegistry = mock();
+
+    @BeforeEach
+    void setUp(ServiceExtensionContext context) {
+        context.registerService(WebService.class, webService);
+        context.registerService(DspApiConfiguration.class, dspApiConfiguration);
+        context.registerService(TypeTransformerRegistry.class, transformerRegistry);
+    }
+
+    @Test
+    void shouldRegisterApiController(DspVersionApiExtension extension, ServiceExtensionContext context) {
+        when(dspApiConfiguration.getContextAlias()).thenReturn("context-alias");
+
+        extension.initialize(context);
+
+        verify(webService).registerResource(eq("context-alias"), isA(DspVersionApiController.class));
+        verify(transformerRegistry).register(isA(JsonObjectFromProtocolVersionsTransformer.class));
+    }
+}

--- a/data-protocols/dsp/dsp-version/dsp-version-api/src/test/java/org/eclipse/edc/protocol/dsp/version/api/transformer/JsonObjectFromProtocolVersionsTransformerTest.java
+++ b/data-protocols/dsp/dsp-version/dsp-version-api/src/test/java/org/eclipse/edc/protocol/dsp/version/api/transformer/JsonObjectFromProtocolVersionsTransformerTest.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.version.api.transformer;
+
+import jakarta.json.JsonValue;
+import org.eclipse.edc.connector.spi.protocol.ProtocolVersion;
+import org.eclipse.edc.connector.spi.protocol.ProtocolVersions;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.protocol.dsp.type.DspVersionPropertyAndTypeNames.DSPACE_PROPERTY_PATH;
+import static org.eclipse.edc.protocol.dsp.type.DspVersionPropertyAndTypeNames.DSPACE_PROPERTY_PROTOCOL_VERSIONS;
+import static org.eclipse.edc.protocol.dsp.type.DspVersionPropertyAndTypeNames.DSPACE_PROPERTY_VERSION;
+import static org.mockito.Mockito.mock;
+
+class JsonObjectFromProtocolVersionsTransformerTest {
+
+    private final TransformerContext context = mock();
+    private final JsonObjectFromProtocolVersionsTransformer transformer =
+            new JsonObjectFromProtocolVersionsTransformer();
+
+    @Test
+    void shouldTransform() {
+        var protocolVersion = new ProtocolVersion("version", "/path");
+        var protocolVersions = new ProtocolVersions(List.of(protocolVersion));
+
+        var result = transformer.transform(protocolVersions, context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getJsonArray(DSPACE_PROPERTY_PROTOCOL_VERSIONS)).isNotEmpty()
+                .hasSize(1).first().extracting(JsonValue::asJsonObject).satisfies(version -> {
+                    assertThat(version.getString(DSPACE_PROPERTY_VERSION)).isEqualTo("version");
+                    assertThat(version.getString(DSPACE_PROPERTY_PATH)).isEqualTo("/path");
+                });
+    }
+}

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/SqlContractNegotiationStore.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/contractnegotiation/store/SqlContractNegotiationStore.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.store.sql.contractnegotiation.store.schema.ContractNegotiationStatements;
+import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.entity.ProtocolMessages;
 import org.eclipse.edc.spi.persistence.EdcPersistenceException;
 import org.eclipse.edc.spi.query.Criterion;
@@ -354,8 +355,7 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
                 .consumerId(resultSet.getString(statements.getConsumerAgentColumn()))
                 .assetId(resultSet.getString(statements.getAssetIdColumn()))
                 .contractSigningDate(resultSet.getLong(statements.getSigningDateColumn()))
-                .policy(fromJson(resultSet.getString(statements.getPolicyColumn()), new TypeReference<>() {
-                }))
+                .policy(fromJson(resultSet.getString(statements.getPolicyColumn()), Policy.class))
                 .build();
     }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -83,6 +83,7 @@ include(":data-protocols:dsp:dsp-transfer-process")
 include(":data-protocols:dsp:dsp-transfer-process:dsp-transfer-process-api")
 include(":data-protocols:dsp:dsp-transfer-process:dsp-transfer-process-http-dispatcher")
 include(":data-protocols:dsp:dsp-transfer-process:dsp-transfer-process-transform")
+include(":data-protocols:dsp:dsp-version:dsp-version-api")
 
 // modules for technology- or cloud-provider extensions --------------------------------------------
 include(":extensions:common:api:api-core")
@@ -236,9 +237,9 @@ include(":system-tests:e2e-transfer-test:data-plane")
 include(":system-tests:e2e-transfer-test:runner")
 include(":system-tests:management-api:management-api-test-runner")
 include(":system-tests:management-api:management-api-test-runtime")
+include(":system-tests:protocol-test")
 include(":system-tests:sts-api:sts-api-test-runner")
 include(":system-tests:sts-api:sts-api-test-runtime")
-
 include(":system-tests:telemetry:telemetry-test-runner")
 include(":system-tests:telemetry:telemetry-test-runtime")
 

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/protocol/ProtocolTokenValidator.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/protocol/ProtocolTokenValidator.java
@@ -28,6 +28,17 @@ import org.eclipse.edc.spi.result.ServiceResult;
 public interface ProtocolTokenValidator {
 
     /**
+     * Verify the {@link TokenRepresentation}
+     *
+     * @param tokenRepresentation The token
+     * @param policyScope         The policy scope
+     * @return Returns the extracted {@link ParticipantAgent} if successful, failure otherwise
+     */
+    default ServiceResult<ParticipantAgent> verify(TokenRepresentation tokenRepresentation, String policyScope) {
+        return verify(tokenRepresentation, policyScope, Policy.Builder.newInstance().build());
+    }
+
+    /**
      * Verify the {@link TokenRepresentation} in the context of a policy
      *
      * @param tokenRepresentation The token

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/protocol/ProtocolVersion.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/protocol/ProtocolVersion.java
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.spi.protocol;
+
+/**
+ * Supported dataspace protocol version
+ */
+public record ProtocolVersion(String version, String path) {
+}

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/protocol/ProtocolVersionRegistry.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/protocol/ProtocolVersionRegistry.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.spi.protocol;
+
+/**
+ * Keeps track of all the dataspace protocol versions.
+ */
+public interface ProtocolVersionRegistry {
+
+    /**
+     * Register a protocol version
+     *
+     * @param protocolVersion the protocol version.
+     */
+    void register(ProtocolVersion protocolVersion);
+
+    /**
+     * get all the protocol versions.
+     *
+     * @return the protocol versions.
+     */
+    ProtocolVersions getAll();
+}

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/protocol/ProtocolVersions.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/protocol/ProtocolVersions.java
@@ -1,0 +1,23 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.spi.protocol;
+
+import java.util.List;
+
+/**
+ * Wrapper class that represent a {@link List} of {@link ProtocolVersion}
+ */
+public record ProtocolVersions(List<ProtocolVersion> protocolVersions) {
+}

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/protocol/VersionProtocolService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/protocol/VersionProtocolService.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.spi.protocol;
+
+import org.eclipse.edc.spi.iam.TokenRepresentation;
+import org.eclipse.edc.spi.result.ServiceResult;
+
+/**
+ * Mediates access of {@link ProtocolVersion} on protocol communication.
+ */
+public interface VersionProtocolService {
+
+    /**
+     * Get all the versions.
+     *
+     * @param tokenRepresentation the token.
+     * @return a {@link ServiceResult} with the list of versions.
+     */
+    ServiceResult<ProtocolVersions> getAll(TokenRepresentation tokenRepresentation);
+}

--- a/system-tests/protocol-test/build.gradle.kts
+++ b/system-tests/protocol-test/build.gradle.kts
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+plugins {
+    java
+}
+
+dependencies {
+    testImplementation(project(":data-protocols:dsp:dsp-http-spi"))
+    testImplementation(project(":core:common:junit"))
+    testImplementation(project(":extensions:common:json-ld"))
+    testImplementation(libs.restAssured)
+}
+
+edcBuild {
+    publish.set(false)
+}

--- a/system-tests/protocol-test/src/test/java/org/eclipse/edc/test/e2e/protocol/DspCatalogApiEndToEndTest.java
+++ b/system-tests/protocol-test/src/test/java/org/eclipse/edc/test/e2e/protocol/DspCatalogApiEndToEndTest.java
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.e2e.protocol;
+
+import org.eclipse.edc.connector.spi.protocol.ProtocolVersionRegistry;
+import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.junit.extensions.EdcRuntimeExtension;
+import org.eclipse.edc.junit.testfixtures.TestUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static jakarta.json.Json.createObjectBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
+import static org.eclipse.edc.protocol.dsp.type.DspCatalogPropertyAndTypeNames.DSPACE_TYPE_CATALOG_REQUEST_MESSAGE;
+import static org.eclipse.edc.protocol.dsp.version.DspVersions.V_2024_1;
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
+
+@EndToEndTest
+public class DspCatalogApiEndToEndTest {
+
+    private static final int PROTOCOL_PORT = TestUtils.getFreePort();
+
+    @RegisterExtension
+    static EdcRuntimeExtension runtime = new EdcRuntimeExtension(
+            "runtime",
+            Map.of(
+                    "web.http.protocol.path", "/protocol",
+                    "web.http.protocol.port", String.valueOf(PROTOCOL_PORT)
+            ),
+            ":data-protocols:dsp:dsp-catalog:dsp-catalog-api",
+            ":data-protocols:dsp:dsp-catalog:dsp-catalog-transform",
+            ":data-protocols:dsp:dsp-api-configuration",
+            ":data-protocols:dsp:dsp-http-core",
+            ":extensions:common:iam:iam-mock",
+            ":core:control-plane:control-plane-aggregate-services",
+            ":core:control-plane:control-plane-core",
+            ":extensions:common:http"
+    );
+
+    @Test
+    void shouldExposeVersion2024_1() {
+        given()
+                .port(PROTOCOL_PORT)
+                .basePath("/protocol")
+                .contentType(JSON)
+                .header("Authorization", "{\"region\": \"any\", \"audience\": \"any\", \"clientId\":\"any\"}")
+                .body(createObjectBuilder()
+                        .add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
+                        .add(TYPE, DSPACE_TYPE_CATALOG_REQUEST_MESSAGE)
+                        .build())
+                .post("/2024/1/catalog/request")
+                .then()
+                .log().ifError()
+                .statusCode(200)
+                .contentType(JSON);
+
+        assertThat(runtime.getContext().getService(ProtocolVersionRegistry.class).getAll().protocolVersions())
+                .contains(V_2024_1);
+    }
+
+}

--- a/system-tests/protocol-test/src/test/java/org/eclipse/edc/test/e2e/protocol/DspNegotiationApiEndToEndTest.java
+++ b/system-tests/protocol-test/src/test/java/org/eclipse/edc/test/e2e/protocol/DspNegotiationApiEndToEndTest.java
@@ -1,0 +1,87 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.e2e.protocol;
+
+import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.spi.protocol.ProtocolVersionRegistry;
+import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.junit.extensions.EdcRuntimeExtension;
+import org.eclipse.edc.junit.testfixtures.TestUtils;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates.REQUESTED;
+import static org.eclipse.edc.protocol.dsp.version.DspVersions.V_2024_1;
+
+@EndToEndTest
+public class DspNegotiationApiEndToEndTest {
+
+    private static final int PROTOCOL_PORT = TestUtils.getFreePort();
+
+    @RegisterExtension
+    static EdcRuntimeExtension runtime = new EdcRuntimeExtension(
+            "runtime",
+            Map.of(
+                    "web.http.protocol.path", "/protocol",
+                    "web.http.protocol.port", String.valueOf(PROTOCOL_PORT)
+            ),
+            ":data-protocols:dsp:dsp-negotiation:dsp-negotiation-api",
+            ":data-protocols:dsp:dsp-negotiation:dsp-negotiation-transform",
+            ":data-protocols:dsp:dsp-api-configuration",
+            ":data-protocols:dsp:dsp-http-core",
+            ":extensions:common:iam:iam-mock",
+            ":core:control-plane:control-plane-aggregate-services",
+            ":core:control-plane:control-plane-core",
+            ":extensions:common:http"
+    );
+
+    @Test
+    void shouldExposeVersion2024_1() {
+        var id = UUID.randomUUID().toString();
+        var negotiation = ContractNegotiation.Builder.newInstance()
+                .id(id).counterPartyId("any").counterPartyAddress("any").protocol("any").state(REQUESTED.code())
+                .correlationId(UUID.randomUUID().toString())
+                .contractOffer(ContractOffer.Builder.newInstance()
+                        .id(UUID.randomUUID().toString()).assetId(UUID.randomUUID().toString())
+                        .policy(Policy.Builder.newInstance().build())
+                        .build())
+                .build();
+        runtime.getService(ContractNegotiationStore.class).save(negotiation);
+
+        given()
+                .port(PROTOCOL_PORT)
+                .basePath("/protocol")
+                .contentType(JSON)
+                .header("Authorization", "{\"region\": \"any\", \"audience\": \"any\", \"clientId\":\"any\"}")
+                .get("/2024/1/negotiations/" + id)
+                .then()
+                .log().ifError()
+                .statusCode(200)
+                .contentType(JSON);
+
+        assertThat(runtime.getContext().getService(ProtocolVersionRegistry.class).getAll().protocolVersions())
+                .contains(V_2024_1);
+    }
+
+}

--- a/system-tests/protocol-test/src/test/java/org/eclipse/edc/test/e2e/protocol/DspTransferApiEndToEndTest.java
+++ b/system-tests/protocol-test/src/test/java/org/eclipse/edc/test/e2e/protocol/DspTransferApiEndToEndTest.java
@@ -1,0 +1,107 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.e2e.protocol;
+
+import org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiationStates;
+import org.eclipse.edc.connector.spi.protocol.ProtocolVersionRegistry;
+import org.eclipse.edc.connector.transfer.spi.store.TransferProcessStore;
+import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
+import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
+import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.junit.extensions.EdcRuntimeExtension;
+import org.eclipse.edc.junit.testfixtures.TestUtils;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.types.domain.agreement.ContractAgreement;
+import org.eclipse.edc.spi.types.domain.offer.ContractOffer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.connector.transfer.spi.types.TransferProcessStates.REQUESTED;
+import static org.eclipse.edc.protocol.dsp.version.DspVersions.V_2024_1;
+
+@EndToEndTest
+public class DspTransferApiEndToEndTest {
+
+    private static final int PROTOCOL_PORT = TestUtils.getFreePort();
+
+    @RegisterExtension
+    static EdcRuntimeExtension runtime = new EdcRuntimeExtension(
+            "runtime",
+            Map.of(
+                    "web.http.protocol.path", "/protocol",
+                    "web.http.protocol.port", String.valueOf(PROTOCOL_PORT)
+            ),
+            ":data-protocols:dsp:dsp-transfer-process:dsp-transfer-process-api",
+            ":data-protocols:dsp:dsp-transfer-process:dsp-transfer-process-transform",
+            ":data-protocols:dsp:dsp-api-configuration",
+            ":data-protocols:dsp:dsp-http-core",
+            ":extensions:common:iam:iam-mock",
+            ":core:control-plane:control-plane-aggregate-services",
+            ":core:control-plane:control-plane-core",
+            ":extensions:common:http"
+    );
+
+    @Test
+    void shouldExposeVersion2024_1() {
+        var id = UUID.randomUUID().toString();
+        var contractId = UUID.randomUUID().toString();
+        var transfer = TransferProcess.Builder.newInstance()
+                .id(id).dataRequest(DataRequest.Builder.newInstance().id("any").destinationType("any").contractId(contractId).build()).state(REQUESTED.code())
+                .build();
+        runtime.getService(TransferProcessStore.class).save(transfer);
+        runtime.getService(ContractNegotiationStore.class).save(createNegotiationWithAgreement(contractId));
+
+        given()
+                .port(PROTOCOL_PORT)
+                .basePath("/protocol")
+                .contentType(JSON)
+                .header("Authorization", "{\"region\": \"any\", \"audience\": \"any\", \"clientId\":\"any\"}")
+                .get("/2024/1/transfers/" + id)
+                .then()
+                .log().ifError()
+                .statusCode(200)
+                .contentType(JSON);
+
+        assertThat(runtime.getContext().getService(ProtocolVersionRegistry.class).getAll().protocolVersions())
+                .contains(V_2024_1);
+    }
+
+    private static ContractNegotiation createNegotiationWithAgreement(String contractId) {
+        return ContractNegotiation.Builder.newInstance()
+                .id(UUID.randomUUID().toString()).counterPartyId("any").counterPartyAddress("any").protocol("any").state(ContractNegotiationStates.REQUESTED.code())
+                .correlationId(UUID.randomUUID().toString())
+                .contractOffer(ContractOffer.Builder.newInstance()
+                        .id(UUID.randomUUID().toString()).assetId(UUID.randomUUID().toString())
+                        .policy(Policy.Builder.newInstance().build())
+                        .build())
+                .contractAgreement(ContractAgreement.Builder.newInstance()
+                        .id(contractId)
+                        .providerId("any")
+                        .consumerId("any")
+                        .assetId("any")
+                        .policy(Policy.Builder.newInstance().build())
+                        .build())
+                .build();
+    }
+
+}

--- a/system-tests/protocol-test/src/test/java/org/eclipse/edc/test/e2e/protocol/DspVersionApiEndToEndTest.java
+++ b/system-tests/protocol-test/src/test/java/org/eclipse/edc/test/e2e/protocol/DspVersionApiEndToEndTest.java
@@ -1,0 +1,93 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.e2e.protocol;
+
+import io.restassured.http.ContentType;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import org.eclipse.edc.connector.spi.protocol.ProtocolVersion;
+import org.eclipse.edc.connector.spi.protocol.ProtocolVersionRegistry;
+import org.eclipse.edc.jsonld.TitaniumJsonLd;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.junit.extensions.EdcRuntimeExtension;
+import org.eclipse.edc.junit.testfixtures.TestUtils;
+import org.eclipse.edc.spi.monitor.ConsoleMonitor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.protocol.dsp.type.DspVersionPropertyAndTypeNames.DSPACE_PROPERTY_PATH;
+import static org.eclipse.edc.protocol.dsp.type.DspVersionPropertyAndTypeNames.DSPACE_PROPERTY_PROTOCOL_VERSIONS;
+import static org.eclipse.edc.protocol.dsp.type.DspVersionPropertyAndTypeNames.DSPACE_PROPERTY_VERSION;
+
+@EndToEndTest
+public class DspVersionApiEndToEndTest {
+
+    private static final int PROTOCOL_PORT = TestUtils.getFreePort();
+    private final JsonLd jsonLd = new TitaniumJsonLd(new ConsoleMonitor());
+
+    @RegisterExtension
+    static EdcRuntimeExtension runtime = new EdcRuntimeExtension(
+            "runtime",
+            Map.of(
+                    "web.http.protocol.path", "/protocol",
+                    "web.http.protocol.port", String.valueOf(PROTOCOL_PORT)
+            ),
+            ":data-protocols:dsp:dsp-version:dsp-version-api",
+            ":data-protocols:dsp:dsp-api-configuration",
+            ":data-protocols:dsp:dsp-http-core",
+            ":extensions:common:iam:iam-mock",
+            ":core:control-plane:control-plane-aggregate-services",
+            ":core:control-plane:control-plane-core",
+            ":extensions:common:http"
+    );
+
+    @Test
+    void shouldReturnValidJsonLd() {
+        runtime.getContext().getService(ProtocolVersionRegistry.class)
+                        .register(new ProtocolVersion("1.0", "/v1/path"));
+
+        var compacted = given()
+                .port(PROTOCOL_PORT)
+                .basePath("/protocol")
+                .header("Authorization", "{\"region\": \"any\", \"audience\": \"any\", \"clientId\":\"any\"}")
+                .get("/.well-known/dspace-version")
+                .then()
+                .log().ifError()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .extract().body().as(JsonObject.class);
+
+        var expansion = jsonLd.expand(compacted);
+
+        assertThat(expansion).isSucceeded().satisfies(expanded -> {
+            assertThat(expanded.getJsonArray(DSPACE_PROPERTY_PROTOCOL_VERSIONS)).hasSize(1).extracting(JsonValue::asJsonObject)
+                    .first().satisfies(protocolVersion -> versionIs(protocolVersion, "1.0", "/v1/path"));
+        });
+    }
+
+    private void versionIs(JsonObject protocolVersion, String version, String path) {
+        assertThat(protocolVersion.getJsonArray(DSPACE_PROPERTY_VERSION)).hasSize(1).first()
+                .extracting(JsonValue::asJsonObject).extracting(it -> it.getString(VALUE)).isEqualTo(version);
+        assertThat(protocolVersion.getJsonArray(DSPACE_PROPERTY_PATH)).hasSize(1).first()
+                .extracting(JsonValue::asJsonObject).extracting(it -> it.getString(VALUE)).isEqualTo(path);
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

Add modules to expose the `.well-known/dspace-version` endpoint.
the design follows the standard way, so:
controller -> service -> registry

then the versions are registered on the registry by the other dsp endpoint extensions

## Why it does that

DSP compliance

## Further notes

- the current "not versioned" endpoints are still exposed for backward compatibility
- the versioned `2024/1` are the same exact endpoints as the "not versioned" ones
- no additional work has been done to support multiple different versions, it will be done when it'll be needed.

## Linked Issue(s)

Closes #3842

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
