### PR TITLE
feat: store additional properties with the AccessTokenData

### DIFF
--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/iam/DataPlaneAuthorizationServiceImpl.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/iam/DataPlaneAuthorizationServiceImpl.java
@@ -30,6 +30,7 @@ import java.time.Clock;
 import java.util.Map;
 import java.util.UUID;
 
+import static java.util.stream.Collectors.toMap;
 import static org.eclipse.edc.spi.result.Result.success;
 
 public class DataPlaneAuthorizationServiceImpl implements DataPlaneAuthorizationService {
@@ -59,7 +60,9 @@ public class DataPlaneAuthorizationServiceImpl implements DataPlaneAuthorization
     public Result<DataAddress> createEndpointDataReference(DataFlowStartMessage message) {
         var endpoint = endpointGenerator.generateFor(message.getSourceDataAddress());
 
-        return endpoint.compose(e -> accessTokenService.obtainToken(createTokenParams(message), message.getSourceDataAddress()))
+        var additionalProperties = message.getProperties().entrySet().stream().collect(toMap(Map.Entry::getKey, entry -> (Object) entry.getValue()));
+        
+        return endpoint.compose(e -> accessTokenService.obtainToken(createTokenParams(message), message.getSourceDataAddress(), additionalProperties))
                 .compose(tokenRepresentation -> createDataAddress(tokenRepresentation, endpoint.getContent()));
     }
 

--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/iam/DefaultDataPlaneAccessTokenServiceImpl.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/iam/DefaultDataPlaneAccessTokenServiceImpl.java
@@ -75,7 +75,7 @@ public class DefaultDataPlaneAccessTokenServiceImpl implements DataPlaneAccessTo
      *
      * @param parameters          Headers and claims that are to be included in the token. If the claims do <em>not</em> contain a "jti" claim, one is generated randomly and inserted into the claims.
      * @param backendDataAddress  Information about the data resource for which the token is to be generated. May contain additional information about the token, such as an {@code authType}
-     * @param additionalTokenData Additional data that further characterizes the token, but should not be included in the resulting {@link TokenRepresentation}.
+     * @param additionalTokenData Additional data that further characterizes the token, but should not be included in the resulting {@link TokenRepresentation}. Will be persisted in the {@link AccessTokenDataStore}.
      * @return A token representation in serialized JWT format (signed). The JWTs "kid" header contains the ID of the public key that can be used to verify the token.
      */
     @Override

--- a/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/iam/DataPlaneAuthorizationServiceImplTest.java
+++ b/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/iam/DataPlaneAuthorizationServiceImplTest.java
@@ -64,7 +64,7 @@ class DataPlaneAuthorizationServiceImplTest {
 
     @Test
     void createEndpointDataReference() {
-        when(accessTokenService.obtainToken(any(), any(), Map.of())).thenReturn(Result.success(TokenRepresentation.Builder.newInstance().token("footoken").build()));
+        when(accessTokenService.obtainToken(any(), any(), anyMap())).thenReturn(Result.success(TokenRepresentation.Builder.newInstance().token("footoken").build()));
         var startMsg = createStartMessage().build();
 
         var result = authorizationService.createEndpointDataReference(startMsg);
@@ -89,7 +89,7 @@ class DataPlaneAuthorizationServiceImplTest {
 
     @Test
     void createEndpointDataReference_withAuthType() {
-        when(accessTokenService.obtainToken(any(), any(), Map.of())).thenReturn(Result.success(TokenRepresentation.Builder.newInstance()
+        when(accessTokenService.obtainToken(any(), any(), anyMap())).thenReturn(Result.success(TokenRepresentation.Builder.newInstance()
                 .token("footoken")
                 .additional(Map.of("authType", "bearer", "fizz", "buzz"))
                 .build()));
@@ -108,7 +108,7 @@ class DataPlaneAuthorizationServiceImplTest {
 
     @Test
     void createEndpointDataReference_tokenServiceFails() {
-        when(accessTokenService.obtainToken(any(), any(), Map.of())).thenReturn(Result.failure("test-failure"));
+        when(accessTokenService.obtainToken(any(), any(), anyMap())).thenReturn(Result.failure("test-failure"));
         var startMsg = createStartMessage().build();
         assertThat(authorizationService.createEndpointDataReference(startMsg)).isFailed()
                 .detail().isEqualTo("test-failure");

--- a/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/iam/DataPlaneAuthorizationServiceImplTest.java
+++ b/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/iam/DataPlaneAuthorizationServiceImplTest.java
@@ -41,6 +41,7 @@ import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.ISSUER;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.JWT_ID;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.SUBJECT;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -63,7 +64,7 @@ class DataPlaneAuthorizationServiceImplTest {
 
     @Test
     void createEndpointDataReference() {
-        when(accessTokenService.obtainToken(any(), any())).thenReturn(Result.success(TokenRepresentation.Builder.newInstance().token("footoken").build()));
+        when(accessTokenService.obtainToken(any(), any(), Map.of())).thenReturn(Result.success(TokenRepresentation.Builder.newInstance().token("footoken").build()));
         var startMsg = createStartMessage().build();
 
         var result = authorizationService.createEndpointDataReference(startMsg);
@@ -82,13 +83,13 @@ class DataPlaneAuthorizationServiceImplTest {
             assertThat(tp.getStringClaim(ISSUER)).isEqualTo(OWN_PARTICIPANT_ID);
             assertThat(tp.getStringClaim(SUBJECT)).isEqualTo(OWN_PARTICIPANT_ID);
             assertThat(tp.getClaims().get(ISSUED_AT)).isNotNull();
-        }), any());
+        }), any(), anyMap());
     }
 
 
     @Test
     void createEndpointDataReference_withAuthType() {
-        when(accessTokenService.obtainToken(any(), any())).thenReturn(Result.success(TokenRepresentation.Builder.newInstance()
+        when(accessTokenService.obtainToken(any(), any(), Map.of())).thenReturn(Result.success(TokenRepresentation.Builder.newInstance()
                 .token("footoken")
                 .additional(Map.of("authType", "bearer", "fizz", "buzz"))
                 .build()));
@@ -107,7 +108,7 @@ class DataPlaneAuthorizationServiceImplTest {
 
     @Test
     void createEndpointDataReference_tokenServiceFails() {
-        when(accessTokenService.obtainToken(any(), any())).thenReturn(Result.failure("test-failure"));
+        when(accessTokenService.obtainToken(any(), any(), Map.of())).thenReturn(Result.failure("test-failure"));
         var startMsg = createStartMessage().build();
         assertThat(authorizationService.createEndpointDataReference(startMsg)).isFailed()
                 .detail().isEqualTo("test-failure");

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/iam/DataPlaneAccessTokenService.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/iam/DataPlaneAccessTokenService.java
@@ -38,7 +38,7 @@ public interface DataPlaneAccessTokenService {
      *
      * @param parameters          Headers and claims that are to be included in the token.
      * @param backendDataAddress  Information about the backend data resource for which the token is to be generated. May contain additional information about the token, such as an {@code authType}
-     * @param additionalTokenData
+     * @param additionalTokenData Additional data that further characterizes the token, but should not be included in the resulting {@link TokenRepresentation}.
      * @return The token representation
      */
     Result<TokenRepresentation> obtainToken(TokenParameters parameters, DataAddress backendDataAddress, Map<String, Object> additionalTokenData);

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/iam/DataPlaneAccessTokenService.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/iam/DataPlaneAccessTokenService.java
@@ -21,6 +21,8 @@ import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 
+import java.util.Map;
+
 /**
  * This service serves as facility to both create and validate access tokens.
  */
@@ -34,11 +36,12 @@ public interface DataPlaneAccessTokenService {
      * <p>
      * Common patterns include encoding that information directly in the token, or storing that information in a separate store and correlating it with the token ID.
      *
-     * @param parameters Headers and claims that are to be included in the token.
-     * @param backendDataAddress    Information about the backend data resource for which the token is to be generated. May contain additional information about the token, such as an {@code authType}
+     * @param parameters          Headers and claims that are to be included in the token.
+     * @param backendDataAddress  Information about the backend data resource for which the token is to be generated. May contain additional information about the token, such as an {@code authType}
+     * @param additionalTokenData
      * @return The token representation
      */
-    Result<TokenRepresentation> obtainToken(TokenParameters parameters, DataAddress backendDataAddress);
+    Result<TokenRepresentation> obtainToken(TokenParameters parameters, DataAddress backendDataAddress, Map<String, Object> additionalTokenData);
 
     /**
      * Takes a token and restores from it the original information that was used to create the token, most notably claims ({@link org.eclipse.edc.spi.iam.ClaimToken})


### PR DESCRIPTION
## What this PR changes/adds

This PR adds a feature that reads all of the `DataFlowStartMessage#properties` and stores them in the `AccessTokenData#additionalProperties` field.

## Why it does that

When generating access tokens, we may need to store additional information, such as participant aliases etc. that should _not_ end up in the token itself.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
