### PR TITLE
chore: Participant self method as protected 

### DIFF
--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/test/system/utils/Participant.java
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/test/system/utils/Participant.java
@@ -639,7 +639,7 @@ public class Participant {
         }
 
         @SuppressWarnings("unchecked")
-        private B self() {
+        protected B self() {
             return (B) this;
         }
     }


### PR DESCRIPTION
## What this PR changes/adds

Changes Participant#self method to  protected for extensibility

## Why it does that

extensibility

