### PR TITLE
refactor: make resource manifest generator handle TransferProcess

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -81,7 +81,7 @@ maven/mavencentral/com.lmax/disruptor/3.4.4, Apache-2.0, approved, clearlydefine
 maven/mavencentral/com.networknt/json-schema-validator/1.0.76, Apache-2.0, approved, CQ22638
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.28, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.37.3, Apache-2.0, approved, #11701
-maven/mavencentral/com.puppycrawl.tools/checkstyle/10.14.0, , restricted, clearlydefined
+maven/mavencentral/com.puppycrawl.tools/checkstyle/10.14.0, LGPL-2.1-or-later AND (Apache-2.0 AND LGPL-2.1-or-later) AND Apache-2.0, approved, #13562
 maven/mavencentral/com.samskivert/jmustache/1.15, BSD-2-Clause, approved, clearlydefined
 maven/mavencentral/com.squareup.okhttp3/okhttp-dnsoverhttps/4.12.0, Apache-2.0, approved, #11159
 maven/mavencentral/com.squareup.okhttp3/okhttp/4.12.0, Apache-2.0, approved, #11156
@@ -214,7 +214,7 @@ maven/mavencentral/org.apache.httpcomponents/httpclient/4.5.13, Apache-2.0 AND L
 maven/mavencentral/org.apache.httpcomponents/httpcore/4.4.13, Apache-2.0, approved, CQ23528
 maven/mavencentral/org.apache.httpcomponents/httpcore/4.4.14, Apache-2.0, approved, CQ23528
 maven/mavencentral/org.apache.httpcomponents/httpmime/4.5.13, Apache-2.0, approved, CQ11718
-maven/mavencentral/org.apache.kafka/kafka-clients/3.7.0, , restricted, clearlydefined
+maven/mavencentral/org.apache.kafka/kafka-clients/3.7.0, Apache-2.0 AND (Apache-2.0 AND MIT) AND (Apache-2.0 AND BSD-3-Clause), approved, #13623
 maven/mavencentral/org.apache.maven.doxia/doxia-core/1.12.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.maven.doxia/doxia-logging-api/1.12.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.maven.doxia/doxia-module-xdoc/1.12.0, Apache-2.0, approved, clearlydefined

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImpl.java
@@ -192,7 +192,7 @@ public class TransferProcessManagerImpl extends AbstractStateEntityManager<Trans
 
         ResourceManifest manifest;
         if (process.getType() == CONSUMER) {
-            var manifestResult = manifestGenerator.generateConsumerResourceManifest(process.getDataRequest(), policy);
+            var manifestResult = manifestGenerator.generateConsumerResourceManifest(process, policy);
             if (manifestResult.failed()) {
                 transitionToTerminated(process, format("Resource manifest for process %s cannot be modified to fulfil policy. %s", process.getId(), manifestResult.getFailureMessages()));
                 return true;
@@ -214,7 +214,7 @@ public class TransferProcessManagerImpl extends AbstractStateEntityManager<Trans
                 vault.storeSecret(dataDestination.getKeyName(), secret);
             }
 
-            manifest = manifestGenerator.generateProviderResourceManifest(process.getDataRequest(), dataAddress, policy);
+            manifest = manifestGenerator.generateProviderResourceManifest(process, dataAddress, policy);
         }
 
         process.transitionProvisioning(manifest);

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/provision/ResourceManifestGeneratorImpl.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/provision/ResourceManifestGeneratorImpl.java
@@ -58,11 +58,9 @@ public class ResourceManifestGeneratorImpl implements ResourceManifestGenerator 
 
     @Override
     public Result<ResourceManifest> generateConsumerResourceManifest(TransferProcess transferProcess, Policy policy) {
-        var dataRequest = transferProcess.getDataRequest();
-
         var definitions = consumerGenerators.stream()
-                .filter(generator -> generator.canGenerate(dataRequest, policy))
-                .map(generator -> generator.generate(dataRequest, policy))
+                .filter(generator -> generator.canGenerate(transferProcess, policy))
+                .map(generator -> generator.generate(transferProcess, policy))
                 .filter(Objects::nonNull).collect(Collectors.toList());
 
         var manifest = ResourceManifest.Builder.newInstance().definitions(definitions).build();
@@ -81,10 +79,9 @@ public class ResourceManifestGeneratorImpl implements ResourceManifestGenerator 
 
     @Override
     public ResourceManifest generateProviderResourceManifest(TransferProcess transferProcess, DataAddress assetAddress, Policy policy) {
-        var dataRequest = transferProcess.getDataRequest();
         var definitions = providerGenerators.stream()
-                .filter(generator -> generator.canGenerate(dataRequest, assetAddress, policy))
-                .map(generator -> generator.generate(dataRequest, assetAddress, policy))
+                .filter(generator -> generator.canGenerate(transferProcess, assetAddress, policy))
+                .map(generator -> generator.generate(transferProcess, assetAddress, policy))
                 .filter(Objects::nonNull).collect(Collectors.toList());
 
         return ResourceManifest.Builder.newInstance().definitions(definitions).build();

--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/provision/ResourceManifestGeneratorImpl.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/provision/ResourceManifestGeneratorImpl.java
@@ -19,8 +19,8 @@ import org.eclipse.edc.connector.transfer.spi.provision.ConsumerResourceDefiniti
 import org.eclipse.edc.connector.transfer.spi.provision.ProviderResourceDefinitionGenerator;
 import org.eclipse.edc.connector.transfer.spi.provision.ResourceManifestContext;
 import org.eclipse.edc.connector.transfer.spi.provision.ResourceManifestGenerator;
-import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
 import org.eclipse.edc.connector.transfer.spi.types.ResourceManifest;
+import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.policy.engine.spi.PolicyContext;
 import org.eclipse.edc.policy.engine.spi.PolicyContextImpl;
 import org.eclipse.edc.policy.engine.spi.PolicyEngine;
@@ -37,6 +37,7 @@ import java.util.stream.Collectors;
  * Default implementation.
  */
 public class ResourceManifestGeneratorImpl implements ResourceManifestGenerator {
+
     private final List<ConsumerResourceDefinitionGenerator> consumerGenerators = new ArrayList<>();
     private final List<ProviderResourceDefinitionGenerator> providerGenerators = new ArrayList<>();
     private final PolicyEngine policyEngine;
@@ -56,7 +57,9 @@ public class ResourceManifestGeneratorImpl implements ResourceManifestGenerator 
     }
 
     @Override
-    public Result<ResourceManifest> generateConsumerResourceManifest(DataRequest dataRequest, Policy policy) {
+    public Result<ResourceManifest> generateConsumerResourceManifest(TransferProcess transferProcess, Policy policy) {
+        var dataRequest = transferProcess.getDataRequest();
+
         var definitions = consumerGenerators.stream()
                 .filter(generator -> generator.canGenerate(dataRequest, policy))
                 .map(generator -> generator.generate(dataRequest, policy))
@@ -77,7 +80,8 @@ public class ResourceManifestGeneratorImpl implements ResourceManifestGenerator 
     }
 
     @Override
-    public ResourceManifest generateProviderResourceManifest(DataRequest dataRequest, DataAddress assetAddress, Policy policy) {
+    public ResourceManifest generateProviderResourceManifest(TransferProcess transferProcess, DataAddress assetAddress, Policy policy) {
+        var dataRequest = transferProcess.getDataRequest();
         var definitions = providerGenerators.stream()
                 .filter(generator -> generator.canGenerate(dataRequest, assetAddress, policy))
                 .map(generator -> generator.generate(dataRequest, assetAddress, policy))

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImplIntegrationTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImplIntegrationTest.java
@@ -103,7 +103,7 @@ class TransferProcessManagerImplIntegrationTest {
     @BeforeEach
     void setup() {
         var resourceManifest = ResourceManifest.Builder.newInstance().definitions(List.of(new TestResourceDefinition())).build();
-        when(manifestGenerator.generateConsumerResourceManifest(any(DataRequest.class), any(Policy.class))).thenReturn(Result.success(resourceManifest));
+        when(manifestGenerator.generateConsumerResourceManifest(any(TransferProcess.class), any(Policy.class))).thenReturn(Result.success(resourceManifest));
 
         var policyArchive = mock(PolicyArchive.class);
         when(policyArchive.findPolicyForContract(anyString())).thenReturn(Policy.Builder.newInstance().build());

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImplTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/process/TransferProcessManagerImplTest.java
@@ -203,7 +203,7 @@ class TransferProcessManagerImplTest {
                 .thenReturn(List.of(transferProcess))
                 .thenReturn(emptyList());
         var resourceManifest = ResourceManifest.Builder.newInstance().definitions(List.of(new TestResourceDefinition())).build();
-        when(manifestGenerator.generateConsumerResourceManifest(any(DataRequest.class), any(Policy.class)))
+        when(manifestGenerator.generateConsumerResourceManifest(any(TransferProcess.class), any(Policy.class)))
                 .thenReturn(Result.success(resourceManifest));
 
         manager.start();
@@ -222,7 +222,7 @@ class TransferProcessManagerImplTest {
         when(transferProcessStore.nextNotLeased(anyInt(), stateIs(INITIAL.code())))
                 .thenReturn(List.of(transferProcess))
                 .thenReturn(emptyList());
-        when(manifestGenerator.generateConsumerResourceManifest(any(DataRequest.class), any(Policy.class)))
+        when(manifestGenerator.generateConsumerResourceManifest(any(TransferProcess.class), any(Policy.class)))
                 .thenReturn(Result.failure("error"));
 
         manager.start();
@@ -259,7 +259,7 @@ class TransferProcessManagerImplTest {
         var contentDataAddress = DataAddress.Builder.newInstance().type("type").build();
         when(addressResolver.resolveForAsset(any())).thenReturn(contentDataAddress);
         var resourceManifest = ResourceManifest.Builder.newInstance().definitions(List.of(new TestResourceDefinition())).build();
-        when(manifestGenerator.generateProviderResourceManifest(any(DataRequest.class), any(), any()))
+        when(manifestGenerator.generateProviderResourceManifest(any(TransferProcess.class), any(), any()))
                 .thenReturn(resourceManifest);
 
         manager.start();
@@ -290,7 +290,7 @@ class TransferProcessManagerImplTest {
         when(transferProcessStore.nextNotLeased(anyInt(), stateIs(INITIAL.code()))).thenReturn(List.of(transferProcess)).thenReturn(emptyList());
         when(addressResolver.resolveForAsset(any())).thenReturn(DataAddress.Builder.newInstance().type("type").build());
         var resourceManifest = ResourceManifest.Builder.newInstance().definitions(List.of(new TestResourceDefinition())).build();
-        when(manifestGenerator.generateProviderResourceManifest(any(DataRequest.class), any(), any()))
+        when(manifestGenerator.generateProviderResourceManifest(any(TransferProcess.class), any(), any()))
                 .thenReturn(resourceManifest);
 
         manager.start();

--- a/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/provision/ResourceManifestGeneratorImplTest.java
+++ b/core/control-plane/transfer-core/src/test/java/org/eclipse/edc/connector/transfer/provision/ResourceManifestGeneratorImplTest.java
@@ -18,6 +18,7 @@ import org.eclipse.edc.connector.transfer.TestResourceDefinition;
 import org.eclipse.edc.connector.transfer.spi.provision.ConsumerResourceDefinitionGenerator;
 import org.eclipse.edc.connector.transfer.spi.provision.ProviderResourceDefinitionGenerator;
 import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
+import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.policy.engine.spi.PolicyContext;
 import org.eclipse.edc.policy.engine.spi.PolicyEngine;
 import org.eclipse.edc.policy.model.Policy;
@@ -40,28 +41,25 @@ class ResourceManifestGeneratorImplTest {
     private final ConsumerResourceDefinitionGenerator consumerGenerator = mock();
     private final ProviderResourceDefinitionGenerator providerGenerator = mock();
     private final PolicyEngine policyEngine = mock();
-    private ResourceManifestGeneratorImpl generator;
-    private Policy policy;
-    private DataAddress dataAddress;
+    private final ResourceManifestGeneratorImpl generator = new ResourceManifestGeneratorImpl(policyEngine);
+    private final Policy policy = Policy.Builder.newInstance().build();
+    private final DataAddress dataAddress = DataAddress.Builder.newInstance().type("test").build();
 
     @BeforeEach
     void setUp() {
-        generator = new ResourceManifestGeneratorImpl(policyEngine);
         generator.registerGenerator(consumerGenerator);
         generator.registerGenerator(providerGenerator);
-        policy = Policy.Builder.newInstance().build();
-        dataAddress = DataAddress.Builder.newInstance().type("test").build();
     }
 
     @Test
     void shouldGenerateResourceManifestForConsumerManagedTransferProcess() {
-        var dataRequest = createDataRequest();
+        var transferProcess = TransferProcess.Builder.newInstance().dataRequest(createDataRequest()).build();
         var resourceDefinition = TestResourceDefinition.Builder.newInstance().id(UUID.randomUUID().toString()).build();
         when(consumerGenerator.canGenerate(any(), any())).thenReturn(true);
         when(consumerGenerator.generate(any(), any())).thenReturn(resourceDefinition);
         when(policyEngine.evaluate(any(), any(), isA(PolicyContext.class))).thenReturn(Result.success());
 
-        var result = generator.generateConsumerResourceManifest(dataRequest, policy);
+        var result = generator.generateConsumerResourceManifest(transferProcess, policy);
 
         assertThat(result.succeeded()).isTrue();
         assertThat(result.getContent().getDefinitions()).hasSize(1).containsExactly(resourceDefinition);
@@ -70,11 +68,11 @@ class ResourceManifestGeneratorImplTest {
 
     @Test
     void shouldGenerateEmptyResourceManifestForNotGeneratedFilter() {
-        var dataRequest = createDataRequest();
+        var transferProcess = TransferProcess.Builder.newInstance().dataRequest(createDataRequest()).build();
         when(consumerGenerator.canGenerate(any(), any())).thenReturn(false);
         when(policyEngine.evaluate(any(), any(), isA(PolicyContext.class))).thenReturn(Result.success());
 
-        var result = generator.generateConsumerResourceManifest(dataRequest, policy);
+        var result = generator.generateConsumerResourceManifest(transferProcess, policy);
 
         assertThat(result.getContent().getDefinitions()).hasSize(0);
         verifyNoInteractions(providerGenerator);
@@ -82,24 +80,24 @@ class ResourceManifestGeneratorImplTest {
 
     @Test
     void shouldReturnFailedResultForConsumerWhenPolicyEvaluationFailed() {
-        var dataRequest = createDataRequest();
+        var transferProcess = TransferProcess.Builder.newInstance().dataRequest(createDataRequest()).build();
         var resourceDefinition = TestResourceDefinition.Builder.newInstance().id(UUID.randomUUID().toString()).build();
         when(consumerGenerator.generate(any(), any())).thenReturn(resourceDefinition);
         when(policyEngine.evaluate(any(), any(), isA(PolicyContext.class))).thenReturn(Result.failure("error"));
 
-        var result = generator.generateConsumerResourceManifest(dataRequest, policy);
+        var result = generator.generateConsumerResourceManifest(transferProcess, policy);
 
         assertThat(result.succeeded()).isFalse();
     }
 
     @Test
     void shouldGenerateResourceManifestForProviderTransferProcess() {
-        var process = createDataRequest();
+        var transferProcess = TransferProcess.Builder.newInstance().dataRequest(createDataRequest()).build();
         var resourceDefinition = TestResourceDefinition.Builder.newInstance().id(UUID.randomUUID().toString()).build();
         when(providerGenerator.canGenerate(any(), any(), any())).thenReturn(true);
         when(providerGenerator.generate(any(), any(), any())).thenReturn(resourceDefinition);
 
-        var resourceManifest = generator.generateProviderResourceManifest(process, dataAddress, policy);
+        var resourceManifest = generator.generateProviderResourceManifest(transferProcess, dataAddress, policy);
 
         assertThat(resourceManifest.getDefinitions()).hasSize(1).containsExactly(resourceDefinition);
         verifyNoInteractions(consumerGenerator);
@@ -107,10 +105,10 @@ class ResourceManifestGeneratorImplTest {
 
     @Test
     void shouldGenerateEmptyResourceManifestForProviderTransferProcess() {
-        var process = createDataRequest();
+        var transferProcess = TransferProcess.Builder.newInstance().dataRequest(createDataRequest()).build();
         when(providerGenerator.canGenerate(any(), any(), any())).thenReturn(false);
 
-        var resourceManifest = generator.generateProviderResourceManifest(process, dataAddress, policy);
+        var resourceManifest = generator.generateProviderResourceManifest(transferProcess, dataAddress, policy);
 
         assertThat(resourceManifest.getDefinitions()).hasSize(0);
         verifyNoInteractions(consumerGenerator);

--- a/extensions/control-plane/provision/provision-http/src/main/java/org/eclipse/edc/connector/provision/http/impl/HttpProviderResourceDefinitionGenerator.java
+++ b/extensions/control-plane/provision/provision-http/src/main/java/org/eclipse/edc/connector/provision/http/impl/HttpProviderResourceDefinitionGenerator.java
@@ -17,10 +17,9 @@
 package org.eclipse.edc.connector.provision.http.impl;
 
 import org.eclipse.edc.connector.transfer.spi.provision.ProviderResourceDefinitionGenerator;
-import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
 import org.eclipse.edc.connector.transfer.spi.types.ResourceDefinition;
+import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.policy.model.Policy;
-import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.jetbrains.annotations.Nullable;
 
@@ -39,23 +38,17 @@ public class HttpProviderResourceDefinitionGenerator implements ProviderResource
     }
 
     @Override
-    public @Nullable ResourceDefinition generate(DataRequest dataRequest, DataAddress assetAddress, Policy policy) {
-        var assetId = dataRequest.getAssetId();
-
-        if (assetId == null) {
-            // programming error
-            throw new EdcException("Asset id was null for request: " + dataRequest.getId());
-        }
+    public @Nullable ResourceDefinition generate(TransferProcess transferProcess, DataAddress assetAddress, Policy policy) {
         return HttpProviderResourceDefinition.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
                 .dataAddressType(dataAddressType)
-                .transferProcessId(dataRequest.getProcessId())
-                .assetId(assetId)
+                .transferProcessId(transferProcess.getId())
+                .assetId(transferProcess.getAssetId())
                 .build();
     }
 
     @Override
-    public boolean canGenerate(DataRequest dataRequest, DataAddress assetAddress, Policy policy) {
+    public boolean canGenerate(TransferProcess transferProcess, DataAddress assetAddress, Policy policy) {
         return dataAddressType.equals(assetAddress.getType());
     }
 }

--- a/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/impl/HttpProviderResourceDefinitionGeneratorTest.java
+++ b/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/provision/http/impl/HttpProviderResourceDefinitionGeneratorTest.java
@@ -18,34 +18,27 @@ package org.eclipse.edc.connector.provision.http.impl;
 
 
 import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
+import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.policy.model.Policy;
-import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class HttpProviderResourceDefinitionGeneratorTest {
+
     private static final String DATA_ADDRESS_TYPE = "test-address";
 
-    private HttpProviderResourceDefinitionGenerator generator;
-
-    @BeforeEach
-    void setUp() {
-        generator = new HttpProviderResourceDefinitionGenerator(DATA_ADDRESS_TYPE);
-    }
-
+    private final HttpProviderResourceDefinitionGenerator generator = new HttpProviderResourceDefinitionGenerator(DATA_ADDRESS_TYPE);
 
     @Test
     void generate() {
         var dataRequest = DataRequest.Builder.newInstance().destinationType("destination").assetId("asset-id").processId("process-id").build();
+        var transferProcess = TransferProcess.Builder.newInstance().id("process-id").dataRequest(dataRequest).build();
         var policy = Policy.Builder.newInstance().build();
-
         var assetAddress1 = DataAddress.Builder.newInstance().type(DATA_ADDRESS_TYPE).build();
 
-        var definition = generator.generate(dataRequest, assetAddress1, policy);
+        var definition = generator.generate(transferProcess, assetAddress1, policy);
 
         assertThat(definition).isInstanceOf(HttpProviderResourceDefinition.class);
         var objectDef = (HttpProviderResourceDefinition) definition;
@@ -55,45 +48,26 @@ class HttpProviderResourceDefinitionGeneratorTest {
     }
 
     @Test
-    void generate_noDataRequestAsParameter() {
-        var assetAddress1 = DataAddress.Builder.newInstance().type(DATA_ADDRESS_TYPE).build();
-        var policy = Policy.Builder.newInstance().build();
-
-        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> generator.generate(null, assetAddress1, policy));
-    }
-
-    @Test
-    void generate_assetIdIsNull() {
-        var dataRequest = DataRequest.Builder.newInstance().destinationType("destination").processId("process-id").build();
-        var policy = Policy.Builder.newInstance().build();
-
-        var assetAddress1 = DataAddress.Builder.newInstance().type(DATA_ADDRESS_TYPE).build();
-
-        assertThatExceptionOfType(EdcException.class).isThrownBy(() -> generator.generate(dataRequest, assetAddress1, policy));
-
-    }
-
-    @Test
     void canGenerate() {
-
         var dataRequest = DataRequest.Builder.newInstance().destinationType("destination").assetId("asset-id").processId("process-id").build();
+        var transferProcess = TransferProcess.Builder.newInstance().dataRequest(dataRequest).build();
         var policy = Policy.Builder.newInstance().build();
-
         var assetAddress1 = DataAddress.Builder.newInstance().type(DATA_ADDRESS_TYPE).build();
 
-        var definition = generator.canGenerate(dataRequest, assetAddress1, policy);
+        var definition = generator.canGenerate(transferProcess, assetAddress1, policy);
+
         assertThat(definition).isTrue();
     }
 
     @Test
     void canGenerate_dataAddressTypeDifferentThanAssetAddressType() {
-
         var dataRequest = DataRequest.Builder.newInstance().destinationType("destination").assetId("asset-id").processId("process-id").build();
+        var transferProcess = TransferProcess.Builder.newInstance().dataRequest(dataRequest).build();
         var policy = Policy.Builder.newInstance().build();
-
         var assetAddress1 = DataAddress.Builder.newInstance().type("a-different-addressType").build();
 
-        var definition = generator.canGenerate(dataRequest, assetAddress1, policy);
+        var definition = generator.canGenerate(transferProcess, assetAddress1, policy);
+
         assertThat(definition).isFalse();
     }
 

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/provision/ConsumerResourceDefinitionGenerator.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/provision/ConsumerResourceDefinitionGenerator.java
@@ -14,8 +14,8 @@
 
 package org.eclipse.edc.connector.transfer.spi.provision;
 
-import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
 import org.eclipse.edc.connector.transfer.spi.types.ResourceDefinition;
+import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.policy.model.Policy;
 import org.jetbrains.annotations.Nullable;
 
@@ -27,19 +27,19 @@ public interface ConsumerResourceDefinitionGenerator {
     /**
      * Generates a ResourceDefinition. If no resource definition is generated, return null.
      *
-     * @param dataRequest the data request associated with transfer process
-     * @param policy      the contract agreement usage policy for the asset being transferred
+     * @param transferProcess the transfer process
+     * @param policy          the contract agreement usage policy for the asset being transferred
      */
     @Nullable
-    ResourceDefinition generate(DataRequest dataRequest, Policy policy);
+    ResourceDefinition generate(TransferProcess transferProcess, Policy policy);
 
     /**
      * checks if a ResourceDefinition can be generated
      *
-     * @param dataRequest the data request associated with transfer process
-     * @param policy      the contract agreement usage policy for the asset being transferred
+     * @param transferProcess the transfer process
+     * @param policy          the contract agreement usage policy for the asset being transferred
      */
 
-    boolean canGenerate(DataRequest dataRequest, Policy policy);
+    boolean canGenerate(TransferProcess transferProcess, Policy policy);
 
 }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/provision/ProviderResourceDefinitionGenerator.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/provision/ProviderResourceDefinitionGenerator.java
@@ -14,8 +14,8 @@
 
 package org.eclipse.edc.connector.transfer.spi.provision;
 
-import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
 import org.eclipse.edc.connector.transfer.spi.types.ResourceDefinition;
+import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.jetbrains.annotations.Nullable;
@@ -28,21 +28,20 @@ public interface ProviderResourceDefinitionGenerator {
     /**
      * Generates a ResourceDefinition. If no resource definition is generated, return null.
      *
-     * @param dataRequest  the data request associated with transfer process
-     * @param assetAddress the asset data address
-     * @param policy       the contract agreement usage policy for the asset being transferred
+     * @param transferProcess the transfer process
+     * @param assetAddress    the asset data address
+     * @param policy          the contract agreement usage policy for the asset being transferred
      */
     @Nullable
-    ResourceDefinition generate(DataRequest dataRequest, DataAddress assetAddress, Policy policy);
+    ResourceDefinition generate(TransferProcess transferProcess, DataAddress assetAddress, Policy policy);
 
     /**
      * checks if a ResourceDefinition can be generated
      *
-     * @param dataRequest  the data request associated with transfer process
-     * @param assetAddress the asset data address
-     * @param policy       the contract agreement usage policy for the asset being transferred
+     * @param transferProcess the transfer process
+     * @param assetAddress    the asset data address
+     * @param policy          the contract agreement usage policy for the asset being transferred
      */
-
-    boolean canGenerate(DataRequest dataRequest, DataAddress assetAddress, Policy policy);
+    boolean canGenerate(TransferProcess transferProcess, DataAddress assetAddress, Policy policy);
 
 }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/provision/ResourceManifestGenerator.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/provision/ResourceManifestGenerator.java
@@ -15,8 +15,8 @@
 
 package org.eclipse.edc.connector.transfer.spi.provision;
 
-import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
 import org.eclipse.edc.connector.transfer.spi.types.ResourceManifest;
+import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.policy.engine.spi.PolicyScope;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
@@ -47,19 +47,19 @@ public interface ResourceManifestGenerator {
     void registerGenerator(ProviderResourceDefinitionGenerator generator);
 
     /**
-     * Generates a resource manifest for a consumer-side data request. Operations must be idempotent.
+     * Generates a resource manifest for a consumer-side transfer process. Operations must be idempotent.
      *
-     * @param dataRequest the data request associated with transfer process
-     * @param policy      the contract agreement usage policy for the asset being transferred
+     * @param transferProcess the transfer process
+     * @param policy          the contract agreement usage policy for the asset being transferred
      */
-    Result<ResourceManifest> generateConsumerResourceManifest(DataRequest dataRequest, Policy policy);
+    Result<ResourceManifest> generateConsumerResourceManifest(TransferProcess transferProcess, Policy policy);
 
     /**
-     * Generates a resource manifest for a provider-side data request. Operations must be idempotent.
+     * Generates a resource manifest for a provider-side transfer process. Operations must be idempotent.
      *
-     * @param dataRequest  the data request associated with transfer process
-     * @param assetAddress the asset data address
-     * @param policy       the contract agreement usage policy for the asset being transferred
+     * @param transferProcess  the transfer process
+     * @param assetAddress     the asset data address
+     * @param policy           the contract agreement usage policy for the asset being transferred
      */
-    ResourceManifest generateProviderResourceManifest(DataRequest dataRequest, DataAddress assetAddress, Policy policy);
+    ResourceManifest generateProviderResourceManifest(TransferProcess transferProcess, DataAddress assetAddress, Policy policy);
 }


### PR DESCRIPTION
## What this PR changes/adds

First refactoring step to inline `DataRequest`, make `ResourceManifestGenerator` and relative consumer/provider interfaces to accept `TransferProcess` instead of `DataRequest`
** Breaking change ** for those who implemented a custom `ConsumerResourceDefinitionGenerator` or a `ProviderResourceDefinitionGenerator`, pretty straightforward to adapt

## Why it does that

refactoring

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Part of #3732 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
