### PR TITLE
docs: generate Swagger API documentation for DSP APIs

### DIFF
--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-api/build.gradle.kts
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-api/build.gradle.kts
@@ -14,6 +14,7 @@
 
 plugins {
     `java-library`
+    id("io.swagger.core.v3.swagger-gradle-plugin")
 }
 
 dependencies {
@@ -32,4 +33,10 @@ dependencies {
     testImplementation(project(":core:common:junit"))
     testImplementation(project(":data-protocols:dsp:dsp-catalog:dsp-catalog-transform"))
     testImplementation(libs.restAssured)
+}
+
+edcBuild {
+    swagger {
+        apiGroup.set("dsp-api")
+    }
 }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/build.gradle.kts
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-api/build.gradle.kts
@@ -14,6 +14,7 @@
 
 plugins {
     `java-library`
+    id("io.swagger.core.v3.swagger-gradle-plugin")
 }
 
 dependencies {
@@ -32,4 +33,10 @@ dependencies {
     testImplementation(project(":core:common:junit"))
     testImplementation(testFixtures(project(":extensions:common:http:jersey-core")))
     testImplementation(libs.restAssured)
+}
+
+edcBuild {
+    swagger {
+        apiGroup.set("dsp-api")
+    }
 }

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-api/build.gradle.kts
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-api/build.gradle.kts
@@ -14,6 +14,7 @@
 
 plugins {
     `java-library`
+    id("io.swagger.core.v3.swagger-gradle-plugin")
 }
 
 dependencies {
@@ -32,4 +33,10 @@ dependencies {
     testImplementation(testFixtures(project(":extensions:common:http:jersey-core")))
 
     testImplementation(libs.restAssured)
+}
+
+edcBuild {
+    swagger {
+        apiGroup.set("dsp-api")
+    }
 }

--- a/data-protocols/dsp/dsp-version/dsp-version-api/build.gradle.kts
+++ b/data-protocols/dsp/dsp-version/dsp-version-api/build.gradle.kts
@@ -14,6 +14,7 @@
 
 plugins {
     `java-library`
+    id("io.swagger.core.v3.swagger-gradle-plugin")
 }
 
 dependencies {
@@ -27,4 +28,10 @@ dependencies {
     testImplementation(project(":extensions:common:json-ld"))
     testImplementation(testFixtures(project(":extensions:common:http:jersey-core")))
     testImplementation(libs.restAssured)
+}
+
+edcBuild {
+    swagger {
+        apiGroup.set("dsp-api")
+    }
 }


### PR DESCRIPTION
## What this PR changes/adds

Generate Swagger documentation for DSP APIs.

## Why it does that

Documentation.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
