### PR TITLE
chore: refactor DataFlowRequest into DataFlowStartMessage

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -223,7 +223,6 @@ maven/mavencentral/org.apache.velocity/velocity-engine-core/2.3, Apache-2.0, app
 maven/mavencentral/org.apache.velocity/velocity-engine-scripting/2.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.xbean/xbean-reflect/3.7, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.assertj/assertj-core/3.25.1, Apache-2.0, approved, #12585
 maven/mavencentral/org.assertj/assertj-core/3.25.3, Apache-2.0, approved, #12585
 maven/mavencentral/org.awaitility/awaitility/4.2.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.72, MIT, approved, #3789

--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImpl.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImpl.java
@@ -25,7 +25,7 @@ import org.eclipse.edc.spi.entity.StatefulEntity;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.result.Result;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.eclipse.edc.statemachine.Processor;
 import org.eclipse.edc.statemachine.ProcessorImpl;
 import org.eclipse.edc.statemachine.StateMachineManager;
@@ -63,7 +63,7 @@ public class DataPlaneManagerImpl extends AbstractStateEntityManager<DataFlow, D
     }
 
     @Override
-    public Result<Boolean> validate(DataFlowRequest dataRequest) {
+    public Result<Boolean> validate(DataFlowStartMessage dataRequest) {
         var transferService = transferServiceRegistry.resolveTransferService(dataRequest);
         return transferService != null ?
                 transferService.validate(dataRequest) :
@@ -72,7 +72,7 @@ public class DataPlaneManagerImpl extends AbstractStateEntityManager<DataFlow, D
     }
 
     @Override
-    public void initiate(DataFlowRequest dataRequest) {
+    public void initiate(DataFlowStartMessage dataRequest) {
         var dataFlow = DataFlow.Builder.newInstance()
                 .id(dataRequest.getProcessId())
                 .source(dataRequest.getSourceDataAddress())

--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/pipeline/PipelineServiceImpl.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/pipeline/PipelineServiceImpl.java
@@ -24,7 +24,7 @@ import org.eclipse.edc.connector.dataplane.spi.pipeline.PipelineService;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.StreamResult;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -51,12 +51,12 @@ public class PipelineServiceImpl implements PipelineService {
     }
 
     @Override
-    public boolean canHandle(DataFlowRequest request) {
+    public boolean canHandle(DataFlowStartMessage request) {
         return getSourceFactory(request) != null && getSinkFactory(request) != null;
     }
 
     @Override
-    public Result<Boolean> validate(DataFlowRequest request) {
+    public Result<Boolean> validate(DataFlowStartMessage request) {
         var sourceFactory = getSourceFactory(request);
         if (sourceFactory == null) {
             // NB: do not include the source type as that can possibly leak internal information
@@ -84,7 +84,7 @@ public class PipelineServiceImpl implements PipelineService {
 
     @WithSpan
     @Override
-    public CompletableFuture<StreamResult<Object>> transfer(DataFlowRequest request) {
+    public CompletableFuture<StreamResult<Object>> transfer(DataFlowStartMessage request) {
         var sourceFactory = getSourceFactory(request);
         if (sourceFactory == null) {
             return noSourceFactory(request);
@@ -102,7 +102,7 @@ public class PipelineServiceImpl implements PipelineService {
     }
 
     @Override
-    public CompletableFuture<StreamResult<Object>> transfer(DataFlowRequest request, DataSink sink) {
+    public CompletableFuture<StreamResult<Object>> transfer(DataFlowStartMessage request, DataSink sink) {
         var sourceFactory = getSourceFactory(request);
         if (sourceFactory == null) {
             return noSourceFactory(request);
@@ -140,22 +140,22 @@ public class PipelineServiceImpl implements PipelineService {
     }
 
     @Nullable
-    private DataSourceFactory getSourceFactory(DataFlowRequest request) {
+    private DataSourceFactory getSourceFactory(DataFlowStartMessage request) {
         return sourceFactories.stream().filter(s -> s.canHandle(request)).findFirst().orElse(null);
     }
 
     @Nullable
-    private DataSinkFactory getSinkFactory(DataFlowRequest request) {
+    private DataSinkFactory getSinkFactory(DataFlowStartMessage request) {
         return sinkFactories.stream().filter(s -> s.canHandle(request)).findFirst().orElse(null);
     }
 
     @NotNull
-    private CompletableFuture<StreamResult<Object>> noSourceFactory(DataFlowRequest request) {
+    private CompletableFuture<StreamResult<Object>> noSourceFactory(DataFlowStartMessage request) {
         return completedFuture(StreamResult.error("Unknown data source type: " + request.getSourceDataAddress().getType()));
     }
 
     @NotNull
-    private CompletableFuture<StreamResult<Object>> noSinkFactory(DataFlowRequest request) {
+    private CompletableFuture<StreamResult<Object>> noSinkFactory(DataFlowStartMessage request) {
         return completedFuture(StreamResult.error("Unknown data sink type: " + request.getDestinationDataAddress().getType()));
     }
 

--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/registry/TransferServiceRegistryImpl.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/registry/TransferServiceRegistryImpl.java
@@ -16,7 +16,7 @@ package org.eclipse.edc.connector.dataplane.framework.registry;
 
 import org.eclipse.edc.connector.dataplane.spi.pipeline.TransferService;
 import org.eclipse.edc.connector.dataplane.spi.registry.TransferServiceRegistry;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
@@ -41,7 +41,7 @@ public class TransferServiceRegistryImpl implements TransferServiceRegistry {
 
     @Override
     @Nullable
-    public TransferService resolveTransferService(DataFlowRequest request) {
+    public TransferService resolveTransferService(DataFlowStartMessage request) {
         var possibleServices = transferServices.stream().filter(s -> s.canHandle(request));
         return transferServiceSelectionStrategy.chooseTransferService(request, possibleServices);
     }

--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/registry/TransferServiceSelectionStrategy.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/registry/TransferServiceSelectionStrategy.java
@@ -15,26 +15,26 @@
 package org.eclipse.edc.connector.dataplane.framework.registry;
 
 import org.eclipse.edc.connector.dataplane.spi.pipeline.TransferService;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.stream.Stream;
 
 /**
  * Functional interface for selecting which of (potentially) multiple {@link TransferService}s to use
- * for serving a particular {@link DataFlowRequest}.
+ * for serving a particular {@link DataFlowStartMessage}.
  */
 public interface TransferServiceSelectionStrategy {
     /**
      * Selects which of (potentially) multiple {@link TransferService}s to use
-     * for serving a particular {@link DataFlowRequest}.
+     * for serving a particular {@link DataFlowStartMessage}.
      *
      * @param request          the request.
      * @param transferServices any number of services which are able to handle the request. May be an empty {@link Stream}.
      * @return the service to be used to serve the request, selected among the input {@code transferServices}, or {@code null} if the stream is empty or no service should be used.
      */
     @Nullable
-    TransferService chooseTransferService(DataFlowRequest request, Stream<TransferService> transferServices);
+    TransferService chooseTransferService(DataFlowStartMessage request, Stream<TransferService> transferServices);
 
     /**
      * Default strategy: use first matching service. This allows integrators to select

--- a/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImplTest.java
+++ b/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImplTest.java
@@ -26,7 +26,7 @@ import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.StoreResult;
 import org.eclipse.edc.spi.system.ExecutorInstrumentation;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -70,7 +70,7 @@ class DataPlaneManagerImplTest {
     private final TransferService transferService = mock();
     private final TransferProcessApiClient transferProcessApiClient = mock();
     private final DataPlaneStore store = mock();
-    private final DataFlowRequest request = createRequest();
+    private final DataFlowStartMessage request = createRequest();
     private final TransferServiceRegistry registry = mock();
     private DataPlaneManagerImpl manager;
 
@@ -88,7 +88,7 @@ class DataPlaneManagerImplTest {
 
     @Test
     void initiateDataFlow() {
-        var request = DataFlowRequest.Builder.newInstance()
+        var request = DataFlowStartMessage.Builder.newInstance()
                 .id("1")
                 .processId("1")
                 .sourceDataAddress(DataAddress.Builder.newInstance().type("type").build())
@@ -186,7 +186,7 @@ class DataPlaneManagerImplTest {
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferService).transfer(isA(DataFlowRequest.class));
+            verify(transferService).transfer(isA(DataFlowStartMessage.class));
             verify(store).save(argThat(it -> it.getState() == STARTED.code()));
         });
     }
@@ -203,7 +203,7 @@ class DataPlaneManagerImplTest {
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferService).transfer(isA(DataFlowRequest.class));
+            verify(transferService).transfer(isA(DataFlowStartMessage.class));
             verify(store, atLeastOnce()).save(argThat(it -> it.getState() == COMPLETED.code()));
         });
     }
@@ -221,7 +221,7 @@ class DataPlaneManagerImplTest {
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferService).transfer(isA(DataFlowRequest.class));
+            verify(transferService).transfer(isA(DataFlowStartMessage.class));
             verify(store, never()).save(argThat(it -> it.getState() == COMPLETED.code()));
         });
     }
@@ -238,7 +238,7 @@ class DataPlaneManagerImplTest {
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferService).transfer(isA(DataFlowRequest.class));
+            verify(transferService).transfer(isA(DataFlowStartMessage.class));
             verify(store, atLeastOnce()).save(argThat(it -> it.getState() == FAILED.code() && it.getErrorDetail().equals("an error")));
         });
     }
@@ -255,7 +255,7 @@ class DataPlaneManagerImplTest {
         manager.start();
 
         await().untilAsserted(() -> {
-            verify(transferService).transfer(isA(DataFlowRequest.class));
+            verify(transferService).transfer(isA(DataFlowStartMessage.class));
             verify(store, atLeastOnce()).save(argThat(it -> it.getState() == RECEIVED.code()));
         });
     }
@@ -348,8 +348,8 @@ class DataPlaneManagerImplTest {
         return aryEq(new Criterion[]{ hasState(state) });
     }
 
-    private DataFlowRequest createRequest() {
-        return DataFlowRequest.Builder.newInstance()
+    private DataFlowStartMessage createRequest() {
+        return DataFlowStartMessage.Builder.newInstance()
                 .id("1")
                 .processId("1")
                 .sourceDataAddress(DataAddress.Builder.newInstance().type("type").build())

--- a/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/pipeline/PipelineServiceImplTest.java
+++ b/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/pipeline/PipelineServiceImplTest.java
@@ -23,7 +23,7 @@ import org.eclipse.edc.connector.dataplane.spi.pipeline.StreamFailure;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.StreamResult;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -56,7 +56,7 @@ class PipelineServiceImplTest {
 
     Monitor monitor = mock();
     PipelineServiceImpl service = new PipelineServiceImpl(monitor);
-    DataFlowRequest request = DataFlowRequest.Builder.newInstance()
+    DataFlowStartMessage request = DataFlowStartMessage.Builder.newInstance()
             .id("1")
             .processId("1")
             .sourceDataAddress(DataAddress.Builder.newInstance().type("test").build())

--- a/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/pipeline/PipelineServiceIntegrationTest.java
+++ b/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/pipeline/PipelineServiceIntegrationTest.java
@@ -23,7 +23,7 @@ import org.eclipse.edc.connector.dataplane.spi.pipeline.StreamResult;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
@@ -74,8 +74,8 @@ public class PipelineServiceIntegrationTest {
         });
     }
 
-    private DataFlowRequest.Builder createRequest() {
-        return DataFlowRequest.Builder.newInstance()
+    private DataFlowStartMessage.Builder createRequest() {
+        return DataFlowStartMessage.Builder.newInstance()
                 .id("1")
                 .processId("1")
                 .sourceDataAddress(DataAddress.Builder.newInstance().type("any").build())
@@ -90,17 +90,17 @@ public class PipelineServiceIntegrationTest {
         }
 
         @Override
-        public boolean canHandle(DataFlowRequest request) {
+        public boolean canHandle(DataFlowStartMessage request) {
             return true;
         }
 
         @Override
-        public DataSink createSink(DataFlowRequest request) {
+        public DataSink createSink(DataFlowStartMessage request) {
             return sink;
         }
 
         @Override
-        public @NotNull Result<Void> validateRequest(DataFlowRequest request) {
+        public @NotNull Result<Void> validateRequest(DataFlowStartMessage request) {
             return Result.success();
         }
     }
@@ -117,17 +117,17 @@ public class PipelineServiceIntegrationTest {
         }
 
         @Override
-        public boolean canHandle(DataFlowRequest request) {
+        public boolean canHandle(DataFlowStartMessage request) {
             return true;
         }
 
         @Override
-        public DataSource createSource(DataFlowRequest request) {
+        public DataSource createSource(DataFlowStartMessage request) {
             return new InputStreamDataSource("test", new ByteArrayInputStream(data.getBytes()));
         }
 
         @Override
-        public @NotNull Result<Void> validateRequest(DataFlowRequest request) {
+        public @NotNull Result<Void> validateRequest(DataFlowStartMessage request) {
             return Result.success();
         }
     }

--- a/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/registry/TransferServiceRegistryImplTest.java
+++ b/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/registry/TransferServiceRegistryImplTest.java
@@ -16,7 +16,7 @@ package org.eclipse.edc.connector.dataplane.framework.registry;
 
 import org.eclipse.edc.connector.dataplane.spi.pipeline.TransferService;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -33,7 +33,7 @@ class TransferServiceRegistryImplTest {
     TransferService transferService = mock(TransferService.class);
     TransferService transferService2 = mock(TransferService.class);
 
-    DataFlowRequest request = createRequest().build();
+    DataFlowStartMessage request = createRequest().build();
     TransferServiceSelectionStrategy transferServiceSelectionStrategy = mock(TransferServiceSelectionStrategy.class);
     @SuppressWarnings("unchecked")
     ArgumentCaptor<Stream<TransferService>> streamCaptor = ArgumentCaptor.forClass(Stream.class);
@@ -89,8 +89,8 @@ class TransferServiceRegistryImplTest {
         verify(transferServiceSelectionStrategy).chooseTransferService(eq(request), streamCaptor.capture());
     }
 
-    private DataFlowRequest.Builder createRequest() {
-        return DataFlowRequest.Builder.newInstance()
+    private DataFlowStartMessage.Builder createRequest() {
+        return DataFlowStartMessage.Builder.newInstance()
                 .id("1")
                 .processId("1")
                 .sourceDataAddress(DataAddress.Builder.newInstance().type("any").build())

--- a/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/registry/TransferServiceSelectionStrategyTest.java
+++ b/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/registry/TransferServiceSelectionStrategyTest.java
@@ -16,7 +16,7 @@ package org.eclipse.edc.connector.dataplane.framework.registry;
 
 import org.eclipse.edc.connector.dataplane.spi.pipeline.TransferService;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.junit.jupiter.api.Test;
 
 import java.util.stream.Stream;
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.mock;
 class TransferServiceSelectionStrategyTest {
 
     TransferServiceSelectionStrategy strategy = TransferServiceSelectionStrategy.selectFirst();
-    DataFlowRequest request = createRequest().build();
+    DataFlowStartMessage request = createRequest().build();
     TransferService service1 = mock();
     TransferService service2 = mock();
 
@@ -46,8 +46,8 @@ class TransferServiceSelectionStrategyTest {
         assertThat(strategy.chooseTransferService(request, Stream.of(service1, service2))).isEqualTo(service1);
     }
 
-    private DataFlowRequest.Builder createRequest() {
-        return DataFlowRequest.Builder.newInstance()
+    private DataFlowStartMessage.Builder createRequest() {
+        return DataFlowStartMessage.Builder.newInstance()
                 .id("1")
                 .processId("1")
                 .sourceDataAddress(DataAddress.Builder.newInstance().type("any").build())

--- a/extensions/control-plane/api/control-plane-api-client/src/test/java/org/eclipse/edc/connector/api/client/transferprocess/TransferProcessHttpClientIntegrationTest.java
+++ b/extensions/control-plane/api/control-plane-api-client/src/test/java/org/eclipse/edc/connector/api/client/transferprocess/TransferProcessHttpClientIntegrationTest.java
@@ -39,7 +39,7 @@ import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -159,8 +159,8 @@ public class TransferProcessHttpClientIntegrationTest {
                 .build();
     }
 
-    private DataFlowRequest createDataFlowRequest(String processId, URI callbackAddress) {
-        return DataFlowRequest.Builder.newInstance()
+    private DataFlowStartMessage createDataFlowRequest(String processId, URI callbackAddress) {
+        return DataFlowStartMessage.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
                 .processId(processId)
                 .callbackAddress(callbackAddress)

--- a/extensions/control-plane/api/control-plane-api-client/src/test/java/org/eclipse/edc/connector/api/client/transferprocess/TransferProcessHttpClientTest.java
+++ b/extensions/control-plane/api/control-plane-api-client/src/test/java/org/eclipse/edc/connector/api/client/transferprocess/TransferProcessHttpClientTest.java
@@ -21,7 +21,7 @@ import okhttp3.Response;
 import okhttp3.ResponseBody;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
@@ -125,8 +125,8 @@ public class TransferProcessHttpClientTest {
         verifyNoInteractions(monitor);
     }
 
-    private DataFlowRequest.Builder createRequest() {
-        return DataFlowRequest.Builder.newInstance()
+    private DataFlowStartMessage.Builder createRequest() {
+        return DataFlowStartMessage.Builder.newInstance()
                 .id("1")
                 .processId("1")
                 .sourceDataAddress(DataAddress.Builder.newInstance().type("type").build())

--- a/extensions/control-plane/transfer/transfer-data-plane/src/main/java/org/eclipse/edc/connector/transfer/dataplane/flow/ProviderPushTransferDataFlowController.java
+++ b/extensions/control-plane/transfer/transfer-data-plane/src/main/java/org/eclipse/edc/connector/transfer/dataplane/flow/ProviderPushTransferDataFlowController.java
@@ -24,7 +24,7 @@ import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
@@ -61,7 +61,7 @@ public class ProviderPushTransferDataFlowController implements DataFlowControlle
 
     @Override
     public @NotNull StatusResult<DataFlowResponse> initiateFlow(TransferProcess transferProcess, Policy policy) {
-        var dataFlowRequest = DataFlowRequest.Builder.newInstance()
+        var dataFlowRequest = DataFlowStartMessage.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
                 .processId(transferProcess.getId())
                 .trackable(true)

--- a/extensions/control-plane/transfer/transfer-data-plane/src/test/java/org/eclipse/edc/connector/transfer/dataplane/flow/ProviderPushTransferDataFlowControllerTest.java
+++ b/extensions/control-plane/transfer/transfer-data-plane/src/test/java/org/eclipse/edc/connector/transfer/dataplane/flow/ProviderPushTransferDataFlowControllerTest.java
@@ -25,7 +25,7 @@ import org.eclipse.edc.spi.response.ResponseStatus;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.asset.Asset;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -70,7 +70,7 @@ class ProviderPushTransferDataFlowControllerTest {
                 .contentDataAddress(testDataAddress())
                 .build();
 
-        when(dataPlaneClient.transfer(any(DataFlowRequest.class))).thenReturn(StatusResult.success());
+        when(dataPlaneClient.transfer(any(DataFlowStartMessage.class))).thenReturn(StatusResult.success());
         var dataPlaneInstance = createDataPlaneInstance();
         when(selectorService.select(any(), any())).thenReturn(dataPlaneInstance);
         when(dataPlaneClientFactory.createClient(any())).thenReturn(dataPlaneClient);
@@ -78,7 +78,7 @@ class ProviderPushTransferDataFlowControllerTest {
         var result = flowController.initiateFlow(transferProcess, Policy.Builder.newInstance().build());
 
         assertThat(result.succeeded()).isTrue();
-        var captor = ArgumentCaptor.forClass(DataFlowRequest.class);
+        var captor = ArgumentCaptor.forClass(DataFlowStartMessage.class);
         verify(dataPlaneClient).transfer(captor.capture());
         var captured = captor.getValue();
         assertThat(captured.isTrackable()).isTrue();

--- a/extensions/data-plane/data-plane-client/src/main/java/org/eclipse/edc/connector/dataplane/client/EmbeddedDataPlaneClient.java
+++ b/extensions/data-plane/data-plane-client/src/main/java/org/eclipse/edc/connector/dataplane/client/EmbeddedDataPlaneClient.java
@@ -19,7 +19,7 @@ import org.eclipse.edc.connector.dataplane.selector.spi.client.DataPlaneClient;
 import org.eclipse.edc.connector.dataplane.spi.manager.DataPlaneManager;
 import org.eclipse.edc.spi.response.ResponseStatus;
 import org.eclipse.edc.spi.response.StatusResult;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 
 import java.util.Objects;
 
@@ -37,7 +37,7 @@ public class EmbeddedDataPlaneClient implements DataPlaneClient {
 
     @WithSpan
     @Override
-    public StatusResult<Void> transfer(DataFlowRequest request) {
+    public StatusResult<Void> transfer(DataFlowStartMessage request) {
         var result = dataPlaneManager.validate(request);
         if (result.failed()) {
             return StatusResult.failure(ResponseStatus.FATAL_ERROR, result.getFailureDetail());

--- a/extensions/data-plane/data-plane-client/src/main/java/org/eclipse/edc/connector/dataplane/client/RemoteDataPlaneClient.java
+++ b/extensions/data-plane/data-plane-client/src/main/java/org/eclipse/edc/connector/dataplane/client/RemoteDataPlaneClient.java
@@ -29,7 +29,7 @@ import org.eclipse.edc.connector.dataplane.spi.response.TransferErrorResponse;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.http.EdcHttpClient;
 import org.eclipse.edc.spi.response.StatusResult;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -54,17 +54,17 @@ public class RemoteDataPlaneClient implements DataPlaneClient {
 
     @WithSpan
     @Override
-    public StatusResult<Void> transfer(DataFlowRequest dataFlowRequest) {
+    public StatusResult<Void> transfer(DataFlowStartMessage dataFlowStartMessage) {
         RequestBody body;
         try {
-            body = RequestBody.create(mapper.writeValueAsString(dataFlowRequest), TYPE_JSON);
+            body = RequestBody.create(mapper.writeValueAsString(dataFlowStartMessage), TYPE_JSON);
         } catch (JsonProcessingException e) {
             throw new EdcException(e);
         }
         var request = new Request.Builder().post(body).url(dataPlane.getUrl()).build();
 
         try (var response = httpClient.execute(request)) {
-            return handleResponse(response, dataFlowRequest.getId());
+            return handleResponse(response, dataFlowStartMessage.getId());
         } catch (IOException e) {
             return StatusResult.failure(FATAL_ERROR, e.getMessage());
         }

--- a/extensions/data-plane/data-plane-client/src/test/java/org/eclipse/edc/connector/dataplane/client/EmbeddedDataPlaneClientTest.java
+++ b/extensions/data-plane/data-plane-client/src/test/java/org/eclipse/edc/connector/dataplane/client/EmbeddedDataPlaneClientTest.java
@@ -19,7 +19,7 @@ import org.eclipse.edc.connector.dataplane.spi.manager.DataPlaneManager;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -75,8 +75,8 @@ class EmbeddedDataPlaneClientTest {
         verify(dataPlaneManager).terminate("dataFlowId");
     }
 
-    private static DataFlowRequest createDataFlowRequest() {
-        return DataFlowRequest.Builder.newInstance()
+    private static DataFlowStartMessage createDataFlowRequest() {
+        return DataFlowStartMessage.Builder.newInstance()
                 .trackable(true)
                 .id("123")
                 .processId("456")

--- a/extensions/data-plane/data-plane-client/src/test/java/org/eclipse/edc/connector/dataplane/client/RemoteDataPlaneClientTest.java
+++ b/extensions/data-plane/data-plane-client/src/test/java/org/eclipse/edc/connector/dataplane/client/RemoteDataPlaneClientTest.java
@@ -22,7 +22,7 @@ import org.eclipse.edc.connector.dataplane.spi.response.TransferErrorResponse;
 import org.eclipse.edc.spi.response.ResponseStatus;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -154,8 +154,8 @@ class RemoteDataPlaneClientTest {
                 .withBody(MAPPER.writeValueAsString(new TransferErrorResponse(List.of(errorMsg))), MediaType.APPLICATION_JSON);
     }
 
-    private static DataFlowRequest createDataFlowRequest() {
-        return DataFlowRequest.Builder.newInstance()
+    private static DataFlowStartMessage createDataFlowRequest() {
+        return DataFlowStartMessage.Builder.newInstance()
                 .trackable(true)
                 .id("123")
                 .processId("456")

--- a/extensions/data-plane/data-plane-control-api/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlaneControlApi.java
+++ b/extensions/data-plane/data-plane-control-api/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlaneControlApi.java
@@ -20,7 +20,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.ws.rs.container.AsyncResponse;
 import org.eclipse.edc.connector.dataplane.spi.DataFlowStates;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 
 @OpenAPIDefinition
 @Tag(name = "Data Plane control API",
@@ -34,7 +34,7 @@ public interface DataPlaneControlApi {
                     @ApiResponse(responseCode = "200", description = "Data transfer initiated"),
             }
     )
-    void initiateTransfer(DataFlowRequest request, AsyncResponse response);
+    void initiateTransfer(DataFlowStartMessage request, AsyncResponse response);
 
     @Operation(description = "Get the current state of a data transfer.",
             responses = @ApiResponse(responseCode = "200", description = "Missing access token")

--- a/extensions/data-plane/data-plane-control-api/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlaneControlApiController.java
+++ b/extensions/data-plane/data-plane-control-api/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlaneControlApiController.java
@@ -28,7 +28,7 @@ import jakarta.ws.rs.core.Response;
 import org.eclipse.edc.connector.dataplane.spi.DataFlowStates;
 import org.eclipse.edc.connector.dataplane.spi.manager.DataPlaneManager;
 import org.eclipse.edc.connector.dataplane.spi.response.TransferErrorResponse;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 
 import java.util.List;
 
@@ -47,7 +47,7 @@ public class DataPlaneControlApiController implements DataPlaneControlApi {
 
     @POST
     @Override
-    public void initiateTransfer(DataFlowRequest request, @Suspended AsyncResponse response) {
+    public void initiateTransfer(DataFlowStartMessage request, @Suspended AsyncResponse response) {
         // TODO token authentication
         var result = dataPlaneManager.validate(request);
         if (result.succeeded()) {

--- a/extensions/data-plane/data-plane-control-api/src/test/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlaneControlApiControllerTest.java
+++ b/extensions/data-plane/data-plane-control-api/src/test/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlaneControlApiControllerTest.java
@@ -23,7 +23,7 @@ import org.eclipse.edc.junit.annotations.ApiTest;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
@@ -47,14 +47,14 @@ class DataPlaneControlApiControllerTest extends RestControllerTestBase {
 
     @Test
     void should_callDataPlaneManager_if_requestIsValid() {
-        var flowRequest = DataFlowRequest.Builder.newInstance()
+        var flowRequest = DataFlowStartMessage.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
                 .processId(UUID.randomUUID().toString())
                 .sourceDataAddress(testDestAddress())
                 .destinationDataAddress(testDestAddress())
                 .build();
 
-        when(manager.validate(isA(DataFlowRequest.class))).thenReturn(Result.success(Boolean.TRUE));
+        when(manager.validate(isA(DataFlowStartMessage.class))).thenReturn(Result.success(Boolean.TRUE));
 
         baseRequest()
                 .contentType(ContentType.JSON)
@@ -63,20 +63,20 @@ class DataPlaneControlApiControllerTest extends RestControllerTestBase {
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode());
 
-        verify(manager).initiate(isA(DataFlowRequest.class));
+        verify(manager).initiate(isA(DataFlowStartMessage.class));
     }
 
     @Test
     void should_returnBadRequest_if_requestIsInValid() {
         var errorMsg = "test error message";
-        var flowRequest = DataFlowRequest.Builder.newInstance()
+        var flowRequest = DataFlowStartMessage.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
                 .processId(UUID.randomUUID().toString())
                 .sourceDataAddress(testDestAddress())
                 .destinationDataAddress(testDestAddress())
                 .build();
 
-        when(manager.validate(isA(DataFlowRequest.class))).thenReturn(Result.failure(errorMsg));
+        when(manager.validate(isA(DataFlowStartMessage.class))).thenReturn(Result.failure(errorMsg));
 
         baseRequest()
                 .contentType(ContentType.JSON)

--- a/extensions/data-plane/data-plane-http-oauth2-core/src/main/java/org/eclipse/edc/connector/dataplane/http/oauth2/Oauth2HttpRequestParamsDecorator.java
+++ b/extensions/data-plane/data-plane-http-oauth2-core/src/main/java/org/eclipse/edc/connector/dataplane/http/oauth2/Oauth2HttpRequestParamsDecorator.java
@@ -20,7 +20,7 @@ import org.eclipse.edc.connector.dataplane.http.spi.HttpRequestParams;
 import org.eclipse.edc.iam.oauth2.spi.Oauth2DataAddressValidator;
 import org.eclipse.edc.iam.oauth2.spi.client.Oauth2Client;
 import org.eclipse.edc.spi.EdcException;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 
 /**
  * Requests the OAuth2 token if configured in the DataAddress
@@ -37,7 +37,7 @@ public class Oauth2HttpRequestParamsDecorator implements HttpParamsDecorator {
     }
 
     @Override
-    public HttpRequestParams.Builder decorate(DataFlowRequest request, HttpDataAddress address, HttpRequestParams.Builder params) {
+    public HttpRequestParams.Builder decorate(DataFlowStartMessage request, HttpDataAddress address, HttpRequestParams.Builder params) {
         if (validator.test(address)) {
             return requestFactory.create(address)
                     .compose(client::requestToken)

--- a/extensions/data-plane/data-plane-http-oauth2-core/src/test/java/org/eclipse/edc/connector/dataplane/http/oauth2/Oauth2HttpRequestParamsDecoratorTest.java
+++ b/extensions/data-plane/data-plane-http-oauth2-core/src/test/java/org/eclipse/edc/connector/dataplane/http/oauth2/Oauth2HttpRequestParamsDecoratorTest.java
@@ -21,7 +21,7 @@ import org.eclipse.edc.iam.oauth2.spi.client.SharedSecretOauth2CredentialsReques
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.result.Result;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
@@ -102,8 +102,8 @@ class Oauth2HttpRequestParamsDecoratorTest {
                 .build();
     }
 
-    private DataFlowRequest dummyDataFlowRequest() {
-        return DataFlowRequest.Builder.newInstance()
+    private DataFlowStartMessage dummyDataFlowRequest() {
+        return DataFlowStartMessage.Builder.newInstance()
                 .processId(UUID.randomUUID().toString())
                 .sourceDataAddress(dummyAddress())
                 .destinationDataAddress(dummyAddress())

--- a/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/params/HttpRequestParamsProviderImpl.java
+++ b/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/params/HttpRequestParamsProviderImpl.java
@@ -23,7 +23,7 @@ import org.eclipse.edc.connector.dataplane.http.spi.HttpRequestParams;
 import org.eclipse.edc.connector.dataplane.http.spi.HttpRequestParamsProvider;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.types.TypeManager;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -52,7 +52,7 @@ public class HttpRequestParamsProviderImpl implements HttpRequestParamsProvider 
     }
 
     @Override
-    public HttpRequestParams provideSourceParams(DataFlowRequest request) {
+    public HttpRequestParams provideSourceParams(DataFlowStartMessage request) {
         var params = HttpRequestParams.Builder.newInstance();
         var address = HttpDataAddress.Builder.newInstance().copyFrom(request.getSourceDataAddress()).build();
         sourceDecorators.forEach(decorator -> decorator.decorate(request, address, params));
@@ -60,7 +60,7 @@ public class HttpRequestParamsProviderImpl implements HttpRequestParamsProvider 
     }
 
     @Override
-    public HttpRequestParams provideSinkParams(DataFlowRequest request) {
+    public HttpRequestParams provideSinkParams(DataFlowStartMessage request) {
         var params = HttpRequestParams.Builder.newInstance();
         var address = HttpDataAddress.Builder.newInstance().copyFrom(request.getDestinationDataAddress()).build();
         sinkDecorators.forEach(decorator -> decorator.decorate(request, address, params));

--- a/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/params/decorators/BaseCommonHttpParamsDecorator.java
+++ b/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/params/decorators/BaseCommonHttpParamsDecorator.java
@@ -20,7 +20,7 @@ import org.eclipse.edc.connector.dataplane.http.spi.HttpRequestParams;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.types.TypeManager;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 
 import java.util.Map;
 import java.util.Optional;
@@ -38,7 +38,7 @@ public class BaseCommonHttpParamsDecorator implements HttpParamsDecorator {
     }
 
     @Override
-    public HttpRequestParams.Builder decorate(DataFlowRequest request, HttpDataAddress address, HttpRequestParams.Builder params) {
+    public HttpRequestParams.Builder decorate(DataFlowStartMessage request, HttpDataAddress address, HttpRequestParams.Builder params) {
         var requestId = request.getId();
         var baseUrl = Optional.ofNullable(address.getBaseUrl())
                 .orElseThrow(() -> new EdcException(format("DataFlowRequest %s: 'baseUrl' property is missing in HttpDataAddress", requestId)));

--- a/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/params/decorators/BaseSinkHttpParamsDecorator.java
+++ b/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/params/decorators/BaseSinkHttpParamsDecorator.java
@@ -17,7 +17,7 @@ package org.eclipse.edc.connector.dataplane.http.params.decorators;
 import org.eclipse.edc.connector.dataplane.http.spi.HttpDataAddress;
 import org.eclipse.edc.connector.dataplane.http.spi.HttpParamsDecorator;
 import org.eclipse.edc.connector.dataplane.http.spi.HttpRequestParams;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 
 import java.util.Optional;
 
@@ -25,7 +25,7 @@ public class BaseSinkHttpParamsDecorator implements HttpParamsDecorator {
     private static final String DEFAULT_METHOD = "POST";
 
     @Override
-    public HttpRequestParams.Builder decorate(DataFlowRequest request, HttpDataAddress address, HttpRequestParams.Builder params) {
+    public HttpRequestParams.Builder decorate(DataFlowStartMessage request, HttpDataAddress address, HttpRequestParams.Builder params) {
         var method = Optional.ofNullable(address.getMethod()).orElse(DEFAULT_METHOD);
         params.method(method);
         params.path(address.getPath());

--- a/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/params/decorators/BaseSourceHttpParamsDecorator.java
+++ b/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/params/decorators/BaseSourceHttpParamsDecorator.java
@@ -18,7 +18,7 @@ import org.eclipse.edc.connector.dataplane.http.spi.HttpDataAddress;
 import org.eclipse.edc.connector.dataplane.http.spi.HttpParamsDecorator;
 import org.eclipse.edc.connector.dataplane.http.spi.HttpRequestParams;
 import org.eclipse.edc.spi.EdcException;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.eclipse.edc.util.string.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -39,7 +39,7 @@ public class BaseSourceHttpParamsDecorator implements HttpParamsDecorator {
     private static final String DEFAULT_METHOD = "GET";
 
     @Override
-    public HttpRequestParams.Builder decorate(DataFlowRequest request, HttpDataAddress address, HttpRequestParams.Builder params) {
+    public HttpRequestParams.Builder decorate(DataFlowStartMessage request, HttpDataAddress address, HttpRequestParams.Builder params) {
         params.method(extractMethod(address, request));
         params.path(extractPath(address, request));
         params.queryParams(extractQueryParams(address, request));
@@ -52,7 +52,7 @@ public class BaseSourceHttpParamsDecorator implements HttpParamsDecorator {
         return params;
     }
 
-    private @NotNull String extractMethod(HttpDataAddress address, DataFlowRequest request) {
+    private @NotNull String extractMethod(HttpDataAddress address, DataFlowStartMessage request) {
         if (Boolean.parseBoolean(address.getProxyMethod()) && "HttpProxy".equals(request.getDestinationDataAddress().getType())) {
             return Optional.ofNullable(request.getProperties().get(METHOD))
                     .orElseThrow(() -> new EdcException(format("DataFlowRequest %s: 'method' property is missing", request.getId())));
@@ -60,11 +60,11 @@ public class BaseSourceHttpParamsDecorator implements HttpParamsDecorator {
         return Optional.ofNullable(address.getMethod()).orElse(DEFAULT_METHOD);
     }
 
-    private @Nullable String extractPath(HttpDataAddress address, DataFlowRequest request) {
+    private @Nullable String extractPath(HttpDataAddress address, DataFlowStartMessage request) {
         return Boolean.parseBoolean(address.getProxyPath()) ? request.getProperties().get(PATH) : address.getPath();
     }
 
-    private @Nullable String extractQueryParams(HttpDataAddress address, DataFlowRequest request) {
+    private @Nullable String extractQueryParams(HttpDataAddress address, DataFlowStartMessage request) {
         var queryParams = Stream.of(address.getQueryParams(), getRequestQueryParams(address, request))
                 .filter(s -> !StringUtils.isNullOrBlank(s))
                 .collect(Collectors.joining("&"));
@@ -72,17 +72,17 @@ public class BaseSourceHttpParamsDecorator implements HttpParamsDecorator {
     }
 
     @Nullable
-    private String extractContentType(HttpDataAddress address, DataFlowRequest request) {
+    private String extractContentType(HttpDataAddress address, DataFlowStartMessage request) {
         return Boolean.parseBoolean(address.getProxyBody()) ? request.getProperties().get(MEDIA_TYPE) : address.getContentType();
     }
 
     @Nullable
-    private String extractBody(HttpDataAddress address, DataFlowRequest request) {
+    private String extractBody(HttpDataAddress address, DataFlowStartMessage request) {
         return Boolean.parseBoolean(address.getProxyBody()) ? request.getProperties().get(BODY) : null;
     }
 
     @Nullable
-    private String getRequestQueryParams(HttpDataAddress address, DataFlowRequest request) {
+    private String getRequestQueryParams(HttpDataAddress address, DataFlowStartMessage request) {
         return Boolean.parseBoolean(address.getProxyQueryParams()) ? request.getProperties().get(QUERY_PARAMS) : null;
     }
 }

--- a/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSinkFactory.java
+++ b/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSinkFactory.java
@@ -23,7 +23,7 @@ import org.eclipse.edc.dataaddress.httpdata.spi.HttpDataAddressSchema;
 import org.eclipse.edc.spi.http.EdcHttpClient;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.concurrent.ExecutorService;
@@ -55,12 +55,12 @@ public class HttpDataSinkFactory implements DataSinkFactory {
     }
 
     @Override
-    public boolean canHandle(DataFlowRequest request) {
+    public boolean canHandle(DataFlowStartMessage request) {
         return HTTP_DATA_TYPE.equals(request.getDestinationDataAddress().getType());
     }
 
     @Override
-    public @NotNull Result<Void> validateRequest(DataFlowRequest request) {
+    public @NotNull Result<Void> validateRequest(DataFlowStartMessage request) {
         try {
             createSink(request);
         } catch (Exception e) {
@@ -70,7 +70,7 @@ public class HttpDataSinkFactory implements DataSinkFactory {
     }
 
     @Override
-    public DataSink createSink(DataFlowRequest request) {
+    public DataSink createSink(DataFlowStartMessage request) {
         return HttpDataSink.Builder.newInstance()
                 .params(requestParamsProvider.provideSinkParams(request))
                 .requestId(request.getId())

--- a/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSourceFactory.java
+++ b/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSourceFactory.java
@@ -24,7 +24,7 @@ import org.eclipse.edc.dataaddress.httpdata.spi.HttpDataAddressSchema;
 import org.eclipse.edc.spi.http.EdcHttpClient;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.jetbrains.annotations.NotNull;
 
 import static org.eclipse.edc.dataaddress.httpdata.spi.HttpDataAddressSchema.HTTP_DATA_TYPE;
@@ -47,12 +47,12 @@ public class HttpDataSourceFactory implements DataSourceFactory {
     }
 
     @Override
-    public boolean canHandle(DataFlowRequest request) {
+    public boolean canHandle(DataFlowStartMessage request) {
         return HTTP_DATA_TYPE.equals(request.getSourceDataAddress().getType());
     }
 
     @Override
-    public @NotNull Result<Void> validateRequest(DataFlowRequest request) {
+    public @NotNull Result<Void> validateRequest(DataFlowStartMessage request) {
         try {
             createSource(request);
         } catch (Exception e) {
@@ -62,7 +62,7 @@ public class HttpDataSourceFactory implements DataSourceFactory {
     }
 
     @Override
-    public DataSource createSource(DataFlowRequest request) {
+    public DataSource createSource(DataFlowStartMessage request) {
         var dataAddress = HttpDataAddress.Builder.newInstance()
                 .copyFrom(request.getSourceDataAddress())
                 .build();

--- a/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/edc/connector/dataplane/http/DataPlaneHttpExtensionTest.java
+++ b/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/edc/connector/dataplane/http/DataPlaneHttpExtensionTest.java
@@ -19,7 +19,7 @@ import org.eclipse.edc.connector.dataplane.http.spi.HttpRequestParamsProvider;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.PipelineService;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.StreamResult;
 import org.eclipse.edc.junit.extensions.EdcExtension;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -68,7 +68,7 @@ public class DataPlaneHttpExtensionTest {
         sourceServer.when(request()).respond(HttpResponse.response().withStatusCode(200));
         destinationServer.when(request()).respond(HttpResponse.response().withStatusCode(200));
 
-        var request = DataFlowRequest.Builder.newInstance()
+        var request = DataFlowStartMessage.Builder.newInstance()
                 .processId(UUID.randomUUID().toString())
                 .sourceDataAddress(source)
                 .destinationDataAddress(destination)
@@ -96,7 +96,7 @@ public class DataPlaneHttpExtensionTest {
         sourceServer.when(request()).respond(HttpResponse.response().withStatusCode(200));
         destinationServer.when(request()).respond(HttpResponse.response().withStatusCode(200));
 
-        var request = DataFlowRequest.Builder.newInstance()
+        var request = DataFlowStartMessage.Builder.newInstance()
                 .processId(UUID.randomUUID().toString())
                 .sourceDataAddress(source)
                 .destinationDataAddress(destination)

--- a/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/edc/connector/dataplane/http/params/HttpRequestParamsProviderImplSinkTest.java
+++ b/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/edc/connector/dataplane/http/params/HttpRequestParamsProviderImplSinkTest.java
@@ -18,7 +18,7 @@ import org.eclipse.edc.connector.dataplane.http.spi.HttpDataAddress;
 import org.eclipse.edc.connector.dataplane.http.spi.HttpRequestParamsProvider;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.types.TypeManager;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
@@ -40,7 +40,7 @@ class HttpRequestParamsProviderImplSinkTest {
                 .contentType("test/content-type")
                 .nonChunkedTransfer(true)
                 .build();
-        var dataFlowRequest = DataFlowRequest.Builder.newInstance()
+        var dataFlowRequest = DataFlowStartMessage.Builder.newInstance()
                 .processId(UUID.randomUUID().toString())
                 .sourceDataAddress(dummyAddress())
                 .destinationDataAddress(destination)
@@ -62,7 +62,7 @@ class HttpRequestParamsProviderImplSinkTest {
         var destination = HttpDataAddress.Builder.newInstance()
                 .baseUrl("http://destination")
                 .build();
-        var dataFlowRequest = DataFlowRequest.Builder.newInstance()
+        var dataFlowRequest = DataFlowStartMessage.Builder.newInstance()
                 .processId(UUID.randomUUID().toString())
                 .sourceDataAddress(dummyAddress())
                 .destinationDataAddress(destination)

--- a/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/edc/connector/dataplane/http/params/HttpRequestParamsProviderImplSourceTest.java
+++ b/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/edc/connector/dataplane/http/params/HttpRequestParamsProviderImplSourceTest.java
@@ -18,7 +18,7 @@ import org.eclipse.edc.connector.dataplane.http.spi.HttpDataAddress;
 import org.eclipse.edc.connector.dataplane.http.spi.HttpRequestParamsProvider;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -47,7 +47,7 @@ class HttpRequestParamsProviderImplSourceTest {
                 .contentType("test/content-type")
                 .nonChunkedTransfer(true)
                 .build();
-        var dataFlowRequest = DataFlowRequest.Builder.newInstance()
+        var dataFlowRequest = DataFlowStartMessage.Builder.newInstance()
                 .processId(UUID.randomUUID().toString())
                 .sourceDataAddress(source)
                 .destinationDataAddress(dummyHttpDataAddress())
@@ -76,7 +76,7 @@ class HttpRequestParamsProviderImplSourceTest {
                 .contentType("test/content-type")
                 .nonChunkedTransfer(true)
                 .build();
-        var dataFlowRequest = DataFlowRequest.Builder.newInstance()
+        var dataFlowRequest = DataFlowStartMessage.Builder.newInstance()
                 .processId(UUID.randomUUID().toString())
                 .sourceDataAddress(source)
                 .destinationDataAddress(DataAddress.Builder.newInstance().type("HttpProxy").build())
@@ -105,7 +105,7 @@ class HttpRequestParamsProviderImplSourceTest {
         var source = HttpDataAddress.Builder.newInstance()
                 .baseUrl("http://source")
                 .build();
-        var dataFlowRequest = DataFlowRequest.Builder.newInstance()
+        var dataFlowRequest = DataFlowStartMessage.Builder.newInstance()
                 .processId(UUID.randomUUID().toString())
                 .sourceDataAddress(source)
                 .destinationDataAddress(dummyHttpDataAddress())
@@ -131,7 +131,7 @@ class HttpRequestParamsProviderImplSourceTest {
                 .contentType("test/content-type")
                 .nonChunkedTransfer(true)
                 .build();
-        var dataFlowRequest = DataFlowRequest.Builder.newInstance()
+        var dataFlowRequest = DataFlowStartMessage.Builder.newInstance()
                 .processId(UUID.randomUUID().toString())
                 .sourceDataAddress(source)
                 .destinationDataAddress(DataAddress.Builder.newInstance().type("HttpProxy").build())
@@ -151,7 +151,7 @@ class HttpRequestParamsProviderImplSourceTest {
                 .nonChunkedTransfer(true)
                 .method("POST")
                 .build();
-        var dataFlowRequest = DataFlowRequest.Builder.newInstance()
+        var dataFlowRequest = DataFlowStartMessage.Builder.newInstance()
                 .processId(UUID.randomUUID().toString())
                 .sourceDataAddress(source)
                 .destinationDataAddress(dummyHttpDataAddress())

--- a/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/edc/connector/dataplane/http/params/HttpRequestParamsProviderImplTest.java
+++ b/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/edc/connector/dataplane/http/params/HttpRequestParamsProviderImplTest.java
@@ -21,7 +21,7 @@ import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -164,8 +164,8 @@ class HttpRequestParamsProviderImplTest {
         return TYPE_MANAGER.writeValueAsString(map);
     }
 
-    private DataFlowRequest createRequest(DataAddress source) {
-        return DataFlowRequest.Builder.newInstance()
+    private DataFlowStartMessage createRequest(DataAddress source) {
+        return DataFlowStartMessage.Builder.newInstance()
                 .destinationDataAddress(DataAddress.Builder.newInstance().type("test-type").build())
                 .sourceDataAddress(source)
                 .processId(UUID.randomUUID().toString())

--- a/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSinkFactoryTest.java
+++ b/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSinkFactoryTest.java
@@ -28,7 +28,7 @@ import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.http.EdcHttpClient;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -139,8 +139,8 @@ class HttpDataSinkFactoryTest {
                 .satisfies(result -> assertThat(result.succeeded()).isTrue());
     }
 
-    private DataFlowRequest createRequest(DataAddress destination) {
-        return DataFlowRequest.Builder.newInstance()
+    private DataFlowStartMessage createRequest(DataAddress destination) {
+        return DataFlowStartMessage.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
                 .processId(UUID.randomUUID().toString())
                 .sourceDataAddress(DataAddress.Builder.newInstance().type("test-type").build())

--- a/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSourceFactoryTest.java
+++ b/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSourceFactoryTest.java
@@ -27,7 +27,7 @@ import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.http.EdcHttpClient;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -100,7 +100,7 @@ class HttpDataSourceFactoryTest {
         assertThat(source).usingRecursiveComparison().isEqualTo(expected);
     }
 
-    private DataFlowRequest createRequest(DataAddress source) {
+    private DataFlowStartMessage createRequest(DataAddress source) {
         return TestFunctions.createRequest(emptyMap(), source, DataAddress.Builder.newInstance().type("Test type").build()).build();
     }
 }

--- a/extensions/data-plane/data-plane-http/src/testFixtures/java/org/eclipse/edc/connector/dataplane/http/testfixtures/TestFunctions.java
+++ b/extensions/data-plane/data-plane-http/src/testFixtures/java/org/eclipse/edc/connector/dataplane/http/testfixtures/TestFunctions.java
@@ -22,7 +22,7 @@ import okhttp3.ResponseBody;
 import okio.Okio;
 import org.eclipse.edc.connector.dataplane.spi.schema.DataFlowRequestSchema;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -38,7 +38,7 @@ public class TestFunctions {
     private TestFunctions() {
     }
 
-    public static DataFlowRequest.Builder createRequest(String type) {
+    public static DataFlowStartMessage.Builder createRequest(String type) {
         return createRequest(
                 Map.of(DataFlowRequestSchema.METHOD, "GET"),
                 DataAddress.Builder.newInstance().type(type).properties(emptyMap()).build(),
@@ -46,8 +46,8 @@ public class TestFunctions {
         );
     }
 
-    public static DataFlowRequest.Builder createRequest(Map<String, String> properties, DataAddress source, DataAddress destination) {
-        return DataFlowRequest.Builder.newInstance()
+    public static DataFlowStartMessage.Builder createRequest(Map<String, String> properties, DataAddress source, DataAddress destination) {
+        return DataFlowStartMessage.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
                 .processId(UUID.randomUUID().toString())
                 .properties(properties)

--- a/extensions/data-plane/data-plane-integration-tests/src/test/java/org/eclipse/edc/connector/dataplane/http/DataPlaneHttpIntegrationTests.java
+++ b/extensions/data-plane/data-plane-integration-tests/src/test/java/org/eclipse/edc/connector/dataplane/http/DataPlaneHttpIntegrationTests.java
@@ -25,7 +25,7 @@ import org.eclipse.edc.connector.dataplane.spi.schema.DataFlowRequestSchema;
 import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.junit.extensions.EdcRuntimeExtension;
 import org.eclipse.edc.spi.types.TypeManager;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -266,7 +266,7 @@ public class DataPlaneHttpIntegrationTests {
     /**
      * Request payload to initiate DPF transfer.
      *
-     * @param processId ProcessID of transfer.See {@link DataFlowRequest}
+     * @param processId ProcessID of transfer.See {@link DataFlowStartMessage}
      * @return JSON object. see {@link ObjectNode}.
      */
     private ObjectNode transferRequestPayload(String processId, TypeManager typeManager) {
@@ -276,7 +276,7 @@ public class DataPlaneHttpIntegrationTests {
     /**
      * Request payload with query params to initiate DPF transfer.
      *
-     * @param processId   ProcessID of transfer.See {@link DataFlowRequest}
+     * @param processId   ProcessID of transfer.See {@link DataFlowStartMessage}
      * @param queryParams Query params name and value as key-value entries.
      * @return JSON object. see {@link ObjectNode}.
      */

--- a/extensions/data-plane/data-plane-kafka/src/main/java/org/eclipse/edc/dataplane/kafka/pipeline/KafkaDataSinkFactory.java
+++ b/extensions/data-plane/data-plane-kafka/src/main/java/org/eclipse/edc/dataplane/kafka/pipeline/KafkaDataSinkFactory.java
@@ -21,7 +21,7 @@ import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.eclipse.edc.validator.dataaddress.kafka.KafkaDataAddressValidator;
 import org.eclipse.edc.validator.spi.ValidationResult;
 import org.eclipse.edc.validator.spi.Validator;
@@ -47,18 +47,18 @@ public class KafkaDataSinkFactory implements DataSinkFactory {
     }
 
     @Override
-    public boolean canHandle(DataFlowRequest dataRequest) {
+    public boolean canHandle(DataFlowStartMessage dataRequest) {
         return KAFKA_TYPE.equalsIgnoreCase(dataRequest.getDestinationDataAddress().getType());
     }
 
     @Override
-    public @NotNull Result<Void> validateRequest(DataFlowRequest request) {
+    public @NotNull Result<Void> validateRequest(DataFlowStartMessage request) {
         var destination = request.getDestinationDataAddress();
         return validation.validate(destination).flatMap(ValidationResult::toResult);
     }
 
     @Override
-    public DataSink createSink(DataFlowRequest request) {
+    public DataSink createSink(DataFlowStartMessage request) {
         var validationResult = validateRequest(request);
         if (validationResult.failed()) {
             throw new EdcException(validationResult.getFailureDetail());

--- a/extensions/data-plane/data-plane-kafka/src/main/java/org/eclipse/edc/dataplane/kafka/pipeline/KafkaDataSourceFactory.java
+++ b/extensions/data-plane/data-plane-kafka/src/main/java/org/eclipse/edc/dataplane/kafka/pipeline/KafkaDataSourceFactory.java
@@ -22,7 +22,7 @@ import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.eclipse.edc.validator.dataaddress.kafka.KafkaDataAddressValidator;
 import org.eclipse.edc.validator.spi.ValidationResult;
 import org.eclipse.edc.validator.spi.Validator;
@@ -55,18 +55,18 @@ public class KafkaDataSourceFactory implements DataSourceFactory {
     }
 
     @Override
-    public boolean canHandle(DataFlowRequest dataRequest) {
+    public boolean canHandle(DataFlowStartMessage dataRequest) {
         return KAFKA_TYPE.equalsIgnoreCase(dataRequest.getSourceDataAddress().getType());
     }
 
     @Override
-    public @NotNull Result<Void> validateRequest(DataFlowRequest request) {
+    public @NotNull Result<Void> validateRequest(DataFlowStartMessage request) {
         var source = request.getSourceDataAddress();
         return validation.validate(source).flatMap(ValidationResult::toResult);
     }
 
     @Override
-    public DataSource createSource(DataFlowRequest request) {
+    public DataSource createSource(DataFlowStartMessage request) {
         var validationResult = validateRequest(request);
         if (validationResult.failed()) {
             throw new EdcException(validationResult.getFailureDetail());

--- a/extensions/data-plane/data-plane-kafka/src/test/java/org/eclipse/edc/dataplane/kafka/pipeline/KafkaDataSinkFactoryTest.java
+++ b/extensions/data-plane/data-plane-kafka/src/test/java/org/eclipse/edc/dataplane/kafka/pipeline/KafkaDataSinkFactoryTest.java
@@ -19,7 +19,7 @@ import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -114,8 +114,8 @@ class KafkaDataSinkFactoryTest {
         assertThatExceptionOfType(EdcException.class).isThrownBy(() -> factory.createSink(request));
     }
 
-    private DataFlowRequest createRequest(String destinationType, Map<String, Object> destinationProperties) {
-        return DataFlowRequest.Builder.newInstance()
+    private DataFlowStartMessage createRequest(String destinationType, Map<String, Object> destinationProperties) {
+        return DataFlowStartMessage.Builder.newInstance()
                 .id("id")
                 .processId("processId")
                 .destinationDataAddress(DataAddress.Builder.newInstance()

--- a/extensions/data-plane/data-plane-kafka/src/test/java/org/eclipse/edc/dataplane/kafka/pipeline/KafkaDataSourceFactoryTest.java
+++ b/extensions/data-plane/data-plane-kafka/src/test/java/org/eclipse/edc/dataplane/kafka/pipeline/KafkaDataSourceFactoryTest.java
@@ -19,7 +19,7 @@ import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -111,8 +111,8 @@ class KafkaDataSourceFactoryTest {
         assertThatExceptionOfType(EdcException.class).isThrownBy(() -> factory.createSource(request));
     }
 
-    private DataFlowRequest createRequest(String sourceType, Map<String, Object> sourceProperties) {
-        return DataFlowRequest.Builder.newInstance()
+    private DataFlowStartMessage createRequest(String sourceType, Map<String, Object> sourceProperties) {
+        return DataFlowStartMessage.Builder.newInstance()
                 .id("id")
                 .processId("processId")
                 .destinationDataAddress(DataAddress.Builder.newInstance().type("notused").build())

--- a/extensions/data-plane/data-plane-public-api/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/DataFlowRequestSupplier.java
+++ b/extensions/data-plane/data-plane-public-api/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/DataFlowRequestSupplier.java
@@ -16,7 +16,7 @@ package org.eclipse.edc.connector.dataplane.api.controller;
 
 import org.eclipse.edc.connector.dataplane.util.sink.AsyncStreamingDataSink;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -30,19 +30,19 @@ import static org.eclipse.edc.connector.dataplane.spi.schema.DataFlowRequestSche
 import static org.eclipse.edc.connector.dataplane.spi.schema.DataFlowRequestSchema.PATH;
 import static org.eclipse.edc.connector.dataplane.spi.schema.DataFlowRequestSchema.QUERY_PARAMS;
 
-public class DataFlowRequestSupplier implements BiFunction<ContainerRequestContextApi, DataAddress, DataFlowRequest> {
+public class DataFlowRequestSupplier implements BiFunction<ContainerRequestContextApi, DataAddress, DataFlowStartMessage> {
 
     /**
-     * Create a {@link DataFlowRequest} based on incoming request and claims decoded from the access token.
+     * Create a {@link DataFlowStartMessage} based on incoming request and claims decoded from the access token.
      *
      * @param contextApi  Api for accessing request properties.
      * @param dataAddress Source data address.
      * @return DataFlowRequest
      */
     @Override
-    public DataFlowRequest apply(ContainerRequestContextApi contextApi, DataAddress dataAddress) {
+    public DataFlowStartMessage apply(ContainerRequestContextApi contextApi, DataAddress dataAddress) {
         var props = createProps(contextApi);
-        return DataFlowRequest.Builder.newInstance()
+        return DataFlowStartMessage.Builder.newInstance()
                 .processId(UUID.randomUUID().toString())
                 .sourceDataAddress(dataAddress)
                 .destinationDataAddress(DataAddress.Builder.newInstance()

--- a/extensions/data-plane/data-plane-public-api/src/test/java/org/eclipse/edc/connector/dataplane/api/controller/DataFlowStartMessageSupplierTest.java
+++ b/extensions/data-plane/data-plane-public-api/src/test/java/org/eclipse/edc/connector/dataplane/api/controller/DataFlowStartMessageSupplierTest.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-class DataFlowRequestSupplierTest {
+class DataFlowStartMessageSupplierTest {
 
 
     private final DataFlowRequestSupplier supplier = new DataFlowRequestSupplier();

--- a/extensions/data-plane/data-plane-public-api/src/test/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlanePublicApiControllerTest.java
+++ b/extensions/data-plane/data-plane-public-api/src/test/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlanePublicApiControllerTest.java
@@ -25,7 +25,7 @@ import org.eclipse.edc.connector.dataplane.util.sink.AsyncStreamingDataSink;
 import org.eclipse.edc.junit.annotations.ApiTest;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -112,7 +112,7 @@ class DataPlanePublicApiControllerTest extends RestControllerTestBase {
         var token = UUID.randomUUID().toString();
         var errorMsg = UUID.randomUUID().toString();
         when(dataAddressResolver.resolve(any())).thenReturn(Result.success(testDestAddress()));
-        when(pipelineService.transfer(any(DataFlowRequest.class), any()))
+        when(pipelineService.transfer(any(DataFlowStartMessage.class), any()))
                 .thenReturn(failedFuture(new RuntimeException(errorMsg)));
 
         baseRequest()
@@ -144,7 +144,7 @@ class DataPlanePublicApiControllerTest extends RestControllerTestBase {
                 .extract().body().asString();
 
         assertThat(responseBody).isEqualTo("data");
-        var requestCaptor = ArgumentCaptor.forClass(DataFlowRequest.class);
+        var requestCaptor = ArgumentCaptor.forClass(DataFlowStartMessage.class);
         verify(pipelineService).transfer(requestCaptor.capture(), any());
         var request = requestCaptor.getValue();
         assertThat(request.getDestinationDataAddress().getType()).isEqualTo(AsyncStreamingDataSink.TYPE);

--- a/extensions/data-plane/data-plane-signaling-api/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/v1/DataPlaneSignalingApi.java
+++ b/extensions/data-plane/data-plane-signaling-api/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/v1/DataPlaneSignalingApi.java
@@ -34,7 +34,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest.EDC_DATA_FLOW_START_MESSAGE_SIMPLE_TYPE;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_SIMPLE_TYPE;
 
 @OpenAPIDefinition
 @Tag(name = "Data Plane Signaling api API",

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/transfer/DataFlowResponseMessage.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/transfer/DataFlowResponseMessage.java
@@ -19,7 +19,7 @@ import org.eclipse.edc.spi.types.domain.DataAddress;
 import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 
 /**
- * A response message from the data plane upon receiving a {@link DataFlowRequest}
+ * A response message from the data plane upon receiving a {@link DataFlowStartMessage}
  */
 public record DataFlowResponseMessage(DataAddress dataAddress) {
 

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/transfer/DataFlowStartMessage.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/transfer/DataFlowStartMessage.java
@@ -33,8 +33,8 @@ import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
  * A request to transfer data from a source to destination.
  */
 @JsonTypeName("dataspaceconnector:dataflowrequest")
-@JsonDeserialize(builder = DataFlowRequest.Builder.class)
-public class DataFlowRequest implements Polymorphic, TraceCarrier {
+@JsonDeserialize(builder = DataFlowStartMessage.Builder.class)
+public class DataFlowStartMessage implements Polymorphic, TraceCarrier {
 
     public static final String DC_DATA_FLOW_START_MESSAGE_ID = EDC_NAMESPACE + "id";
     public static final String DC_DATA_FLOW_START_MESSAGE_PROCESS_ID = EDC_NAMESPACE + "processId";
@@ -52,6 +52,10 @@ public class DataFlowRequest implements Polymorphic, TraceCarrier {
     private String id;
     private String processId;
 
+    private String assetId;
+    private String participantId;
+    private String agreementId;
+
     private DataAddress sourceDataAddress;
     private DataAddress destinationDataAddress;
     private String transferType;
@@ -61,7 +65,7 @@ public class DataFlowRequest implements Polymorphic, TraceCarrier {
     private Map<String, String> properties = Map.of();
     private Map<String, String> traceContext = Map.of(); // TODO: should this stay in the DataFlow class?
 
-    private DataFlowRequest() {
+    private DataFlowStartMessage() {
     }
 
     /**
@@ -97,6 +101,29 @@ public class DataFlowRequest implements Polymorphic, TraceCarrier {
      */
     public String getTransferType() {
         return transferType;
+    }
+
+
+    /**
+     * The agreement id associated to the request
+     */
+    public String getAgreementId() {
+        return agreementId;
+    }
+
+    /**
+     * The asset id associated to the request
+     */
+    public String getAssetId() {
+        return assetId;
+    }
+
+
+    /**
+     * The participant id associated to the request
+     */
+    public String getParticipantId() {
+        return participantId;
     }
 
     /**
@@ -137,13 +164,13 @@ public class DataFlowRequest implements Polymorphic, TraceCarrier {
 
     @JsonPOJOBuilder(withPrefix = "")
     public static class Builder {
-        private final DataFlowRequest request;
+        private final DataFlowStartMessage request;
 
         private Builder() {
-            this(new DataFlowRequest());
+            this(new DataFlowStartMessage());
         }
 
-        private Builder(DataFlowRequest request) {
+        private Builder(DataFlowStartMessage request) {
             this.request = request;
         }
 
@@ -186,6 +213,22 @@ public class DataFlowRequest implements Polymorphic, TraceCarrier {
             return this;
         }
 
+        public Builder agreementId(String agreementId) {
+            request.agreementId = agreementId;
+            return this;
+        }
+
+        public Builder participantId(String participantId) {
+            request.participantId = participantId;
+            return this;
+        }
+
+        public Builder assetId(String assetId) {
+            request.assetId = assetId;
+            return this;
+        }
+
+
         public Builder trackable(boolean value) {
             request.trackable = value;
             return this;
@@ -206,7 +249,7 @@ public class DataFlowRequest implements Polymorphic, TraceCarrier {
             return this;
         }
 
-        public DataFlowRequest build() {
+        public DataFlowStartMessage build() {
             if (request.id == null) {
                 request.id = UUID.randomUUID().toString();
             }

--- a/spi/common/core-spi/src/test/java/org/eclipse/edc/spi/types/domain/transfer/DataFlowStartMessageTest.java
+++ b/spi/common/core-spi/src/test/java/org/eclipse/edc/spi/types/domain/transfer/DataFlowStartMessageTest.java
@@ -25,14 +25,14 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class DataFlowRequestTest {
+class DataFlowStartMessageTest {
 
     @Test
     void verifySerializeDeserialize() throws JsonProcessingException {
 
         var uri = URI.create("http://test");
         var mapper = new TypeManager().getMapper();
-        var request = DataFlowRequest.Builder.newInstance()
+        var request = DataFlowStartMessage.Builder.newInstance()
                 .sourceDataAddress(DataAddress.Builder.newInstance().type("foo").build())
                 .destinationDataAddress(DataAddress.Builder.newInstance().type("bar").build())
                 .id(UUID.randomUUID().toString())
@@ -43,7 +43,7 @@ class DataFlowRequestTest {
                 .traceContext(Map.of("key2", "value2"))
                 .build();
         var serialized = mapper.writeValueAsString(request);
-        var deserialized = mapper.readValue(serialized, DataFlowRequest.class);
+        var deserialized = mapper.readValue(serialized, DataFlowStartMessage.class);
 
         assertThat(deserialized).isNotNull();
         assertThat(deserialized.getProperties().get("key")).isEqualTo("value");

--- a/spi/common/core-spi/src/test/java/org/eclipse/edc/spi/types/domain/transfer/DataFlowStartMessageTest.java
+++ b/spi/common/core-spi/src/test/java/org/eclipse/edc/spi/types/domain/transfer/DataFlowStartMessageTest.java
@@ -41,6 +41,10 @@ class DataFlowStartMessageTest {
                 .callbackAddress(uri)
                 .properties(Map.of("key", "value"))
                 .traceContext(Map.of("key2", "value2"))
+                .participantId("participantId")
+                .transferType("transferType")
+                .agreementId("agreementId")
+                .assetId("assetId")
                 .build();
         var serialized = mapper.writeValueAsString(request);
         var deserialized = mapper.readValue(serialized, DataFlowStartMessage.class);
@@ -49,5 +53,9 @@ class DataFlowStartMessageTest {
         assertThat(deserialized.getProperties().get("key")).isEqualTo("value");
         assertThat(deserialized.getTraceContext().get("key2")).isEqualTo("value2");
         assertThat(deserialized.getCallbackAddress()).isEqualTo(uri);
+        assertThat(deserialized.getAgreementId()).isEqualTo("agreementId");
+        assertThat(deserialized.getTransferType()).isEqualTo("transferType");
+        assertThat(deserialized.getAssetId()).isEqualTo("assetId");
+        assertThat(deserialized.getParticipantId()).isEqualTo("participantId");
     }
 }

--- a/spi/control-plane/control-plane-api-client-spi/src/main/java/org/eclipse/edc/connector/api/client/spi/transferprocess/TransferProcessApiClient.java
+++ b/spi/control-plane/control-plane-api-client-spi/src/main/java/org/eclipse/edc/connector/api/client/spi/transferprocess/TransferProcessApiClient.java
@@ -17,7 +17,7 @@ package org.eclipse.edc.connector.api.client.spi.transferprocess;
 
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import org.eclipse.edc.spi.result.Result;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 
 /**
  * {@link TransferProcessApiClient} is an abstraction for talking with Control Plane, in this case for signaling back
@@ -29,17 +29,17 @@ import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
 public interface TransferProcessApiClient {
 
     /**
-     * Mark the TransferProcess referenced by {@link DataFlowRequest#getProcessId()} as completed
+     * Mark the TransferProcess referenced by {@link DataFlowStartMessage#getProcessId()} as completed
      *
-     * @param request The completed {@link DataFlowRequest}
+     * @param request The completed {@link DataFlowStartMessage}
      */
-    Result<Void> completed(DataFlowRequest request);
+    Result<Void> completed(DataFlowStartMessage request);
 
     /**
-     * Mark the TransferProcess referenced by {@link DataFlowRequest#getProcessId()} as failed
+     * Mark the TransferProcess referenced by {@link DataFlowStartMessage#getProcessId()} as failed
      *
-     * @param request The failed {@link DataFlowRequest}
+     * @param request The failed {@link DataFlowStartMessage}
      */
-    Result<Void> failed(DataFlowRequest request, String reason);
+    Result<Void> failed(DataFlowStartMessage request, String reason);
 
 }

--- a/spi/control-plane/transfer-data-plane-spi/src/main/java/org/eclipse/edc/connector/transfer/dataplane/spi/TransferDataPlaneConstants.java
+++ b/spi/control-plane/transfer-data-plane-spi/src/main/java/org/eclipse/edc/connector/transfer/dataplane/spi/TransferDataPlaneConstants.java
@@ -14,14 +14,14 @@
 
 package org.eclipse.edc.connector.transfer.dataplane.spi;
 
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 
 /**
  * Type of Data Plane transfer.
  */
 public interface TransferDataPlaneConstants {
     /**
-     * {@link DataFlowRequest} type that triggers client-pull data transfer.
+     * {@link DataFlowStartMessage} type that triggers client-pull data transfer.
      */
     String HTTP_PROXY = "HttpProxy";
 

--- a/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/client/DataPlaneClient.java
+++ b/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/client/DataPlaneClient.java
@@ -16,7 +16,7 @@ package org.eclipse.edc.connector.dataplane.selector.spi.client;
 
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import org.eclipse.edc.spi.response.StatusResult;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 
 /**
  * Main interaction interface for an EDC runtime (=control plane) to communicate with the DPF.
@@ -27,7 +27,7 @@ public interface DataPlaneClient {
     /**
      * Delegates data transfer to the Data Plane.
      */
-    StatusResult<Void> transfer(DataFlowRequest request);
+    StatusResult<Void> transfer(DataFlowStartMessage request);
 
     /**
      * Terminate the transfer.

--- a/spi/data-plane/data-plane-http-spi/src/main/java/org/eclipse/edc/connector/dataplane/http/spi/HttpParamsDecorator.java
+++ b/spi/data-plane/data-plane-http-spi/src/main/java/org/eclipse/edc/connector/dataplane/http/spi/HttpParamsDecorator.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.edc.connector.dataplane.http.spi;
 
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 
 /**
  * Define how to decorate the {@link HttpRequestParams} builder.
@@ -25,5 +25,5 @@ public interface HttpParamsDecorator {
     /**
      * Decorate params with information coming from the request and the data address. Return the param object.
      */
-    HttpRequestParams.Builder decorate(DataFlowRequest request, HttpDataAddress address, HttpRequestParams.Builder params);
+    HttpRequestParams.Builder decorate(DataFlowStartMessage request, HttpDataAddress address, HttpRequestParams.Builder params);
 }

--- a/spi/data-plane/data-plane-http-spi/src/main/java/org/eclipse/edc/connector/dataplane/http/spi/HttpRequestParamsProvider.java
+++ b/spi/data-plane/data-plane-http-spi/src/main/java/org/eclipse/edc/connector/dataplane/http/spi/HttpRequestParamsProvider.java
@@ -14,11 +14,11 @@
 
 package org.eclipse.edc.connector.dataplane.http.spi;
 
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 
 /**
  * Permit to register {@link HttpRequestParams} decorators, that are used to enrich the HTTP request with
- * information taken from {@link DataFlowRequest}
+ * information taken from {@link DataFlowStartMessage}
  */
 public interface HttpRequestParamsProvider {
 
@@ -35,10 +35,10 @@ public interface HttpRequestParamsProvider {
     /**
      * Provide HTTP request params for HttpDataSource
      */
-    HttpRequestParams provideSourceParams(DataFlowRequest request);
+    HttpRequestParams provideSourceParams(DataFlowStartMessage request);
 
     /**
      * Provide HTTP request params for HttpDataSink
      */
-    HttpRequestParams provideSinkParams(DataFlowRequest request);
+    HttpRequestParams provideSinkParams(DataFlowStartMessage request);
 }

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/DataFlow.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/DataFlow.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.eclipse.edc.spi.entity.StatefulEntity;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 
 import java.net.URI;
 import java.util.Map;
@@ -80,8 +80,8 @@ public class DataFlow extends StatefulEntity<DataFlow> {
         return properties;
     }
 
-    public DataFlowRequest toRequest() {
-        return DataFlowRequest.Builder.newInstance()
+    public DataFlowStartMessage toRequest() {
+        return DataFlowStartMessage.Builder.newInstance()
                 .id(getId())
                 .sourceDataAddress(getSource())
                 .destinationDataAddress(getDestination())

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/manager/DataPlaneManager.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/manager/DataPlaneManager.java
@@ -19,7 +19,7 @@ import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import org.eclipse.edc.spi.entity.StateEntityManager;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.result.Result;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 
 /**
  * Manages the execution of data plane requests.
@@ -30,12 +30,12 @@ public interface DataPlaneManager extends StateEntityManager {
     /**
      * Determines if the data flow request is valid and can be processed by this runtime.
      */
-    Result<Boolean> validate(DataFlowRequest dataRequest);
+    Result<Boolean> validate(DataFlowStartMessage dataRequest);
 
     /**
      * Initiates a transfer for the data flow request. This method is non-blocking with respect to processing the request.
      */
-    void initiate(DataFlowRequest dataRequest);
+    void initiate(DataFlowStartMessage dataRequest);
 
     /**
      * Returns the transfer state for the process.

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/pipeline/DataSinkFactory.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/pipeline/DataSinkFactory.java
@@ -15,27 +15,27 @@
 package org.eclipse.edc.connector.dataplane.spi.pipeline;
 
 import org.eclipse.edc.spi.result.Result;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Creates {@link DataFlowRequest}s
+ * Creates {@link DataFlowStartMessage}s
  */
 public interface DataSinkFactory {
 
     /**
      * Returns true if this factory can create a {@link DataSink} for the request.
      */
-    boolean canHandle(DataFlowRequest request);
+    boolean canHandle(DataFlowStartMessage request);
 
     /**
      * Creates a sink to send data to.
      */
-    DataSink createSink(DataFlowRequest request);
+    DataSink createSink(DataFlowStartMessage request);
 
     /**
      * Returns a Result object of the validation result.
      */
-    @NotNull Result<Void> validateRequest(DataFlowRequest request);
+    @NotNull Result<Void> validateRequest(DataFlowStartMessage request);
 
 }

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/pipeline/DataSourceFactory.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/pipeline/DataSourceFactory.java
@@ -15,7 +15,7 @@
 package org.eclipse.edc.connector.dataplane.spi.pipeline;
 
 import org.eclipse.edc.spi.result.Result;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -26,16 +26,16 @@ public interface DataSourceFactory {
     /**
      * Returns true if this factory can create a {@link DataSource} for the request.
      */
-    boolean canHandle(DataFlowRequest request);
+    boolean canHandle(DataFlowStartMessage request);
 
     /**
      * Creates a source to access data to be sent.
      */
-    DataSource createSource(DataFlowRequest request);
+    DataSource createSource(DataFlowStartMessage request);
 
     /**
      * Returns a Result object of the validation result.
      */
-    @NotNull Result<Void> validateRequest(DataFlowRequest request);
+    @NotNull Result<Void> validateRequest(DataFlowStartMessage request);
 
 }

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/pipeline/TransferService.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/pipeline/TransferService.java
@@ -16,12 +16,12 @@ package org.eclipse.edc.connector.dataplane.spi.pipeline;
 
 import org.eclipse.edc.connector.dataplane.spi.DataFlow;
 import org.eclipse.edc.spi.result.Result;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 
 import java.util.concurrent.CompletableFuture;
 
 /**
- * A service that can satisfy a {@link DataFlowRequest} by transferring data from a source to a destination.
+ * A service that can satisfy a {@link DataFlowStartMessage} by transferring data from a source to a destination.
  * This could be done in the Data-Plane internally, or it could leverage on external and more performant systems.
  */
 public interface TransferService {
@@ -29,12 +29,12 @@ public interface TransferService {
     /**
      * Returns true if this service can transfer the request.
      */
-    boolean canHandle(DataFlowRequest request);
+    boolean canHandle(DataFlowStartMessage request);
 
     /**
      * Returns a true result if the request is valid.
      */
-    Result<Boolean> validate(DataFlowRequest request);
+    Result<Boolean> validate(DataFlowStartMessage request);
 
     /**
      * Transfers data from a source to a destination using the provided data flow request.
@@ -42,7 +42,7 @@ public interface TransferService {
      * @param request The data flow request containing the necessary information for the transfer.
      * @return A CompletableFuture wrapping a StreamResult indicating the success or failure of the transfer.
      */
-    CompletableFuture<StreamResult<Object>> transfer(DataFlowRequest request);
+    CompletableFuture<StreamResult<Object>> transfer(DataFlowStartMessage request);
 
     /**
      * Transfers data from a source to a destination using the provided data flow request and data sink.
@@ -51,7 +51,7 @@ public interface TransferService {
      * @param sink    The data sink that will receive the transferred data.
      * @return A CompletableFuture wrapping a StreamResult indicating the success or failure of the transfer.
      */
-    CompletableFuture<StreamResult<Object>> transfer(DataFlowRequest request, DataSink sink);
+    CompletableFuture<StreamResult<Object>> transfer(DataFlowStartMessage request, DataSink sink);
 
     /**
      * Terminate a data flow.

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/registry/TransferServiceRegistry.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/registry/TransferServiceRegistry.java
@@ -16,7 +16,7 @@ package org.eclipse.edc.connector.dataplane.spi.registry;
 
 import org.eclipse.edc.connector.dataplane.spi.pipeline.TransferService;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -33,11 +33,11 @@ public interface TransferServiceRegistry {
 
 
     /**
-     * Resolves a {@link TransferService}s to use for serving a particular {@link DataFlowRequest}.
+     * Resolves a {@link TransferService}s to use for serving a particular {@link DataFlowStartMessage}.
      *
      * @param request the request to resolve.
      * @return the service to be used to serve the request, or {@code null} if no service was resolved.
      */
     @Nullable
-    TransferService resolveTransferService(DataFlowRequest request);
+    TransferService resolveTransferService(DataFlowStartMessage request);
 }

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/schema/DataFlowRequestSchema.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/schema/DataFlowRequestSchema.java
@@ -14,10 +14,10 @@
 
 package org.eclipse.edc.connector.dataplane.spi.schema;
 
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 
 /**
- * Schema of {@link DataFlowRequest} properties.
+ * Schema of {@link DataFlowStartMessage} properties.
  */
 public interface DataFlowRequestSchema {
 


### PR DESCRIPTION
## What this PR changes/adds

renames `DataFlowRequest` to `DataFlowStartMessage` and additional fields added

-  participantId
-  assetId
- agreementId

## Why it does that

refactoring for data plane signaling

## Linked Issue(s)

Closes #3908 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
