### PR TITLE
fix: accessService serialization

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -103,9 +103,9 @@ maven/mavencentral/commons-logging/commons-logging/1.2, Apache-2.0, approved, CQ
 maven/mavencentral/dev.failsafe/failsafe-okhttp/3.3.2, Apache-2.0, approved, #9178
 maven/mavencentral/dev.failsafe/failsafe/3.3.2, Apache-2.0, approved, #9268
 maven/mavencentral/info.picocli/picocli/4.7.5, Apache-2.0, approved, #4365
-maven/mavencentral/io.cloudevents/cloudevents-api/3.0.0, , restricted, clearlydefined
-maven/mavencentral/io.cloudevents/cloudevents-core/3.0.0, , restricted, clearlydefined
-maven/mavencentral/io.cloudevents/cloudevents-http-basic/3.0.0, , restricted, clearlydefined
+maven/mavencentral/io.cloudevents/cloudevents-api/3.0.0, Apache-2.0, approved, #14228
+maven/mavencentral/io.cloudevents/cloudevents-core/3.0.0, Apache-2.0, approved, #14227
+maven/mavencentral/io.cloudevents/cloudevents-http-basic/3.0.0, Apache-2.0, approved, #14229
 maven/mavencentral/io.github.classgraph/classgraph/4.8.154, MIT, approved, CQ22530
 maven/mavencentral/io.micrometer/micrometer-commons/1.12.4, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #11679
 maven/mavencentral/io.micrometer/micrometer-core/1.12.4, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #11678

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/main/java/org/eclipse/edc/protocol/dsp/catalog/transform/from/JsonObjectFromDistributionTransformer.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/main/java/org/eclipse/edc/protocol/dsp/catalog/transform/from/JsonObjectFromDistributionTransformer.java
@@ -42,14 +42,13 @@ public class JsonObjectFromDistributionTransformer extends AbstractJsonLdTransfo
 
     @Override
     public @Nullable JsonObject transform(@NotNull Distribution distribution, @NotNull TransformerContext context) {
-        var objectBuilder = jsonFactory.createObjectBuilder();
-        objectBuilder.add(TYPE, DCAT_DISTRIBUTION_TYPE);
-        objectBuilder.add(DCT_FORMAT_ATTRIBUTE, jsonFactory.createObjectBuilder()
-                .add(ID, distribution.getFormat())
-                .build());
-        objectBuilder.add(DCAT_ACCESS_SERVICE_ATTRIBUTE, distribution.getDataService().getId());
-
-        return objectBuilder.build();
+        return jsonFactory.createObjectBuilder()
+                .add(TYPE, DCAT_DISTRIBUTION_TYPE)
+                .add(DCT_FORMAT_ATTRIBUTE, jsonFactory.createObjectBuilder()
+                    .add(ID, distribution.getFormat())
+                    .build())
+                .add(DCAT_ACCESS_SERVICE_ATTRIBUTE, context.transform(distribution.getDataService(), JsonObject.class))
+                .build();
     }
 
 }

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/test/java/org/eclipse/edc/protocol/dsp/catalog/transform/from/JsonObjectFromDistributionTransformerTest.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/test/java/org/eclipse/edc/protocol/dsp/catalog/transform/from/JsonObjectFromDistributionTransformerTest.java
@@ -16,10 +16,10 @@ package org.eclipse.edc.protocol.dsp.catalog.transform.from;
 
 import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.catalog.spi.DataService;
 import org.eclipse.edc.connector.controlplane.catalog.spi.Distribution;
 import org.eclipse.edc.transform.spi.TransformerContext;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -30,37 +30,37 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_ACCESS_SERVICE_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DISTRIBUTION_TYPE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCT_FORMAT_ATTRIBUTE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class JsonObjectFromDistributionTransformerTest {
 
-    private JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
-    private TransformerContext context = mock(TransformerContext.class);
+    private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
+    private final TransformerContext context = mock();
 
-    private JsonObjectFromDistributionTransformer transformer;
-
-    @BeforeEach
-    void setUp() {
-        transformer = new JsonObjectFromDistributionTransformer(jsonFactory);
-    }
+    private final JsonObjectFromDistributionTransformer transformer = new JsonObjectFromDistributionTransformer(jsonFactory);
 
     @Test
     void transform_returnJsonObject() {
-        var distribution = getDistribution();
+        var accessServiceJson = jsonFactory.createObjectBuilder().add(ID, "dataServiceId").build();
+        when(context.transform(any(), eq(JsonObject.class))).thenReturn(accessServiceJson);
+        var distribution = Distribution.Builder.newInstance()
+                .format("format")
+                .dataService(DataService.Builder.newInstance().id("dataServiceId").build())
+                .build();
+
         var result = transformer.transform(distribution, context);
 
         assertThat(result).isNotNull();
         assertThat(result.getJsonString(TYPE).getString()).isEqualTo(DCAT_DISTRIBUTION_TYPE);
         assertThat(result.getJsonObject(DCT_FORMAT_ATTRIBUTE).getJsonString(ID).getString())
                 .isEqualTo(distribution.getFormat());
-        assertThat(result.getJsonString(DCAT_ACCESS_SERVICE_ATTRIBUTE).getString())
-                .isEqualTo(distribution.getDataService().getId());
+        assertThat(result.getJsonObject(DCAT_ACCESS_SERVICE_ATTRIBUTE).getString(ID)).isEqualTo("dataServiceId");
+        verify(context).transform(isA(DataService.class), eq(JsonObject.class));
     }
 
-    private Distribution getDistribution() {
-        return Distribution.Builder.newInstance()
-                .format("format")
-                .dataService(DataService.Builder.newInstance().id("dataServiceId").build())
-                .build();
-    }
 }

--- a/system-tests/management-api/management-api-test-runner/build.gradle.kts
+++ b/system-tests/management-api/management-api-test-runner/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     testImplementation(project(":spi:common:json-ld-spi"))
     testImplementation(project(":spi:control-plane:asset-spi"))
     testImplementation(project(":spi:control-plane:contract-spi"))
+    testImplementation(project(":spi:data-plane-selector:data-plane-selector-spi"))
     testImplementation(project(":core:common:connector-core"))
 
     //useful for generic DTOs etc.


### PR DESCRIPTION
## What this PR changes/adds

Fix `accessService` serialization

## Why it does that

it was serialized as a string, but it should follow a [specific representation.](https://www.w3.org/TR/vocab-dcat-2/#Property:distribution_access_service)

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #3995

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
