### PR TITLE
feat: introduce allowedTransferTypes in DataPlaneInstance

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -182,9 +182,10 @@ maven/mavencentral/javax.ws.rs/javax.ws.rs-api/2.1, (CDDL-1.1 OR GPL-2.0 WITH Cl
 maven/mavencentral/joda-time/joda-time/2.10.5, Apache-2.0, approved, clearlydefined
 maven/mavencentral/junit/junit/4.13.2, EPL-2.0, approved, CQ23636
 maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.1, Apache-2.0, approved, #7164
-maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.11, Apache-2.0, approved, #7164
+maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.12, Apache-2.0, approved, #7164
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.1, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.11, Apache-2.0 AND BSD-3-Clause, approved, #7163
+maven/mavencentral/net.bytebuddy/byte-buddy/1.14.12, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.java.dev.jna/jna/5.13.0, Apache-2.0 AND LGPL-2.1-or-later, approved, #6709
 maven/mavencentral/net.javacrumbs.json-unit/json-unit-core/2.36.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/net.minidev/accessors-smart/2.4.7, Apache-2.0, approved, #7515
@@ -321,8 +322,8 @@ maven/mavencentral/org.lz4/lz4-java/1.8.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.mock-server/mockserver-client-java/5.15.0, Apache-2.0 AND LGPL-3.0-only, approved, #9324
 maven/mavencentral/org.mock-server/mockserver-core/5.15.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.mock-server/mockserver-netty/5.15.0, Apache-2.0, approved, #9276
+maven/mavencentral/org.mockito/mockito-core/5.11.0, MIT AND (Apache-2.0 AND MIT) AND Apache-2.0, approved, #13505
 maven/mavencentral/org.mockito/mockito-core/5.2.0, MIT AND (Apache-2.0 AND MIT) AND Apache-2.0, approved, #7401
-maven/mavencentral/org.mockito/mockito-core/5.9.0, MIT AND (Apache-2.0 AND MIT) AND Apache-2.0, approved, #12774
 maven/mavencentral/org.mockito/mockito-inline/5.2.0, MIT, approved, clearlydefined
 maven/mavencentral/org.mozilla/rhino/1.7.7.2, MPL-2.0 AND BSD-3-Clause AND ISC, approved, CQ16320
 maven/mavencentral/org.objenesis/objenesis/3.3, Apache-2.0, approved, clearlydefined

--- a/core/data-plane-selector/data-plane-selector-core/src/main/java/org/eclipse/edc/connector/dataplane/selector/service/EmbeddedDataPlaneSelectorService.java
+++ b/core/data-plane-selector/data-plane-selector-core/src/main/java/org/eclipse/edc/connector/dataplane/selector/service/EmbeddedDataPlaneSelectorService.java
@@ -47,7 +47,7 @@ public class EmbeddedDataPlaneSelectorService implements DataPlaneSelectorServic
     }
 
     @Override
-    public DataPlaneInstance select(DataAddress source, DataAddress destination, String selectionStrategy) {
+    public DataPlaneInstance select(DataAddress source, DataAddress destination, String selectionStrategy, String transferType) {
         var strategy = selectionStrategyRegistry.find(selectionStrategy);
         if (strategy == null) {
             throw new IllegalArgumentException("Strategy " + selectionStrategy + " was not found");
@@ -55,7 +55,7 @@ public class EmbeddedDataPlaneSelectorService implements DataPlaneSelectorServic
 
         return transactionContext.execute(() -> {
             try (var stream = store.getAll()) {
-                var dataPlanes = stream.filter(dataPlane -> dataPlane.canHandle(source, destination)).toList();
+                var dataPlanes = stream.filter(dataPlane -> dataPlane.canHandle(source, destination, transferType)).toList();
                 return strategy.apply(dataPlanes);
             }
         });

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/DataplaneSelectorApiController.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/DataplaneSelectorApiController.java
@@ -68,7 +68,7 @@ public class DataplaneSelectorApiController implements DataplaneSelectorApi {
                 .orElseThrow(InvalidRequestException::new);
 
         var dpi = ofNullable(request.getStrategy())
-                .map(strategy -> catchException(() -> selectionService.select(request.getSource(), request.getDestination(), strategy)))
+                .map(strategy -> catchException(() -> selectionService.select(request.getSource(), request.getDestination(), strategy, request.getTransferType())))
                 .orElseGet(() -> catchException(() -> selectionService.select(request.getSource(), request.getDestination())));
 
         if (dpi == null) {

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/model/SelectionRequest.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/model/SelectionRequest.java
@@ -27,10 +27,13 @@ public class SelectionRequest {
     public static final String SELECTION_REQUEST_TYPE = EDC_NAMESPACE + "SelectionRequest";
     public static final String SOURCE_ADDRESS = EDC_NAMESPACE + "source";
     public static final String DEST_ADDRESS = EDC_NAMESPACE + "destination";
+    public static final String TRANSFER_TYPE = EDC_NAMESPACE + "transferType";
     public static final String STRATEGY = EDC_NAMESPACE + "strategy";
     private DataAddress source;
     private DataAddress destination;
     private String strategy;
+
+    private String transferType;
 
     private SelectionRequest() {
     }
@@ -47,6 +50,9 @@ public class SelectionRequest {
         return strategy;
     }
 
+    public String getTransferType() {
+        return transferType;
+    }
 
     public static final class Builder {
         private final SelectionRequest instance;
@@ -71,6 +77,11 @@ public class SelectionRequest {
 
         public Builder strategy(String strategy) {
             this.instance.strategy = strategy;
+            return this;
+        }
+
+        public Builder transferType(String transferType) {
+            this.instance.transferType = transferType;
             return this;
         }
 

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/schemas/DataPlaneInstanceSchema.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/schemas/DataPlaneInstanceSchema.java
@@ -52,7 +52,8 @@ public record DataPlaneInstanceSchema(
                     "source-type1",
                     "source-type2"
                 ],
-                "allowedDestTypes": ["your-dest-type"]
+                "allowedDestTypes": ["your-dest-type"],
+                "allowedTransferTypes": ["transfer-type"]
             }
             """;
 }

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/schemas/SelectionRequestSchema.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/schemas/SelectionRequestSchema.java
@@ -25,6 +25,7 @@ public record SelectionRequestSchema(
         @Schema(name = TYPE, example = SELECTION_REQUEST_TYPE)
         String type,
         String strategy,
+        String transferType,
         ManagementApiSchema.DataAddressSchema source,
         ManagementApiSchema.DataAddressSchema destination
 ) {
@@ -41,7 +42,8 @@ public record SelectionRequestSchema(
                     "@type": "https://w3id.org/edc/v0.0.1/ns/DataAddress",
                     "type": "test-dst2"
                 },
-                "strategy": "you_custom_strategy"
+                "strategy": "you_custom_strategy",
+                "transferType": "you_custom_transfer_type"
             }
             """;
 }

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/transformer/JsonObjectFromDataPlaneInstanceTransformer.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/transformer/JsonObjectFromDataPlaneInstanceTransformer.java
@@ -25,6 +25,7 @@ import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_DEST_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_SOURCE_TYPES;
+import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_TRANSFER_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.LAST_ACTIVE;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.PROPERTIES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.TURN_COUNT;
@@ -63,6 +64,9 @@ public class JsonObjectFromDataPlaneInstanceTransformer extends AbstractJsonLdTr
 
         var dstBldr = jsonFactory.createArrayBuilder(dataPlaneInstance.getAllowedDestTypes());
         builder.add(ALLOWED_DEST_TYPES, dstBldr);
+
+        var transferTypesBldr = jsonFactory.createArrayBuilder(dataPlaneInstance.getAllowedTransferTypes());
+        builder.add(ALLOWED_TRANSFER_TYPES, transferTypesBldr);
 
 
         return builder.build();

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/transformer/JsonObjectToDataPlaneInstanceTransformer.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/transformer/JsonObjectToDataPlaneInstanceTransformer.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_DEST_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_SOURCE_TYPES;
+import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_TRANSFER_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.Builder;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.LAST_ACTIVE;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.PROPERTIES;
@@ -70,6 +71,10 @@ public class JsonObjectToDataPlaneInstanceTransformer extends AbstractJsonLdTran
             case ALLOWED_SOURCE_TYPES -> {
                 var set = jsonValue.asJsonArray().stream().map(jv -> transformString(jv, context)).collect(Collectors.toSet());
                 builder.allowedSourceTypes(set);
+            }
+            case ALLOWED_TRANSFER_TYPES -> {
+                var set = jsonValue.asJsonArray().stream().map(jv -> transformString(jv, context)).collect(Collectors.toSet());
+                builder.allowedTransferType(set);
             }
             case PROPERTIES -> {
                 var props = jsonValue.asJsonArray().getJsonObject(0);

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/transformer/JsonObjectToSelectionRequestTransformer.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/transformer/JsonObjectToSelectionRequestTransformer.java
@@ -41,6 +41,7 @@ public class JsonObjectToSelectionRequestTransformer extends AbstractJsonLdTrans
                 case SelectionRequest.SOURCE_ADDRESS ->
                         builder.source(transformObject(jsonValue, DataAddress.class, context));
                 case SelectionRequest.STRATEGY -> builder.strategy(transformString(jsonValue, context));
+                case SelectionRequest.TRANSFER_TYPE -> builder.transferType(transformString(jsonValue, context));
                 default -> throw new IllegalStateException("Unexpected value: " + key);
             }
         });

--- a/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/api/DataPlaneApiSelectorTest.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/api/DataPlaneApiSelectorTest.java
@@ -66,6 +66,7 @@ public class DataPlaneApiSelectorTest {
                     assertThat(transformed.getUrl().toString()).isEqualTo("http://somewhere.com:1234/api/v1");
                     assertThat(transformed.getAllowedDestTypes()).containsExactlyInAnyOrder("your-dest-type");
                     assertThat(transformed.getAllowedSourceTypes()).containsExactlyInAnyOrder("source-type1", "source-type2");
+                    assertThat(transformed.getAllowedTransferTypes()).containsExactlyInAnyOrder("transfer-type");
                 });
     }
 
@@ -83,6 +84,7 @@ public class DataPlaneApiSelectorTest {
                     assertThat(transformed.getStrategy()).isNotBlank();
                     assertThat(transformed.getDestination()).isNotNull();
                     assertThat(transformed.getSource()).isNotNull();
+                    assertThat(transformed.getTransferType()).isNotNull();
                 });
     }
 

--- a/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/transformer/JsonObjectFromDataPlaneInstanceTransformerTest.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/transformer/JsonObjectFromDataPlaneInstanceTransformerTest.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_DEST_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_SOURCE_TYPES;
+import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_TRANSFER_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.LAST_ACTIVE;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.PROPERTIES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.TURN_COUNT;
@@ -51,6 +52,7 @@ class JsonObjectFromDataPlaneInstanceTransformerTest {
                 .url("http://foo.bar")
                 .allowedSourceType("test-source-type")
                 .allowedDestType("test-dest-type")
+                .allowedTransferType("test-transfer-type")
                 .lastActive(15)
                 .turnCount(42)
                 .property("foo", "bar")
@@ -63,6 +65,7 @@ class JsonObjectFromDataPlaneInstanceTransformerTest {
         assertThat(jsonObject.getString(URL)).isEqualTo("http://foo.bar");
         assertThat(jsonObject.getJsonArray(ALLOWED_SOURCE_TYPES)).hasSize(1).allMatch(v -> ((JsonString) v).getString().equals("test-source-type"));
         assertThat(jsonObject.getJsonArray(ALLOWED_DEST_TYPES)).hasSize(1).allMatch(v -> ((JsonString) v).getString().equals("test-dest-type"));
+        assertThat(jsonObject.getJsonArray(ALLOWED_TRANSFER_TYPES)).hasSize(1).allMatch(v -> ((JsonString) v).getString().equals("test-transfer-type"));
         assertThat(jsonObject.getJsonNumber(LAST_ACTIVE).intValue()).isEqualTo(15);
         assertThat(jsonObject.getJsonNumber(TURN_COUNT).intValue()).isEqualTo(42);
         assertThat(jsonObject.getJsonObject(PROPERTIES).getJsonString("foo").getString()).isEqualTo("bar");

--- a/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/transformer/JsonObjectToDataPlaneInstanceTransformerTest.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/transformer/JsonObjectToDataPlaneInstanceTransformerTest.java
@@ -32,6 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_DEST_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_SOURCE_TYPES;
+import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_TRANSFER_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.LAST_ACTIVE;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.TURN_COUNT;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.URL;
@@ -93,6 +94,28 @@ class JsonObjectToDataPlaneInstanceTransformerTest {
         var dpi = transformer.transform(expand(jsonObject), context);
         assertThat(dpi).isNotNull();
         assertThat(dpi.getProperties()).containsEntry(EDC_NAMESPACE + "publicApiUrl", "http://localhost/public");
+    }
+
+    @Test
+    void transform_withTransferTypes() {
+        var json = createObjectBuilder()
+                .add(ID, "test-id")
+                .add(URL, "http://somewhere.com:1234/api/v1")
+                .add(ALLOWED_SOURCE_TYPES, createArrayBuilder(Set.of("source1", "source2")))
+                .add(LAST_ACTIVE, 234L)
+                .add(TURN_COUNT, 42)
+                .add(ALLOWED_DEST_TYPES, createArrayBuilder(Set.of("dest1", "dest2")))
+                .add(ALLOWED_TRANSFER_TYPES, createArrayBuilder(Set.of("transfer1", "transfer2")))
+                .build();
+
+        var dpi = transformer.transform(expand(json), context);
+        assertThat(dpi).isNotNull();
+        assertThat(dpi.getUrl().toString()).isEqualTo("http://somewhere.com:1234/api/v1");
+        assertThat(dpi.getTurnCount()).isEqualTo(42);
+        assertThat(dpi.getLastActive()).isEqualTo(234L);
+        assertThat(dpi.getAllowedDestTypes()).hasSize(2).containsExactlyInAnyOrder("dest1", "dest2");
+        assertThat(dpi.getAllowedSourceTypes()).hasSize(2).containsExactlyInAnyOrder("source1", "source2");
+        assertThat(dpi.getAllowedTransferTypes()).hasSize(2).containsExactlyInAnyOrder("transfer1", "transfer2");
     }
 
     @Test

--- a/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/transformer/JsonObjectToSelectionRequestTransformerTest.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/transformer/JsonObjectToSelectionRequestTransformerTest.java
@@ -28,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.dataplane.selector.api.v2.model.SelectionRequest.DEST_ADDRESS;
 import static org.eclipse.edc.connector.dataplane.selector.api.v2.model.SelectionRequest.SOURCE_ADDRESS;
 import static org.eclipse.edc.connector.dataplane.selector.api.v2.model.SelectionRequest.STRATEGY;
+import static org.eclipse.edc.connector.dataplane.selector.api.v2.model.SelectionRequest.TRANSFER_TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
@@ -59,7 +60,8 @@ class JsonObjectToSelectionRequestTransformerTest {
                         .add(TYPE, DataAddress.EDC_DATA_ADDRESS_TYPE)
                         .add(DataAddress.EDC_DATA_ADDRESS_TYPE_PROPERTY, "test-type")
                         .add(DataAddress.EDC_DATA_ADDRESS_KEY_NAME, "test-key")
-                );
+                )
+                .add(TRANSFER_TYPE, "transfer-type");
         if (strategy != null) {
             builder.add(STRATEGY, strategy);
         }
@@ -70,6 +72,7 @@ class JsonObjectToSelectionRequestTransformerTest {
         assertThat(rq.getStrategy()).isEqualTo(strategy);
         assertThat(rq.getDestination()).isNotNull();
         assertThat(rq.getSource()).isNotNull();
+        assertThat(rq.getTransferType()).isEqualTo("transfer-type");
     }
 
 }

--- a/extensions/data-plane-selector/data-plane-selector-client/src/main/java/org/eclipse/edc/connector/dataplane/selector/RemoteDataPlaneSelectorService.java
+++ b/extensions/data-plane-selector/data-plane-selector-client/src/main/java/org/eclipse/edc/connector/dataplane/selector/RemoteDataPlaneSelectorService.java
@@ -85,7 +85,7 @@ public class RemoteDataPlaneSelectorService implements DataPlaneSelectorService 
     }
 
     @Override
-    public DataPlaneInstance select(DataAddress source, DataAddress destination, String selectionStrategy) {
+    public DataPlaneInstance select(DataAddress source, DataAddress destination, String selectionStrategy, String transferType) {
         var srcAddress = typeTransformerRegistry.transform(source, JsonObject.class).orElseThrow(f -> new EdcException(f.getFailureDetail()));
         var dstAddress = typeTransformerRegistry.transform(destination, JsonObject.class).orElseThrow(f -> new EdcException(f.getFailureDetail()));
         var jsonObject = Json.createObjectBuilder()
@@ -98,6 +98,10 @@ public class RemoteDataPlaneSelectorService implements DataPlaneSelectorService 
             jsonObject.add(EDC_NAMESPACE + "strategy", selectionStrategy);
         } else {
             jsonObject.add(EDC_NAMESPACE + "strategy", this.selectionStrategy);
+        }
+
+        if (transferType != null) {
+            jsonObject.add(EDC_NAMESPACE + "transferType", transferType);
         }
 
         var body = RequestBody.create(jsonObject.build().toString(), TYPE_JSON);

--- a/extensions/data-plane-selector/data-plane-selector-client/src/test/java/org/eclipse/edc/connector/dataplane/selector/RemoteDataPlaneSelectorServiceTest.java
+++ b/extensions/data-plane-selector/data-plane-selector-client/src/test/java/org/eclipse/edc/connector/dataplane/selector/RemoteDataPlaneSelectorServiceTest.java
@@ -47,6 +47,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.junit.testfixtures.TestUtils.testHttpClient;
 import static org.eclipse.edc.spi.CoreConstants.JSON_LD;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -94,6 +95,17 @@ class RemoteDataPlaneSelectorServiceTest extends RestControllerTestBase {
         when(SELECTOR_SERVICE_MOCK.select(any(), any())).thenReturn(expected);
 
         var result = service.select(DataAddress.Builder.newInstance().type("test1").build(), DataAddress.Builder.newInstance().type("test2").build());
+
+        assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+
+    }
+
+    @Test
+    void find_withTransferType() {
+        var expected = createInstance("some-instance");
+        when(SELECTOR_SERVICE_MOCK.select(any(), any(), eq("random"), eq("transferType"))).thenReturn(expected);
+
+        var result = service.select(DataAddress.Builder.newInstance().type("test1").build(), DataAddress.Builder.newInstance().type("test2").build(), "random", "transferType");
 
         assertThat(result).usingRecursiveComparison().isEqualTo(expected);
 

--- a/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/DataPlaneSelectorService.java
+++ b/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/DataPlaneSelectorService.java
@@ -18,6 +18,7 @@ import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstan
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
@@ -44,7 +45,16 @@ public interface DataPlaneSelectorService {
      * Selects the {@link DataPlaneInstance} that can handle a source and destination {@link DataAddress} using the passed
      * strategy.
      */
-    DataPlaneInstance select(DataAddress source, DataAddress destination, String selectionStrategy);
+    default DataPlaneInstance select(DataAddress source, DataAddress destination, String selectionStrategy) {
+        return select(source, destination, selectionStrategy, null);
+    }
+
+    /**
+     * Selects the {@link DataPlaneInstance} that can handle a source and destination {@link DataAddress} using the passed
+     * strategy and the optional transferType.
+     */
+    DataPlaneInstance select(DataAddress source, DataAddress destination, String selectionStrategy, @Nullable String transferType);
+    
 
     /**
      * Add a data plane instance

--- a/spi/data-plane-selector/data-plane-selector-spi/src/test/java/org/eclipse/edc/connector/dataplane/selector/spi/instance/DataPlaneInstanceTest.java
+++ b/spi/data-plane-selector/data-plane-selector-spi/src/test/java/org/eclipse/edc/connector/dataplane/selector/spi/instance/DataPlaneInstanceTest.java
@@ -91,6 +91,37 @@ class DataPlaneInstanceTest {
 
     }
 
+    @Test
+    void verifyCanHandle_withTransferType() throws MalformedURLException {
+        var srcType1 = "srcType1";
+        var srcType2 = "srcType1";
+        var destType1 = "destType1";
+        var destType2 = "destType2";
+        var transferType1 = "customTransferType1";
+        var transferType2 = "customTransferType2";
+
+        var inst = DataPlaneInstance.Builder.newInstance()
+                .id("test-id")
+                .url(new URL("http://localhost:8234/some/path"))
+                .allowedSourceType(srcType1)
+                .allowedSourceType(srcType2)
+                .allowedDestType(destType1)
+                .allowedDestType(destType2)
+                .allowedTransferType(transferType1)
+                .allowedTransferType(transferType2)
+                .build();
+
+        assertThat(inst.canHandle(createAddress(srcType1), createAddress(destType1), transferType1)).isTrue();
+        assertThat(inst.canHandle(createAddress(srcType1), createAddress(destType2), transferType1)).isTrue();
+        assertThat(inst.canHandle(createAddress(srcType2), createAddress(destType2), transferType2)).isTrue();
+        assertThat(inst.canHandle(createAddress(srcType2), createAddress(destType1), transferType2)).isTrue();
+        assertThat(inst.canHandle(createAddress(srcType2), createAddress("notexist"))).isFalse();
+        assertThat(inst.canHandle(createAddress("notexist"), createAddress(destType1))).isFalse();
+        assertThat(inst.canHandle(createAddress(srcType1), createAddress(destType1), "notexist")).isFalse();
+
+
+    }
+
     private DataAddress createAddress(String type) {
         return DataAddress.Builder.newInstance().type(type).build();
     }

--- a/spi/data-plane-selector/data-plane-selector-spi/src/testFixtures/java/org/eclipse/edc/connector/dataplane/selector/spi/testfixtures/TestFunctions.java
+++ b/spi/data-plane-selector/data-plane-selector-spi/src/testFixtures/java/org/eclipse/edc/connector/dataplane/selector/spi/testfixtures/TestFunctions.java
@@ -28,10 +28,13 @@ public class TestFunctions {
     }
 
     public static DataPlaneInstance createInstance(String id) {
+        return createInstanceBuilder(id).build();
+    }
+
+    public static DataPlaneInstance.Builder createInstanceBuilder(String id) {
         return DataPlaneInstance.Builder.newInstance()
                 .id(id)
-                .url("http://somewhere.com:1234/api/v1")
-                .build();
+                .url("http://somewhere.com:1234/api/v1");
     }
 
     public static DataPlaneInstance createCustomInstance(String id, String name) {

--- a/spi/data-plane-selector/data-plane-selector-spi/src/testFixtures/java/org/eclipse/edc/connector/dataplane/selector/spi/testfixtures/store/DataPlaneInstanceStoreTestBase.java
+++ b/spi/data-plane-selector/data-plane-selector-spi/src/testFixtures/java/org/eclipse/edc/connector/dataplane/selector/spi/testfixtures/store/DataPlaneInstanceStoreTestBase.java
@@ -35,6 +35,13 @@ public abstract class DataPlaneInstanceStoreTestBase {
     }
 
     @Test
+    void save_withAllowedTransferTypes() {
+        var inst = TestFunctions.createInstanceBuilder("test-id").allowedTransferType("transfer-type").build();
+        getStore().create(inst);
+        Assertions.assertThat(getStore().getAll()).usingRecursiveFieldByFieldElementComparator().containsExactly(inst);
+    }
+
+    @Test
     void save_whenExists_shouldNotUpsert() {
         var inst = TestFunctions.createInstance("test-id");
         getStore().create(inst);


### PR DESCRIPTION
## What this PR changes/adds

Introduces `allowedTransferTypes` in DataPlaneInstance.

A new `select` method has been added to `DataPlaneSelectorService` to support selection based also on the `transferType`. If it's  not present the behaviour will be as today only inspecting source/destination.

The current `DataFlowController`s don't use the `transferType` for selection. For the data plane signaling a new `DataFlowController` will be introduced #3901 that will take into account the `transferType` for dispatching the request to the right data plane.  

## Why it does that

enabling data plane signaling protocol for selecting the correct data plane instance

## Linked Issue(s)

Closes #3943 

