### PR TITLE
feat(dsp): map participant ids to/from IRI

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -125,7 +125,7 @@ maven/mavencentral/io.netty/netty-tcnative-classes/2.0.56.Final, Apache-2.0, app
 maven/mavencentral/io.netty/netty-transport-native-unix-common/4.1.86.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-transport/4.1.86.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations/1.32.0, Apache-2.0, approved, #11684
-maven/mavencentral/io.opentelemetry.proto/opentelemetry-proto/1.1.0-alpha, None, restricted, #12956
+maven/mavencentral/io.opentelemetry.proto/opentelemetry-proto/1.1.0-alpha, Apache-2.0, approved, #12956
 maven/mavencentral/io.opentelemetry/opentelemetry-api/1.32.0, Apache-2.0, approved, #11682
 maven/mavencentral/io.opentelemetry/opentelemetry-context/1.32.0, Apache-2.0, approved, #11683
 maven/mavencentral/io.prometheus/simpleclient/0.16.0, Apache-2.0, approved, clearlydefined

--- a/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/CoreDefaultServicesExtension.java
+++ b/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/CoreDefaultServicesExtension.java
@@ -20,11 +20,13 @@ import okhttp3.OkHttpClient;
 import org.eclipse.edc.connector.core.base.EdcHttpClientImpl;
 import org.eclipse.edc.connector.core.base.OkHttpClientFactory;
 import org.eclipse.edc.connector.core.base.RetryPolicyFactory;
+import org.eclipse.edc.connector.core.base.agent.NoOpParticipantIdMapper;
 import org.eclipse.edc.connector.core.event.EventExecutorServiceContainer;
 import org.eclipse.edc.connector.core.vault.InMemoryVault;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.agent.ParticipantIdMapper;
 import org.eclipse.edc.spi.http.EdcHttpClient;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.system.ExecutorInstrumentation;
@@ -51,8 +53,6 @@ public class CoreDefaultServicesExtension implements ServiceExtension {
     @Inject(required = false)
     private EventListener okHttpEventListener;
 
-    private InMemoryVault inMemoryVault;
-
     @Override
     public String name() {
         return NAME;
@@ -77,7 +77,7 @@ public class CoreDefaultServicesExtension implements ServiceExtension {
 
     @Provider(isDefault = true)
     public EventExecutorServiceContainer eventExecutorServiceContainer() {
-        return new EventExecutorServiceContainer(Executors.newFixedThreadPool(1)); // TODO: make configurable
+        return new EventExecutorServiceContainer(Executors.newFixedThreadPool(1));
     }
 
     @Provider(isDefault = true)
@@ -105,14 +105,15 @@ public class CoreDefaultServicesExtension implements ServiceExtension {
         return RetryPolicyFactory.create(context);
     }
 
-
     @Provider(isDefault = true)
     public Vault createInmemVault(ServiceExtensionContext context) {
         context.getMonitor().warning("Using the InMemoryVault is not suitable for production scenarios and should be replaced with an actual Vault!");
-        if (inMemoryVault == null) {
-            inMemoryVault = new InMemoryVault(context.getMonitor());
-        }
-        return inMemoryVault;
+        return new InMemoryVault(context.getMonitor());
+    }
+
+    @Provider(isDefault = true)
+    public ParticipantIdMapper participantIdMapper() {
+        return new NoOpParticipantIdMapper();
     }
 
 }

--- a/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/base/agent/NoOpParticipantIdMapper.java
+++ b/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/base/agent/NoOpParticipantIdMapper.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.core.base.agent;
+
+import org.eclipse.edc.spi.agent.ParticipantIdMapper;
+
+/**
+ * No-op implementation of the mapper, the ID is already its IRI representation.
+ */
+public class NoOpParticipantIdMapper implements ParticipantIdMapper {
+
+    @Override
+    public String toIri(String participantId) {
+        return participantId;
+    }
+
+    @Override
+    public String fromIri(String iriParticipantId) {
+        return iriParticipantId;
+    }
+}

--- a/core/common/transform-core/src/main/java/org/eclipse/edc/core/transform/transformer/OdrlTransformersFactory.java
+++ b/core/common/transform-core/src/main/java/org/eclipse/edc/core/transform/transformer/OdrlTransformersFactory.java
@@ -21,6 +21,7 @@ import org.eclipse.edc.core.transform.transformer.to.JsonObjectToOperatorTransfo
 import org.eclipse.edc.core.transform.transformer.to.JsonObjectToPermissionTransformer;
 import org.eclipse.edc.core.transform.transformer.to.JsonObjectToPolicyTransformer;
 import org.eclipse.edc.core.transform.transformer.to.JsonObjectToProhibitionTransformer;
+import org.eclipse.edc.spi.agent.ParticipantIdMapper;
 import org.eclipse.edc.transform.spi.TypeTransformer;
 
 import java.util.stream.Stream;
@@ -30,9 +31,9 @@ public final class OdrlTransformersFactory {
     private OdrlTransformersFactory() {
     }
 
-    public static Stream<TypeTransformer<?, ?>> jsonObjectToOdrlTransformers() {
+    public static Stream<TypeTransformer<?, ?>> jsonObjectToOdrlTransformers(ParticipantIdMapper participantIdMapper) {
         return Stream.of(
-                new JsonObjectToPolicyTransformer(),
+                new JsonObjectToPolicyTransformer(participantIdMapper),
                 new JsonObjectToPermissionTransformer(),
                 new JsonObjectToProhibitionTransformer(),
                 new JsonObjectToDutyTransformer(),

--- a/core/common/transform-core/src/main/java/org/eclipse/edc/core/transform/transformer/to/JsonObjectToPolicyTransformer.java
+++ b/core/common/transform-core/src/main/java/org/eclipse/edc/core/transform/transformer/to/JsonObjectToPolicyTransformer.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.policy.model.Permission;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.policy.model.PolicyType;
 import org.eclipse.edc.policy.model.Prohibition;
+import org.eclipse.edc.spi.agent.ParticipantIdMapper;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -42,8 +43,11 @@ import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIB
  */
 public class JsonObjectToPolicyTransformer extends AbstractJsonLdTransformer<JsonObject, Policy> {
 
-    public JsonObjectToPolicyTransformer() {
+    private final ParticipantIdMapper participantIdMapper;
+
+    public JsonObjectToPolicyTransformer(ParticipantIdMapper participantIdMapper) {
         super(JsonObject.class, Policy.class);
+        this.participantIdMapper = participantIdMapper;
     }
 
     @Override
@@ -78,8 +82,8 @@ public class JsonObjectToPolicyTransformer extends AbstractJsonLdTransformer<Jso
             case ODRL_PROHIBITION_ATTRIBUTE -> v -> builder.prohibitions(transformArray(v, Prohibition.class, context));
             case ODRL_OBLIGATION_ATTRIBUTE -> v -> builder.duties(transformArray(v, Duty.class, context));
             case ODRL_TARGET_ATTRIBUTE -> v -> builder.target(transformString(v, context));
-            case ODRL_ASSIGNER_ATTRIBUTE -> v -> builder.assigner(transformString(v, context));
-            case ODRL_ASSIGNEE_ATTRIBUTE -> v -> builder.assignee(transformString(v, context));
+            case ODRL_ASSIGNER_ATTRIBUTE -> v -> builder.assigner(participantIdMapper.fromIri(transformString(v, context)));
+            case ODRL_ASSIGNEE_ATTRIBUTE -> v -> builder.assignee(participantIdMapper.fromIri(transformString(v, context)));
             default -> v -> builder.extensibleProperty(key, transformGenericProperty(v, context));
         });
 

--- a/core/common/transform-core/src/test/java/org/eclipse/edc/core/transform/transformer/to/JsonObjectToPolicyTransformerTest.java
+++ b/core/common/transform-core/src/test/java/org/eclipse/edc/core/transform/transformer/to/JsonObjectToPolicyTransformerTest.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.policy.model.Duty;
 import org.eclipse.edc.policy.model.Permission;
 import org.eclipse.edc.policy.model.PolicyType;
 import org.eclipse.edc.policy.model.Prohibition;
+import org.eclipse.edc.spi.agent.ParticipantIdMapper;
 import org.eclipse.edc.transform.spi.ProblemBuilder;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.junit.jupiter.api.BeforeEach;
@@ -67,21 +68,20 @@ class JsonObjectToPolicyTransformerTest {
 
     private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
     private final TransformerContext context = mock();
+    private final ParticipantIdMapper participantIdMapper = mock();
     private final Permission permission = Permission.Builder.newInstance().build();
     private final Prohibition prohibition = Prohibition.Builder.newInstance().build();
     private final Duty duty = Duty.Builder.newInstance().build();
 
-    private JsonObjectToPolicyTransformer transformer;
+    private final JsonObjectToPolicyTransformer transformer = new JsonObjectToPolicyTransformer(participantIdMapper);
 
     @BeforeEach
     void setUp() {
-        transformer = new JsonObjectToPolicyTransformer();
-
         when(context.transform(isA(JsonObject.class), eq(Permission.class))).thenReturn(permission);
         when(context.transform(isA(JsonObject.class), eq(Prohibition.class))).thenReturn(prohibition);
         when(context.transform(isA(JsonObject.class), eq(Duty.class))).thenReturn(duty);
+        when(participantIdMapper.fromIri(any())).thenAnswer(it -> it.getArgument(0));
     }
-
 
     @Test
     void transform_withAllRuleTypesAsObjects_returnPolicy() {
@@ -117,6 +117,8 @@ class JsonObjectToPolicyTransformerTest {
         verify(context, times(1)).transform(isA(JsonObject.class), eq(Permission.class));
         verify(context, times(1)).transform(isA(JsonObject.class), eq(Prohibition.class));
         verify(context, times(1)).transform(isA(JsonObject.class), eq(Duty.class));
+        verify(participantIdMapper).fromIri("assignee");
+        verify(participantIdMapper).fromIri("assigner");
     }
 
     @Test

--- a/data-protocols/dsp/dsp-api-configuration/src/main/java/org/eclipse/edc/protocol/dsp/api/configuration/DspApiConfigurationExtension.java
+++ b/data-protocols/dsp/dsp-api-configuration/src/main/java/org/eclipse/edc/protocol/dsp/api/configuration/DspApiConfigurationExtension.java
@@ -33,6 +33,7 @@ import org.eclipse.edc.protocol.dsp.spi.configuration.DspApiConfiguration;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provides;
+import org.eclipse.edc.spi.agent.ParticipantIdMapper;
 import org.eclipse.edc.spi.protocol.ProtocolWebhook;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
@@ -97,6 +98,8 @@ public class DspApiConfigurationExtension implements ServiceExtension {
     private JsonLd jsonLd;
     @Inject
     private TypeTransformerRegistry transformerRegistry;
+    @Inject
+    private ParticipantIdMapper participantIdMapper;
 
     @Override
     public String name() {
@@ -132,7 +135,7 @@ public class DspApiConfigurationExtension implements ServiceExtension {
         var jsonBuilderFactory = Json.createBuilderFactory(Map.of());
 
         // EDC model to JSON-LD transformers
-        transformerRegistry.register(new JsonObjectFromPolicyTransformer(jsonBuilderFactory));
+        transformerRegistry.register(new JsonObjectFromPolicyTransformer(jsonBuilderFactory, participantIdMapper));
         transformerRegistry.register(new JsonObjectFromAssetTransformer(jsonBuilderFactory, mapper));
         transformerRegistry.register(new JsonObjectFromDataAddressTransformer(jsonBuilderFactory));
         transformerRegistry.register(new JsonObjectFromQuerySpecTransformer(jsonBuilderFactory));
@@ -140,7 +143,7 @@ public class DspApiConfigurationExtension implements ServiceExtension {
 
         // JSON-LD to EDC model transformers
         // ODRL Transformers
-        OdrlTransformersFactory.jsonObjectToOdrlTransformers().forEach(transformerRegistry::register);
+        OdrlTransformersFactory.jsonObjectToOdrlTransformers(participantIdMapper).forEach(transformerRegistry::register);
 
         transformerRegistry.register(new JsonValueToGenericTypeTransformer(mapper));
         transformerRegistry.register(new JsonObjectToAssetTransformer());

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/main/java/org/eclipse/edc/protocol/dsp/catalog/transform/DspCatalogTransformExtension.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/main/java/org/eclipse/edc/protocol/dsp/catalog/transform/DspCatalogTransformExtension.java
@@ -23,6 +23,7 @@ import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromDistrib
 import org.eclipse.edc.protocol.dsp.catalog.transform.to.JsonObjectToCatalogRequestMessageTransformer;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.agent.ParticipantIdMapper;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
@@ -46,6 +47,9 @@ public class DspCatalogTransformExtension implements ServiceExtension {
     @Inject
     private TypeManager typeManager;
 
+    @Inject
+    private ParticipantIdMapper participantIdMapper;
+
     @Override
     public String name() {
         return NAME;
@@ -59,7 +63,7 @@ public class DspCatalogTransformExtension implements ServiceExtension {
         registry.register(new JsonObjectFromCatalogRequestMessageTransformer(jsonFactory));
         registry.register(new JsonObjectToCatalogRequestMessageTransformer());
 
-        registry.register(new JsonObjectFromCatalogTransformer(jsonFactory, mapper));
+        registry.register(new JsonObjectFromCatalogTransformer(jsonFactory, mapper, participantIdMapper));
         registry.register(new JsonObjectFromDatasetTransformer(jsonFactory, mapper));
         registry.register(new JsonObjectFromDistributionTransformer(jsonFactory));
         registry.register(new JsonObjectFromDataServiceTransformer(jsonFactory));

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/main/java/org/eclipse/edc/protocol/dsp/catalog/transform/from/JsonObjectFromCatalogTransformer.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/main/java/org/eclipse/edc/protocol/dsp/catalog/transform/from/JsonObjectFromCatalogTransformer.java
@@ -19,6 +19,7 @@ import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.catalog.spi.Catalog;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.spi.agent.ParticipantIdMapper;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -37,11 +38,13 @@ import static org.eclipse.edc.protocol.dsp.type.DspCatalogPropertyAndTypeNames.D
 public class JsonObjectFromCatalogTransformer extends AbstractJsonLdTransformer<Catalog, JsonObject> {
     private final JsonBuilderFactory jsonFactory;
     private final ObjectMapper mapper;
+    private final ParticipantIdMapper participantIdMapper;
 
-    public JsonObjectFromCatalogTransformer(JsonBuilderFactory jsonFactory, ObjectMapper mapper) {
+    public JsonObjectFromCatalogTransformer(JsonBuilderFactory jsonFactory, ObjectMapper mapper, ParticipantIdMapper participantIdMapper) {
         super(Catalog.class, JsonObject.class);
         this.jsonFactory = jsonFactory;
         this.mapper = mapper;
+        this.participantIdMapper = participantIdMapper;
     }
 
     @Override
@@ -57,7 +60,7 @@ public class JsonObjectFromCatalogTransformer extends AbstractJsonLdTransformer<
         var objectBuilder = jsonFactory.createObjectBuilder()
                 .add(ID, catalog.getId())
                 .add(TYPE, DCAT_CATALOG_TYPE)
-                .add(DSPACE_PROPERTY_PARTICIPANT_ID, catalog.getParticipantId())
+                .add(DSPACE_PROPERTY_PARTICIPANT_ID, participantIdMapper.toIri(catalog.getParticipantId()))
                 .add(DCAT_DATASET_ATTRIBUTE, datasets)
                 .add(DCAT_DATA_SERVICE_ATTRIBUTE, dataServices);
     

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiTest.java
@@ -62,7 +62,7 @@ class ContractNegotiationApiTest {
         transformer.register(new JsonObjectToContractOfferDescriptionTransformer());
         transformer.register(new JsonObjectToCallbackAddressTransformer());
         transformer.register(new JsonObjectToTerminateNegotiationCommandTransformer());
-        OdrlTransformersFactory.jsonObjectToOdrlTransformers().forEach(transformer::register);
+        OdrlTransformersFactory.jsonObjectToOdrlTransformers(mock()).forEach(transformer::register);
     }
 
     @Test

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiTest.java
@@ -38,6 +38,7 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.EDC_CREATED_AT;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.junit.extensions.TestServiceExtensionContext.testServiceExtensionContext;
+import static org.mockito.Mockito.mock;
 
 class PolicyDefinitionApiTest {
 
@@ -48,7 +49,7 @@ class PolicyDefinitionApiTest {
     @BeforeEach
     void setUp() {
         transformer.register(new JsonObjectToPolicyDefinitionTransformer());
-        OdrlTransformersFactory.jsonObjectToOdrlTransformers().forEach(transformer::register);
+        OdrlTransformersFactory.jsonObjectToOdrlTransformers(mock()).forEach(transformer::register);
     }
 
     @Test

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/agent/ParticipantIdMapper.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/agent/ParticipantIdMapper.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.spi.agent;
+
+import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
+
+/**
+ * Map participant ID from/to the IRI representation
+ */
+@ExtensionPoint
+public interface ParticipantIdMapper {
+
+    /**
+     * Return IRI representation of the participant ID.
+     *
+     * @return IRI representation.
+     */
+    String toIri(String participantId);
+
+    /**
+     * Extract participant ID from the IRI representation.
+     *
+     * @return participant ID.
+     */
+    String fromIri(String iriParticipantId);
+
+}


### PR DESCRIPTION
## What this PR changes/adds

Permits to map the participantId in the DSP messages to/from IRI.
By default this service returns what gets in input, but it could be extended accordingly (e.g. to provide/parse a specific `urn`)

## Why it does that

dsp compliance

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #3930 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
