### PR TITLE
fix: typo in odrl:neq operator

### DIFF
--- a/extensions/common/json-ld/src/main/resources/document/odrl.jsonld
+++ b/extensions/common/json-ld/src/main/resources/document/odrl.jsonld
@@ -182,7 +182,7 @@
     "gteq":                 "odrl:gteq",
     "lt":                   "odrl:lt",
     "lteq":                 "odrl:lteq",
-    "neq":                  "odrl:neg",
+    "neq":                  "odrl:neq",
     "isA":                  "odrl:isA",
     "hasPart":              "odrl:hasPart",
     "isPartOf":             "odrl:isPartOf",


### PR DESCRIPTION
## What this PR changes/adds

Adds the correct value with regards to the standard https://www.w3.org/TR/odrl-vocab/#constraintRelationalOperators :octocat: 🎉 

## Linked Issue(s)

Closes #3976 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
