### PR TITLE
fix: convert RSA private key to JWK

### DIFF
--- a/core/common/lib/crypto-common-lib/src/test/java/org/eclipse/edc/security/token/jwt/CryptoConverterTest.java
+++ b/core/common/lib/crypto-common-lib/src/test/java/org/eclipse/edc/security/token/jwt/CryptoConverterTest.java
@@ -149,6 +149,33 @@ class CryptoConverterTest {
     }
 
     @Test
+    void createJwk_rsaKey_onlyPrivate() throws NoSuchAlgorithmException {
+        var pk = createRsa();
+        var keypair = new KeyPair(null, pk.getPrivate());
+        var jwk = CryptoConverter.createJwk(keypair);
+        assertThat(jwk).isInstanceOf(RSAKey.class);
+        assertThat(jwk.isPrivate()).isTrue();
+        assertThat(jwk.getKeyID()).isNull();
+    }
+
+    @Test
+    void createJwk_rsaKey_whenEmptyKeypair() throws NoSuchAlgorithmException {
+        var keypair = new KeyPair(null, null);
+        assertThatThrownBy(() -> CryptoConverter.createJwk(keypair))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void createJwk_rsaKey_onlyPublic() throws NoSuchAlgorithmException {
+        var pk = createRsa();
+        var keypair = new KeyPair(pk.getPublic(), null);
+        var jwk = CryptoConverter.createJwk(keypair);
+        assertThat(jwk).isInstanceOf(RSAKey.class);
+        assertThat(jwk.isPrivate()).isFalse();
+        assertThat(jwk.getKeyID()).isNull();
+    }
+
+    @Test
     void createJwk_rsaKey_withKeyId() throws NoSuchAlgorithmException {
         var pk = createRsa();
         var jwk = CryptoConverter.createJwk(pk, "test-key-id");


### PR DESCRIPTION
## What this PR changes/adds

This PR allows to convert a RSA key -> JWK if only the private portion of the key is specified by restoring the 
public key from the modulus and the exponent.

## Why it does that

Using RSA keys in LDP-VPs is impossible otherwise

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #4054

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
