### PR TITLE
chore: allow OBJECT or ARRAY when deserializing VC

### DIFF
--- a/extensions/common/iam/verifiable-credentials/src/main/java/org/eclipse/edc/iam/verifiablecredentials/StatusList2021RevocationService.java
+++ b/extensions/common/iam/verifiable-credentials/src/main/java/org/eclipse/edc/iam/verifiablecredentials/StatusList2021RevocationService.java
@@ -42,7 +42,9 @@ public class StatusList2021RevocationService implements RevocationListService {
     private final Cache<String, VerifiableCredential> cache;
 
     public StatusList2021RevocationService(ObjectMapper objectMapper, long cacheValidity) {
-        this.objectMapper = objectMapper.copy().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES); // let's make sure this is disabled, because the "@context" would cause problems
+        this.objectMapper = objectMapper.copy()
+                .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY) // technically, credential subjects and credential status can be objects AND Arrays
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES); // let's make sure this is disabled, because the "@context" would cause problems
         cache = new Cache<>(this::updateCredential, cacheValidity);
     }
 

--- a/extensions/common/iam/verifiable-credentials/src/test/java/org/eclipse/edc/iam/verifiablecredentials/TestData.java
+++ b/extensions/common/iam/verifiable-credentials/src/test/java/org/eclipse/edc/iam/verifiablecredentials/TestData.java
@@ -16,7 +16,7 @@ package org.eclipse.edc.iam.verifiablecredentials;
 
 public class TestData {
     // test data taken from https://www.w3.org/TR/2023/WD-vc-status-list-20230427/#example-example-statuslist2021credential-0
-    public static final String STATUS_LIST_CREDENTIAL = """
+    public static final String STATUS_LIST_CREDENTIAL_SUBJECT_IS_ARRAY = """
             {
               "@context": [
                 "https://www.w3.org/2018/credentials/v1",
@@ -26,12 +26,33 @@ public class TestData {
               "type": ["VerifiableCredential", "StatusList2021Credential"],
               "issuer": "did:example:12345",
               "issued": "2021-04-05T14:27:40Z",
-              "credentialSubject": [{
+              "credentialSubject": [
+              {
                 "id": "https://example.com/status/3#list",
                 "type": "StatusList2021",
                 "https://w3id.org/vc/status-list#statusPurpose": "revocation",
                 "https://w3id.org/vc/status-list#encodedList": "H4sIAAAAAAAAA-3BMQEAAADCoPVPbQwfoAAAAAAAAAAAAAAAAAAAAIC3AYbSVKsAQAAA"
-              }]
+              }
+              ]
+            }
+            """;
+
+    public static final String STATUS_LIST_CREDENTIAL_SINGLE_SUBJECT = """
+            {
+              "@context": [
+                "https://www.w3.org/2018/credentials/v1",
+                "https://w3id.org/vc/status-list/2021/v1"
+              ],
+              "id": "https://example.com/credentials/status/3",
+              "type": ["VerifiableCredential", "StatusList2021Credential"],
+              "issuer": "did:example:12345",
+              "issued": "2021-04-05T14:27:40Z",
+              "credentialSubject": {
+                "id": "https://example.com/status/3#list",
+                "type": "StatusList2021",
+                "https://w3id.org/vc/status-list#statusPurpose": "revocation",
+                "https://w3id.org/vc/status-list#encodedList": "H4sIAAAAAAAAA-3BMQEAAADCoPVPbQwfoAAAAAAAAAAAAAAAAAAAAIC3AYbSVKsAQAAA"
+              }
             }
             """;
 }


### PR DESCRIPTION
## What this PR changes/adds

sometimes VCs are deserialized as plain JSON, e.g. when obtaining StatusList2021 credentials. The spec says that `credentialStatus` and `credentialSubject`
can be either an ARRAY or an OBJECT, so a custom deserialization feature is enabled to allow that.

## Why it does that

The StatusList2021 specification (and the VC DataModel, for that matter) demand that.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
