### PR TITLE
build: add openapi ui publish workflow

### DIFF
--- a/.github/workflows/publish-openapi-ui.yml
+++ b/.github/workflows/publish-openapi-ui.yml
@@ -1,0 +1,11 @@
+name: publish openapi ui
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    uses: eclipse-edc/.github/.github/workflows/publish-openapi-ui.yml@main
+    secrets: inherit


### PR DESCRIPTION
## What this PR changes/adds

On every push on main branch will trigger the `.github` workflow to publish the static ui

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
