### PR TITLE
feat: filter remedies in prohibitions

### DIFF
--- a/core/common/lib/policy-engine-lib/src/main/java/org/eclipse/edc/policy/engine/ScopeFilter.java
+++ b/core/common/lib/policy-engine-lib/src/main/java/org/eclipse/edc/policy/engine/ScopeFilter.java
@@ -29,8 +29,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.Objects;
-
-import static java.util.stream.Collectors.toList;
+import java.util.function.Function;
 
 /**
  * Filters a policy for a scope. This involves recursively removing rules and constraints not bound to the scope and
@@ -56,9 +55,9 @@ public class ScopeFilter {
     }
 
     public Policy applyScope(Policy policy, String scope) {
-        var filteredObligations = policy.getObligations().stream().map(d -> applyScope(d, scope)).filter(Objects::nonNull).collect(toList());
-        var filteredPermissions = policy.getPermissions().stream().map(p -> applyScope(p, scope)).filter(Objects::nonNull).collect(toList());
-        var filteredProhibitions = policy.getProhibitions().stream().map(p -> applyScope(p, scope)).filter(Objects::nonNull).collect(toList());
+        var filteredObligations = filterBy(policy.getObligations(), d -> applyScope(d, scope));
+        var filteredPermissions = filterBy(policy.getPermissions(), d -> applyScope(d, scope));
+        var filteredProhibitions = filterBy(policy.getProhibitions(), d -> applyScope(d, scope));
         return Policy.Builder.newInstance()
                 .type(policy.getType())
                 .assignee(policy.getAssignee())
@@ -77,8 +76,8 @@ public class ScopeFilter {
         if (actionNotInScope(permission, scope)) {
             return null;
         }
-        var filteredConstraints = applyScope(permission.getConstraints(), scope);
-        var filteredDuties = permission.getDuties().stream().map(d -> applyScope(d, scope)).filter(Objects::nonNull).toList();
+        var filteredConstraints = filterBy(permission.getConstraints(), c -> applyScope(c, scope));
+        var filteredDuties = filterBy(permission.getDuties(), d -> applyScope(d, scope));
 
         return Permission.Builder.newInstance()
                 .action(permission.getAction())
@@ -92,11 +91,8 @@ public class ScopeFilter {
         if (actionNotInScope(duty, scope)) {
             return null;
         }
-        var filteredConsequences = duty.getConsequences().stream()
-                .map(consequence -> applyScope(consequence, scope))
-                .filter(Objects::nonNull)
-                .toList();
-        var filteredConstraints = applyScope(duty.getConstraints(), scope);
+        var filteredConsequences = filterBy(duty.getConsequences(), d -> applyScope(d, scope));
+        var filteredConstraints = filterBy(duty.getConstraints(), c -> applyScope(c, scope));
 
         return Duty.Builder.newInstance()
                 .action(duty.getAction())
@@ -111,11 +107,13 @@ public class ScopeFilter {
         if (actionNotInScope(prohibition, scope)) {
             return null;
         }
-        var filteredConstraints = applyScope(prohibition.getConstraints(), scope);
+        var filteredConstraints = filterBy(prohibition.getConstraints(), c -> applyScope(c, scope));
+        var filteredRemedies = filterBy(prohibition.getRemedies(), d -> applyScope(d, scope));
 
         return Prohibition.Builder.newInstance()
                 .action(prohibition.getAction())
                 .constraints(filteredConstraints)
+                .remedies(filteredRemedies)
                 .build();
     }
 
@@ -134,10 +132,6 @@ public class ScopeFilter {
         return rule.getAction() != null && !registry.isInScope(rule.getAction().getType(), scope);
     }
 
-    private List<Constraint> applyScope(List<Constraint> constraints, String scope) {
-        return constraints.stream().map(constraint -> applyScope(constraint, scope)).filter(Objects::nonNull).toList();
-    }
-
     @Nullable
     private Constraint applyScope(AtomicConstraint constraint, String scope) {
         if (constraint.getLeftExpression() instanceof LiteralExpression literalExpression) {
@@ -145,5 +139,9 @@ public class ScopeFilter {
         } else {
             return constraint;
         }
+    }
+
+    private <T> List<T> filterBy(List<T> list, Function<T, T> filterFunction) {
+        return list.stream().map(filterFunction).filter(Objects::nonNull).toList();
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

#4056 added `remedy` to `Prohibition` but the `ScopeFilter` part was missing

## Why it does that

policy evaluation

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Part of #3959 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
