### PR TITLE
feat: support String-Array query parameter in DP public API

### DIFF
--- a/extensions/data-plane/data-plane-public-api-v2/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/DataFlowRequestSupplier.java
+++ b/extensions/data-plane/data-plane-public-api-v2/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/DataFlowRequestSupplier.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Amadeus - initial API and implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - make it a PULL request by default
  *
  */
 
@@ -17,6 +18,7 @@ package org.eclipse.edc.connector.dataplane.api.controller;
 import org.eclipse.edc.connector.dataplane.util.sink.AsyncStreamingDataSink;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
+import org.eclipse.edc.spi.types.domain.transfer.FlowType;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -61,6 +63,7 @@ public class DataFlowRequestSupplier implements BiFunction<ContainerRequestConte
         return DataFlowStartMessage.Builder.newInstance()
                 .processId(UUID.randomUUID().toString())
                 .sourceDataAddress(dataAddress)
+                .flowType(FlowType.PULL) // if a request hits the public DP API, we can assume a PULL transfer
                 .destinationDataAddress(DataAddress.Builder.newInstance()
                         .type(AsyncStreamingDataSink.TYPE)
                         .build())

--- a/extensions/data-plane/data-plane-public-api-v2/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlanePublicApiV2.java
+++ b/extensions/data-plane/data-plane-public-api-v2/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlanePublicApiV2.java
@@ -9,7 +9,7 @@
  *
  *  Contributors:
  *       Amadeus - Initial implementation
- *
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - handle HEAD requests
  */
 
 package org.eclipse.edc.connector.dataplane.api.controller;
@@ -42,6 +42,15 @@ public interface DataPlanePublicApiV2 {
             }
     )
     void get(ContainerRequestContext context, AsyncResponse response);
+
+    @Operation(description = "Send `HEAD` data query to the Data Plane.",
+            responses = {
+                    @ApiResponse(responseCode = "400", description = "Missing access token"),
+                    @ApiResponse(responseCode = "403", description = "Access token is expired or invalid"),
+                    @ApiResponse(responseCode = "500", description = "Failed to transfer data")
+            }
+    )
+    void head(ContainerRequestContext context, AsyncResponse response);
 
     @Operation(description = "Send `POST` data query to the Data Plane.",
             responses = {

--- a/extensions/data-plane/data-plane-public-api-v2/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlanePublicApiV2Controller.java
+++ b/extensions/data-plane/data-plane-public-api-v2/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlanePublicApiV2Controller.java
@@ -9,13 +9,14 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
- *
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - handle HEAD requests
  */
 
 package org.eclipse.edc.connector.dataplane.api.controller;
 
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HEAD;
 import jakarta.ws.rs.PATCH;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.PUT;
@@ -71,6 +72,12 @@ public class DataPlanePublicApiV2Controller implements DataPlanePublicApiV2 {
     @GET
     @Override
     public void get(@Context ContainerRequestContext requestContext, @Suspended AsyncResponse response) {
+        handle(requestContext, response);
+    }
+
+    @HEAD
+    @Override
+    public void head(@Context ContainerRequestContext requestContext, @Suspended AsyncResponse response) {
         handle(requestContext, response);
     }
 

--- a/system-tests/e2e-dataplane-tests/tests/src/test/java/org/eclipse/edc/test/e2e/DataPlanePublicApiEndToEndTest.java
+++ b/system-tests/e2e-dataplane-tests/tests/src/test/java/org/eclipse/edc/test/e2e/DataPlanePublicApiEndToEndTest.java
@@ -29,9 +29,15 @@ import org.eclipse.edc.spi.iam.ClaimToken;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.model.HttpResponse;
+import org.mockserver.model.Parameter;
+import org.mockserver.verify.VerificationTimes;
 
 import java.security.Key;
 import java.security.PrivateKey;
@@ -40,17 +46,38 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
+import static org.eclipse.edc.util.io.Ports.getFreePort;
 import static org.mockito.Mockito.mock;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.verify.VerificationTimes.exactly;
 
 public class DataPlanePublicApiEndToEndTest extends AbstractDataPlaneTest {
 
     public static final String PUBLIC_KEY_ALIAS = "public-key";
     public static final String PRIVATE_KEY_ALIAS = "1";
     // this is a data address representing the private backend for an HTTP pull transfer
-    public static final DataAddress BACKEND_API_DATAADDRESS = DataAddress.Builder.newInstance()
-            .type("HttpData")
-            .property(EDC_NAMESPACE + "baseUrl", "https://jsonplaceholder.typicode.com/todos")
-            .build();
+    public static DataAddress backendDataAddress;
+
+    private ClientAndServer backendServer;
+
+    @BeforeEach
+    void setup() {
+        backendServer = ClientAndServer.startClientAndServer(getFreePort());
+        backendDataAddress = DataAddress.Builder.newInstance()
+                .type("HttpData")
+                .property(EDC_NAMESPACE + "baseUrl", "http://localhost:%d/foo".formatted(backendServer.getPort()))
+                .property(EDC_NAMESPACE + "proxyQueryParams", "true")
+                .property(EDC_NAMESPACE + "proxyPath", "true")
+                .property(EDC_NAMESPACE + "proxyMethod", "true")
+                .build();
+
+        backendServer.when(request()).respond(HttpResponse.response().withBody("""
+                {
+                   "foo": "bar",
+                   "fizz": "buzz",
+                }
+                """).withStatusCode(200));
+    }
 
     @Test
     void httpPull_missingToken_expect401() {
@@ -67,6 +94,8 @@ public class DataPlanePublicApiEndToEndTest extends AbstractDataPlaneTest {
                 .then()
                 .statusCode(401)
                 .body(Matchers.containsString("Missing Authorization Header"));
+
+        backendServer.verify(request().withMethod("POST"), VerificationTimes.never());
     }
 
     @Test
@@ -86,9 +115,13 @@ public class DataPlanePublicApiEndToEndTest extends AbstractDataPlaneTest {
                 .statusCode(403);
     }
 
+    @DisplayName("Test methods with request body")
     @ParameterizedTest(name = "Method = {0}")
-    @ValueSource(strings = { "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD" })
-    void request_expect200(String method) {
+    @ValueSource(strings = { "POST", "PUT", "PATCH" })
+    void request_withBody_expect200(String method) {
+        backendDataAddress.getProperties().put(EDC_NAMESPACE + "proxyBody", "true");
+        backendDataAddress.getProperties().put(EDC_NAMESPACE + "MEDIA_TYPE", "application/json");
+
         var token = createEdr();
         var body = DATAPLANE.getDataPlanePublicEndpoint()
                 .baseRequest()
@@ -100,6 +133,49 @@ public class DataPlanePublicApiEndToEndTest extends AbstractDataPlaneTest {
                 .statusCode(200)
                 .extract().body().asString();
         assertThat(body).isNotNull();
+
+        backendServer.verify(request().withMethod(method).withPath("/foo/v2/bar/baz"), exactly(1));
+    }
+
+    @DisplayName("Test methods without request body")
+    @ParameterizedTest(name = "Method = {0}")
+    @ValueSource(strings = { "GET", "DELETE", "HEAD" })
+    void request_noBody_expect200(String method) {
+        var token = createEdr();
+        var body = DATAPLANE.getDataPlanePublicEndpoint()
+                .baseRequest()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, token)
+                .request(method, "/v2/bar/baz")
+                .then()
+                .log().ifError()
+                .statusCode(200)
+                .extract().body().asString();
+        assertThat(body).isNotNull();
+
+        backendServer.verify(request().withMethod(method).withPath("/foo/v2/bar/baz"), exactly(1));
+    }
+
+    @Test
+    void request_getMultipleIdenticalQuery() {
+        var token = createEdr();
+        var body = DATAPLANE.getDataPlanePublicEndpoint()
+                .baseRequest()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, token)
+                .request("GET", "/v2/bar/baz?foo=bar&foo=fizz&foo=buzz")
+                .then()
+                .log().ifError()
+                .statusCode(200)
+                .extract().body().asString();
+        assertThat(body).isNotNull();
+
+        backendServer.verify(request()
+                .withPath("/foo/v2/bar/baz")
+                .withQueryStringParameters(new Parameter("foo", "bar"),
+                        new Parameter("foo", "fizz"),
+                        new Parameter("foo", "buzz")
+                ), exactly(1));
     }
 
     private Key resolvePrivateKey() {
@@ -120,7 +196,7 @@ public class DataPlanePublicApiEndToEndTest extends AbstractDataPlaneTest {
 
         // store the EDR
         var accessTokenStore = runtime.getService(AccessTokenDataStore.class);
-        accessTokenStore.store(new AccessTokenData(tokenId, ClaimToken.Builder.newInstance().build(), BACKEND_API_DATAADDRESS));
+        accessTokenStore.store(new AccessTokenData(tokenId, ClaimToken.Builder.newInstance().build(), backendDataAddress));
         return jwt;
     }
 


### PR DESCRIPTION
## What this PR changes/adds

This PR adds support for multiple identical HTTP query parameters. For example, parameters like `foo=bar&foo=baz` were collapsed, and only `foo=bar` was forwarded to the HTTP target.
With this PR, the same query param string is preserved as string-array.

## Why it does that

A Tractus-X [system standard](https://app.swaggerhub.com/apis/Plattform_i40/DiscoveryServiceSpecification/V3.0.1_SSP-001#/Asset%20Administration%20Shell%20Basic%20Discovery%20API/GetAllAssetAdministrationShellIdsByAssetLink) requires the support of string-array query parameters. 

## Further notes

- the `DataPlanePublicApiEndToEndTest` was improved to verify HTTP requests using the Netty MockServer (instead of calling a dummy URL)
- The `DataPlanePublicApiV2` now supports `HEAD` requests, they were missing before.
- By default, requests that hit the public API of the dataplane are classified as `PULL` flows

NB: that this behaviour will *NOT* be backported to the legacy version of the public dataplane API!

## Linked Issue(s)

Closes #4022

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
