### PR TITLE
chore: fix after IATP changes

### DIFF
--- a/extensions/common/crypto/jwt-verifiable-credentials/src/main/java/org/eclipse/edc/verifiablecredentials/jwt/rules/TokenNotNullRule.java
+++ b/extensions/common/crypto/jwt-verifiable-credentials/src/main/java/org/eclipse/edc/verifiablecredentials/jwt/rules/TokenNotNullRule.java
@@ -23,17 +23,17 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
 
-import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_ACCESS_TOKEN_CLAIM;
+import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_TOKEN_CLAIM;
 
 /**
- * Verifies that the "access_token" claim is present (= non-empty)
+ * Verifies that the "token" claim is present (= non-empty)
  */
-public class AccessTokenNotNullRule implements TokenValidationRule {
+public class TokenNotNullRule implements TokenValidationRule {
 
     @Override
     public Result<Void> checkRule(@NotNull ClaimToken toVerify, @Nullable Map<String, Object> additional) {
-        return StringUtils.isNullOrEmpty(toVerify.getStringClaim(PRESENTATION_ACCESS_TOKEN_CLAIM)) ?
-                Result.failure("The '%s' claim is mandatory and must not be null.".formatted(PRESENTATION_ACCESS_TOKEN_CLAIM)) :
+        return StringUtils.isNullOrEmpty(toVerify.getStringClaim(PRESENTATION_TOKEN_CLAIM)) ?
+                Result.failure("The '%s' claim is mandatory and must not be null.".formatted(PRESENTATION_TOKEN_CLAIM)) :
                 Result.success();
     }
 }

--- a/extensions/common/crypto/jwt-verifiable-credentials/src/test/java/org/eclipse/edc/verifiablecredentials/jwt/JwtPresentationVerifierTest.java
+++ b/extensions/common/crypto/jwt-verifiable-credentials/src/test/java/org/eclipse/edc/verifiablecredentials/jwt/JwtPresentationVerifierTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.edc.verifiablecredentials.jwt;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.jwk.Curve;
@@ -102,7 +104,7 @@ class JwtPresentationVerifierTest {
     @Test
     void verifyPresentation_noCredential() {
         // create VP-JWT (signed by the presenter) that contains the VP as a claim
-        var vpJwt = JwtCreationUtils.createJwt(vpSigningKey, VP_HOLDER_ID, "degreePres", MY_OWN_DID, Map.of("vp", VP_CONTENT_TEMPLATE.formatted("")));
+        var vpJwt = JwtCreationUtils.createJwt(vpSigningKey, VP_HOLDER_ID, "degreePres", MY_OWN_DID, Map.of("vp", asMap(VP_CONTENT_TEMPLATE.formatted(""))));
 
         var context = VerifierContext.Builder.newInstance()
                 .verifier(verifier)
@@ -116,11 +118,7 @@ class JwtPresentationVerifierTest {
     @Test
     void verifyPresentation_invalidVpJson() {
         // create VP-JWT (signed by the presenter) that contains the VP as a claim
-        var vpJwt = JwtCreationUtils.createJwt(vpSigningKey, VP_HOLDER_ID, "degreePres", MY_OWN_DID, Map.of("vp", """
-                {
-                    "key": "this is very invalid!"
-                }
-                """));
+        var vpJwt = JwtCreationUtils.createJwt(vpSigningKey, VP_HOLDER_ID, "degreePres", MY_OWN_DID, Map.of("vp", Map.of("key", "this is very invalid!")));
 
         var context = VerifierContext.Builder.newInstance()
                 .verifier(verifier)
@@ -137,7 +135,7 @@ class JwtPresentationVerifierTest {
         var vcJwt1 = JwtCreationUtils.createJwt(vcSigningKey, CENTRAL_ISSUER_DID, "degreeSub", VP_HOLDER_ID, Map.of("vc", VC_CONTENT_DEGREE_EXAMPLE));
 
         // create VP-JWT (signed by the presenter) that contains the VP as a claim
-        var vpJwt = JwtCreationUtils.createJwt(vpSigningKey, VP_HOLDER_ID, "degreePres", MY_OWN_DID, Map.of("vp", VP_CONTENT_TEMPLATE.formatted("\"" + vcJwt1 + "\"")));
+        var vpJwt = JwtCreationUtils.createJwt(vpSigningKey, VP_HOLDER_ID, "degreePres", MY_OWN_DID, Map.of("vp", asMap(VP_CONTENT_TEMPLATE.formatted("\"" + vcJwt1 + "\""))));
 
         var context = VerifierContext.Builder.newInstance()
                 .verifier(verifier)
@@ -158,7 +156,7 @@ class JwtPresentationVerifierTest {
 
         // create VP-JWT (signed by the presenter) that contains the VP as a claim
         var vpContent = "\"%s\", \"%s\"".formatted(vcJwt1, vcJwt2);
-        var vpJwt = JwtCreationUtils.createJwt(vpSigningKey, VP_HOLDER_ID, "testSub", MY_OWN_DID, Map.of("vp", VP_CONTENT_TEMPLATE.formatted(vpContent)));
+        var vpJwt = JwtCreationUtils.createJwt(vpSigningKey, VP_HOLDER_ID, "testSub", MY_OWN_DID, Map.of("vp", asMap(VP_CONTENT_TEMPLATE.formatted(vpContent))));
 
         var context = VerifierContext.Builder.newInstance()
                 .verifier(verifier)
@@ -179,7 +177,7 @@ class JwtPresentationVerifierTest {
         var vcJwt1 = JwtCreationUtils.createJwt(spoofedKey, CENTRAL_ISSUER_DID, "degreeSub", VP_HOLDER_ID, Map.of("vc", VC_CONTENT_DEGREE_EXAMPLE));
 
         // create VP-JWT (signed by the presenter) that contains the VP as a claim
-        var vpJwt = JwtCreationUtils.createJwt(vpSigningKey, VP_HOLDER_ID, "degreePres", MY_OWN_DID, Map.of("vp", VP_CONTENT_TEMPLATE.formatted("\"" + vcJwt1 + "\"")));
+        var vpJwt = JwtCreationUtils.createJwt(vpSigningKey, VP_HOLDER_ID, "degreePres", MY_OWN_DID, Map.of("vp", asMap(VP_CONTENT_TEMPLATE.formatted("\"" + vcJwt1 + "\""))));
 
         var context = VerifierContext.Builder.newInstance()
                 .verifier(verifier)
@@ -199,7 +197,7 @@ class JwtPresentationVerifierTest {
         var vcJwt1 = JwtCreationUtils.createJwt(vcSigningKey, CENTRAL_ISSUER_DID, "degreeSub", VP_HOLDER_ID, Map.of("vc", VC_CONTENT_DEGREE_EXAMPLE));
 
         // create VP-JWT (signed by the presenter) that contains the VP as a claim
-        var vpJwt = JwtCreationUtils.createJwt(spoofedKey, VP_HOLDER_ID, "degreePres", MY_OWN_DID, Map.of("vp", VP_CONTENT_TEMPLATE.formatted("\"" + vcJwt1 + "\"")));
+        var vpJwt = JwtCreationUtils.createJwt(spoofedKey, VP_HOLDER_ID, "degreePres", MY_OWN_DID, Map.of("vp", asMap(VP_CONTENT_TEMPLATE.formatted("\"" + vcJwt1 + "\""))));
 
         var context = VerifierContext.Builder.newInstance()
                 .verifier(verifier)
@@ -216,7 +214,7 @@ class JwtPresentationVerifierTest {
         var vcJwt1 = JwtCreationUtils.createJwt(vcSigningKey, CENTRAL_ISSUER_DID, "degreeSub", VP_HOLDER_ID, Map.of("vc", VC_CONTENT_DEGREE_EXAMPLE));
 
         // create VP-JWT (signed by the presenter) that contains the VP as a claim
-        var vpJwt = JwtCreationUtils.createJwt(vpSigningKey, VP_HOLDER_ID, null, MY_OWN_DID, Map.of("vp", VP_CONTENT_TEMPLATE.formatted("\"" + vcJwt1 + "\"")));
+        var vpJwt = JwtCreationUtils.createJwt(vpSigningKey, VP_HOLDER_ID, null, MY_OWN_DID, Map.of("vp", asMap(VP_CONTENT_TEMPLATE.formatted("\"" + vcJwt1 + "\""))));
 
         var context = VerifierContext.Builder.newInstance()
                 .verifier(verifier)
@@ -233,7 +231,7 @@ class JwtPresentationVerifierTest {
         var vcJwt1 = JwtCreationUtils.createJwt(vcSigningKey, CENTRAL_ISSUER_DID, "test-cred-sub", VP_HOLDER_ID, Map.of("vc", VC_CONTENT_DEGREE_EXAMPLE));
 
         // create VP-JWT (signed by the presenter) that contains the VP as a claim
-        var vpJwt = JwtCreationUtils.createJwt(vpSigningKey, VP_HOLDER_ID, "test-pres-sub", "invalid-vp-audience", Map.of("vp", VP_CONTENT_TEMPLATE.formatted("\"" + vcJwt1 + "\"")));
+        var vpJwt = JwtCreationUtils.createJwt(vpSigningKey, VP_HOLDER_ID, "test-pres-sub", "invalid-vp-audience", Map.of("vp", asMap(VP_CONTENT_TEMPLATE.formatted("\"" + vcJwt1 + "\""))));
 
         var context = VerifierContext.Builder.newInstance()
                 .verifier(verifier)
@@ -241,6 +239,15 @@ class JwtPresentationVerifierTest {
                 .build();
         var result = verifier.verify(vpJwt, context);
         assertThat(result).isFailed().detail().contains("Token audience claim (aud -> [invalid-vp-audience]) did not contain expected audience: did:web:myself");
+    }
+
+    private Map<String, Object> asMap(String rawContent) {
+        try {
+            return mapper.readValue(rawContent, new TypeReference<>() {
+            });
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
     }
 
 }

--- a/extensions/common/crypto/jwt-verifiable-credentials/src/test/java/org/eclipse/edc/verifiablecredentials/jwt/rules/TokenNotNullRuleTest.java
+++ b/extensions/common/crypto/jwt-verifiable-credentials/src/test/java/org/eclipse/edc/verifiablecredentials/jwt/rules/TokenNotNullRuleTest.java
@@ -22,22 +22,22 @@ import java.util.Map;
 
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 
-class AccessTokenNotNullRuleTest {
+class TokenNotNullRuleTest {
 
-    private final AccessTokenNotNullRule rule = new AccessTokenNotNullRule();
+    private final TokenNotNullRule rule = new TokenNotNullRule();
 
     @Test
     void accessTokenClaimPresent() {
-        assertThat(rule.checkRule(ClaimToken.Builder.newInstance().claim("access_token", "foobartoken").build(), Map.of()))
+        assertThat(rule.checkRule(ClaimToken.Builder.newInstance().claim("token", "foobartoken").build(), Map.of()))
                 .isSucceeded();
     }
 
     @Test
     void accessTokenClaimEmpty() {
-        assertThat(rule.checkRule(ClaimToken.Builder.newInstance().claim("access_token", "").build(), Map.of()))
+        assertThat(rule.checkRule(ClaimToken.Builder.newInstance().claim("token", "").build(), Map.of()))
                 .isFailed()
                 .detail()
-                .isEqualTo("The 'access_token' claim is mandatory and must not be null.");
+                .isEqualTo("The 'token' claim is mandatory and must not be null.");
     }
 
     @Test
@@ -45,6 +45,6 @@ class AccessTokenNotNullRuleTest {
         assertThat(rule.checkRule(ClaimToken.Builder.newInstance().build(), Map.of()))
                 .isFailed()
                 .detail()
-                .isEqualTo("The 'access_token' claim is mandatory and must not be null.");
+                .isEqualTo("The 'token' claim is mandatory and must not be null.");
     }
 }

--- a/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtension.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtension.java
@@ -43,16 +43,15 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.token.rules.AudienceValidationRule;
 import org.eclipse.edc.token.rules.ExpirationIssuedAtValidationRule;
-import org.eclipse.edc.token.rules.NotBeforeValidationRule;
 import org.eclipse.edc.token.spi.TokenValidationRulesRegistry;
 import org.eclipse.edc.token.spi.TokenValidationService;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.verifiablecredentials.jwt.JwtPresentationVerifier;
-import org.eclipse.edc.verifiablecredentials.jwt.rules.AccessTokenNotNullRule;
 import org.eclipse.edc.verifiablecredentials.jwt.rules.HasSubjectRule;
 import org.eclipse.edc.verifiablecredentials.jwt.rules.IssuerEqualsSubjectRule;
 import org.eclipse.edc.verifiablecredentials.jwt.rules.JtiValidationRule;
 import org.eclipse.edc.verifiablecredentials.jwt.rules.SubJwkIsNullRule;
+import org.eclipse.edc.verifiablecredentials.jwt.rules.TokenNotNullRule;
 import org.eclipse.edc.verifiablecredentials.linkeddata.DidMethodResolver;
 import org.eclipse.edc.verifiablecredentials.linkeddata.LdpVerifier;
 import org.jetbrains.annotations.NotNull;
@@ -128,8 +127,7 @@ public class IdentityAndTrustExtension implements ServiceExtension {
         rulesRegistry.addRule(IATP_SELF_ISSUED_TOKEN_CONTEXT, new AudienceValidationRule(getOwnDid(context)));
         rulesRegistry.addRule(IATP_SELF_ISSUED_TOKEN_CONTEXT, new JtiValidationRule(context.getMonitor()));
         rulesRegistry.addRule(IATP_SELF_ISSUED_TOKEN_CONTEXT, new ExpirationIssuedAtValidationRule(clock, 5));
-        rulesRegistry.addRule(IATP_SELF_ISSUED_TOKEN_CONTEXT, new NotBeforeValidationRule(clock, 5));
-        rulesRegistry.addRule(IATP_SELF_ISSUED_TOKEN_CONTEXT, new AccessTokenNotNullRule());
+        rulesRegistry.addRule(IATP_SELF_ISSUED_TOKEN_CONTEXT, new TokenNotNullRule());
 
         // add all rules for validating VerifiableCredential JWTs
         rulesRegistry.addRule(JWT_VC_TOKEN_CONTEXT, new HasSubjectRule());

--- a/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/defaults/DefaultCredentialServiceClient.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/defaults/DefaultCredentialServiceClient.java
@@ -45,7 +45,7 @@ import static org.eclipse.edc.spi.result.Result.failure;
 import static org.eclipse.edc.spi.result.Result.success;
 
 public class DefaultCredentialServiceClient implements CredentialServiceClient {
-    public static final String PRESENTATION_ENDPOINT = "/presentation/query";
+    public static final String PRESENTATION_ENDPOINT = "/presentations/query";
     private final EdcHttpClient httpClient;
     private final JsonBuilderFactory jsonFactory;
     private final ObjectMapper objectMapper;
@@ -73,7 +73,7 @@ public class DefaultCredentialServiceClient implements CredentialServiceClient {
             var request = new Request.Builder()
                     .post(RequestBody.create(requestJson, MediaType.parse("application/json")))
                     .url(url)
-                    .addHeader("Authorization", "%s".formatted(selfIssuedTokenJwt))
+                    .addHeader("Authorization", "Bearer %s".formatted(selfIssuedTokenJwt))
                     .build();
 
             var response = httpClient.execute(request);
@@ -149,7 +149,6 @@ public class DefaultCredentialServiceClient implements CredentialServiceClient {
                         .add(VcConstants.PRESENTATION_EXCHANGE_URL)
                         .add(VcConstants.IATP_CONTEXT_URL))
                 .add(JsonLdKeywords.TYPE, PresentationQueryMessage.PRESENTATION_QUERY_MESSAGE_TYPE)
-                .add("scope", scopeArray.build())
                 .build();
     }
 }

--- a/extensions/common/iam/identity-trust/identity-trust-core/src/test/java/org/eclipse/edc/iam/identitytrust/core/defaults/DefaultCredentialServiceClientTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/test/java/org/eclipse/edc/iam/identitytrust/core/defaults/DefaultCredentialServiceClientTest.java
@@ -60,6 +60,7 @@ import static org.mockito.Mockito.when;
 
 class DefaultCredentialServiceClientTest {
 
+    public static final String PRESENTATION_QUERY = "/presentations/query";
     private static final String CS_URL = "http://test.com/cs";
     private final EdcHttpClient httpClientMock = mock();
     private DefaultCredentialServiceClient client;
@@ -91,7 +92,7 @@ class DefaultCredentialServiceClientTest {
         var result = client.requestPresentation(CS_URL, "foo", List.of());
         assertThat(result.succeeded()).isTrue();
         assertThat(result.getContent()).hasSize(1).allMatch(vpc -> vpc.format() == CredentialFormat.JSON_LD);
-        verify(httpClientMock).execute(argThat(rq -> rq.url().toString().endsWith("/presentation/query")));
+        verify(httpClientMock).execute(argThat(rq -> rq.url().toString().endsWith(PRESENTATION_QUERY)));
     }
 
     @Test
@@ -103,7 +104,7 @@ class DefaultCredentialServiceClientTest {
         var result = client.requestPresentation(CS_URL, "foo", List.of());
         assertThat(result.succeeded()).isTrue();
         assertThat(result.getContent()).hasSize(1).allMatch(vpc -> vpc.format() == CredentialFormat.JWT);
-        verify(httpClientMock).execute(argThat(rq -> rq.url().toString().endsWith("/presentation/query")));
+        verify(httpClientMock).execute(argThat(rq -> rq.url().toString().endsWith(PRESENTATION_QUERY)));
     }
 
     @Test
@@ -117,7 +118,7 @@ class DefaultCredentialServiceClientTest {
         assertThat(result.getContent()).hasSize(2)
                 .anySatisfy(vp -> assertThat(vp.format()).isEqualTo(CredentialFormat.JSON_LD))
                 .anySatisfy(vp -> assertThat(vp.format()).isEqualTo(CredentialFormat.JWT));
-        verify(httpClientMock).execute(argThat(rq -> rq.url().toString().endsWith("/presentation/query")));
+        verify(httpClientMock).execute(argThat(rq -> rq.url().toString().endsWith(PRESENTATION_QUERY)));
     }
 
     @Test
@@ -130,7 +131,7 @@ class DefaultCredentialServiceClientTest {
         assertThat(result.succeeded()).isTrue();
         assertThat(result.getContent()).hasSize(2)
                 .allSatisfy(vp -> assertThat(vp.format()).isEqualTo(CredentialFormat.JSON_LD));
-        verify(httpClientMock).execute(argThat(rq -> rq.url().toString().endsWith("/presentation/query")));
+        verify(httpClientMock).execute(argThat(rq -> rq.url().toString().endsWith(PRESENTATION_QUERY)));
     }
 
     @Test
@@ -143,7 +144,7 @@ class DefaultCredentialServiceClientTest {
         assertThat(result.succeeded()).isTrue();
         assertThat(result.getContent()).hasSize(2)
                 .allSatisfy(vp -> assertThat(vp.format()).isEqualTo(CredentialFormat.JWT));
-        verify(httpClientMock).execute(argThat(rq -> rq.url().toString().endsWith("/presentation/query")));
+        verify(httpClientMock).execute(argThat(rq -> rq.url().toString().endsWith(PRESENTATION_QUERY)));
     }
 
     @ParameterizedTest(name = "CS returns HTTP error code {0}")
@@ -155,7 +156,7 @@ class DefaultCredentialServiceClientTest {
         var res = client.requestPresentation(CS_URL, "foo", List.of());
         assertThat(res.failed()).isTrue();
         assertThat(res.getFailureDetail()).isEqualTo("Presentation Query failed: HTTP %s, message: Test failure".formatted(httpCode));
-        verify(httpClientMock).execute(argThat(rq -> rq.url().toString().endsWith("/presentation/query")));
+        verify(httpClientMock).execute(argThat(rq -> rq.url().toString().endsWith(PRESENTATION_QUERY)));
     }
 
     @DisplayName("CS returns an empty array, because no VC was found")
@@ -167,7 +168,7 @@ class DefaultCredentialServiceClientTest {
         var res = client.requestPresentation(CS_URL, "foo", List.of());
         assertThat(res.succeeded()).isTrue();
         assertThat(res.getContent()).isNotNull().doesNotContainNull().isEmpty();
-        verify(httpClientMock).execute(argThat(rq -> rq.url().toString().endsWith("/presentation/query")));
+        verify(httpClientMock).execute(argThat(rq -> rq.url().toString().endsWith(PRESENTATION_QUERY)));
     }
 
     private VerifiablePresentation createPresentation() {

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/IdentityAndTrustService.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/IdentityAndTrustService.java
@@ -48,7 +48,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_ACCESS_TOKEN_CLAIM;
+import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_TOKEN_CLAIM;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.AUDIENCE;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.EXPIRATION_TIME;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.ISSUED_AT;
@@ -140,10 +140,10 @@ public class IdentityAndTrustService implements IdentityService {
 
         // create our own SI token, to request the VPs
         var claimToken = claimTokenResult.getContent();
-        var accessToken = claimToken.getStringClaim(PRESENTATION_ACCESS_TOKEN_CLAIM);
+        var accessToken = claimToken.getStringClaim(PRESENTATION_TOKEN_CLAIM);
         var issuer = claimToken.getStringClaim(ISSUER);
 
-        var siTokenClaims = Map.of(PRESENTATION_ACCESS_TOKEN_CLAIM, accessToken,
+        var siTokenClaims = Map.of(PRESENTATION_TOKEN_CLAIM, accessToken,
                 ISSUED_AT, Instant.now().toString(),
                 AUDIENCE, issuer,
                 ISSUER, myOwnDid,

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/test/java/org/eclipse/edc/iam/identitytrust/service/IdentityAndTrustServiceTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/test/java/org/eclipse/edc/iam/identitytrust/service/IdentityAndTrustServiceTest.java
@@ -51,7 +51,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_ACCESS_TOKEN_CLAIM;
+import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_TOKEN_CLAIM;
 import static org.eclipse.edc.identitytrust.TestFunctions.TRUSTED_ISSUER;
 import static org.eclipse.edc.identitytrust.TestFunctions.createCredentialBuilder;
 import static org.eclipse.edc.identitytrust.TestFunctions.createJwt;
@@ -90,7 +90,7 @@ class IdentityAndTrustServiceTest {
 
         when(actionMock.apply(any())).thenReturn(success(ClaimToken.Builder.newInstance()
                 .claim("iss", CONSUMER_DID)
-                .claim(PRESENTATION_ACCESS_TOKEN_CLAIM, jwt.getToken()).build()));
+                .claim(PRESENTATION_TOKEN_CLAIM, jwt.getToken()).build()));
 
         when(mockedSts.createToken(any(), any())).thenReturn(success(TokenRepresentation.Builder.newInstance().build()));
     }
@@ -104,8 +104,8 @@ class IdentityAndTrustServiceTest {
     @Nested
     class ObtainClientCredentials {
         @ParameterizedTest(name = "{0}")
-        @ValueSource(strings = {"org.eclipse.edc:TestCredential:modify", "org.eclipse.edc:TestCredential:", "org.eclipse.edc:TestCredential: ", "org.eclipse.edc:TestCredential:write*", ":TestCredential:read",
-                "org.eclipse.edc:fooCredential:+"})
+        @ValueSource(strings = { "org.eclipse.edc:TestCredential:modify", "org.eclipse.edc:TestCredential:", "org.eclipse.edc:TestCredential: ", "org.eclipse.edc:TestCredential:write*", ":TestCredential:read",
+                "org.eclipse.edc:fooCredential:+" })
         void obtainClientCredentials_invalidScopeString(String scope) {
             var tp = TokenParameters.Builder.newInstance()
                     .claims(SCOPE, scope)
@@ -118,8 +118,8 @@ class IdentityAndTrustServiceTest {
         }
 
         @ParameterizedTest(name = "Scope: {0}")
-        @ValueSource(strings = {"org.eclipse.edc:TestCredential:modify", "org.eclipse.edc:TestCredential:", "org.eclipse.edc:TestCredential: ", "org.eclipse.edc:TestCredential:write*", ":TestCredential:read",
-                "org.eclipse.edc:fooCredential:+"})
+        @ValueSource(strings = { "org.eclipse.edc:TestCredential:modify", "org.eclipse.edc:TestCredential:", "org.eclipse.edc:TestCredential: ", "org.eclipse.edc:TestCredential:write*", ":TestCredential:read",
+                "org.eclipse.edc:fooCredential:+" })
         @NullSource
         @EmptySource
         void obtainClientCredentials_validScopeString(String scope) {

--- a/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-api/src/main/java/org/eclipse/edc/connector/api/sts/controller/SecureTokenServiceApiController.java
+++ b/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-api/src/main/java/org/eclipse/edc/connector/api/sts/controller/SecureTokenServiceApiController.java
@@ -65,7 +65,7 @@ public class SecureTokenServiceApiController implements SecureTokenServiceApi {
     private StsClientTokenAdditionalParams additionalParams(StsTokenRequest request) {
         return StsClientTokenAdditionalParams.Builder.newInstance()
                 .audience(request.getAudience())
-                .accessToken(request.getAccessToken())
+                .accessToken(request.getToken())
                 .bearerAccessScope(request.getBearerAccessScope())
                 .build();
     }

--- a/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-api/src/main/java/org/eclipse/edc/connector/api/sts/model/StsTokenRequest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-api/src/main/java/org/eclipse/edc/connector/api/sts/model/StsTokenRequest.java
@@ -26,8 +26,8 @@ import jakarta.ws.rs.FormParam;
  *  <li>clientId:           Client ID identifier.</li>
  *  <li>clientSecret:       Authorization secret for the client/</li>
  *  <li>audience:           Audience according to the <a href="https://datatracker.ietf.org/doc/html/draft-tschofenig-oauth-audience-00#section-3">spec</a>.</li>
- *  <li>bearerAccessScope:  Space-delimited scopes to be included in the access_token claim.</li>
- *  <li>accessToken:        VP/VC Access Token to be included as access_token claim.</li>
+ *  <li>bearerAccessScope:  Space-delimited scopes to be included in the token claim.</li>
+ *  <li>token:        VP/VC Access Token to be included as token claim.</li>
  *  <li>grantType:          Type of grant. Must be client_credentials.</li>
  * </ul>
  */
@@ -47,14 +47,14 @@ public final class StsTokenRequest {
     @FormParam("audience")
     private String audience;
 
-    @Parameter(name = "bearer_access_scope", description = "Scope to be added in the VP access token", style = ParameterStyle.FORM)
+    @Parameter(name = "bearer_access_scope", description = "Scope to be added in the VP token", style = ParameterStyle.FORM)
     @FormParam("bearer_access_scope")
     private String bearerAccessScope;
 
 
-    @Parameter(name = "access_token", description = "VP access token to be added as a claim in the SI token", style = ParameterStyle.FORM)
-    @FormParam("access_token")
-    private String accessToken;
+    @Parameter(name = "token", description = "VP token to be added as a claim in the SI token", style = ParameterStyle.FORM)
+    @FormParam("token")
+    private String token;
 
     @Parameter(name = "client_secret", description = "Secret of the client requesting an SI token", required = true, style = ParameterStyle.FORM)
     @FormParam("client_secret")
@@ -85,8 +85,8 @@ public final class StsTokenRequest {
     }
 
 
-    public String getAccessToken() {
-        return accessToken;
+    public String getToken() {
+        return token;
     }
 
     public static class Builder {
@@ -122,7 +122,7 @@ public final class StsTokenRequest {
         }
 
         public Builder accessToken(String accessToken) {
-            this.request.accessToken = accessToken;
+            this.request.token = accessToken;
             return this;
         }
 

--- a/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-core/src/main/java/org/eclipse/edc/iam/identitytrust/sts/core/defaults/service/StsClientTokenGeneratorServiceImpl.java
+++ b/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-core/src/main/java/org/eclipse/edc/iam/identitytrust/sts/core/defaults/service/StsClientTokenGeneratorServiceImpl.java
@@ -30,7 +30,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
-import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_ACCESS_TOKEN_CLAIM;
+import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_TOKEN_CLAIM;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.AUDIENCE;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.ISSUER;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.SUBJECT;
@@ -38,7 +38,7 @@ import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.SUBJECT;
 public class StsClientTokenGeneratorServiceImpl implements StsClientTokenGeneratorService {
 
     private static final Map<String, Function<StsClientTokenAdditionalParams, String>> CLAIM_MAPPERS = Map.of(
-            PRESENTATION_ACCESS_TOKEN_CLAIM, StsClientTokenAdditionalParams::getAccessToken);
+            PRESENTATION_TOKEN_CLAIM, StsClientTokenAdditionalParams::getAccessToken);
 
     private final long tokenExpiration;
     private final StsTokenGenerationProvider tokenGenerationProvider;

--- a/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-core/src/test/java/org/eclipse/edc/iam/identitytrust/sts/core/defaults/StsClientTokenIssuanceIntegrationTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-core/src/test/java/org/eclipse/edc/iam/identitytrust/sts/core/defaults/StsClientTokenIssuanceIntegrationTest.java
@@ -47,7 +47,7 @@ import static com.nimbusds.jwt.JWTClaimNames.JWT_ID;
 import static com.nimbusds.jwt.JWTClaimNames.SUBJECT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.iam.identitytrust.sts.store.fixtures.TestFunctions.createClientBuilder;
-import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_ACCESS_TOKEN_CLAIM;
+import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_TOKEN_CLAIM;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.CLIENT_ID;
 import static org.mockito.Mockito.mock;
 
@@ -142,7 +142,7 @@ public class StsClientTokenIssuanceIntegrationTest {
                 .containsEntry(ISSUER, did)
                 .containsEntry(SUBJECT, did)
                 .containsEntry(AUDIENCE, List.of(audience))
-                .containsKeys(JWT_ID, EXPIRATION_TIME, ISSUED_AT, "access_token")
+                .containsKeys(JWT_ID, EXPIRATION_TIME, ISSUED_AT, PRESENTATION_TOKEN_CLAIM)
                 .doesNotContainKey(CLIENT_ID);
 
     }
@@ -179,7 +179,7 @@ public class StsClientTokenIssuanceIntegrationTest {
                 .containsEntry(ISSUER, did)
                 .containsEntry(SUBJECT, did)
                 .containsEntry(AUDIENCE, List.of(audience))
-                .containsEntry(PRESENTATION_ACCESS_TOKEN_CLAIM, accessToken)
+                .containsEntry(PRESENTATION_TOKEN_CLAIM, accessToken)
                 .containsKeys(JWT_ID, EXPIRATION_TIME, ISSUED_AT)
                 .doesNotContainKey(CLIENT_ID);
 

--- a/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-embedded/src/main/java/org/eclipse/edc/iam/identitytrust/sts/embedded/EmbeddedSecureTokenService.java
+++ b/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-embedded/src/main/java/org/eclipse/edc/iam/identitytrust/sts/embedded/EmbeddedSecureTokenService.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static java.util.Optional.ofNullable;
-import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_ACCESS_TOKEN_CLAIM;
+import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_TOKEN_CLAIM;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.AUDIENCE;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.ISSUER;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.SCOPE;
@@ -78,7 +78,7 @@ public class EmbeddedSecureTokenService implements SecureTokenService {
     private Result<Void> createAndAcceptAccessToken(Map<String, String> claims, String scope, BiConsumer<String, String> consumer) {
         return createAccessToken(claims, scope)
                 .compose(tokenRepresentation -> success(tokenRepresentation.getToken()))
-                .onSuccess(withClaim(PRESENTATION_ACCESS_TOKEN_CLAIM, consumer))
+                .onSuccess(withClaim(PRESENTATION_TOKEN_CLAIM, consumer))
                 .mapTo();
     }
 

--- a/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-embedded/src/test/java/org/eclipse/edc/iam/identitytrust/sts/embedded/EmbeddedSecureTokenServiceIntegrationTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-embedded/src/test/java/org/eclipse/edc/iam/identitytrust/sts/embedded/EmbeddedSecureTokenServiceIntegrationTest.java
@@ -46,7 +46,7 @@ import static com.nimbusds.jwt.JWTClaimNames.SUBJECT;
 import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
-import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_ACCESS_TOKEN_CLAIM;
+import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_TOKEN_CLAIM;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.SCOPE;
 
@@ -81,7 +81,7 @@ public class EmbeddedSecureTokenServiceIntegrationTest {
                     assertThat(jwt.getJWTClaimsSet().getClaims())
                             .containsEntry(ISSUER, issuer)
                             .containsKeys(JWT_ID, EXPIRATION_TIME, ISSUED_AT)
-                            .doesNotContainKey(PRESENTATION_ACCESS_TOKEN_CLAIM);
+                            .doesNotContainKey(PRESENTATION_TOKEN_CLAIM);
                 });
 
     }
@@ -102,7 +102,7 @@ public class EmbeddedSecureTokenServiceIntegrationTest {
                     assertThat(jwt.getJWTClaimsSet().getClaims())
                             .containsEntry(ISSUER, issuer)
                             .containsKeys(JWT_ID, EXPIRATION_TIME, ISSUED_AT)
-                            .extractingByKey(PRESENTATION_ACCESS_TOKEN_CLAIM, as(STRING))
+                            .extractingByKey(PRESENTATION_TOKEN_CLAIM, as(STRING))
                             .satisfies(accessToken -> {
                                 var accessTokenJwt = SignedJWT.parse(accessToken);
                                 assertThat(accessTokenJwt.verify(createVerifier(accessTokenJwt.getHeader(), keyPair.getPublic()))).isTrue();
@@ -115,7 +115,7 @@ public class EmbeddedSecureTokenServiceIntegrationTest {
                             });
                 });
     }
-    
+
     @ParameterizedTest
     @ArgumentsSource(ClaimsArguments.class)
     void createToken_shouldFail_withMissingClaims(Map<String, String> claims) {

--- a/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-remote/src/main/java/org/eclipse/edc/iam/identitytrust/sts/remote/RemoteSecureTokenService.java
+++ b/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-remote/src/main/java/org/eclipse/edc/iam/identitytrust/sts/remote/RemoteSecureTokenService.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.BEARER_ACCESS_SCOPE;
-import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_ACCESS_TOKEN_CLAIM;
+import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_TOKEN_CLAIM;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.AUDIENCE;
 
 public class RemoteSecureTokenService implements SecureTokenService {
@@ -37,7 +37,7 @@ public class RemoteSecureTokenService implements SecureTokenService {
 
     private static final Map<String, String> CLAIM_MAPPING = Map.of(
             AUDIENCE, AUDIENCE_PARAM,
-            PRESENTATION_ACCESS_TOKEN_CLAIM, PRESENTATION_ACCESS_TOKEN_CLAIM);
+            PRESENTATION_TOKEN_CLAIM, PRESENTATION_TOKEN_CLAIM);
 
     private final Oauth2Client oauth2Client;
     private final StsRemoteClientConfiguration configuration;

--- a/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-remote/src/test/java/org/eclipse/edc/iam/identitytrust/sts/remote/RemoteSecureTokenServiceTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-remote/src/test/java/org/eclipse/edc/iam/identitytrust/sts/remote/RemoteSecureTokenServiceTest.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.iam.identitytrust.sts.remote.RemoteSecureTokenService.AUDIENCE_PARAM;
 import static org.eclipse.edc.iam.identitytrust.sts.remote.RemoteSecureTokenService.GRANT_TYPE;
 import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.BEARER_ACCESS_SCOPE;
-import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_ACCESS_TOKEN_CLAIM;
+import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_TOKEN_CLAIM;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.AUDIENCE;
 import static org.mockito.ArgumentMatchers.any;
@@ -92,7 +92,7 @@ public class RemoteSecureTokenServiceTest {
         var audience = "aud";
         var accessToken = "accessToken";
         when(oauth2Client.requestToken(any())).thenReturn(Result.success(TokenRepresentation.Builder.newInstance().build()));
-        assertThat(secureTokenService.createToken(Map.of(AUDIENCE, audience, PRESENTATION_ACCESS_TOKEN_CLAIM, accessToken), null)).isSucceeded();
+        assertThat(secureTokenService.createToken(Map.of(AUDIENCE, audience, PRESENTATION_TOKEN_CLAIM, accessToken), null)).isSucceeded();
 
         var captor = ArgumentCaptor.forClass(SharedSecretOauth2CredentialsRequest.class);
         verify(oauth2Client).requestToken(captor.capture());
@@ -104,8 +104,8 @@ public class RemoteSecureTokenServiceTest {
             assertThat(request.getClientSecret()).isEqualTo(configuration.clientSecret());
             assertThat(request.getParams())
                     .containsEntry(AUDIENCE_PARAM, audience)
-                    .containsEntry(PRESENTATION_ACCESS_TOKEN_CLAIM, accessToken);
+                    .containsEntry(PRESENTATION_TOKEN_CLAIM, accessToken);
         });
     }
-    
+
 }

--- a/launchers/sts-server/README.md
+++ b/launchers/sts-server/README.md
@@ -11,7 +11,8 @@ To build the STS just run this command in the root of the connector project:
 ./gradlew launchers:sts-server:build
 ```
 
-Once the build end, the STS jar should be available in the build directory `aunchers/sts-server/build/libs/sts-server.jar`
+Once the build end, the STS jar should be available in the build
+directory `aunchers/sts-server/build/libs/sts-server.jar`
 
 ### How to run the STS
 
@@ -39,7 +40,7 @@ The STS will be available on `9292` port.
 
 ### Fetching tokens
 
-The only client configured is `testClient` one via `config.properties` file. The STS for now supports only 
+The only client configured is `testClient` one via `config.properties` file. The STS for now supports only
 OAuth2 client credentials with some custom parameters.
 
 To fetch a token run this curl command:
@@ -54,7 +55,8 @@ curl --request POST \
   --data audience=test10 
 ```
 
-For attaching the `bearer_access_scope` as described in the IATP [spec](https://github.com/eclipse-tractusx/identity-trust/blob/main/specifications/M1/identity.protocol.base.md#6-using-the-oauth-2-client-credential-grant-to-obtain-access-tokens-from-an-sts) :
+For attaching the `bearer_access_scope` as described in the
+IATP [spec](https://github.com/eclipse-tractusx/identity-trust/blob/main/specifications/M1/identity.protocol.base.md#6-using-the-oauth-2-client-credential-grant-to-obtain-access-tokens-from-an-sts) :
 
 ```shell
 curl --request POST \
@@ -67,4 +69,4 @@ curl --request POST \
   --data bearer_access_scope=test
 ```
 
-It will generate an additional claim `access_token` with the scopes inside.
+It will generate an additional claim `token` with the scopes inside.

--- a/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/SecureTokenService.java
+++ b/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/SecureTokenService.java
@@ -31,7 +31,7 @@ public interface SecureTokenService {
      *
      * @param claims            a set of claims, that are to be included in the SI token. MUST include {@code iss}, {@code sub} and {@code aud}.
      * @param bearerAccessScope if non-null, must be a space-separated list of scopes as per <a href="https://github.com/eclipse-tractusx/identity-trust/blob/main/specifications/M1/verifiable.presentation.protocol.md#31-access-scopes">IATP specification</a>
-     *                          if bearerAccessScope != null -> creates an {@code access_token} claim, which is another JWT containing the scope as claims.
+     *                          if bearerAccessScope != null -> creates a {@code token} claim, which is another JWT containing the scope as claims.
      *                          if bearerAccessScope == null -> creates a normal JWT using all the claims in the map
      */
     Result<TokenRepresentation> createToken(Map<String, String> claims, @Nullable String bearerAccessScope);

--- a/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/SelfIssuedTokenConstants.java
+++ b/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/identitytrust/SelfIssuedTokenConstants.java
@@ -22,8 +22,8 @@ public final class SelfIssuedTokenConstants {
     /**
      * VP access token claim
      */
-    public static final String PRESENTATION_ACCESS_TOKEN_CLAIM = "access_token";
-    
+    public static final String PRESENTATION_TOKEN_CLAIM = "token";
+
     /**
      * Scopes to be encoded in the VP access token
      */

--- a/spi/common/identity-trust-spi/src/testFixtures/java/org/eclipse/edc/identitytrust/TestFunctions.java
+++ b/spi/common/identity-trust-spi/src/testFixtures/java/org/eclipse/edc/identitytrust/TestFunctions.java
@@ -36,7 +36,7 @@ import java.util.Date;
 import java.util.Map;
 
 import static java.time.Instant.now;
-import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_ACCESS_TOKEN_CLAIM;
+import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_TOKEN_CLAIM;
 
 public class TestFunctions {
 
@@ -81,7 +81,7 @@ public class TestFunctions {
         var claimsSet = new JWTClaimsSet.Builder()
                 .subject(subject)
                 .issuer(issuer)
-                .claim(PRESENTATION_ACCESS_TOKEN_CLAIM, createJwt(new JWTClaimsSet.Builder().claim("scope", "fooscope").build()).getToken())
+                .claim(PRESENTATION_TOKEN_CLAIM, createJwt(new JWTClaimsSet.Builder().claim("scope", "fooscope").build()).getToken())
                 .expirationTime(new Date(new Date().getTime() + 60 * 1000))
                 .build();
         return createJwt(claimsSet);

--- a/system-tests/sts-api/sts-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/sts/api/RemoteStsEndToEndTest.java
+++ b/system-tests/sts-api/sts-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/sts/api/RemoteStsEndToEndTest.java
@@ -37,7 +37,7 @@ import static com.nimbusds.jwt.JWTClaimNames.ISSUER;
 import static com.nimbusds.jwt.JWTClaimNames.JWT_ID;
 import static com.nimbusds.jwt.JWTClaimNames.SUBJECT;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_ACCESS_TOKEN_CLAIM;
+import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_TOKEN_CLAIM;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.junit.testfixtures.TestUtils.getFreePort;
 import static org.eclipse.edc.junit.testfixtures.TestUtils.testHttpClient;
@@ -93,7 +93,7 @@ public class RemoteStsEndToEndTest extends StsEndToEndTestBase {
                 });
 
     }
-    
+
     @Test
     void requestToken_withBearerScope() {
         var audience = "audience";
@@ -113,7 +113,7 @@ public class RemoteStsEndToEndTest extends StsEndToEndTestBase {
                             .containsEntry(AUDIENCE, List.of(audience))
                             .doesNotContainKey(CLIENT_ID)
                             .containsKeys(JWT_ID, EXPIRATION_TIME, ISSUED_AT)
-                            .hasEntrySatisfying(PRESENTATION_ACCESS_TOKEN_CLAIM, (accessToken) -> {
+                            .hasEntrySatisfying(PRESENTATION_TOKEN_CLAIM, (accessToken) -> {
                                 assertThat(parseClaims((String) accessToken))
                                         .containsEntry(ISSUER, client.getDid())
                                         .containsEntry(SUBJECT, audience)
@@ -131,7 +131,7 @@ public class RemoteStsEndToEndTest extends StsEndToEndTestBase {
         var accessToken = "test_token";
         var params = Map.of(
                 AUDIENCE, audience,
-                PRESENTATION_ACCESS_TOKEN_CLAIM, accessToken);
+                PRESENTATION_TOKEN_CLAIM, accessToken);
 
         var client = initClient(config.clientId(), config.clientSecret());
 
@@ -144,7 +144,7 @@ public class RemoteStsEndToEndTest extends StsEndToEndTestBase {
                             .containsEntry(SUBJECT, client.getDid())
                             .containsEntry(AUDIENCE, List.of(audience))
                             .doesNotContainKey(CLIENT_ID)
-                            .containsEntry(PRESENTATION_ACCESS_TOKEN_CLAIM, accessToken)
+                            .containsEntry(PRESENTATION_TOKEN_CLAIM, accessToken)
                             .containsKeys(JWT_ID, EXPIRATION_TIME, ISSUED_AT);
                 });
     }

--- a/system-tests/sts-api/sts-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/sts/api/StsApiEndToEndTest.java
+++ b/system-tests/sts-api/sts-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/sts/api/StsApiEndToEndTest.java
@@ -36,7 +36,7 @@ import static com.nimbusds.jwt.JWTClaimNames.SUBJECT;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_ACCESS_TOKEN_CLAIM;
+import static org.eclipse.edc.identitytrust.SelfIssuedTokenConstants.PRESENTATION_TOKEN_CLAIM;
 import static org.eclipse.edc.junit.testfixtures.TestUtils.getFreePort;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.CLIENT_ID;
 import static org.hamcrest.Matchers.is;
@@ -126,7 +126,7 @@ public class StsApiEndToEndTest extends StsEndToEndTestBase {
                 .containsEntry(AUDIENCE, List.of(audience))
                 .doesNotContainKey(CLIENT_ID)
                 .containsKeys(JWT_ID, EXPIRATION_TIME, ISSUED_AT)
-                .hasEntrySatisfying(PRESENTATION_ACCESS_TOKEN_CLAIM, (accessToken) -> {
+                .hasEntrySatisfying(PRESENTATION_TOKEN_CLAIM, (accessToken) -> {
                     assertThat(parseClaims((String) accessToken))
                             .containsEntry(ISSUER, client.getDid())
                             .containsEntry(SUBJECT, audience)
@@ -139,7 +139,7 @@ public class StsApiEndToEndTest extends StsEndToEndTestBase {
     void requestToken_withAttachedAccessScope() throws IOException, ParseException {
         var clientSecret = "client_secret";
         var audience = "audience";
-        var accessToken = "test_token";
+        var token = "test_token";
         var expiresIn = 300;
         var client = initClient(clientSecret);
 
@@ -147,10 +147,10 @@ public class StsApiEndToEndTest extends StsEndToEndTestBase {
         var params = Map.of(
                 "client_id", client.getClientId(),
                 "audience", audience,
-                "access_token", accessToken,
+                "token", token,
                 "client_secret", clientSecret);
 
-        var token = tokenRequest(params)
+        var accessToken = tokenRequest(params)
                 .statusCode(200)
                 .contentType(JSON)
                 .body("access_token", notNullValue())
@@ -160,12 +160,12 @@ public class StsApiEndToEndTest extends StsEndToEndTestBase {
                 .jsonPath().getString("access_token");
 
 
-        assertThat(parseClaims(token))
+        assertThat(parseClaims(accessToken))
                 .containsEntry(ISSUER, client.getDid())
                 .containsEntry(SUBJECT, client.getDid())
                 .containsEntry(AUDIENCE, List.of(audience))
                 .doesNotContainKey(CLIENT_ID)
-                .containsEntry(PRESENTATION_ACCESS_TOKEN_CLAIM, accessToken)
+                .containsEntry(PRESENTATION_TOKEN_CLAIM, token)
                 .containsKeys(JWT_ID, EXPIRATION_TIME, ISSUED_AT);
     }
 


### PR DESCRIPTION
## What this PR changes/adds

Fixes after IATP changes about renaming `access_token` to `token`.

Also in this PR:

- Fixes some case of  Verifiable Presentation verification in JWT format
- Removed the `nbf` claim verification
- Changed the API path for the presentation query to `{base_path}/presentations/query`



