### PR TITLE
fix: avoid NPE when attributes are null

### DIFF
--- a/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/transform/JsonObjectFromTransferProcessTransformerTest.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/transform/JsonObjectFromTransferProcessTransformerTest.java
@@ -97,4 +97,13 @@ class JsonObjectFromTransferProcessTransformerTest {
         assertThat(result.getString(TRANSFER_PROCESS_ERROR_DETAIL)).isEqualTo("an error");
     }
 
+    @Test
+    void shouldNotThrownException_whenBareboneTransferProcess() {
+        var input = TransferProcess.Builder.newInstance()
+                .build();
+
+        var result = transformer.transform(input, context);
+
+        assertThat(result).isNotNull();
+    }
 }


### PR DESCRIPTION
## What this PR changes/adds

Avoid NPEs when TP attributes are null.
The egress transformers should fail as less as possible.

## Why it does that

Avoid NPE

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #4078 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
