### PR TITLE
feat(dsp): catalog pagination through continuation token and Link header

### DIFF
--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/build.gradle.kts
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
 
     testImplementation(testFixtures(project(":extensions:common:http:jersey-core")))
     testImplementation(project(":core:common:junit"))
+    testImplementation(project(":core:common:lib:transform-lib"))
     testImplementation(project(":data-protocols:dsp:dsp-catalog:dsp-catalog-transform"))
     testImplementation(libs.restAssured)
 }

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiController20241.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiController20241.java
@@ -18,6 +18,7 @@ import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import org.eclipse.edc.connector.controlplane.services.spi.catalog.CatalogProtocolService;
+import org.eclipse.edc.protocol.dsp.http.spi.message.ContinuationTokenManager;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
 import org.eclipse.edc.protocol.dsp.spi.version.DspVersions;
 
@@ -32,7 +33,8 @@ import static org.eclipse.edc.protocol.dsp.catalog.http.api.CatalogApiPaths.BASE
 @Path(DspVersions.V_2024_1_PATH + BASE_PATH)
 public class DspCatalogApiController20241 extends DspCatalogApiController {
 
-    public DspCatalogApiController20241(CatalogProtocolService service, DspRequestHandler dspRequestHandler) {
-        super(service, dspRequestHandler);
+    public DspCatalogApiController20241(CatalogProtocolService service, DspRequestHandler dspRequestHandler,
+                                        ContinuationTokenManager responseDecorator) {
+        super(service, dspRequestHandler, responseDecorator);
     }
 }

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/decorator/Base64continuationTokenSerDes.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/decorator/Base64continuationTokenSerDes.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.catalog.http.api.decorator;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.protocol.dsp.http.spi.message.ContinuationTokenSerDes;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+
+import java.io.ByteArrayInputStream;
+import java.util.Base64;
+
+public class Base64continuationTokenSerDes implements ContinuationTokenSerDes {
+
+    private final TypeTransformerRegistry typeTransformerRegistry;
+    private final JsonLd jsonLd;
+
+    public Base64continuationTokenSerDes(TypeTransformerRegistry typeTransformerRegistry, JsonLd jsonLd) {
+        this.typeTransformerRegistry = typeTransformerRegistry;
+        this.jsonLd = jsonLd;
+    }
+
+    @Override
+    public Result<String> serialize(QuerySpec querySpec) {
+        return typeTransformerRegistry.transform(querySpec, JsonObject.class)
+                .map(Object::toString)
+                .map(String::getBytes)
+                .map(Base64.getEncoder()::encodeToString);
+    }
+
+    @Override
+    public Result<JsonObject> deserialize(String serialized) {
+        try {
+            var decode = Base64.getDecoder().decode(serialized);
+            var jsonObject = Json.createReader(new ByteArrayInputStream(decode)).readObject();
+            return jsonLd.expand(jsonObject);
+        } catch (Exception e) {
+            return Result.failure("Cannot deserialize continuationToken: " + e.getMessage());
+        }
+
+    }
+}

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/decorator/CatalogPaginationResponseDecorator.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/decorator/CatalogPaginationResponseDecorator.java
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.catalog.http.api.decorator;
+
+import jakarta.ws.rs.core.Response;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequestMessage;
+import org.eclipse.edc.protocol.dsp.http.spi.message.ContinuationTokenSerDes;
+import org.eclipse.edc.protocol.dsp.http.spi.message.ResponseDecorator;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.query.QuerySpec;
+
+import java.net.URI;
+import java.util.function.IntBinaryOperator;
+
+public class CatalogPaginationResponseDecorator implements ResponseDecorator<CatalogRequestMessage, Catalog> {
+
+    private static final String NEXT = "next";
+    private static final String PREV = "prev";
+
+    private final String requestUrl;
+    private final ContinuationTokenSerDes continuationTokenSerDes;
+    private final Monitor monitor;
+
+    public CatalogPaginationResponseDecorator(String requestUrl, ContinuationTokenSerDes continuationTokenSerDes, Monitor monitor) {
+        this.requestUrl = requestUrl;
+        this.continuationTokenSerDes = continuationTokenSerDes;
+        this.monitor = monitor;
+    }
+
+    @Override
+    public Response.ResponseBuilder decorate(Response.ResponseBuilder responseBuilder, CatalogRequestMessage requestBody, Catalog responseBody) {
+        var currentQuerySpec = requestBody.getQuerySpec();
+        if (responseBody.getDatasets().size() == currentQuerySpec.getLimit()) {
+            addLink(NEXT, responseBuilder, currentQuerySpec, (offset, limit) -> offset + limit);
+        }
+
+        if (currentQuerySpec.getOffset() >= currentQuerySpec.getLimit()) {
+            addLink(PREV, responseBuilder, currentQuerySpec, (offset, limit) -> offset - limit);
+        }
+
+        return responseBuilder;
+    }
+
+    private void addLink(String rel, Response.ResponseBuilder responseBuilder, QuerySpec currentQuerySpec, IntBinaryOperator newOffsetOperator) {
+        var newOffset = newOffsetOperator.applyAsInt(currentQuerySpec.getOffset(), currentQuerySpec.getLimit());
+        continuationTokenSerDes.serialize(currentQuerySpec.toBuilder().offset(newOffset).build())
+                .onSuccess(token -> responseBuilder.link(URI.create(requestUrl + "?continuationToken=" + token), rel))
+                .onFailure(failure -> monitor.warning("Cannot serialize continuationToken for catalog pagination: " + failure.getFailureDetail()));
+    }
+}

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/decorator/ContinuationTokenManagerImpl.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/decorator/ContinuationTokenManagerImpl.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.catalog.http.api.decorator;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequestMessage;
+import org.eclipse.edc.protocol.dsp.http.spi.message.ContinuationTokenManager;
+import org.eclipse.edc.protocol.dsp.http.spi.message.ResponseDecorator;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.result.Result;
+
+import static org.eclipse.edc.protocol.dsp.spi.type.DspCatalogPropertyAndTypeNames.DSPACE_PROPERTY_FILTER;
+
+public class ContinuationTokenManagerImpl implements ContinuationTokenManager {
+
+    private final Base64continuationTokenSerDes continuationTokenSerDes;
+    private final Monitor monitor;
+
+    public ContinuationTokenManagerImpl(Base64continuationTokenSerDes continuationTokenSerDes, Monitor monitor) {
+        this.continuationTokenSerDes = continuationTokenSerDes;
+        this.monitor = monitor;
+    }
+
+    @Override
+    public ResponseDecorator<CatalogRequestMessage, Catalog> createResponseDecorator(String requestUrl) {
+        return new CatalogPaginationResponseDecorator(requestUrl, continuationTokenSerDes, monitor);
+    }
+
+    @Override
+    public Result<JsonObject> applyQueryFromToken(JsonObject requestMessage, String continuationToken) {
+        return continuationTokenSerDes.deserialize(continuationToken)
+                .map(query -> Json.createArrayBuilder().add(query))
+                .map(filter -> Json.createObjectBuilder(requestMessage).add(DSPACE_PROPERTY_FILTER, filter))
+                .map(JsonObjectBuilder::build);
+    }
+}

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/test/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiControllerTest.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/test/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiControllerTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.protocol.dsp.catalog.http.api.controller;
 
 import io.restassured.specification.RequestSpecification;
+import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
@@ -24,12 +25,15 @@ import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
 import org.eclipse.edc.connector.controlplane.services.spi.catalog.CatalogProtocolService;
 import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
 import org.eclipse.edc.junit.annotations.ApiTest;
+import org.eclipse.edc.protocol.dsp.http.spi.message.ContinuationTokenManager;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
 import org.eclipse.edc.protocol.dsp.http.spi.message.GetDspRequest;
 import org.eclipse.edc.protocol.dsp.http.spi.message.PostDspRequest;
+import org.eclipse.edc.protocol.dsp.http.spi.message.ResponseDecorator;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -46,8 +50,10 @@ import static org.eclipse.edc.protocol.dsp.catalog.http.api.CatalogApiPaths.DATA
 import static org.eclipse.edc.protocol.dsp.spi.type.DspCatalogPropertyAndTypeNames.DSPACE_TYPE_CATALOG_REQUEST_MESSAGE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ApiTest
@@ -56,32 +62,78 @@ class DspCatalogApiControllerTest extends RestControllerTestBase {
     private final TypeTransformerRegistry transformerRegistry = mock();
     private final CatalogProtocolService service = mock();
     private final DspRequestHandler dspRequestHandler = mock();
+    private final ContinuationTokenManager continuationTokenManager = mock();
 
-    @Test
-    void requestCatalog_shouldCreateResource() {
-        var requestBody = createObjectBuilder().add(TYPE, DSPACE_TYPE_CATALOG_REQUEST_MESSAGE).build();
-        var catalog = createObjectBuilder().add(JsonLdKeywords.TYPE, "catalog").build();
+    @Nested
+    class RequestCatalog {
 
-        when(transformerRegistry.transform(any(Catalog.class), eq(JsonObject.class))).thenReturn(Result.success(catalog));
-        when(dspRequestHandler.createResource(any())).thenReturn(Response.ok().type(APPLICATION_JSON_TYPE).build());
+        @Test
+        void shouldCreateResource() {
+            var requestBody = createObjectBuilder().add(TYPE, DSPACE_TYPE_CATALOG_REQUEST_MESSAGE).build();
+            var catalog = createObjectBuilder().add(JsonLdKeywords.TYPE, "catalog").build();
+            when(transformerRegistry.transform(any(Catalog.class), eq(JsonObject.class))).thenReturn(Result.success(catalog));
+            when(dspRequestHandler.createResource(any(), any())).thenReturn(Response.ok().type(APPLICATION_JSON_TYPE).build());
+            when(continuationTokenManager.createResponseDecorator(any())).thenReturn(mock());
 
-        baseRequest()
-                .contentType(JSON)
-                .body(requestBody)
-                .post(CATALOG_REQUEST)
-                .then()
-                .statusCode(200)
-                .contentType(JSON);
+            baseRequest()
+                    .contentType(JSON)
+                    .body(requestBody)
+                    .post(CATALOG_REQUEST)
+                    .then()
+                    .statusCode(200)
+                    .contentType(JSON);
 
-        var captor = ArgumentCaptor.forClass(PostDspRequest.class);
-        verify(dspRequestHandler).createResource(captor.capture());
-        var request = captor.getValue();
-        assertThat(request.getInputClass()).isEqualTo(CatalogRequestMessage.class);
-        assertThat(request.getResultClass()).isEqualTo(Catalog.class);
-        assertThat(request.getExpectedMessageType()).isEqualTo(DSPACE_TYPE_CATALOG_REQUEST_MESSAGE);
-        assertThat(request.getProcessId()).isNull();
-        assertThat(request.getToken()).isEqualTo("auth");
-        assertThat(request.getMessage()).isEqualTo(requestBody);
+            var captor = ArgumentCaptor.forClass(PostDspRequest.class);
+            verify(dspRequestHandler).createResource(captor.capture(), isA(ResponseDecorator.class));
+            var request = captor.getValue();
+            assertThat(request.getInputClass()).isEqualTo(CatalogRequestMessage.class);
+            assertThat(request.getResultClass()).isEqualTo(Catalog.class);
+            assertThat(request.getExpectedMessageType()).isEqualTo(DSPACE_TYPE_CATALOG_REQUEST_MESSAGE);
+            assertThat(request.getProcessId()).isNull();
+            assertThat(request.getToken()).isEqualTo("auth");
+            assertThat(request.getMessage()).isEqualTo(requestBody);
+            verify(continuationTokenManager).createResponseDecorator("http://localhost:%d/catalog/request".formatted(port));
+        }
+
+        @Test
+        void shouldApplyContinuationToken_whenPassed() {
+            var requestBody = createObjectBuilder().add(TYPE, DSPACE_TYPE_CATALOG_REQUEST_MESSAGE).build();
+            var catalog = createObjectBuilder().add(JsonLdKeywords.TYPE, "catalog").build();
+            when(transformerRegistry.transform(any(Catalog.class), eq(JsonObject.class))).thenReturn(Result.success(catalog));
+            when(dspRequestHandler.createResource(any(), any())).thenReturn(Response.ok().type(APPLICATION_JSON_TYPE).build());
+            when(continuationTokenManager.createResponseDecorator(any())).thenReturn(mock());
+            var enrichedRequestBody = createObjectBuilder(requestBody).add("query", Json.createObjectBuilder()).build();
+            when(continuationTokenManager.applyQueryFromToken(any(), any())).thenReturn(Result.success(enrichedRequestBody));
+
+            baseRequest()
+                    .contentType(JSON)
+                    .body(requestBody)
+                    .post(CATALOG_REQUEST + "?continuationToken=pagination-token")
+                    .then()
+                    .statusCode(200)
+                    .contentType(JSON);
+
+            var captor = ArgumentCaptor.forClass(PostDspRequest.class);
+            verify(dspRequestHandler).createResource(captor.capture(), isA(ResponseDecorator.class));
+            var request = captor.getValue();
+            assertThat(request.getMessage()).isSameAs(enrichedRequestBody);
+            verify(continuationTokenManager).applyQueryFromToken(requestBody, "pagination-token");
+        }
+
+        @Test
+        void shouldReturnBadRequest_whenContinuationTokenIsNotValid() {
+            var requestBody = createObjectBuilder().add(TYPE, DSPACE_TYPE_CATALOG_REQUEST_MESSAGE).build();
+            when(continuationTokenManager.applyQueryFromToken(any(), any())).thenReturn(Result.failure("error"));
+
+            baseRequest()
+                    .contentType(JSON)
+                    .body(requestBody)
+                    .post(CATALOG_REQUEST + "?continuationToken=pagination-token")
+                    .then()
+                    .statusCode(400);
+
+            verifyNoInteractions(dspRequestHandler, transformerRegistry);
+        }
     }
 
     @Test
@@ -105,7 +157,7 @@ class DspCatalogApiControllerTest extends RestControllerTestBase {
 
     @Override
     protected Object controller() {
-        return new DspCatalogApiController(service, dspRequestHandler);
+        return new DspCatalogApiController(service, dspRequestHandler, continuationTokenManager);
     }
 
     private RequestSpecification baseRequest() {

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/test/java/org/eclipse/edc/protocol/dsp/catalog/http/api/decorator/Base64ContinuationTokenSerDesTest.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/test/java/org/eclipse/edc/protocol/dsp/catalog/http/api/decorator/Base64ContinuationTokenSerDesTest.java
@@ -1,0 +1,92 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.catalog.http.api.decorator;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.json.Json;
+import org.apache.commons.codec.binary.Base64;
+import org.eclipse.edc.jsonld.TitaniumJsonLd;
+import org.eclipse.edc.jsonld.util.JacksonJsonLd;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.query.SortOrder;
+import org.eclipse.edc.transform.TypeTransformerRegistryImpl;
+import org.eclipse.edc.transform.transformer.edc.from.JsonObjectFromCriterionTransformer;
+import org.eclipse.edc.transform.transformer.edc.from.JsonObjectFromQuerySpecTransformer;
+import org.eclipse.edc.transform.transformer.edc.to.JsonObjectToCriterionTransformer;
+import org.eclipse.edc.transform.transformer.edc.to.JsonObjectToQuerySpecTransformer;
+import org.eclipse.edc.transform.transformer.edc.to.JsonValueToGenericTypeTransformer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_FILTER_EXPRESSION;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_LIMIT;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_OFFSET;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_SORT_FIELD;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_SORT_ORDER;
+import static org.mockito.Mockito.mock;
+
+class Base64ContinuationTokenSerDesTest {
+
+    private final TypeTransformerRegistryImpl typeTransformerRegistry = new TypeTransformerRegistryImpl();
+    private final ObjectMapper objectMapper = JacksonJsonLd.createObjectMapper();
+    private final Base64continuationTokenSerDes serDes = new Base64continuationTokenSerDes(typeTransformerRegistry, new TitaniumJsonLd(mock()));
+
+    @BeforeEach
+    void setup() {
+        var builderFactory = Json.createBuilderFactory(emptyMap());
+        typeTransformerRegistry.register(new JsonObjectFromQuerySpecTransformer(builderFactory));
+        typeTransformerRegistry.register(new JsonObjectFromCriterionTransformer(builderFactory, objectMapper));
+        typeTransformerRegistry.register(new JsonValueToGenericTypeTransformer(objectMapper));
+        typeTransformerRegistry.register(new JsonObjectToQuerySpecTransformer());
+        typeTransformerRegistry.register(new JsonObjectToCriterionTransformer());
+    }
+
+    @Test
+    void shouldSerializeAsBase64andDeserializeAsExpandedJsonLd() {
+        var original = QuerySpec.Builder.newInstance()
+                .limit(12)
+                .sortField("any")
+                .filter(List.of(Criterion.criterion("any", "any", "any")))
+                .sortOrder(SortOrder.DESC)
+                .offset(42)
+                .build();
+
+        assertThat(serDes.serialize(original)).isSucceeded()
+                .matches(Base64::isBase64)
+                .satisfies(serialized -> {
+                    assertThat(serDes.deserialize(serialized)).isSucceeded().satisfies(jsonObject -> {
+                        assertThat(jsonObject.getJsonArray(EDC_QUERY_SPEC_LIMIT).getJsonObject(0).getInt(VALUE)).isEqualTo(12);
+                        assertThat(jsonObject.getJsonArray(EDC_QUERY_SPEC_SORT_FIELD).getJsonObject(0).getString(VALUE)).isEqualTo("any");
+                        assertThat(jsonObject.getJsonArray(EDC_QUERY_SPEC_SORT_ORDER).getJsonObject(0).getString(VALUE)).isEqualTo("DESC");
+                        assertThat(jsonObject.getJsonArray(EDC_QUERY_SPEC_OFFSET).getJsonObject(0).getInt(VALUE)).isEqualTo(42);
+                        assertThat(jsonObject.getJsonArray(EDC_QUERY_SPEC_FILTER_EXPRESSION)).hasSize(1);
+                    });
+                });
+    }
+
+    @Test
+    void deserialize_shouldFail_whenBodyNotBase64() {
+        var result = serDes.deserialize("not-base-64");
+
+        assertThat(result).isFailed();
+    }
+}

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/test/java/org/eclipse/edc/protocol/dsp/catalog/http/api/decorator/CatalogPaginationResponseDecoratorTest.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/test/java/org/eclipse/edc/protocol/dsp/catalog/http/api/decorator/CatalogPaginationResponseDecoratorTest.java
@@ -1,0 +1,118 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.catalog.http.api.decorator;
+
+import jakarta.ws.rs.core.Response;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequestMessage;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
+import org.eclipse.edc.protocol.dsp.http.spi.message.ContinuationTokenSerDes;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.Result;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CatalogPaginationResponseDecoratorTest {
+
+    private final String requestUrl = "http://request.url/path";
+    private final ContinuationTokenSerDes continuationTokenSerDes = mock();
+    private final Monitor monitor = mock();
+    private final CatalogPaginationResponseDecorator decorator = new CatalogPaginationResponseDecorator(requestUrl, continuationTokenSerDes, monitor);
+
+    @Nested
+    class Next {
+        @Test
+        void shouldSetLink_whenDatasetCountEqualsToLimit() {
+            var responseBuilder = Response.ok();
+            var querySpec = QuerySpec.Builder.newInstance().offset(0).limit(1).build();
+            var message = CatalogRequestMessage.Builder.newInstance().querySpec(querySpec).build();
+            var catalog = Catalog.Builder.newInstance().dataset(Dataset.Builder.newInstance().build()).build();
+            when(continuationTokenSerDes.serialize(any())).thenReturn(Result.success("serializedToken"));
+
+            var response = decorator.decorate(responseBuilder, message, catalog).build();
+
+            assertThat(response.hasLink("next")).isTrue();
+            assertThat(response.getLink("next").getUri().toString()).isEqualTo(requestUrl + "?continuationToken=serializedToken");
+            verify(continuationTokenSerDes).serialize(argThat(q -> q.getOffset() == 1));
+        }
+
+        @Test
+        void shouldNotSetLink_whenDatasetSizeSmallerThanLimit() {
+            var responseBuilder = Response.ok();
+            var querySpec = QuerySpec.Builder.newInstance().limit(2).build();
+            var message = CatalogRequestMessage.Builder.newInstance().querySpec(querySpec).build();
+            var catalog = Catalog.Builder.newInstance().dataset(Dataset.Builder.newInstance().build()).build();
+
+            var response = decorator.decorate(responseBuilder, message, catalog).build();
+
+            assertThat(response.hasLink("next")).isFalse();
+        }
+
+        @Test
+        void shouldNotSetLink_whenSerializationFails() {
+            var responseBuilder = Response.ok();
+            var querySpec = QuerySpec.Builder.newInstance().offset(0).limit(1).build();
+            var message = CatalogRequestMessage.Builder.newInstance().querySpec(querySpec).build();
+            var catalog = Catalog.Builder.newInstance().dataset(Dataset.Builder.newInstance().build()).build();
+            when(continuationTokenSerDes.serialize(any())).thenReturn(Result.failure("error"));
+
+            var response = decorator.decorate(responseBuilder, message, catalog).build();
+
+            assertThat(response.hasLink("next")).isFalse();
+            verify(monitor).warning(any(String.class));
+        }
+    }
+
+    @Nested
+    class Prev {
+        @Test
+        void shouldSetLink_whenOffsetGreaterOrEqualLimit() {
+            var responseBuilder = Response.ok();
+            var querySpec = QuerySpec.Builder.newInstance().offset(1).limit(1).build();
+            var message = CatalogRequestMessage.Builder.newInstance().querySpec(querySpec).build();
+            var catalog = Catalog.Builder.newInstance().build();
+            when(continuationTokenSerDes.serialize(any())).thenReturn(Result.success("serializedToken"));
+
+            var response = decorator.decorate(responseBuilder, message, catalog).build();
+
+            assertThat(response.hasLink("prev")).isTrue();
+            assertThat(response.getLink("prev").getUri().toString()).isEqualTo(requestUrl + "?continuationToken=serializedToken");
+            verify(continuationTokenSerDes).serialize(argThat(q -> q.getOffset() == 0));
+        }
+
+        @Test
+        void shouldNotSetLink_whenSerializationFails() {
+            var responseBuilder = Response.ok();
+            var querySpec = QuerySpec.Builder.newInstance().offset(1).limit(1).build();
+            var message = CatalogRequestMessage.Builder.newInstance().querySpec(querySpec).build();
+            var catalog = Catalog.Builder.newInstance().build();
+            when(continuationTokenSerDes.serialize(any())).thenReturn(Result.failure("error"));
+
+            var response = decorator.decorate(responseBuilder, message, catalog).build();
+
+            assertThat(response.hasLink("next")).isFalse();
+            verify(monitor).warning(any(String.class));
+        }
+    }
+
+}

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/test/java/org/eclipse/edc/protocol/dsp/catalog/http/api/decorator/ContinuationTokenManagerImplTest.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/test/java/org/eclipse/edc/protocol/dsp/catalog/http/api/decorator/ContinuationTokenManagerImplTest.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.catalog.http.api.decorator;
+
+import jakarta.json.Json;
+import org.eclipse.edc.spi.result.Result;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspCatalogPropertyAndTypeNames.DSPACE_PROPERTY_FILTER;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ContinuationTokenManagerImplTest {
+
+    private final Base64continuationTokenSerDes serDes = mock();
+    private final ContinuationTokenManagerImpl continuationTokenManager = new ContinuationTokenManagerImpl(serDes, mock());
+
+    @Test
+    void apply_shouldReplaceQueryWithTheOnePassedInTheToken() {
+        var filter = Json.createObjectBuilder().add("offset", 1).build();
+        when(serDes.deserialize(any())).thenReturn(Result.success(filter));
+
+        var result = continuationTokenManager.applyQueryFromToken(Json.createObjectBuilder().build(), "token");
+
+        assertThat(result).isSucceeded().satisfies(jsonObject -> {
+            assertThat(jsonObject.getJsonArray(DSPACE_PROPERTY_FILTER)).hasSize(1).first().isEqualTo(filter);
+        });
+    }
+
+    @Test
+    void apply_shouldFail_whenSerDesFails() {
+        when(serDes.deserialize(any())).thenReturn(Result.failure("error"));
+
+        var result = continuationTokenManager.applyQueryFromToken(Json.createObjectBuilder().build(), "token");
+
+        assertThat(result).isFailed();
+    }
+}

--- a/data-protocols/dsp/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/http/dispatcher/DspHttpRemoteMessageDispatcherImpl.java
+++ b/data-protocols/dsp/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/http/dispatcher/DspHttpRemoteMessageDispatcherImpl.java
@@ -117,9 +117,7 @@ public class DspHttpRemoteMessageDispatcherImpl implements DspHttpRemoteMessageD
 
         }
 
-        tokenParametersBuilder = tokenDecorator.decorate(tokenParametersBuilder);
-
-        var tokenParameters = tokenParametersBuilder
+        var tokenParameters = tokenDecorator.decorate(tokenParametersBuilder)
                 .claims(AUDIENCE_CLAIM, audienceResolver.resolve(message)) // enforce the audience, ignore anything a decorator might have set
                 .build();
 

--- a/data-protocols/dsp/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/http/message/DspRequestHandlerImplTest.java
+++ b/data-protocols/dsp/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/http/message/DspRequestHandlerImplTest.java
@@ -244,6 +244,29 @@ class DspRequestHandlerImplTest {
             assertThat(result.getStatus()).isEqualTo(500);
         }
 
+        @Test
+        void shouldDecorateResponse_whenDecoratorSpecified() {
+            var jsonMessage = Json.createObjectBuilder().build();
+            var message = mock(TestProcessRemoteMessage.class);
+            var content = new Object();
+            var responseJson = Json.createObjectBuilder().build();
+            BiFunction<TestProcessRemoteMessage, TokenRepresentation, ServiceResult<Object>> serviceCall = (m, t) -> ServiceResult.success(content);
+            when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
+            when(transformerRegistry.transform(any(), eq(TestProcessRemoteMessage.class))).thenReturn(Result.success(message));
+            when(transformerRegistry.transform(any(), eq(JsonObject.class))).thenReturn(Result.success(responseJson));
+            var request = PostDspRequest.Builder.newInstance(TestProcessRemoteMessage.class, Object.class)
+                    .token("token")
+                    .expectedMessageType("expected-message-type")
+                    .message(jsonMessage)
+                    .serviceCall(serviceCall)
+                    .errorType("errorType")
+                    .build();
+
+            var result = handler.createResource(request, (r, i, o) -> r.header("test", "test"));
+
+            assertThat(result.getHeaderString("test")).isEqualTo("test");
+        }
+
         private PostDspRequest.Builder<TestProcessRemoteMessage, Object> postDspRequestBuilder() {
             return PostDspRequest.Builder
                     .newInstance(TestProcessRemoteMessage.class, Object.class)

--- a/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/http/spi/message/ContinuationTokenManager.java
+++ b/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/http/spi/message/ContinuationTokenManager.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.http.spi.message;
+
+import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequestMessage;
+import org.eclipse.edc.spi.result.Result;
+
+/**
+ * Provides functionality to manage the continuation token for resource pagination.
+ */
+public interface ContinuationTokenManager {
+
+    /**
+     * Apply the continuation token on the request message.
+     *
+     * @param requestMessage the request message.
+     * @param continuationToken the continuation token.
+     * @return the enriched {@link JsonObject} if operation succeeded, failure otherwise.
+     */
+    Result<JsonObject> applyQueryFromToken(JsonObject requestMessage, String continuationToken);
+
+    /**
+     * Create response decorator for specified request url.
+     *
+     * @param requestUrl the request url.
+     * @return the {@link ResponseDecorator} for the url.
+     */
+    ResponseDecorator<CatalogRequestMessage, Catalog> createResponseDecorator(String requestUrl);
+}

--- a/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/http/spi/message/ContinuationTokenSerDes.java
+++ b/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/http/spi/message/ContinuationTokenSerDes.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.http.spi.message;
+
+import jakarta.json.JsonObject;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.Result;
+
+/**
+ * Provides serialization and deserialization for continuation token, used for resource pagination.
+ */
+public interface ContinuationTokenSerDes {
+
+    /**
+     * Serialize query spec to continuation token
+     *
+     * @param querySpec {@link QuerySpec}.
+     * @return the token if success, failure otherwise.
+     */
+    Result<String> serialize(QuerySpec querySpec);
+
+    /**
+     * Deserialize continuation token to expanded json ld representation.
+     *
+     * @param serialized the continuation token.
+     * @return the {@link JsonObject} if success, failure otherwise.
+     */
+    Result<JsonObject> deserialize(String serialized);
+}

--- a/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/http/spi/message/DspRequestHandler.java
+++ b/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/http/spi/message/DspRequestHandler.java
@@ -36,11 +36,24 @@ public interface DspRequestHandler {
      * return as response.
      *
      * @param request the request.
+     * @param <I> the input type.
+     * @param <R> the result type.
+     * @return the response to be returned to the client.
+     */
+    default <I extends RemoteMessage, R> Response createResource(PostDspRequest<I, R> request) {
+        return createResource(request, (b, i, o) -> b);
+    }
+
+    /**
+     * Verify identity, validate incoming message, transform, call the service to create the resource, transform it,
+     * create the response, decorate it and return as response.
+     *
+     * @param request the request.
      * @return the response to be returned to the client.
      * @param <I> the input type.
      * @param <R> the result type.
      */
-    <I extends RemoteMessage, R> Response createResource(PostDspRequest<I, R> request);
+    <I extends RemoteMessage, R> Response createResource(PostDspRequest<I, R> request, ResponseDecorator<I, R> responseDecorator);
 
     /**
      * Verify identity, validate incoming message, transform and call the service.

--- a/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/http/spi/message/ResponseDecorator.java
+++ b/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/http/spi/message/ResponseDecorator.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.http.spi.message;
+
+import jakarta.ws.rs.core.Response;
+
+/**
+ * Describe a decorator to be used on a {@link Response}
+ */
+@FunctionalInterface
+public interface ResponseDecorator<I, O> {
+
+    /**
+     * Decorate the response builder.
+     *
+     * @param responseBuilder the response builder.
+     * @param requestBody the object contained in the request.
+     * @param responseBody the object contained in the response.
+     * @return the decorated ResponseBuilder.
+     */
+    Response.ResponseBuilder decorate(Response.ResponseBuilder responseBuilder, I requestBody, O responseBody);
+}

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/QuerySpec.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/QuerySpec.java
@@ -57,6 +57,43 @@ public class QuerySpec {
         return sortField;
     }
 
+    public int getOffset() {
+        return offset;
+    }
+
+    public int getLimit() {
+        return limit;
+    }
+
+    @JsonIgnore
+    public Range getRange() {
+        return new Range(offset, offset + limit);
+    }
+
+    public List<Criterion> getFilterExpression() {
+        return filterExpression;
+    }
+
+    public SortOrder getSortOrder() {
+        return sortOrder;
+    }
+
+    /**
+     * Checks whether any {@link Criterion} contains the given left-hand operand
+     */
+    public boolean containsAnyLeftOperand(String leftOperand) {
+        return getFilterExpression().stream().anyMatch(c -> c.getOperandLeft().toString().startsWith(leftOperand));
+    }
+
+    public Builder toBuilder() {
+        return new Builder()
+                .offset(offset)
+                .limit(limit)
+                .filter(filterExpression)
+                .sortOrder(sortOrder)
+                .sortField(sortField);
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(offset, limit, filterExpression, sortOrder, sortField);
@@ -85,33 +122,6 @@ public class QuerySpec {
                 '}';
     }
 
-    public int getOffset() {
-        return offset;
-    }
-
-    public int getLimit() {
-        return limit;
-    }
-
-    @JsonIgnore
-    public Range getRange() {
-        return new Range(offset, offset + limit);
-    }
-
-    public List<Criterion> getFilterExpression() {
-        return filterExpression;
-    }
-
-    public SortOrder getSortOrder() {
-        return sortOrder;
-    }
-
-    /**
-     * Checks whether any {@link Criterion} contains the given left-hand operand
-     */
-    public boolean containsAnyLeftOperand(String leftOperand) {
-        return getFilterExpression().stream().anyMatch(c -> c.getOperandLeft().toString().startsWith(leftOperand));
-    }
 
     public static final class Builder {
         private final QuerySpec querySpec;

--- a/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/Catalog.java
+++ b/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/Catalog.java
@@ -31,7 +31,7 @@ import static java.util.UUID.randomUUID;
 @JsonDeserialize(builder = Catalog.Builder.class)
 public class Catalog {
     private String id;
-    private List<Dataset> datasets;
+    private List<Dataset> datasets = new ArrayList<>();
     private List<DataService> dataServices;
     private Map<String, Object> properties;
     private String participantId;
@@ -74,14 +74,11 @@ public class Catalog {
         }
 
         public Builder datasets(List<Dataset> datasets) {
-            catalog.datasets = datasets;
+            catalog.datasets.addAll(datasets);
             return this;
         }
 
         public Builder dataset(Dataset dataset) {
-            if (catalog.datasets == null) {
-                catalog.datasets = new ArrayList<>();
-            }
             catalog.datasets.add(dataset);
             return this;
         }

--- a/system-tests/protocol-test/src/test/java/org/eclipse/edc/test/e2e/protocol/DspCatalogApiEndToEndTest.java
+++ b/system-tests/protocol-test/src/test/java/org/eclipse/edc/test/e2e/protocol/DspCatalogApiEndToEndTest.java
@@ -14,9 +14,18 @@
 
 package org.eclipse.edc.test.e2e.protocol;
 
+import jakarta.json.Json;
+import org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset;
+import org.eclipse.edc.connector.controlplane.asset.spi.index.AssetIndex;
+import org.eclipse.edc.connector.controlplane.contract.spi.offer.store.ContractDefinitionStore;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractDefinition;
+import org.eclipse.edc.connector.controlplane.policy.spi.PolicyDefinition;
+import org.eclipse.edc.connector.controlplane.policy.spi.store.PolicyDefinitionStore;
 import org.eclipse.edc.connector.controlplane.services.spi.protocol.ProtocolVersionRegistry;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.junit.extensions.EdcRuntimeExtension;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.util.io.Ports;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -26,14 +35,20 @@ import java.util.Map;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static jakarta.json.Json.createObjectBuilder;
+import static java.util.Arrays.stream;
+import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspCatalogPropertyAndTypeNames.DSPACE_PROPERTY_FILTER;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspCatalogPropertyAndTypeNames.DSPACE_TYPE_CATALOG_REQUEST_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.spi.version.DspVersions.V_2024_1;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.not;
 
 @EndToEndTest
 public class DspCatalogApiEndToEndTest {
@@ -70,7 +85,7 @@ public class DspCatalogApiEndToEndTest {
                         .build())
                 .post("/2024/1/catalog/request")
                 .then()
-                .log().ifError()
+                .log().ifValidationFails()
                 .statusCode(200)
                 .contentType(JSON)
                 .body("'dspace:participantId'", notNullValue());
@@ -79,4 +94,62 @@ public class DspCatalogApiEndToEndTest {
                 .contains(V_2024_1);
     }
 
+    @Test
+    void shouldPermitPaginationWithLinkHeader() {
+        var assetIndex = runtime.getContext().getService(AssetIndex.class);
+        range(0, 8)
+                .mapToObj(i -> Asset.Builder.newInstance().id(i + "").dataAddress(DataAddress.Builder.newInstance().type("any").build()).build())
+                .forEach(assetIndex::create);
+        var policyDefinitionStore = runtime.getContext().getService(PolicyDefinitionStore.class);
+        policyDefinitionStore.create(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build())
+                .onSuccess(policy -> {
+                    var contractDefinition = ContractDefinition.Builder.newInstance().accessPolicyId(policy.getId()).contractPolicyId(policy.getId()).build();
+                    runtime.getContext().getService(ContractDefinitionStore.class).save(contractDefinition);
+                });
+
+        var link = given()
+                .port(PROTOCOL_PORT)
+                .basePath("/protocol")
+                .contentType(JSON)
+                .header("Authorization", "{\"region\": \"any\", \"audience\": \"any\", \"clientId\":\"any\"}")
+                .body(createObjectBuilder()
+                        .add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
+                        .add(TYPE, DSPACE_TYPE_CATALOG_REQUEST_MESSAGE)
+                        .add(DSPACE_PROPERTY_FILTER, Json.createObjectBuilder()
+                                .add("offset", 0)
+                                .add("limit", 5))
+                        .build())
+                .post("/2024/1/catalog/request")
+                .then()
+                .log().ifValidationFails()
+                .statusCode(200)
+                .contentType(JSON)
+                .body("'dcat:dataset'.size()", equalTo(5))
+                .header("Link", containsString("/2024/1/catalog/request"))
+                .header("Link", containsString("next"))
+                .header("Link", not(containsString("prev")))
+                .extract().header("Link");
+
+        var nextPageUrl = stream(link.split(", ")).filter(it -> it.endsWith("\"next\"")).findAny()
+                .map(it -> it.split(">;")).map(it -> it[0]).map(it -> it.substring(1))
+                .orElseThrow();
+
+        given()
+                .contentType(JSON)
+                .header("Authorization", "{\"region\": \"any\", \"audience\": \"any\", \"clientId\":\"any\"}")
+                .body(createObjectBuilder()
+                        .add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
+                        .add(TYPE, DSPACE_TYPE_CATALOG_REQUEST_MESSAGE)
+                        .build()
+                )
+                .post(nextPageUrl)
+                .then()
+                .log().ifValidationFails()
+                .body("'dcat:dataset'.size()", equalTo(3))
+                .statusCode(200)
+                .contentType(JSON)
+                .header("Link", containsString("/2024/1/catalog/request"))
+                .header("Link", containsString("prev"))
+                .header("Link", not(containsString("next")));
+    }
 }


### PR DESCRIPTION
## What this PR changes/adds

Implement pagination as described by [DSP specification](https://docs.internationaldataspaces.org/ids-knowledgebase/v/dataspace-protocol/catalog/catalog.binding.https#id-3.1-pagination).
The continuationToken is the json representation of a `QuerySpec` object encoded in base64.

The core of the implementation is the `ContinuationTokenManager` component that provides two features:
- being able to eventually deserialize and apply to the requestBody the continuationToken
- set the `Link` header on the response through the `ResponseDecorator` 

## Why it does that

dsp completion

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #3866

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
