### PR TITLE
chore: fix scope in case of empty one from policy expression

### DIFF
--- a/data-protocols/dsp/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/dispatcher/DspHttpRemoteMessageDispatcherImpl.java
+++ b/data-protocols/dsp/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/dispatcher/DspHttpRemoteMessageDispatcherImpl.java
@@ -53,17 +53,15 @@ import static org.eclipse.edc.spi.response.ResponseStatus.FATAL_ERROR;
  */
 public class DspHttpRemoteMessageDispatcherImpl implements DspHttpRemoteMessageDispatcher {
 
+    private static final String AUDIENCE_CLAIM = "aud";
+    private static final String SCOPE_CLAIM = "scope";
     private final Map<Class<? extends RemoteMessage>, MessageHandler<?, ?>> handlers = new HashMap<>();
     private final Map<Class<? extends RemoteMessage>, PolicyScope<? extends RemoteMessage>> policyScopes = new HashMap<>();
     private final EdcHttpClient httpClient;
     private final IdentityService identityService;
     private final PolicyEngine policyEngine;
     private final TokenDecorator tokenDecorator;
-
     private final AudienceResolver audienceResolver;
-
-    private static final String AUDIENCE_CLAIM = "aud";
-    private static final String SCOPE_CLAIM = "scope";
 
 
     public DspHttpRemoteMessageDispatcherImpl(EdcHttpClient httpClient,
@@ -92,7 +90,7 @@ public class DspHttpRemoteMessageDispatcherImpl implements DspHttpRemoteMessageD
 
         var request = handler.requestFactory.createRequest(message);
 
-        var tokenParametersBuilder = tokenDecorator.decorate(TokenParameters.Builder.newInstance());
+        var tokenParametersBuilder = TokenParameters.Builder.newInstance();
 
         var policyScope = policyScopes.get(message.getClass());
         if (policyScope != null) {
@@ -103,9 +101,16 @@ public class DspHttpRemoteMessageDispatcherImpl implements DspHttpRemoteMessageD
             var policyProvider = (Function<M, Policy>) policyScope.policyProvider;
             policyEngine.evaluate(policyScope.scope, policyProvider.apply(message), context);
 
-            tokenParametersBuilder.claims(SCOPE_CLAIM, String.join(" ", requestScopeBuilder.build().getScopes()));
+            var scopes = requestScopeBuilder.build().getScopes();
+
+            // Only add the scope claim if there are scopes returned from the policy engine evaluation
+            if (!scopes.isEmpty()) {
+                tokenParametersBuilder.claims(SCOPE_CLAIM, String.join(" ", requestScopeBuilder.build().getScopes()));
+            }
 
         }
+
+        tokenParametersBuilder = tokenDecorator.decorate(tokenParametersBuilder);
 
         var tokenParameters = tokenParametersBuilder
                 .claims(AUDIENCE_CLAIM, audienceResolver.resolve(message)) // enforce the audience, ignore anything a decorator might have set
@@ -124,14 +129,14 @@ public class DspHttpRemoteMessageDispatcherImpl implements DspHttpRemoteMessageD
     }
 
     @Override
-    public <M extends RemoteMessage> void registerPolicyScope(Class<M> messageClass, String scope, Function<M, Policy> policyProvider) {
-        policyScopes.put(messageClass, new PolicyScope<>(messageClass, scope, policyProvider));
-    }
-
-    @Override
     public <M extends RemoteMessage, R> void registerMessage(Class<M> clazz, DspHttpRequestFactory<M> requestFactory,
                                                              DspHttpResponseBodyExtractor<R> bodyExtractor) {
         handlers.put(clazz, new MessageHandler<>(requestFactory, bodyExtractor));
+    }
+
+    @Override
+    public <M extends RemoteMessage> void registerPolicyScope(Class<M> messageClass, String scope, Function<M, Policy> policyProvider) {
+        policyScopes.put(messageClass, new PolicyScope<>(messageClass, scope, policyProvider));
     }
 
     @NotNull


### PR DESCRIPTION
## What this PR changes/adds

Fixes the calculation of the scope. Currently if there are no polic pre/post validators the `scopes` set from the evaluation process is always empty and that will be set as `scope` claim in the `TokenParameters` that leads the OAuth2 Identity service to send the `scope` parameter empty to the AuthService.

The fix applied check If the scopes set deriving from the policy evaluation is empty, then no `scope` claim is applied

If there is a custom `TokenDecorator`  that adds the `scope` claim, it will override the policy evaluation one if any.

## Why it does that

bug fix OAuth2 Identity Service

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #3923 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
