### PR TITLE
feat: introduce DPS-API JSON-LD transformer registry

### DIFF
--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/build.gradle.kts
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/build.gradle.kts
@@ -24,10 +24,10 @@ dependencies {
 
     implementation(project(":core:common:transform-core")) // for the transformer registry impl
     implementation(project(":core:common:jersey-providers"))
-    implementation(project(":extensions:data-plane:data-plane-signaling:data-plane-signaling-transform"))
     implementation(libs.jakarta.rsApi)
 
     testImplementation(project(":core:common:junit"))
+    testImplementation(project(":extensions:common:json-ld"))
 }
 edcBuild {
     swagger {

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/main/java/org/eclipse/edc/connector/api/signaling/transform/SignalingApiTransformerRegistry.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/main/java/org/eclipse/edc/connector/api/signaling/transform/SignalingApiTransformerRegistry.java
@@ -1,0 +1,23 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.signaling.transform;
+
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+
+/**
+ * Type transformer used in the data plane signaling api context
+ */
+public interface SignalingApiTransformerRegistry extends TypeTransformerRegistry {
+}

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/main/java/org/eclipse/edc/connector/api/signaling/transform/SignalingApiTransformerRegistryImpl.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/main/java/org/eclipse/edc/connector/api/signaling/transform/SignalingApiTransformerRegistryImpl.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.signaling.transform;
+
+import org.eclipse.edc.core.transform.TypeTransformerRegistryImpl;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.transform.spi.TypeTransformer;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.jetbrains.annotations.NotNull;
+
+public class SignalingApiTransformerRegistryImpl extends TypeTransformerRegistryImpl implements SignalingApiTransformerRegistry {
+    private final TypeTransformerRegistry fallback;
+
+    public SignalingApiTransformerRegistryImpl(TypeTransformerRegistry fallback) {
+        this.fallback = fallback;
+    }
+
+    @Override
+    public @NotNull <INPUT, OUTPUT> TypeTransformer<INPUT, OUTPUT> transformerFor(@NotNull INPUT input, @NotNull Class<OUTPUT> outputType) {
+        try {
+            return super.transformerFor(input, outputType);
+        } catch (EdcException exception) {
+            return fallback.transformerFor(input, outputType);
+        }
+    }
+}

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/main/java/org/eclipse/edc/connector/api/signaling/transform/from/JsonObjectFromDataFlowSuspendMessageTransformer.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/main/java/org/eclipse/edc/connector/api/signaling/transform/from/JsonObjectFromDataFlowSuspendMessageTransformer.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.core.transform.transformer.from;
+package org.eclipse.edc.connector.api.signaling.transform.from;
 
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/main/java/org/eclipse/edc/connector/api/signaling/transform/from/JsonObjectFromDataFlowTerminateMessageTransformer.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/main/java/org/eclipse/edc/connector/api/signaling/transform/from/JsonObjectFromDataFlowTerminateMessageTransformer.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.core.transform.transformer.from;
+package org.eclipse.edc.connector.api.signaling.transform.from;
 
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/main/java/org/eclipse/edc/connector/api/signaling/transform/to/JsonObjectToDataFlowSuspendMessageTransformer.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/main/java/org/eclipse/edc/connector/api/signaling/transform/to/JsonObjectToDataFlowSuspendMessageTransformer.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.core.transform.transformer.to;
+package org.eclipse.edc.connector.api.signaling.transform.to;
 
 import jakarta.json.JsonObject;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/main/java/org/eclipse/edc/connector/api/signaling/transform/to/JsonObjectToDataFlowTerminateMessageTransformer.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/main/java/org/eclipse/edc/connector/api/signaling/transform/to/JsonObjectToDataFlowTerminateMessageTransformer.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.core.transform.transformer.to;
+package org.eclipse.edc.connector.api.signaling.transform.to;
 
 import jakarta.json.JsonObject;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+#
+#
+
+org.eclipse.edc.connector.api.signaling.configuration.SignalingApiConfigurationExtension

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/test/java/org/eclipse/edc/connector/api/signaling/transform/SignalingApiTransformerRegistryImplTest.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/test/java/org/eclipse/edc/connector/api/signaling/transform/SignalingApiTransformerRegistryImplTest.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.signaling.transform;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.core.transform.TypeTransformerRegistryImpl;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.eclipse.edc.transform.spi.TypeTransformer;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+class SignalingApiTransformerRegistryImplTest {
+
+    @Test
+    void shouldUseRegisteredTransformer() {
+        var fallbackRegistry = spy(new TypeTransformerRegistryImpl());
+        TypeTransformer<String, JsonObject> fallbackTransformer = spy(new StringJsonObjectTypeTransformer());
+        fallbackRegistry.register(fallbackTransformer);
+        var transformerRegistry = new SignalingApiTransformerRegistryImpl(fallbackRegistry);
+        TypeTransformer<String, JsonObject> transformer = spy(new StringJsonObjectTypeTransformer());
+        transformerRegistry.register(transformer);
+
+        transformerRegistry.transform("{}", JsonObject.class);
+
+        verify(transformer).transform(eq("{}"), any());
+        verifyNoInteractions(fallbackTransformer);
+    }
+
+    @Test
+    void shouldUsePassedRegistryTransformer_whenNoTransformerFound() {
+        var fallbackRegistry = new TypeTransformerRegistryImpl();
+        TypeTransformer<String, JsonObject> fallbackTransformer = spy(new StringJsonObjectTypeTransformer());
+        fallbackRegistry.register(fallbackTransformer);
+        var transformerRegistry = new SignalingApiTransformerRegistryImpl(fallbackRegistry);
+
+        transformerRegistry.transform("{}", JsonObject.class);
+
+        verify(fallbackTransformer).transform(eq("{}"), any());
+    }
+
+    private static class StringJsonObjectTypeTransformer implements TypeTransformer<String, JsonObject> {
+        @Override
+        public Class<String> getInputType() {
+            return String.class;
+        }
+
+        @Override
+        public Class<JsonObject> getOutputType() {
+            return JsonObject.class;
+        }
+
+        @Override
+        public @Nullable JsonObject transform(@NotNull String s, @NotNull TransformerContext context) {
+            return Json.createObjectBuilder().build();
+        }
+    }
+}

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/test/java/org/eclipse/edc/connector/api/signaling/transform/TestFunctions.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/test/java/org/eclipse/edc/connector/api/signaling/transform/TestFunctions.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.signaling.transform;
+
+import com.apicatalog.jsonld.document.JsonDocument;
+import jakarta.json.JsonObject;
+
+import static com.apicatalog.jsonld.JsonLd.expand;
+
+public class TestFunctions {
+
+    /**
+     * Expands test input as Json-ld is required to be in this form
+     */
+    public static JsonObject getExpanded(JsonObject message) {
+        try {
+            return expand(JsonDocument.of(message)).get().asJsonArray().getJsonObject(0);
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/test/java/org/eclipse/edc/connector/api/signaling/transform/from/JsonObjectFromDataFlowSuspendMessageTransformerTest.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/test/java/org/eclipse/edc/connector/api/signaling/transform/from/JsonObjectFromDataFlowSuspendMessageTransformerTest.java
@@ -12,10 +12,10 @@
  *
  */
 
-package org.eclipse.edc.core.transform.transformer.from;
+package org.eclipse.edc.connector.api.signaling.transform.from;
 
 import jakarta.json.Json;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowTerminateMessage;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowSuspendMessage;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,46 +24,46 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.spi.types.domain.transfer.DataFlowTerminateMessage.DATA_FLOW_TERMINATE_MESSAGE_REASON;
-import static org.eclipse.edc.spi.types.domain.transfer.DataFlowTerminateMessage.DATA_FLOW_TERMINATE_MESSAGE_TYPE;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowSuspendMessage.DATA_FLOW_SUSPEND_MESSAGE_REASON;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowSuspendMessage.DATA_FLOW_SUSPEND_MESSAGE_TYPE;
 import static org.mockito.Mockito.mock;
 
-class JsonObjectFromDataFlowTerminateMessageTransformerTest {
+class JsonObjectFromDataFlowSuspendMessageTransformerTest {
 
 
     private final TransformerContext context = mock(TransformerContext.class);
-    private JsonObjectFromDataFlowTerminateMessageTransformer transformer;
+    private JsonObjectFromDataFlowSuspendMessageTransformer transformer;
 
     @BeforeEach
     void setUp() {
-        transformer = new JsonObjectFromDataFlowTerminateMessageTransformer(Json.createBuilderFactory(Map.of()));
+        transformer = new JsonObjectFromDataFlowSuspendMessageTransformer(Json.createBuilderFactory(Map.of()));
     }
 
     @Test
     void transform() {
 
-        var message = DataFlowTerminateMessage.Builder.newInstance().reason("reason").build();
+        var message = DataFlowSuspendMessage.Builder.newInstance().reason("reason").build();
 
         var jsonObject = transformer.transform(message, context);
 
         assertThat(jsonObject).isNotNull();
 
-        assertThat(jsonObject.getJsonString(TYPE).getString()).isEqualTo(DATA_FLOW_TERMINATE_MESSAGE_TYPE);
-        assertThat(jsonObject.getJsonString(DATA_FLOW_TERMINATE_MESSAGE_REASON).getString()).isEqualTo("reason");
+        assertThat(jsonObject.getJsonString(TYPE).getString()).isEqualTo(DATA_FLOW_SUSPEND_MESSAGE_TYPE);
+        assertThat(jsonObject.getJsonString(DATA_FLOW_SUSPEND_MESSAGE_REASON).getString()).isEqualTo("reason");
 
     }
 
     @Test
     void transform_withoutReason() {
 
-        var message = DataFlowTerminateMessage.Builder.newInstance().build();
+        var message = DataFlowSuspendMessage.Builder.newInstance().build();
 
         var jsonObject = transformer.transform(message, context);
 
         assertThat(jsonObject).isNotNull();
 
-        assertThat(jsonObject.getJsonString(TYPE).getString()).isEqualTo(DATA_FLOW_TERMINATE_MESSAGE_TYPE);
-        assertThat(jsonObject.containsKey(DATA_FLOW_TERMINATE_MESSAGE_REASON)).isFalse();
+        assertThat(jsonObject.getJsonString(TYPE).getString()).isEqualTo(DATA_FLOW_SUSPEND_MESSAGE_TYPE);
+        assertThat(jsonObject.containsKey(DATA_FLOW_SUSPEND_MESSAGE_REASON)).isFalse();
 
     }
 

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/test/java/org/eclipse/edc/connector/api/signaling/transform/from/JsonObjectFromDataFlowTerminateMessageTransformerTest.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/test/java/org/eclipse/edc/connector/api/signaling/transform/from/JsonObjectFromDataFlowTerminateMessageTransformerTest.java
@@ -12,10 +12,10 @@
  *
  */
 
-package org.eclipse.edc.core.transform.transformer.from;
+package org.eclipse.edc.connector.api.signaling.transform.from;
 
 import jakarta.json.Json;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowSuspendMessage;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowTerminateMessage;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,46 +24,46 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.spi.types.domain.transfer.DataFlowSuspendMessage.DATA_FLOW_SUSPEND_MESSAGE_REASON;
-import static org.eclipse.edc.spi.types.domain.transfer.DataFlowSuspendMessage.DATA_FLOW_SUSPEND_MESSAGE_TYPE;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowTerminateMessage.DATA_FLOW_TERMINATE_MESSAGE_REASON;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowTerminateMessage.DATA_FLOW_TERMINATE_MESSAGE_TYPE;
 import static org.mockito.Mockito.mock;
 
-class JsonObjectFromDataFlowSuspendMessageTransformerTest {
+class JsonObjectFromDataFlowTerminateMessageTransformerTest {
 
 
     private final TransformerContext context = mock(TransformerContext.class);
-    private JsonObjectFromDataFlowSuspendMessageTransformer transformer;
+    private JsonObjectFromDataFlowTerminateMessageTransformer transformer;
 
     @BeforeEach
     void setUp() {
-        transformer = new JsonObjectFromDataFlowSuspendMessageTransformer(Json.createBuilderFactory(Map.of()));
+        transformer = new JsonObjectFromDataFlowTerminateMessageTransformer(Json.createBuilderFactory(Map.of()));
     }
 
     @Test
     void transform() {
 
-        var message = DataFlowSuspendMessage.Builder.newInstance().reason("reason").build();
+        var message = DataFlowTerminateMessage.Builder.newInstance().reason("reason").build();
 
         var jsonObject = transformer.transform(message, context);
 
         assertThat(jsonObject).isNotNull();
 
-        assertThat(jsonObject.getJsonString(TYPE).getString()).isEqualTo(DATA_FLOW_SUSPEND_MESSAGE_TYPE);
-        assertThat(jsonObject.getJsonString(DATA_FLOW_SUSPEND_MESSAGE_REASON).getString()).isEqualTo("reason");
+        assertThat(jsonObject.getJsonString(TYPE).getString()).isEqualTo(DATA_FLOW_TERMINATE_MESSAGE_TYPE);
+        assertThat(jsonObject.getJsonString(DATA_FLOW_TERMINATE_MESSAGE_REASON).getString()).isEqualTo("reason");
 
     }
 
     @Test
     void transform_withoutReason() {
 
-        var message = DataFlowSuspendMessage.Builder.newInstance().build();
+        var message = DataFlowTerminateMessage.Builder.newInstance().build();
 
         var jsonObject = transformer.transform(message, context);
 
         assertThat(jsonObject).isNotNull();
 
-        assertThat(jsonObject.getJsonString(TYPE).getString()).isEqualTo(DATA_FLOW_SUSPEND_MESSAGE_TYPE);
-        assertThat(jsonObject.containsKey(DATA_FLOW_SUSPEND_MESSAGE_REASON)).isFalse();
+        assertThat(jsonObject.getJsonString(TYPE).getString()).isEqualTo(DATA_FLOW_TERMINATE_MESSAGE_TYPE);
+        assertThat(jsonObject.containsKey(DATA_FLOW_TERMINATE_MESSAGE_REASON)).isFalse();
 
     }
 

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/test/java/org/eclipse/edc/connector/api/signaling/transform/to/JsonObjectToDataFlowSuspendMessageTransformerTest.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/test/java/org/eclipse/edc/connector/api/signaling/transform/to/JsonObjectToDataFlowSuspendMessageTransformerTest.java
@@ -12,11 +12,14 @@
  *
  */
 
-package org.eclipse.edc.core.transform.transformer.to;
+package org.eclipse.edc.connector.api.signaling.transform.to;
 
 import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObjectBuilder;
+import org.eclipse.edc.jsonld.TitaniumJsonLd;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowSuspendMessage;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,25 +27,24 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.core.transform.transformer.TestInput.getExpanded;
+import static org.eclipse.edc.connector.api.signaling.transform.TestFunctions.getExpanded;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
 import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 import static org.eclipse.edc.spi.CoreConstants.EDC_PREFIX;
-import static org.eclipse.edc.spi.types.domain.transfer.DataFlowTerminateMessage.DATA_FLOW_TERMINATE_MESSAGE_TYPE;
 import static org.mockito.Mockito.mock;
 
-class JsonObjectToDataFlowTerminateMessageTransformerTest {
+class JsonObjectToDataFlowSuspendMessageTransformerTest {
 
     private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
     private final TransformerContext context = mock(TransformerContext.class);
-
-    private JsonObjectToDataFlowTerminateMessageTransformer transformer;
+    private final TitaniumJsonLd jsonLd = new TitaniumJsonLd(mock(Monitor.class));
+    private JsonObjectToDataFlowSuspendMessageTransformer transformer;
 
     @BeforeEach
     void setUp() {
-        transformer = new JsonObjectToDataFlowTerminateMessageTransformer();
+        transformer = new JsonObjectToDataFlowSuspendMessageTransformer();
     }
 
     @Test
@@ -50,7 +52,7 @@ class JsonObjectToDataFlowTerminateMessageTransformerTest {
 
         var jsonObj = jsonFactory.createObjectBuilder()
                 .add(CONTEXT, createContextBuilder().build())
-                .add(TYPE, DATA_FLOW_TERMINATE_MESSAGE_TYPE)
+                .add(TYPE, DataFlowSuspendMessage.DATA_FLOW_SUSPEND_MESSAGE_TYPE)
                 .add("reason", "reason")
                 .build();
 
@@ -66,7 +68,7 @@ class JsonObjectToDataFlowTerminateMessageTransformerTest {
 
         var jsonObj = jsonFactory.createObjectBuilder()
                 .add(CONTEXT, createContextBuilder().build())
-                .add(TYPE, DATA_FLOW_TERMINATE_MESSAGE_TYPE)
+                .add(TYPE, DataFlowSuspendMessage.DATA_FLOW_SUSPEND_MESSAGE_TYPE)
                 .build();
 
         var message = transformer.transform(getExpanded(jsonObj), context);
@@ -81,4 +83,5 @@ class JsonObjectToDataFlowTerminateMessageTransformerTest {
                 .add(VOCAB, EDC_NAMESPACE)
                 .add(EDC_PREFIX, EDC_NAMESPACE);
     }
+
 }

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/test/java/org/eclipse/edc/connector/api/signaling/transform/to/JsonObjectToDataFlowTerminateMessageTransformerTest.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/test/java/org/eclipse/edc/connector/api/signaling/transform/to/JsonObjectToDataFlowTerminateMessageTransformerTest.java
@@ -12,14 +12,11 @@
  *
  */
 
-package org.eclipse.edc.core.transform.transformer.to;
+package org.eclipse.edc.connector.api.signaling.transform.to;
 
 import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObjectBuilder;
-import org.eclipse.edc.jsonld.TitaniumJsonLd;
-import org.eclipse.edc.spi.monitor.Monitor;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowSuspendMessage;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,24 +24,25 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.core.transform.transformer.TestInput.getExpanded;
+import static org.eclipse.edc.connector.api.signaling.transform.TestFunctions.getExpanded;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
 import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 import static org.eclipse.edc.spi.CoreConstants.EDC_PREFIX;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowTerminateMessage.DATA_FLOW_TERMINATE_MESSAGE_TYPE;
 import static org.mockito.Mockito.mock;
 
-class JsonObjectToDataFlowSuspendMessageTransformerTest {
+class JsonObjectToDataFlowTerminateMessageTransformerTest {
 
     private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
     private final TransformerContext context = mock(TransformerContext.class);
-    private final TitaniumJsonLd jsonLd = new TitaniumJsonLd(mock(Monitor.class));
-    private JsonObjectToDataFlowSuspendMessageTransformer transformer;
+
+    private JsonObjectToDataFlowTerminateMessageTransformer transformer;
 
     @BeforeEach
     void setUp() {
-        transformer = new JsonObjectToDataFlowSuspendMessageTransformer();
+        transformer = new JsonObjectToDataFlowTerminateMessageTransformer();
     }
 
     @Test
@@ -52,7 +50,7 @@ class JsonObjectToDataFlowSuspendMessageTransformerTest {
 
         var jsonObj = jsonFactory.createObjectBuilder()
                 .add(CONTEXT, createContextBuilder().build())
-                .add(TYPE, DataFlowSuspendMessage.DATA_FLOW_SUSPEND_MESSAGE_TYPE)
+                .add(TYPE, DATA_FLOW_TERMINATE_MESSAGE_TYPE)
                 .add("reason", "reason")
                 .build();
 
@@ -68,7 +66,7 @@ class JsonObjectToDataFlowSuspendMessageTransformerTest {
 
         var jsonObj = jsonFactory.createObjectBuilder()
                 .add(CONTEXT, createContextBuilder().build())
-                .add(TYPE, DataFlowSuspendMessage.DATA_FLOW_SUSPEND_MESSAGE_TYPE)
+                .add(TYPE, DATA_FLOW_TERMINATE_MESSAGE_TYPE)
                 .build();
 
         var message = transformer.transform(getExpanded(jsonObj), context);
@@ -83,5 +81,4 @@ class JsonObjectToDataFlowSuspendMessageTransformerTest {
                 .add(VOCAB, EDC_NAMESPACE)
                 .add(EDC_PREFIX, EDC_NAMESPACE);
     }
-
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -172,6 +172,7 @@ include(":extensions:data-plane:data-plane-client")
 include(":extensions:data-plane:data-plane-control-api")
 include(":extensions:data-plane:data-plane-signaling:data-plane-signaling-api")
 include(":extensions:data-plane:data-plane-signaling:data-plane-signaling-api-configuration")
+include(":extensions:data-plane:data-plane-signaling:data-plane-signaling-transform")
 include(":extensions:data-plane:data-plane-public-api")
 
 include(":extensions:data-plane:data-plane-http")


### PR DESCRIPTION
## What this PR changes/adds

This PR introduces the `data-plane-signaling-transform` module, which contains JSON-LD transformers specific to the DP-Signaling API as well as
an explicitly typed `SignalingApiTransformerRegistry`.

## Why it does that

The Signaling API will employ different serialization formats than e.g. the DSP APIs or the management API. Thus, we need to contain
the transformers to that particular HTTP context.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
