### PR TITLE
fix: removes v2 from the new public endpoint

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -348,7 +348,7 @@ maven/mavencentral/org.slf4j/slf4j-api/2.0.9, MIT, approved, #5915
 maven/mavencentral/org.testcontainers/database-commons/1.19.7, Apache-2.0, approved, #10345
 maven/mavencentral/org.testcontainers/jdbc/1.19.7, Apache-2.0, approved, #10348
 maven/mavencentral/org.testcontainers/junit-jupiter/1.19.7, MIT, approved, #10344
-maven/mavencentral/org.testcontainers/kafka/1.19.7, None, restricted, #14177
+maven/mavencentral/org.testcontainers/kafka/1.19.7, MIT, approved, #14177
 maven/mavencentral/org.testcontainers/postgresql/1.19.7, MIT, approved, #10350
 maven/mavencentral/org.testcontainers/testcontainers/1.19.7, Apache-2.0 AND MIT, approved, #10347
 maven/mavencentral/org.testcontainers/vault/1.19.7, MIT, approved, #10852

--- a/extensions/data-plane/data-plane-public-api-v2/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlanePublicApiV2Controller.java
+++ b/extensions/data-plane/data-plane-public-api-v2/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlanePublicApiV2Controller.java
@@ -48,7 +48,7 @@ import static jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static jakarta.ws.rs.core.Response.Status.UNAUTHORIZED;
 import static jakarta.ws.rs.core.Response.status;
 
-@Path("/v2/{any:.*}")
+@Path("{any:.*}")
 @Produces(WILDCARD)
 public class DataPlanePublicApiV2Controller implements DataPlanePublicApiV2 {
 

--- a/extensions/data-plane/data-plane-public-api-v2/src/test/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlanePublicApiV2ControllerTest.java
+++ b/extensions/data-plane/data-plane-public-api-v2/src/test/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlanePublicApiV2ControllerTest.java
@@ -161,7 +161,7 @@ class DataPlanePublicApiV2ControllerTest extends RestControllerTestBase {
         var request = requestCaptor.getValue();
         assertThat(request.getDestinationDataAddress().getType()).isEqualTo(AsyncStreamingDataSink.TYPE);
         assertThat(request.getSourceDataAddress().getType()).isEqualTo("test");
-        assertThat(request.getProperties()).containsEntry("method", "POST").containsEntry("pathSegments", "v2/any").containsEntry("queryParams", "foo=bar");
+        assertThat(request.getProperties()).containsEntry("method", "POST").containsEntry("pathSegments", "any").containsEntry("queryParams", "foo=bar");
     }
 
     @Override
@@ -171,7 +171,7 @@ class DataPlanePublicApiV2ControllerTest extends RestControllerTestBase {
 
     private RequestSpecification baseRequest() {
         return given()
-                .baseUri("http://localhost:" + port + "/v2")
+                .baseUri("http://localhost:" + port)
                 .when();
     }
 


### PR DESCRIPTION
## What this PR changes/adds

removes v2 from the new public endpoint

## Why it does that

Having `/v2` in the  `@Path` means that we'd have to remove it when proxying the request. Since there is no way to make 
the old public api and the new one working in the same runtime, we decided to remove it from the `@Path` instead of
stripping it at runtime

## Linked Issue(s)

Closes #4072 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
