### PR TITLE
fix: several smaller fixes re Credential Revocation

### DIFF
--- a/extensions/common/crypto/ldp-verifiable-credentials/src/test/java/org/eclipse/edc/verifiablecredentials/linkeddata/LdpVerifierTest.java
+++ b/extensions/common/crypto/ldp-verifiable-credentials/src/test/java/org/eclipse/edc/verifiablecredentials/linkeddata/LdpVerifierTest.java
@@ -382,7 +382,7 @@ class LdpVerifierTest {
             }
 
         }
-    }
+‹    }
 
     @Nested
     class Ed25519Signature2018 {

--- a/extensions/common/crypto/ldp-verifiable-credentials/src/test/java/org/eclipse/edc/verifiablecredentials/linkeddata/LdpVerifierTest.java
+++ b/extensions/common/crypto/ldp-verifiable-credentials/src/test/java/org/eclipse/edc/verifiablecredentials/linkeddata/LdpVerifierTest.java
@@ -382,7 +382,7 @@ class LdpVerifierTest {
             }
 
         }
-‹    }
+    }
 
     @Nested
     class Ed25519Signature2018 {

--- a/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtension.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtension.java
@@ -62,6 +62,7 @@ import java.net.URISyntaxException;
 import java.time.Clock;
 import java.util.Map;
 
+import static org.eclipse.edc.iam.verifiablecredentials.spi.VcConstants.STATUSLIST_2021_URL;
 import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
 import static org.eclipse.edc.verifiablecredentials.jwt.JwtPresentationVerifier.JWT_VC_TOKEN_CONTEXT;
 
@@ -143,9 +144,8 @@ public class IdentityAndTrustExtension implements ServiceExtension {
         // TODO move in a separated extension?
         signatureSuiteRegistry.register(JSON_2020_SIGNATURE_SUITE, new JwsSignature2020Suite(typeManager.getMapper(JSON_LD)));
 
-        var uri = getClass().getClassLoader().getResource("statuslist2021.json");
         try {
-            jsonLd.registerCachedDocument("https://w3id.org/vc/status-list/2021/v1", uri.toURI());
+            jsonLd.registerCachedDocument(STATUSLIST_2021_URL, getClass().getClassLoader().getResource("statuslist2021.json").toURI());
         } catch (URISyntaxException e) {
             context.getMonitor().warning("Could not load JSON-LD file", e);
         }

--- a/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtension.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtension.java
@@ -58,6 +58,7 @@ import org.eclipse.edc.verifiablecredentials.linkeddata.DidMethodResolver;
 import org.eclipse.edc.verifiablecredentials.linkeddata.LdpVerifier;
 import org.jetbrains.annotations.NotNull;
 
+import java.net.URISyntaxException;
 import java.time.Clock;
 import java.util.Map;
 
@@ -142,6 +143,13 @@ public class IdentityAndTrustExtension implements ServiceExtension {
         // TODO move in a separated extension?
         signatureSuiteRegistry.register(JSON_2020_SIGNATURE_SUITE, new JwsSignature2020Suite(typeManager.getMapper(JSON_LD)));
 
+        var uri = getClass().getClassLoader().getResource("statuslist2021.json");
+        try {
+            jsonLd.registerCachedDocument("https://w3id.org/vc/status-list/2021/v1", uri.toURI());
+        } catch (URISyntaxException e) {
+            context.getMonitor().warning("Could not load JSON-LD file", e);
+        }
+
         participantAgentService.register(participantAgentServiceExtension);
     }
 
@@ -151,7 +159,7 @@ public class IdentityAndTrustExtension implements ServiceExtension {
         var validationAction = tokenValidationAction();
 
         return new IdentityAndTrustService(secureTokenService, getOwnDid(context), getPresentationVerifier(context),
-                getCredentialServiceClient(context), validationAction, registry, clock, credentialServiceUrlResolver, claimTokenFunction, revocationListService);
+                getCredentialServiceClient(context), validationAction, registry, clock, credentialServiceUrlResolver, claimTokenFunction, createRevocationListService(context));
     }
 
     @Provider

--- a/extensions/common/iam/identity-trust/identity-trust-core/src/main/resources/statuslist2021.json
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/main/resources/statuslist2021.json
@@ -1,0 +1,39 @@
+{
+  "@context": {
+    "@protected": true,
+    "StatusList2021Credential": {
+      "@id": "https://w3id.org/vc/status-list#StatusList2021Credential",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "description": "http://schema.org/description",
+        "name": "http://schema.org/name"
+      }
+    },
+    "StatusList2021": {
+      "@id": "https://w3id.org/vc/status-list#StatusList2021",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "statusPurpose": "https://w3id.org/vc/status-list#statusPurpose",
+        "encodedList": "https://w3id.org/vc/status-list#encodedList"
+      }
+    },
+    "StatusList2021Entry": {
+      "@id": "https://w3id.org/vc/status-list#StatusList2021Entry",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "statusPurpose": "https://w3id.org/vc/status-list#statusPurpose",
+        "statusListIndex": "https://w3id.org/vc/status-list#statusListIndex",
+        "statusListCredential": {
+          "@id": "https://w3id.org/vc/status-list#statusListCredential",
+          "@type": "@id"
+        }
+      }
+    }
+  }
+}

--- a/extensions/common/iam/identity-trust/identity-trust-core/src/test/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtensionTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/test/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtensionTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.atLeastOnce;
@@ -39,9 +38,7 @@ class IdentityAndTrustExtensionTest {
     @BeforeEach
     void setUp(ServiceExtensionContext context) {
         context.registerService(SecureTokenService.class, mock());
-        TypeManager mockedTm = mock();
-        when(mockedTm.getMapper(eq(JSON_LD))).thenReturn(mock());
-        context.registerService(TypeManager.class, mockedTm);
+        context.registerService(TypeManager.class, new TypeManager());
     }
 
     @Test

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/service/IdentityAndTrustService.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/service/IdentityAndTrustService.java
@@ -16,7 +16,7 @@ package org.eclipse.edc.iam.identitytrust.service;
 
 import org.eclipse.edc.iam.identitytrust.service.validation.rules.HasValidIssuer;
 import org.eclipse.edc.iam.identitytrust.service.validation.rules.HasValidSubjectIds;
-import org.eclipse.edc.iam.identitytrust.service.validation.rules.IsNotExpired;
+import org.eclipse.edc.iam.identitytrust.service.validation.rules.IsInValidityPeriod;
 import org.eclipse.edc.iam.identitytrust.service.validation.rules.IsNotRevoked;
 import org.eclipse.edc.iam.identitytrust.spi.ClaimTokenCreatorFunction;
 import org.eclipse.edc.iam.identitytrust.spi.CredentialServiceClient;
@@ -189,7 +189,7 @@ public class IdentityAndTrustService implements IdentityService {
 
         // in addition, verify that all VCs are valid
         var filters = new ArrayList<>(List.of(
-                new IsNotExpired(clock),
+                new IsInValidityPeriod(clock),
                 new HasValidSubjectIds(issuer),
                 new IsNotRevoked(revocationListService),
                 new HasValidIssuer(getTrustedIssuerIds())));

--- a/extensions/common/iam/verifiable-credentials/src/main/java/org/eclipse/edc/iam/verifiablecredentials/StatusList2021RevocationService.java
+++ b/extensions/common/iam/verifiable-credentials/src/main/java/org/eclipse/edc/iam/verifiablecredentials/StatusList2021RevocationService.java
@@ -71,7 +71,7 @@ public class StatusList2021RevocationService implements RevocationListService {
         var bitset = BitSet.valueOf(bytes);
         var index = status.getStatusListIndex();
         if (bitset.get(index)) {
-            return Result.failure("Credential status is '%s', status at index %d is '1''".formatted(purpose, index));
+            return Result.failure("Credential status is '%s', status at index %d is '1'".formatted(purpose, index));
         }
         return Result.success();
     }

--- a/extensions/common/iam/verifiable-credentials/src/test/java/org/eclipse/edc/iam/verifiablecredentials/TestData.java
+++ b/extensions/common/iam/verifiable-credentials/src/test/java/org/eclipse/edc/iam/verifiablecredentials/TestData.java
@@ -29,8 +29,8 @@ public class TestData {
               "credentialSubject": [{
                 "id": "https://example.com/status/3#list",
                 "type": "StatusList2021",
-                "statusPurpose": "revocation",
-                "encodedList": "H4sIAAAAAAAAA-3BMQEAAADCoPVPbQwfoAAAAAAAAAAAAAAAAAAAAIC3AYbSVKsAQAAA"
+                "https://w3id.org/vc/status-list#statusPurpose": "revocation",
+                "https://w3id.org/vc/status-list#encodedList": "H4sIAAAAAAAAA-3BMQEAAADCoPVPbQwfoAAAAAAAAAAAAAAAAAAAAIC3AYbSVKsAQAAA"
               }]
             }
             """;

--- a/spi/common/verifiable-credentials-spi/src/main/java/org/eclipse/edc/iam/verifiablecredentials/spi/VcConstants.java
+++ b/spi/common/verifiable-credentials-spi/src/main/java/org/eclipse/edc/iam/verifiablecredentials/spi/VcConstants.java
@@ -28,4 +28,6 @@ public interface VcConstants {
     String JWS_2020_SIGNATURE_SUITE = "JsonWebSignature2020";
     String ED25519_SIGNATURE_SUITE = "Ed25519Signature2020"; // not used right now
     String VC_PREFIX_V2 = "https://www.w3.org/ns/credentials/v2";
+    String STATUSLIST_2021_URL = "https://w3id.org/vc/status-list/2021/v1";
+    String STATUSLIST_2021_PREFIX = "https://w3id.org/vc/status-list#";
 }

--- a/spi/common/verifiable-credentials-spi/src/main/java/org/eclipse/edc/iam/verifiablecredentials/spi/model/statuslist/StatusList2021Credential.java
+++ b/spi/common/verifiable-credentials-spi/src/main/java/org/eclipse/edc/iam/verifiablecredentials/spi/model/statuslist/StatusList2021Credential.java
@@ -16,6 +16,8 @@ package org.eclipse.edc.iam.verifiablecredentials.spi.model.statuslist;
 
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredential;
 
+import static org.eclipse.edc.iam.verifiablecredentials.spi.VcConstants.STATUSLIST_2021_PREFIX;
+
 /**
  * Represents a special {@link VerifiableCredential}, specifically a <a href="https://www.w3.org/TR/2023/WD-vc-status-list-20230427/">W3C StatusList2021</a> credential.
  * That means that the shape of the {@link VerifiableCredential#getCredentialSubject()} is not arbitrary anymore, but must contain specific items.
@@ -26,8 +28,10 @@ import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredential;
 public class StatusList2021Credential extends VerifiableCredential {
     public static final String STATUSLIST_2021_TYPE = "StatusList2021";
     public static final String STATUSLIST_2021_CREDENTIAL = STATUSLIST_2021_TYPE + "Credential";
-    public static final String ENCODED_LIST = "encodedList";
-    public static final String STATUS_PURPOSE = "statusPurpose";
+    public static final String STATUS_LIST_ENCODED_LIST = STATUSLIST_2021_PREFIX + "encodedList";
+    public static final String STATUS_LIST_CREDENTIAL = STATUSLIST_2021_PREFIX + "statusListCredential";
+    public static final String STATUS_LIST_INDEX = STATUSLIST_2021_PREFIX + "statusListIndex";
+    public static final String STATUS_LIST_PURPOSE = STATUSLIST_2021_PREFIX + "statusPurpose";
 
     private StatusList2021Credential() {
     }
@@ -47,11 +51,11 @@ public class StatusList2021Credential extends VerifiableCredential {
     }
 
     public String encodedList() {
-        return (String) credentialSubject.get(0).getClaims().get(ENCODED_LIST);
+        return (String) credentialSubject.get(0).getClaims().get(STATUS_LIST_ENCODED_LIST);
     }
 
     public String statusPurpose() {
-        return (String) credentialSubject.get(0).getClaims().get(STATUS_PURPOSE);
+        return (String) credentialSubject.get(0).getClaims().get(STATUS_LIST_PURPOSE);
     }
 
     public static class Builder extends VerifiableCredential.Builder<StatusList2021Credential, Builder> {
@@ -79,10 +83,10 @@ public class StatusList2021Credential extends VerifiableCredential {
 
             // check mandatory fields of the credentialSubject object
             var subject = instance.credentialSubject.get(0);
-            if (!subject.getClaims().containsKey(ENCODED_LIST)) {
+            if (!subject.getClaims().containsKey(STATUS_LIST_ENCODED_LIST)) {
                 throw new IllegalArgumentException("Status list credentials must contain a 'credentialSubject.encodedList' field.");
             }
-            if (!subject.getClaims().containsKey(STATUS_PURPOSE)) {
+            if (!subject.getClaims().containsKey(STATUS_LIST_PURPOSE)) {
                 throw new IllegalArgumentException("Status list credentials must contain a 'credentialSubject.statusPurpose' field.");
             }
             return instance;
@@ -93,4 +97,6 @@ public class StatusList2021Credential extends VerifiableCredential {
             return this;
         }
     }
+
+
 }

--- a/spi/common/verifiable-credentials-spi/src/main/java/org/eclipse/edc/iam/verifiablecredentials/spi/model/statuslist/StatusListStatus.java
+++ b/spi/common/verifiable-credentials-spi/src/main/java/org/eclipse/edc/iam/verifiablecredentials/spi/model/statuslist/StatusListStatus.java
@@ -16,16 +16,19 @@ package org.eclipse.edc.iam.verifiablecredentials.spi.model.statuslist;
 
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialStatus;
 
+import java.util.Map;
+
 import static java.util.Optional.ofNullable;
+import static org.eclipse.edc.iam.verifiablecredentials.spi.VcConstants.STATUSLIST_2021_PREFIX;
 
 /**
  * Specialized {@code credentialStatus}, that contains information mandated by the StatusList2021 standard.
  */
 public class StatusListStatus {
-    public static final String STATUS_LIST_CREDENTIAL = "statusListCredential";
-    public static final String STATUS_LIST_INDEX = "statusListIndex";
-    public static final String STATUS_PURPOSE = "statusPurpose";
-    
+    public static final String STATUS_LIST_CREDENTIAL = STATUSLIST_2021_PREFIX + "statusListCredential";
+    public static final String STATUS_LIST_INDEX = STATUSLIST_2021_PREFIX + "statusListIndex";
+    public static final String STATUS_PURPOSE = STATUSLIST_2021_PREFIX + "statusPurpose";
+
     private String statusListPurpose;
     private int statusListIndex;
     private String statusListCredential;
@@ -35,7 +38,7 @@ public class StatusListStatus {
 
     public static StatusListStatus parse(CredentialStatus status) {
         var instance = new StatusListStatus();
-        instance.statusListCredential = ofNullable(status.additionalProperties().get(STATUS_LIST_CREDENTIAL))
+        instance.statusListCredential = ofNullable(getId(status))
                 .map(Object::toString)
                 .orElseThrow(() -> new IllegalArgumentException(missingProperty(STATUS_LIST_CREDENTIAL)));
 
@@ -49,6 +52,14 @@ public class StatusListStatus {
                 .orElseThrow(() -> new IllegalArgumentException(missingProperty(STATUS_PURPOSE)));
 
         return instance;
+    }
+
+    private static Object getId(CredentialStatus status) {
+        var credentialId = status.additionalProperties().get(STATUS_LIST_CREDENTIAL);
+        if (credentialId instanceof Map<?, ?> map) {
+            return map.get("@id");
+        }
+        return credentialId;
     }
 
     private static String missingProperty(String property) {

--- a/spi/common/verifiable-credentials-spi/src/main/java/org/eclipse/edc/iam/verifiablecredentials/spi/model/statuslist/StatusListStatus.java
+++ b/spi/common/verifiable-credentials-spi/src/main/java/org/eclipse/edc/iam/verifiablecredentials/spi/model/statuslist/StatusListStatus.java
@@ -19,15 +19,11 @@ import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialStatus;
 import java.util.Map;
 
 import static java.util.Optional.ofNullable;
-import static org.eclipse.edc.iam.verifiablecredentials.spi.VcConstants.STATUSLIST_2021_PREFIX;
 
 /**
  * Specialized {@code credentialStatus}, that contains information mandated by the StatusList2021 standard.
  */
 public class StatusListStatus {
-    public static final String STATUS_LIST_CREDENTIAL = STATUSLIST_2021_PREFIX + "statusListCredential";
-    public static final String STATUS_LIST_INDEX = STATUSLIST_2021_PREFIX + "statusListIndex";
-    public static final String STATUS_PURPOSE = STATUSLIST_2021_PREFIX + "statusPurpose";
 
     private String statusListPurpose;
     private int statusListIndex;
@@ -40,22 +36,22 @@ public class StatusListStatus {
         var instance = new StatusListStatus();
         instance.statusListCredential = ofNullable(getId(status))
                 .map(Object::toString)
-                .orElseThrow(() -> new IllegalArgumentException(missingProperty(STATUS_LIST_CREDENTIAL)));
+                .orElseThrow(() -> new IllegalArgumentException(missingProperty(StatusList2021Credential.STATUS_LIST_CREDENTIAL)));
 
-        instance.statusListIndex = ofNullable(status.additionalProperties().get(STATUS_LIST_INDEX))
+        instance.statusListIndex = ofNullable(status.additionalProperties().get(StatusList2021Credential.STATUS_LIST_INDEX))
                 .map(Object::toString)
                 .map(Integer::parseInt)
-                .orElseThrow(() -> new IllegalArgumentException(missingProperty(STATUS_LIST_INDEX)));
+                .orElseThrow(() -> new IllegalArgumentException(missingProperty(StatusList2021Credential.STATUS_LIST_INDEX)));
 
-        instance.statusListPurpose = ofNullable(status.additionalProperties().get(STATUS_PURPOSE))
+        instance.statusListPurpose = ofNullable(status.additionalProperties().get(StatusList2021Credential.STATUS_LIST_PURPOSE))
                 .map(Object::toString)
-                .orElseThrow(() -> new IllegalArgumentException(missingProperty(STATUS_PURPOSE)));
+                .orElseThrow(() -> new IllegalArgumentException(missingProperty(StatusList2021Credential.STATUS_LIST_PURPOSE)));
 
         return instance;
     }
 
     private static Object getId(CredentialStatus status) {
-        var credentialId = status.additionalProperties().get(STATUS_LIST_CREDENTIAL);
+        var credentialId = status.additionalProperties().get(StatusList2021Credential.STATUS_LIST_CREDENTIAL);
         if (credentialId instanceof Map<?, ?> map) {
             return map.get("@id");
         }
@@ -63,7 +59,7 @@ public class StatusListStatus {
     }
 
     private static String missingProperty(String property) {
-        return "A StatusList2021 credentialStatus must have a 'credentialStatus.%s' property".formatted(property);
+        return "A StatusList2021 credential must have a credentialStatus object with the '%s' property".formatted(property);
     }
 
     public String getStatusListPurpose() {
@@ -77,5 +73,6 @@ public class StatusListStatus {
     public String getStatusListCredential() {
         return statusListCredential;
     }
+
 
 }

--- a/spi/common/verifiable-credentials-spi/src/test/java/org/eclipse/edc/iam/verifiablecredentials/spi/model/statuslist/StatusList2021CredentialTest.java
+++ b/spi/common/verifiable-credentials-spi/src/test/java/org/eclipse/edc/iam/verifiablecredentials/spi/model/statuslist/StatusList2021CredentialTest.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.iam.verifiablecredentials.spi.model.statuslist.StatusList2021Credential.STATUS_LIST_ENCODED_LIST;
+import static org.eclipse.edc.iam.verifiablecredentials.spi.model.statuslist.StatusList2021Credential.STATUS_LIST_PURPOSE;
 
 public class StatusList2021CredentialTest {
 
@@ -38,8 +40,8 @@ public class StatusList2021CredentialTest {
                 .credentialSubject(CredentialSubject.Builder.newInstance()
                         .id("https://example.com/status/3#list")
                         .claim("type", "StatusList2021")
-                        .claim("statusPurpose", "revocation")
-                        .claim("encodedList", "H4sIAAAAAAAAA-3BMQEAAADCoPVPbQwfoAAAAAAAAAAAAAAAAAAAAIC3AYbSVKsAQAAA")
+                        .claim(STATUS_LIST_PURPOSE, "revocation")
+                        .claim(STATUS_LIST_ENCODED_LIST, "H4sIAAAAAAAAA-3BMQEAAADCoPVPbQwfoAAAAAAAAAAAAAAAAAAAAIC3AYbSVKsAQAAA")
                         .build())
                 .build();
 
@@ -60,8 +62,8 @@ public class StatusList2021CredentialTest {
                 .credentialSubject(CredentialSubject.Builder.newInstance()
                         .id("https://example.com/status/3#list")
                         .claim("type", "StatusList2021")
-                        .claim("statusPurpose", "revocation")
-                        .claim("encodedList", "H4sIAAAAAAAAA-3BMQEAAADCoPVPbQwfoAAAAAAAAAAAAAAAAAAAAIC3AYbSVKsAQAAA")
+                        .claim(STATUS_LIST_PURPOSE, "revocation")
+                        .claim(STATUS_LIST_ENCODED_LIST, "H4sIAAAAAAAAA-3BMQEAAADCoPVPbQwfoAAAAAAAAAAAAAAAAAAAAIC3AYbSVKsAQAAA")
                         .build())
                 .build();
 

--- a/spi/common/verifiable-credentials-spi/src/test/java/org/eclipse/edc/iam/verifiablecredentials/spi/model/statuslist/StatusListStatusTest.java
+++ b/spi/common/verifiable-credentials-spi/src/test/java/org/eclipse/edc/iam/verifiablecredentials/spi/model/statuslist/StatusListStatusTest.java
@@ -21,15 +21,18 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.eclipse.edc.iam.verifiablecredentials.spi.model.statuslist.StatusList2021Credential.STATUS_LIST_CREDENTIAL;
+import static org.eclipse.edc.iam.verifiablecredentials.spi.model.statuslist.StatusList2021Credential.STATUS_LIST_INDEX;
+import static org.eclipse.edc.iam.verifiablecredentials.spi.model.statuslist.StatusList2021Credential.STATUS_LIST_PURPOSE;
 
 class StatusListStatusTest {
 
     @Test
     void verifyStatusList2021() {
         Map<String, Object> props = Map.of(
-                "statusPurpose", "revocation",
-                "statusListIndex", "237",
-                "statusListCredential", "https://example.com/credentials/status/3"
+                STATUS_LIST_PURPOSE, "revocation",
+                STATUS_LIST_INDEX, "237",
+                STATUS_LIST_CREDENTIAL, "https://example.com/credentials/status/3"
         );
         var credentialStatus = new CredentialStatus("https://example.com/credentials/status/3#94567", "StatusList2021Entry", props);
 
@@ -43,8 +46,8 @@ class StatusListStatusTest {
     void verifyMissingPurpose() {
         Map<String, Object> props = Map.of(
                 //"statusPurpose", "revocation",
-                "statusListIndex", "237",
-                "statusListCredential", "https://example.com/credentials/status/3"
+                STATUS_LIST_INDEX, "237",
+                STATUS_LIST_CREDENTIAL, "https://example.com/credentials/status/3"
         );
         var credentialStatus = new CredentialStatus("https://example.com/credentials/status/3#94567", "StatusList2021Entry", props);
         assertThatThrownBy(() -> StatusListStatus.parse(credentialStatus)).isInstanceOf(IllegalArgumentException.class)
@@ -54,9 +57,9 @@ class StatusListStatusTest {
     @Test
     void verifyMissingIndex() {
         Map<String, Object> props = Map.of(
-                "statusPurpose", "revocation",
+                STATUS_LIST_PURPOSE, "revocation",
                 //"statusListIndex", "237",
-                "statusListCredential", "https://example.com/credentials/status/3"
+                STATUS_LIST_CREDENTIAL, "https://example.com/credentials/status/3"
         );
         var credentialStatus = new CredentialStatus("https://example.com/credentials/status/3#94567", "StatusList2021Entry", props);
         assertThatThrownBy(() -> StatusListStatus.parse(credentialStatus)).isInstanceOf(IllegalArgumentException.class)
@@ -66,9 +69,9 @@ class StatusListStatusTest {
     @Test
     void verifyMissingCredential() {
         Map<String, Object> props = Map.of(
-                "statusPurpose", "revocation",
-                "statusListIndex", "237"
-                //"statusListCredential", "https://example.com/credentials/status/3"
+                STATUS_LIST_PURPOSE, "revocation",
+                STATUS_LIST_INDEX, "237"
+                // "statusListCredential", "https://example.com/credentials/status/3"
         );
         var credentialStatus = new CredentialStatus("https://example.com/credentials/status/3#94567", "StatusList2021Entry", props);
         assertThatThrownBy(() -> StatusListStatus.parse(credentialStatus)).isInstanceOf(IllegalArgumentException.class)

--- a/system-tests/e2e-dataplane-tests/tests/src/test/java/org/eclipse/edc/test/e2e/DataPlanePublicApiEndToEndTest.java
+++ b/system-tests/e2e-dataplane-tests/tests/src/test/java/org/eclipse/edc/test/e2e/DataPlanePublicApiEndToEndTest.java
@@ -23,6 +23,7 @@ import io.restassured.http.ContentType;
 import jakarta.ws.rs.core.HttpHeaders;
 import org.eclipse.edc.connector.dataplane.spi.AccessTokenData;
 import org.eclipse.edc.connector.dataplane.spi.store.AccessTokenDataStore;
+import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.keys.keyparsers.PemParser;
 import org.eclipse.edc.security.token.jwt.CryptoConverter;
 import org.eclipse.edc.spi.iam.ClaimToken;
@@ -52,6 +53,7 @@ import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.JsonBody.json;
 import static org.mockserver.verify.VerificationTimes.exactly;
 
+@EndToEndTest
 public class DataPlanePublicApiEndToEndTest extends AbstractDataPlaneTest {
 
     public static final String PUBLIC_KEY_ALIAS = "public-key";


### PR DESCRIPTION
## What this PR changes/adds

This PR fixes some smaller issues with credential revocation, such as caching the StatusList context, using property prefixes, etc.

## Why it does that

Needed to utilize the `StatusList2021` credential revocation list.
## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
