### PR TITLE
feat: add update method to AccessTokenDataStore

### DIFF
--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/store/InMemoryAccessTokenDataStore.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/store/InMemoryAccessTokenDataStore.java
@@ -53,6 +53,15 @@ public class InMemoryAccessTokenDataStore implements AccessTokenDataStore {
     }
 
     @Override
+    public StoreResult<Void> update(AccessTokenData accessTokenData) {
+        if (store.containsKey(accessTokenData.id())) {
+            store.put(accessTokenData.id(), accessTokenData);
+            return StoreResult.success();
+        }
+        return StoreResult.notFound(OBJECT_NOT_FOUND.formatted(accessTokenData.id()));
+    }
+
+    @Override
     public StoreResult<Void> deleteById(String id) {
         var prev = store.remove(id);
         return Optional.ofNullable(prev)

--- a/extensions/data-plane/store/sql/accesstokendata-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/schema/AccessTokenDataStatements.java
+++ b/extensions/data-plane/store/sql/accesstokendata-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/schema/AccessTokenDataStatements.java
@@ -49,7 +49,8 @@ public interface AccessTokenDataStatements extends SqlStatements {
 
     String getDeleteTemplate();
 
-    SqlQueryStatement createQuery(QuerySpec querySpec);
+    String getUpdateTemplate();
 
+    SqlQueryStatement createQuery(QuerySpec querySpec);
 }
 

--- a/extensions/data-plane/store/sql/accesstokendata-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/schema/BaseSqlAccessTokenStatements.java
+++ b/extensions/data-plane/store/sql/accesstokendata-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/schema/BaseSqlAccessTokenStatements.java
@@ -49,6 +49,16 @@ public class BaseSqlAccessTokenStatements implements AccessTokenDataStatements {
     }
 
     @Override
+    public String getUpdateTemplate() {
+        return executeStatement()
+                .column(getIdColumn())
+                .jsonColumn(getClaimTokenColumn())
+                .jsonColumn(getDataAddressColumn())
+                .jsonColumn(getAdditionalPropertiesColumn())
+                .update(getTableName(), getIdColumn());
+    }
+
+    @Override
     public SqlQueryStatement createQuery(QuerySpec querySpec) {
         return new SqlQueryStatement(getSelectTemplate(), querySpec, new AccessTokenDataMapping(this), operatorTranslator);
     }

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/store/AccessTokenDataStore.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/store/AccessTokenDataStore.java
@@ -47,6 +47,14 @@ public interface AccessTokenDataStore {
     StoreResult<Void> store(AccessTokenData accessTokenData);
 
     /**
+     * Replaces an {@link AccessTokenData} object int the persistence layer. Will return a failure if an object with that ID does not exist.
+     *
+     * @param accessTokenData the new object
+     * @return success if updated, a failure if an object with the same ID does not exist.
+     */
+    StoreResult<Void> update(AccessTokenData accessTokenData);
+
+    /**
      * Deletes an {@link AccessTokenData} entity with the given ID.
      *
      * @param id The ID of the {@link AccessTokenData} that is supposed to be deleted.

--- a/spi/data-plane/data-plane-spi/src/testFixtures/java/org/eclipse/edc/connector/dataplane/spi/store/AccessTokenDataTestBase.java
+++ b/spi/data-plane/data-plane-spi/src/testFixtures/java/org/eclipse/edc/connector/dataplane/spi/store/AccessTokenDataTestBase.java
@@ -154,6 +154,21 @@ public abstract class AccessTokenDataTestBase {
         assertThat(getStore().query(q)).hasSize(50);
     }
 
+    @Test
+    void update() {
+        var object = accessTokenData("1");
+        getStore().store(object);
+
+        var update = new AccessTokenData("1", object.claimToken(), object.dataAddress(), Map.of("fizz", "buzz"));
+
+        assertThat(getStore().update(update).succeeded()).isTrue();
+    }
+
+    @Test
+    void update_whenNotExist() {
+        var object = accessTokenData("1");
+        assertThat(getStore().update(object).failed()).isTrue();
+    }
 
     protected abstract AccessTokenDataStore getStore();
 


### PR DESCRIPTION
## What this PR changes/adds

This PR adds an `update()` method to the `AccessTokenDataStore`.

## Why it does that


In certain scenarios it is necessary to be able to update an `AccessTokenData` entry, e.g. when implementing a token-refresh mechanism

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
