### PR TITLE
feat: data plane refactor for DPS

### DIFF
--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/DataPlaneFrameworkExtension.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/DataPlaneFrameworkExtension.java
@@ -101,6 +101,8 @@ public class DataPlaneFrameworkExtension implements ServiceExtension {
     @Inject
     private PublicEndpointGeneratorService endpointGenerator;
 
+    private DataPlaneAuthorizationService authorizationService;
+
     @Override
     public String name() {
         return NAME;
@@ -132,6 +134,7 @@ public class DataPlaneFrameworkExtension implements ServiceExtension {
                 .transferServiceRegistry(transferServiceRegistry)
                 .store(store)
                 .transferProcessClient(transferProcessApiClient)
+                .authorizationService(authorizationService(context))
                 .monitor(monitor)
                 .telemetry(telemetry)
                 .build();
@@ -153,7 +156,10 @@ public class DataPlaneFrameworkExtension implements ServiceExtension {
 
     @Provider
     public DataPlaneAuthorizationService authorizationService(ServiceExtensionContext context) {
-        return new DataPlaneAuthorizationServiceImpl(accessTokenService, endpointGenerator, accessControlService, context.getParticipantId(), clock);
+        if (authorizationService == null) {
+            authorizationService = new DataPlaneAuthorizationServiceImpl(accessTokenService, endpointGenerator, accessControlService, context.getParticipantId(), clock);
+        }
+        return authorizationService;
     }
 
     @NotNull

--- a/extensions/control-plane/api/control-plane-api-client/src/test/java/org/eclipse/edc/connector/api/client/transferprocess/TransferProcessHttpClientIntegrationTest.java
+++ b/extensions/control-plane/api/control-plane-api-client/src/test/java/org/eclipse/edc/connector/api/client/transferprocess/TransferProcessHttpClientIntegrationTest.java
@@ -40,6 +40,7 @@ import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
+import org.eclipse.edc.spi.types.domain.transfer.FlowType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -100,7 +101,7 @@ public class TransferProcessHttpClientIntegrationTest {
         store.save(createTransferProcess(id));
         var dataFlowRequest = createDataFlowRequest(id, callbackUrl.get());
 
-        manager.initiate(dataFlowRequest);
+        manager.start(dataFlowRequest);
 
         await().untilAsserted(() -> {
             var transferProcess = store.findById("tp-id");
@@ -116,7 +117,7 @@ public class TransferProcessHttpClientIntegrationTest {
         store.save(createTransferProcess(id));
         var dataFlowRequest = createDataFlowRequest(id, callbackUrl.get());
 
-        manager.initiate(dataFlowRequest);
+        manager.start(dataFlowRequest);
 
         await().untilAsserted(() -> {
             var transferProcess = store.findById("tp-id");
@@ -134,7 +135,7 @@ public class TransferProcessHttpClientIntegrationTest {
         store.save(createTransferProcess(id));
         var dataFlowRequest = createDataFlowRequest(id, callbackUrl.get());
 
-        manager.initiate(dataFlowRequest);
+        manager.start(dataFlowRequest);
 
         await().untilAsserted(() -> {
             var transferProcess = store.findById("tp-id");
@@ -166,6 +167,7 @@ public class TransferProcessHttpClientIntegrationTest {
                 .callbackAddress(callbackAddress)
                 .sourceDataAddress(DataAddress.Builder.newInstance().type("file").build())
                 .destinationDataAddress(DataAddress.Builder.newInstance().type("file").build())
+                .flowType(FlowType.PUSH)
                 .build();
     }
 

--- a/extensions/data-plane/data-plane-client-embedded/build.gradle.kts
+++ b/extensions/data-plane/data-plane-client-embedded/build.gradle.kts
@@ -18,19 +18,12 @@ plugins {
 }
 
 dependencies {
-    api(project(":spi:common:http-spi"))
-    api(project(":spi:common:core-spi"))
+    api(project(":spi:data-plane:data-plane-spi"))
     api(project(":spi:data-plane-selector:data-plane-selector-spi"))
-    implementation(project(":core:common:util"))
-    implementation(project(":core:common:transform-core"))
-    implementation(project(":extensions:data-plane:data-plane-signaling:data-plane-signaling-transform"))
-    implementation(project(":extensions:data-plane:data-plane-client-embedded"))
 
     implementation(libs.opentelemetry.instrumentation.annotations)
 
     testImplementation(project(":core:common:junit"))
-    testImplementation(project(":core:common:transform-core"))
-    testImplementation(project(":extensions:common:json-ld"))
     testImplementation(libs.restAssured)
     testImplementation(libs.mockserver.netty)
     testImplementation(libs.mockserver.client)

--- a/extensions/data-plane/data-plane-client-embedded/src/main/java/org/eclipse/edc/connector/dataplane/client/EmbeddedDataPlaneClient.java
+++ b/extensions/data-plane/data-plane-client-embedded/src/main/java/org/eclipse/edc/connector/dataplane/client/EmbeddedDataPlaneClient.java
@@ -43,8 +43,11 @@ public class EmbeddedDataPlaneClient implements DataPlaneClient {
         if (result.failed()) {
             return StatusResult.failure(ResponseStatus.FATAL_ERROR, result.getFailureDetail());
         }
-        dataPlaneManager.initiate(request);
-        return StatusResult.success(DataFlowResponseMessage.Builder.newInstance().build());
+        var startResult = dataPlaneManager.start(request);
+        if (startResult.failed()) {
+            return StatusResult.failure(ResponseStatus.FATAL_ERROR, startResult.getFailureDetail());
+        }
+        return StatusResult.success(startResult.getContent());
     }
 
     @Override

--- a/extensions/data-plane/data-plane-client/build.gradle.kts
+++ b/extensions/data-plane/data-plane-client/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     api(project(":spi:data-plane:data-plane-spi"))
     api(project(":spi:data-plane-selector:data-plane-selector-spi"))
     implementation(project(":core:common:util"))
+    implementation(project(":extensions:data-plane:data-plane-client-embedded"))
 
     implementation(libs.opentelemetry.instrumentation.annotations)
 

--- a/extensions/data-plane/data-plane-control-api/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlaneControlApiController.java
+++ b/extensions/data-plane/data-plane-control-api/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlaneControlApiController.java
@@ -51,7 +51,7 @@ public class DataPlaneControlApiController implements DataPlaneControlApi {
         // TODO token authentication
         var result = dataPlaneManager.validate(request);
         if (result.succeeded()) {
-            dataPlaneManager.initiate(request);
+            dataPlaneManager.start(request);
             response.resume(Response.ok().build());
         } else {
             var resp = result.getFailureMessages().isEmpty() ?

--- a/extensions/data-plane/data-plane-control-api/src/test/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlaneControlApiControllerTest.java
+++ b/extensions/data-plane/data-plane-control-api/src/test/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlaneControlApiControllerTest.java
@@ -63,7 +63,7 @@ class DataPlaneControlApiControllerTest extends RestControllerTestBase {
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode());
 
-        verify(manager).initiate(isA(DataFlowStartMessage.class));
+        verify(manager).start(isA(DataFlowStartMessage.class));
     }
 
     @Test
@@ -86,7 +86,7 @@ class DataPlaneControlApiControllerTest extends RestControllerTestBase {
                 .statusCode(Response.Status.BAD_REQUEST.getStatusCode())
                 .body("errors", CoreMatchers.equalTo(List.of(errorMsg)));
 
-        verify(manager, never()).initiate(any());
+        verify(manager, never()).start(any());
     }
 
     @Test

--- a/extensions/data-plane/data-plane-http/src/testFixtures/java/org/eclipse/edc/connector/dataplane/http/testfixtures/TestFunctions.java
+++ b/extensions/data-plane/data-plane-http/src/testFixtures/java/org/eclipse/edc/connector/dataplane/http/testfixtures/TestFunctions.java
@@ -23,6 +23,7 @@ import okio.Okio;
 import org.eclipse.edc.connector.dataplane.spi.schema.DataFlowRequestSchema;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
+import org.eclipse.edc.spi.types.domain.transfer.FlowType;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -52,6 +53,7 @@ public class TestFunctions {
                 .processId(UUID.randomUUID().toString())
                 .properties(properties)
                 .sourceDataAddress(source)
+                .flowType(FlowType.PUSH)
                 .destinationDataAddress(destination);
     }
 

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-api/src/main/java/org/eclipse/edc/connector/dataplane/api/DataPlaneSignalingApiExtension.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-api/src/main/java/org/eclipse/edc/connector/dataplane/api/DataPlaneSignalingApiExtension.java
@@ -16,7 +16,6 @@ package org.eclipse.edc.connector.dataplane.api;
 
 import org.eclipse.edc.connector.api.signaling.configuration.SignalingApiConfiguration;
 import org.eclipse.edc.connector.dataplane.api.controller.v1.DataPlaneSignalingApiController;
-import org.eclipse.edc.connector.dataplane.spi.iam.DataPlaneAuthorizationService;
 import org.eclipse.edc.connector.dataplane.spi.manager.DataPlaneManager;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
@@ -38,8 +37,6 @@ public class DataPlaneSignalingApiExtension implements ServiceExtension {
     @Inject
     private TypeTransformerRegistry transformerRegistry;
     @Inject
-    private DataPlaneAuthorizationService authorizationService;
-    @Inject
     private DataPlaneManager dataPlaneManager;
 
     @Override
@@ -50,7 +47,7 @@ public class DataPlaneSignalingApiExtension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
         var signalingApiTypeTransformerRegistry = transformerRegistry.forContext("signaling-api");
-        var controller = new DataPlaneSignalingApiController(signalingApiTypeTransformerRegistry, authorizationService,
+        var controller = new DataPlaneSignalingApiController(signalingApiTypeTransformerRegistry,
                 dataPlaneManager, context.getMonitor().withPrefix("SignalingAPI"));
         webService.registerResource(controlApiConfiguration.getContextAlias(), controller);
     }

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/main/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClientExtension.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/main/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClientExtension.java
@@ -16,14 +16,18 @@ package org.eclipse.edc.connector.dataplane.client;
 
 import org.eclipse.edc.connector.dataplane.selector.spi.client.DataPlaneClient;
 import org.eclipse.edc.connector.dataplane.selector.spi.client.DataPlaneClientFactory;
+import org.eclipse.edc.connector.dataplane.spi.manager.DataPlaneManager;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.spi.http.EdcHttpClient;
 import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+
+import java.util.Objects;
 
 import static org.eclipse.edc.spi.CoreConstants.JSON_LD;
 
@@ -34,7 +38,7 @@ import static org.eclipse.edc.spi.CoreConstants.JSON_LD;
 public class DataPlaneSignalingClientExtension implements ServiceExtension {
     public static final String NAME = "Data Plane Signaling Client";
 
-    @Inject
+    @Inject(required = false)
     private EdcHttpClient httpClient;
 
     @Inject
@@ -45,6 +49,8 @@ public class DataPlaneSignalingClientExtension implements ServiceExtension {
 
     @Inject
     private JsonLd jsonLd;
+    @Inject(required = false)
+    private DataPlaneManager dataPlaneManager;
 
     @Override
     public String name() {
@@ -52,8 +58,17 @@ public class DataPlaneSignalingClientExtension implements ServiceExtension {
     }
 
     @Provider
-    public DataPlaneClientFactory dataPlaneClientFactory() {
+    public DataPlaneClientFactory dataPlaneClientFactory(ServiceExtensionContext context) {
+
+        if (dataPlaneManager != null) {
+            // Data plane manager is embedded in the current runtime
+            context.getMonitor().debug(() -> "Using embedded Data Plane client.");
+            return instance -> new EmbeddedDataPlaneClient(dataPlaneManager);
+        }
+
         var mapper = typeManager.getMapper(JSON_LD);
+        context.getMonitor().debug(() -> "Using remote Data Plane client.");
+        Objects.requireNonNull(httpClient, "To use remote Data Plane client, an EdcHttpClient instance must be registered");
         var signalingApiTypeTransformerRegistry = transformerRegistry.forContext("signaling-api");
         return instance -> new DataPlaneSignalingClient(httpClient, signalingApiTypeTransformerRegistry, jsonLd, mapper, instance);
     }

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/test/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClientExtensionTest.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/test/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClientExtensionTest.java
@@ -15,7 +15,10 @@
 package org.eclipse.edc.connector.dataplane.client;
 
 import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
+import org.eclipse.edc.connector.dataplane.spi.manager.DataPlaneManager;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.system.injection.ObjectFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -25,11 +28,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 class DataPlaneSignalingClientExtensionTest {
 
     @Test
-    void verifyDataPlaneClientFactory(DataPlaneSignalingClientExtension extension) {
+    void verifyDataPlaneClientFactory(ServiceExtensionContext context, ObjectFactory factory) {
+        context.registerService(DataPlaneManager.class, null);
+        var extension = factory.constructInstance(DataPlaneSignalingClientExtension.class);
 
-        var client = extension.dataPlaneClientFactory().createClient(createDataPlaneInstance());
+        var client = extension.dataPlaneClientFactory(context).createClient(createDataPlaneInstance());
 
         assertThat(client).isInstanceOf(DataPlaneSignalingClient.class);
+    }
+
+    @Test
+    void verifyDataPlaneClientFactory_withEmbedded(ServiceExtensionContext context, DataPlaneSignalingClientExtension extension) {
+        var client = extension.dataPlaneClientFactory(context).createClient(createDataPlaneInstance());
+
+        assertThat(client).isInstanceOf(EmbeddedDataPlaneClient.class);
     }
 
 

--- a/extensions/data-plane/store/sql/data-plane-store-sql/docs/schema.sql
+++ b/extensions/data-plane/store/sql/data-plane-store-sql/docs/schema.sql
@@ -30,7 +30,8 @@ CREATE TABLE IF NOT EXISTS edc_data_plane
                     ON DELETE SET NULL,
     source               JSON,
     destination          JSON,
-    properties           JSON
+    properties           JSON,
+    flow_type            VARCHAR
 );
 
 COMMENT ON COLUMN edc_data_plane.trace_context IS 'Java Map serialized as JSON';

--- a/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/SqlDataPlaneStore.java
+++ b/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/SqlDataPlaneStore.java
@@ -23,6 +23,7 @@ import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.StoreResult;
 import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.transfer.FlowType;
 import org.eclipse.edc.sql.QueryExecutor;
 import org.eclipse.edc.sql.lease.SqlLeaseContextBuilder;
 import org.eclipse.edc.sql.store.AbstractSqlStore;
@@ -147,7 +148,8 @@ public class SqlDataPlaneStore extends AbstractSqlStore implements DataPlaneStor
                 Optional.ofNullable(dataFlow.getCallbackAddress()).map(URI::toString).orElse(null),
                 toJson(dataFlow.getSource()),
                 toJson(dataFlow.getDestination()),
-                toJson(dataFlow.getProperties())
+                toJson(dataFlow.getProperties()),
+                dataFlow.getFlowType().toString()
         );
     }
 
@@ -164,6 +166,7 @@ public class SqlDataPlaneStore extends AbstractSqlStore implements DataPlaneStor
                 toJson(dataFlow.getSource()),
                 toJson(dataFlow.getDestination()),
                 toJson(dataFlow.getProperties()),
+                dataFlow.getFlowType().toString(),
                 dataFlow.getId());
     }
 
@@ -181,6 +184,7 @@ public class SqlDataPlaneStore extends AbstractSqlStore implements DataPlaneStor
                 .source(fromJson(resultSet.getString(statements.getSourceColumn()), DataAddress.class))
                 .destination(fromJson(resultSet.getString(statements.getDestinationColumn()), DataAddress.class))
                 .properties(fromJson(resultSet.getString(statements.getPropertiesColumn()), getTypeRef()))
+                .flowType(FlowType.valueOf(resultSet.getString(statements.getFlowTypeColumn())))
                 .build();
     }
 

--- a/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/schema/BaseSqlDataPlaneStatements.java
+++ b/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/schema/BaseSqlDataPlaneStatements.java
@@ -44,6 +44,7 @@ public class BaseSqlDataPlaneStatements implements DataPlaneStatements {
                 .jsonColumn(getSourceColumn())
                 .jsonColumn(getDestinationColumn())
                 .jsonColumn(getPropertiesColumn())
+                .column(getFlowTypeColumn())
                 .insertInto(getDataPlaneTable());
     }
 
@@ -60,6 +61,7 @@ public class BaseSqlDataPlaneStatements implements DataPlaneStatements {
                 .jsonColumn(getSourceColumn())
                 .jsonColumn(getDestinationColumn())
                 .jsonColumn(getPropertiesColumn())
+                .column(getFlowTypeColumn())
                 .update(getDataPlaneTable(), getIdColumn());
     }
 

--- a/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/schema/DataPlaneStatements.java
+++ b/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/schema/DataPlaneStatements.java
@@ -48,6 +48,10 @@ public interface DataPlaneStatements extends StatefulEntityStatements, LeaseStat
         return "properties";
     }
 
+    default String getFlowTypeColumn() {
+        return "flow_type";
+    }
+
     String getInsertTemplate();
 
     String getUpdateTemplate();

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -173,6 +173,7 @@ include(":extensions:control-plane:callback:callback-static-endpoint")
 
 
 include(":extensions:data-plane:data-plane-client")
+include(":extensions:data-plane:data-plane-client-embedded")
 include(":extensions:data-plane:data-plane-control-api")
 include(":extensions:data-plane:data-plane-signaling:data-plane-signaling-api")
 include(":extensions:data-plane:data-plane-signaling:data-plane-signaling-api-configuration")

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/transfer/DataFlowStartMessage.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/transfer/DataFlowStartMessage.java
@@ -59,7 +59,7 @@ public class DataFlowStartMessage implements Polymorphic, TraceCarrier {
 
     private DataAddress sourceDataAddress;
     private DataAddress destinationDataAddress;
-    private FlowType flowType;
+    private FlowType flowType = FlowType.PUSH;
     private URI callbackAddress;
 
     private Map<String, String> properties = new HashMap<>();
@@ -249,6 +249,7 @@ public class DataFlowStartMessage implements Polymorphic, TraceCarrier {
             Objects.requireNonNull(request.sourceDataAddress, "sourceDataAddress");
             Objects.requireNonNull(request.destinationDataAddress, "destinationDataAddress");
             Objects.requireNonNull(request.traceContext, "traceContext");
+            Objects.requireNonNull(request.flowType, "flowType");
             return request;
         }
 

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/DataFlow.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/DataFlow.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.eclipse.edc.spi.entity.StatefulEntity;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
+import org.eclipse.edc.spi.types.domain.transfer.FlowType;
 import org.jetbrains.annotations.Nullable;
 
 import java.net.URI;
@@ -46,13 +47,16 @@ public class DataFlow extends StatefulEntity<DataFlow> {
     private URI callbackAddress;
     private Map<String, String> properties = new HashMap<>();
 
+    private FlowType flowType = FlowType.PULL;
+
     @Override
     public DataFlow copy() {
         var builder = Builder.newInstance()
                 .source(source)
                 .destination(destination)
                 .callbackAddress(callbackAddress)
-                .properties(properties);
+                .properties(properties)
+                .flowType(flowType);
 
         return copy(builder);
     }
@@ -78,6 +82,10 @@ public class DataFlow extends StatefulEntity<DataFlow> {
         return Collections.unmodifiableMap(properties);
     }
 
+    public FlowType getFlowType() {
+        return flowType;
+    }
+
     public DataFlowStartMessage toRequest() {
         return DataFlowStartMessage.Builder.newInstance()
                 .id(getId())
@@ -87,6 +95,7 @@ public class DataFlow extends StatefulEntity<DataFlow> {
                 .callbackAddress(getCallbackAddress())
                 .traceContext(traceContext)
                 .properties(getProperties())
+                .flowType(getFlowType())
                 .build();
     }
 
@@ -158,6 +167,11 @@ public class DataFlow extends StatefulEntity<DataFlow> {
 
         public Builder callbackAddress(URI callbackAddress) {
             entity.callbackAddress = callbackAddress;
+            return this;
+        }
+
+        public Builder flowType(FlowType flowType) {
+            entity.flowType = flowType;
             return this;
         }
 

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/manager/DataPlaneManager.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/manager/DataPlaneManager.java
@@ -35,9 +35,12 @@ public interface DataPlaneManager extends StateEntityManager {
     Result<Boolean> validate(DataFlowStartMessage dataRequest);
 
     /**
-     * Initiates a transfer for the data flow request. This method is non-blocking with respect to processing the request.
+     * Starts a transfer for the data flow request. This method is non-blocking with respect to processing the request.
+     *
+     * @param startMessage The {@link DataFlowStartMessage}
+     * @return success with the {@link DataFlowResponseMessage} if the request was correctly processed, failure otherwise
      */
-    Result<DataFlowResponseMessage> start(DataFlowStartMessage dataRequest);
+    Result<DataFlowResponseMessage> start(DataFlowStartMessage startMessage);
 
     /**
      * Returns the transfer state for the process.

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/manager/DataPlaneManager.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/manager/DataPlaneManager.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import org.eclipse.edc.spi.entity.StateEntityManager;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowResponseMessage;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.jetbrains.annotations.Nullable;
 
@@ -36,7 +37,7 @@ public interface DataPlaneManager extends StateEntityManager {
     /**
      * Initiates a transfer for the data flow request. This method is non-blocking with respect to processing the request.
      */
-    void initiate(DataFlowStartMessage dataRequest);
+    Result<DataFlowResponseMessage> start(DataFlowStartMessage dataRequest);
 
     /**
      * Returns the transfer state for the process.

--- a/spi/data-plane/data-plane-spi/src/testFixtures/java/org/eclipse/edc/connector/dataplane/spi/testfixtures/store/DataPlaneStoreTestBase.java
+++ b/spi/data-plane/data-plane-spi/src/testFixtures/java/org/eclipse/edc/connector/dataplane/spi/testfixtures/store/DataPlaneStoreTestBase.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.spi.entity.MutableEntity;
 import org.eclipse.edc.spi.entity.StatefulEntity;
 import org.eclipse.edc.spi.result.StoreFailure;
 import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.transfer.FlowType;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -60,6 +61,7 @@ public abstract class DataPlaneStoreTestBase {
                 .callbackAddress(URI.create("http://any"))
                 .source(DataAddress.Builder.newInstance().type("src-type").build())
                 .destination(DataAddress.Builder.newInstance().type("dest-type").build())
+                .flowType(FlowType.PUSH)
                 .state(state.code())
                 .build();
     }

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/participant/EndToEndTransferParticipant.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/participant/EndToEndTransferParticipant.java
@@ -292,6 +292,7 @@ public class EndToEndTransferParticipant extends Participant {
                 put("edc.vault", resourceAbsolutePath(getName() + "-vault.properties"));
                 put("edc.keystore", resourceAbsolutePath("certs/cert.pfx"));
                 put("edc.keystore.password", "123456");
+                put("edc.dataplane.api.public.baseurl", dataPlanePublic + "/v2/");
                 put("edc.dataplane.token.validation.endpoint", controlPlaneControl + "/token");
                 put("edc.transfer.proxy.token.signer.privatekey.alias", "1");
                 put("edc.transfer.proxy.token.verifier.publickey.alias", "public-key");

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/signaling/EmbeddedSignalingTransferInMemoryTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/signaling/EmbeddedSignalingTransferInMemoryTest.java
@@ -20,35 +20,29 @@ import org.eclipse.edc.junit.extensions.EdcRuntimeExtension;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.HashMap;
+import java.util.Map;
 
 @EndToEndTest
-class SignalingTransferInMemoryTest extends AbstractSignalingTransfer {
+class EmbeddedSignalingTransferInMemoryTest extends AbstractSignalingTransfer {
 
-    static String[] controlPlaneModules = new String[]{
+    static String[] providerPlaneModules = new String[]{
             ":system-tests:e2e-transfer-test:control-plane",
             ":extensions:control-plane:transfer:transfer-data-plane-signaling",
-            ":extensions:control-plane:callback:callback-event-dispatcher",
-            ":extensions:control-plane:callback:callback-http-dispatcher",
-            ":extensions:data-plane:data-plane-signaling:data-plane-signaling-client"
-    };
-
-    static String[] dataPlanePostgresqlModules = new String[]{
             ":system-tests:e2e-transfer-test:data-plane",
             ":extensions:data-plane:data-plane-public-api-v2"
     };
-
-    static EdcRuntimeExtension dataPlane = new EdcRuntimeExtension(
-            "provider-data-plane",
-            PROVIDER.dataPlaneConfiguration(),
-            dataPlanePostgresqlModules
-    );
+    static String[] consumerPlaneModules = new String[]{
+            ":system-tests:e2e-transfer-test:control-plane",
+            ":extensions:control-plane:callback:callback-event-dispatcher",
+            ":extensions:control-plane:callback:callback-http-dispatcher"
+    };
 
     @RegisterExtension
     static EdcClassRuntimesExtension runtimes = new EdcClassRuntimesExtension(
             new EdcRuntimeExtension(
                     "consumer-control-plane",
                     CONSUMER.controlPlaneConfiguration(),
-                    controlPlaneModules
+                    consumerPlaneModules
             ),
             new EdcRuntimeExtension(
                     ":system-tests:e2e-transfer-test:backend-service",
@@ -59,11 +53,10 @@ class SignalingTransferInMemoryTest extends AbstractSignalingTransfer {
                         }
                     }
             ),
-            dataPlane,
             new EdcRuntimeExtension(
                     "provider-control-plane",
-                    PROVIDER.controlPlaneConfiguration(),
-                    controlPlaneModules
+                    providerConfig(),
+                    providerPlaneModules
             ),
             new EdcRuntimeExtension(
                     ":system-tests:e2e-transfer-test:backend-service",
@@ -75,5 +68,12 @@ class SignalingTransferInMemoryTest extends AbstractSignalingTransfer {
                     }
             )
     );
-    
+
+
+    private static Map<String, String> providerConfig() {
+        var cfg = PROVIDER.dataPlaneConfiguration();
+        cfg.putAll(PROVIDER.controlPlaneConfiguration());
+        return cfg;
+    }
+
 }


### PR DESCRIPTION
## What this PR changes/adds

In this PR:


- `DataPlaneManager#initiate` renamed to `start` and now it returns directly the `DataFlowResponseMessage`.
-  moved `EmbeddedDataPlaneClient` into `data-plane-client-embedded` module and adapted to the `DataPlaneManager` refactor.
-  The `DataPlaneAuthorizationService` usage has been moved from the controller to the `DataPlaneManagerImpl` for reaching the same functionality when running the dataplane in embedded and remote deployment.
- When a `PULL` request hits the dataplane the generation of the EDR is called and if succeeded a DataFlow is created in the `STARTED` state (RECEIVED in case of PUSH scenario).
- The `DataFlow` now contains also the `flowType` which can be useful when terminating the transfer which differs PULL/PUSH.
- Introduced a new E2E test `EmbeddedSignalingTransferInMemoryTest`  for testing a transfer with DPS in data plane embedded mode.

## Why it does that

data plane signaling


## Linked Issue(s)

Closes #3990 
