### PR TITLE
fix: minor fixes in management API

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -224,7 +224,7 @@ maven/mavencentral/org.apache.velocity/velocity-engine-scripting/2.3, Apache-2.0
 maven/mavencentral/org.apache.xbean/xbean-reflect/3.7, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.assertj/assertj-core/3.25.3, Apache-2.0, approved, #12585
-maven/mavencentral/org.awaitility/awaitility/4.2.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.awaitility/awaitility/4.2.0, Apache-2.0, approved, #14178
 maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.72, MIT, approved, #3789
 maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.77, MIT, approved, #11593
 maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.72, MIT AND CC0-1.0, approved, #3538
@@ -347,7 +347,7 @@ maven/mavencentral/org.slf4j/slf4j-api/2.0.9, MIT, approved, #5915
 maven/mavencentral/org.testcontainers/database-commons/1.19.7, Apache-2.0, approved, #10345
 maven/mavencentral/org.testcontainers/jdbc/1.19.7, Apache-2.0, approved, #10348
 maven/mavencentral/org.testcontainers/junit-jupiter/1.19.7, MIT, approved, #10344
-maven/mavencentral/org.testcontainers/kafka/1.19.7, , restricted, clearlydefined
+maven/mavencentral/org.testcontainers/kafka/1.19.7, None, restricted, #14177
 maven/mavencentral/org.testcontainers/postgresql/1.19.7, MIT, approved, #10350
 maven/mavencentral/org.testcontainers/testcontainers/1.19.7, Apache-2.0 AND MIT, approved, #10347
 maven/mavencentral/org.testcontainers/vault/1.19.7, MIT, approved, #10852

--- a/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/api/management/catalog/CatalogApiController.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/api/management/catalog/CatalogApiController.java
@@ -36,9 +36,9 @@ import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.eclipse.edc.catalog.spi.CatalogRequest.CATALOG_REQUEST_TYPE;
 import static org.eclipse.edc.catalog.spi.DatasetRequest.DATASET_REQUEST_TYPE;
 
-@Path("/v2/catalog")
 @Consumes(APPLICATION_JSON)
 @Produces(APPLICATION_JSON)
+@Path("/v2/catalog")
 public class CatalogApiController implements CatalogApi {
 
     private final CatalogService service;

--- a/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/api/management/contractagreement/ContractAgreementApi.java
+++ b/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/api/management/contractagreement/ContractAgreementApi.java
@@ -40,7 +40,7 @@ public interface ContractAgreementApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             }
     )
-    JsonArray queryAllAgreements(JsonObject querySpecJson);
+    JsonArray queryAgreements(JsonObject querySpecJson);
 
     @Operation(description = "Gets an contract agreement with the given ID",
             responses = {

--- a/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/api/management/contractagreement/ContractAgreementApiController.java
+++ b/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/api/management/contractagreement/ContractAgreementApiController.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.api.management.contractagreement;
 
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -41,6 +42,7 @@ import static jakarta.json.stream.JsonCollectors.toJsonArray;
 import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE;
 import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMapper;
 
+@Consumes({MediaType.APPLICATION_JSON})
 @Produces({MediaType.APPLICATION_JSON})
 @Path("/v2/contractagreements")
 public class ContractAgreementApiController implements ContractAgreementApi {
@@ -60,7 +62,7 @@ public class ContractAgreementApiController implements ContractAgreementApi {
     @POST
     @Path("/request")
     @Override
-    public JsonArray queryAllAgreements(JsonObject querySpecJson) {
+    public JsonArray queryAgreements(JsonObject querySpecJson) {
         QuerySpec querySpec;
         if (querySpecJson == null) {
             querySpec = QuerySpec.Builder.newInstance().build();

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionApi.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionApi.java
@@ -49,7 +49,7 @@ public interface ContractDefinitionApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             }
     )
-    JsonArray queryAllContractDefinitions(JsonObject querySpecJson);
+    JsonArray queryContractDefinitions(JsonObject querySpecJson);
 
     @Operation(description = "Gets an contract definition with the given ID",
             responses = {
@@ -71,7 +71,7 @@ public interface ContractDefinitionApi {
                     @ApiResponse(responseCode = "400", description = "Request body was malformed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
                     @ApiResponse(responseCode = "409", description = "Could not create contract definition, because a contract definition with that ID already exists",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))) }
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))}
     )
     JsonObject createContractDefinition(JsonObject createObject);
 

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionApiController.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/api/management/contractdefinition/ContractDefinitionApiController.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.api.management.contractdefinition;
 
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
@@ -44,7 +45,8 @@ import static org.eclipse.edc.connector.contract.spi.types.offer.ContractDefinit
 import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMapper;
 
 
-@Produces({ MediaType.APPLICATION_JSON })
+@Consumes({MediaType.APPLICATION_JSON})
+@Produces({MediaType.APPLICATION_JSON})
 @Path("/v2/contractdefinitions")
 public class ContractDefinitionApiController implements ContractDefinitionApi {
     private final TypeTransformerRegistry transformerRegistry;
@@ -63,7 +65,7 @@ public class ContractDefinitionApiController implements ContractDefinitionApi {
     @POST
     @Path("/request")
     @Override
-    public JsonArray queryAllContractDefinitions(JsonObject querySpecJson) {
+    public JsonArray queryContractDefinitions(JsonObject querySpecJson) {
         QuerySpec querySpec;
         if (querySpecJson == null) {
             querySpec = QuerySpec.Builder.newInstance().build();

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiController.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiController.java
@@ -49,9 +49,8 @@ import static org.eclipse.edc.connector.contract.spi.types.negotiation.ContractR
 import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE;
 import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMapper;
 
-@Consumes({ MediaType.APPLICATION_JSON })
-@Produces({ MediaType.APPLICATION_JSON })
-
+@Consumes({MediaType.APPLICATION_JSON})
+@Produces({MediaType.APPLICATION_JSON})
 @Path("/v2/contractnegotiations")
 public class ContractNegotiationApiController implements ContractNegotiationApi {
     private final ContractNegotiationService service;

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/DataplaneSelectorApi.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/DataplaneSelectorApi.java
@@ -35,6 +35,7 @@ import org.eclipse.edc.connector.dataplane.selector.api.v2.schemas.SelectionRequ
 public interface DataplaneSelectorApi {
 
     @Operation(method = "POST",
+            operationId = "selectDataPlaneInstance",
             description = "Finds the best fitting data plane instance for a particular query",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = SelectionRequestSchema.class))),
             responses = {
@@ -45,9 +46,10 @@ public interface DataplaneSelectorApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             })
     @POST
-    JsonObject find(JsonObject request);
+    JsonObject selectDataPlaneInstance(JsonObject request);
 
     @Operation(method = "POST",
+            operationId = "addDataPlaneInstance",
             description = "Adds one dataplane instance to the internal database of the selector",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = DataPlaneInstanceSchema.class))),
             responses = {
@@ -56,9 +58,10 @@ public interface DataplaneSelectorApi {
             }
     )
     @POST
-    JsonObject addEntry(JsonObject instance);
+    JsonObject addDataPlaneInstance(JsonObject instance);
 
     @Operation(method = "GET",
+            operationId = "getAllDataPlaneInstances",
             description = "Returns a list of all currently registered data plane instances",
             responses = {
                     @ApiResponse(responseCode = "200", description = "A (potentially empty) list of currently registered data plane instances",
@@ -66,6 +69,6 @@ public interface DataplaneSelectorApi {
             }
     )
     @GET
-    JsonArray getAll();
+    JsonArray getAllDataPlaneInstances();
 
 }

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/DataplaneSelectorApiController.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/DataplaneSelectorApiController.java
@@ -41,8 +41,8 @@ import static java.util.Optional.ofNullable;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.DATAPLANE_INSTANCE_TYPE;
 import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMapper;
 
-@Consumes({ MediaType.APPLICATION_JSON })
-@Produces({ MediaType.APPLICATION_JSON })
+@Consumes({MediaType.APPLICATION_JSON})
+@Produces({MediaType.APPLICATION_JSON})
 @Path("/v2/dataplanes")
 public class DataplaneSelectorApiController implements DataplaneSelectorApi {
 
@@ -63,7 +63,7 @@ public class DataplaneSelectorApiController implements DataplaneSelectorApi {
     @Override
     @POST
     @Path("select")
-    public JsonObject find(JsonObject requestObject) {
+    public JsonObject selectDataPlaneInstance(JsonObject requestObject) {
         var request = transformerRegistry.transform(requestObject, SelectionRequest.class)
                 .orElseThrow(InvalidRequestException::new);
 
@@ -80,7 +80,7 @@ public class DataplaneSelectorApiController implements DataplaneSelectorApi {
 
     @Override
     @POST
-    public JsonObject addEntry(JsonObject jsonObject) {
+    public JsonObject addDataPlaneInstance(JsonObject jsonObject) {
         validatorRegistry.validate(DATAPLANE_INSTANCE_TYPE, jsonObject).orElseThrow(ValidationFailureException::new);
 
         var instance = transformerRegistry.transform(jsonObject, DataPlaneInstance.class)
@@ -100,7 +100,7 @@ public class DataplaneSelectorApiController implements DataplaneSelectorApi {
 
     @Override
     @GET
-    public JsonArray getAll() {
+    public JsonArray getAllDataPlaneInstances() {
         var instances = selectionService.getAll();
         return instances.stream()
                 .map(i -> transformerRegistry.transform(i, JsonObject.class))

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/model/SelectionRequest.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/model/SelectionRequest.java
@@ -20,7 +20,7 @@ import org.eclipse.edc.spi.types.domain.DataAddress;
 import static org.eclipse.edc.spi.CoreConstants.EDC_NAMESPACE;
 
 /**
- * Represents the request body that the {@link DataplaneSelectorApi#find(jakarta.json.JsonObject)} endpoint requires
+ * Represents the request body that the {@link DataplaneSelectorApi#selectDataPlaneInstance(jakarta.json.JsonObject)} endpoint requires
  * Contains source and destination address and optionally the name of a selection strategy
  */
 public class SelectionRequest {


### PR DESCRIPTION
## What this PR changes/adds

- Align management API operation names.
- add missing `@Consumes` annotation in some API controllers.

## Why it does that

Harmonize the management APIs

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
