### PR TITLE
feat: register default PublicEndpointGenerator fct

### DIFF
--- a/extensions/data-plane/data-plane-public-api-v2/src/main/java/org/eclipse/edc/connector/dataplane/api/DataPlanePublicApiExtension.java
+++ b/extensions/data-plane/data-plane-public-api-v2/src/main/java/org/eclipse/edc/connector/dataplane/api/DataPlanePublicApiExtension.java
@@ -15,11 +15,15 @@
 package org.eclipse.edc.connector.dataplane.api;
 
 import org.eclipse.edc.connector.dataplane.api.controller.DataPlanePublicApiV2Controller;
+import org.eclipse.edc.connector.dataplane.spi.Endpoint;
 import org.eclipse.edc.connector.dataplane.spi.iam.DataPlaneAuthorizationService;
+import org.eclipse.edc.connector.dataplane.spi.iam.PublicEndpointGeneratorService;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.PipelineService;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.system.ExecutorInstrumentation;
+import org.eclipse.edc.spi.system.Hostname;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.web.spi.WebServer;
@@ -36,13 +40,17 @@ import java.util.concurrent.Executors;
 @Extension(value = DataPlanePublicApiExtension.NAME)
 public class DataPlanePublicApiExtension implements ServiceExtension {
     public static final String NAME = "Data Plane Public API";
-    private static final int DEFAULT_PUBLIC_PORT = 8185;
-    private static final String PUBLIC_API_CONFIG = "web.http.public";
-    private static final String PUBLIC_CONTEXT_ALIAS = "public";
-    private static final String PUBLIC_CONTEXT_PATH = "/api/v2/public";
+
+
+    public static final int DEFAULT_PUBLIC_PORT = 8185;
+    public static final String PUBLIC_API_CONFIG = "web.http.public";
+    public static final String PUBLIC_CONTEXT_ALIAS = "public";
+    public static final String PUBLIC_CONTEXT_PATH = "/api/v2/public";
+    @Setting(value = "Base url of the public API endpoint without the trailing slash. This should correspond to the values configured " +
+            "in '" + DEFAULT_PUBLIC_PORT + "' and '" + PUBLIC_CONTEXT_PATH + "'.", defaultValue = "http://<HOST>:" + DEFAULT_PUBLIC_PORT + PUBLIC_CONTEXT_PATH)
+    public static final String PUBLIC_ENDPOINT = "edc.dataplane.api.public.baseurl";
 
     private static final int DEFAULT_THREAD_POOL = 10;
-
     private static final WebServiceSettings PUBLIC_SETTINGS = WebServiceSettings.Builder.newInstance()
             .apiConfigKey(PUBLIC_API_CONFIG)
             .contextAlias(PUBLIC_CONTEXT_ALIAS)
@@ -65,8 +73,15 @@ public class DataPlanePublicApiExtension implements ServiceExtension {
 
     @Inject
     private ExecutorInstrumentation executorInstrumentation;
+
     @Inject
     private DataPlaneAuthorizationService authorizationService;
+
+    @Inject
+    private PublicEndpointGeneratorService generatorService;
+
+    @Inject
+    private Hostname hostname;
 
     @Override
     public String name() {
@@ -80,6 +95,15 @@ public class DataPlanePublicApiExtension implements ServiceExtension {
                 Executors.newFixedThreadPool(DEFAULT_THREAD_POOL),
                 "Data plane proxy transfers"
         );
+
+        var publicEndpoint = context.getSetting(PUBLIC_ENDPOINT, null);
+        if (publicEndpoint == null) {
+            publicEndpoint = "http://%s:%d%s".formatted(hostname.get(), configuration.getPort(), configuration.getPath());
+            context.getMonitor().warning("Config property '%s' was not specified, the default '%s' will be used.".formatted(PUBLIC_ENDPOINT, publicEndpoint));
+        }
+        var endpoint = Endpoint.url(publicEndpoint);
+        generatorService.addGeneratorFunction("HttpData", dataAddress -> endpoint);
+
         var publicApiController = new DataPlanePublicApiV2Controller(pipelineService, executorService, authorizationService);
         webService.registerResource(configuration.getContextAlias(), publicApiController);
     }

--- a/system-tests/e2e-dataplane-tests/tests/src/test/java/org/eclipse/edc/test/e2e/DataPlaneSignalingApiEndToEndTest.java
+++ b/system-tests/e2e-dataplane-tests/tests/src/test/java/org/eclipse/edc/test/e2e/DataPlaneSignalingApiEndToEndTest.java
@@ -23,8 +23,6 @@ import org.eclipse.edc.connector.api.signaling.transform.from.JsonObjectFromData
 import org.eclipse.edc.connector.api.signaling.transform.to.JsonObjectToDataFlowResponseMessageTransformer;
 import org.eclipse.edc.connector.dataplane.spi.DataFlow;
 import org.eclipse.edc.connector.dataplane.spi.DataFlowStates;
-import org.eclipse.edc.connector.dataplane.spi.Endpoint;
-import org.eclipse.edc.connector.dataplane.spi.iam.PublicEndpointGeneratorService;
 import org.eclipse.edc.connector.dataplane.spi.store.DataPlaneStore;
 import org.eclipse.edc.core.transform.TypeTransformerRegistryImpl;
 import org.eclipse.edc.core.transform.transformer.dspace.from.JsonObjectFromDataAddressDspaceTransformer;
@@ -60,7 +58,7 @@ import static org.hamcrest.Matchers.notNullValue;
 @EndToEndTest
 public class DataPlaneSignalingApiEndToEndTest extends AbstractDataPlaneTest {
 
-    private static final String DATAPLANE_PUBLIC_ENDPOINT_URL = "http://fizz.buzz/bar";
+    private static final String DATAPLANE_PUBLIC_ENDPOINT_URL = DATAPLANE.getDataPlanePublicEndpoint().getUrl().toString();
     private final TypeTransformerRegistry registry = new TypeTransformerRegistryImpl();
     private ObjectMapper mapper;
 
@@ -77,8 +75,6 @@ public class DataPlaneSignalingApiEndToEndTest extends AbstractDataPlaneTest {
     @DisplayName("Verify the POST /v1/dataflows endpoint returns the correct EDR")
     @Test
     void startTransfer() throws JsonProcessingException {
-        var generator = runtime.getContext().getService(PublicEndpointGeneratorService.class);
-        generator.addGeneratorFunction("HttpData", dataAddress -> Endpoint.url(DATAPLANE_PUBLIC_ENDPOINT_URL));
         var jsonLd = runtime.getContext().getService(JsonLd.class);
 
         var processId = "test-processId";


### PR DESCRIPTION
## What this PR changes/adds

This PR adds an optional config property `edc.dataplane.api.public.baseurl` that configures the base URL (including host, port) of the `DataPlanePublicApiController`.

If that config value is not provided, a fallback `http://<HOST>:<PORT>/<PATH>` is constructed dynamically, and is determined by the following config properties:
- `HOST`: determined by the injected `Hostname`, defaulting to `localhost`
- `PORT`: determined by `web.http.public.port` , defaulting to `8185`
- `PATH`: determined by `web.http.public.path`, defaulting to `/api/v1/public`

## Why it does that

Every dataplane should be able to represent itself as `Endpoint`

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
