### PR TITLE
feat: EDR (data address) and metadata storage/cache

### DIFF
--- a/core/common/edr-store-core/build.gradle.kts
+++ b/core/common/edr-store-core/build.gradle.kts
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+    `maven-publish`
+}
+
+dependencies {
+    api(project(":spi:common:edr-store-spi"))
+    implementation(project(":core:common:connector-core"))
+
+    testImplementation(project(":core:common:junit"))
+    testImplementation(testFixtures(project(":spi:common:edr-store-spi")))
+}

--- a/core/common/edr-store-core/src/main/java/org/eclipse/edc/core/edr/EndpointDataReferenceStoreDefaultServicesExtension.java
+++ b/core/common/edr-store-core/src/main/java/org/eclipse/edc/core/edr/EndpointDataReferenceStoreDefaultServicesExtension.java
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.core.edr;
+
+import org.eclipse.edc.core.edr.defaults.InMemoryEndpointDataReferenceEntryIndex;
+import org.eclipse.edc.core.edr.defaults.VaultEndpointDataReferenceCache;
+import org.eclipse.edc.edr.spi.store.EndpointDataReferenceCache;
+import org.eclipse.edc.edr.spi.store.EndpointDataReferenceEntryIndex;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.spi.query.CriterionOperatorRegistry;
+import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+
+import static org.eclipse.edc.core.edr.EndpointDataReferenceStoreExtension.NAME;
+
+@Extension(NAME)
+public class EndpointDataReferenceStoreDefaultServicesExtension implements ServiceExtension {
+
+    public static final String DEFAULT_EDR_VAULT_PATH = "";
+    @Setting(value = "Directory/Path where to store EDRs in the vault for vaults that supports hierarchical structuring.", defaultValue = DEFAULT_EDR_VAULT_PATH)
+    public static final String EDC_EDR_VAULT_PATH = "edc.edr.vault.path";
+    protected static final String NAME = "Endpoint Data Reference Core Default Services Extension";
+    @Inject
+    private EndpointDataReferenceEntryIndex edrEntryStore;
+
+    @Inject
+    private EndpointDataReferenceCache edrCache;
+
+    @Inject
+    private CriterionOperatorRegistry criterionOperatorRegistry;
+
+    @Inject
+    private Vault vault;
+
+    @Inject
+    private TypeManager typeManager;
+
+
+    @Provider(isDefault = true)
+    public EndpointDataReferenceCache endpointDataReferenceCache(ServiceExtensionContext context) {
+        var vaultDirectory = context.getConfig().getString(EDC_EDR_VAULT_PATH, DEFAULT_EDR_VAULT_PATH);
+        return new VaultEndpointDataReferenceCache(vault, vaultDirectory, typeManager.getMapper());
+    }
+
+    @Provider(isDefault = true)
+    public EndpointDataReferenceEntryIndex endpointDataReferenceEntryStore() {
+        return new InMemoryEndpointDataReferenceEntryIndex(criterionOperatorRegistry);
+    }
+}

--- a/core/common/edr-store-core/src/main/java/org/eclipse/edc/core/edr/EndpointDataReferenceStoreExtension.java
+++ b/core/common/edr-store-core/src/main/java/org/eclipse/edc/core/edr/EndpointDataReferenceStoreExtension.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.core.edr;
+
+import org.eclipse.edc.core.edr.store.EndpointDataReferenceStoreImpl;
+import org.eclipse.edc.edr.spi.store.EndpointDataReferenceCache;
+import org.eclipse.edc.edr.spi.store.EndpointDataReferenceEntryIndex;
+import org.eclipse.edc.edr.spi.store.EndpointDataReferenceStore;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+
+import static org.eclipse.edc.core.edr.EndpointDataReferenceStoreExtension.NAME;
+
+@Extension(NAME)
+public class EndpointDataReferenceStoreExtension implements ServiceExtension {
+
+    protected static final String NAME = "Endpoint Data Reference Core Extension";
+
+    @Inject
+    private EndpointDataReferenceEntryIndex edrIndex;
+
+    @Inject
+    private EndpointDataReferenceCache edrCache;
+
+    @Inject
+    private TransactionContext transactionContext;
+
+    @Provider
+    public EndpointDataReferenceStore endpointDataReferenceService() {
+        return new EndpointDataReferenceStoreImpl(edrIndex, edrCache, transactionContext);
+    }
+}

--- a/core/common/edr-store-core/src/main/java/org/eclipse/edc/core/edr/defaults/InMemoryEndpointDataReferenceEntryIndex.java
+++ b/core/common/edr-store-core/src/main/java/org/eclipse/edc/core/edr/defaults/InMemoryEndpointDataReferenceEntryIndex.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.core.edr.defaults;
+
+import org.eclipse.edc.connector.core.store.ReflectionBasedQueryResolver;
+import org.eclipse.edc.edr.spi.store.EndpointDataReferenceEntryIndex;
+import org.eclipse.edc.edr.spi.types.EndpointDataReferenceEntry;
+import org.eclipse.edc.spi.query.CriterionOperatorRegistry;
+import org.eclipse.edc.spi.query.QueryResolver;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.StoreResult;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+/**
+ * In memory implementation of {@link EndpointDataReferenceEntryIndex}
+ */
+public class InMemoryEndpointDataReferenceEntryIndex implements EndpointDataReferenceEntryIndex {
+
+    private final QueryResolver<EndpointDataReferenceEntry> queryResolver;
+    private final Map<String, EndpointDataReferenceEntry> cache = new ConcurrentHashMap<>();
+
+    public InMemoryEndpointDataReferenceEntryIndex(CriterionOperatorRegistry criterionOperatorRegistry) {
+        queryResolver = new ReflectionBasedQueryResolver<>(EndpointDataReferenceEntry.class, criterionOperatorRegistry);
+    }
+
+    @Override
+    public StoreResult<List<EndpointDataReferenceEntry>> query(QuerySpec spec) {
+        return StoreResult.success(queryResolver.query(cache.values().stream(), spec).collect(Collectors.toList()));
+    }
+
+    @Override
+    public StoreResult<Void> save(EndpointDataReferenceEntry entry) {
+        cache.put(entry.getTransferProcessId(), entry);
+        return StoreResult.success();
+    }
+
+    @Override
+    public StoreResult<EndpointDataReferenceEntry> delete(String transferProcessId) {
+        return Optional.ofNullable(cache.remove(transferProcessId))
+                .map(StoreResult::success)
+                .orElse(StoreResult.notFound("EDR entry not found for transfer process %s".formatted(transferProcessId)));
+    }
+}

--- a/core/common/edr-store-core/src/main/java/org/eclipse/edc/core/edr/defaults/VaultEndpointDataReferenceCache.java
+++ b/core/common/edr-store-core/src/main/java/org/eclipse/edc/core/edr/defaults/VaultEndpointDataReferenceCache.java
@@ -1,0 +1,92 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.core.edr.defaults;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.edc.edr.spi.store.EndpointDataReferenceCache;
+import org.eclipse.edc.spi.persistence.EdcPersistenceException;
+import org.eclipse.edc.spi.result.StoreResult;
+import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+
+import java.util.Optional;
+
+/**
+ * Vault implementation of {@link EndpointDataReferenceCache}
+ */
+public class VaultEndpointDataReferenceCache implements EndpointDataReferenceCache {
+
+    public static final String SEPARATOR = "--";
+    public static final String VAULT_PREFIX = "edr" + SEPARATOR;
+
+    private final Vault vault;
+    private final String vaultPath;
+
+    private final ObjectMapper objectMapper;
+
+    public VaultEndpointDataReferenceCache(Vault vault, String vaultPath, ObjectMapper objectMapper) {
+        this.vault = vault;
+        this.vaultPath = vaultPath;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public StoreResult<DataAddress> get(String transferProcessId) {
+        var key = toKey(transferProcessId);
+        return Optional.ofNullable(vault.resolveSecret(key))
+                .map(this::fromJson)
+                .map(StoreResult::success)
+                .orElse(StoreResult.notFound("EDR not found in the vault for transfer process: %s".formatted(transferProcessId)));
+    }
+
+    @Override
+    public StoreResult<Void> put(String transferProcessId, DataAddress edr) {
+        var result = vault.storeSecret(toKey(transferProcessId), toJson(edr));
+        if (result.failed()) {
+            return StoreResult.generalError(result.getFailureDetail());
+        }
+        return StoreResult.success();
+    }
+
+    @Override
+    public StoreResult<Void> delete(String transferProcessId) {
+        var result = vault.deleteSecret(toKey(transferProcessId));
+        if (result.failed()) {
+            return StoreResult.generalError(result.getFailureDetail());
+        }
+        return StoreResult.success();
+    }
+
+    private String toJson(DataAddress dataAddress) {
+        try {
+            return objectMapper.writeValueAsString(dataAddress);
+        } catch (JsonProcessingException e) {
+            throw new EdcPersistenceException(e);
+        }
+    }
+
+    private DataAddress fromJson(String dataAddress) {
+        try {
+            return objectMapper.readValue(dataAddress, DataAddress.class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String toKey(String transferProcessId) {
+        return vaultPath + VAULT_PREFIX + transferProcessId;
+    }
+}

--- a/core/common/edr-store-core/src/main/java/org/eclipse/edc/core/edr/store/EndpointDataReferenceStoreImpl.java
+++ b/core/common/edr-store-core/src/main/java/org/eclipse/edc/core/edr/store/EndpointDataReferenceStoreImpl.java
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.core.edr.store;
+
+import org.eclipse.edc.edr.spi.store.EndpointDataReferenceCache;
+import org.eclipse.edc.edr.spi.store.EndpointDataReferenceEntryIndex;
+import org.eclipse.edc.edr.spi.store.EndpointDataReferenceStore;
+import org.eclipse.edc.edr.spi.types.EndpointDataReferenceEntry;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.StoreResult;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+
+import java.util.List;
+
+/**
+ * Default implementation of {@link EndpointDataReferenceStore}. It makes usage of two subcomponents
+ * The metadata storage {@link EndpointDataReferenceEntryIndex} and the EDR cache {@link EndpointDataReferenceCache}
+ * and coordinate the interaction between then for fulfilling the {@link EndpointDataReferenceStore} interface
+ */
+public class EndpointDataReferenceStoreImpl implements EndpointDataReferenceStore {
+
+    private final EndpointDataReferenceEntryIndex dataReferenceEntryIndex;
+    private final EndpointDataReferenceCache dataReferenceCache;
+    private final TransactionContext transactionalContext;
+
+    public EndpointDataReferenceStoreImpl(EndpointDataReferenceEntryIndex dataReferenceEntryIndex, EndpointDataReferenceCache dataReferenceCache, TransactionContext transactionalContext) {
+        this.dataReferenceEntryIndex = dataReferenceEntryIndex;
+        this.dataReferenceCache = dataReferenceCache;
+        this.transactionalContext = transactionalContext;
+    }
+
+    @Override
+    public StoreResult<DataAddress> resolveByTransferProcess(String transferProcessId) {
+        return transactionalContext.execute(() -> dataReferenceCache.get(transferProcessId));
+    }
+
+    @Override
+    public StoreResult<List<EndpointDataReferenceEntry>> query(QuerySpec querySpec) {
+        return transactionalContext.execute(() -> dataReferenceEntryIndex.query(querySpec));
+    }
+
+    @Override
+    public StoreResult<EndpointDataReferenceEntry> delete(String transferProcessId) {
+        return transactionalContext.execute(() -> dataReferenceCache.delete(transferProcessId)
+                .compose((i) -> dataReferenceEntryIndex.delete(transferProcessId)));
+    }
+
+    @Override
+    public StoreResult<Void> save(EndpointDataReferenceEntry entry, DataAddress dataAddress) {
+        return transactionalContext.execute(() -> dataReferenceCache.put(entry.getTransferProcessId(), dataAddress)
+                .compose(i -> dataReferenceEntryIndex.save(entry)));
+    }
+}

--- a/core/common/edr-store-core/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/core/common/edr-store-core/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,16 @@
+#
+#  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+#
+#
+
+
+org.eclipse.edc.core.edr.EndpointDataReferenceStoreExtension

--- a/core/common/edr-store-core/src/test/java/org/eclipse/edc/core/edr/EndpointDataReferenceStoreDefaultServicesExtensionTest.java
+++ b/core/common/edr-store-core/src/test/java/org/eclipse/edc/core/edr/EndpointDataReferenceStoreDefaultServicesExtensionTest.java
@@ -1,0 +1,87 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.core.edr;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.edc.core.edr.defaults.InMemoryEndpointDataReferenceEntryIndex;
+import org.eclipse.edc.core.edr.defaults.VaultEndpointDataReferenceCache;
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.system.configuration.Config;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.core.edr.EndpointDataReferenceStoreDefaultServicesExtension.EDC_EDR_VAULT_PATH;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(DependencyInjectionExtension.class)
+public class EndpointDataReferenceStoreDefaultServicesExtensionTest {
+
+    private final Vault vault = mock();
+
+    private final TypeManager typeManager = mock();
+
+    @BeforeEach
+    void setUp(ServiceExtensionContext context) {
+        context.registerService(Vault.class, vault);
+        context.registerService(TypeManager.class, typeManager);
+    }
+
+    @Test
+    void initializeTheCache(ServiceExtensionContext context, EndpointDataReferenceStoreDefaultServicesExtension extension) {
+
+        var cache = extension.endpointDataReferenceCache(context);
+
+        assertThat(cache).isInstanceOf(VaultEndpointDataReferenceCache.class);
+    }
+
+    @Test
+    void initializeTheCache_withPath(ServiceExtensionContext context, EndpointDataReferenceStoreDefaultServicesExtension extension) {
+        var config = mock(Config.class);
+        when(context.getConfig()).thenReturn(config);
+        when(config.getString(eq(EDC_EDR_VAULT_PATH), any())).thenReturn("path/");
+        when(typeManager.getMapper()).thenReturn(new ObjectMapper());
+
+        var cache = extension.endpointDataReferenceCache(context);
+
+        when(vault.storeSecret(any(), any())).thenReturn(Result.success());
+
+        assertThat(cache).isInstanceOf(VaultEndpointDataReferenceCache.class);
+
+        cache.put("id", DataAddress.Builder.newInstance().type("type").build());
+
+        verify(vault).storeSecret(argThat(s -> s.startsWith("path/")), any());
+    }
+
+    @Test
+    void initializeTheStore(ServiceExtensionContext context, EndpointDataReferenceStoreDefaultServicesExtension extension) {
+
+        var store = extension.endpointDataReferenceEntryStore();
+
+        assertThat(store).isInstanceOf(InMemoryEndpointDataReferenceEntryIndex.class);
+    }
+
+}

--- a/core/common/edr-store-core/src/test/java/org/eclipse/edc/core/edr/EndpointDataReferenceStoreExtensionTest.java
+++ b/core/common/edr-store-core/src/test/java/org/eclipse/edc/core/edr/EndpointDataReferenceStoreExtensionTest.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.core.edr;
+
+import org.eclipse.edc.core.edr.store.EndpointDataReferenceStoreImpl;
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(DependencyInjectionExtension.class)
+public class EndpointDataReferenceStoreExtensionTest {
+
+    @Test
+    void shouldInitializeTheService(EndpointDataReferenceStoreExtension extension) {
+
+        var cache = extension.endpointDataReferenceService();
+
+        assertThat(cache).isInstanceOf(EndpointDataReferenceStoreImpl.class);
+    }
+}

--- a/core/common/edr-store-core/src/test/java/org/eclipse/edc/core/edr/defaults/InMemoryEndpointDataReferenceEntryStoreTest.java
+++ b/core/common/edr-store-core/src/test/java/org/eclipse/edc/core/edr/defaults/InMemoryEndpointDataReferenceEntryStoreTest.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.core.edr.defaults;
+
+import org.eclipse.edc.connector.core.store.CriterionOperatorRegistryImpl;
+import org.eclipse.edc.edr.spi.store.EndpointDataReferenceEntryIndex;
+import org.eclipse.tractusx.edc.edr.spi.store.EndpointDataReferenceEntryIndexTestBase;
+
+public class InMemoryEndpointDataReferenceEntryStoreTest extends EndpointDataReferenceEntryIndexTestBase {
+
+    private final InMemoryEndpointDataReferenceEntryIndex store = new InMemoryEndpointDataReferenceEntryIndex(CriterionOperatorRegistryImpl.ofDefaults());
+
+    @Override
+    protected EndpointDataReferenceEntryIndex getStore() {
+        return store;
+    }
+}

--- a/core/common/edr-store-core/src/test/java/org/eclipse/edc/core/edr/defaults/VaultEndpointDataReferenceCacheTest.java
+++ b/core/common/edr-store-core/src/test/java/org/eclipse/edc/core/edr/defaults/VaultEndpointDataReferenceCacheTest.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.core.edr.defaults;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.edc.connector.core.vault.InMemoryVault;
+import org.eclipse.edc.edr.spi.store.EndpointDataReferenceCache;
+import org.eclipse.tractusx.edc.edr.spi.store.EndpointDataReferenceCacheTestBase;
+
+import static org.mockito.Mockito.mock;
+
+public class VaultEndpointDataReferenceCacheTest extends EndpointDataReferenceCacheTestBase {
+
+    private final VaultEndpointDataReferenceCache cache = new VaultEndpointDataReferenceCache(new InMemoryVault(mock()), "", new ObjectMapper());
+
+    @Override
+    protected EndpointDataReferenceCache getCache() {
+        return cache;
+    }
+}

--- a/core/common/edr-store-core/src/test/java/org/eclipse/edc/core/edr/store/EndpointDataReferenceStoreImplTest.java
+++ b/core/common/edr-store-core/src/test/java/org/eclipse/edc/core/edr/store/EndpointDataReferenceStoreImplTest.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.core.edr.store;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.edc.connector.core.store.CriterionOperatorRegistryImpl;
+import org.eclipse.edc.connector.core.vault.InMemoryVault;
+import org.eclipse.edc.core.edr.defaults.InMemoryEndpointDataReferenceEntryIndex;
+import org.eclipse.edc.core.edr.defaults.VaultEndpointDataReferenceCache;
+import org.eclipse.edc.edr.spi.store.EndpointDataReferenceStore;
+import org.eclipse.edc.transaction.spi.NoopTransactionContext;
+import org.eclipse.tractusx.edc.edr.spi.store.EndpointDataReferenceStoreTestBase;
+
+import static org.mockito.Mockito.mock;
+
+public class EndpointDataReferenceStoreImplTest extends EndpointDataReferenceStoreTestBase {
+
+    private final InMemoryEndpointDataReferenceEntryIndex store = new InMemoryEndpointDataReferenceEntryIndex(CriterionOperatorRegistryImpl.ofDefaults());
+    private final VaultEndpointDataReferenceCache cache = new VaultEndpointDataReferenceCache(new InMemoryVault(mock()), "", new ObjectMapper());
+    private final EndpointDataReferenceStoreImpl endpointDataReferenceService = new EndpointDataReferenceStoreImpl(store, cache, new NoopTransactionContext());
+    
+    @Override
+    protected EndpointDataReferenceStore getStore() {
+        return endpointDataReferenceService;
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -53,6 +53,7 @@ include(":core:common:transform-core")
 include(":core:common:transform-dspace")
 include(":core:common:validator-core")
 include(":core:common:util")
+include(":core:common:edr-store-core")
 
 include(":core:control-plane:catalog-core")
 include(":core:control-plane:contract-core")
@@ -66,6 +67,7 @@ include(":core:data-plane:data-plane-core")
 include(":core:data-plane-selector:data-plane-selector-core")
 
 include(":core:policy-monitor:policy-monitor-core")
+
 
 // modules that provide implementations for data ingress/egress ------------------------------------
 include(":data-protocols:dsp:dsp-api-configuration")
@@ -220,6 +222,7 @@ include(":spi:common:validator-spi")
 include(":spi:common:web-spi")
 include(":spi:common:identity-trust-spi")
 include(":spi:common:identity-trust-sts-spi")
+include(":spi:common:edr-store-spi")
 
 
 include(":spi:control-plane:asset-spi")

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/StoreFailure.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/StoreFailure.java
@@ -30,6 +30,6 @@ public class StoreFailure extends Failure {
     }
 
     public enum Reason {
-        NOT_FOUND, ALREADY_EXISTS, DUPLICATE_KEYS, ALREADY_LEASED
+        NOT_FOUND, ALREADY_EXISTS, DUPLICATE_KEYS, ALREADY_LEASED, GENERAL_ERROR
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/StoreResult.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/result/StoreResult.java
@@ -23,6 +23,7 @@ import java.util.List;
 import static org.eclipse.edc.spi.result.StoreFailure.Reason.ALREADY_EXISTS;
 import static org.eclipse.edc.spi.result.StoreFailure.Reason.ALREADY_LEASED;
 import static org.eclipse.edc.spi.result.StoreFailure.Reason.DUPLICATE_KEYS;
+import static org.eclipse.edc.spi.result.StoreFailure.Reason.GENERAL_ERROR;
 import static org.eclipse.edc.spi.result.StoreFailure.Reason.NOT_FOUND;
 
 /**
@@ -50,6 +51,10 @@ public class StoreResult<T> extends AbstractResult<T, StoreFailure, StoreResult<
 
     public static <T> StoreResult<T> duplicateKeys(String message) {
         return new StoreResult<>(null, new StoreFailure(List.of(message), DUPLICATE_KEYS));
+    }
+
+    public static <T> StoreResult<T> generalError(String message) {
+        return new StoreResult<>(null, new StoreFailure(List.of(message), GENERAL_ERROR));
     }
 
     public static <T> StoreResult<T> success() {

--- a/spi/common/edr-store-spi/build.gradle.kts
+++ b/spi/common/edr-store-spi/build.gradle.kts
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+    `java-test-fixtures`
+}
+
+dependencies {
+    api(project(":spi:common:core-spi"))
+    api(project(":spi:common:transaction-spi"))
+    
+    // needed by the abstract test spec located in testFixtures
+    testFixturesImplementation(libs.bundles.jupiter)
+    testFixturesImplementation(libs.mockito.core)
+    testFixturesImplementation(libs.assertj)
+    testFixturesImplementation(project(":core:common:junit"))
+    testFixturesRuntimeOnly(libs.junit.jupiter.engine)
+}
+
+

--- a/spi/common/edr-store-spi/src/main/java/org/eclipse/edc/edr/spi/store/EndpointDataReferenceCache.java
+++ b/spi/common/edr-store-spi/src/main/java/org/eclipse/edc/edr/spi/store/EndpointDataReferenceCache.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.edr.spi.store;
+
+import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
+import org.eclipse.edc.spi.result.StoreResult;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+
+/**
+ * Client side Cache for {@link DataAddress} associated to a transfer process in PULL scenario
+ */
+@ExtensionPoint
+public interface EndpointDataReferenceCache {
+
+    /**
+     * Resolves an {@link DataAddress} for the transfer process
+     *
+     * @param transferProcessId The id of the transfer process
+     * @return The {@link DataAddress} if found, failure otherwise
+     */
+    StoreResult<DataAddress> get(String transferProcessId);
+
+    /**
+     * Caches a {@link DataAddress} for a transfer process
+     *
+     * @param transferProcessId The id of the transfer process
+     * @param edr               The {@link DataAddress} to cache
+     * @return success if cached correctly, failure otherwise
+     */
+    StoreResult<Void> put(String transferProcessId, DataAddress edr);
+
+    /**
+     * Deletes a {@link DataAddress} from the cache
+     *
+     * @param transferProcessId The id of the transfer process
+     * @return success if deleted correctly, failure otherwise
+     */
+    StoreResult<Void> delete(String transferProcessId);
+
+}

--- a/spi/common/edr-store-spi/src/main/java/org/eclipse/edc/edr/spi/store/EndpointDataReferenceEntryIndex.java
+++ b/spi/common/edr-store-spi/src/main/java/org/eclipse/edc/edr/spi/store/EndpointDataReferenceEntryIndex.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.edr.spi.store;
+
+import org.eclipse.edc.edr.spi.types.EndpointDataReferenceEntry;
+import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.StoreResult;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+
+import java.util.List;
+
+/**
+ * Stores and queries metadata {@link EndpointDataReferenceEntry} associated with an EDR ({@link DataAddress})
+ */
+@ExtensionPoint
+public interface EndpointDataReferenceEntryIndex {
+
+    /**
+     * Returns all the EDR entries in the store that are covered by a given {@link QuerySpec}.
+     *
+     * @param querySpec The {@link QuerySpec}
+     * @return success with the matched {@link EndpointDataReferenceEntry}s
+     */
+    StoreResult<List<EndpointDataReferenceEntry>> query(QuerySpec querySpec);
+
+    /**
+     * Saves an {@link EndpointDataReferenceEntry}.
+     *
+     * @param entry The {@link EndpointDataReferenceEntry} to store
+     * @return success if saved correctly, failure otherwise
+     */
+    StoreResult<Void> save(EndpointDataReferenceEntry entry);
+
+    /**
+     * Deletes an {@link EndpointDataReferenceEntry} by the transfer process id.
+     *
+     * @param transferProcessId The id of the transfer process
+     * @return success with the deleted {@link EndpointDataReferenceEntry}, failure if some error happens
+     */
+    StoreResult<EndpointDataReferenceEntry> delete(String transferProcessId);
+
+}

--- a/spi/common/edr-store-spi/src/main/java/org/eclipse/edc/edr/spi/store/EndpointDataReferenceStore.java
+++ b/spi/common/edr-store-spi/src/main/java/org/eclipse/edc/edr/spi/store/EndpointDataReferenceStore.java
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.edr.spi.store;
+
+import org.eclipse.edc.edr.spi.types.EndpointDataReferenceEntry;
+import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.StoreResult;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+
+import java.util.List;
+
+/**
+ * Stores and retrieves {@link DataAddress} and {@link EndpointDataReferenceEntry}.
+ * in the underlying storage/cache. Implementors of {@link EndpointDataReferenceStore}
+ * can decide to split the storage in two parts by using {@link EndpointDataReferenceCache} for caching
+ * the actual EDRs in a secured environment and {@link EndpointDataReferenceEntryIndex} for storing the associated metadata.
+ */
+@ExtensionPoint
+public interface EndpointDataReferenceStore {
+
+    /**
+     * Return a {@link DataAddress} associated with the transferProcessId in input
+     *
+     * @param transferProcessId The transferProcessId
+     * @return The result containing the {@link DataAddress}
+     */
+    StoreResult<DataAddress> resolveByTransferProcess(String transferProcessId);
+
+    /**
+     * Returns all the EDR entries in the store that are covered by a given {@link QuerySpec}.
+     *
+     * @param querySpec The {@link QuerySpec}
+     * @return success with the matched {@link EndpointDataReferenceEntry}s, failure if some error happens
+     */
+    StoreResult<List<EndpointDataReferenceEntry>> query(QuerySpec querySpec);
+
+    /**
+     * Deletes an {@link EndpointDataReferenceEntry} by the transfer process id.
+     *
+     * @param transferProcessId The id of the transfer process
+     * @return success with the deleted {@link EndpointDataReferenceEntry}, failure if some error happens
+     */
+    StoreResult<EndpointDataReferenceEntry> delete(String transferProcessId);
+
+    /**
+     * Saves an {@link EndpointDataReferenceEntry} and the associated {@link DataAddress} .
+     *
+     * @param entry       The {@link EndpointDataReferenceEntry} to store
+     * @param dataAddress The {@link DataAddress} to store
+     * @return success if saved correctly, failure otherwise
+     */
+    StoreResult<Void> save(EndpointDataReferenceEntry entry, DataAddress dataAddress);
+}

--- a/spi/common/edr-store-spi/src/main/java/org/eclipse/edc/edr/spi/types/EndpointDataReferenceEntry.java
+++ b/spi/common/edr-store-spi/src/main/java/org/eclipse/edc/edr/spi/types/EndpointDataReferenceEntry.java
@@ -1,0 +1,118 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.edr.spi.types;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import static java.util.Objects.requireNonNull;
+import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
+
+/**
+ * Represents metadata associated with an EDR
+ */
+public class EndpointDataReferenceEntry {
+
+    public static final String SIMPLE_TYPE = "EndpointDataReferenceEntry";
+    public static final String EDR_ENTRY_TYPE = EDC_NAMESPACE + SIMPLE_TYPE;
+
+    public static final String ASSET_ID = "assetId";
+    public static final String EDR_ENTRY_ASSET_ID = EDC_NAMESPACE + ASSET_ID;
+    public static final String AGREEMENT_ID = "agreementId";
+    public static final String EDR_ENTRY_AGREEMENT_ID = EDC_NAMESPACE + AGREEMENT_ID;
+    public static final String CONTRACT_NEGOTIATION_ID = "contractNegotiationId";
+    public static final String EDR_ENTRY_CONTRACT_NEGOTIATION_ID = EDC_NAMESPACE + CONTRACT_NEGOTIATION_ID;
+
+    public static final String TRANSFER_PROCESS_ID = "transferProcessId";
+    public static final String EDR_ENTRY_TRANSFER_PROCESS_ID = EDC_NAMESPACE + TRANSFER_PROCESS_ID;
+    public static final String PROVIDER_ID = "providerId";
+    public static final String EDR_ENTRY_PROVIDER_ID = EDC_NAMESPACE + PROVIDER_ID;
+    private String assetId;
+    private String agreementId;
+    private String transferProcessId;
+    private String contractNegotiationId;
+    private String providerId;
+
+    private EndpointDataReferenceEntry() {
+    }
+
+
+    public String getAgreementId() {
+        return agreementId;
+    }
+
+    public String getTransferProcessId() {
+        return transferProcessId;
+    }
+
+    public String getProviderId() {
+        return providerId;
+    }
+
+    public String getContractNegotiationId() {
+        return contractNegotiationId;
+    }
+
+    public String getAssetId() {
+        return assetId;
+    }
+
+    public static class Builder {
+
+        private final EndpointDataReferenceEntry entry;
+
+        private Builder() {
+            entry = new EndpointDataReferenceEntry();
+        }
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder assetId(String assetId) {
+            entry.assetId = assetId;
+            return this;
+        }
+
+        public Builder agreementId(String agreementId) {
+            entry.agreementId = agreementId;
+            return this;
+        }
+
+        public Builder transferProcessId(String transferProcessId) {
+            entry.transferProcessId = transferProcessId;
+            return this;
+        }
+
+        public Builder providerId(String providerId) {
+            entry.providerId = providerId;
+            return this;
+        }
+
+        public Builder contractNegotiationId(String contractNegotiationId) {
+            entry.contractNegotiationId = contractNegotiationId;
+            return this;
+        }
+
+        public EndpointDataReferenceEntry build() {
+            requireNonNull(entry.assetId, ASSET_ID);
+            requireNonNull(entry.agreementId, AGREEMENT_ID);
+            requireNonNull(entry.transferProcessId, TRANSFER_PROCESS_ID);
+            requireNonNull(entry.contractNegotiationId, TRANSFER_PROCESS_ID);
+            requireNonNull(entry.providerId, TRANSFER_PROCESS_ID);
+            return entry;
+        }
+    }
+}

--- a/spi/common/edr-store-spi/src/testFixtures/java/org/eclipse/tractusx/edc/edr/spi/TestFunctions.java
+++ b/spi/common/edr-store-spi/src/testFixtures/java/org/eclipse/tractusx/edc/edr/spi/TestFunctions.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.tractusx.edc.edr.spi;
+
+
+import org.eclipse.edc.edr.spi.types.EndpointDataReferenceEntry;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+
+import java.util.UUID;
+
+public class TestFunctions {
+
+    public static EndpointDataReferenceEntry edrEntry(String assetId, String agreementId, String transferProcessId, String contractNegotiationId) {
+        return EndpointDataReferenceEntry.Builder.newInstance()
+                .assetId(assetId)
+                .agreementId(agreementId)
+                .transferProcessId(transferProcessId)
+                .providerId(UUID.randomUUID().toString())
+                .contractNegotiationId(contractNegotiationId)
+                .build();
+    }
+
+    public static EndpointDataReferenceEntry edrEntry() {
+        return edrEntry("assetId", "agreementId", "transferProcessId", "contractNegotiationId");
+    }
+
+    public static DataAddress dataAddress() {
+        return DataAddress.Builder.newInstance().type("test").build();
+    }
+
+}

--- a/spi/common/edr-store-spi/src/testFixtures/java/org/eclipse/tractusx/edc/edr/spi/store/EndpointDataReferenceCacheTestBase.java
+++ b/spi/common/edr-store-spi/src/testFixtures/java/org/eclipse/tractusx/edc/edr/spi/store/EndpointDataReferenceCacheTestBase.java
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.tractusx.edc.edr.spi.store;
+
+import org.eclipse.edc.edr.spi.store.EndpointDataReferenceCache;
+import org.eclipse.edc.junit.assertions.AbstractResultAssert;
+import org.eclipse.edc.spi.result.StoreFailure;
+import org.eclipse.edc.spi.result.StoreResult;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.junit.jupiter.api.Test;
+
+import static java.util.UUID.randomUUID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.tractusx.edc.edr.spi.TestFunctions.edrEntry;
+
+/**
+ * Default test suite for {@link EndpointDataReferenceCache} implementors
+ */
+public abstract class EndpointDataReferenceCacheTestBase {
+
+    @Test
+    void put() {
+        var tpId = "tp1";
+        var assetId = "asset1";
+        var dataAddress = dataAddress();
+        var entry = edrEntry(assetId, randomUUID().toString(), tpId, randomUUID().toString());
+
+        getCache().put(entry.getTransferProcessId(), dataAddress);
+
+        AbstractResultAssert.assertThat(getCache().get(tpId))
+                .isSucceeded()
+                .usingRecursiveComparison()
+                .isEqualTo(dataAddress);
+
+    }
+
+    @Test
+    void delete_shouldDelete_WhenFound() {
+
+        var entry = edrEntry("assetId", "agreementId", "tpId", "cnId");
+        getCache().put(entry.getTransferProcessId(), DataAddress.Builder.newInstance().type("test").build());
+
+        AbstractResultAssert.assertThat(getCache().delete(entry.getTransferProcessId())).isSucceeded();
+
+        AbstractResultAssert.assertThat(getCache().get("tpId")).isFailed();
+
+    }
+
+    @Test
+    void delete_shouldReturnError_whenNotFound() {
+        assertThat(getCache().delete("notFound"))
+                .extracting(StoreResult::reason)
+                .isEqualTo(StoreFailure.Reason.GENERAL_ERROR);
+    }
+
+    protected abstract EndpointDataReferenceCache getCache();
+
+    private DataAddress dataAddress() {
+        return DataAddress.Builder.newInstance().type("test").build();
+    }
+
+
+}

--- a/spi/common/edr-store-spi/src/testFixtures/java/org/eclipse/tractusx/edc/edr/spi/store/EndpointDataReferenceEntryIndexTestBase.java
+++ b/spi/common/edr-store-spi/src/testFixtures/java/org/eclipse/tractusx/edc/edr/spi/store/EndpointDataReferenceEntryIndexTestBase.java
@@ -1,0 +1,143 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.tractusx.edc.edr.spi.store;
+
+import org.eclipse.edc.edr.spi.store.EndpointDataReferenceEntryIndex;
+import org.eclipse.edc.edr.spi.types.EndpointDataReferenceEntry;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.StoreFailure;
+import org.eclipse.edc.spi.result.StoreResult;
+import org.junit.jupiter.api.Test;
+
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static java.util.UUID.randomUUID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.tractusx.edc.edr.spi.TestFunctions.edrEntry;
+
+/**
+ * Default test suite for {@link EndpointDataReferenceEntryIndex} implementors
+ */
+public abstract class EndpointDataReferenceEntryIndexTestBase {
+
+    @Test
+    void save() {
+
+        var tpId = "tp1";
+        var assetId = "asset1";
+
+        var entry = edrEntry(assetId, randomUUID().toString(), tpId, randomUUID().toString());
+
+        getStore().save(entry);
+
+        var results = getStore().query(QuerySpec.max());
+
+        assertThat(results.succeeded()).isTrue();
+        assertThat(results.getContent()).hasSize(1)
+                .first()
+                .isNotNull()
+                .extracting(EndpointDataReferenceEntry::getTransferProcessId)
+                .isEqualTo(tpId);
+
+    }
+
+    @Test
+    void query_noQuerySpec() {
+        var all = IntStream.range(0, 10)
+                .mapToObj(i -> edrEntry("assetId" + i, "agreementId" + i, "tpId" + i, "cnId" + i))
+                .peek(entry -> getStore().save(entry))
+                .collect(Collectors.toList());
+
+        var results = getStore().query(QuerySpec.max());
+
+        assertThat(results.succeeded()).isTrue();
+        assertThat(results.getContent()).containsExactlyInAnyOrderElementsOf(all);
+
+    }
+
+    @Test
+    void query_assetIdQuerySpec() {
+        IntStream.range(0, 10)
+                .mapToObj(i -> edrEntry("assetId" + i, "agreementId" + i, "tpId" + i, "cnId" + i))
+                .forEach(entry -> getStore().save(entry));
+
+        var entry = edrEntry("assetId", "agreementId", "tpId", "cnId");
+        getStore().save(entry);
+
+        var filter = Criterion.Builder.newInstance()
+                .operandLeft("assetId")
+                .operator("=")
+                .operandRight(entry.getAssetId())
+                .build();
+
+        var results = getStore().query(QuerySpec.Builder.newInstance().filter(filter).build());
+
+        assertThat(results.succeeded()).isTrue();
+        assertThat(results.getContent()).containsOnly(entry);
+
+    }
+
+    @Test
+    void query_agreementIdQuerySpec() {
+        IntStream.range(0, 10)
+                .mapToObj(i -> edrEntry("assetId" + i, "agreementId" + i, "tpId" + i, "cnId" + i))
+                .forEach(entry -> getStore().save(entry));
+
+
+        var entry = edrEntry("assetId", "agreementId", "tpId", "cnId");
+        getStore().save(entry);
+
+        var filter = Criterion.Builder.newInstance()
+                .operandLeft("agreementId")
+                .operator("=")
+                .operandRight(entry.getAgreementId())
+                .build();
+
+        var results = getStore().query(QuerySpec.Builder.newInstance().filter(filter).build());
+
+        assertThat(results.succeeded()).isTrue();
+        assertThat(results.getContent()).containsOnly(entry);
+
+    }
+    
+    @Test
+    void delete_shouldDelete_WhenFound() {
+
+        var entry = edrEntry("assetId", "agreementId", "tpId", "cnId");
+        getStore().save(entry);
+
+        assertThat(getStore().delete(entry.getTransferProcessId()))
+                .extracting(StoreResult::getContent)
+                .isEqualTo(entry);
+
+        var results = getStore().query(QuerySpec.max());
+
+        assertThat(results.succeeded()).isTrue();
+        assertThat(results.getContent()).hasSize(0);
+
+    }
+
+    @Test
+    void deleteX_shouldReturnError_whenNotFound() {
+        assertThat(getStore().delete("notFound"))
+                .extracting(StoreResult::reason)
+                .isEqualTo(StoreFailure.Reason.NOT_FOUND);
+    }
+
+    protected abstract EndpointDataReferenceEntryIndex getStore();
+
+}

--- a/spi/common/edr-store-spi/src/testFixtures/java/org/eclipse/tractusx/edc/edr/spi/store/EndpointDataReferenceStoreTestBase.java
+++ b/spi/common/edr-store-spi/src/testFixtures/java/org/eclipse/tractusx/edc/edr/spi/store/EndpointDataReferenceStoreTestBase.java
@@ -1,0 +1,143 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.tractusx.edc.edr.spi.store;
+
+import org.eclipse.edc.edr.spi.store.EndpointDataReferenceStore;
+import org.eclipse.edc.edr.spi.types.EndpointDataReferenceEntry;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.StoreResult;
+import org.junit.jupiter.api.Test;
+
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static java.util.UUID.randomUUID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.spi.result.StoreFailure.Reason.GENERAL_ERROR;
+import static org.eclipse.tractusx.edc.edr.spi.TestFunctions.dataAddress;
+import static org.eclipse.tractusx.edc.edr.spi.TestFunctions.edrEntry;
+
+/**
+ * Default test suite for {@link EndpointDataReferenceStore} implementors
+ */
+public abstract class EndpointDataReferenceStoreTestBase {
+
+    @Test
+    void save() {
+
+        var tpId = "tp1";
+        var assetId = "asset1";
+
+        var entry = edrEntry(assetId, randomUUID().toString(), tpId, randomUUID().toString());
+
+        getStore().save(entry, dataAddress());
+
+        var result = getStore().query(QuerySpec.max());
+        assertThat(result.succeeded()).isTrue();
+        assertThat(result.getContent())
+                .first()
+                .isNotNull()
+                .extracting(EndpointDataReferenceEntry::getTransferProcessId)
+                .isEqualTo(tpId);
+
+
+        assertThat(getStore().resolveByTransferProcess(tpId)).extracting(StoreResult::getContent)
+                .isNotNull();
+    }
+
+    @Test
+    void query_noQuerySpec() {
+        var all = IntStream.range(0, 10)
+                .mapToObj(i -> edrEntry("assetId" + i, "agreementId" + i, "tpId" + i, "cnId" + i))
+                .peek(entry -> getStore().save(entry, dataAddress()))
+                .collect(Collectors.toList());
+
+
+        var result = getStore().query(QuerySpec.none());
+        assertThat(result.succeeded()).isTrue();
+        assertThat(result.getContent()).containsExactlyInAnyOrderElementsOf(all);
+
+    }
+
+    @Test
+    void query_assetIdQuerySpec() {
+        IntStream.range(0, 10)
+                .mapToObj(i -> edrEntry("assetId" + i, "agreementId" + i, "tpId" + i, "cnId" + i))
+                .forEach(entry -> getStore().save(entry, dataAddress()));
+
+        var entry = edrEntry("assetId", "agreementId", "tpId", "cnId");
+        getStore().save(entry, dataAddress());
+
+        var filter = Criterion.Builder.newInstance()
+                .operandLeft("assetId")
+                .operator("=")
+                .operandRight(entry.getAssetId())
+                .build();
+
+        var result = getStore().query(QuerySpec.Builder.newInstance().filter(filter).build());
+        assertThat(result.succeeded()).isTrue();
+        assertThat(result.getContent()).containsOnly(entry);
+    }
+
+    @Test
+    void query_agreementIdQuerySpec() {
+        IntStream.range(0, 10)
+                .mapToObj(i -> edrEntry("assetId" + i, "agreementId" + i, "tpId" + i, "cnId" + i))
+                .forEach(entry -> getStore().save(entry, dataAddress()));
+
+
+        var entry = edrEntry("assetId", "agreementId", "tpId", "cnId");
+        getStore().save(entry, dataAddress());
+
+        var filter = Criterion.Builder.newInstance()
+                .operandLeft("agreementId")
+                .operator("=")
+                .operandRight(entry.getAgreementId())
+                .build();
+
+
+        var result = getStore().query(QuerySpec.Builder.newInstance().filter(filter).build());
+        assertThat(result.succeeded()).isTrue();
+        assertThat(result.getContent()).containsOnly(entry);
+    }
+
+    @Test
+    void delete_shouldDelete_WhenFound() {
+
+        var entry = edrEntry("assetId", "agreementId", "tpId", "cnId");
+        getStore().save(entry, dataAddress());
+
+        assertThat(getStore().delete(entry.getTransferProcessId()))
+                .extracting(StoreResult::getContent)
+                .isEqualTo(entry);
+
+        var result = getStore().query(QuerySpec.max());
+
+        assertThat(result.succeeded()).isTrue();
+        assertThat(result.getContent()).hasSize(0);
+
+    }
+
+    @Test
+    void deleteX_shouldReturnError_whenNotFound() {
+        assertThat(getStore().delete("notFound"))
+                .extracting(StoreResult::reason)
+                .isEqualTo(GENERAL_ERROR);
+    }
+
+    protected abstract EndpointDataReferenceStore getStore();
+
+}


### PR DESCRIPTION
## What this PR changes/adds

Introduces an EDR (dataaddress) cache and associated metadata storage:

- introduced `edr-store-spi` module
- introduced `edr-store-core` module with default implementations

In the `spi` three extensible interface are introduced:

- `EndpointDataReferenceStore`: the main entry point for storing and retrieving EDR and metadata associated
- `EndpointDataReferenceCache` subcomponent for caching EDR (DataAddress) in a secured environment
- `EndpointDataReferenceEntryIndex` subcomponent for storing EDR metadata (assetId, agreementId, ..etc)

The default implementation of `EndpointDataReferenceStore` uses the two subcomponents for dealing with EDR and metadata. 

A default implementation of `EndpointDataReferenceCache` backed by the `Vault` is provider as well as an in memory one for the metadata storage `EndpointDataReferenceEntryIndex`

## Why it does that

data plane signaling, user experience

## Linked Issue(s)

Closes #3973 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
