### PR TITLE
feat: introduces properties provider for DataFlowStartMessage

### DIFF
--- a/extensions/control-plane/transfer/transfer-data-plane-signaling/src/main/java/org/eclipse/edc/connector/transfer/dataplane/TransferDataPlaneSignalingExtension.java
+++ b/extensions/control-plane/transfer/transfer-data-plane-signaling/src/main/java/org/eclipse/edc/connector/transfer/dataplane/TransferDataPlaneSignalingExtension.java
@@ -19,11 +19,15 @@ import org.eclipse.edc.connector.dataplane.selector.spi.client.DataPlaneClientFa
 import org.eclipse.edc.connector.transfer.dataplane.flow.DataPlaneSignalingFlowController;
 import org.eclipse.edc.connector.transfer.spi.callback.ControlApiUrl;
 import org.eclipse.edc.connector.transfer.spi.flow.DataFlowManager;
+import org.eclipse.edc.connector.transfer.spi.flow.DataFlowPropertiesProvider;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+
+import java.util.Map;
 
 import static org.eclipse.edc.connector.transfer.dataplane.TransferDataPlaneSignalingExtension.NAME;
 
@@ -47,10 +51,17 @@ public class TransferDataPlaneSignalingExtension implements ServiceExtension {
     @Inject
     private DataPlaneClientFactory clientFactory;
 
+    @Inject(required = false)
+    private DataFlowPropertiesProvider propertiesProvider;
 
     @Override
     public void initialize(ServiceExtensionContext context) {
         var selectionStrategy = context.getSetting(DPF_SELECTOR_STRATEGY, DEFAULT_DATAPLANE_SELECTOR_STRATEGY);
-        dataFlowManager.register(new DataPlaneSignalingFlowController(callbackUrl, selectorService, clientFactory, selectionStrategy));
+        dataFlowManager.register(new DataPlaneSignalingFlowController(callbackUrl, selectorService, getPropertiesProvider(), clientFactory, selectionStrategy));
     }
+
+    private DataFlowPropertiesProvider getPropertiesProvider() {
+        return propertiesProvider == null ? (tp, p) -> StatusResult.success(Map.of()) : propertiesProvider;
+    }
+
 }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/flow/DataFlowPropertiesProvider.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/transfer/spi/flow/DataFlowPropertiesProvider.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.transfer.spi.flow;
+
+import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
+
+import java.util.Map;
+
+/**
+ * Extension point allows additional properties to be included in a {@link DataFlowStartMessage}
+ */
+@FunctionalInterface
+@ExtensionPoint
+public interface DataFlowPropertiesProvider {
+
+    StatusResult<Map<String, String>> propertiesFor(TransferProcess transferProcess, Policy policy);
+    
+}


### PR DESCRIPTION
## What this PR changes/adds

Allows adding additional/custom properties when sending the `DataFlowStartMessage` with the DPS protocol

A default provider is created, which returns an empty map

## Why it does that

extensibility

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #4043 
