### PR TITLE
feat: data plane client for signaling protocol

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -302,21 +302,17 @@ maven/mavencentral/org.jetbrains/annotations/24.1.0, Apache-2.0, approved, clear
 maven/mavencentral/org.junit-pioneer/junit-pioneer/2.2.0, EPL-2.0, approved, #11857
 maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.10.1, EPL-2.0, approved, #9714
 maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.10.2, EPL-2.0, approved, #9714
-maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.9.2, EPL-2.0, approved, #3133
 maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.10.1, EPL-2.0, approved, #9711
 maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.10.2, EPL-2.0, approved, #9711
-maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.9.2, EPL-2.0, approved, #3125
 maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.10.1, EPL-2.0, approved, #9708
 maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.10.2, EPL-2.0, approved, #9708
-maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.9.2, EPL-2.0, approved, #3134
 maven/mavencentral/org.junit.platform/junit-platform-commons/1.10.1, EPL-2.0, approved, #9715
 maven/mavencentral/org.junit.platform/junit-platform-commons/1.10.2, EPL-2.0, approved, #9715
-maven/mavencentral/org.junit.platform/junit-platform-commons/1.9.2, EPL-2.0, approved, #3130
 maven/mavencentral/org.junit.platform/junit-platform-engine/1.10.1, EPL-2.0, approved, #9709
 maven/mavencentral/org.junit.platform/junit-platform-engine/1.10.2, EPL-2.0, approved, #9709
-maven/mavencentral/org.junit.platform/junit-platform-engine/1.9.2, EPL-2.0, approved, #3128
+maven/mavencentral/org.junit.platform/junit-platform-launcher/1.10.1, EPL-2.0, approved, #9704
 maven/mavencentral/org.junit.platform/junit-platform-launcher/1.10.2, EPL-2.0, approved, #9704
-maven/mavencentral/org.junit.platform/junit-platform-launcher/1.9.2, EPL-2.0, approved, #3132
+maven/mavencentral/org.junit/junit-bom/5.10.1, EPL-2.0, approved, #9844
 maven/mavencentral/org.junit/junit-bom/5.10.2, EPL-2.0, approved, #9844
 maven/mavencentral/org.junit/junit-bom/5.9.2, EPL-2.0, approved, #4711
 maven/mavencentral/org.jvnet.mimepull/mimepull/1.9.15, CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, CQ21484

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -302,17 +302,21 @@ maven/mavencentral/org.jetbrains/annotations/24.1.0, Apache-2.0, approved, clear
 maven/mavencentral/org.junit-pioneer/junit-pioneer/2.2.0, EPL-2.0, approved, #11857
 maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.10.1, EPL-2.0, approved, #9714
 maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.10.2, EPL-2.0, approved, #9714
+maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.9.2, EPL-2.0, approved, #3133
 maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.10.1, EPL-2.0, approved, #9711
 maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.10.2, EPL-2.0, approved, #9711
+maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.9.2, EPL-2.0, approved, #3125
 maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.10.1, EPL-2.0, approved, #9708
 maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.10.2, EPL-2.0, approved, #9708
+maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.9.2, EPL-2.0, approved, #3134
 maven/mavencentral/org.junit.platform/junit-platform-commons/1.10.1, EPL-2.0, approved, #9715
 maven/mavencentral/org.junit.platform/junit-platform-commons/1.10.2, EPL-2.0, approved, #9715
+maven/mavencentral/org.junit.platform/junit-platform-commons/1.9.2, EPL-2.0, approved, #3130
 maven/mavencentral/org.junit.platform/junit-platform-engine/1.10.1, EPL-2.0, approved, #9709
 maven/mavencentral/org.junit.platform/junit-platform-engine/1.10.2, EPL-2.0, approved, #9709
-maven/mavencentral/org.junit.platform/junit-platform-launcher/1.10.1, EPL-2.0, approved, #9704
+maven/mavencentral/org.junit.platform/junit-platform-engine/1.9.2, EPL-2.0, approved, #3128
 maven/mavencentral/org.junit.platform/junit-platform-launcher/1.10.2, EPL-2.0, approved, #9704
-maven/mavencentral/org.junit/junit-bom/5.10.1, EPL-2.0, approved, #9844
+maven/mavencentral/org.junit.platform/junit-platform-launcher/1.9.2, EPL-2.0, approved, #3132
 maven/mavencentral/org.junit/junit-bom/5.10.2, EPL-2.0, approved, #9844
 maven/mavencentral/org.junit/junit-bom/5.9.2, EPL-2.0, approved, #4711
 maven/mavencentral/org.jvnet.mimepull/mimepull/1.9.15, CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, CQ21484

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/build.gradle.kts
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/build.gradle.kts
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(project(":spi:common:http-spi"))
+    api(project(":spi:common:core-spi"))
+    api(project(":spi:data-plane-selector:data-plane-selector-spi"))
+    implementation(project(":core:common:transform-core")) // for the transformer registry impl
+    implementation(project(":core:common:util"))
+    implementation(project(":extensions:data-plane:data-plane-signaling:data-plane-signaling-transform"))
+
+    implementation(libs.opentelemetry.instrumentation.annotations)
+
+    testImplementation(project(":core:common:junit"))
+    testImplementation(project(":extensions:common:json-ld"))
+    testImplementation(libs.restAssured)
+    testImplementation(libs.mockserver.netty)
+    testImplementation(libs.mockserver.client)
+}
+
+

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/main/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClient.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/main/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClient.java
@@ -1,0 +1,151 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.client;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
+import jakarta.json.JsonObject;
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.eclipse.edc.connector.dataplane.selector.spi.client.DataPlaneClient;
+import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
+import org.eclipse.edc.connector.dataplane.spi.manager.DataPlaneManager;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.spi.http.EdcHttpClient;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowResponseMessage;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowTerminateMessage;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static java.lang.String.format;
+import static org.eclipse.edc.spi.response.ResponseStatus.FATAL_ERROR;
+
+/**
+ * Implementation of a {@link DataPlaneClient} that uses a remote {@link DataPlaneManager} accessible from a REST API using
+ * the data plane signaling protocol.
+ */
+public class DataPlaneSignalingClient implements DataPlaneClient {
+    public static final MediaType TYPE_JSON = MediaType.parse("application/json");
+    private final EdcHttpClient httpClient;
+    private final DataPlaneInstance dataPlane;
+    private final TypeTransformerRegistry transformerRegistry;
+    private final JsonLd jsonLd;
+
+    private final ObjectMapper mapper;
+
+    public DataPlaneSignalingClient(EdcHttpClient httpClient, TypeTransformerRegistry transformerRegistry, JsonLd jsonLd, ObjectMapper mapper, DataPlaneInstance dataPlane) {
+        this.httpClient = httpClient;
+        this.transformerRegistry = transformerRegistry;
+        this.jsonLd = jsonLd;
+        this.mapper = mapper;
+        this.dataPlane = dataPlane;
+    }
+
+    @WithSpan
+    @Override
+    public StatusResult<DataFlowResponseMessage> start(DataFlowStartMessage message) {
+        var requestBuilder = transformerRegistry.transform(message, JsonObject.class)
+                .compose(jsonLd::compact)
+                .compose(this::serializeMessage)
+                .map(rawBody -> RequestBody.create(rawBody, TYPE_JSON))
+                .map(body -> new Request.Builder().post(body).url(dataPlane.getUrl()).build());
+
+        if (requestBuilder.succeeded()) {
+            return sendRequest(requestBuilder.getContent(), message.getProcessId(), this::handleStartResponse);
+        } else {
+            return StatusResult.failure(FATAL_ERROR, requestBuilder.getFailureDetail());
+        }
+    }
+
+    @Override
+    public StatusResult<Void> terminate(String transferProcessId) {
+        var url = "%s/%s/terminate".formatted(dataPlane.getUrl(), transferProcessId);
+        var message = DataFlowTerminateMessage.Builder.newInstance().build();
+        var requestBuilder = transformerRegistry.transform(message, JsonObject.class)
+                .compose(jsonLd::compact)
+                .compose(this::serializeMessage)
+                .map(rawBody -> RequestBody.create(rawBody, TYPE_JSON))
+                .map(body -> new Request.Builder().post(body).url(url).build());
+
+        if (requestBuilder.succeeded()) {
+            return sendRequest(requestBuilder.getContent(), transferProcessId, (r) -> StatusResult.success());
+        } else {
+            return StatusResult.failure(FATAL_ERROR, requestBuilder.getFailureDetail());
+        }
+    }
+
+    private StatusResult<DataFlowResponseMessage> handleStartResponse(Response response) {
+        try (var body = response.body()) {
+            return Optional.ofNullable(body)
+                    .map(this::deserializeStartMessage)
+                    .orElseGet(() -> StatusResult.failure(FATAL_ERROR, "Body missing"));
+        }
+    }
+
+    private StatusResult<DataFlowResponseMessage> deserializeStartMessage(ResponseBody body) {
+        try {
+            var jsonObject = mapper.readValue(body.string(), JsonObject.class);
+            var result = jsonLd.expand(jsonObject)
+                    .compose(expanded -> transformerRegistry.transform(expanded, DataFlowResponseMessage.class));
+            if (result.succeeded()) {
+                return StatusResult.success(result.getContent());
+            } else {
+                return StatusResult.failure(FATAL_ERROR, result.getFailureDetail());
+            }
+        } catch (IOException e) {
+            return StatusResult.failure(FATAL_ERROR, e.getMessage());
+
+        }
+    }
+
+    private Result<String> serializeMessage(Object message) {
+        try {
+            return Result.success(mapper.writeValueAsString(message));
+        } catch (JsonProcessingException e) {
+            return Result.failure(e.getMessage());
+        }
+    }
+
+    private <T> StatusResult<T> sendRequest(Request request, String transferProcessId, Function<Response, StatusResult<T>> bodyMapper) {
+        try (var response = httpClient.execute(request)) {
+            return handleResponse(response, transferProcessId, bodyMapper);
+        } catch (IOException e) {
+            return StatusResult.failure(FATAL_ERROR, e.getMessage());
+        }
+    }
+
+    private <T> StatusResult<T> handleResponse(Response response, String requestId, Function<Response, StatusResult<T>> bodyMapper) {
+        if (response.isSuccessful()) {
+            return bodyMapper.apply(response);
+        } else {
+            return handleError(response, requestId);
+        }
+    }
+
+    private <T> StatusResult<T> handleError(Response response, String requestId) {
+        return StatusResult.failure(FATAL_ERROR, format("Transfer request failed with status code %s for request %s", response.code(), requestId));
+    }
+
+}

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/main/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClientExtension.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/main/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClientExtension.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.client;
+
+import org.eclipse.edc.connector.api.signaling.transform.SignalingApiTransformerRegistry;
+import org.eclipse.edc.connector.dataplane.selector.spi.client.DataPlaneClient;
+import org.eclipse.edc.connector.dataplane.selector.spi.client.DataPlaneClientFactory;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.http.EdcHttpClient;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.types.TypeManager;
+
+import static org.eclipse.edc.spi.CoreConstants.JSON_LD;
+
+/**
+ * This extension provides an implementation of {@link DataPlaneClient} compliant with the data plane signaling protocol
+ */
+@Extension(value = DataPlaneSignalingClientExtension.NAME)
+public class DataPlaneSignalingClientExtension implements ServiceExtension {
+    public static final String NAME = "Data Plane Signaling Client";
+
+
+    @Inject
+    private EdcHttpClient httpClient;
+
+    @Inject
+    private TypeManager typeManager;
+
+    @Inject
+    private SignalingApiTransformerRegistry transformerRegistry;
+
+    private JsonLd jsonLd;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Provider
+    public DataPlaneClientFactory dataPlaneClientFactory() {
+        var mapper = typeManager.getMapper(JSON_LD);
+        return instance -> new DataPlaneSignalingClient(httpClient, transformerRegistry, jsonLd, mapper, instance);
+    }
+}
+
+

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/main/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClientTransformExtension.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/main/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClientTransformExtension.java
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.client;
+
+import jakarta.json.Json;
+import org.eclipse.edc.connector.api.signaling.transform.SignalingApiTransformerRegistry;
+import org.eclipse.edc.connector.api.signaling.transform.SignalingApiTransformerRegistryImpl;
+import org.eclipse.edc.connector.api.signaling.transform.from.JsonObjectFromDataFlowStartMessageTransformer;
+import org.eclipse.edc.connector.api.signaling.transform.from.JsonObjectFromDataFlowSuspendMessageTransformer;
+import org.eclipse.edc.connector.api.signaling.transform.from.JsonObjectFromDataFlowTerminateMessageTransformer;
+import org.eclipse.edc.connector.api.signaling.transform.to.JsonObjectToDataFlowResponseMessageTransformer;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+
+import java.util.Map;
+
+import static org.eclipse.edc.spi.CoreConstants.JSON_LD;
+
+/**
+ * This extension provides an implementation of {@link SignalingApiTransformerRegistry}
+ * with all transformers relevant for the data plane signaling protocol
+ */
+@Extension(value = DataPlaneSignalingClientTransformExtension.NAME)
+public class DataPlaneSignalingClientTransformExtension implements ServiceExtension {
+
+    public static final String NAME = "Data Plane Signaling transform Client";
+
+    @Inject
+    private TypeTransformerRegistry transformerRegistry;
+
+    @Inject
+    private TypeManager typeManager;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Provider
+    public SignalingApiTransformerRegistry signalingApiTransformerRegistry() {
+        var mapper = typeManager.getMapper(JSON_LD);
+        var factory = Json.createBuilderFactory(Map.of());
+
+        var registry = new SignalingApiTransformerRegistryImpl(this.transformerRegistry);
+        registry.register(new JsonObjectFromDataFlowStartMessageTransformer(factory, mapper));
+        registry.register(new JsonObjectFromDataFlowSuspendMessageTransformer(factory));
+        registry.register(new JsonObjectFromDataFlowTerminateMessageTransformer(factory));
+        registry.register(new JsonObjectToDataFlowResponseMessageTransformer());
+        return registry;
+    }
+}
+
+

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,16 @@
+#
+#  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+#
+#
+
+org.eclipse.edc.connector.dataplane.client.DataPlaneSignalingClientExtension
+org.eclipse.edc.connector.dataplane.client.DataPlaneSignalingClientTransformExtension

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/test/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClientExtensionTest.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/test/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClientExtensionTest.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.client;
+
+import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(DependencyInjectionExtension.class)
+class DataPlaneSignalingClientExtensionTest {
+
+    @Test
+    void verifyDataPlaneClientFactory(DataPlaneSignalingClientExtension extension) {
+
+        var client = extension.dataPlaneClientFactory().createClient(createDataPlaneInstance());
+
+        assertThat(client).isInstanceOf(DataPlaneSignalingClient.class);
+    }
+
+
+    private DataPlaneInstance createDataPlaneInstance() {
+        return DataPlaneInstance.Builder.newInstance().url("http://any").build();
+    }
+}

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/test/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClientTest.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/test/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClientTest.java
@@ -1,0 +1,316 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.client;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.api.signaling.transform.SignalingApiTransformerRegistryImpl;
+import org.eclipse.edc.connector.api.signaling.transform.from.JsonObjectFromDataFlowResponseMessageTransformer;
+import org.eclipse.edc.connector.api.signaling.transform.from.JsonObjectFromDataFlowStartMessageTransformer;
+import org.eclipse.edc.connector.api.signaling.transform.from.JsonObjectFromDataFlowSuspendMessageTransformer;
+import org.eclipse.edc.connector.api.signaling.transform.from.JsonObjectFromDataFlowTerminateMessageTransformer;
+import org.eclipse.edc.connector.api.signaling.transform.to.JsonObjectToDataFlowResponseMessageTransformer;
+import org.eclipse.edc.connector.dataplane.selector.spi.client.DataPlaneClient;
+import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
+import org.eclipse.edc.connector.dataplane.spi.response.TransferErrorResponse;
+import org.eclipse.edc.jsonld.TitaniumJsonLd;
+import org.eclipse.edc.junit.annotations.ComponentTest;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.response.ResponseStatus;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowResponseMessage;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
+import org.eclipse.edc.spi.types.domain.transfer.FlowType;
+import org.eclipse.edc.transform.spi.TypeTransformer;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.model.HttpRequest;
+import org.mockserver.model.HttpResponse;
+import org.mockserver.model.HttpStatusCode;
+import org.mockserver.model.MediaType;
+import org.mockserver.verify.VerificationTimes;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
+import static org.eclipse.edc.jsonld.util.JacksonJsonLd.createObjectMapper;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.junit.testfixtures.TestUtils.getFreePort;
+import static org.eclipse.edc.junit.testfixtures.TestUtils.testHttpClient;
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockserver.integration.ClientAndServer.startClientAndServer;
+import static org.mockserver.matchers.Times.once;
+import static org.mockserver.model.HttpResponse.response;
+import static org.mockserver.model.HttpStatusCode.CONFLICT_409;
+import static org.mockserver.model.HttpStatusCode.NO_CONTENT_204;
+import static org.mockserver.stop.Stop.stopQuietly;
+
+@ComponentTest
+class DataPlaneSignalingClientTest {
+
+    private static final ObjectMapper MAPPER = createObjectMapper();
+
+    private static final int DATA_PLANE_API_PORT = getFreePort();
+    private static final String DATA_PLANE_PATH = "/v1/dataflows";
+    private static final String DATA_PLANE_API_URI = "http://localhost:" + DATA_PLANE_API_PORT + DATA_PLANE_PATH;
+
+    private static final TypeTransformerRegistry underlyingRegistry = mock();
+    private static final TypeTransformerRegistry transformerRegistry = new SignalingApiTransformerRegistryImpl(underlyingRegistry);
+    private static final TypeTransformer<DataAddress, JsonObject> fromDataAddressTransformer = mock();
+    private static final TypeTransformer<JsonObject, DataAddress> toDataAddressTransformer = mock();
+    private static final TitaniumJsonLd jsonLd = new TitaniumJsonLd(mock(Monitor.class));
+    private static ClientAndServer dataPlane;
+    private final DataPlaneInstance instance = DataPlaneInstance.Builder.newInstance().url(DATA_PLANE_API_URI).build();
+    private final DataPlaneClient dataPlaneClient = new DataPlaneSignalingClient(testHttpClient(), transformerRegistry, jsonLd, MAPPER, instance);
+
+    @BeforeAll
+    public static void setUp() {
+        var factory = Json.createBuilderFactory(Map.of());
+
+        jsonLd.registerNamespace(VOCAB, EDC_NAMESPACE);
+        dataPlane = startClientAndServer(DATA_PLANE_API_PORT);
+        transformerRegistry.register(new JsonObjectFromDataFlowTerminateMessageTransformer(factory));
+        transformerRegistry.register(new JsonObjectFromDataFlowSuspendMessageTransformer(factory));
+        transformerRegistry.register(new JsonObjectFromDataFlowStartMessageTransformer(factory, MAPPER));
+        transformerRegistry.register(new JsonObjectFromDataFlowResponseMessageTransformer(factory));
+        transformerRegistry.register(new JsonObjectToDataFlowResponseMessageTransformer());
+
+        when(underlyingRegistry.transformerFor(any(DataAddress.class), eq(JsonObject.class))).thenReturn(fromDataAddressTransformer);
+        when(underlyingRegistry.transformerFor(any(JsonObject.class), eq(DataAddress.class))).thenReturn(toDataAddressTransformer);
+        when(fromDataAddressTransformer.transform(any(DataAddress.class), any())).thenReturn(Json.createObjectBuilder().build());
+        when(toDataAddressTransformer.transform(any(JsonObject.class), any())).thenReturn(DataAddress.Builder.newInstance().type("type").build());
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        stopQuietly(dataPlane);
+    }
+
+    private static HttpResponse withResponse(String errorMsg) throws JsonProcessingException {
+        return response().withStatusCode(HttpStatusCode.BAD_REQUEST_400.code())
+                .withBody(MAPPER.writeValueAsString(new TransferErrorResponse(List.of(errorMsg))), MediaType.APPLICATION_JSON);
+    }
+
+    private static DataFlowStartMessage createDataFlowRequest() {
+        return DataFlowStartMessage.Builder.newInstance()
+                .id("123")
+                .processId("456")
+                .flowType(FlowType.PULL)
+                .assetId("assetId")
+                .agreementId("agreementId")
+                .participantId("participantId")
+                .callbackAddress(URI.create("http://void"))
+                .sourceDataAddress(DataAddress.Builder.newInstance().type("test").build())
+                .destinationDataAddress(DataAddress.Builder.newInstance().type("test").build())
+                .build();
+    }
+
+    @AfterEach
+    public void resetMockServer() {
+        dataPlane.reset();
+    }
+
+    @Test
+    void start_verifyReturnFatalErrorIfReceiveResponseWithNullBody() throws JsonProcessingException {
+        var flowRequest = createDataFlowRequest();
+
+        var expected = transformerRegistry.transform(flowRequest, JsonObject.class)
+                .compose(jsonLd::compact)
+                .orElseThrow((e) -> new EdcException(e.getFailureDetail()));
+
+        var httpRequest = new HttpRequest().withPath(DATA_PLANE_PATH).withBody(MAPPER.writeValueAsString(expected));
+        dataPlane.when(httpRequest, once()).respond(response().withStatusCode(HttpStatusCode.BAD_REQUEST_400.code()));
+
+        var result = dataPlaneClient.start(flowRequest);
+
+        dataPlane.verify(httpRequest, VerificationTimes.once());
+
+        assertThat(result.failed()).isTrue();
+        assertThat(result.getFailure().status()).isEqualTo(ResponseStatus.FATAL_ERROR);
+        assertThat(result.getFailureMessages())
+                .anySatisfy(s -> assertThat(s)
+                        .isEqualTo("Transfer request failed with status code 400 for request %s", flowRequest.getProcessId())
+                );
+    }
+
+    @Test
+    void start_verifyReturnFatalErrorIfReceiveErrorInResponse() throws JsonProcessingException {
+        var flowRequest = createDataFlowRequest();
+
+        var expected = transformerRegistry.transform(flowRequest, JsonObject.class)
+                .compose(jsonLd::compact)
+                .orElseThrow((e) -> new EdcException(e.getFailureDetail()));
+
+        var httpRequest = new HttpRequest().withPath(DATA_PLANE_PATH).withBody(MAPPER.writeValueAsString(expected));
+        var errorMsg = UUID.randomUUID().toString();
+        dataPlane.when(httpRequest, once()).respond(withResponse(errorMsg));
+
+        var result = dataPlaneClient.start(flowRequest);
+
+        dataPlane.verify(httpRequest, VerificationTimes.once());
+
+        assertThat(result.failed()).isTrue();
+        assertThat(result.getFailure().status()).isEqualTo(ResponseStatus.FATAL_ERROR);
+        assertThat(result.getFailureMessages())
+                .anySatisfy(s -> assertThat(s)
+                        .isEqualTo(format("Transfer request failed with status code 400 for request %s", flowRequest.getProcessId()))
+                );
+    }
+
+    @Test
+    void start_verifyReturnFatalErrorIfTransformFails() {
+        var flowRequest = createDataFlowRequest();
+        TypeTransformerRegistry registry = mock();
+        var dataPlaneClient = new DataPlaneSignalingClient(testHttpClient(), registry, jsonLd, MAPPER, instance);
+
+        when(registry.transform(any(), any())).thenReturn(Result.failure("Transform Failure"));
+
+        var result = dataPlaneClient.start(flowRequest);
+
+        assertThat(result.failed()).isTrue();
+        assertThat(result.getFailure().status()).isEqualTo(ResponseStatus.FATAL_ERROR);
+        assertThat(result.getFailureMessages())
+                .anySatisfy(s -> assertThat(s)
+                        .isEqualTo("Transform Failure")
+                );
+    }
+
+    @Test
+    void start_verifyReturnFatalError_whenBadResponse() throws JsonProcessingException {
+        var flowRequest = createDataFlowRequest();
+        var expected = transformerRegistry.transform(flowRequest, JsonObject.class)
+                .compose(jsonLd::compact)
+                .orElseThrow((e) -> new EdcException(e.getFailureDetail()));
+
+
+        var httpRequest = new HttpRequest().withPath(DATA_PLANE_PATH).withBody(MAPPER.writeValueAsString(expected));
+        dataPlane.when(httpRequest, once()).respond(response().withBody("{}").withStatusCode(HttpStatusCode.OK_200.code()));
+
+        var result = dataPlaneClient.start(flowRequest);
+
+        dataPlane.verify(httpRequest, VerificationTimes.once());
+
+        assertThat(result.failed()).isTrue();
+        assertThat(result.getFailure().status()).isEqualTo(ResponseStatus.FATAL_ERROR);
+        assertThat(result.getFailureMessages())
+                .anySatisfy(s -> assertThat(s)
+                        .contains("Error expanding JSON-LD structure")
+                );
+    }
+
+    @Test
+    void start_verifyTransferSuccess() throws JsonProcessingException {
+        var flowRequest = createDataFlowRequest();
+        var expected = transformerRegistry.transform(flowRequest, JsonObject.class)
+                .compose(jsonLd::compact)
+                .orElseThrow((e) -> new EdcException(e.getFailureDetail()));
+
+        var flowResponse = DataFlowResponseMessage.Builder.newInstance().dataAddress(DataAddress.Builder.newInstance().type("type").build()).build();
+        var response = transformerRegistry.transform(flowResponse, JsonObject.class)
+                .compose(jsonLd::compact)
+                .orElseThrow((e) -> new EdcException(e.getFailureDetail()));
+
+
+        var httpRequest = new HttpRequest().withPath(DATA_PLANE_PATH).withBody(MAPPER.writeValueAsString(expected));
+        dataPlane.when(httpRequest, once()).respond(response().withBody(MAPPER.writeValueAsString(response)).withStatusCode(HttpStatusCode.OK_200.code()));
+
+        var result = dataPlaneClient.start(flowRequest);
+
+        dataPlane.verify(httpRequest, VerificationTimes.once());
+
+        assertThat(result.succeeded()).isTrue();
+
+        assertThat(result.getContent().getDataAddress()).isNotNull();
+    }
+
+    @Test
+    void start_verifyTransferSuccess_withoutDataAddress() throws JsonProcessingException {
+        var flowRequest = createDataFlowRequest();
+        var expected = transformerRegistry.transform(flowRequest, JsonObject.class)
+                .compose(jsonLd::compact)
+                .orElseThrow((e) -> new EdcException(e.getFailureDetail()));
+
+        var flowResponse = DataFlowResponseMessage.Builder.newInstance().build();
+        var response = transformerRegistry.transform(flowResponse, JsonObject.class)
+                .compose(jsonLd::compact)
+                .orElseThrow((e) -> new EdcException(e.getFailureDetail()));
+
+
+        var httpRequest = new HttpRequest().withPath(DATA_PLANE_PATH).withBody(MAPPER.writeValueAsString(expected));
+        dataPlane.when(httpRequest, once()).respond(response().withBody(MAPPER.writeValueAsString(response)).withStatusCode(HttpStatusCode.OK_200.code()));
+
+        var result = dataPlaneClient.start(flowRequest);
+
+        dataPlane.verify(httpRequest, VerificationTimes.once());
+
+        assertThat(result.succeeded()).isTrue();
+        assertThat(result.getContent().getDataAddress()).isNull();
+    }
+
+    @Test
+    void terminate_shouldCallTerminateOnAllTheAvailableDataPlanes() {
+        var httpRequest = new HttpRequest().withMethod("POST").withPath(DATA_PLANE_PATH + "/processId/terminate");
+        dataPlane.when(httpRequest, once()).respond(response().withStatusCode(NO_CONTENT_204.code()));
+
+        var result = dataPlaneClient.terminate("processId");
+
+        assertThat(result).isSucceeded();
+        dataPlane.verify(httpRequest, VerificationTimes.once());
+    }
+
+    @Test
+    void terminate_shouldFail_whenConflictResponse() {
+        var httpRequest = new HttpRequest().withMethod("POST").withPath(DATA_PLANE_PATH + "/processId/terminate");
+        dataPlane.when(httpRequest, once()).respond(response().withStatusCode(CONFLICT_409.code()));
+
+        var result = dataPlaneClient.terminate("processId");
+
+        assertThat(result).isFailed();
+    }
+
+    @Test
+    void terminate_verifyReturnFatalErrorIfTransformFails() {
+        TypeTransformerRegistry registry = mock();
+        var dataPlaneClient = new DataPlaneSignalingClient(testHttpClient(), registry, jsonLd, MAPPER, instance);
+
+        when(registry.transform(any(), any())).thenReturn(Result.failure("Transform Failure"));
+
+        var result = dataPlaneClient.terminate("processId");
+
+        assertThat(result.failed()).isTrue();
+        assertThat(result.getFailure().status()).isEqualTo(ResponseStatus.FATAL_ERROR);
+        assertThat(result.getFailureMessages())
+                .anySatisfy(s -> assertThat(s)
+                        .isEqualTo("Transform Failure")
+                );
+    }
+}

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/test/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClientTransformExtensionTest.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/test/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClientTransformExtensionTest.java
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.client;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.api.signaling.transform.from.JsonObjectFromDataFlowStartMessageTransformer;
+import org.eclipse.edc.connector.api.signaling.transform.from.JsonObjectFromDataFlowSuspendMessageTransformer;
+import org.eclipse.edc.connector.api.signaling.transform.from.JsonObjectFromDataFlowTerminateMessageTransformer;
+import org.eclipse.edc.connector.api.signaling.transform.to.JsonObjectToDataFlowResponseMessageTransformer;
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowResponseMessage;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowSuspendMessage;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowTerminateMessage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(DependencyInjectionExtension.class)
+class DataPlaneSignalingClientTransformExtensionTest {
+
+    @Test
+    void verifyTransformerRegistry(DataPlaneSignalingClientTransformExtension extension) {
+
+        var registry = extension.signalingApiTransformerRegistry();
+
+        assertThat(registry.transformerFor(DataFlowSuspendMessage.Builder.newInstance().build(), JsonObject.class))
+                .isInstanceOf(JsonObjectFromDataFlowSuspendMessageTransformer.class);
+
+        assertThat(registry.transformerFor(DataFlowTerminateMessage.Builder.newInstance().build(), JsonObject.class))
+                .isInstanceOf(JsonObjectFromDataFlowTerminateMessageTransformer.class);
+
+        assertThat(registry.transformerFor(startMessage(), JsonObject.class))
+                .isInstanceOf(JsonObjectFromDataFlowStartMessageTransformer.class);
+
+        assertThat(registry.transformerFor(Json.createObjectBuilder().build(), DataFlowResponseMessage.class))
+                .isInstanceOf(JsonObjectToDataFlowResponseMessageTransformer.class);
+    }
+
+    private DataFlowStartMessage startMessage() {
+        var dataAddress = DataAddress.Builder.newInstance().type("type").build();
+        return DataFlowStartMessage.Builder.newInstance()
+                .processId("processId")
+                .sourceDataAddress(dataAddress)
+                .destinationDataAddress(dataAddress)
+                .build();
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -172,6 +172,7 @@ include(":extensions:data-plane:data-plane-client")
 include(":extensions:data-plane:data-plane-control-api")
 include(":extensions:data-plane:data-plane-signaling:data-plane-signaling-api")
 include(":extensions:data-plane:data-plane-signaling:data-plane-signaling-api-configuration")
+include(":extensions:data-plane:data-plane-signaling:data-plane-signaling-client")
 include(":extensions:data-plane:data-plane-signaling:data-plane-signaling-transform")
 include(":extensions:data-plane:data-plane-public-api")
 


### PR DESCRIPTION
## What this PR changes/adds

Introduces a new module `data-plane-signaling-client` that implements a `DataPlaneClient` for the data plane signaling protocol.

## Why it does that

data plane signaling adoption

## Linked Issue(s)

Closes #3900 


