### PR TITLE
fix: handle multiple consequences in ODRL duty

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -348,7 +348,7 @@ maven/mavencentral/org.slf4j/slf4j-api/2.0.9, MIT, approved, #5915
 maven/mavencentral/org.testcontainers/database-commons/1.19.7, Apache-2.0, approved, #10345
 maven/mavencentral/org.testcontainers/jdbc/1.19.7, Apache-2.0, approved, #10348
 maven/mavencentral/org.testcontainers/junit-jupiter/1.19.7, MIT, approved, #10344
-maven/mavencentral/org.testcontainers/kafka/1.19.7, None, restricted, #14177
+maven/mavencentral/org.testcontainers/kafka/1.19.7, MIT, approved, #14177
 maven/mavencentral/org.testcontainers/postgresql/1.19.7, MIT, approved, #10350
 maven/mavencentral/org.testcontainers/testcontainers/1.19.7, Apache-2.0 AND MIT, approved, #10347
 maven/mavencentral/org.testcontainers/vault/1.19.7, MIT, approved, #10852

--- a/core/common/lib/policy-engine-lib/src/test/java/org/eclipse/edc/policy/engine/ScopeFilterTest.java
+++ b/core/common/lib/policy-engine-lib/src/test/java/org/eclipse/edc/policy/engine/ScopeFilterTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ScopeFilterTest {
+
     public static final String BOUND_SCOPE = "scope1";
     private static final Action REPORT_ACTION = Action.Builder.newInstance().type("report").build();
     private static final Action SUB_ACTION = Action.Builder.newInstance().type("subaction").build();
@@ -80,7 +81,6 @@ class ScopeFilterTest {
         assertThat(filteredPolicy.getObligations()).isNotEmpty();
         assertThat(filteredPolicy.getProhibitions()).isNotEmpty();
         assertThat(filteredPolicy.getExtensibleProperties()).isNotEmpty();
-
     }
 
     @Test
@@ -163,7 +163,7 @@ class ScopeFilterTest {
 
         assertThat(filteredDuty).isNotNull();
         assertThat(filteredDuty.getAction()).isNotNull();
-        assertThat(filteredDuty.getConsequence()).isNotNull();
+        assertThat(filteredDuty.getConsequences()).hasSize(1);
         assertThat(filteredDuty.getConstraints().size()).isEqualTo(1);  // verify that the unbound constraint was removed
         assertThat(filteredDuty.getConstraints()).contains(BOUND_CONSTRAINT);
     }

--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/odrl/from/JsonObjectFromPolicyTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/odrl/from/JsonObjectFromPolicyTransformer.java
@@ -210,9 +210,10 @@ public class JsonObjectFromPolicyTransformer extends AbstractJsonLdTransformer<P
         public JsonObject visitDuty(Duty duty) {
             var obligationBuilder = visitRule(duty);
 
-            if (duty.getConsequence() != null) {
-                var consequence = visitDuty(duty.getConsequence());
-                obligationBuilder.add(ODRL_CONSEQUENCE_ATTRIBUTE, consequence);
+            var consequences = duty.getConsequences();
+            if (consequences != null && !consequences.isEmpty()) {
+                var consequencesJson = consequences.stream().map(this::visitDuty).collect(toJsonArray());
+                obligationBuilder.add(ODRL_CONSEQUENCE_ATTRIBUTE, consequencesJson);
             }
 
             return obligationBuilder.build();

--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/odrl/to/JsonObjectToDutyTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/odrl/to/JsonObjectToDutyTransformer.java
@@ -43,7 +43,7 @@ public class JsonObjectToDutyTransformer extends AbstractJsonLdTransformer<JsonO
         visitProperties(object, key -> switch (key) {
             case ODRL_ACTION_ATTRIBUTE -> value -> builder.action(transformObject(value, Action.class, context));
             case ODRL_CONSTRAINT_ATTRIBUTE -> value -> builder.constraints(transformArray(value, Constraint.class, context));
-            case ODRL_CONSEQUENCE_ATTRIBUTE -> value -> builder.consequence(transformObject(value, Duty.class, context));
+            case ODRL_CONSEQUENCE_ATTRIBUTE -> value -> builder.consequences(transformArray(value, Duty.class, context));
             default -> doNothing();
         });
 

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/odrl/from/JsonObjectFromPolicyTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/odrl/from/JsonObjectFromPolicyTransformerTest.java
@@ -273,11 +273,13 @@ class JsonObjectFromPolicyTransformerTest {
     void transform_dutyWithConstraintAndConsequence_returnJsonObject() {
         var constraint = getConstraint();
         var action = getAction();
-        var consequence = Duty.Builder.newInstance().action(action).build();
+        var firstConsequence = Duty.Builder.newInstance().action(action).build();
+        var secondConsequence = Duty.Builder.newInstance().action(action).build();
         var duty = Duty.Builder.newInstance()
                 .action(action)
                 .constraint(constraint)
-                .consequence(consequence)
+                .consequence(firstConsequence)
+                .consequence(secondConsequence)
                 .build();
         var policy = Policy.Builder.newInstance().duty(duty).build();
 
@@ -294,8 +296,10 @@ class JsonObjectFromPolicyTransformerTest {
         assertThat(constraintJson.getJsonObject(ODRL_RIGHT_OPERAND_ATTRIBUTE).getJsonString(VALUE).getString())
                 .isEqualTo(((LiteralExpression) constraint.getRightExpression()).getValue());
 
-        var consequenceJson = dutyJson.getJsonObject(ODRL_CONSEQUENCE_ATTRIBUTE);
-        assertThat(consequenceJson.getJsonObject(ODRL_ACTION_ATTRIBUTE)).isNotNull();
+        var consequencesJson = dutyJson.getJsonArray(ODRL_CONSEQUENCE_ATTRIBUTE);
+        assertThat(consequencesJson).hasSize(2).map(JsonValue::asJsonObject).allSatisfy(consequenceJson -> {
+            assertThat(consequenceJson.getJsonObject(ODRL_ACTION_ATTRIBUTE)).isNotNull();
+        });
 
         verify(context, never()).reportProblem(anyString());
     }

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/odrl/to/JsonObjectToDutyTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/odrl/to/JsonObjectToDutyTransformerTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.connector.controlplane.transform.odrl.to;
 
-import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.transform.TestInput;
 import org.eclipse.edc.policy.model.Action;
@@ -23,12 +22,10 @@ import org.eclipse.edc.policy.model.Constraint;
 import org.eclipse.edc.policy.model.Duty;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.Test;
 
-import java.util.Map;
-import java.util.stream.Stream;
-
+import static jakarta.json.Json.createArrayBuilder;
+import static jakarta.json.Json.createObjectBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ACTION_ATTRIBUTE;
@@ -47,7 +44,7 @@ import static org.mockito.Mockito.when;
 class JsonObjectToDutyTransformerTest {
     private static final String TARGET = "target";
 
-    private final TransformerContext context = mock(TransformerContext.class);
+    private final TransformerContext context = mock();
 
     private final Action action = Action.Builder.newInstance().type("type").build();
     private final Constraint constraint = AtomicConstraint.Builder.newInstance().build();
@@ -64,46 +61,32 @@ class JsonObjectToDutyTransformerTest {
         when(context.transform(isA(JsonObject.class), eq(Duty.class))).thenReturn(consequence);
     }
 
-    @ParameterizedTest
-    @MethodSource("jsonSource")
-    void transform_returnDuty(JsonObject jsonDuty) {
+    @Test
+    void transform_returnDuty() {
+        var actionJson = createObjectBuilder().add(TYPE, "action");
+        var constraintJson = createObjectBuilder().add(TYPE, "constraint");
+        var consequencesJson = createArrayBuilder()
+                .add(createObjectBuilder().add(TYPE, "consequence"))
+                .add(createObjectBuilder().add(TYPE, "consequence"));
+        var jsonDuty = createObjectBuilder()
+                .add(ODRL_ACTION_ATTRIBUTE, actionJson)
+                .add(ODRL_CONSTRAINT_ATTRIBUTE, constraintJson)
+                .add(ODRL_CONSEQUENCE_ATTRIBUTE, consequencesJson)
+                .add(ODRL_TARGET_ATTRIBUTE, TARGET)
+                .build();
+
         var result = transformer.transform(TestInput.getExpanded(jsonDuty), context);
 
         assertThat(result).isNotNull();
         assertThat(result.getAction()).isEqualTo(action);
         assertThat(result.getConstraints()).hasSize(1);
         assertThat(result.getConstraints().get(0)).isEqualTo(constraint);
-        assertThat(result.getConsequence()).isEqualTo(consequence);
+        assertThat(result.getConsequences()).hasSize(2).first().isEqualTo(consequence);
 
         verify(context, never()).reportProblem(anyString());
         verify(context, times(1)).transform(isA(JsonObject.class), eq(Action.class));
         verify(context, times(1)).transform(isA(JsonObject.class), eq(Constraint.class));
-        verify(context, times(1)).transform(isA(JsonObject.class), eq(Duty.class));
-    }
-
-    static Stream<JsonObject> jsonSource() {
-        var jsonFactory = Json.createBuilderFactory(Map.of());
-        var actionJson = jsonFactory.createObjectBuilder().add(TYPE, "action");
-        var constraintJson = jsonFactory.createObjectBuilder().add(TYPE, "constraint");
-        var consequenceJson = jsonFactory.createObjectBuilder().add(TYPE, "consequence");
-
-        return Stream.of(
-                // as object
-                jsonFactory.createObjectBuilder()
-                        .add(ODRL_ACTION_ATTRIBUTE, actionJson)
-                        .add(ODRL_CONSTRAINT_ATTRIBUTE, constraintJson)
-                        .add(ODRL_CONSEQUENCE_ATTRIBUTE, consequenceJson)
-                        .add(ODRL_TARGET_ATTRIBUTE, TARGET)
-                        .build(),
-
-                // as arrays
-                jsonFactory.createObjectBuilder()
-                        .add(ODRL_ACTION_ATTRIBUTE, jsonFactory.createArrayBuilder().add(actionJson))
-                        .add(ODRL_CONSTRAINT_ATTRIBUTE, jsonFactory.createArrayBuilder().add(constraintJson))
-                        .add(ODRL_CONSEQUENCE_ATTRIBUTE, jsonFactory.createArrayBuilder().add(consequenceJson))
-                        .add(ODRL_TARGET_ATTRIBUTE, jsonFactory.createArrayBuilder().add(TARGET))
-                        .build()
-        );
+        verify(context, times(2)).transform(isA(JsonObject.class), eq(Duty.class));
     }
 
 }

--- a/spi/common/policy-model/src/main/java/org/eclipse/edc/policy/model/Duty.java
+++ b/spi/common/policy-model/src/main/java/org/eclipse/edc/policy/model/Duty.java
@@ -21,24 +21,20 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static java.util.stream.Collectors.joining;
 
 /**
  * An obligation that must be performed if all its constraints are satisfied.
- * TODO: Do we need to support deserializing the parent permission setting?
  */
 @JsonDeserialize(builder = Duty.Builder.class)
 @JsonTypeName("dataspaceconnector:duty")
 public class Duty extends Rule {
 
     private Permission parentPermission;
-
-    @Nullable
-    private Duty consequence;
-
-    public Duty getConsequence() {
-        return consequence;
-    }
+    private final List<Duty> consequences = new ArrayList<>();
 
     /**
      * If this duty is part of a permission, returns the parent permission; otherwise returns null.
@@ -46,6 +42,10 @@ public class Duty extends Rule {
     @Nullable
     public Permission getParentPermission() {
         return parentPermission;
+    }
+
+    public List<Duty> getConsequences() {
+        return consequences;
     }
 
     void setParentPermission(Permission permission) {
@@ -80,7 +80,12 @@ public class Duty extends Rule {
         }
 
         public Builder consequence(Duty consequence) {
-            rule.consequence = consequence;
+            rule.consequences.add(consequence);
+            return this;
+        }
+
+        public Builder consequences(List<Duty> consequences) {
+            rule.consequences.addAll(consequences);
             return this;
         }
 

--- a/spi/control-plane/policy-spi/src/test/java/org/eclipse/edc/connector/controlplane/policy/spi/PolicyDefinitionSerializationTest.java
+++ b/spi/control-plane/policy-spi/src/test/java/org/eclipse/edc/connector/controlplane/policy/spi/PolicyDefinitionSerializationTest.java
@@ -31,7 +31,6 @@ class PolicyDefinitionSerializationTest {
 
     private final TypeManager typeManager = new TypeManager();
 
-
     @Test
     void verifySerialization() {
         var policyDef = PolicyDefinition.Builder.newInstance()
@@ -42,9 +41,7 @@ class PolicyDefinitionSerializationTest {
                 .build();
 
         var json = typeManager.writeValueAsString(policyDef);
-        assertThat(json).isNotNull();
-        assertThat(json).contains("createdAt");
-        assertThat(json).contains("sampleInheritsFrom");
+        assertThat(json).isNotNull().contains("createdAt").contains("sampleInheritsFrom");
 
         var deserialized = typeManager.readValue(json, PolicyDefinition.class);
         assertThat(deserialized).usingRecursiveComparison().isEqualTo(policyDef);
@@ -52,21 +49,14 @@ class PolicyDefinitionSerializationTest {
     }
 
     private Policy createPolicy() {
-        var permission = Permission.Builder.newInstance().build();
-
-        var prohibition = Prohibition.Builder.newInstance().build();
-
-        var duty = Duty.Builder.newInstance().build();
-
-        var p = Policy.Builder.newInstance()
-                .permission(permission)
-                .prohibition(prohibition)
-                .duties(List.of(duty))
+        return Policy.Builder.newInstance()
+                .permission(Permission.Builder.newInstance().build())
+                .prohibition(Prohibition.Builder.newInstance().build())
+                .duties(List.of(Duty.Builder.newInstance().build()))
                 .inheritsFrom("sampleInheritsFrom")
                 .assigner("sampleAssigner")
                 .assignee("sampleAssignee")
                 .target("sampleTarget")
-                .type(PolicyType.SET);
-        return p.build();
+                .type(PolicyType.SET).build();
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Permit to define multiple `consequence` in the ODRL duty object, as reported by the ODRL spec.

## Why it does that

dsp completion

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #3960 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
