### PR TITLE
feat(dsp): replace consumerId and providerId with odrl assignee and assigner

### DIFF
--- a/core/common/transform-core/src/main/java/org/eclipse/edc/core/transform/transformer/from/JsonObjectFromPolicyTransformer.java
+++ b/core/common/transform-core/src/main/java/org/eclipse/edc/core/transform/transformer/from/JsonObjectFromPolicyTransformer.java
@@ -48,6 +48,8 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ACTION_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ACTION_TYPE_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_AND_CONSTRAINT_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ASSIGNEE_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ASSIGNER_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_CONSEQUENCE_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_CONSTRAINT_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_DUTY_ATTRIBUTE;
@@ -157,6 +159,9 @@ public class JsonObjectFromPolicyTransformer extends AbstractJsonLdTransformer<P
                     .add(ODRL_PROHIBITION_ATTRIBUTE, prohibitionsBuilder)
                     .add(ODRL_OBLIGATION_ATTRIBUTE, obligationsBuilder);
 
+            Optional.ofNullable(policy.getAssignee()).ifPresent(it -> builder.add(ODRL_ASSIGNEE_ATTRIBUTE, it));
+            Optional.ofNullable(policy.getAssigner()).ifPresent(it -> builder.add(ODRL_ASSIGNER_ATTRIBUTE, it));
+
             Optional.ofNullable(policy.getTarget())
                     .ifPresent(target -> builder.add(
                             ODRL_TARGET_ATTRIBUTE,
@@ -242,6 +247,7 @@ public class JsonObjectFromPolicyTransformer extends AbstractJsonLdTransformer<P
                 case CONTRACT -> ODRL_POLICY_TYPE_AGREEMENT;
             };
         }
+
     }
 
 }

--- a/core/common/transform-core/src/main/java/org/eclipse/edc/core/transform/transformer/to/JsonObjectToPolicyTransformer.java
+++ b/core/common/transform-core/src/main/java/org/eclipse/edc/core/transform/transformer/to/JsonObjectToPolicyTransformer.java
@@ -27,6 +27,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ASSIGNEE_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ASSIGNER_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_OBLIGATION_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_PERMISSION_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_AGREEMENT;
@@ -76,6 +78,8 @@ public class JsonObjectToPolicyTransformer extends AbstractJsonLdTransformer<Jso
             case ODRL_PROHIBITION_ATTRIBUTE -> v -> builder.prohibitions(transformArray(v, Prohibition.class, context));
             case ODRL_OBLIGATION_ATTRIBUTE -> v -> builder.duties(transformArray(v, Duty.class, context));
             case ODRL_TARGET_ATTRIBUTE -> v -> builder.target(transformString(v, context));
+            case ODRL_ASSIGNER_ATTRIBUTE -> v -> builder.assigner(transformString(v, context));
+            case ODRL_ASSIGNEE_ATTRIBUTE -> v -> builder.assignee(transformString(v, context));
             default -> v -> builder.extensibleProperty(key, transformGenericProperty(v, context));
         });
 

--- a/core/common/transform-core/src/test/java/org/eclipse/edc/core/transform/transformer/from/JsonObjectFromPolicyTransformerTest.java
+++ b/core/common/transform-core/src/test/java/org/eclipse/edc/core/transform/transformer/from/JsonObjectFromPolicyTransformerTest.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.LIST;
 import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
@@ -51,6 +52,8 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ACTION_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ACTION_TYPE_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_AND_CONSTRAINT_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ASSIGNEE_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ASSIGNER_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_CONSEQUENCE_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_CONSTRAINT_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_DUTY_ATTRIBUTE;
@@ -97,6 +100,8 @@ class JsonObjectFromPolicyTransformerTest {
         var duty = Duty.Builder.newInstance().action(action).build();
         var policy = Policy.Builder.newInstance()
                 .target("target")
+                .assignee("assignee")
+                .assigner("assigner")
                 .permission(permission)
                 .prohibition(prohibition)
                 .duty(duty)
@@ -111,10 +116,13 @@ class JsonObjectFromPolicyTransformerTest {
                 .isInstanceOf(JsonArray.class)
                 .extracting(JsonValue::asJsonArray)
                 .matches(it -> !it.isEmpty())
-                .asList().first()
+                .asInstanceOf(LIST).first()
                 .asInstanceOf(type(JsonObject.class))
                 .matches(it -> it.getString(ID).equals("target"));
-    
+
+        assertThat(result.getString(ODRL_ASSIGNEE_ATTRIBUTE)).isEqualTo("assignee");
+        assertThat(result.getString(ODRL_ASSIGNER_ATTRIBUTE)).isEqualTo("assigner");
+
         assertThat(result.get(ODRL_PERMISSION_ATTRIBUTE))
                 .isNotNull()
                 .isInstanceOf(JsonArray.class)

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/policy/PolicyEquality.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/policy/PolicyEquality.java
@@ -19,10 +19,12 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.types.TypeManager;
 
+import java.util.List;
 import java.util.function.BiPredicate;
 
 public class PolicyEquality implements BiPredicate<Policy, Policy> {
 
+    private static final List<String> EXCLUDED_PROPERTIES = List.of("@type", "assignee", "target");
     private final ObjectMapper mapper;
 
     public PolicyEquality(TypeManager typeManager) {
@@ -33,10 +35,10 @@ public class PolicyEquality implements BiPredicate<Policy, Policy> {
     public boolean test(Policy one, Policy two) {
         var oneTree = mapper.<ObjectNode>valueToTree(one);
         var twoTree = mapper.<ObjectNode>valueToTree(two);
-        oneTree.remove("@type");
-        twoTree.remove("@type");
-        oneTree.remove("target");
-        twoTree.remove("target");
+        EXCLUDED_PROPERTIES.forEach(property -> {
+            oneTree.remove(property);
+            twoTree.remove(property);
+        });
         return oneTree.equals(twoTree);
     }
 }

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/policy/PolicyEqualityTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/policy/PolicyEqualityTest.java
@@ -56,4 +56,14 @@ class PolicyEqualityTest {
 
         assertThat(result).isTrue();
     }
+
+    @Test
+    void assigneeIsExcludedFromTheComparison() {
+        var one = Policy.Builder.newInstance().assignee("one").build();
+        var two = Policy.Builder.newInstance().assignee("other").build();
+
+        var result = comparator.test(one, two);
+
+        assertThat(result).isTrue();
+    }
 }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/build.gradle.kts
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     api(project(":data-protocols:dsp:dsp-spi"))
     api(project(":data-protocols:dsp:dsp-http-spi"))
     api(project(":extensions:common:json-ld"))
+    api(project(":spi:common:json-ld-spi"))
     api(project(":spi:common:transform-spi"))
     api(project(":spi:control-plane:contract-spi"))
 }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractAgreementMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractAgreementMessageTransformer.java
@@ -26,6 +26,8 @@ import org.jetbrains.annotations.Nullable;
 import static java.time.Instant.ofEpochSecond;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ASSIGNEE_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ASSIGNER_ATTRIBUTE;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_AGREEMENT;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_ID;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_ID;
@@ -50,13 +52,6 @@ public class JsonObjectFromContractAgreementMessageTransformer extends AbstractJ
 
     @Override
     public @Nullable JsonObject transform(@NotNull ContractAgreementMessage agreementMessage, @NotNull TransformerContext context) {
-        var builder = jsonFactory.createObjectBuilder()
-                .add(ID, agreementMessage.getId())
-                .add(TYPE, DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE)
-                .add(DSPACE_PROPERTY_PROVIDER_PID, agreementMessage.getProviderPid())
-                .add(DSPACE_PROPERTY_CONSUMER_PID, agreementMessage.getConsumerPid())
-                .add(DSPACE_PROPERTY_PROCESS_ID, agreementMessage.getProcessId());
-
         var agreement = agreementMessage.getContractAgreement();
 
         var policy = context.transform(agreement.getPolicy(), JsonObject.class);
@@ -69,19 +64,25 @@ public class JsonObjectFromContractAgreementMessageTransformer extends AbstractJ
             return null;
         }
 
-        // add the consumer id, provider id, and signing timestamp to the agreement
         var signing = ofEpochSecond(agreement.getContractSigningDate()).toString();
 
         var copiedPolicy = Json.createObjectBuilder(policy)
                 .add(ID, agreement.getId())
+                .add(ODRL_ASSIGNEE_ATTRIBUTE, agreement.getConsumerId())
+                .add(ODRL_ASSIGNER_ATTRIBUTE, agreement.getProviderId())
                 .add(DSPACE_PROPERTY_CONSUMER_ID, agreement.getConsumerId())
                 .add(DSPACE_PROPERTY_PROVIDER_ID, agreement.getProviderId())
                 .add(DSPACE_PROPERTY_TIMESTAMP, signing)
                 .build();
 
-        builder.add(DSPACE_PROPERTY_AGREEMENT, copiedPolicy);
-
-        return builder.build();
+        return jsonFactory.createObjectBuilder()
+                .add(ID, agreementMessage.getId())
+                .add(TYPE, DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE)
+                .add(DSPACE_PROPERTY_PROVIDER_PID, agreementMessage.getProviderPid())
+                .add(DSPACE_PROPERTY_CONSUMER_PID, agreementMessage.getConsumerPid())
+                .add(DSPACE_PROPERTY_PROCESS_ID, agreementMessage.getProcessId())
+                .add(DSPACE_PROPERTY_AGREEMENT, copiedPolicy)
+                .build();
     }
 
 }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractAgreementMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractAgreementMessageTransformer.java
@@ -126,9 +126,17 @@ public class JsonObjectToContractAgreementMessageTransformer extends AbstractJso
                     .report();
             return null;
         }
-        builder.id(agreementId);
 
-        if (!transformMandatoryString(jsonAgreement.get(DSPACE_PROPERTY_CONSUMER_ID), builder::consumerId, context)) {
+        var assignee = policy.getAssignee();
+        var assigner = policy.getAssigner();
+
+        builder.id(agreementId)
+                .consumerId(assignee)
+                .providerId(assigner)
+                .policy(policy)
+                .assetId(policy.getTarget());
+
+        if (assignee == null && !transformMandatoryString(jsonAgreement.get(DSPACE_PROPERTY_CONSUMER_ID), builder::consumerId, context)) {
             context.problem()
                     .missingProperty()
                     .type(DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE)
@@ -137,7 +145,7 @@ public class JsonObjectToContractAgreementMessageTransformer extends AbstractJso
             return null;
         }
 
-        if (!transformMandatoryString(jsonAgreement.get(DSPACE_PROPERTY_PROVIDER_ID), builder::providerId, context)) {
+        if (assigner == null && !transformMandatoryString(jsonAgreement.get(DSPACE_PROPERTY_PROVIDER_ID), builder::providerId, context)) {
             context.problem()
                     .missingProperty()
                     .type(DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE)
@@ -145,9 +153,6 @@ public class JsonObjectToContractAgreementMessageTransformer extends AbstractJso
                     .report();
             return null;
         }
-
-        builder.policy(policy);
-        builder.assetId(policy.getTarget());
 
         var timestamp = transformString(jsonAgreement.get(DSPACE_PROPERTY_TIMESTAMP), context);
         if (timestamp == null) {

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractAgreementMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractAgreementMessageTransformerTest.java
@@ -35,6 +35,8 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ASSIGNEE_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ASSIGNER_ATTRIBUTE;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_AGREEMENT;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_ID;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_ID;
@@ -53,6 +55,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class JsonObjectFromContractAgreementMessageTransformerTest {
+
     private static final String PROVIDER_ID = "providerId";
     private static final String CONSUMER_ID = "consumerId";
     private static final String TIMESTAMP = "1970-01-01T00:00:00Z";
@@ -60,7 +63,7 @@ class JsonObjectFromContractAgreementMessageTransformerTest {
     public static final String AGREEMENT_ID = UUID.randomUUID().toString();
 
     private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
-    private final TransformerContext context = mock(TransformerContext.class);
+    private final TransformerContext context = mock();
 
     private final JsonObjectFromContractAgreementMessageTransformer transformer =
             new JsonObjectFromContractAgreementMessageTransformer(jsonFactory);
@@ -78,7 +81,12 @@ class JsonObjectFromContractAgreementMessageTransformerTest {
                 .providerPid("providerPid")
                 .consumerPid("consumerPid")
                 .counterPartyAddress("https://example.com")
-                .contractAgreement(contractAgreement())
+                .contractAgreement(ContractAgreement.Builder.newInstance()
+                        .id(AGREEMENT_ID)
+                        .providerId(PROVIDER_ID)
+                        .consumerId(CONSUMER_ID)
+                        .assetId("assetId")
+                        .policy(policy()).build())
                 .build();
         var policyObject = jsonFactory.createObjectBuilder()
                 .add(ID, "contractOfferId")
@@ -100,6 +108,38 @@ class JsonObjectFromContractAgreementMessageTransformerTest {
         assertThat(jsonAgreement).isNotNull();
         assertThat(jsonAgreement.getString(ID)).isEqualTo(AGREEMENT_ID);
         assertThat(jsonAgreement.getString(DSPACE_PROPERTY_TIMESTAMP)).isEqualTo(TIMESTAMP);
+        assertThat(jsonAgreement.getString(ODRL_ASSIGNEE_ATTRIBUTE)).isEqualTo(CONSUMER_ID);
+        assertThat(jsonAgreement.getString(ODRL_ASSIGNER_ATTRIBUTE)).isEqualTo(PROVIDER_ID);
+
+        verify(context, never()).reportProblem(anyString());
+    }
+
+    @Deprecated
+    @Test
+    void shouldSetConsumerIdAndProviderIdForBackwardCompatibility() {
+        var message = ContractAgreementMessage.Builder.newInstance()
+                .protocol(DSP)
+                .processId("processId")
+                .providerPid("providerPid")
+                .consumerPid("consumerPid")
+                .counterPartyAddress("https://example.com")
+                .contractAgreement(ContractAgreement.Builder.newInstance()
+                        .id(AGREEMENT_ID)
+                        .providerId(PROVIDER_ID)
+                        .consumerId(CONSUMER_ID)
+                        .assetId("assetId")
+                        .policy(policy()).build())
+                .build();
+        var policyObject = jsonFactory.createObjectBuilder()
+                .add(ID, "contractOfferId")
+                .build();
+
+        when(context.transform(any(Policy.class), eq(JsonObject.class))).thenReturn(policyObject);
+
+        var result = transformer.transform(message, context);
+
+        assertThat(result).isNotNull();
+        var jsonAgreement = result.getJsonObject(DSPACE_PROPERTY_AGREEMENT);
         assertThat(jsonAgreement.getString(DSPACE_PROPERTY_CONSUMER_ID)).isEqualTo(CONSUMER_ID);
         assertThat(jsonAgreement.getString(DSPACE_PROPERTY_PROVIDER_ID)).isEqualTo(PROVIDER_ID);
 
@@ -114,7 +154,12 @@ class JsonObjectFromContractAgreementMessageTransformerTest {
                 .providerPid("providerPid")
                 .consumerPid("consumerPid")
                 .counterPartyAddress("https://example.com")
-                .contractAgreement(contractAgreement())
+                .contractAgreement(ContractAgreement.Builder.newInstance()
+                        .id(AGREEMENT_ID)
+                        .providerId(PROVIDER_ID)
+                        .consumerId(CONSUMER_ID)
+                        .assetId("assetId")
+                        .policy(policy()).build())
                 .build();
 
         when(context.transform(any(Policy.class), eq(JsonObject.class))).thenReturn(null);
@@ -122,15 +167,6 @@ class JsonObjectFromContractAgreementMessageTransformerTest {
         assertThat(transformer.transform(message, context)).isNull();
 
         verify(context, times(1)).reportProblem(anyString());
-    }
-
-    private ContractAgreement contractAgreement() {
-        return ContractAgreement.Builder.newInstance()
-                .id(AGREEMENT_ID)
-                .providerId(PROVIDER_ID)
-                .consumerId(CONSUMER_ID)
-                .assetId("assetId")
-                .policy(policy()).build();
     }
 
     private Policy policy() {

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractAgreementMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractAgreementMessageTransformerTest.java
@@ -18,7 +18,6 @@ import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.contract.spi.types.agreement.ContractAgreementMessage;
-import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
 import org.eclipse.edc.policy.model.Action;
 import org.eclipse.edc.policy.model.Duty;
 import org.eclipse.edc.policy.model.Permission;
@@ -34,6 +33,10 @@ import java.time.Instant;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ASSIGNEE_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ASSIGNER_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_AGREEMENT;
 import static org.eclipse.edc.protocol.dsp.negotiation.transform.to.TestInput.getExpanded;
 import static org.eclipse.edc.protocol.dsp.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_AGREEMENT;
@@ -76,14 +79,60 @@ class JsonObjectToContractAgreementMessageTransformerTest {
     @Test
     void transform() {
         var message = jsonFactory.createObjectBuilder()
-                .add(JsonLdKeywords.ID, MESSAGE_ID)
-                .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE)
+                .add(ID, MESSAGE_ID)
+                .add(TYPE, DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE)
                 .add(DSPACE_PROPERTY_CONSUMER_PID, "consumerPid")
                 .add(DSPACE_PROPERTY_PROVIDER_PID, "providerPid")
-                .add(DSPACE_PROPERTY_AGREEMENT, contractAgreement())
+                .add(DSPACE_PROPERTY_AGREEMENT, jsonFactory.createObjectBuilder()
+                        .add(ID, AGREEMENT_ID)
+                        .add(TYPE, ODRL_POLICY_TYPE_AGREEMENT)
+                        .add(ODRL_ASSIGNEE_ATTRIBUTE, CONSUMER_ID)
+                        .add(ODRL_ASSIGNER_ATTRIBUTE, PROVIDER_ID)
+                        .add(DSPACE_PROPERTY_TIMESTAMP, TIMESTAMP)
+                        .build())
                 .build();
 
         when(context.transform(any(JsonObject.class), eq(Policy.class))).thenReturn(policy());
+
+        var result = transformer.transform(getExpanded(message), context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getClass()).isEqualTo(ContractAgreementMessage.class);
+        assertThat(result.getProtocol()).isNotEmpty();
+        assertThat(result.getConsumerPid()).isEqualTo("consumerPid");
+        assertThat(result.getProviderPid()).isEqualTo("providerPid");
+
+        var agreement = result.getContractAgreement();
+        assertThat(agreement).isNotNull();
+        assertThat(agreement.getClass()).isEqualTo(ContractAgreement.class);
+        assertThat(agreement.getId()).isEqualTo(AGREEMENT_ID);
+        assertThat(agreement.getConsumerId()).isEqualTo("assignee");
+        assertThat(agreement.getProviderId()).isEqualTo("assigner");
+        assertThat(agreement.getAssetId()).isEqualTo(TARGET);
+        assertThat(agreement.getContractSigningDate()).isEqualTo(Instant.parse(TIMESTAMP).getEpochSecond());
+
+        verify(context, never()).reportProblem(anyString());
+    }
+
+    @Deprecated
+    @Test
+    void transformFallbackConsumerIdProviderId_whenAssigneeAndAssignerAreMissing() {
+        var message = jsonFactory.createObjectBuilder()
+                .add(ID, MESSAGE_ID)
+                .add(TYPE, DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE)
+                .add(DSPACE_PROPERTY_CONSUMER_PID, "consumerPid")
+                .add(DSPACE_PROPERTY_PROVIDER_PID, "providerPid")
+                .add(DSPACE_PROPERTY_AGREEMENT, jsonFactory.createObjectBuilder()
+                        .add(ID, AGREEMENT_ID)
+                        .add(TYPE, ODRL_POLICY_TYPE_AGREEMENT)
+                        .add(DSPACE_PROPERTY_CONSUMER_ID, CONSUMER_ID)
+                        .add(DSPACE_PROPERTY_PROVIDER_ID, PROVIDER_ID)
+                        .add(DSPACE_PROPERTY_TIMESTAMP, TIMESTAMP)
+                        .build())
+                .build();
+
+        var policy = policyBuilder().assignee(null).assigner(null).build();
+        when(context.transform(any(JsonObject.class), eq(Policy.class))).thenReturn(policy);
 
         var result = transformer.transform(getExpanded(message), context);
 
@@ -109,10 +158,16 @@ class JsonObjectToContractAgreementMessageTransformerTest {
     @Test
     void transform_processId() {
         var message = jsonFactory.createObjectBuilder()
-                .add(JsonLdKeywords.ID, MESSAGE_ID)
-                .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE)
+                .add(ID, MESSAGE_ID)
+                .add(TYPE, DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE)
                 .add(DSPACE_PROPERTY_PROCESS_ID, "processId")
-                .add(DSPACE_PROPERTY_AGREEMENT, contractAgreement())
+                .add(DSPACE_PROPERTY_AGREEMENT, jsonFactory.createObjectBuilder()
+                        .add(ID, AGREEMENT_ID)
+                        .add(TYPE, ODRL_POLICY_TYPE_AGREEMENT)
+                        .add(ODRL_ASSIGNEE_ATTRIBUTE, CONSUMER_ID)
+                        .add(ODRL_ASSIGNER_ATTRIBUTE, PROVIDER_ID)
+                        .add(DSPACE_PROPERTY_TIMESTAMP, TIMESTAMP)
+                        .build())
                 .build();
 
         when(context.transform(any(JsonObject.class), eq(Policy.class))).thenReturn(policy());
@@ -129,8 +184,6 @@ class JsonObjectToContractAgreementMessageTransformerTest {
         assertThat(agreement).isNotNull();
         assertThat(agreement.getClass()).isEqualTo(ContractAgreement.class);
         assertThat(agreement.getId()).isEqualTo(AGREEMENT_ID);
-        assertThat(agreement.getConsumerId()).isEqualTo(CONSUMER_ID);
-        assertThat(agreement.getProviderId()).isEqualTo(PROVIDER_ID);
         assertThat(agreement.getAssetId()).isEqualTo(TARGET);
         assertThat(agreement.getContractSigningDate()).isEqualTo(Instant.parse(TIMESTAMP).getEpochSecond());
 
@@ -141,11 +194,17 @@ class JsonObjectToContractAgreementMessageTransformerTest {
     void transform_nullPolicy() {
         var value = "example";
         var message = jsonFactory.createObjectBuilder()
-                .add(JsonLdKeywords.ID, value)
-                .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE)
+                .add(ID, value)
+                .add(TYPE, DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE)
                 .add(DSPACE_PROPERTY_CONSUMER_PID, "consumerPid")
                 .add(DSPACE_PROPERTY_PROVIDER_PID, "providerPid")
-                .add(DSPACE_PROPERTY_AGREEMENT, contractAgreement())
+                .add(DSPACE_PROPERTY_AGREEMENT, jsonFactory.createObjectBuilder()
+                        .add(ID, AGREEMENT_ID)
+                        .add(TYPE, ODRL_POLICY_TYPE_AGREEMENT)
+                        .add(ODRL_ASSIGNEE_ATTRIBUTE, CONSUMER_ID)
+                        .add(ODRL_ASSIGNER_ATTRIBUTE, PROVIDER_ID)
+                        .add(DSPACE_PROPERTY_TIMESTAMP, TIMESTAMP)
+                        .build())
                 .add(DSPACE_PROPERTY_TIMESTAMP, "123")
                 .build();
 
@@ -159,16 +218,16 @@ class JsonObjectToContractAgreementMessageTransformerTest {
     @Test
     void transform_invalidTimestamp() {
         var agreement = jsonFactory.createObjectBuilder()
-                .add(JsonLdKeywords.ID, AGREEMENT_ID)
-                .add(JsonLdKeywords.TYPE, ODRL_POLICY_TYPE_AGREEMENT)
-                .add(DSPACE_PROPERTY_CONSUMER_ID, CONSUMER_ID)
-                .add(DSPACE_PROPERTY_PROVIDER_ID, PROVIDER_ID)
+                .add(ID, AGREEMENT_ID)
+                .add(TYPE, ODRL_POLICY_TYPE_AGREEMENT)
+                .add(ODRL_ASSIGNEE_ATTRIBUTE, CONSUMER_ID)
+                .add(ODRL_ASSIGNER_ATTRIBUTE, PROVIDER_ID)
                 .add(DSPACE_PROPERTY_TIMESTAMP, "Invalid Timestamp")
                 .build();
 
         var message = jsonFactory.createObjectBuilder()
-                .add(JsonLdKeywords.ID, "messageId")
-                .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE)
+                .add(ID, "messageId")
+                .add(TYPE, DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE)
                 .add(DSPACE_PROPERTY_CONSUMER_PID, "consumerPid")
                 .add(DSPACE_PROPERTY_PROVIDER_PID, "providerPid")
                 .add(DSPACE_PROPERTY_AGREEMENT, agreement)
@@ -184,15 +243,15 @@ class JsonObjectToContractAgreementMessageTransformerTest {
     @Test
     void transform_missingTimestamp() {
         var agreement = jsonFactory.createObjectBuilder()
-                .add(JsonLdKeywords.ID, AGREEMENT_ID)
-                .add(JsonLdKeywords.TYPE, ODRL_POLICY_TYPE_AGREEMENT)
-                .add(DSPACE_PROPERTY_CONSUMER_ID, CONSUMER_ID)
-                .add(DSPACE_PROPERTY_PROVIDER_ID, PROVIDER_ID)
+                .add(ID, AGREEMENT_ID)
+                .add(TYPE, ODRL_POLICY_TYPE_AGREEMENT)
+                .add(ODRL_ASSIGNEE_ATTRIBUTE, CONSUMER_ID)
+                .add(ODRL_ASSIGNER_ATTRIBUTE, PROVIDER_ID)
                 .build();
 
         var message = jsonFactory.createObjectBuilder()
-                .add(JsonLdKeywords.ID, "messageId")
-                .add(JsonLdKeywords.TYPE, DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE)
+                .add(ID, "messageId")
+                .add(TYPE, DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE)
                 .add(DSPACE_PROPERTY_CONSUMER_PID, "consumerPid")
                 .add(DSPACE_PROPERTY_PROVIDER_PID, "providerPid")
                 .add(DSPACE_PROPERTY_AGREEMENT, agreement)
@@ -205,17 +264,11 @@ class JsonObjectToContractAgreementMessageTransformerTest {
         verify(context, times(1)).reportProblem(contains(DSPACE_PROPERTY_TIMESTAMP));
     }
 
-    private JsonObject contractAgreement() {
-        return jsonFactory.createObjectBuilder()
-                .add(JsonLdKeywords.ID, AGREEMENT_ID)
-                .add(JsonLdKeywords.TYPE, ODRL_POLICY_TYPE_AGREEMENT)
-                .add(DSPACE_PROPERTY_CONSUMER_ID, CONSUMER_ID)
-                .add(DSPACE_PROPERTY_PROVIDER_ID, PROVIDER_ID)
-                .add(DSPACE_PROPERTY_TIMESTAMP, TIMESTAMP)
-                .build();
+    private Policy policy() {
+        return policyBuilder().build();
     }
 
-    private Policy policy() {
+    private static Policy.Builder policyBuilder() {
         var action = Action.Builder.newInstance().type("use").build();
         var permission = Permission.Builder.newInstance().action(action).build();
         var prohibition = Prohibition.Builder.newInstance().action(action).build();
@@ -223,9 +276,10 @@ class JsonObjectToContractAgreementMessageTransformerTest {
         return Policy.Builder.newInstance()
                 .permission(permission)
                 .prohibition(prohibition)
+                .assigner("assigner")
+                .assignee("assignee")
                 .duty(duty)
-                .target(TARGET)
-                .build();
+                .target(TARGET);
     }
 
 

--- a/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/type/DspNegotiationPropertyAndTypeNames.java
+++ b/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/type/DspNegotiationPropertyAndTypeNames.java
@@ -38,7 +38,9 @@ public interface DspNegotiationPropertyAndTypeNames {
     String DSPACE_PROPERTY_AGREEMENT = DSPACE_SCHEMA + "agreement";
     String DSPACE_PROPERTY_OFFER = DSPACE_SCHEMA + "offer";
     String DSPACE_PROPERTY_TIMESTAMP = DSPACE_SCHEMA + "timestamp";
+    @Deprecated(since = "0.5.1")
     String DSPACE_PROPERTY_CONSUMER_ID = DSPACE_SCHEMA + "consumerId";
+    @Deprecated(since = "0.5.1")
     String DSPACE_PROPERTY_PROVIDER_ID = DSPACE_SCHEMA + "providerId";
 
     // event types

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApi.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApi.java
@@ -152,6 +152,7 @@ public interface ContractNegotiationApi {
                         "@context": "http://www.w3.org/ns/odrl.jsonld",
                         "@type": "odrl:Offer",
                         "@id": "policy-id",
+                        "assigner": "providerId",
                         "permission": [],
                         "prohibition": [],
                         "obligation": [],

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/validation/ContractRequestValidator.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/validation/ContractRequestValidator.java
@@ -35,6 +35,7 @@ import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractR
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.OFFER;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.POLICY;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.PROTOCOL;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ASSIGNER_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_OFFER;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIBUTE;
 
@@ -68,8 +69,11 @@ public class ContractRequestValidator {
                     .verifyObject(POLICY, builder -> builder
                             .verifyId(MandatoryIdNotBlank::new)
                             .verify(path -> new TypeIs(path, ODRL_POLICY_TYPE_OFFER))
+                            .verify(ODRL_ASSIGNER_ATTRIBUTE, MandatoryObject::new)
+                            .verifyObject(ODRL_ASSIGNER_ATTRIBUTE, b -> b.verifyId(MandatoryIdNotBlank::new))
                             .verify(ODRL_TARGET_ATTRIBUTE, MandatoryObject::new)
-                            .verifyObject(ODRL_TARGET_ATTRIBUTE, b -> b.verifyId(MandatoryIdNotBlank::new)))
+                            .verifyObject(ODRL_TARGET_ATTRIBUTE, b -> b.verifyId(MandatoryIdNotBlank::new))
+                    )
                     .build();
 
             return validator.validate(input);

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/validation/ContractRequestValidatorTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/validation/ContractRequestValidatorTest.java
@@ -38,6 +38,7 @@ import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractR
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ASSIGNER_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_OFFER;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIBUTE;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
@@ -59,7 +60,9 @@ class ContractRequestValidatorTest {
                 .add(POLICY, createArrayBuilder().add(createObjectBuilder()
                         .add(TYPE, createArrayBuilder().add(ODRL_POLICY_TYPE_OFFER))
                         .add(ID, "offer-id")
-                        .add(ODRL_TARGET_ATTRIBUTE, createArrayBuilder().add(createObjectBuilder().add(ID, "target")))))
+                        .add(ODRL_ASSIGNER_ATTRIBUTE, createArrayBuilder().add(createObjectBuilder().add(ID, "assigner")))
+                        .add(ODRL_TARGET_ATTRIBUTE, createArrayBuilder().add(createObjectBuilder().add(ID, "target"))))
+                )
                 .build();
 
         var result = validator.validate(input);
@@ -87,6 +90,7 @@ class ContractRequestValidatorTest {
                 .allSatisfy(violation -> assertThat(violation.path()).startsWith(POLICY))
                 .anySatisfy(violation -> assertThat(violation.path()).endsWith(TYPE))
                 .anySatisfy(violation -> assertThat(violation.path()).endsWith(ODRL_TARGET_ATTRIBUTE))
+                .anySatisfy(violation -> assertThat(violation.path()).endsWith(ODRL_ASSIGNER_ATTRIBUTE))
                 .anySatisfy(violation -> assertThat(violation.path()).endsWith(ID));
     }
 
@@ -165,6 +169,7 @@ class ContractRequestValidatorTest {
                 .add(POLICY, createArrayBuilder().add(createObjectBuilder()
                         .add(ID, "offer-id")
                         .add(TYPE, createArrayBuilder().add(ODRL_POLICY_TYPE_OFFER))
+                        .add(ODRL_ASSIGNER_ATTRIBUTE, createArrayBuilder().add(createObjectBuilder().add(ID, "assigner")))
                         .add(ODRL_TARGET_ATTRIBUTE, createArrayBuilder().add(createObjectBuilder().add(ID, "target")))))
                 .build();
 

--- a/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/PropertyAndTypeNames.java
+++ b/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/PropertyAndTypeNames.java
@@ -51,6 +51,8 @@ public interface PropertyAndTypeNames {
     String ODRL_LOGICAL_CONSTRAINT_TYPE = ODRL_SCHEMA + "LogicalConstraint";
 
     String ODRL_TARGET_ATTRIBUTE = ODRL_SCHEMA + "target";
+    String ODRL_ASSIGNEE_ATTRIBUTE = ODRL_SCHEMA + "assignee";
+    String ODRL_ASSIGNER_ATTRIBUTE = ODRL_SCHEMA + "assigner";
     String ODRL_PERMISSION_ATTRIBUTE = ODRL_SCHEMA + "permission";
     String ODRL_PROHIBITION_ATTRIBUTE = ODRL_SCHEMA + "prohibition";
     String ODRL_OBLIGATION_ATTRIBUTE = ODRL_SCHEMA + "obligation";

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractNegotiationApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractNegotiationApiEndToEndTest.java
@@ -309,6 +309,7 @@ public class ContractNegotiationApiEndToEndTest {
                     .add("permission", permissionJson)
                     .add("prohibition", prohibitionJson)
                     .add("obligation", dutyJson)
+                    .add("assigner", "provider-id")
                     .add("target", "asset-id")
                     .build();
         }

--- a/system-tests/telemetry/telemetry-test-runner/src/test/java/org/eclipse/edc/test/e2e/tracing/TracingEndToEndTest.java
+++ b/system-tests/telemetry/telemetry-test-runner/src/test/java/org/eclipse/edc/test/e2e/tracing/TracingEndToEndTest.java
@@ -78,11 +78,11 @@ public class TracingEndToEndTest extends BaseTelemetryEndToEndTest {
                 .add("counterPartyAddress", "test-address")
                 .add("protocol", "test-protocol")
                 .add("providerId", "test-provider-id")
-                .add("consumerId", "test-consumer-id")
                 .add("policy", Json.createObjectBuilder()
                         .add(CONTEXT, "http://www.w3.org/ns/odrl.jsonld")
                         .add(TYPE, "Offer")
                         .add(ID, "offer-id")
+                        .add("assigner", "providerId")
                         .add("target", "test-asset")
                         .build())
                 .build();


### PR DESCRIPTION
## What this PR changes/adds

Map `assigner` and `assignee` fields in the `Policy` object in the transformers.
Ensures that every `Offer` has the `assigner` property set.

## Why it does that

DSP compliance

## Further notes

- in the model objects like `ContractAgreement` I kept the current nomenclature (`consumerId` and `providerId`), to avoid disruptive changes

## Linked Issue(s)

Closes #3792
_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
