### PR TITLE
feat: console colors

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -290,10 +290,10 @@ maven/mavencentral/org.jacoco/org.jacoco.core/0.8.9, EPL-2.0, approved, CQ23283
 maven/mavencentral/org.jacoco/org.jacoco.report/0.8.9, EPL-2.0 AND Apache-2.0, approved, CQ23284
 maven/mavencentral/org.javassist/javassist/3.28.0-GA, Apache-2.0 OR LGPL-2.1-or-later OR MPL-1.1, approved, #327
 maven/mavencentral/org.javassist/javassist/3.29.2-GA, Apache-2.0 AND LGPL-2.1-or-later AND MPL-1.1, approved, #6023
-maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-common/1.9.10, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.9.10, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-common/1.9.10, Apache-2.0, approved, #14186
+maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.9.10, None, restricted, #14188
 maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.8.21, Apache-2.0, approved, #8919
-maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.9.10, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.9.10, None, restricted, #14185
 maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib/1.9.10, Apache-2.0, approved, #11827
 maven/mavencentral/org.jetbrains/annotations/13.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.jetbrains/annotations/17.0.0, Apache-2.0, approved, clearlydefined

--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/ExtensionLoader.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/ExtensionLoader.java
@@ -34,6 +34,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.HashMap;
 import java.util.List;
 import java.util.ServiceLoader;
+import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -81,14 +82,14 @@ public class ExtensionLoader {
         };
     }
 
-    public static @NotNull Monitor loadMonitor() {
+    public static @NotNull Monitor loadMonitor(String... programArgs) {
         var loader = ServiceLoader.load(MonitorExtension.class);
-        return loadMonitor(loader.stream().map(ServiceLoader.Provider::get).collect(Collectors.toList()));
+        return loadMonitor(loader.stream().map(ServiceLoader.Provider::get).collect(Collectors.toList()), programArgs);
     }
 
-    static @NotNull Monitor loadMonitor(List<MonitorExtension> availableMonitors) {
+    static @NotNull Monitor loadMonitor(List<MonitorExtension> availableMonitors, String... programArgs) {
         if (availableMonitors.isEmpty()) {
-            return new ConsoleMonitor();
+            return new ConsoleMonitor(!Set.of(programArgs).contains("--no-color"));
         }
 
         if (availableMonitors.size() > 1) {

--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/runtime/BaseRuntime.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/runtime/BaseRuntime.java
@@ -51,6 +51,7 @@ import static java.lang.String.format;
  */
 public class BaseRuntime {
 
+    private static String[] programArgs = new String[0];
     protected final ServiceLocator serviceLocator;
     private final AtomicReference<HealthCheckResult> startupStatus = new AtomicReference<>(HealthCheckResult.failed("Startup not complete"));
     private final ExtensionLoader extensionLoader;
@@ -68,6 +69,7 @@ public class BaseRuntime {
 
     public static void main(String[] args) {
         BaseRuntime runtime = new BaseRuntime();
+        programArgs = args;
         runtime.boot();
     }
 
@@ -153,7 +155,7 @@ public class BaseRuntime {
      * Create a {@link ServiceExtensionContext} that will be used in this runtime. If e.g. a third-party dependency-injection framework were to be used,
      * this would likely need to be overridden.
      *
-     * @param monitor     a Monitor
+     * @param monitor a Monitor
      * @return a {@code ServiceExtensionContext}
      */
     @NotNull
@@ -181,14 +183,14 @@ public class BaseRuntime {
     }
 
     /**
-     * Hook point to instantiate a {@link Monitor}. By default, the runtime instantiates a {@code Monitor} using the Service Loader mechanism, i.e. by calling the {@link ExtensionLoader#loadMonitor()} method.
+     * Hook point to instantiate a {@link Monitor}. By default, the runtime instantiates a {@code Monitor} using the Service Loader mechanism, i.e. by calling the {@link ExtensionLoader#loadMonitor(String...)} method.
      * <p>
      * Please consider using the extension mechanism (i.e. {@link MonitorExtension}) rather than supplying a custom monitor by overriding this method.
      * However, for development/testing scenarios it might be an easy solution to just override this method.
      */
     @NotNull
     protected Monitor createMonitor() {
-        return ExtensionLoader.loadMonitor();
+        return ExtensionLoader.loadMonitor(programArgs);
     }
 
     private void boot(boolean addShutdownHook) {

--- a/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/EdcRuntimeExtension.java
+++ b/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/EdcRuntimeExtension.java
@@ -58,9 +58,9 @@ public class EdcRuntimeExtension extends EdcExtension {
     /**
      * Initialize an Edc runtime given a base runtime module
      *
-     * @param baseModulePath the base runtime module path
-     * @param name the name.
-     * @param properties the properties to be used as configuration.
+     * @param baseModulePath    the base runtime module path
+     * @param name              the name.
+     * @param properties        the properties to be used as configuration.
      * @param additionalModules modules that will be added to the runtime.
      */
     public EdcRuntimeExtension(String baseModulePath, String name, Map<String, String> properties, String... additionalModules) {
@@ -70,9 +70,9 @@ public class EdcRuntimeExtension extends EdcExtension {
     /**
      * Initialize an Edc runtime
      *
-     * @param name the name.
+     * @param name       the name.
      * @param properties the properties to be used as configuration.
-     * @param modules the modules that will be used to load the runtime.
+     * @param modules    the modules that will be used to load the runtime.
      */
     public EdcRuntimeExtension(String name, Map<String, String> properties, String... modules) {
         this.modules = modules;
@@ -159,7 +159,7 @@ public class EdcRuntimeExtension extends EdcExtension {
             return new Monitor() {
             };
         } else {
-            return new ConsoleMonitor(name, ConsoleMonitor.Level.DEBUG);
+            return new ConsoleMonitor(name, ConsoleMonitor.Level.DEBUG, true);
         }
     }
 

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/monitor/ConsoleColor.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/monitor/ConsoleColor.java
@@ -1,0 +1,90 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.spi.monitor;
+
+public interface ConsoleColor {
+    // Reset
+    String RESET = "\033[0m";  // Text Reset
+
+    // Regular Colors
+    String BLACK = "\033[0;30m";   // BLACK
+    String RED = "\033[0;31m";     // RED
+    String GREEN = "\033[0;32m";   // GREEN
+    String YELLOW = "\033[0;33m";  // YELLOW
+    String BLUE = "\033[0;34m";    // BLUE
+    String PURPLE = "\033[0;35m";  // PURPLE
+    String CYAN = "\033[0;36m";    // CYAN
+    String WHITE = "\033[0;37m";   // WHITE
+
+    // Bold
+    String BLACK_BOLD = "\033[1;30m";  // BLACK
+    String RED_BOLD = "\033[1;31m";    // RED
+    String GREEN_BOLD = "\033[1;32m";  // GREEN
+    String YELLOW_BOLD = "\033[1;33m"; // YELLOW
+    String BLUE_BOLD = "\033[1;34m";   // BLUE
+    String PURPLE_BOLD = "\033[1;35m"; // PURPLE
+    String CYAN_BOLD = "\033[1;36m";   // CYAN
+    String WHITE_BOLD = "\033[1;37m";  // WHITE
+
+    // Underline
+    String BLACK_UNDERLINED = "\033[4;30m";  // BLACK
+    String RED_UNDERLINED = "\033[4;31m";    // RED
+    String GREEN_UNDERLINED = "\033[4;32m";  // GREEN
+    String YELLOW_UNDERLINED = "\033[4;33m"; // YELLOW
+    String BLUE_UNDERLINED = "\033[4;34m";   // BLUE
+    String PURPLE_UNDERLINED = "\033[4;35m"; // PURPLE
+    String CYAN_UNDERLINED = "\033[4;36m";   // CYAN
+    String WHITE_UNDERLINED = "\033[4;37m";  // WHITE
+
+    // Background
+    String BLACK_BACKGROUND = "\033[40m";  // BLACK
+    String RED_BACKGROUND = "\033[41m";    // RED
+    String GREEN_BACKGROUND = "\033[42m";  // GREEN
+    String YELLOW_BACKGROUND = "\033[43m"; // YELLOW
+    String BLUE_BACKGROUND = "\033[44m";   // BLUE
+    String PURPLE_BACKGROUND = "\033[45m"; // PURPLE
+    String CYAN_BACKGROUND = "\033[46m";   // CYAN
+    String WHITE_BACKGROUND = "\033[47m";  // WHITE
+
+    // High Intensity
+    String BLACK_BRIGHT = "\033[0;90m";  // BLACK
+    String RED_BRIGHT = "\033[0;91m";    // RED
+    String GREEN_BRIGHT = "\033[0;92m";  // GREEN
+    String YELLOW_BRIGHT = "\033[0;93m"; // YELLOW
+    String BLUE_BRIGHT = "\033[0;94m";   // BLUE
+    String PURPLE_BRIGHT = "\033[0;95m"; // PURPLE
+    String CYAN_BRIGHT = "\033[0;96m";   // CYAN
+    String WHITE_BRIGHT = "\033[0;97m";  // WHITE
+
+    // Bold High Intensity
+    String BLACK_BOLD_BRIGHT = "\033[1;90m"; // BLACK
+    String RED_BOLD_BRIGHT = "\033[1;91m";   // RED
+    String GREEN_BOLD_BRIGHT = "\033[1;92m"; // GREEN
+    String YELLOW_BOLD_BRIGHT = "\033[1;93m";// YELLOW
+    String BLUE_BOLD_BRIGHT = "\033[1;94m";  // BLUE
+    String PURPLE_BOLD_BRIGHT = "\033[1;95m";// PURPLE
+    String CYAN_BOLD_BRIGHT = "\033[1;96m";  // CYAN
+    String WHITE_BOLD_BRIGHT = "\033[1;97m"; // WHITE
+
+    // High Intensity backgrounds
+    String BLACK_BACKGROUND_BRIGHT = "\033[0;100m";// BLACK
+    String RED_BACKGROUND_BRIGHT = "\033[0;101m";// RED
+    String GREEN_BACKGROUND_BRIGHT = "\033[0;102m";// GREEN
+    String YELLOW_BACKGROUND_BRIGHT = "\033[0;103m";// YELLOW
+    String BLUE_BACKGROUND_BRIGHT = "\033[0;104m";// BLUE
+    String PURPLE_BACKGROUND_BRIGHT = "\033[0;105m"; // PURPLE
+    String CYAN_BACKGROUND_BRIGHT = "\033[0;106m";  // CYAN
+    String WHITE_BACKGROUND_BRIGHT = "\033[0;107m";   // WHITE
+}

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/monitor/ConsoleColor.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/monitor/ConsoleColor.java
@@ -16,75 +16,75 @@ package org.eclipse.edc.spi.monitor;
 
 public interface ConsoleColor {
     // Reset
-    String RESET = "\033[0m";  // Text Reset
+    String RESET = "\033[0m";
 
     // Regular Colors
-    String BLACK = "\033[0;30m";   // BLACK
-    String RED = "\033[0;31m";     // RED
-    String GREEN = "\033[0;32m";   // GREEN
-    String YELLOW = "\033[0;33m";  // YELLOW
-    String BLUE = "\033[0;34m";    // BLUE
-    String PURPLE = "\033[0;35m";  // PURPLE
-    String CYAN = "\033[0;36m";    // CYAN
-    String WHITE = "\033[0;37m";   // WHITE
+    String BLACK = "\033[0;30m";
+    String RED = "\033[0;31m";
+    String GREEN = "\033[0;32m";
+    String YELLOW = "\033[0;33m";
+    String BLUE = "\033[0;34m";
+    String PURPLE = "\033[0;35m";
+    String CYAN = "\033[0;36m";
+    String WHITE = "\033[0;37m";
 
     // Bold
-    String BLACK_BOLD = "\033[1;30m";  // BLACK
-    String RED_BOLD = "\033[1;31m";    // RED
-    String GREEN_BOLD = "\033[1;32m";  // GREEN
-    String YELLOW_BOLD = "\033[1;33m"; // YELLOW
-    String BLUE_BOLD = "\033[1;34m";   // BLUE
-    String PURPLE_BOLD = "\033[1;35m"; // PURPLE
-    String CYAN_BOLD = "\033[1;36m";   // CYAN
-    String WHITE_BOLD = "\033[1;37m";  // WHITE
+    String BLACK_BOLD = "\033[1;30m";
+    String RED_BOLD = "\033[1;31m";
+    String GREEN_BOLD = "\033[1;32m";
+    String YELLOW_BOLD = "\033[1;33m";
+    String BLUE_BOLD = "\033[1;34m";
+    String PURPLE_BOLD = "\033[1;35m";
+    String CYAN_BOLD = "\033[1;36m";
+    String WHITE_BOLD = "\033[1;37m";
 
     // Underline
-    String BLACK_UNDERLINED = "\033[4;30m";  // BLACK
-    String RED_UNDERLINED = "\033[4;31m";    // RED
-    String GREEN_UNDERLINED = "\033[4;32m";  // GREEN
-    String YELLOW_UNDERLINED = "\033[4;33m"; // YELLOW
-    String BLUE_UNDERLINED = "\033[4;34m";   // BLUE
-    String PURPLE_UNDERLINED = "\033[4;35m"; // PURPLE
-    String CYAN_UNDERLINED = "\033[4;36m";   // CYAN
-    String WHITE_UNDERLINED = "\033[4;37m";  // WHITE
+    String BLACK_UNDERLINED = "\033[4;30m";
+    String RED_UNDERLINED = "\033[4;31m";
+    String GREEN_UNDERLINED = "\033[4;32m";
+    String YELLOW_UNDERLINED = "\033[4;33m";
+    String BLUE_UNDERLINED = "\033[4;34m";
+    String PURPLE_UNDERLINED = "\033[4;35m";
+    String CYAN_UNDERLINED = "\033[4;36m";
+    String WHITE_UNDERLINED = "\033[4;37m";
 
     // Background
-    String BLACK_BACKGROUND = "\033[40m";  // BLACK
-    String RED_BACKGROUND = "\033[41m";    // RED
-    String GREEN_BACKGROUND = "\033[42m";  // GREEN
-    String YELLOW_BACKGROUND = "\033[43m"; // YELLOW
-    String BLUE_BACKGROUND = "\033[44m";   // BLUE
-    String PURPLE_BACKGROUND = "\033[45m"; // PURPLE
-    String CYAN_BACKGROUND = "\033[46m";   // CYAN
-    String WHITE_BACKGROUND = "\033[47m";  // WHITE
+    String BLACK_BACKGROUND = "\033[40m";
+    String RED_BACKGROUND = "\033[41m";
+    String GREEN_BACKGROUND = "\033[42m";
+    String YELLOW_BACKGROUND = "\033[43m";
+    String BLUE_BACKGROUND = "\033[44m";
+    String PURPLE_BACKGROUND = "\033[45m";
+    String CYAN_BACKGROUND = "\033[46m";
+    String WHITE_BACKGROUND = "\033[47m";
 
     // High Intensity
-    String BLACK_BRIGHT = "\033[0;90m";  // BLACK
-    String RED_BRIGHT = "\033[0;91m";    // RED
-    String GREEN_BRIGHT = "\033[0;92m";  // GREEN
-    String YELLOW_BRIGHT = "\033[0;93m"; // YELLOW
-    String BLUE_BRIGHT = "\033[0;94m";   // BLUE
-    String PURPLE_BRIGHT = "\033[0;95m"; // PURPLE
-    String CYAN_BRIGHT = "\033[0;96m";   // CYAN
-    String WHITE_BRIGHT = "\033[0;97m";  // WHITE
+    String BLACK_BRIGHT = "\033[0;90m";
+    String RED_BRIGHT = "\033[0;91m";
+    String GREEN_BRIGHT = "\033[0;92m";
+    String YELLOW_BRIGHT = "\033[0;93m";
+    String BLUE_BRIGHT = "\033[0;94m";
+    String PURPLE_BRIGHT = "\033[0;95m";
+    String CYAN_BRIGHT = "\033[0;96m";
+    String WHITE_BRIGHT = "\033[0;97m";
 
     // Bold High Intensity
-    String BLACK_BOLD_BRIGHT = "\033[1;90m"; // BLACK
-    String RED_BOLD_BRIGHT = "\033[1;91m";   // RED
-    String GREEN_BOLD_BRIGHT = "\033[1;92m"; // GREEN
-    String YELLOW_BOLD_BRIGHT = "\033[1;93m";// YELLOW
-    String BLUE_BOLD_BRIGHT = "\033[1;94m";  // BLUE
-    String PURPLE_BOLD_BRIGHT = "\033[1;95m";// PURPLE
-    String CYAN_BOLD_BRIGHT = "\033[1;96m";  // CYAN
-    String WHITE_BOLD_BRIGHT = "\033[1;97m"; // WHITE
+    String BLACK_BOLD_BRIGHT = "\033[1;90m";
+    String RED_BOLD_BRIGHT = "\033[1;91m";
+    String GREEN_BOLD_BRIGHT = "\033[1;92m";
+    String YELLOW_BOLD_BRIGHT = "\033[1;93m";
+    String BLUE_BOLD_BRIGHT = "\033[1;94m";
+    String PURPLE_BOLD_BRIGHT = "\033[1;95m";
+    String CYAN_BOLD_BRIGHT = "\033[1;96m";
+    String WHITE_BOLD_BRIGHT = "\033[1;97m";
 
     // High Intensity backgrounds
-    String BLACK_BACKGROUND_BRIGHT = "\033[0;100m";// BLACK
-    String RED_BACKGROUND_BRIGHT = "\033[0;101m";// RED
-    String GREEN_BACKGROUND_BRIGHT = "\033[0;102m";// GREEN
-    String YELLOW_BACKGROUND_BRIGHT = "\033[0;103m";// YELLOW
-    String BLUE_BACKGROUND_BRIGHT = "\033[0;104m";// BLUE
-    String PURPLE_BACKGROUND_BRIGHT = "\033[0;105m"; // PURPLE
-    String CYAN_BACKGROUND_BRIGHT = "\033[0;106m";  // CYAN
-    String WHITE_BACKGROUND_BRIGHT = "\033[0;107m";   // WHITE
+    String BLACK_BACKGROUND_BRIGHT = "\033[0;100m";
+    String RED_BACKGROUND_BRIGHT = "\033[0;101m";
+    String GREEN_BACKGROUND_BRIGHT = "\033[0;102m";
+    String YELLOW_BACKGROUND_BRIGHT = "\033[0;103m";
+    String BLUE_BACKGROUND_BRIGHT = "\033[0;104m";
+    String PURPLE_BACKGROUND_BRIGHT = "\033[0;105m";
+    String CYAN_BACKGROUND_BRIGHT = "\033[0;106m";
+    String WHITE_BACKGROUND_BRIGHT = "\033[0;107m";
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/monitor/ConsoleMonitor.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/monitor/ConsoleMonitor.java
@@ -84,12 +84,12 @@ public class ConsoleMonitor implements Monitor {
 
     private void output(String level, Supplier<String> supplier, Throwable... errors) {
         var time = ZonedDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
-        var colorCode = getColorCode(level);
+        var colorCode = useColor ? getColorCode(level) : "";
         var resetCode = useColor ? ConsoleColor.RESET : "";
 
         System.out.println(colorCode + prefix + level + " " + time + " " + sanitizeMessage(supplier) + resetCode);
         if (errors != null) {
-            for (Throwable error : errors) {
+            for (var error : errors) {
                 if (error != null) {
                     System.out.print(colorCode);
                     error.printStackTrace(System.out);
@@ -100,10 +100,6 @@ public class ConsoleMonitor implements Monitor {
     }
 
     private String getColorCode(String level) {
-        if (!useColor) {
-            return "";
-        }
-
         return switch (level) {
             case SEVERE -> ConsoleColor.RED;
             case WARNING -> ConsoleColor.YELLOW;


### PR DESCRIPTION
## What this PR changes/adds

This PR adds colored console output to the `ConsoleMonitor`. This is achieved by inserting special unicode characters before log lines to access ANSI coloring.
Note that the _actual_ color depends on the color configuration in your terminal.

This behaviour is on by default, and it can be deactivated by passing the `--no-color` command line argument. This might be useful in certain environments, for example running in clustered environments, where log tools like [stern](https://github.com/stern/stern) are used, that do coloring on their own.

Also, some docker base images may not print colored output correctly, depending on the shell they use. There are ways to mitigate it, e.g. using the `tty: true` property in docker-compose, or passing the `--it` parameter to `docker run`.



## Why it does that

Better readability.

## Further notes

I had considered several ways to toggle the coloring: 
1. using a config property: does not work properly, because the default `ConsoleMonitor` is instantiated before the `ServiceExtensionContext`, so we'd have a chicken-and-egg-problem
2. using a dedicated `monitor-coloring` module that contains a custom monitor. Decided against it, because I wanted to be able to toggle within the same runtime.
3. passing a command line arg `--no-color`. Needs to be implemented by the runtime base class, but has the least impact on the code base. Also, central configuration of the monitor in test runtimes was possible. 
## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
