### PR TITLE
feat: add trasformers from/to for DataFlowResponseMessage

### DIFF
--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-api-configuration/src/main/java/org/eclipse/edc/connector/api/signaling/configuration/SignalingApiConfigurationExtension.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-api-configuration/src/main/java/org/eclipse/edc/connector/api/signaling/configuration/SignalingApiConfigurationExtension.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.connector.api.signaling.configuration;
 import jakarta.json.Json;
 import org.eclipse.edc.connector.api.signaling.transform.SignalingApiTransformerRegistry;
 import org.eclipse.edc.connector.api.signaling.transform.SignalingApiTransformerRegistryImpl;
+import org.eclipse.edc.connector.api.signaling.transform.from.JsonObjectFromDataFlowResponseMessageTransformer;
 import org.eclipse.edc.connector.api.signaling.transform.to.JsonObjectToDataAddressTransformer;
 import org.eclipse.edc.connector.api.signaling.transform.to.JsonObjectToDataFlowSuspendMessageTransformer;
 import org.eclipse.edc.connector.api.signaling.transform.to.JsonObjectToDataFlowTerminateMessageTransformer;
@@ -99,6 +100,7 @@ public class SignalingApiConfigurationExtension implements ServiceExtension {
         registry.register(new JsonObjectToDataFlowSuspendMessageTransformer());
         registry.register(new JsonObjectToDataFlowTerminateMessageTransformer());
         registry.register(new JsonObjectToDataAddressTransformer());
+        registry.register(new JsonObjectFromDataFlowResponseMessageTransformer(factory));
         return registry;
     }
 }

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/main/java/org/eclipse/edc/connector/api/signaling/transform/from/JsonObjectFromDataFlowResponseMessageTransformer.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/main/java/org/eclipse/edc/connector/api/signaling/transform/from/JsonObjectFromDataFlowResponseMessageTransformer.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.signaling.transform.from;
+
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowResponseMessage;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
+
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowResponseMessage.DATA_FLOW_RESPONSE_MESSAGE_DATA_ADDRESS;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowResponseMessage.DATA_FLOW_RESPONSE_MESSAGE_TYPE;
+
+/**
+ * Converts from a {@link DataFlowResponseMessage} to a {@link JsonObject} in JSON-LD expanded form .
+ */
+public class JsonObjectFromDataFlowResponseMessageTransformer extends AbstractJsonLdTransformer<DataFlowResponseMessage, JsonObject> {
+    private final JsonBuilderFactory jsonFactory;
+
+    public JsonObjectFromDataFlowResponseMessageTransformer(JsonBuilderFactory jsonFactory) {
+        super(DataFlowResponseMessage.class, JsonObject.class);
+        this.jsonFactory = jsonFactory;
+    }
+
+    @Override
+    public @Nullable JsonObject transform(@NotNull DataFlowResponseMessage message, @NotNull TransformerContext context) {
+        var builder = jsonFactory.createObjectBuilder()
+                .add(TYPE, DATA_FLOW_RESPONSE_MESSAGE_TYPE);
+
+        Optional.ofNullable(message.getDataAddress())
+                .ifPresent(dataAddress -> builder.add(DATA_FLOW_RESPONSE_MESSAGE_DATA_ADDRESS, context.transform(message.getDataAddress(), JsonObject.class)));
+        return builder.build();
+    }
+}

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/main/java/org/eclipse/edc/connector/api/signaling/transform/to/JsonObjectToDataFlowResponseMessageTransformer.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/main/java/org/eclipse/edc/connector/api/signaling/transform/to/JsonObjectToDataFlowResponseMessageTransformer.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.signaling.transform.to;
+
+import jakarta.json.JsonObject;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowResponseMessage;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
+
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowResponseMessage.DATA_FLOW_RESPONSE_MESSAGE_DATA_ADDRESS;
+
+/**
+ * Converts from a {@link JsonObject} in JSON-LD expanded form to a {@link DataFlowResponseMessage}.
+ */
+public class JsonObjectToDataFlowResponseMessageTransformer extends AbstractJsonLdTransformer<JsonObject, DataFlowResponseMessage> {
+
+    public JsonObjectToDataFlowResponseMessageTransformer() {
+        super(JsonObject.class, DataFlowResponseMessage.class);
+    }
+
+    @Override
+    public @Nullable DataFlowResponseMessage transform(@NotNull JsonObject object, @NotNull TransformerContext context) {
+        var builder = DataFlowResponseMessage.Builder.newInstance();
+
+        Optional.ofNullable(object.get(DATA_FLOW_RESPONSE_MESSAGE_DATA_ADDRESS))
+                .ifPresent(jsonValue -> builder.dataAddress(transformObject(jsonValue, DataAddress.class, context)));
+        
+        return builder.build();
+    }
+}

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/test/java/org/eclipse/edc/connector/api/signaling/transform/from/JsonObjectFromDataFlowResponseMessageTransformerTest.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/test/java/org/eclipse/edc/connector/api/signaling/transform/from/JsonObjectFromDataFlowResponseMessageTransformerTest.java
@@ -1,0 +1,76 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.signaling.transform.from;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowResponseMessage;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowResponseMessage.DATA_FLOW_RESPONSE_MESSAGE_DATA_ADDRESS;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowResponseMessage.DATA_FLOW_RESPONSE_MESSAGE_TYPE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class JsonObjectFromDataFlowResponseMessageTransformerTest {
+
+
+    private final TransformerContext context = mock(TransformerContext.class);
+    private JsonObjectFromDataFlowResponseMessageTransformer transformer;
+
+    @BeforeEach
+    void setUp() {
+        transformer = new JsonObjectFromDataFlowResponseMessageTransformer(Json.createBuilderFactory(Map.of()));
+        when(context.transform(any(DataAddress.class), eq(JsonObject.class))).thenReturn(Json.createObjectBuilder().build());
+    }
+
+    @Test
+    void transform() {
+
+        var message = DataFlowResponseMessage.Builder.newInstance().dataAddress(DataAddress.Builder.newInstance().type("type").build()).build();
+
+        var jsonObject = transformer.transform(message, context);
+
+        assertThat(jsonObject).isNotNull();
+
+        assertThat(jsonObject.getJsonString(TYPE).getString()).isEqualTo(DATA_FLOW_RESPONSE_MESSAGE_TYPE);
+        assertThat(jsonObject.get(DATA_FLOW_RESPONSE_MESSAGE_DATA_ADDRESS)).isNotNull();
+
+    }
+
+    @Test
+    void transform_withoutDataAddress() {
+
+        var message = DataFlowResponseMessage.Builder.newInstance().build();
+
+        var jsonObject = transformer.transform(message, context);
+
+        assertThat(jsonObject).isNotNull();
+
+        assertThat(jsonObject.getJsonString(TYPE).getString()).isEqualTo(DATA_FLOW_RESPONSE_MESSAGE_TYPE);
+        assertThat(jsonObject.containsKey(DATA_FLOW_RESPONSE_MESSAGE_DATA_ADDRESS)).isFalse();
+
+    }
+
+}

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/test/java/org/eclipse/edc/connector/api/signaling/transform/to/JsonObjectToDataFlowResponseMessageTransformerTest.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/test/java/org/eclipse/edc/connector/api/signaling/transform/to/JsonObjectToDataFlowResponseMessageTransformerTest.java
@@ -1,0 +1,90 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.signaling.transform.to;
+
+import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.connector.api.signaling.transform.TestFunctions.getExpanded;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
+import static org.eclipse.edc.spi.CoreConstants.EDC_PREFIX;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowResponseMessage.DATA_FLOW_RESPONSE_MESSAGE_SIMPLE_TYPE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class JsonObjectToDataFlowResponseMessageTransformerTest {
+
+    private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
+    private final TransformerContext context = mock(TransformerContext.class);
+    private JsonObjectToDataFlowResponseMessageTransformer transformer;
+
+    @BeforeEach
+    void setUp() {
+        transformer = new JsonObjectToDataFlowResponseMessageTransformer();
+        when(context.transform(any(JsonObject.class), eq(DataAddress.class))).thenReturn(DataAddress.Builder.newInstance().type("type").build());
+    }
+
+    @Test
+    void transform() {
+
+        var jsonObj = jsonFactory.createObjectBuilder()
+                .add(CONTEXT, createContextBuilder().build())
+                .add(TYPE, DATA_FLOW_RESPONSE_MESSAGE_SIMPLE_TYPE)
+                .add("dataAddress", jsonFactory.createObjectBuilder().build())
+                .build();
+
+        var message = transformer.transform(getExpanded(jsonObj), context);
+
+        assertThat(message).isNotNull();
+
+        assertThat(message.getDataAddress()).isNotNull();
+    }
+
+    @Test
+    void transform_withoutDataAddress() {
+
+        var jsonObj = jsonFactory.createObjectBuilder()
+                .add(CONTEXT, createContextBuilder().build())
+                .add(TYPE, DATA_FLOW_RESPONSE_MESSAGE_SIMPLE_TYPE)
+                .build();
+
+        var message = transformer.transform(getExpanded(jsonObj), context);
+
+        assertThat(message).isNotNull();
+
+        assertThat(message.getDataAddress()).isNull();
+    }
+
+    private JsonObjectBuilder createContextBuilder() {
+        return jsonFactory.createObjectBuilder()
+                .add(VOCAB, EDC_NAMESPACE)
+                .add(EDC_PREFIX, EDC_NAMESPACE);
+    }
+
+}


### PR DESCRIPTION
## What this PR changes/adds

 adds trasformers from/to for DataFlowResponseMessage

## Why it does that

data plane signaling protocol

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Part of #3934 


