### PR TITLE
feat: implements revocation in DataPlaneAuthorizationService

### DIFF
--- a/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/listener/TransferProcessEventListener.java
+++ b/core/control-plane/transfer-core/src/main/java/org/eclipse/edc/connector/transfer/listener/TransferProcessEventListener.java
@@ -95,19 +95,17 @@ public class TransferProcessEventListener implements TransferProcessListener {
     }
 
     @Override
-    public void suspended(TransferProcess process) {
-        var event = TransferProcessSuspended.Builder.newInstance()
+    public void terminated(TransferProcess process) {
+        var event = withBaseProperties(TransferProcessTerminated.Builder.newInstance(), process)
                 .reason(process.getErrorDetail())
-                .transferProcessId(process.getId())
-                .callbackAddresses(process.getCallbackAddresses())
                 .build();
 
         publish(event);
     }
 
     @Override
-    public void terminated(TransferProcess process) {
-        var event = withBaseProperties(TransferProcessTerminated.Builder.newInstance(), process)
+    public void suspended(TransferProcess process) {
+        var event = withBaseProperties(TransferProcessSuspended.Builder.newInstance(), process)
                 .reason(process.getErrorDetail())
                 .build();
 

--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/iam/DataPlaneAuthorizationServiceImpl.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/iam/DataPlaneAuthorizationServiceImpl.java
@@ -83,6 +83,11 @@ public class DataPlaneAuthorizationServiceImpl implements DataPlaneAuthorization
                 .map(u -> accessTokenDataResult.getContent().dataAddress());
     }
 
+    @Override
+    public Result<Void> revokeEndpointDataReference(String transferProcessId, String reason) {
+        return accessTokenService.revoke(transferProcessId, reason);
+    }
+
     private Result<DataAddress> createDataAddress(TokenRepresentation tokenRepresentation, Endpoint publicEndpoint) {
         var address = DataAddress.Builder.newInstance()
                 .type(publicEndpoint.endpointType())

--- a/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/iam/DataPlaneAuthorizationServiceImplTest.java
+++ b/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/iam/DataPlaneAuthorizationServiceImplTest.java
@@ -161,6 +161,27 @@ class DataPlaneAuthorizationServiceImplTest {
         verifyNoMoreInteractions(accessTokenService, accessControlService);
     }
 
+    @Test
+    void revoke() {
+        when(accessTokenService.revoke(eq("id"), eq("reason"))).thenReturn(Result.success());
+
+        assertThat(authorizationService.revokeEndpointDataReference("id", "reason")).isSucceeded();
+
+        verify(accessTokenService).revoke(eq("id"), eq("reason"));
+        verifyNoMoreInteractions(accessTokenService, accessControlService);
+    }
+
+    @Test
+    void revoke_error() {
+        when(accessTokenService.revoke(eq("id"), eq("reason"))).thenReturn(Result.failure("failure"));
+
+        assertThat(authorizationService.revokeEndpointDataReference("id", "reason")).isFailed()
+                .detail().contains("failure");
+
+        verify(accessTokenService).revoke(eq("id"), eq("reason"));
+        verifyNoMoreInteractions(accessTokenService, accessControlService);
+    }
+
     private DataFlowStartMessage.Builder createStartMessage() {
         return DataFlowStartMessage.Builder.newInstance()
                 .processId("test-processid")

--- a/extensions/control-plane/edr/edr-store-receiver/src/main/java/org/eclipse/edc/connector/edr/store/receiver/EndpointDataReferenceStoreReceiver.java
+++ b/extensions/control-plane/edr/edr-store-receiver/src/main/java/org/eclipse/edc/connector/edr/store/receiver/EndpointDataReferenceStoreReceiver.java
@@ -20,6 +20,7 @@ import org.eclipse.edc.connector.spi.contractagreement.ContractAgreementService;
 import org.eclipse.edc.connector.transfer.spi.event.TransferProcessCompleted;
 import org.eclipse.edc.connector.transfer.spi.event.TransferProcessEvent;
 import org.eclipse.edc.connector.transfer.spi.event.TransferProcessStarted;
+import org.eclipse.edc.connector.transfer.spi.event.TransferProcessSuspended;
 import org.eclipse.edc.connector.transfer.spi.event.TransferProcessTerminated;
 import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.edr.spi.store.EndpointDataReferenceStore;
@@ -59,6 +60,7 @@ public class EndpointDataReferenceStoreReceiver implements EventSubscriber {
         this.monitor = monitor;
         registerHandler(TransferProcessStarted.class, this::handleTransferStarted);
         registerHandler(TransferProcessTerminated.class, this::handleTransferTerminated);
+        registerHandler(TransferProcessSuspended.class, this::handleTransferSuspended);
         registerHandler(TransferProcessCompleted.class, this::handleTransferCompleted);
     }
 
@@ -122,6 +124,10 @@ public class EndpointDataReferenceStoreReceiver implements EventSubscriber {
 
     private Result<Void> handleTransferTerminated(TransferProcessTerminated transferProcessTerminated) {
         return removeCachedEdr(transferProcessTerminated.getTransferProcessId());
+    }
+
+    private Result<Void> handleTransferSuspended(TransferProcessSuspended transferProcessSuspended) {
+        return removeCachedEdr(transferProcessSuspended.getTransferProcessId());
     }
 
     private Result<Void> handleTransferCompleted(TransferProcessCompleted transferProcessCompleted) {

--- a/extensions/control-plane/edr/edr-store-receiver/src/test/java/org/eclipse/edc/connector/edr/store/receiver/EndpointDataReferenceStoreReceiverTest.java
+++ b/extensions/control-plane/edr/edr-store-receiver/src/test/java/org/eclipse/edc/connector/edr/store/receiver/EndpointDataReferenceStoreReceiverTest.java
@@ -26,6 +26,7 @@ import org.eclipse.edc.connector.transfer.spi.event.TransferProcessProvisioned;
 import org.eclipse.edc.connector.transfer.spi.event.TransferProcessProvisioningRequested;
 import org.eclipse.edc.connector.transfer.spi.event.TransferProcessRequested;
 import org.eclipse.edc.connector.transfer.spi.event.TransferProcessStarted;
+import org.eclipse.edc.connector.transfer.spi.event.TransferProcessSuspended;
 import org.eclipse.edc.connector.transfer.spi.event.TransferProcessTerminated;
 import org.eclipse.edc.edr.spi.store.EndpointDataReferenceStore;
 import org.eclipse.edc.edr.spi.types.EndpointDataReferenceEntry;
@@ -219,7 +220,8 @@ public class EndpointDataReferenceStoreReceiverTest {
 
             var eventBuilders = Stream.of(
                     TransferProcessTerminated.Builder.newInstance(),
-                    TransferProcessCompleted.Builder.newInstance()
+                    TransferProcessCompleted.Builder.newInstance(),
+                    TransferProcessSuspended.Builder.newInstance()
             );
 
             return eventBuilders

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/DataFlow.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/DataFlow.java
@@ -48,7 +48,7 @@ public class DataFlow extends StatefulEntity<DataFlow> {
     private URI callbackAddress;
     private Map<String, String> properties = new HashMap<>();
 
-    private FlowType flowType = FlowType.PULL;
+    private FlowType flowType = FlowType.PUSH;
 
     @Override
     public DataFlow copy() {

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/iam/DataPlaneAccessTokenService.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/iam/DataPlaneAccessTokenService.java
@@ -51,4 +51,14 @@ public interface DataPlaneAccessTokenService {
      * @return A {@link AccessTokenData} that contains the original claims and the data resource ({@link DataAddress}. If the token could not be restored, a failure is returned.
      */
     Result<AccessTokenData> resolve(String token);
+
+    /**
+     * Revokes the {@link AccessTokenData} associated with the id
+     *
+     * @param transferProcessId The id of the {@link AccessTokenData}
+     * @param reason            The reason for the revocation
+     * @return Success if revoked, failure otherwise
+     */
+    Result<Void> revoke(String transferProcessId, String reason);
+
 }

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/iam/DataPlaneAuthorizationService.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/iam/DataPlaneAuthorizationService.java
@@ -78,4 +78,14 @@ public interface DataPlaneAuthorizationService {
      * @return The {@link DataAddress} that was encapsulated in the original {@link DataFlowStartMessage}
      */
     Result<DataAddress> authorize(String token, Map<String, Object> requestData);
+
+
+    /**
+     * Revokes the {@link DataAddress} created with {@link #createEndpointDataReference(DataFlowStartMessage)}
+     *
+     * @param transferProcessId The id of the transfer process associated to the {@link DataAddress}
+     * @param reason            The reason of the revocation
+     * @return Successful if revoked, fails otherwise
+     */
+    Result<Void> revokeEndpointDataReference(String transferProcessId, String reason);
 }

--- a/spi/data-plane/data-plane-spi/src/testFixtures/java/org/eclipse/edc/connector/dataplane/spi/store/AccessTokenDataTestBase.java
+++ b/spi/data-plane/data-plane-spi/src/testFixtures/java/org/eclipse/edc/connector/dataplane/spi/store/AccessTokenDataTestBase.java
@@ -105,6 +105,19 @@ public abstract class AccessTokenDataTestBase {
     }
 
     @Test
+    void query_byAdditionalProperty() {
+        var ct = ClaimToken.Builder.newInstance().claim("foo", "bar").build();
+        var atd = new AccessTokenData("test-id", ct, DataAddress.Builder.newInstance().type("foo-type").property("qux", "quz").build(), Map.of("participant_id", "participantId"));
+        getStore().store(atd);
+        getStore().store(new AccessTokenData("another-id", ClaimToken.Builder.newInstance().build(), DataAddress.Builder.newInstance().type("foo-type").build()));
+
+        assertThat(getStore().query(QuerySpec.Builder.newInstance().filter(new Criterion("additionalProperties.participant_id", "=", "participantId")).build()))
+                .hasSize(1)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactly(atd);
+    }
+
+    @Test
     void query_byMultipleCriteria() {
         var ct = ClaimToken.Builder.newInstance().claim("foo", "bar").build();
         var atd = new AccessTokenData("test-id", ct, DataAddress.Builder.newInstance().type("foo-type").property("qux", "quz").build());


### PR DESCRIPTION
## What this PR changes/adds

implements revocation in DataPlaneAuthorizationService

## Why it does that

Notify the `DataPlaneAuthorizationService` that the transfer has been terminated or suspended
## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #3997

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
