### PR TITLE
feat: DataFlowTerminateMessage and DataFlowSuspendMessage transformers

### DIFF
--- a/core/common/transform-core/src/main/java/org/eclipse/edc/core/transform/transformer/from/JsonObjectFromDataFlowSuspendMessageTransformer.java
+++ b/core/common/transform-core/src/main/java/org/eclipse/edc/core/transform/transformer/from/JsonObjectFromDataFlowSuspendMessageTransformer.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.core.transform.transformer.from;
+
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowSuspendMessage;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
+
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowSuspendMessage.DATA_FLOW_SUSPEND_MESSAGE_REASON;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowSuspendMessage.DATA_FLOW_SUSPEND_MESSAGE_TYPE;
+
+/**
+ * Converts from a {@link DataFlowSuspendMessage} to a {@link JsonObject} in JSON-LD expanded form .
+ */
+public class JsonObjectFromDataFlowSuspendMessageTransformer extends AbstractJsonLdTransformer<DataFlowSuspendMessage, JsonObject> {
+    private final JsonBuilderFactory jsonFactory;
+
+    public JsonObjectFromDataFlowSuspendMessageTransformer(JsonBuilderFactory jsonFactory) {
+        super(DataFlowSuspendMessage.class, JsonObject.class);
+        this.jsonFactory = jsonFactory;
+    }
+
+    @Override
+    public @Nullable JsonObject transform(@NotNull DataFlowSuspendMessage message, @NotNull TransformerContext context) {
+        var builder = jsonFactory.createObjectBuilder()
+                .add(TYPE, DATA_FLOW_SUSPEND_MESSAGE_TYPE);
+
+        Optional.ofNullable(message.getReason()).ifPresent(reason -> builder.add(DATA_FLOW_SUSPEND_MESSAGE_REASON, reason));
+
+        return builder.build();
+    }
+}

--- a/core/common/transform-core/src/main/java/org/eclipse/edc/core/transform/transformer/from/JsonObjectFromDataFlowTerminateMessageTransformer.java
+++ b/core/common/transform-core/src/main/java/org/eclipse/edc/core/transform/transformer/from/JsonObjectFromDataFlowTerminateMessageTransformer.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.core.transform.transformer.from;
+
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowTerminateMessage;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
+
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowTerminateMessage.DATA_FLOW_TERMINATE_MESSAGE_REASON;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowTerminateMessage.DATA_FLOW_TERMINATE_MESSAGE_TYPE;
+
+
+/**
+ * Converts from a {@link DataFlowTerminateMessage} to a {@link JsonObject} in JSON-LD expanded form .
+ */
+public class JsonObjectFromDataFlowTerminateMessageTransformer extends AbstractJsonLdTransformer<DataFlowTerminateMessage, JsonObject> {
+    private final JsonBuilderFactory jsonFactory;
+
+    public JsonObjectFromDataFlowTerminateMessageTransformer(JsonBuilderFactory jsonFactory) {
+        super(DataFlowTerminateMessage.class, JsonObject.class);
+        this.jsonFactory = jsonFactory;
+    }
+
+    @Override
+    public @Nullable JsonObject transform(@NotNull DataFlowTerminateMessage message, @NotNull TransformerContext context) {
+        var builder = jsonFactory.createObjectBuilder()
+                .add(TYPE, DATA_FLOW_TERMINATE_MESSAGE_TYPE);
+
+        Optional.ofNullable(message.getReason()).ifPresent(reason -> builder.add(DATA_FLOW_TERMINATE_MESSAGE_REASON, reason));
+
+        return builder.build();
+    }
+}

--- a/core/common/transform-core/src/main/java/org/eclipse/edc/core/transform/transformer/to/JsonObjectToDataFlowSuspendMessageTransformer.java
+++ b/core/common/transform-core/src/main/java/org/eclipse/edc/core/transform/transformer/to/JsonObjectToDataFlowSuspendMessageTransformer.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.core.transform.transformer.to;
+
+import jakarta.json.JsonObject;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowSuspendMessage;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowSuspendMessage.Builder;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowSuspendMessage.DATA_FLOW_SUSPEND_MESSAGE_REASON;
+
+/**
+ * Converts from a {@link JsonObject} in JSON-LD expanded form to a {@link DataFlowSuspendMessage}.
+ */
+public class JsonObjectToDataFlowSuspendMessageTransformer extends AbstractJsonLdTransformer<JsonObject, DataFlowSuspendMessage> {
+
+    public JsonObjectToDataFlowSuspendMessageTransformer() {
+        super(JsonObject.class, DataFlowSuspendMessage.class);
+    }
+
+    @Override
+    public @Nullable DataFlowSuspendMessage transform(@NotNull JsonObject object, @NotNull TransformerContext context) {
+        var builder = Builder.newInstance();
+        transformString(object.get(DATA_FLOW_SUSPEND_MESSAGE_REASON), builder::reason, context);
+        return builder.build();
+    }
+
+}

--- a/core/common/transform-core/src/main/java/org/eclipse/edc/core/transform/transformer/to/JsonObjectToDataFlowTerminateMessageTransformer.java
+++ b/core/common/transform-core/src/main/java/org/eclipse/edc/core/transform/transformer/to/JsonObjectToDataFlowTerminateMessageTransformer.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.core.transform.transformer.to;
+
+import jakarta.json.JsonObject;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowTerminateMessage;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowTerminateMessage.Builder;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowTerminateMessage.DATA_FLOW_TERMINATE_MESSAGE_REASON;
+
+/**
+ * Converts from a {@link JsonObject} in JSON-LD expanded form to a {@link DataFlowTerminateMessage}.
+ */
+public class JsonObjectToDataFlowTerminateMessageTransformer extends AbstractJsonLdTransformer<JsonObject, DataFlowTerminateMessage> {
+
+    public JsonObjectToDataFlowTerminateMessageTransformer() {
+        super(JsonObject.class, DataFlowTerminateMessage.class);
+    }
+
+    @Override
+    public @Nullable DataFlowTerminateMessage transform(@NotNull JsonObject object, @NotNull TransformerContext context) {
+        var builder = Builder.newInstance();
+        transformString(object.get(DATA_FLOW_TERMINATE_MESSAGE_REASON), builder::reason, context);
+        return builder.build();
+    }
+
+}

--- a/core/common/transform-core/src/test/java/org/eclipse/edc/core/transform/transformer/from/JsonObjectFromDataFlowSuspendMessageTransformerTest.java
+++ b/core/common/transform-core/src/test/java/org/eclipse/edc/core/transform/transformer/from/JsonObjectFromDataFlowSuspendMessageTransformerTest.java
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.core.transform.transformer.from;
+
+import jakarta.json.Json;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowSuspendMessage;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowSuspendMessage.DATA_FLOW_SUSPEND_MESSAGE_REASON;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowSuspendMessage.DATA_FLOW_SUSPEND_MESSAGE_TYPE;
+import static org.mockito.Mockito.mock;
+
+class JsonObjectFromDataFlowSuspendMessageTransformerTest {
+
+
+    private final TransformerContext context = mock(TransformerContext.class);
+    private JsonObjectFromDataFlowSuspendMessageTransformer transformer;
+
+    @BeforeEach
+    void setUp() {
+        transformer = new JsonObjectFromDataFlowSuspendMessageTransformer(Json.createBuilderFactory(Map.of()));
+    }
+
+    @Test
+    void transform() {
+
+        var message = DataFlowSuspendMessage.Builder.newInstance().reason("reason").build();
+
+        var jsonObject = transformer.transform(message, context);
+
+        assertThat(jsonObject).isNotNull();
+
+        assertThat(jsonObject.getJsonString(TYPE).getString()).isEqualTo(DATA_FLOW_SUSPEND_MESSAGE_TYPE);
+        assertThat(jsonObject.getJsonString(DATA_FLOW_SUSPEND_MESSAGE_REASON).getString()).isEqualTo("reason");
+
+    }
+
+    @Test
+    void transform_withoutReason() {
+
+        var message = DataFlowSuspendMessage.Builder.newInstance().build();
+
+        var jsonObject = transformer.transform(message, context);
+
+        assertThat(jsonObject).isNotNull();
+
+        assertThat(jsonObject.getJsonString(TYPE).getString()).isEqualTo(DATA_FLOW_SUSPEND_MESSAGE_TYPE);
+        assertThat(jsonObject.containsKey(DATA_FLOW_SUSPEND_MESSAGE_REASON)).isFalse();
+
+    }
+
+}

--- a/core/common/transform-core/src/test/java/org/eclipse/edc/core/transform/transformer/from/JsonObjectFromDataFlowTerminateMessageTransformerTest.java
+++ b/core/common/transform-core/src/test/java/org/eclipse/edc/core/transform/transformer/from/JsonObjectFromDataFlowTerminateMessageTransformerTest.java
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.core.transform.transformer.from;
+
+import jakarta.json.Json;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowTerminateMessage;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowTerminateMessage.DATA_FLOW_TERMINATE_MESSAGE_REASON;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowTerminateMessage.DATA_FLOW_TERMINATE_MESSAGE_TYPE;
+import static org.mockito.Mockito.mock;
+
+class JsonObjectFromDataFlowTerminateMessageTransformerTest {
+
+
+    private final TransformerContext context = mock(TransformerContext.class);
+    private JsonObjectFromDataFlowTerminateMessageTransformer transformer;
+
+    @BeforeEach
+    void setUp() {
+        transformer = new JsonObjectFromDataFlowTerminateMessageTransformer(Json.createBuilderFactory(Map.of()));
+    }
+
+    @Test
+    void transform() {
+
+        var message = DataFlowTerminateMessage.Builder.newInstance().reason("reason").build();
+
+        var jsonObject = transformer.transform(message, context);
+
+        assertThat(jsonObject).isNotNull();
+
+        assertThat(jsonObject.getJsonString(TYPE).getString()).isEqualTo(DATA_FLOW_TERMINATE_MESSAGE_TYPE);
+        assertThat(jsonObject.getJsonString(DATA_FLOW_TERMINATE_MESSAGE_REASON).getString()).isEqualTo("reason");
+
+    }
+
+    @Test
+    void transform_withoutReason() {
+
+        var message = DataFlowTerminateMessage.Builder.newInstance().build();
+
+        var jsonObject = transformer.transform(message, context);
+
+        assertThat(jsonObject).isNotNull();
+
+        assertThat(jsonObject.getJsonString(TYPE).getString()).isEqualTo(DATA_FLOW_TERMINATE_MESSAGE_TYPE);
+        assertThat(jsonObject.containsKey(DATA_FLOW_TERMINATE_MESSAGE_REASON)).isFalse();
+
+    }
+
+}

--- a/core/common/transform-core/src/test/java/org/eclipse/edc/core/transform/transformer/to/JsonObjectToDataFlowSuspendMessageTransformerTest.java
+++ b/core/common/transform-core/src/test/java/org/eclipse/edc/core/transform/transformer/to/JsonObjectToDataFlowSuspendMessageTransformerTest.java
@@ -1,0 +1,87 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.core.transform.transformer.to;
+
+import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObjectBuilder;
+import org.eclipse.edc.jsonld.TitaniumJsonLd;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowSuspendMessage;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.core.transform.transformer.TestInput.getExpanded;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
+import static org.eclipse.edc.spi.CoreConstants.EDC_PREFIX;
+import static org.mockito.Mockito.mock;
+
+class JsonObjectToDataFlowSuspendMessageTransformerTest {
+
+    private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
+    private final TransformerContext context = mock(TransformerContext.class);
+    private final TitaniumJsonLd jsonLd = new TitaniumJsonLd(mock(Monitor.class));
+    private JsonObjectToDataFlowSuspendMessageTransformer transformer;
+
+    @BeforeEach
+    void setUp() {
+        transformer = new JsonObjectToDataFlowSuspendMessageTransformer();
+    }
+
+    @Test
+    void transform() {
+
+        var jsonObj = jsonFactory.createObjectBuilder()
+                .add(CONTEXT, createContextBuilder().build())
+                .add(TYPE, DataFlowSuspendMessage.DATA_FLOW_SUSPEND_MESSAGE_TYPE)
+                .add("reason", "reason")
+                .build();
+
+        var message = transformer.transform(getExpanded(jsonObj), context);
+
+        assertThat(message).isNotNull();
+
+        assertThat(message.getReason()).isEqualTo("reason");
+    }
+
+    @Test
+    void transform_withoutReason() {
+
+        var jsonObj = jsonFactory.createObjectBuilder()
+                .add(CONTEXT, createContextBuilder().build())
+                .add(TYPE, DataFlowSuspendMessage.DATA_FLOW_SUSPEND_MESSAGE_TYPE)
+                .build();
+
+        var message = transformer.transform(getExpanded(jsonObj), context);
+
+        assertThat(message).isNotNull();
+
+        assertThat(message.getReason()).isNull();
+    }
+
+    private JsonObjectBuilder createContextBuilder() {
+        return jsonFactory.createObjectBuilder()
+                .add(VOCAB, EDC_NAMESPACE)
+                .add(EDC_PREFIX, EDC_NAMESPACE);
+    }
+
+}

--- a/core/common/transform-core/src/test/java/org/eclipse/edc/core/transform/transformer/to/JsonObjectToDataFlowTerminateMessageTransformerTest.java
+++ b/core/common/transform-core/src/test/java/org/eclipse/edc/core/transform/transformer/to/JsonObjectToDataFlowTerminateMessageTransformerTest.java
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.core.transform.transformer.to;
+
+import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObjectBuilder;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.core.transform.transformer.TestInput.getExpanded;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
+import static org.eclipse.edc.spi.CoreConstants.EDC_PREFIX;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowTerminateMessage.DATA_FLOW_TERMINATE_MESSAGE_TYPE;
+import static org.mockito.Mockito.mock;
+
+class JsonObjectToDataFlowTerminateMessageTransformerTest {
+
+    private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
+    private final TransformerContext context = mock(TransformerContext.class);
+
+    private JsonObjectToDataFlowTerminateMessageTransformer transformer;
+
+    @BeforeEach
+    void setUp() {
+        transformer = new JsonObjectToDataFlowTerminateMessageTransformer();
+    }
+
+    @Test
+    void transform() {
+
+        var jsonObj = jsonFactory.createObjectBuilder()
+                .add(CONTEXT, createContextBuilder().build())
+                .add(TYPE, DATA_FLOW_TERMINATE_MESSAGE_TYPE)
+                .add("reason", "reason")
+                .build();
+
+        var message = transformer.transform(getExpanded(jsonObj), context);
+
+        assertThat(message).isNotNull();
+
+        assertThat(message.getReason()).isEqualTo("reason");
+    }
+
+    @Test
+    void transform_withoutReason() {
+
+        var jsonObj = jsonFactory.createObjectBuilder()
+                .add(CONTEXT, createContextBuilder().build())
+                .add(TYPE, DATA_FLOW_TERMINATE_MESSAGE_TYPE)
+                .build();
+
+        var message = transformer.transform(getExpanded(jsonObj), context);
+
+        assertThat(message).isNotNull();
+
+        assertThat(message.getReason()).isNull();
+    }
+
+    private JsonObjectBuilder createContextBuilder() {
+        return jsonFactory.createObjectBuilder()
+                .add(VOCAB, EDC_NAMESPACE)
+                .add(EDC_PREFIX, EDC_NAMESPACE);
+    }
+}

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/transfer/DataFlowSuspendMessage.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/transfer/DataFlowSuspendMessage.java
@@ -14,15 +14,55 @@
 
 package org.eclipse.edc.spi.types.domain.transfer;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
 import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 
 /**
  * A message for suspending an in progress transfer in the data plane
  */
-public record DataFlowSuspendMessage(String reason) {
+public class DataFlowSuspendMessage {
 
     public static final String DATA_FLOW_SUSPEND_MESSAGE_SIMPLE_TYPE = "DataFlowSuspendMessage";
     public static final String DATA_FLOW_SUSPEND_MESSAGE_TYPE = EDC_NAMESPACE + DATA_FLOW_SUSPEND_MESSAGE_SIMPLE_TYPE;
     public static final String DATA_FLOW_SUSPEND_MESSAGE_REASON = EDC_NAMESPACE + "reason";
 
+    private String reason;
+
+    private DataFlowSuspendMessage() {
+
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder {
+        private final DataFlowSuspendMessage message;
+
+        private Builder() {
+            this(new DataFlowSuspendMessage());
+        }
+
+        private Builder(DataFlowSuspendMessage message) {
+            this.message = message;
+        }
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder reason(String reason) {
+            message.reason = reason;
+            return this;
+        }
+
+        public DataFlowSuspendMessage build() {
+            return message;
+        }
+
+    }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/transfer/DataFlowTerminateMessage.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/transfer/DataFlowTerminateMessage.java
@@ -14,15 +14,55 @@
 
 package org.eclipse.edc.spi.types.domain.transfer;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
 import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 
 /**
  * A message for terminating an in progress transfer in the data plane
  */
-public record DataFlowTerminateMessage(String reason) {
+public class DataFlowTerminateMessage {
 
     public static final String DATA_FLOW_TERMINATE_MESSAGE_SIMPLE_TYPE = "DataFlowTerminateMessage";
     public static final String DATA_FLOW_TERMINATE_MESSAGE_TYPE = EDC_NAMESPACE + DATA_FLOW_TERMINATE_MESSAGE_SIMPLE_TYPE;
     public static final String DATA_FLOW_TERMINATE_MESSAGE_REASON = EDC_NAMESPACE + "reason";
+    private String reason;
 
+    private DataFlowTerminateMessage() {
+
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder {
+        private final DataFlowTerminateMessage message;
+
+        private Builder() {
+            this(new DataFlowTerminateMessage());
+        }
+
+        private Builder(DataFlowTerminateMessage message) {
+            this.message = message;
+        }
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public DataFlowTerminateMessage.Builder reason(String reason) {
+            message.reason = reason;
+            return this;
+        }
+        
+        public DataFlowTerminateMessage build() {
+
+            return message;
+        }
+
+    }
 }


### PR DESCRIPTION

## What this PR changes/adds

add trasformers from/to for DataFlowTerminateMessage and DataFlowSuspendMessage

## Why it does that

dataplane signaling


## Linked Issue(s)

Part of #3934 
