### PR TITLE
feat: store claims on additionalProperties

### DIFF
--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/DataPlaneDefaultIamServicesExtension.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/DataPlaneDefaultIamServicesExtension.java
@@ -58,7 +58,7 @@ public class DataPlaneDefaultIamServicesExtension implements ServiceExtension {
     @Provider(isDefault = true)
     public DataPlaneAccessControlService defaultAccessControlService(ServiceExtensionContext context) {
         context.getMonitor().debug("DataPlane Access Control: default implementation is used, will always return Result.success()");
-        return (claimToken, address, requestData) -> Result.success();
+        return (claimToken, address, requestData, additionalData) -> Result.success();
     }
 
     @Provider(isDefault = true)

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/iam/DataPlaneAccessControlService.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/iam/DataPlaneAccessControlService.java
@@ -39,10 +39,11 @@ public interface DataPlaneAccessControlService {
      * detail to the requestor for security reasons.
      * <p>
      *
-     * @param claimToken  The credential that was attached to the data request received by the data plane
-     * @param address     The resource address of the data that is being requested
-     * @param requestData Additional information about the request, e.g. URL pattern, additional headers, query params, etc.
+     * @param claimToken     The credential that was attached to the data request received by the data plane
+     * @param address        The resource address of the data that is being requested
+     * @param requestData    Additional information about the request, e.g. URL pattern, additional headers, query params, etc.
+     * @param additionalData Additional information about the claim token, such as participant ID, agreement ID, transfer process ID etc.
      * @return success if access to the resource is granted, a failure otherwise.
      */
-    Result<Void> checkAccess(ClaimToken claimToken, DataAddress address, Map<String, Object> requestData);
+    Result<Void> checkAccess(ClaimToken claimToken, DataAddress address, Map<String, Object> requestData, Map<String, Object> additionalData);
 }


### PR DESCRIPTION
## What this PR changes/adds

some additional claims, that were previously stored as claims on the EDR's `access_token` were moved to the `additionalProperties` map on the `AccessTokenData`.
Specifically: `participantId, processId, assetId, agreementId, transferType`

## Why it does that

Having those on the access token is not necessary. The access token should be as slim as possible.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
