### PR TITLE
chore: deprecate provider_id field in ContractRequest

### DIFF
--- a/core/common/validator-core/src/main/java/org/eclipse/edc/validator/jsonobject/JsonObjectValidator.java
+++ b/core/common/validator-core/src/main/java/org/eclipse/edc/validator/jsonobject/JsonObjectValidator.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       T-Systems International GmbH - extended method implementation
  *
  */
 
@@ -16,6 +17,7 @@ package org.eclipse.edc.validator.jsonobject;
 
 import jakarta.json.JsonObject;
 import jakarta.json.JsonString;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.validator.spi.ValidationResult;
 import org.eclipse.edc.validator.spi.Validator;
 import org.eclipse.edc.validator.spi.Violation;
@@ -102,6 +104,36 @@ public class JsonObjectValidator implements Validator<JsonObject> {
         public Builder verify(String fieldName, Function<JsonLdPath, Validator<JsonObject>> provider) {
             var newPath = validator.path.append(fieldName);
             validator.validators.add(provider.apply(newPath));
+            return this;
+        }
+
+        @FunctionalInterface
+        public interface DeprecatedValidatorFunction<JsonLdPath, Validator> {
+            /**
+             * Add a validator on a deprecated field.
+             *
+             * @param jsonLdPath the root object level.
+             * @param deprecatedType the type of the field that is deprecated.
+             * @param attributeToUse the name of the attribute to be used instead of the field.
+             * @param monitor logger.
+             * @return the Validator.
+             */
+            Validator apply(JsonLdPath jsonLdPath, String deprecatedType, String attributeToUse, Monitor monitor);
+        }
+
+        /**
+         * Add a validator on a deprecated field.
+         *
+         * @param fieldName the name of the field to be validated.
+         * @param deprecatedType the type of the field that is deprecated.
+         * @param attributeToUse the name of the attribute to be used instead of the field.
+         * @param monitor logger.
+         * @param provider the validator provider.
+         * @return the builder.
+         */
+        public Builder verify(String fieldName, String deprecatedType, String attributeToUse, Monitor monitor, DeprecatedValidatorFunction<JsonLdPath, Validator<JsonObject>> provider) {
+            var newPath = validator.path.append(fieldName);
+            validator.validators.add(provider.apply(newPath, deprecatedType, attributeToUse, monitor));
             return this;
         }
 

--- a/core/common/validator-core/src/main/java/org/eclipse/edc/validator/jsonobject/JsonObjectValidator.java
+++ b/core/common/validator-core/src/main/java/org/eclipse/edc/validator/jsonobject/JsonObjectValidator.java
@@ -9,7 +9,6 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
- *       T-Systems International GmbH - extended method implementation
  *
  */
 
@@ -17,7 +16,6 @@ package org.eclipse.edc.validator.jsonobject;
 
 import jakarta.json.JsonObject;
 import jakarta.json.JsonString;
-import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.validator.spi.ValidationResult;
 import org.eclipse.edc.validator.spi.Validator;
 import org.eclipse.edc.validator.spi.Violation;
@@ -104,36 +102,6 @@ public class JsonObjectValidator implements Validator<JsonObject> {
         public Builder verify(String fieldName, Function<JsonLdPath, Validator<JsonObject>> provider) {
             var newPath = validator.path.append(fieldName);
             validator.validators.add(provider.apply(newPath));
-            return this;
-        }
-
-        @FunctionalInterface
-        public interface DeprecatedValidatorFunction<JsonLdPath, Validator> {
-            /**
-             * Add a validator on a deprecated field.
-             *
-             * @param jsonLdPath the root object level.
-             * @param deprecatedType the type of the field that is deprecated.
-             * @param attributeToUse the name of the attribute to be used instead of the field.
-             * @param monitor logger.
-             * @return the Validator.
-             */
-            Validator apply(JsonLdPath jsonLdPath, String deprecatedType, String attributeToUse, Monitor monitor);
-        }
-
-        /**
-         * Add a validator on a deprecated field.
-         *
-         * @param fieldName the name of the field to be validated.
-         * @param deprecatedType the type of the field that is deprecated.
-         * @param attributeToUse the name of the attribute to be used instead of the field.
-         * @param monitor logger.
-         * @param provider the validator provider.
-         * @return the builder.
-         */
-        public Builder verify(String fieldName, String deprecatedType, String attributeToUse, Monitor monitor, DeprecatedValidatorFunction<JsonLdPath, Validator<JsonObject>> provider) {
-            var newPath = validator.path.append(fieldName);
-            validator.validators.add(provider.apply(newPath, deprecatedType, attributeToUse, monitor));
             return this;
         }
 

--- a/core/common/validator-core/src/main/java/org/eclipse/edc/validator/jsonobject/validators/LogDeprecatedValue.java
+++ b/core/common/validator-core/src/main/java/org/eclipse/edc/validator/jsonobject/validators/LogDeprecatedValue.java
@@ -25,23 +25,20 @@ import java.util.Optional;
 import static java.lang.String.format;
 
 /**
- * Verify that a @value is present but deprecated.
+ * Verifies if a deprecated value is present and, if so, logs a warning message.
  */
 public class LogDeprecatedValue implements Validator<JsonObject> {
     public final String deprecatedLog;
     private final JsonLdPath path;
     private final Monitor monitor;
 
-    public LogDeprecatedValue(JsonLdPath path, String deprecatedLog, Monitor monitor) {
+    public LogDeprecatedValue(JsonLdPath path, String deprecatedType, String attributeToUse, Monitor monitor) {
         this.path = path;
         this.monitor = monitor;
-        this.deprecatedLog = deprecatedLog;
+        this.deprecatedLog = format("The attribute %s has been deprecated in type %s, please use %s",
+                path.last(), deprecatedType, attributeToUse);
     }
 
-    public LogDeprecatedValue(JsonLdPath path, String deprecatedType, String attributeToUse, Monitor monitor) {
-        this(path, format("The attribute %s has been deprecated in type %s, please use %s",
-                path.last(), deprecatedType, attributeToUse), monitor);
-    }
     @Override
     public ValidationResult validate(JsonObject input) {
         return Optional.ofNullable(input.getJsonArray(path.last()))

--- a/core/common/validator-core/src/main/java/org/eclipse/edc/validator/jsonobject/validators/LogDeprecatedValue.java
+++ b/core/common/validator-core/src/main/java/org/eclipse/edc/validator/jsonobject/validators/LogDeprecatedValue.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2024 T-Systems International GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       T-Systems International GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.validator.jsonobject.validators;
+
+import jakarta.json.JsonObject;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.validator.jsonobject.JsonLdPath;
+import org.eclipse.edc.validator.spi.ValidationResult;
+import org.eclipse.edc.validator.spi.Validator;
+
+import java.util.Optional;
+
+import static java.lang.String.format;
+
+/**
+ * Verify that a @value is present but deprecated.
+ */
+public class LogDeprecatedValue implements Validator<JsonObject> {
+    public final String deprecatedLog;
+    private final JsonLdPath path;
+    private final Monitor monitor;
+
+    public LogDeprecatedValue(JsonLdPath path, String deprecatedLog, Monitor monitor) {
+        this.path = path;
+        this.monitor = monitor;
+        this.deprecatedLog = deprecatedLog;
+    }
+
+    public LogDeprecatedValue(JsonLdPath path, String deprecatedType, String attributeToUse, Monitor monitor) {
+        this(path, format("The attribute %s has been deprecated in type %s, please use %s",
+                path.last(), deprecatedType, attributeToUse), monitor);
+    }
+    @Override
+    public ValidationResult validate(JsonObject input) {
+        return Optional.ofNullable(input.getJsonArray(path.last()))
+                .filter(it -> !it.isEmpty())
+                .map(it -> {
+                    monitor.warning(deprecatedLog);
+                    return ValidationResult.success();
+                }).orElseGet(ValidationResult::success);
+    }
+}

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
@@ -122,7 +122,6 @@ class ConsumerContractNegotiationManagerImplTest {
         var contractOffer = contractOffer();
 
         var request = ContractRequest.Builder.newInstance()
-                .providerId("providerId")
                 .counterPartyAddress("callbackAddress")
                 .protocol("protocol")
                 .contractOffer(contractOffer)
@@ -323,7 +322,7 @@ class ConsumerContractNegotiationManagerImplTest {
 
     private ContractOffer contractOffer() {
         return ContractOffer.Builder.newInstance().id("id:assetId:random")
-                .policy(Policy.Builder.newInstance().build())
+                .policy(Policy.Builder.newInstance().assigner("providerId").build())
                 .assetId("assetId")
                 .build();
     }

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -186,7 +186,6 @@ class ContractNegotiationIntegrationTest {
 
         // Create an initial request and trigger consumer manager
         var request = ContractRequest.Builder.newInstance()
-                .providerId(PROVIDER_ID)
                 .counterPartyAddress("callbackAddress")
                 .contractOffer(offer)
                 .protocol("protocol")
@@ -237,7 +236,6 @@ class ContractNegotiationIntegrationTest {
 
         // Create an initial request and trigger consumer manager
         var request = ContractRequest.Builder.newInstance()
-                .providerId("connectorId")
                 .counterPartyAddress("callbackAddress")
                 .contractOffer(offer)
                 .protocol("protocol")
@@ -270,7 +268,6 @@ class ContractNegotiationIntegrationTest {
 
         // Create an initial request and trigger consumer manager
         var request = ContractRequest.Builder.newInstance()
-                .providerId("connectorId")
                 .counterPartyAddress("callbackAddress")
                 .contractOffer(offer)
                 .protocol("protocol")

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/contractnegotiation/ContractNegotiationServiceImplTest.java
@@ -190,7 +190,6 @@ class ContractNegotiationServiceImplTest {
         when(consumerManager.initiate(isA(ContractRequest.class))).thenReturn(StatusResult.success(contractNegotiation));
 
         var request = ContractRequest.Builder.newInstance()
-                .providerId("providerId")
                 .counterPartyAddress("address")
                 .protocol("protocol")
                 .contractOffer(createContractOffer())

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApi.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApi.java
@@ -132,8 +132,6 @@ public interface ContractNegotiationApi {
             String connectorAddress,
             @Schema(requiredMode = REQUIRED)
             String counterPartyAddress,
-            @Schema(requiredMode = REQUIRED)
-            String providerId,
             @Deprecated(since = "0.3.2")
             @Schema(deprecated = true, description = "please use policy instead of offer")
             ContractOfferDescriptionSchema offer,
@@ -147,7 +145,6 @@ public interface ContractNegotiationApi {
                     "@type": "https://w3id.org/edc/v0.0.1/ns/ContractRequest",
                     "counterPartyAddress": "http://provider-address",
                     "protocol": "dataspace-protocol-http",
-                    "providerId": "provider-id",
                     "policy": {
                         "@context": "http://www.w3.org/ns/odrl.jsonld",
                         "@type": "odrl:Offer",

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApi.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApi.java
@@ -132,6 +132,9 @@ public interface ContractNegotiationApi {
             String connectorAddress,
             @Schema(requiredMode = REQUIRED)
             String counterPartyAddress,
+            @Deprecated(since = "0.5.1")
+            @Schema(deprecated = true, description = "please use policy.assigner instead")
+            String providerId,
             @Deprecated(since = "0.3.2")
             @Schema(deprecated = true, description = "please use policy instead of offer")
             ContractOfferDescriptionSchema offer,

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectToContractRequestTransformer.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectToContractRequestTransformer.java
@@ -30,7 +30,6 @@ import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractR
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.OFFER;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.POLICY;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.PROTOCOL;
-import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.PROVIDER_ID;
 
 public class JsonObjectToContractRequestTransformer extends AbstractJsonLdTransformer<JsonObject, ContractRequest> {
 
@@ -41,7 +40,6 @@ public class JsonObjectToContractRequestTransformer extends AbstractJsonLdTransf
     @Override
     public @Nullable ContractRequest transform(@NotNull JsonObject jsonObject, @NotNull TransformerContext context) {
         var contractRequestBuilder = ContractRequest.Builder.newInstance()
-                .providerId(getProviderId(jsonObject, context))
                 .counterPartyAddress(counterPartyAddressOrConnectorAddress(jsonObject, context))
                 .protocol(transformString(jsonObject.get(PROTOCOL), context));
 
@@ -72,16 +70,6 @@ public class JsonObjectToContractRequestTransformer extends AbstractJsonLdTransf
         }
 
         return null;
-    }
-
-    private String getProviderId(@NotNull JsonObject jsonObject, @NotNull TransformerContext context) {
-        var providerId = jsonObject.get(PROVIDER_ID);
-        if (providerId != null) {
-            return transformString(providerId, context);
-        }
-
-        return counterPartyAddressOrConnectorAddress(jsonObject, context);
-
     }
 
     /**

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/validation/ContractRequestValidator.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/validation/ContractRequestValidator.java
@@ -43,9 +43,9 @@ import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIB
 public class ContractRequestValidator {
     public static Validator<JsonObject> instance(Monitor monitor) {
         return JsonObjectValidator.newValidator()
-                .verify(PROVIDER_ID, CONTRACT_REQUEST_TYPE, ODRL_ASSIGNER_ATTRIBUTE, monitor, LogDeprecatedValue::new)
-                .verify(OFFER, CONTRACT_REQUEST_TYPE, POLICY, monitor, LogDeprecatedValue::new)
-                .verify(CONNECTOR_ADDRESS, CONTRACT_REQUEST_TYPE, CONTRACT_REQUEST_COUNTER_PARTY_ADDRESS, monitor, LogDeprecatedValue::new)
+                .verify(path -> new LogDeprecatedValue(path.append(PROVIDER_ID), CONTRACT_REQUEST_TYPE, ODRL_ASSIGNER_ATTRIBUTE, monitor))
+                .verify(path -> new LogDeprecatedValue(path.append(OFFER), CONTRACT_REQUEST_TYPE, POLICY, monitor))
+                .verify(path -> new LogDeprecatedValue(path.append(CONNECTOR_ADDRESS), CONTRACT_REQUEST_TYPE, CONTRACT_REQUEST_COUNTER_PARTY_ADDRESS, monitor))
                 .verify(path -> new MandatoryCounterPartyAddressOrConnectorAddress(path, monitor))
                 .verify(PROTOCOL, MandatoryValue::new)
                 .verify(path -> new MandatoryOfferOrPolicy(path, monitor))

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/validation/ContractRequestValidator.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/validation/ContractRequestValidator.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.connector.api.management.contractnegotiation.model.Contra
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.validator.jsonobject.JsonLdPath;
 import org.eclipse.edc.validator.jsonobject.JsonObjectValidator;
+import org.eclipse.edc.validator.jsonobject.validators.LogDeprecatedValue;
 import org.eclipse.edc.validator.jsonobject.validators.MandatoryIdNotBlank;
 import org.eclipse.edc.validator.jsonobject.validators.MandatoryObject;
 import org.eclipse.edc.validator.jsonobject.validators.MandatoryValue;
@@ -26,7 +27,6 @@ import org.eclipse.edc.validator.jsonobject.validators.TypeIs;
 import org.eclipse.edc.validator.spi.ValidationResult;
 import org.eclipse.edc.validator.spi.Validator;
 
-import static java.lang.String.format;
 import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractOfferDescription.ASSET_ID;
 import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractOfferDescription.OFFER_ID;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.CONNECTOR_ADDRESS;
@@ -41,11 +41,11 @@ import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_O
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIBUTE;
 
 public class ContractRequestValidator {
-    public static final String DEPRECATED_PROVIDER_ID_LOG = format("The attribute %s has been deprecated in type %s, please use %s",
-            PROVIDER_ID, CONTRACT_REQUEST_TYPE, ODRL_ASSIGNER_ATTRIBUTE);
-
     public static Validator<JsonObject> instance(Monitor monitor) {
         return JsonObjectValidator.newValidator()
+                .verify(PROVIDER_ID, CONTRACT_REQUEST_TYPE, ODRL_ASSIGNER_ATTRIBUTE, monitor, LogDeprecatedValue::new)
+                .verify(OFFER, CONTRACT_REQUEST_TYPE, POLICY, monitor, LogDeprecatedValue::new)
+                .verify(CONNECTOR_ADDRESS, CONTRACT_REQUEST_TYPE, CONTRACT_REQUEST_COUNTER_PARTY_ADDRESS, monitor, LogDeprecatedValue::new)
                 .verify(path -> new MandatoryCounterPartyAddressOrConnectorAddress(path, monitor))
                 .verify(PROTOCOL, MandatoryValue::new)
                 .verify(path -> new MandatoryOfferOrPolicy(path, monitor))
@@ -55,15 +55,8 @@ public class ContractRequestValidator {
     private record MandatoryOfferOrPolicy(JsonLdPath path, Monitor monitor) implements Validator<JsonObject> {
         @Override
         public ValidationResult validate(JsonObject input) {
-            var providerId = new MandatoryObject(path.append(PROVIDER_ID)).validate(input);
-            if  (providerId.succeeded()) {
-                monitor.warning(DEPRECATED_PROVIDER_ID_LOG);
-            }
-
             var offerValidity = new MandatoryObject(path.append(OFFER)).validate(input);
             if (offerValidity.succeeded()) {
-                monitor.warning(format("The attribute %s has been deprecated in type %s, please use %s",
-                        OFFER, CONTRACT_REQUEST_TYPE, POLICY));
                 return JsonObjectValidator.newValidator()
                         .verifyObject(OFFER, v -> v
                                 .verify(OFFER_ID, MandatoryValue::new)
@@ -103,8 +96,6 @@ public class ContractRequestValidator {
             var connectorAddress = new MandatoryValue(path.append(CONNECTOR_ADDRESS));
             var validateConnectorAddress = connectorAddress.validate(input);
             if (validateConnectorAddress.succeeded()) {
-                monitor.warning(format("The attribute %s has been deprecated in type %s, please use %s",
-                        CONNECTOR_ADDRESS, CONTRACT_REQUEST_TYPE, CONTRACT_REQUEST_COUNTER_PARTY_ADDRESS));
                 return ValidationResult.success();
             }
             return validateCounterParty;

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/validation/ContractRequestValidator.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/validation/ContractRequestValidator.java
@@ -35,11 +35,14 @@ import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractR
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.OFFER;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.POLICY;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.PROTOCOL;
+import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.PROVIDER_ID;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ASSIGNER_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_OFFER;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIBUTE;
 
 public class ContractRequestValidator {
+    public static final String DEPRECATED_PROVIDER_ID_LOG = format("The attribute %s has been deprecated in type %s, please use %s",
+            PROVIDER_ID, CONTRACT_REQUEST_TYPE, ODRL_ASSIGNER_ATTRIBUTE);
 
     public static Validator<JsonObject> instance(Monitor monitor) {
         return JsonObjectValidator.newValidator()
@@ -52,6 +55,11 @@ public class ContractRequestValidator {
     private record MandatoryOfferOrPolicy(JsonLdPath path, Monitor monitor) implements Validator<JsonObject> {
         @Override
         public ValidationResult validate(JsonObject input) {
+            var providerId = new MandatoryObject(path.append(PROVIDER_ID)).validate(input);
+            if  (providerId.succeeded()) {
+                monitor.warning(DEPRECATED_PROVIDER_ID_LOG);
+            }
+
             var offerValidity = new MandatoryObject(path.append(OFFER)).validate(input);
             if (offerValidity.succeeded()) {
                 monitor.warning(format("The attribute %s has been deprecated in type %s, please use %s",

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerTest.java
@@ -334,7 +334,6 @@ class ContractNegotiationApiControllerTest extends RestControllerTestBase {
         when(transformerRegistry.transform(any(JsonObject.class), eq(ContractRequest.class))).thenReturn(Result.success(
                 ContractRequest.Builder.newInstance()
                         .protocol("test-protocol")
-                        .providerId("test-provider-id")
                         .counterPartyAddress("test-cb")
                         .contractOffer(ContractOffer.Builder.newInstance()
                                 .id("test-offer-id")

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiTest.java
@@ -77,7 +77,7 @@ class ContractNegotiationApiTest {
                 .satisfies(exp -> assertThat(validator.validate(exp)).isSucceeded())
                 .extracting(e -> transformer.transform(e, ContractRequest.class))
                 .satisfies(transformResult -> assertThat(transformResult).isSucceeded()
-                        .satisfies(transformed -> assertThat(transformed.getProviderId()).isNotBlank()));
+                        .satisfies(transformed -> assertThat(transformed.getProtocol()).isNotBlank()));
     }
 
     @Test

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectToContractRequestTransformerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/transform/JsonObjectToContractRequestTransformerTest.java
@@ -41,9 +41,9 @@ import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractR
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.CONTRACT_REQUEST_COUNTER_PARTY_ADDRESS;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.OFFER;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.PROTOCOL;
-import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.PROVIDER_ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ASSIGNER_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_OBLIGATION_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_PERMISSION_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_SET;
@@ -74,7 +74,6 @@ class JsonObjectToContractRequestTransformerTest {
                 .add(TYPE, ContractRequest.CONTRACT_REQUEST_TYPE)
                 .add(CONTRACT_REQUEST_COUNTER_PARTY_ADDRESS, "test-address")
                 .add(PROTOCOL, "test-protocol")
-                .add(PROVIDER_ID, "test-provider-id")
                 .add(CALLBACK_ADDRESSES, createCallbackAddress())
                 .add(POLICY, createPolicy())
                 .build();
@@ -83,7 +82,7 @@ class JsonObjectToContractRequestTransformerTest {
                 .events(Set.of("foo", "bar"))
                 .transactional(true)
                 .build());
-        var offer = createContractOffer();
+        var offer = createContractOffer("test-provider-id");
         when(context.transform(any(JsonValue.class), eq(ContractOffer.class))).thenReturn(offer);
         
         var request = transformer.transform(jsonLd.expand(jsonObject).getContent(), context);
@@ -103,7 +102,6 @@ class JsonObjectToContractRequestTransformerTest {
                 .add(TYPE, ContractRequest.CONTRACT_REQUEST_TYPE)
                 .add(CONTRACT_REQUEST_COUNTER_PARTY_ADDRESS, "test-address")
                 .add(PROTOCOL, "test-protocol")
-                .add(PROVIDER_ID, "test-provider-id")
                 .add(CALLBACK_ADDRESSES, createCallbackAddress())
                 .add(OFFER, Json.createObjectBuilder()
                         .add(OFFER_ID, "test-offer-id")
@@ -112,7 +110,7 @@ class JsonObjectToContractRequestTransformerTest {
                         .build())
                 .build();
 
-        var policy = Policy.Builder.newInstance().build();
+        var policy = Policy.Builder.newInstance().assigner("test-provider-id").build();
         var contractOfferDescription = ContractOfferDescription.Builder.newInstance()
                 .offerId("offerId")
                 .assetId("assetId")
@@ -151,7 +149,7 @@ class JsonObjectToContractRequestTransformerTest {
                 .add(PROTOCOL, "test-protocol")
                 .add(POLICY, createPolicy())
                 .build();
-        when(context.transform(any(JsonValue.class), eq(ContractOffer.class))).thenReturn(createContractOffer());
+        when(context.transform(any(JsonValue.class), eq(ContractOffer.class))).thenReturn(createContractOffer("test-address"));
 
         var request = transformer.transform(jsonLd.expand(jsonObject).getContent(), context);
 
@@ -159,8 +157,8 @@ class JsonObjectToContractRequestTransformerTest {
         assertThat(request.getProviderId()).isEqualTo("test-address");
     }
 
-    private ContractOffer createContractOffer() {
-        var policy = Policy.Builder.newInstance().target("test-asset").build();
+    private ContractOffer createContractOffer(String providerId) {
+        var policy = Policy.Builder.newInstance().target("test-asset").assigner(providerId).build();
         return ContractOffer.Builder.newInstance().id("offer-id").assetId("asset-id").policy(policy).build();
     }
 
@@ -183,6 +181,7 @@ class JsonObjectToContractRequestTransformerTest {
                 .add(ODRL_PERMISSION_ATTRIBUTE, permissionJson)
                 .add(ODRL_PROHIBITION_ATTRIBUTE, prohibitionJson)
                 .add(ODRL_OBLIGATION_ATTRIBUTE, dutyJson)
+                .add(ODRL_ASSIGNER_ATTRIBUTE, "test-provider-id")
                 .build();
     }
 

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/validation/ContractRequestValidatorTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/validation/ContractRequestValidatorTest.java
@@ -30,10 +30,12 @@ import static org.assertj.core.api.InstanceOfAssertFactories.list;
 import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractOfferDescription.ASSET_ID;
 import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractOfferDescription.OFFER_ID;
 import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractOfferDescription.POLICY;
+import static org.eclipse.edc.connector.api.management.contractnegotiation.validation.ContractRequestValidator.DEPRECATED_PROVIDER_ID_LOG;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.CONNECTOR_ADDRESS;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.CONTRACT_REQUEST_COUNTER_PARTY_ADDRESS;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.OFFER;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.PROTOCOL;
+import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.PROVIDER_ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
@@ -115,6 +117,17 @@ class ContractRequestValidatorTest {
                 .isNotEmpty()
                 .anySatisfy(violation -> assertThat(violation.path()).isEqualTo(CONTRACT_REQUEST_COUNTER_PARTY_ADDRESS))
                 .anySatisfy(violation -> assertThat(violation.path()).isEqualTo(PROTOCOL));
+    }
+
+    @Test
+    void shouldSucceed_whenDeprecatedProviderIdIsUsedWarningLogged() {
+        var input = Json.createObjectBuilder()
+                .add(PROVIDER_ID, value("provider_id"))
+                .build();
+
+        validator.validate(input);
+
+        verify(monitor).warning(DEPRECATED_PROVIDER_ID_LOG);
     }
 
     @Deprecated(since = "0.3.2")

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/validation/ContractRequestValidatorTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/validation/ContractRequestValidatorTest.java
@@ -34,7 +34,6 @@ import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractR
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.CONTRACT_REQUEST_COUNTER_PARTY_ADDRESS;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.OFFER;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.PROTOCOL;
-import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.PROVIDER_ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
@@ -56,7 +55,6 @@ class ContractRequestValidatorTest {
         var input = Json.createObjectBuilder()
                 .add(CONTRACT_REQUEST_COUNTER_PARTY_ADDRESS, value("http://connector-address"))
                 .add(PROTOCOL, value("protocol"))
-                .add(PROVIDER_ID, value("connector-id"))
                 .add(POLICY, createArrayBuilder().add(createObjectBuilder()
                         .add(TYPE, createArrayBuilder().add(ODRL_POLICY_TYPE_OFFER))
                         .add(ID, "offer-id")
@@ -75,7 +73,6 @@ class ContractRequestValidatorTest {
         var input = Json.createObjectBuilder()
                 .add(CONTRACT_REQUEST_COUNTER_PARTY_ADDRESS, value("http://connector-address"))
                 .add(PROTOCOL, value("protocol"))
-                .add(PROVIDER_ID, value("connector-id"))
                 .add(POLICY, createArrayBuilder()
                         .add(createObjectBuilder()
                                 .add(TYPE, createArrayBuilder().add("wrongType"))
@@ -99,7 +96,6 @@ class ContractRequestValidatorTest {
         var input = Json.createObjectBuilder()
                 .add(CONTRACT_REQUEST_COUNTER_PARTY_ADDRESS, value("http://connector-address"))
                 .add(PROTOCOL, value("protocol"))
-                .add(PROVIDER_ID, value("connector-id"))
                 .build();
 
         var result = validator.validate(input);
@@ -128,7 +124,6 @@ class ContractRequestValidatorTest {
                 .add(CONTRACT_REQUEST_COUNTER_PARTY_ADDRESS, value("http://connector-address"))
                 .add(CONNECTOR_ADDRESS, value("http://connector-address"))
                 .add(PROTOCOL, value("protocol"))
-                .add(PROVIDER_ID, value("connector-id"))
                 .add(OFFER, createArrayBuilder().add(createObjectBuilder()))
                 .build();
 
@@ -147,7 +142,6 @@ class ContractRequestValidatorTest {
         var input = Json.createObjectBuilder()
                 .add(CONTRACT_REQUEST_COUNTER_PARTY_ADDRESS, value("http://connector-address"))
                 .add(PROTOCOL, value("protocol"))
-                .add(PROVIDER_ID, value("connector-id"))
                 .add(OFFER, createArrayBuilder().add(createObjectBuilder()
                         .add(OFFER_ID, value("offerId"))
                         .add(ASSET_ID, value("offerId"))
@@ -165,7 +159,6 @@ class ContractRequestValidatorTest {
         var input = Json.createObjectBuilder()
                 .add(CONNECTOR_ADDRESS, value("http://connector-address"))
                 .add(PROTOCOL, value("protocol"))
-                .add(PROVIDER_ID, value("connector-id"))
                 .add(POLICY, createArrayBuilder().add(createObjectBuilder()
                         .add(ID, "offer-id")
                         .add(TYPE, createArrayBuilder().add(ODRL_POLICY_TYPE_OFFER))

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/validation/ContractRequestValidatorTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/validation/ContractRequestValidatorTest.java
@@ -25,14 +25,15 @@ import org.junit.jupiter.api.Test;
 
 import static jakarta.json.Json.createArrayBuilder;
 import static jakarta.json.Json.createObjectBuilder;
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.list;
 import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractOfferDescription.ASSET_ID;
 import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractOfferDescription.OFFER_ID;
 import static org.eclipse.edc.connector.api.management.contractnegotiation.model.ContractOfferDescription.POLICY;
-import static org.eclipse.edc.connector.api.management.contractnegotiation.validation.ContractRequestValidator.DEPRECATED_PROVIDER_ID_LOG;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.CONNECTOR_ADDRESS;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.CONTRACT_REQUEST_COUNTER_PARTY_ADDRESS;
+import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.CONTRACT_REQUEST_TYPE;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.OFFER;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.PROTOCOL;
 import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractRequest.PROVIDER_ID;
@@ -121,13 +122,16 @@ class ContractRequestValidatorTest {
 
     @Test
     void shouldSucceed_whenDeprecatedProviderIdIsUsedWarningLogged() {
+        String expectedLogMessage = format("The attribute %s has been deprecated in type %s, please use %s",
+                PROVIDER_ID, CONTRACT_REQUEST_TYPE, ODRL_ASSIGNER_ATTRIBUTE);
+
         var input = Json.createObjectBuilder()
                 .add(PROVIDER_ID, value("provider_id"))
                 .build();
 
         validator.validate(input);
 
-        verify(monitor).warning(DEPRECATED_PROVIDER_ID_LOG);
+        verify(monitor).warning(expectedLogMessage);
     }
 
     @Deprecated(since = "0.3.2")

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequest.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequest.java
@@ -40,7 +40,6 @@ public class ContractRequest {
     public static final String POLICY = EDC_NAMESPACE + "policy";
     public static final String CALLBACK_ADDRESSES = EDC_NAMESPACE + "callbackAddresses";
 
-    private String providerId;
     private String protocol;
     private String counterPartyAddress;
     private ContractOffer contractOffer;
@@ -51,7 +50,7 @@ public class ContractRequest {
     }
 
     public String getProviderId() {
-        return providerId;
+        return this.contractOffer.getPolicy().getAssigner();
     }
 
     public String getProtocol() {
@@ -79,11 +78,6 @@ public class ContractRequest {
 
         public Builder callbackAddresses(List<CallbackAddress> callbackAddresses) {
             contractRequest.callbackAddresses = callbackAddresses;
-            return this;
-        }
-
-        public Builder providerId(String providerId) {
-            contractRequest.providerId = providerId;
             return this;
         }
 

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequest.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequest.java
@@ -33,8 +33,6 @@ public class ContractRequest {
     public static final String CONNECTOR_ADDRESS = EDC_NAMESPACE + "connectorAddress";
     public static final String CONTRACT_REQUEST_COUNTER_PARTY_ADDRESS = EDC_NAMESPACE + "counterPartyAddress";
     public static final String PROTOCOL = EDC_NAMESPACE + "protocol";
-    @Deprecated(since = "0.5.1")
-    public static final String PROVIDER_ID = EDC_NAMESPACE + "providerId";
     @Deprecated(since = "0.3.2")
     public static final String OFFER = EDC_NAMESPACE + "offer";
     public static final String POLICY = EDC_NAMESPACE + "policy";

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequest.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequest.java
@@ -33,6 +33,8 @@ public class ContractRequest {
     public static final String CONNECTOR_ADDRESS = EDC_NAMESPACE + "connectorAddress";
     public static final String CONTRACT_REQUEST_COUNTER_PARTY_ADDRESS = EDC_NAMESPACE + "counterPartyAddress";
     public static final String PROTOCOL = EDC_NAMESPACE + "protocol";
+    @Deprecated(since = "0.5.1")
+    public static final String PROVIDER_ID = EDC_NAMESPACE + "providerId";
     @Deprecated(since = "0.3.2")
     public static final String OFFER = EDC_NAMESPACE + "offer";
     public static final String POLICY = EDC_NAMESPACE + "policy";

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequest.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/contract/spi/types/negotiation/ContractRequest.java
@@ -33,6 +33,7 @@ public class ContractRequest {
     public static final String CONNECTOR_ADDRESS = EDC_NAMESPACE + "connectorAddress";
     public static final String CONTRACT_REQUEST_COUNTER_PARTY_ADDRESS = EDC_NAMESPACE + "counterPartyAddress";
     public static final String PROTOCOL = EDC_NAMESPACE + "protocol";
+    @Deprecated(since = "0.5.1")
     public static final String PROVIDER_ID = EDC_NAMESPACE + "providerId";
     @Deprecated(since = "0.3.2")
     public static final String OFFER = EDC_NAMESPACE + "offer";


### PR DESCRIPTION
## What this PR changes/adds

Deprecated provider_id field in ContractRequest

## Why it does that

Clean up.

## Linked Issue(s)

Closes #3929

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
