### PR TITLE
refactor: deprecate PolicyDefinition getUid method

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/policydefinition/PolicyDefinitionEventListener.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/policydefinition/PolicyDefinitionEventListener.java
@@ -40,7 +40,7 @@ public class PolicyDefinitionEventListener implements PolicyDefinitionListener {
     @Override
     public void created(PolicyDefinition policyDefinition) {
         var event = PolicyDefinitionCreated.Builder.newInstance()
-                .policyDefinitionId(policyDefinition.getUid())
+                .policyDefinitionId(policyDefinition.getId())
                 .build();
 
         publish(event);
@@ -49,7 +49,7 @@ public class PolicyDefinitionEventListener implements PolicyDefinitionListener {
     @Override
     public void deleted(PolicyDefinition policyDefinition) {
         var event = PolicyDefinitionDeleted.Builder.newInstance()
-                .policyDefinitionId(policyDefinition.getUid())
+                .policyDefinitionId(policyDefinition.getId())
                 .build();
 
         publish(event);
@@ -58,7 +58,7 @@ public class PolicyDefinitionEventListener implements PolicyDefinitionListener {
     @Override
     public void updated(PolicyDefinition policyDefinition) {
         var event = PolicyDefinitionUpdated.Builder.newInstance()
-                .policyDefinitionId(policyDefinition.getUid())
+                .policyDefinitionId(policyDefinition.getId())
                 .build();
 
         publish(event);

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/policydefinition/PolicyDefinitionEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/policydefinition/PolicyDefinitionEventDispatchTest.java
@@ -71,7 +71,7 @@ public class PolicyDefinitionEventDispatchTest {
             verify(eventSubscriber).on(argThat(isEnvelopeOf(PolicyDefinitionUpdated.class)));
         });
 
-        service.deleteById(policyDefinition.getUid());
+        service.deleteById(policyDefinition.getId());
         await().untilAsserted(() -> {
             verify(eventSubscriber).on(argThat(isEnvelopeOf(PolicyDefinitionDeleted.class)));
 

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/policydefinition/PolicyDefinitionServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/policydefinition/PolicyDefinitionServiceImplTest.java
@@ -135,8 +135,6 @@ class PolicyDefinitionServiceImplTest {
 
         var deleted = policyServiceImpl.deleteById("policyId");
 
-        var result = deleted.getContent().getUid();
-
         assertThat(deleted.succeeded()).isTrue();
         assertThat(deleted.getContent()).matches(hasId("policyId"));
     }
@@ -148,8 +146,8 @@ class PolicyDefinitionServiceImplTest {
 
         var contractDefinition = ContractDefinition.Builder.newInstance()
                 .id("A found Contract Definition")
-                .accessPolicyId(policy.getUid())
-                .contractPolicyId(policy.getUid())
+                .accessPolicyId(policy.getId())
+                .contractPolicyId(policy.getId())
                 .assetsSelectorCriterion(criterion("left", "op", "right"))
                 .build();
 
@@ -166,10 +164,10 @@ class PolicyDefinitionServiceImplTest {
         var policy = createPolicy("policyId");
         when(policyStore.delete("policyId")).thenReturn(StoreResult.success(policy));
 
-        ContractDefinition contractDefinition = ContractDefinition.Builder.newInstance()
+        var contractDefinition = ContractDefinition.Builder.newInstance()
                 .id("A found Contract Definition")
-                .accessPolicyId(policy.getUid())
-                .contractPolicyId(policy.getUid())
+                .accessPolicyId(policy.getId())
+                .contractPolicyId(policy.getId())
                 .assetsSelectorCriterion(criterion("left", "op", "right"))
                 .build();
 
@@ -273,7 +271,7 @@ class PolicyDefinitionServiceImplTest {
 
     @NotNull
     private Predicate<PolicyDefinition> hasId(String policyId) {
-        return it -> policyId.equals(it.getUid());
+        return it -> policyId.equals(it.getId());
     }
 
     private PolicyDefinition createPolicy(String policyId) {

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/controlplane/defaults/storage/policydefinition/InMemoryPolicyDefinitionStore.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/controlplane/defaults/storage/policydefinition/InMemoryPolicyDefinitionStore.java
@@ -63,7 +63,7 @@ public class InMemoryPolicyDefinitionStore implements PolicyDefinitionStore {
     public StoreResult<PolicyDefinition> create(PolicyDefinition policy) {
         try {
             return lockManager.writeLock(() -> {
-                var id = policy.getUid();
+                var id = policy.getId();
                 // do not replace if already exists
                 if (policiesById.containsKey(id)) {
                     return StoreResult.alreadyExists(format(POLICY_ALREADY_EXISTS, id));

--- a/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/policydefinition/store/SqlPolicyDefinitionStore.java
+++ b/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/policydefinition/store/SqlPolicyDefinitionStore.java
@@ -97,9 +97,9 @@ public class SqlPolicyDefinitionStore extends AbstractSqlStore implements Policy
     @Override
     public StoreResult<PolicyDefinition> create(PolicyDefinition policy) {
         Objects.requireNonNull(policy);
-        var policyId = policy.getUid();
+        var policyId = policy.getId();
         return transactionContext.execute(() -> {
-            if (findById(policy.getUid()) != null) {
+            if (findById(policyId) != null) {
                 return StoreResult.alreadyExists(format(POLICY_ALREADY_EXISTS, policyId));
             } else {
                 insert(policy);
@@ -110,7 +110,7 @@ public class SqlPolicyDefinitionStore extends AbstractSqlStore implements Policy
 
     @Override
     public StoreResult<PolicyDefinition> update(PolicyDefinition policyDefinition) {
-        var policyId = policyDefinition.getUid();
+        var policyId = policyDefinition.getId();
         if (findById(policyId) != null) {
             return transactionContext.execute(() -> {
                 updateInternal(policyDefinition);
@@ -141,7 +141,7 @@ public class SqlPolicyDefinitionStore extends AbstractSqlStore implements Policy
         transactionContext.execute(() -> {
             try (var connection = getConnection()) {
                 var policy = def.getPolicy();
-                var id = def.getUid();
+                var id = def.getId();
                 queryExecutor.execute(connection, statements.getInsertTemplate(),
                         id,
                         toJson(policy.getPermissions(), permissionListType),
@@ -165,7 +165,7 @@ public class SqlPolicyDefinitionStore extends AbstractSqlStore implements Policy
         transactionContext.execute(() -> {
             try (var connection = getConnection()) {
                 var policy = def.getPolicy();
-                var id = def.getUid();
+                var id = def.getId();
                 queryExecutor.execute(connection, statements.getUpdateTemplate(),
                         toJson(policy.getPermissions(), permissionListType),
                         toJson(policy.getProhibitions(), prohibitionListType),

--- a/spi/control-plane/policy-spi/src/main/java/org/eclipse/edc/connector/controlplane/policy/spi/PolicyDefinition.java
+++ b/spi/control-plane/policy-spi/src/main/java/org/eclipse/edc/connector/controlplane/policy/spi/PolicyDefinition.java
@@ -70,6 +70,7 @@ public class PolicyDefinition extends Entity {
         return Objects.equals(id, that.id) && policy.equals(that.policy);
     }
 
+    @Deprecated(since = "0.6.0", forRemoval = true)
     public String getUid() {
         return id;
     }

--- a/spi/control-plane/policy-spi/src/testFixtures/java/org/eclipse/edc/connector/controlplane/policy/spi/testfixtures/store/PolicyDefinitionStoreTestBase.java
+++ b/spi/control-plane/policy-spi/src/testFixtures/java/org/eclipse/edc/connector/controlplane/policy/spi/testfixtures/store/PolicyDefinitionStoreTestBase.java
@@ -55,7 +55,7 @@ public abstract class PolicyDefinitionStoreTestBase {
 
             getPolicyDefinitionStore().create(policy);
 
-            var policyFromDb = getPolicyDefinitionStore().findById(policy.getUid());
+            var policyFromDb = getPolicyDefinitionStore().findById(policy.getId());
             assertThat(policy).usingRecursiveComparison().isEqualTo(policyFromDb);
         }
 
@@ -98,7 +98,7 @@ public abstract class PolicyDefinitionStoreTestBase {
 
             getPolicyDefinitionStore().create(policy);
 
-            var policyFromDb = getPolicyDefinitionStore().findById(policy.getUid());
+            var policyFromDb = getPolicyDefinitionStore().findById(policy.getId());
             assertThat(policy).usingRecursiveComparison().isEqualTo(policyFromDb);
 
             assertThat(policyFromDb.getPrivateProperties()).hasSize(2);
@@ -304,7 +304,7 @@ public abstract class PolicyDefinitionStoreTestBase {
             var policy = TestFunctions.createPolicy(getRandomId());
             getPolicyDefinitionStore().create(policy);
 
-            var policyFromDb = getPolicyDefinitionStore().findById(policy.getUid());
+            var policyFromDb = getPolicyDefinitionStore().findById(policy.getId());
 
             assertThat(policy).usingRecursiveComparison().isEqualTo(policyFromDb);
         }
@@ -682,7 +682,7 @@ public abstract class PolicyDefinitionStoreTestBase {
             getPolicyDefinitionStore().create(policy2);
             getPolicyDefinitionStore().create(policy3);
 
-            var querySpec = QuerySpec.Builder.newInstance().filter(Criterion.criterion("id", "=", policy1.getUid())).build();
+            var querySpec = QuerySpec.Builder.newInstance().filter(Criterion.criterion("id", "=", policy1.getId())).build();
 
             assertThat(getPolicyDefinitionStore().findAll(querySpec)).usingRecursiveFieldByFieldElementComparator().containsExactly(policy1);
         }
@@ -736,10 +736,10 @@ public abstract class PolicyDefinitionStoreTestBase {
             var store = getPolicyDefinitionStore();
             store.create(policy);
 
-            var result = store.delete(policy.getUid());
+            var result = store.delete(policy.getId());
             assertThat(result.succeeded()).isTrue();
             assertThat(result.getContent()).usingRecursiveComparison().isEqualTo(policy);
-            assertThat(store.findById(policy.getUid())).isNull();
+            assertThat(store.findById(policy.getId())).isNull();
         }
 
         @Test
@@ -749,10 +749,10 @@ public abstract class PolicyDefinitionStoreTestBase {
             var store = getPolicyDefinitionStore();
             store.create(policy);
 
-            var result = store.delete(policy.getUid());
+            var result = store.delete(policy.getId());
             assertThat(result.succeeded()).isTrue();
             assertThat(result.getContent()).usingRecursiveComparison().isEqualTo(policy);
-            assertThat(store.findById(policy.getUid())).isNull();
+            assertThat(store.findById(policy.getId())).isNull();
         }
 
         @Test


### PR DESCRIPTION
## What this PR changes/adds

Deprecate `PolicyDefinition.getUid` and switch usages to `getId`. 

## Why it does that

cleanup

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #4105 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
