### PR TITLE
chore: fix NPE when dataplane is embedded

### DIFF
--- a/extensions/control-plane/transfer/transfer-data-plane/src/main/java/org/eclipse/edc/connector/transfer/dataplane/flow/ProviderPushTransferDataFlowController.java
+++ b/extensions/control-plane/transfer/transfer-data-plane/src/main/java/org/eclipse/edc/connector/transfer/dataplane/flow/ProviderPushTransferDataFlowController.java
@@ -73,9 +73,11 @@ public class ProviderPushTransferDataFlowController implements DataFlowControlle
                 .build();
 
         var dataPlaneInstance = selectorClient.select(transferProcess.getContentDataAddress(), transferProcess.getDataDestination());
+
+        var dataPlaneInstanceId = dataPlaneInstance != null ? dataPlaneInstance.getId() : null;
         return clientFactory.createClient(dataPlaneInstance)
                 .start(dataFlowRequest)
-                .map(it -> DataFlowResponse.Builder.newInstance().dataPlaneId(dataPlaneInstance.getId()).build());
+                .map(it -> DataFlowResponse.Builder.newInstance().dataPlaneId(dataPlaneInstanceId).build());
     }
 
     @Override


### PR DESCRIPTION
## What this PR changes/adds

if the dataplane is embedded the instance will be null, hence we don't have a dataplaneId

## Why it does that

fix NPE

