### PR TITLE
feat: implement Signaling API controller

### DIFF
--- a/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/PublicEndpointGeneratorServiceImplTest.java
+++ b/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/PublicEndpointGeneratorServiceImplTest.java
@@ -18,8 +18,6 @@ import org.eclipse.edc.connector.dataplane.spi.Endpoint;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.junit.jupiter.api.Test;
 
-import java.util.Map;
-
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 
 
@@ -29,7 +27,7 @@ class PublicEndpointGeneratorServiceImplTest {
 
     @Test
     void generateFor() {
-        var endpoint = new Endpoint(Map.of("fizz", "buzz"), "bar-type");
+        var endpoint = new Endpoint("fizz", "bar-type");
         generatorService.addGeneratorFunction("testtype", dataAddress -> endpoint);
 
         assertThat(generatorService.generateFor(DataAddress.Builder.newInstance().type("testtype").build())).isSucceeded()
@@ -43,5 +41,5 @@ class PublicEndpointGeneratorServiceImplTest {
                 .detail()
                 .isEqualTo("No Endpoint generator function registered for source data type 'testtype'");
     }
-    
+
 }

--- a/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/iam/DataPlaneAuthorizationServiceImplTest.java
+++ b/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/iam/DataPlaneAuthorizationServiceImplTest.java
@@ -58,7 +58,7 @@ class DataPlaneAuthorizationServiceImplTest {
 
     @BeforeEach
     void setup() {
-        when(endpointGenerator.generateFor(any())).thenReturn(Result.success(new Endpoint(Map.of("url", "http://example.com"), "https://w3id.org/idsa/v4.1/HTTP")));
+        when(endpointGenerator.generateFor(any())).thenReturn(Result.success(Endpoint.url("http://example.com")));
     }
 
     @Test

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-api-configuration/src/main/java/org/eclipse/edc/connector/api/signaling/configuration/SignalingApiConfigurationExtension.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-api-configuration/src/main/java/org/eclipse/edc/connector/api/signaling/configuration/SignalingApiConfigurationExtension.java
@@ -14,10 +14,13 @@
 
 package org.eclipse.edc.connector.api.signaling.configuration;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.json.Json;
 import org.eclipse.edc.connector.api.signaling.transform.SignalingApiTransformerRegistry;
 import org.eclipse.edc.connector.api.signaling.transform.SignalingApiTransformerRegistryImpl;
+import org.eclipse.edc.connector.api.signaling.transform.from.JsonObjectFromDataAddressTransformer;
 import org.eclipse.edc.connector.api.signaling.transform.to.JsonObjectToDataAddressTransformer;
+import org.eclipse.edc.connector.api.signaling.transform.to.JsonObjectToDataFlowStartMessageTransformer;
 import org.eclipse.edc.connector.api.signaling.transform.to.JsonObjectToDataFlowSuspendMessageTransformer;
 import org.eclipse.edc.connector.api.signaling.transform.to.JsonObjectToDataFlowTerminateMessageTransformer;
 import org.eclipse.edc.jsonld.spi.JsonLd;
@@ -35,6 +38,7 @@ import org.eclipse.edc.web.spi.WebServer;
 import org.eclipse.edc.web.spi.WebService;
 import org.eclipse.edc.web.spi.configuration.WebServiceConfigurer;
 import org.eclipse.edc.web.spi.configuration.WebServiceSettings;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
 
@@ -86,7 +90,7 @@ public class SignalingApiConfigurationExtension implements ServiceExtension {
         context.registerService(SignalingApiConfiguration.class, new SignalingApiConfiguration(webServiceConfiguration));
 
         jsonLd.registerNamespace(ODRL_PREFIX, ODRL_SCHEMA, SIGNALING_SCOPE);
-        var jsonLdMapper = typeManager.getMapper(JSON_LD);
+        var jsonLdMapper = getJsonLdMapper();
         webService.registerResource(webServiceConfiguration.getContextAlias(), new ObjectMapperProvider(jsonLdMapper));
         webService.registerResource(webServiceConfiguration.getContextAlias(), new JerseyJsonLdInterceptor(jsonLd, jsonLdMapper, SIGNALING_SCOPE));
     }
@@ -96,9 +100,16 @@ public class SignalingApiConfigurationExtension implements ServiceExtension {
         var factory = Json.createBuilderFactory(Map.of());
 
         var registry = new SignalingApiTransformerRegistryImpl(this.transformerRegistry);
+        registry.register(new JsonObjectToDataFlowStartMessageTransformer());
         registry.register(new JsonObjectToDataFlowSuspendMessageTransformer());
         registry.register(new JsonObjectToDataFlowTerminateMessageTransformer());
         registry.register(new JsonObjectToDataAddressTransformer());
+        registry.register(new JsonObjectFromDataAddressTransformer(factory, getJsonLdMapper()));
         return registry;
+    }
+
+    @NotNull
+    private ObjectMapper getJsonLdMapper() {
+        return typeManager.getMapper(JSON_LD);
     }
 }

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-api/build.gradle.kts
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-api/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     api(project(":spi:data-plane:data-plane-spi"))
 
     implementation(project(":extensions:common:api:control-api-configuration"))
+    implementation(project(":extensions:data-plane:data-plane-signaling:data-plane-signaling-transform"))
     implementation(project(":extensions:data-plane:data-plane-signaling:data-plane-signaling-api-configuration"))
     implementation(libs.jakarta.rsApi)
 

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-api/src/main/java/org/eclipse/edc/connector/dataplane/api/DataPlaneSignalingApiExtension.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-api/src/main/java/org/eclipse/edc/connector/dataplane/api/DataPlaneSignalingApiExtension.java
@@ -15,7 +15,9 @@
 package org.eclipse.edc.connector.dataplane.api;
 
 import org.eclipse.edc.connector.api.signaling.configuration.SignalingApiConfiguration;
+import org.eclipse.edc.connector.api.signaling.transform.SignalingApiTransformerRegistry;
 import org.eclipse.edc.connector.dataplane.api.controller.v1.DataPlaneSignalingApiController;
+import org.eclipse.edc.connector.dataplane.spi.iam.DataPlaneAuthorizationService;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.system.ServiceExtension;
@@ -34,6 +36,11 @@ public class DataPlaneSignalingApiExtension implements ServiceExtension {
     @Inject
     private SignalingApiConfiguration controlApiConfiguration;
 
+    @Inject
+    private SignalingApiTransformerRegistry transformerRegistry;
+    @Inject
+    private DataPlaneAuthorizationService authorizationService;
+
     @Override
     public String name() {
         return NAME;
@@ -41,6 +48,6 @@ public class DataPlaneSignalingApiExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        webService.registerResource(controlApiConfiguration.getContextAlias(), new DataPlaneSignalingApiController());
+        webService.registerResource(controlApiConfiguration.getContextAlias(), new DataPlaneSignalingApiController(transformerRegistry, authorizationService));
     }
 }

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-api/src/main/java/org/eclipse/edc/connector/dataplane/api/DataPlaneSignalingApiExtension.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-api/src/main/java/org/eclipse/edc/connector/dataplane/api/DataPlaneSignalingApiExtension.java
@@ -18,6 +18,7 @@ import org.eclipse.edc.connector.api.signaling.configuration.SignalingApiConfigu
 import org.eclipse.edc.connector.api.signaling.transform.SignalingApiTransformerRegistry;
 import org.eclipse.edc.connector.dataplane.api.controller.v1.DataPlaneSignalingApiController;
 import org.eclipse.edc.connector.dataplane.spi.iam.DataPlaneAuthorizationService;
+import org.eclipse.edc.connector.dataplane.spi.manager.DataPlaneManager;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.system.ServiceExtension;
@@ -40,6 +41,8 @@ public class DataPlaneSignalingApiExtension implements ServiceExtension {
     private SignalingApiTransformerRegistry transformerRegistry;
     @Inject
     private DataPlaneAuthorizationService authorizationService;
+    @Inject
+    private DataPlaneManager dataPlaneManager;
 
     @Override
     public String name() {
@@ -48,6 +51,7 @@ public class DataPlaneSignalingApiExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        webService.registerResource(controlApiConfiguration.getContextAlias(), new DataPlaneSignalingApiController(transformerRegistry, authorizationService));
+        var controller = new DataPlaneSignalingApiController(transformerRegistry, authorizationService, dataPlaneManager, context.getMonitor().withPrefix("SignalingAPI"));
+        webService.registerResource(controlApiConfiguration.getContextAlias(), controller);
     }
 }

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-api/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/v1/DataPlaneSignalingApi.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-api/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/v1/DataPlaneSignalingApi.java
@@ -51,7 +51,7 @@ public interface DataPlaneSignalingApi {
                             content = @Content(schema = @Schema(implementation = DataFlowResponseMessageSchema.class))),
             }
     )
-    JsonObject start(JsonObject dataFlowStartMessage, AsyncResponse response);
+    void start(JsonObject dataFlowStartMessage, AsyncResponse response);
 
     @Operation(description = "Get the current state of a data transfer.",
             responses = {

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-api/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/v1/DataPlaneSignalingApi.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-api/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/v1/DataPlaneSignalingApi.java
@@ -23,7 +23,6 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.json.JsonObject;
-import jakarta.ws.rs.container.AsyncResponse;
 import org.eclipse.edc.connector.dataplane.api.model.DataFlowState;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowResponseMessage;
@@ -51,7 +50,7 @@ public interface DataPlaneSignalingApi {
                             content = @Content(schema = @Schema(implementation = DataFlowResponseMessageSchema.class))),
             }
     )
-    void start(JsonObject dataFlowStartMessage, AsyncResponse response);
+    JsonObject start(JsonObject dataFlowStartMessage);
 
     @Operation(description = "Get the current state of a data transfer.",
             responses = {

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-api/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/v1/DataPlaneSignalingApiController.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-api/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/v1/DataPlaneSignalingApiController.java
@@ -24,16 +24,47 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.container.AsyncResponse;
 import jakarta.ws.rs.container.Suspended;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.edc.connector.dataplane.spi.iam.DataPlaneAuthorizationService;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.web.spi.exception.InvalidRequestException;
 
 @Consumes({ MediaType.APPLICATION_JSON })
 @Produces({ MediaType.APPLICATION_JSON })
 @Path("/v1/dataflows")
 public class DataPlaneSignalingApiController implements DataPlaneSignalingApi {
 
+    private final TypeTransformerRegistry typeTransformerRegistry;
+    private final DataPlaneAuthorizationService dataPlaneAuthorizationService;
+    private final Monitor monitor;
+
+    public DataPlaneSignalingApiController(TypeTransformerRegistry typeTransformerRegistry, DataPlaneAuthorizationService dataPlaneAuthorizationService, Monitor monitor) {
+        this.typeTransformerRegistry = typeTransformerRegistry;
+        this.dataPlaneAuthorizationService = dataPlaneAuthorizationService;
+        this.monitor = monitor;
+    }
+
     @POST
     @Override
-    public JsonObject start(JsonObject dataFlowStartMessage, @Suspended AsyncResponse response) {
-        throw new UnsupportedOperationException();
+    public void start(JsonObject dataFlowStartMessage, @Suspended AsyncResponse response) {
+        var startMsg = typeTransformerRegistry.transform(dataFlowStartMessage, DataFlowStartMessage.class)
+                .orElseThrow(InvalidRequestException::new);
+
+        var dataAddress = dataPlaneAuthorizationService.createEndpointDataReference(startMsg);
+        if (dataAddress.failed()) {
+            monitor.warning("Error obtaining EDR DataAddress: " + dataAddress.getFailureDetail());
+            response.resume(new InvalidRequestException(dataAddress.getFailure()));
+        }
+
+        var result = typeTransformerRegistry.transform(dataAddress.getContent(), JsonObject.class);
+        result
+                .onFailure(f -> {
+                    monitor.warning("Error obtaining EDR DataAddress: " + result.getFailureDetail());
+                    response.resume(new EdcException(f.getFailureDetail()));
+                })
+                .onSuccess(response::resume);
     }
 
     @GET

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-api/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/v1/DataPlaneSignalingApiController.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-api/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/v1/DataPlaneSignalingApiController.java
@@ -21,13 +21,13 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.container.AsyncResponse;
-import jakarta.ws.rs.container.Suspended;
 import jakarta.ws.rs.core.MediaType;
 import org.eclipse.edc.connector.dataplane.spi.iam.DataPlaneAuthorizationService;
+import org.eclipse.edc.connector.dataplane.spi.manager.DataPlaneManager;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowTerminateMessage;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.web.spi.exception.InvalidRequestException;
 
@@ -38,47 +38,61 @@ public class DataPlaneSignalingApiController implements DataPlaneSignalingApi {
 
     private final TypeTransformerRegistry typeTransformerRegistry;
     private final DataPlaneAuthorizationService dataPlaneAuthorizationService;
+    private final DataPlaneManager dataPlaneManager;
     private final Monitor monitor;
 
-    public DataPlaneSignalingApiController(TypeTransformerRegistry typeTransformerRegistry, DataPlaneAuthorizationService dataPlaneAuthorizationService, Monitor monitor) {
+    public DataPlaneSignalingApiController(TypeTransformerRegistry typeTransformerRegistry, DataPlaneAuthorizationService dataPlaneAuthorizationService, DataPlaneManager dataPlaneManager, Monitor monitor) {
         this.typeTransformerRegistry = typeTransformerRegistry;
         this.dataPlaneAuthorizationService = dataPlaneAuthorizationService;
+        this.dataPlaneManager = dataPlaneManager;
         this.monitor = monitor;
     }
 
     @POST
     @Override
-    public void start(JsonObject dataFlowStartMessage, @Suspended AsyncResponse response) {
+    public JsonObject start(JsonObject dataFlowStartMessage) {
         var startMsg = typeTransformerRegistry.transform(dataFlowStartMessage, DataFlowStartMessage.class)
+                .onFailure(f -> monitor.warning("Error transforming %s: %s".formatted(DataFlowStartMessage.class, f.getFailureDetail())))
                 .orElseThrow(InvalidRequestException::new);
 
-        var dataAddress = dataPlaneAuthorizationService.createEndpointDataReference(startMsg);
-        if (dataAddress.failed()) {
-            monitor.warning("Error obtaining EDR DataAddress: " + dataAddress.getFailureDetail());
-            response.resume(new InvalidRequestException(dataAddress.getFailure()));
-        }
+        dataPlaneManager.validate(startMsg)
+                .onFailure(f -> monitor.warning("Failed to validate request: " + f.getFailureDetail()))
+                .orElseThrow(f -> f.getMessages().isEmpty() ?
+                        new InvalidRequestException("Failed to validate request: %s".formatted(startMsg.getId())) :
+                        new InvalidRequestException(f.getMessages()));
 
-        var result = typeTransformerRegistry.transform(dataAddress.getContent(), JsonObject.class);
-        result
-                .onFailure(f -> {
-                    monitor.warning("Error obtaining EDR DataAddress: " + result.getFailureDetail());
-                    response.resume(new EdcException(f.getFailureDetail()));
-                })
-                .onSuccess(response::resume);
+        monitor.debug("Create EDR");
+        var dataAddress = dataPlaneAuthorizationService.createEndpointDataReference(startMsg)
+                .onFailure(f -> monitor.warning("Error obtaining EDR DataAddress: " + f.getFailureDetail()))
+                .orElseThrow(InvalidRequestException::new);
+
+        dataPlaneManager.initiate(startMsg);
+
+        return typeTransformerRegistry.transform(dataAddress, JsonObject.class)
+                .onFailure(f -> monitor.warning("Error obtaining EDR DataAddress: " + f.getFailureDetail()))
+                .orElseThrow(f -> new EdcException(f.getFailureDetail()));
     }
 
     @GET
     @Path("/{id}/state")
     @Override
     public JsonObject getTransferState(@PathParam("id") String transferProcessId) {
-        throw new UnsupportedOperationException();
+        var state = dataPlaneManager.transferState(transferProcessId);
+        return null;
     }
 
     @POST
     @Path("/{id}/terminate")
     @Override
-    public void terminate(@PathParam("id") String transferProcessId, JsonObject terminationMessage) {
-        throw new UnsupportedOperationException();
+    public void terminate(@PathParam("id") String dataFlowId, JsonObject terminationMessage) {
+
+        var msg = typeTransformerRegistry.transform(terminationMessage, DataFlowTerminateMessage.class)
+                .onFailure(f -> monitor.warning("Error transforming %s: %s".formatted(DataFlowTerminateMessage.class, f.getFailureDetail())))
+                .orElseThrow(InvalidRequestException::new);
+
+        // todo: add msg.reason() to the method signature:
+        dataPlaneManager.terminate(dataFlowId)
+                .orElseThrow(InvalidRequestException::new);
     }
 
     @POST

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/main/java/org/eclipse/edc/connector/api/signaling/transform/from/JsonObjectFromDataAddressTransformer.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/main/java/org/eclipse/edc/connector/api/signaling/transform/from/JsonObjectFromDataAddressTransformer.java
@@ -40,7 +40,7 @@ public class JsonObjectFromDataAddressTransformer extends AbstractJsonLdTransfor
     private final JsonBuilderFactory jsonFactory;
     private final ObjectMapper mapper;
 
-    protected JsonObjectFromDataAddressTransformer(JsonBuilderFactory jsonFactory, ObjectMapper mapper) {
+    public JsonObjectFromDataAddressTransformer(JsonBuilderFactory jsonFactory, ObjectMapper mapper) {
         super(DataAddress.class, JsonObject.class);
         this.jsonFactory = jsonFactory;
         this.mapper = mapper;
@@ -58,7 +58,8 @@ public class JsonObjectFromDataAddressTransformer extends AbstractJsonLdTransfor
         var objectBuilder = jsonFactory.createObjectBuilder()
                 .add(TYPE, DSPACE_DATAADDRESS_TYPE)
                 .add(ENDPOINT_TYPE_PROPERTY, dataAddress.getType())
-                .add(ENDPOINT_PROPERTY, dataAddress.getStringProperty("endpoint"));
+                .add(ENDPOINT_PROPERTY, dataAddress.getProperties().getOrDefault("endpoint", "https://example.com").toString());
+
 
         objectBuilder.add(ENDPOINT_PROPERTIES_PROPERTY, propsBuilder.build());
 

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/Endpoint.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/Endpoint.java
@@ -14,8 +14,6 @@
 
 package org.eclipse.edc.connector.dataplane.spi;
 
-import java.util.Map;
-
 /**
  * Representation of a publicly accessible data egress point. This indicates to consumers the type of data (denoted by the {@code endpointType})
  * and an object containing fields describing the endpoint.
@@ -25,7 +23,7 @@ import java.util.Map;
  * @param endpoint     An object describing the endpoint
  * @param endpointType A string uniquely identifying the type of endpoint
  */
-public record Endpoint(Map<String, Object> endpoint, String endpointType) {
+public record Endpoint(String endpoint, String endpointType) {
 
     /**
      * Convenience factory method to create a HTTP endpoint.
@@ -34,7 +32,7 @@ public record Endpoint(Map<String, Object> endpoint, String endpointType) {
      * @return the endpoint.
      */
     public static Endpoint url(String url) {
-        return new Endpoint(Map.of("url", url), "https://w3id.org/idsa/v4.1/HTTP");
+        return new Endpoint(url, "https://w3id.org/idsa/v4.1/HTTP");
     }
 
 }

--- a/system-tests/e2e-dataplane-tests/tests/build.gradle.kts
+++ b/system-tests/e2e-dataplane-tests/tests/build.gradle.kts
@@ -33,6 +33,9 @@ dependencies {
     testImplementation(libs.junit.jupiter.api)
     testImplementation(libs.mockserver.netty)
     testImplementation(libs.mockserver.client)
+    testImplementation(project(":core:common:transform-core")) // for the transformer registry impl
+
+    implementation(project(":extensions:data-plane:data-plane-signaling:data-plane-signaling-transform"))
     testCompileOnly(project(":system-tests:e2e-dataplane-tests:runtimes:data-plane"))
 }
 

--- a/system-tests/e2e-dataplane-tests/tests/src/test/java/org/eclipse/edc/test/e2e/DataplaneEndToEndTest.java
+++ b/system-tests/e2e-dataplane-tests/tests/src/test/java/org/eclipse/edc/test/e2e/DataplaneEndToEndTest.java
@@ -14,24 +14,43 @@
 
 package org.eclipse.edc.test.e2e;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.api.signaling.transform.SignalingApiTransformerRegistry;
+import org.eclipse.edc.connector.api.signaling.transform.SignalingApiTransformerRegistryImpl;
+import org.eclipse.edc.connector.api.signaling.transform.from.JsonObjectFromDataAddressTransformer;
+import org.eclipse.edc.connector.api.signaling.transform.from.JsonObjectFromDataFlowStartMessageTransformer;
+import org.eclipse.edc.connector.api.signaling.transform.to.JsonObjectToDataAddressTransformer;
 import org.eclipse.edc.connector.dataplane.spi.Endpoint;
 import org.eclipse.edc.connector.dataplane.spi.iam.PublicEndpointGeneratorService;
+import org.eclipse.edc.core.transform.TypeTransformerRegistryImpl;
+import org.eclipse.edc.jsonld.util.JacksonJsonLd;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.junit.extensions.EdcRuntimeExtension;
+import org.eclipse.edc.spi.result.Failure;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.eclipse.edc.spi.types.domain.transfer.FlowType;
 import org.eclipse.edc.test.e2e.participant.DataPlaneParticipant;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import java.net.URI;
 import java.time.Duration;
+import java.util.Map;
+import java.util.function.Function;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 
 @EndToEndTest
 public class DataplaneEndToEndTest {
 
+    public static final String DATAPLANE_PUBLIC_ENDPOINT_URL = "http://fizz.buzz/bar";
     protected static final DataPlaneParticipant DATAPLANE = DataPlaneParticipant.Builder.newInstance()
             .name("provider")
             .id("urn:connector:provider")
@@ -45,19 +64,52 @@ public class DataplaneEndToEndTest {
             );
 
     protected final Duration timeout = Duration.ofSeconds(60);
+    private ObjectMapper mapper;
+    private SignalingApiTransformerRegistry registry;
+
+    @BeforeEach
+    void setup() {
+        // this registry is entirely separate from the one that is included in the runtime
+        registry = new SignalingApiTransformerRegistryImpl(new TypeTransformerRegistryImpl());
+        var builderFactory = Json.createBuilderFactory(Map.of());
+        mapper = JacksonJsonLd.createObjectMapper();
+        registry.register(new JsonObjectFromDataFlowStartMessageTransformer(builderFactory, mapper));
+        registry.register(new JsonObjectFromDataAddressTransformer(builderFactory, mapper));
+        registry.register(new JsonObjectToDataAddressTransformer());
+    }
 
     @Test
-    void startTransfer_httpPull() {
+    void startTransfer_httpPull() throws JsonProcessingException {
         var generator = runtime.getContext().getService(PublicEndpointGeneratorService.class);
-        generator.addGeneratorFunction("HttpData", dataAddress -> Endpoint.url("http//fizz.buzz.com/bar"));
+        generator.addGeneratorFunction("HttpData", dataAddress -> Endpoint.url(DATAPLANE_PUBLIC_ENDPOINT_URL));
 
         var flowMessage = DataFlowStartMessage.Builder.newInstance()
                 .processId("test-processId")
                 .sourceDataAddress(DataAddress.Builder.newInstance().type("HttpData").property(EDC_NAMESPACE + "baseUrl", "http://foo.bar/").build())
                 .destinationDataAddress(DataAddress.Builder.newInstance().type("HttpData").property(EDC_NAMESPACE + "baseUrl", "http://fizz.buzz").build())
                 .flowType(FlowType.PULL)
+                .participantId("some-participantId")
                 .assetId("test-asset")
+                .callbackAddress(URI.create("https://foo.bar/callback"))
                 .agreementId("test-agreement")
                 .build();
+        var jo = registry.transform(flowMessage, JsonObject.class).orElseThrow(failTest());
+
+        var resultJson = DATAPLANE.initiateTransfer(jo);
+        var dataAddress = registry.transform(mapper.readValue(resultJson, JsonObject.class), DataAddress.class)
+                .orElseThrow(failTest());
+
+        // verify basic shape of the DSPACE data address
+        assertThat(dataAddress).isNotNull();
+        assertThat(dataAddress.getType()).isEqualTo("https://w3id.org/idsa/v4.1/HTTP");
+        assertThat(dataAddress.getProperties())
+                .containsKey("authorization")
+                .containsEntry("endpoint", DATAPLANE_PUBLIC_ENDPOINT_URL)
+                .containsEntry("authType", "bearer");
+    }
+
+    @NotNull
+    private Function<Failure, AssertionError> failTest() {
+        return f -> new AssertionError(f.getFailureDetail());
     }
 }

--- a/system-tests/e2e-dataplane-tests/tests/src/test/java/org/eclipse/edc/test/e2e/participant/DataPlaneParticipant.java
+++ b/system-tests/e2e-dataplane-tests/tests/src/test/java/org/eclipse/edc/test/e2e/participant/DataPlaneParticipant.java
@@ -16,7 +16,7 @@ package org.eclipse.edc.test.e2e.participant;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.restassured.http.ContentType;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
+import jakarta.json.JsonObject;
 import org.eclipse.edc.test.system.utils.Participant;
 import org.hamcrest.Matchers;
 import org.jetbrains.annotations.NotNull;
@@ -65,7 +65,7 @@ public class DataPlaneParticipant extends Participant {
     /**
      * Uses the data plane's control API to initiate a transfer
      */
-    public String initiateTransfer(DataFlowStartMessage startMessage) {
+    public String initiateTransfer(JsonObject startMessage) {
         return dataPlaneSignalingApi.baseRequest()
                 .contentType(ContentType.JSON)
                 .body(startMessage)


### PR DESCRIPTION

## What this PR changes/adds

This PR implements the actual API controller of the Signaling API that delegates down to collaborator services

## Why it does that

Full functionality of the signaling API
## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #3911

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
