### PR TITLE
chore: remove the checks for empty trusted issuers in config

### DIFF
--- a/extensions/common/iam/identity-trust/identity-trust-issuers-configuration/src/main/java/org/eclipse/edc/iam/identitytrust/issuer/configuration/TrustedIssuerConfigurationExtension.java
+++ b/extensions/common/iam/identity-trust/identity-trust-issuers-configuration/src/main/java/org/eclipse/edc/iam/identitytrust/issuer/configuration/TrustedIssuerConfigurationExtension.java
@@ -20,7 +20,7 @@ import org.eclipse.edc.iam.verifiablecredentials.spi.model.Issuer;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
-import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.configuration.Config;
@@ -50,13 +50,15 @@ public class TrustedIssuerConfigurationExtension implements ServiceExtension {
     private TrustedIssuerRegistry trustedIssuerRegistry;
     @Inject
     private TypeManager typeManager;
+    @Inject
+    private Monitor monitor;
 
     @Override
     public void initialize(ServiceExtensionContext context) {
         var config = context.getConfig(CONFIG_PREFIX);
         var issuers = config.partition().map(this::configureIssuer).toList();
         if (issuers.isEmpty()) {
-            throw new EdcException("The list of trusted issuers is empty");
+            monitor.warning("The list of trusted issuers is empty");
         }
         issuers.forEach(issuer -> trustedIssuerRegistry.addIssuer(issuer));
     }

--- a/extensions/common/iam/identity-trust/identity-trust-issuers-configuration/src/test/java/org/eclipse/edc/iam/identitytrust/issuer/configuration/TrustedIssuerConfigurationExtensionTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-issuers-configuration/src/test/java/org/eclipse/edc/iam/identitytrust/issuer/configuration/TrustedIssuerConfigurationExtensionTest.java
@@ -17,7 +17,7 @@ package org.eclipse.edc.iam.identitytrust.issuer.configuration;
 import org.eclipse.edc.iam.identitytrust.spi.TrustedIssuerRegistry;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.Issuer;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
-import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.eclipse.edc.spi.types.TypeManager;
@@ -29,11 +29,11 @@ import org.mockito.ArgumentCaptor;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(DependencyInjectionExtension.class)
@@ -58,11 +58,16 @@ public class TrustedIssuerConfigurationExtensionTest {
     }
 
     @Test
-    void initialize_failure_WithNoIssuer(ServiceExtensionContext context, TrustedIssuerConfigurationExtension ext) {
+    void initialize_WithNoIssuer(ServiceExtensionContext context, TrustedIssuerConfigurationExtension ext, Monitor monitor) {
         var cfg = ConfigFactory.fromMap(Map.of());
         when(context.getConfig("edc.iam.trusted-issuer")).thenReturn(cfg);
 
-        assertThatThrownBy(() -> ext.initialize(context)).isInstanceOf(EdcException.class);
+        ext.initialize(context);
+
+        verifyNoMoreInteractions(trustedIssuerRegistry);
+
+        verify(monitor).warning("The list of trusted issuers is empty");
+
     }
 
     @Test


### PR DESCRIPTION
## What this PR changes/adds

Removes the checks for empty trusted issuers in config and replace it with a warning
