### PR TITLE
refactor(dsp): remove no more useful `withTarget` method

### DIFF
--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImpl.java
@@ -113,7 +113,7 @@ public class ContractValidationServiceImpl implements ContractValidationService 
             return failure("No offer found");
         }
 
-        if (!policyEquality.test(agreement.getPolicy().withTarget(latestOffer.getAssetId()), latestOffer.getPolicy())) {
+        if (!policyEquality.test(agreement.getPolicy(), latestOffer.getPolicy())) {
             return failure("Policy in the contract agreement is not equal to the one in the contract offer");
         }
 
@@ -149,7 +149,7 @@ public class ContractValidationServiceImpl implements ContractValidationService 
             return failure("Asset ID from the ContractOffer is not included in the ContractDefinition");
         }
 
-        var contractPolicy = consumerOffer.getContractPolicy().withTarget(consumerOffer.getOfferId().assetIdPart());
+        var contractPolicy = consumerOffer.getContractPolicy();
         return evaluatePolicy(contractPolicy, NEGOTIATION_SCOPE, agent, consumerOffer.getOfferId());
     }
 

--- a/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImplTest.java
+++ b/core/control-plane/contract-core/src/test/java/org/eclipse/edc/connector/contract/validation/ContractValidationServiceImplTest.java
@@ -108,7 +108,6 @@ class ContractValidationServiceImplTest {
 
         assertThat(result.succeeded()).isTrue();
         var validatedOffer = result.getContent().getOffer();
-        assertThat(validatedOffer.getPolicy()).isNotSameAs(originalPolicy); // verify the returned policy is the sanitized one
         assertThat(validatedOffer.getAssetId()).isEqualTo(asset.getId());
         assertThat(result.getContent().getConsumerIdentity()).isEqualTo(CONSUMER_ID); // verify the returned policy has the consumer id set, essential for later validation checks
 
@@ -405,21 +404,17 @@ class ContractValidationServiceImplTest {
                 .build();
     }
 
-    private ValidatableConsumerOffer createValidatableConsumerOffer(Asset asset, Policy policy) {
-        return createValidatableConsumerOffer(asset, policy, policy);
-    }
-
     private ValidatableConsumerOffer createValidatableConsumerOffer() {
         return createValidatableConsumerOffer(Asset.Builder.newInstance().build(), createPolicy());
     }
 
-    private ValidatableConsumerOffer createValidatableConsumerOffer(Asset asset, Policy accessPolicy, Policy contractPolicy) {
+    private ValidatableConsumerOffer createValidatableConsumerOffer(Asset asset, Policy policy) {
         var offerId = ContractOfferId.create("1", asset.getId());
         return ValidatableConsumerOffer.Builder.newInstance()
                 .offerId(offerId)
                 .contractDefinition(createContractDefinition())
-                .accessPolicy(accessPolicy)
-                .contractPolicy(contractPolicy)
+                .accessPolicy(policy)
+                .contractPolicy(policy)
                 .build();
     }
 

--- a/spi/common/policy-model/src/main/java/org/eclipse/edc/policy/model/Policy.java
+++ b/spi/common/policy-model/src/main/java/org/eclipse/edc/policy/model/Policy.java
@@ -107,26 +107,6 @@ public class Policy {
     }
 
     /**
-     * Returns a copy of this policy with the specified target.
-     *
-     * @param target the target.
-     * @return a copy with the specified target.
-     */
-    public Policy withTarget(String target) {
-        return Builder.newInstance()
-                .prohibitions(prohibitions)
-                .permissions(permissions)
-                .duties(obligations)
-                .assigner(assigner)
-                .assignee(assignee)
-                .inheritsFrom(inheritsFrom)
-                .type(type)
-                .extensibleProperties(extensibleProperties)
-                .target(target)
-                .build();
-    }
-
-    /**
      * A {@link Builder} initialized with the current policy.
      */
     public Builder toBuilder() {

--- a/spi/common/policy-model/src/test/java/org/eclipse/edc/policy/model/PolicyTest.java
+++ b/spi/common/policy-model/src/test/java/org/eclipse/edc/policy/model/PolicyTest.java
@@ -25,43 +25,35 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class PolicyTest {
 
-    @Test
-    void serializeDeserialize() throws JsonProcessingException {
-        var mapper = new ObjectMapper();
-
-        var permission = Permission.Builder.newInstance().action(Action.Builder.newInstance().type("use").build()).build();
-        var policy = Policy.Builder.newInstance().permission(permission).build();
-
-        var serialized = mapper.writeValueAsString(policy);
-        assertThat(mapper.readValue(serialized, Policy.class).getPermissions()).isNotEmpty();
-    }
+    private final ObjectMapper mapper = new ObjectMapper();
 
     @Test
-    void withTarget() {
+    void serDes() throws JsonProcessingException {
         var target = "target-id";
         var permission = Permission.Builder.newInstance().action(Action.Builder.newInstance().type("use").build()).build();
-        var prohibition = Prohibition.Builder.newInstance().action(Action.Builder.newInstance().type("MODIFY").build()).build();
-        var duty = Duty.Builder.newInstance().action(Action.Builder.newInstance().type("DELETE").build()).build();
+        var prohibition = Prohibition.Builder.newInstance().action(Action.Builder.newInstance().type("modify").build()).build();
+        var duty = Duty.Builder.newInstance().action(Action.Builder.newInstance().type("delete").build()).build();
         var policy = Policy.Builder.newInstance()
                 .permission(permission)
                 .prohibition(prohibition)
                 .duty(duty)
                 .assigner("assigner")
                 .assignee("assignee")
-                .inheritsFrom("inheritsFroms")
+                .inheritsFrom("inheritsFrom")
                 .type(PolicyType.SET)
                 .extensibleProperties(new HashMap<>())
+                .target(target)
                 .build();
 
-        var copy = policy.withTarget(target);
+        var deserialized = mapper.readValue(mapper.writeValueAsString(policy), Policy.class);
 
-        assertThat(copy.getPermissions().size()).isEqualTo(policy.getPermissions().size());
-        assertThat(copy.getAssigner()).isEqualTo(policy.getAssigner());
-        assertThat(copy.getAssignee()).isEqualTo(policy.getAssignee());
-        assertThat(copy.getInheritsFrom()).isEqualTo(policy.getInheritsFrom());
-        assertThat(copy.getType()).isEqualTo(policy.getType());
-        assertThat(copy.getExtensibleProperties()).isEqualTo(policy.getExtensibleProperties());
-        assertThat(copy.getTarget()).isEqualTo(target);
+        assertThat(deserialized.getPermissions().size()).isEqualTo(policy.getPermissions().size());
+        assertThat(deserialized.getAssigner()).isEqualTo(policy.getAssigner());
+        assertThat(deserialized.getAssignee()).isEqualTo(policy.getAssignee());
+        assertThat(deserialized.getInheritsFrom()).isEqualTo(policy.getInheritsFrom());
+        assertThat(deserialized.getType()).isEqualTo(policy.getType());
+        assertThat(deserialized.getExtensibleProperties()).isEqualTo(policy.getExtensibleProperties());
+        assertThat(deserialized.getTarget()).isEqualTo(target);
     }
 
 }


### PR DESCRIPTION
## What this PR changes/adds

Remove the `withTarget` method that's not useful anymore because now the scope of the `target` field has been set correctly:
- it's not used to check policy equality because `odrl:Set` policy does not have a target defined and `odrl:Offer` has it
- there's no point in setting target to `contractOffer` because it already has a target because on an `odrl:Offer` it is mandatory

## Why it does that

cleanup

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Still part of #3872 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
