### PR TITLE
feat(dsp): cache dspace jsonld context document

### DIFF
--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/JsonLdExtension.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/JsonLdExtension.java
@@ -32,6 +32,7 @@ import org.jetbrains.annotations.NotNull;
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.stream.Stream;
 
 import static java.lang.String.format;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
@@ -89,9 +90,13 @@ public class JsonLdExtension implements ServiceExtension {
         }
         service.registerNamespace(EDC_PREFIX, EDC_NAMESPACE);
 
-        getResourceUri("document" + File.separator + "odrl.jsonld")
-                .onSuccess(uri -> service.registerCachedDocument("http://www.w3.org/ns/odrl.jsonld", uri))
-                .onFailure(failure -> monitor.warning("Failed to register cached json-ld document: " + failure.getFailureDetail()));
+        Stream.of(
+                new JsonLdContext("odrl.jsonld", "http://www.w3.org/ns/odrl.jsonld"),
+                new JsonLdContext("dspace.jsonld", "https://w3id.org/dspace/2024/1/context.json")
+        ).forEach(jsonLdContext -> getResourceUri("document" + File.separator + jsonLdContext.fileName())
+                .onSuccess(uri -> service.registerCachedDocument(jsonLdContext.url(), uri))
+                .onFailure(failure -> monitor.warning("Failed to register cached json-ld document: " + failure.getFailureDetail()))
+        );
 
         registerCachedDocumentsFromConfig(context, service);
 
@@ -126,5 +131,6 @@ public class JsonLdExtension implements ServiceExtension {
         }
     }
 
+    record JsonLdContext(String fileName, String url) { }
 
 }

--- a/extensions/common/json-ld/src/main/resources/document/dspace.jsonld
+++ b/extensions/common/json-ld/src/main/resources/document/dspace.jsonld
@@ -1,0 +1,62 @@
+{
+  "@context": {
+    "odrl": "http://www.w3.org/ns/odrl/2/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "cred": "https://www.w3.org/2018/credentials#",
+    "sec": "https://w3id.org/security#",
+    "foaf": "http://xmlns.com/foaf/0.1/",
+    "cc": "http://creativecommons.org/ns#",
+    "dct": "http://purl.org/dc/terms/",
+    "dcat": "http://www.w3.org/ns/dcat#",
+    "dspace": "https://w3id.org/dspace/2024/1/",
+
+    "dct:title": { "@language": "en" },
+    "dct:creator": { "@type": "@id" },
+    "dct:description": { "@container": "@set" },
+    "dct:issued": { "@type": "xsd:dateTime" },
+    "dct:modified": { "@type": "xsd:dateTime" },
+
+    "dcat:byteSize": { "@type": "xsd:decimal" },
+    "dcat:distribution": { "@container": "@set" },
+    "dcat:theme": { "@type": "@id" },
+    "dcat:conformsTo": { "@type": "@id" },
+    "dcat:dataset": { "@container": "@set" },
+    "dcat:endpointURL": { "@type": "xsd:anyURI" },
+    "dcat:endpointDescription": { "@type": "xsd:anyURI" },
+    "dcat:keyword": { "@container": "@set" },
+    "dcat:servesDataset": {"@container": "@set" },
+    "dcat:service": { "@container": "@set" },
+    "dcat:accessService": { "@container": "@set" },
+
+    "dspace:agreementId": { "@type": "@id" },
+    "dspace:dataset": { "@type": "@id" },
+    "dspace:transportType": { "@type": "@id" },
+    "dspace:state": { "@type": "@id" },
+    "dspace:providerId": { "@type": "@id" },
+    "dspace:consumerId": { "@type": "@id" },
+    "dspace:participantId": { "@type": "@id" },
+    "dspace:reason": { "@container": "@set" },
+    "dspace:catalog": { "@container": "@set" },
+    "dspace:filter": { "@container": "@set" },
+    "dspace:timestamp": { "@type": "xsd:dateTime" },
+    "dspace:callbackAddress": { "@type": "xsd:anyURI" },
+    "dspace:endpointProperties": { "@container": "@set" },
+
+    "foaf:homepage": { "@type": "xsd:anyURI" },
+
+    "odrl:hasPolicy": { "@container": "@set" },
+    "odrl:permission": { "@container": "@set" },
+    "odrl:prohibition": { "@container": "@set" },
+    "odrl:obligation": { "@container": "@set" },
+    "odrl:duty": { "@container": "@set" },
+    "odrl:constraint": { "@container": "@set" },
+    "odrl:action": { "@type": "@id" },
+    "odrl:target": { "@type": "@id" },
+    "odrl:leftOperand": { "@type": "@id" },
+    "odrl:operator": { "@type": "@id" },
+    "odrl:rightOperandReference": { "@type": "@id" },
+    "odrl:profile": { "@container": "@set" }
+    "odrl:assigner": { "@type": "@id" },
+    "odrl:assignee": { "@type": "@id" }
+  }
+}


### PR DESCRIPTION
## What this PR changes/adds

Caches DSPACE jsonld context document in the JsonLd extension

## Why it does that

To permit usage of that context file without having enable the http resolution

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #4047 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
