### PR TITLE
refactor: switch ODRL action `USE` to `use`

### DIFF
--- a/core/common/connector-core/src/test/java/org/eclipse/edc/connector/core/policy/ContractExpiryCheckFunctionEvaluationTest.java
+++ b/core/common/connector-core/src/test/java/org/eclipse/edc/connector/core/policy/ContractExpiryCheckFunctionEvaluationTest.java
@@ -66,7 +66,7 @@ class ContractExpiryCheckFunctionEvaluationTest {
     @BeforeEach
     void setup() {
         // bind/register rule to evaluate contract expiry
-        bindingRegistry.bind("USE", TRANSFER_SCOPE);
+        bindingRegistry.bind("use", TRANSFER_SCOPE);
         bindingRegistry.bind(CONTRACT_EXPIRY_EVALUATION_KEY, TRANSFER_SCOPE);
         policyEngine = new PolicyEngineImpl(new ScopeFilter(bindingRegistry));
         policyEngine.registerFunction(TRANSFER_SCOPE, Permission.class, CONTRACT_EXPIRY_EVALUATION_KEY, function);
@@ -152,7 +152,7 @@ class ContractExpiryCheckFunctionEvaluationTest {
                         .build())
                 .build();
         var permission = Permission.Builder.newInstance()
-                .action(Action.Builder.newInstance().type("USE").build())
+                .action(Action.Builder.newInstance().type("use").build())
                 .constraint(fixedInForceTimeConstraint).build();
 
         return Policy.Builder.newInstance()

--- a/core/common/policy-engine/src/test/java/org/eclipse/edc/policy/engine/PolicyEngineImplScenariosTest.java
+++ b/core/common/policy-engine/src/test/java/org/eclipse/edc/policy/engine/PolicyEngineImplScenariosTest.java
@@ -42,7 +42,7 @@ public class PolicyEngineImplScenariosTest {
     private static final String TEST_SCOPE = "test";
     private static final String ABS_SPATIAL_CONSTRAINT = "absoluteSpatialPosition";
     private static final String CONNECTOR_CONSTRAINT = "connector";
-    private static final Action USE_ACTION = Action.Builder.newInstance().type("USE").build();
+    private static final Action USE_ACTION = Action.Builder.newInstance().type("use").build();
 
     private final RuleBindingRegistry bindingRegistry = new RuleBindingRegistryImpl();
     private PolicyEngineImpl policyEngine;

--- a/core/common/policy-engine/src/test/java/org/eclipse/edc/policy/engine/PolicyEngineImplTest.java
+++ b/core/common/policy-engine/src/test/java/org/eclipse/edc/policy/engine/PolicyEngineImplTest.java
@@ -199,7 +199,7 @@ class PolicyEngineImplTest {
     void validateRuleFunctionOutOfScope() {
         bindingRegistry.bind("foo", ALL_SCOPES);
 
-        var action = Action.Builder.newInstance().type("USE").build();
+        var action = Action.Builder.newInstance().type("use").build();
 
         var permission = Permission.Builder.newInstance().action(action).build();
 

--- a/core/common/policy-evaluator/src/test/java/org/eclipse/edc/policy/evaluator/PolicyEvaluatorTest.java
+++ b/core/common/policy-evaluator/src/test/java/org/eclipse/edc/policy/evaluator/PolicyEvaluatorTest.java
@@ -191,7 +191,7 @@ class PolicyEvaluatorTest {
 
     @Test
     void verifyPermissionRuleFunctions() {
-        var permission = Permission.Builder.newInstance().action(Action.Builder.newInstance().type("USE").build()).build();
+        var permission = Permission.Builder.newInstance().action(Action.Builder.newInstance().type("use").build()).build();
         var policy = Policy.Builder.newInstance().permission(permission).build();
 
         var evaluator = PolicyEvaluator.Builder.newInstance().permissionRuleFunction((p) -> true).build();

--- a/core/common/transform-core/src/test/java/org/eclipse/edc/core/transform/transformer/from/JsonObjectFromPolicyTransformerTest.java
+++ b/core/common/transform-core/src/test/java/org/eclipse/edc/core/transform/transformer/from/JsonObjectFromPolicyTransformerTest.java
@@ -91,7 +91,7 @@ class JsonObjectFromPolicyTransformerTest {
     
     @Test
     void transform_policyWithAllRuleTypes_returnJsonObject() {
-        var action = Action.Builder.newInstance().type("USE").build();
+        var action = Action.Builder.newInstance().type("use").build();
         var permission = Permission.Builder.newInstance().action(action).build();
         var prohibition = Prohibition.Builder.newInstance().action(action).build();
         var duty = Duty.Builder.newInstance().action(action).build();
@@ -147,7 +147,7 @@ class JsonObjectFromPolicyTransformerTest {
     void transform_actionWithAllAttributes_returnJsonObject() {
         var constraint = getConstraint();
         var action = Action.Builder.newInstance()
-                .type("USE")
+                .type("use")
                 .includedIn("includedIn")
                 .constraint(constraint)
                 .build();
@@ -357,7 +357,7 @@ class JsonObjectFromPolicyTransformerTest {
     }
 
     private Action getAction() {
-        return Action.Builder.newInstance().type("USE").build();
+        return Action.Builder.newInstance().type("use").build();
     }
     
     private AtomicConstraint getConstraint() {

--- a/core/common/transform-core/src/test/java/org/eclipse/edc/core/transform/transformer/to/JsonObjectToActionTransformerTest.java
+++ b/core/common/transform-core/src/test/java/org/eclipse/edc/core/transform/transformer/to/JsonObjectToActionTransformerTest.java
@@ -59,12 +59,12 @@ class JsonObjectToActionTransformerTest {
 
     @Test
     void transform_onlyActionType_returnAction() {
-        var action = jsonFactory.createObjectBuilder().add(ODRL_ACTION_TYPE_ATTRIBUTE, "USE").build();
+        var action = jsonFactory.createObjectBuilder().add(ODRL_ACTION_TYPE_ATTRIBUTE, "use").build();
 
         var result = transformer.transform(getExpanded(action), context);
 
         assertThat(result).isNotNull();
-        assertThat(result.getType()).isEqualTo("USE");
+        assertThat(result.getType()).isEqualTo("use");
         assertThat(result.getIncludedIn()).isNull();
         assertThat(result.getConstraint()).isNull();
 
@@ -73,14 +73,14 @@ class JsonObjectToActionTransformerTest {
 
     @Test
     void transform_onlyActionAttribute_returnAction() {
-        var actionContainer = jsonFactory.createObjectBuilder().add(ODRL_ACTION_ATTRIBUTE, "USE").build();
+        var actionContainer = jsonFactory.createObjectBuilder().add(ODRL_ACTION_ATTRIBUTE, "use").build();
         var expanded = getExpanded(actionContainer);
         var action = expanded.getJsonArray(ODRL_ACTION_ATTRIBUTE).get(0).asJsonObject();
 
         var result = transformer.transform(action, context);
 
         assertThat(result).isNotNull();
-        assertThat(result.getType()).isEqualTo("USE");
+        assertThat(result.getType()).isEqualTo("use");
         assertThat(result.getIncludedIn()).isNull();
         assertThat(result.getConstraint()).isNull();
 
@@ -114,7 +114,7 @@ class JsonObjectToActionTransformerTest {
         when(context.transform(any(JsonObject.class), eq(Constraint.class))).thenReturn(constraint);
 
         var action = jsonFactory.createObjectBuilder()
-                .add(ODRL_ACTION_TYPE_ATTRIBUTE, "USE")
+                .add(ODRL_ACTION_TYPE_ATTRIBUTE, "use")
                 .add(ODRL_INCLUDED_IN_ATTRIBUTE, "includedIn")
                 .add(ODRL_REFINEMENT_ATTRIBUTE, jsonFactory.createObjectBuilder().build())
                 .build();
@@ -122,7 +122,7 @@ class JsonObjectToActionTransformerTest {
         var result = transformer.transform(getExpanded(action), context);
 
         assertThat(result).isNotNull();
-        assertThat(result.getType()).isEqualTo("USE");
+        assertThat(result.getType()).isEqualTo("use");
         assertThat(result.getIncludedIn()).isEqualTo("includedIn");
         assertThat(result.getConstraint()).isEqualTo(constraint);
 

--- a/core/control-plane/contract-core/build.gradle.kts
+++ b/core/control-plane/contract-core/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
 }
 
 dependencies {
+    api(project(":spi:common:json-ld-spi"))
     api(project(":spi:common:policy-engine-spi"))
     api(project(":spi:control-plane:contract-spi"))
 

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/ContractCoreExtension.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/ContractCoreExtension.java
@@ -62,7 +62,7 @@ import static org.eclipse.edc.connector.core.entity.AbstractStateEntityManager.D
 import static org.eclipse.edc.connector.core.entity.AbstractStateEntityManager.DEFAULT_SEND_RETRY_BASE_DELAY;
 import static org.eclipse.edc.connector.core.entity.AbstractStateEntityManager.DEFAULT_SEND_RETRY_LIMIT;
 import static org.eclipse.edc.connector.core.policy.ContractExpiryCheckFunction.CONTRACT_EXPIRY_EVALUATION_KEY;
-import static org.eclipse.edc.policy.model.OdrlNamespace.ODRL_SCHEMA;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_USE_ACTION_ATTRIBUTE;
 
 @Provides({
         ContractValidationService.class, ConsumerContractNegotiationManager.class,
@@ -180,8 +180,7 @@ public class ContractCoreExtension implements ServiceExtension {
         context.registerService(ContractValidationService.class, validationService);
 
         // bind/register rule to evaluate contract expiry
-        ruleBindingRegistry.bind("USE", TRANSFER_SCOPE);
-        ruleBindingRegistry.bind(ODRL_SCHEMA + "use", TRANSFER_SCOPE);
+        ruleBindingRegistry.bind(ODRL_USE_ACTION_ATTRIBUTE, TRANSFER_SCOPE);
         ruleBindingRegistry.bind(CONTRACT_EXPIRY_EVALUATION_KEY, TRANSFER_SCOPE);
         var function = new ContractExpiryCheckFunction();
         policyEngine.registerFunction(TRANSFER_SCOPE, Permission.class, CONTRACT_EXPIRY_EVALUATION_KEY, function);

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -381,7 +381,7 @@ class ContractNegotiationIntegrationTest {
                         .assigner("assigner")
                         .assignee("assignee")
                         .duty(Duty.Builder.newInstance()
-                                .action(Action.Builder.newInstance().type("USE").build())
+                                .action(Action.Builder.newInstance().type("use").build())
                                 .build())
                         .build())
                 .build();

--- a/core/policy-monitor/policy-monitor-core/build.gradle.kts
+++ b/core/policy-monitor/policy-monitor-core/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
 
 dependencies {
     api(project(":spi:policy-monitor:policy-monitor-spi"))
+    api(project(":spi:common:json-ld-spi"))
     api(project(":spi:control-plane:control-plane-spi"))
     api(project(":spi:control-plane:policy-spi"))
     api(project(":spi:control-plane:transfer-spi"))

--- a/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/PolicyMonitorExtension.java
+++ b/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/PolicyMonitorExtension.java
@@ -43,7 +43,7 @@ import static org.eclipse.edc.connector.core.entity.AbstractStateEntityManager.D
 import static org.eclipse.edc.connector.core.entity.AbstractStateEntityManager.DEFAULT_ITERATION_WAIT;
 import static org.eclipse.edc.connector.core.policy.ContractExpiryCheckFunction.CONTRACT_EXPIRY_EVALUATION_KEY;
 import static org.eclipse.edc.connector.policy.monitor.PolicyMonitorExtension.NAME;
-import static org.eclipse.edc.policy.model.OdrlNamespace.ODRL_SCHEMA;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_USE_ACTION_ATTRIBUTE;
 
 @Extension(value = NAME)
 @Provides({ PolicyMonitorManager.class })
@@ -94,7 +94,7 @@ public class PolicyMonitorExtension implements ServiceExtension {
         var iterationWaitMillis = context.getSetting(POLICY_MONITOR_ITERATION_WAIT_MILLIS, DEFAULT_ITERATION_WAIT);
         var waitStrategy = new ExponentialWaitStrategy(iterationWaitMillis);
 
-        ruleBindingRegistry.bind(ODRL_SCHEMA + "use", POLICY_MONITOR_SCOPE);
+        ruleBindingRegistry.bind(ODRL_USE_ACTION_ATTRIBUTE, POLICY_MONITOR_SCOPE);
         ruleBindingRegistry.bind(CONTRACT_EXPIRY_EVALUATION_KEY, POLICY_MONITOR_SCOPE);
         policyEngine.registerFunction(POLICY_MONITOR_SCOPE, Permission.class, CONTRACT_EXPIRY_EVALUATION_KEY, new ContractExpiryCheckFunction());
 

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractAgreementMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractAgreementMessageTransformerTest.java
@@ -134,7 +134,7 @@ class JsonObjectFromContractAgreementMessageTransformerTest {
     }
 
     private Policy policy() {
-        var action = Action.Builder.newInstance().type("USE").build();
+        var action = Action.Builder.newInstance().type("use").build();
         var permission = Permission.Builder.newInstance().action(action).build();
         var prohibition = Prohibition.Builder.newInstance().action(action).build();
         var duty = Duty.Builder.newInstance().action(action).build();

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractAgreementMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractAgreementMessageTransformerTest.java
@@ -216,7 +216,7 @@ class JsonObjectToContractAgreementMessageTransformerTest {
     }
 
     private Policy policy() {
-        var action = Action.Builder.newInstance().type("USE").build();
+        var action = Action.Builder.newInstance().type("use").build();
         var permission = Permission.Builder.newInstance().action(action).build();
         var prohibition = Prohibition.Builder.newInstance().action(action).build();
         var duty = Duty.Builder.newInstance().action(action).build();

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractRequestMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractRequestMessageTransformerTest.java
@@ -191,7 +191,7 @@ class JsonObjectToContractRequestMessageTransformerTest {
     }
 
     private Policy policy() {
-        var action = Action.Builder.newInstance().type("USE").build();
+        var action = Action.Builder.newInstance().type("use").build();
         var permission = Permission.Builder.newInstance().action(action).build();
         var prohibition = Prohibition.Builder.newInstance().action(action).build();
         var duty = Duty.Builder.newInstance().action(action).build();

--- a/docs/developer/policy-engine.md
+++ b/docs/developer/policy-engine.md
@@ -37,7 +37,7 @@ As an example, we create the module `:extensions:policy:ids-policy`.
 ### Step 2: Implement a `ServiceExtension`
 
 The new policy extension will provide a service extension class and two constraint functions. In
-`IdsPolicyExtension`, first, the scope `ALL_SCOPES` is bound to the rule type `USE`. Next, both policy 
+`IdsPolicyExtension`, first, the scope `ALL_SCOPES` is bound to the rule type `use`. Next, both policy 
 functions are registered to the policy engine.
 
 ```java
@@ -59,7 +59,7 @@ public class IdsPolicyExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        ruleBindingRegistry.bind(USE, ALL_SCOPES);
+        ruleBindingRegistry.bind("use", ALL_SCOPES);
 
         policyEngine.registerFunction(ALL_SCOPES, Permission.class, ABS_SPATIAL_POSITION, new AbsSpatialPositionConstraintFunction());
         policyEngine.registerFunction(ALL_SCOPES, Permission.class, PARTNER_LEVEL, new PartnerLevelConstraintFunction());

--- a/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/PropertyAndTypeNames.java
+++ b/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/PropertyAndTypeNames.java
@@ -68,5 +68,6 @@ public interface PropertyAndTypeNames {
     String ODRL_AND_CONSTRAINT_ATTRIBUTE = ODRL_SCHEMA + "and";
     String ODRL_OR_CONSTRAINT_ATTRIBUTE = ODRL_SCHEMA + "or";
     String ODRL_XONE_CONSTRAINT_ATTRIBUTE = ODRL_SCHEMA + "xone";
+    String ODRL_USE_ACTION_ATTRIBUTE = ODRL_SCHEMA + "use";
 
 }

--- a/spi/common/policy-model/src/test/java/org/eclipse/edc/policy/model/DutyTest.java
+++ b/spi/common/policy-model/src/test/java/org/eclipse/edc/policy/model/DutyTest.java
@@ -26,7 +26,7 @@ class DutyTest {
     @Test
     void serializeDeserialize() throws JsonProcessingException {
         var mapper = new ObjectMapper();
-        var serialized = mapper.writeValueAsString(Duty.Builder.newInstance().action(Action.Builder.newInstance().type("USE").build()).build());
+        var serialized = mapper.writeValueAsString(Duty.Builder.newInstance().action(Action.Builder.newInstance().type("use").build()).build());
         assertThat(mapper.readValue(serialized, Duty.class).getAction()).isNotNull();
     }
 

--- a/spi/common/policy-model/src/test/java/org/eclipse/edc/policy/model/PermissionTest.java
+++ b/spi/common/policy-model/src/test/java/org/eclipse/edc/policy/model/PermissionTest.java
@@ -26,7 +26,7 @@ class PermissionTest {
     @Test
     void serializeDeserialize() throws JsonProcessingException {
         var mapper = new ObjectMapper();
-        var serialized = mapper.writeValueAsString(Permission.Builder.newInstance().action(Action.Builder.newInstance().type("USE").build()).build());
+        var serialized = mapper.writeValueAsString(Permission.Builder.newInstance().action(Action.Builder.newInstance().type("use").build()).build());
         assertThat(mapper.readValue(serialized, Permission.class).getAction()).isNotNull();
     }
 

--- a/spi/common/policy-model/src/test/java/org/eclipse/edc/policy/model/PolicyTest.java
+++ b/spi/common/policy-model/src/test/java/org/eclipse/edc/policy/model/PolicyTest.java
@@ -29,7 +29,7 @@ class PolicyTest {
     void serializeDeserialize() throws JsonProcessingException {
         var mapper = new ObjectMapper();
 
-        var permission = Permission.Builder.newInstance().action(Action.Builder.newInstance().type("USE").build()).build();
+        var permission = Permission.Builder.newInstance().action(Action.Builder.newInstance().type("use").build()).build();
         var policy = Policy.Builder.newInstance().permission(permission).build();
 
         var serialized = mapper.writeValueAsString(policy);
@@ -39,7 +39,7 @@ class PolicyTest {
     @Test
     void withTarget() {
         var target = "target-id";
-        var permission = Permission.Builder.newInstance().action(Action.Builder.newInstance().type("USE").build()).build();
+        var permission = Permission.Builder.newInstance().action(Action.Builder.newInstance().type("use").build()).build();
         var prohibition = Prohibition.Builder.newInstance().action(Action.Builder.newInstance().type("MODIFY").build()).build();
         var duty = Duty.Builder.newInstance().action(Action.Builder.newInstance().type("DELETE").build()).build();
         var policy = Policy.Builder.newInstance()

--- a/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/negotiation/store/ContractNegotiationStoreTestBase.java
+++ b/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/negotiation/store/ContractNegotiationStoreTestBase.java
@@ -564,7 +564,7 @@ public abstract class ContractNegotiationStoreTestBase {
                     .assigner("test-assigner")
                     .permission(Permission.Builder.newInstance()
                             .action(Action.Builder.newInstance()
-                                    .type("USE")
+                                    .type("use")
                                     .build())
                             .constraint(AtomicConstraint.Builder.newInstance()
                                     .leftExpression(new LiteralExpression("foo"))

--- a/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/negotiation/store/TestFunctions.java
+++ b/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/contract/spi/testfixtures/negotiation/store/TestFunctions.java
@@ -89,7 +89,7 @@ public class TestFunctions {
         return Policy.Builder.newInstance()
                 .permission(Permission.Builder.newInstance()
                         .action(Action.Builder.newInstance()
-                                .type("USE")
+                                .type("use")
                                 .build())
                         .constraint(AtomicConstraint.Builder.newInstance()
                                 .leftExpression(new LiteralExpression("foo"))

--- a/spi/control-plane/policy-spi/src/testFixtures/java/org/eclipse/edc/connector/policy/spi/testfixtures/store/PolicyDefinitionStoreTestBase.java
+++ b/spi/control-plane/policy-spi/src/testFixtures/java/org/eclipse/edc/connector/policy/spi/testfixtures/store/PolicyDefinitionStoreTestBase.java
@@ -233,7 +233,7 @@ public abstract class PolicyDefinitionStoreTestBase {
             var store = getPolicyDefinitionStore();
             store.create(policy);
 
-            var action = Action.Builder.newInstance().type("UPDATED_USE").build();
+            var action = Action.Builder.newInstance().type("play").build();
             var updatedPermission = Permission.Builder.newInstance().action(action).build();
             var updatedDuty = Duty.Builder.newInstance().action(action).build();
             var updatedProhibition = Prohibition.Builder.newInstance().action(action).build();


### PR DESCRIPTION
## What this PR changes/adds

The correct case for such action is [`use`](http://www.w3.org/ns/odrl/2/use)

## Why it does that

ODRL compliance

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #3925

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
