### PR TITLE
fix: add missing SQL mapping in `EndpointDataReferenceEntry`

### DIFF
--- a/extensions/common/store/sql/edr-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/edr/schema/postgres/EndpointDataReferenceEntryMapping.java
+++ b/extensions/common/store/sql/edr-index-sql/src/main/java/org/eclipse/edc/connector/store/sql/edr/schema/postgres/EndpointDataReferenceEntryMapping.java
@@ -24,6 +24,8 @@ import org.eclipse.edc.sql.translation.TranslationMapping;
  */
 public class EndpointDataReferenceEntryMapping extends TranslationMapping {
     public EndpointDataReferenceEntryMapping(EndpointDataReferenceEntryStatements statements) {
+        add("id", statements.getAssetIdColumn());
+        add("createdAt", statements.getCreatedAtColumn());
         add("assetId", statements.getAssetIdColumn());
         add("agreementId", statements.getAgreementIdColumn());
         add("transferProcessId", statements.getTransferProcessIdColumn());


### PR DESCRIPTION
## What this PR changes/adds

Add missing mapping of `createdAt` and `id` for SQL `EnpointDataReferenceEntry`.

## Why it does that

Fix

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
