### PR TITLE
chore: add UNAUTHORIZED case label

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -57,18 +57,17 @@ maven/mavencentral/com.github.stephenc.jcip/jcip-annotations/1.0-1, Apache-2.0, 
 maven/mavencentral/com.google.code.findbugs/jsr305/2.0.1, BSD-3-Clause AND CC-BY-2.5 AND LGPL-2.1+, approved, CQ13390
 maven/mavencentral/com.google.code.findbugs/jsr305/3.0.2, Apache-2.0, approved, #20
 maven/mavencentral/com.google.code.gson/gson/2.10.1, Apache-2.0, approved, #6159
-maven/mavencentral/com.google.collections/google-collections/1.0, Apache-2.0, approved, CQ3285
 maven/mavencentral/com.google.crypto.tink/tink/1.12.0, Apache-2.0, approved, #12041
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.11.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.22.0, Apache-2.0, approved, #10661
-maven/mavencentral/com.google.errorprone/error_prone_annotations/2.23.0, Apache-2.0, approved, #11083
+maven/mavencentral/com.google.errorprone/error_prone_annotations/2.26.1, Apache-2.0, approved, #13657
 maven/mavencentral/com.google.guava/failureaccess/1.0.1, Apache-2.0, approved, CQ22654
 maven/mavencentral/com.google.guava/failureaccess/1.0.2, Apache-2.0, approved, CQ22654
 maven/mavencentral/com.google.guava/guava/28.1-android, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.guava/guava/28.2-android, Apache-2.0 AND LicenseRef-Public-Domain, approved, CQ22437
 maven/mavencentral/com.google.guava/guava/31.0.1-android, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.guava/guava/31.1-jre, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.guava/guava/33.0.0-jre, Apache-2.0 AND CC0-1.0, approved, #12173
+maven/mavencentral/com.google.guava/guava/33.1.0-jre, Apache-2.0 AND CC0-1.0, approved, #13675
 maven/mavencentral/com.google.guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava, Apache-2.0, approved, CQ22657
 maven/mavencentral/com.google.j2objc/j2objc-annotations/1.3, Apache-2.0, approved, CQ21195
 maven/mavencentral/com.google.protobuf/protobuf-java/3.23.4, BSD-3-Clause, approved, #8634
@@ -81,7 +80,7 @@ maven/mavencentral/com.lmax/disruptor/3.4.4, Apache-2.0, approved, clearlydefine
 maven/mavencentral/com.networknt/json-schema-validator/1.0.76, Apache-2.0, approved, CQ22638
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.28, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.37.3, Apache-2.0, approved, #11701
-maven/mavencentral/com.puppycrawl.tools/checkstyle/10.14.0, LGPL-2.1-or-later AND (Apache-2.0 AND LGPL-2.1-or-later) AND Apache-2.0, approved, #13562
+maven/mavencentral/com.puppycrawl.tools/checkstyle/10.14.2, LGPL-2.1-or-later AND (Apache-2.0 AND LGPL-2.1-or-later) AND Apache-2.0, approved, #13562
 maven/mavencentral/com.samskivert/jmustache/1.15, BSD-2-Clause, approved, clearlydefined
 maven/mavencentral/com.squareup.okhttp3/okhttp-dnsoverhttps/4.12.0, Apache-2.0, approved, #11159
 maven/mavencentral/com.squareup.okhttp3/okhttp/4.12.0, Apache-2.0, approved, #11156
@@ -234,7 +233,6 @@ maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.72, MIT, approved, #3790
 maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.77, MIT, approved, #11596
 maven/mavencentral/org.ccil.cowan.tagsoup/tagsoup/1.2.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.checkerframework/checker-qual/3.12.0, MIT, approved, clearlydefined
-maven/mavencentral/org.checkerframework/checker-qual/3.41.0, MIT, approved, #12032
 maven/mavencentral/org.checkerframework/checker-qual/3.42.0, MIT, approved, clearlydefined
 maven/mavencentral/org.codehaus.plexus/plexus-classworlds/2.6.0, Apache-2.0 AND Plexus, approved, CQ22821
 maven/mavencentral/org.codehaus.plexus/plexus-component-annotations/2.1.0, Apache-2.0, approved, #809

--- a/spi/common/web-spi/src/main/java/org/eclipse/edc/web/spi/exception/ServiceResultHandler.java
+++ b/spi/common/web-spi/src/main/java/org/eclipse/edc/web/spi/exception/ServiceResultHandler.java
@@ -28,7 +28,7 @@ public class ServiceResultHandler {
      * Utility method for calling {@link #mapToException(ServiceFailure, Class, String)} when id is null.
      *
      * @param failure The {@link ServiceFailure}
-     * @param clazz The type in whose context the failure occurred. Must not be null.
+     * @param clazz   The type in whose context the failure occurred. Must not be null.
      * @return Exception mapped from failure reason.
      */
     public static EdcException mapToException(@NotNull ServiceFailure failure, @NotNull Class<?> clazz) {
@@ -58,22 +58,19 @@ public class ServiceResultHandler {
      * </table>
      *
      * @param failure The {@link ServiceFailure}
-     * @param clazz The type in whose context the failure occurred. Must not be null.
-     * @param id The id of the entity which was involved in the failure. Can be null for
-     *         {@link ServiceFailure.Reason#BAD_REQUEST}.
+     * @param clazz   The type in whose context the failure occurred. Must not be null.
+     * @param id      The id of the entity which was involved in the failure. Can be null for
+     *                {@link ServiceFailure.Reason#BAD_REQUEST}.
      * @return Exception mapped from failure reason.
      */
     public static EdcException mapToException(@NotNull ServiceFailure failure, @NotNull Class<?> clazz, @Nullable String id) {
-        switch (failure.getReason()) {
-            case NOT_FOUND:
-                return new ObjectNotFoundException(clazz, id);
-            case CONFLICT:
-                return new ObjectConflictException(failure.getMessages());
-            case BAD_REQUEST:
-                return new InvalidRequestException(failure.getMessages());
-            default:
-                return new EdcException("unexpected error: " + failure.getFailureDetail());
-        }
+        return switch (failure.getReason()) {
+            case NOT_FOUND -> new ObjectNotFoundException(clazz, id);
+            case CONFLICT -> new ObjectConflictException(failure.getMessages());
+            case BAD_REQUEST -> new InvalidRequestException(failure.getMessages());
+            case UNAUTHORIZED -> new NotAuthorizedException(failure.getFailureDetail());
+            default -> new EdcException("unexpected error: " + failure.getFailureDetail());
+        };
     }
 
     /**
@@ -91,8 +88,8 @@ public class ServiceResultHandler {
      * Returns a function that can be use as mapper for handling exception in context like {@link  ServiceResult#orElseThrow(Function)}
      *
      * @param clazz The type in whose context the failure occurred. Must not be null.
-     * @param id The id of the entity which was involved in the failure. Can be null for
-     *           {@link ServiceFailure.Reason#BAD_REQUEST}.
+     * @param id    The id of the entity which was involved in the failure. Can be null for
+     *              {@link ServiceFailure.Reason#BAD_REQUEST}.
      * @return The mapper {@link Function}
      */
 


### PR DESCRIPTION
## What this PR changes/adds

Adds the `UNAUTHORIZED` case label to the `ServiceResultHandler`, so exceptions can be properly mapped.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
