### PR TITLE
chore: add support for fetching properties w/wo namespace + bitstring

### DIFF
--- a/extensions/common/iam/verifiable-credentials/src/test/java/org/eclipse/edc/iam/verifiablecredentials/StatusList2021RevocationServiceTest.java
+++ b/extensions/common/iam/verifiable-credentials/src/test/java/org/eclipse/edc/iam/verifiablecredentials/StatusList2021RevocationServiceTest.java
@@ -35,8 +35,8 @@ import static org.eclipse.edc.util.io.Ports.getFreePort;
 import static org.mockserver.model.HttpRequest.request;
 
 class StatusList2021RevocationServiceTest {
-    private static final int NOT_REVOKED_INDEX = 42;
-    private static final int REVOKED_INDEX = 359;
+    private static final int NOT_REVOKED_INDEX = 1;
+    private static final int REVOKED_INDEX = 2;
     private final StatusList2021RevocationService revocationService = new StatusList2021RevocationService(new ObjectMapper().registerModule(new JavaTimeModule()),
             5 * 60 * 1000);
     private ClientAndServer clientAndServer;

--- a/extensions/common/iam/verifiable-credentials/src/test/java/org/eclipse/edc/iam/verifiablecredentials/TestData.java
+++ b/extensions/common/iam/verifiable-credentials/src/test/java/org/eclipse/edc/iam/verifiablecredentials/TestData.java
@@ -31,7 +31,7 @@ public class TestData {
                 "id": "https://example.com/status/3#list",
                 "type": "StatusList2021",
                 "https://w3id.org/vc/status-list#statusPurpose": "revocation",
-                "https://w3id.org/vc/status-list#encodedList": "H4sIAAAAAAAAA-3BMQEAAADCoPVPbQwfoAAAAAAAAAAAAAAAAAAAAIC3AYbSVKsAQAAA"
+                "https://w3id.org/vc/status-list#encodedList": "H4sIAAAAAAAAA+3BIQEAAAACIP+vcKozLEADAAAAAAAAAAAAAAAAAAAAvA0cOP65AEAAAA"
               }
               ]
             }
@@ -51,7 +51,7 @@ public class TestData {
                 "id": "https://example.com/status/3#list",
                 "type": "StatusList2021",
                 "https://w3id.org/vc/status-list#statusPurpose": "revocation",
-                "https://w3id.org/vc/status-list#encodedList": "H4sIAAAAAAAAA-3BMQEAAADCoPVPbQwfoAAAAAAAAAAAAAAAAAAAAIC3AYbSVKsAQAAA"
+                "https://w3id.org/vc/status-list#encodedList": "H4sIAAAAAAAAA+3BIQEAAAACIP+vcKozLEADAAAAAAAAAAAAAAAAAAAAvA0cOP65AEAAAA"
               }
             }
             """;

--- a/spi/common/boot-spi/src/main/java/org/eclipse/edc/spi/result/Result.java
+++ b/spi/common/boot-spi/src/main/java/org/eclipse/edc/spi/result/Result.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * A generic result type.
@@ -46,6 +47,21 @@ public class Result<T> extends AbstractResult<T, Failure, Result<T>> {
 
     public static <T> Result<T> failure(List<String> failures) {
         return new Result<>(null, new Failure(failures));
+    }
+
+
+    /**
+     * Runs the block provided by the {@link Supplier} and wrap the return into a Result
+     *
+     * @param supplier The block to execute
+     * @return The Result of the supplier call. Success if no {@link Exception} were thrown. Failure otherwise
+     */
+    public static <T> Result<T> ofThrowable(Supplier<T> supplier) {
+        try {
+            return Result.success(supplier.get());
+        } catch (Exception e) {
+            return Result.failure(e.getMessage());
+        }
     }
 
     /**

--- a/spi/common/boot-spi/src/test/java/org/eclipse/edc/spi/result/ResultTest.java
+++ b/spi/common/boot-spi/src/test/java/org/eclipse/edc/spi/result/ResultTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.spi.result;
 
 import org.eclipse.edc.junit.assertions.AbstractResultAssert;
+import org.eclipse.edc.spi.EdcException;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
@@ -255,5 +256,21 @@ class ResultTest {
         Function<Failure, Result<String>> failingRecoverFunction = f -> Result.failure("error");
 
         AbstractResultAssert.assertThat(succeededResult.recover(failingRecoverFunction)).isSucceeded();
+    }
+
+    @Test
+    void ofThrowable_success() {
+
+        var result = Result.ofThrowable(String::new);
+        AbstractResultAssert.assertThat(result).isSucceeded().isEqualTo("");
+    }
+
+    @Test
+    void ofThrowable_failure() {
+
+        var result = Result.ofThrowable(() -> {
+            throw new EdcException("Exception");
+        });
+        AbstractResultAssert.assertThat(result).isFailed().detail().contains("Exception");
     }
 }

--- a/spi/common/verifiable-credentials-spi/src/main/java/org/eclipse/edc/iam/verifiablecredentials/spi/model/CredentialStatus.java
+++ b/spi/common/verifiable-credentials-spi/src/main/java/org/eclipse/edc/iam/verifiablecredentials/spi/model/CredentialStatus.java
@@ -16,7 +16,28 @@ package org.eclipse.edc.iam.verifiablecredentials.spi.model;
 
 import java.util.Map;
 
+import static java.util.Optional.ofNullable;
+
 public record CredentialStatus(String id, String type, Map<String, Object> additionalProperties) {
     public static final String CREDENTIAL_STATUS_ID_PROPERTY = "@id";
     public static final String CREDENTIAL_STATUS_TYPE_PROPERTY = "@type";
+
+
+    /**
+     * Returns a property if presents in the properties map. This method
+     * will try first the combination namespace + property and if
+     * not found will fall back to just property when fetching the property
+     * from the underling map
+     *
+     * @param namespace The namespace of the property
+     * @param property  The name of the property
+     * @return The property if present, null otherwise
+     */
+
+    public Object getProperty(String namespace, String property) {
+        return ofNullable(additionalProperties.get(namespace + property))
+                .or(() -> ofNullable(additionalProperties.get(property)))
+                .orElse(null);
+    }
+
 }

--- a/spi/common/verifiable-credentials-spi/src/main/java/org/eclipse/edc/iam/verifiablecredentials/spi/model/CredentialSubject.java
+++ b/spi/common/verifiable-credentials-spi/src/main/java/org/eclipse/edc/iam/verifiablecredentials/spi/model/CredentialSubject.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.HashMap;
 import java.util.Map;
 
+import static java.util.Optional.ofNullable;
 import static org.eclipse.edc.iam.verifiablecredentials.spi.VcConstants.VC_PREFIX;
 
 /**
@@ -38,6 +39,23 @@ public class CredentialSubject {
     @JsonAnySetter
     public void setClaim(String name, Object value) {
         claims.put(name, value);
+    }
+
+
+    /**
+     * Returns a claim if presents in the claims map. This method
+     * will try first the combination namespace + property and if
+     * not found will fall back to just property when fetching the claim
+     * from the underling map
+     *
+     * @param namespace The namespace of the property
+     * @param property  The name of the property
+     * @return The claim if present, null otherwise
+     */
+    public Object getClaim(String namespace, String property) {
+        return ofNullable(claims.get(namespace + property))
+                .or(() -> ofNullable(claims.get(property)))
+                .orElse(null);
     }
 
     public String getId() {

--- a/spi/common/verifiable-credentials-spi/src/main/java/org/eclipse/edc/iam/verifiablecredentials/spi/model/statuslist/BitString.java
+++ b/spi/common/verifiable-credentials-spi/src/main/java/org/eclipse/edc/iam/verifiablecredentials/spi/model/statuslist/BitString.java
@@ -1,0 +1,104 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.iam.verifiablecredentials.spi.model.statuslist;
+
+import org.eclipse.edc.spi.result.Result;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Base64;
+import java.util.zip.GZIPInputStream;
+
+/**
+ * Representation of <a href="https://www.w3.org/TR/2023/WD-vc-status-list-20230427/#bitstring-encoding">StatusList2021Credential#bitstring</a>
+ */
+public class BitString {
+
+    private final boolean leftToRightIndexing;
+    private final byte[] bits;
+    private final int bitsPerByte = 8;
+
+    private BitString(byte[] bits, boolean leftToRightIndexing) {
+        this.bits = bits;
+        this.leftToRightIndexing = leftToRightIndexing;
+    }
+
+    /**
+     * Checks if the bit at the input index is `1`. The input index should be in the
+     * bound (0-bitstring_length - 1). The default bit order is left to right, which means
+     * that for a byte 00000001, the bit value of that first (zeroth) index is `0` and
+     * the last index (seventh) is `1`
+     *
+     * @param idx The bit index to check
+     * @return True if `1`, false otherwise
+     */
+    public boolean get(int idx) {
+
+        if (idx < 0 || idx >= length()) {
+            throw new IllegalArgumentException("Index out of range 0-%s".formatted(length()));
+        }
+        var byteIdx = idx / bitsPerByte;
+        var bitIdx = idx % bitsPerByte;
+        var shift = leftToRightIndexing ? (7 - bitIdx) : bitIdx;
+        return (bits[byteIdx] & (1L << shift)) != 0;
+    }
+
+    public int length() {
+        return bits.length * bitsPerByte;
+    }
+
+    /**
+     * Parser configuration for {@link BitString}
+     */
+    public static final class Parser {
+        private boolean leftToRightIndexing = true;
+        private Base64.Decoder decoder = Base64.getDecoder();
+
+        private Parser() {
+        }
+
+        public static Parser newInstance() {
+            return new Parser();
+        }
+
+        public Parser leftToRightIndexing(boolean leftToRightIndexing) {
+            this.leftToRightIndexing = leftToRightIndexing;
+            return this;
+        }
+
+        public Parser decoder(Base64.Decoder decoder) {
+            this.decoder = decoder;
+            return this;
+        }
+
+        public Result<BitString> parse(String encodedList) {
+            return Result.ofThrowable(() -> decoder.decode(encodedList))
+                    .compose(this::unGzip)
+                    .map(bytes -> new BitString(bytes, leftToRightIndexing));
+        }
+
+        private Result<byte[]> unGzip(byte[] bytes) {
+            try (var inputStream = new GZIPInputStream(new ByteArrayInputStream(bytes))) {
+                try (var outputStream = new ByteArrayOutputStream()) {
+                    inputStream.transferTo(outputStream);
+                    return Result.success(outputStream.toByteArray());
+                }
+            } catch (IOException e) {
+                return Result.failure("Failed to ungzip encoded list: %s".formatted(e.getMessage()));
+            }
+        }
+    }
+}

--- a/spi/common/verifiable-credentials-spi/src/main/java/org/eclipse/edc/iam/verifiablecredentials/spi/model/statuslist/StatusList2021Credential.java
+++ b/spi/common/verifiable-credentials-spi/src/main/java/org/eclipse/edc/iam/verifiablecredentials/spi/model/statuslist/StatusList2021Credential.java
@@ -28,10 +28,14 @@ import static org.eclipse.edc.iam.verifiablecredentials.spi.VcConstants.STATUSLI
 public class StatusList2021Credential extends VerifiableCredential {
     public static final String STATUSLIST_2021_TYPE = "StatusList2021";
     public static final String STATUSLIST_2021_CREDENTIAL = STATUSLIST_2021_TYPE + "Credential";
-    public static final String STATUS_LIST_ENCODED_LIST = STATUSLIST_2021_PREFIX + "encodedList";
-    public static final String STATUS_LIST_CREDENTIAL = STATUSLIST_2021_PREFIX + "statusListCredential";
-    public static final String STATUS_LIST_INDEX = STATUSLIST_2021_PREFIX + "statusListIndex";
-    public static final String STATUS_LIST_PURPOSE = STATUSLIST_2021_PREFIX + "statusPurpose";
+    public static final String STATUS_LIST_ENCODED_LIST_LITERAL = "encodedList";
+    public static final String STATUS_LIST_ENCODED_LIST = STATUSLIST_2021_PREFIX + STATUS_LIST_ENCODED_LIST_LITERAL;
+    public static final String STATUS_LIST_CREDENTIAL_LITERAL = "statusListCredential";
+    public static final String STATUS_LIST_CREDENTIAL = STATUSLIST_2021_PREFIX + STATUS_LIST_CREDENTIAL_LITERAL;
+    public static final String STATUS_LIST_INDEX_LITERAL = "statusListIndex";
+    public static final String STATUS_LIST_INDEX = STATUSLIST_2021_PREFIX + STATUS_LIST_INDEX_LITERAL;
+    public static final String STATUS_LIST_PURPOSE_LITERAL = "statusPurpose";
+    public static final String STATUS_LIST_PURPOSE = STATUSLIST_2021_PREFIX + STATUS_LIST_PURPOSE_LITERAL;
 
     private StatusList2021Credential() {
     }
@@ -51,11 +55,11 @@ public class StatusList2021Credential extends VerifiableCredential {
     }
 
     public String encodedList() {
-        return (String) credentialSubject.get(0).getClaims().get(STATUS_LIST_ENCODED_LIST);
+        return (String) credentialSubject.get(0).getClaim(STATUSLIST_2021_PREFIX, STATUS_LIST_ENCODED_LIST_LITERAL);
     }
 
     public String statusPurpose() {
-        return (String) credentialSubject.get(0).getClaims().get(STATUS_LIST_PURPOSE);
+        return (String) credentialSubject.get(0).getClaim(STATUSLIST_2021_PREFIX, STATUS_LIST_PURPOSE_LITERAL);
     }
 
     public static class Builder extends VerifiableCredential.Builder<StatusList2021Credential, Builder> {
@@ -83,10 +87,10 @@ public class StatusList2021Credential extends VerifiableCredential {
 
             // check mandatory fields of the credentialSubject object
             var subject = instance.credentialSubject.get(0);
-            if (!subject.getClaims().containsKey(STATUS_LIST_ENCODED_LIST)) {
+            if (subject.getClaim(STATUSLIST_2021_PREFIX, STATUS_LIST_ENCODED_LIST_LITERAL) == null) {
                 throw new IllegalArgumentException("Status list credentials must contain a 'credentialSubject.encodedList' field.");
             }
-            if (!subject.getClaims().containsKey(STATUS_LIST_PURPOSE)) {
+            if (subject.getClaim(STATUSLIST_2021_PREFIX, STATUS_LIST_PURPOSE_LITERAL) == null) {
                 throw new IllegalArgumentException("Status list credentials must contain a 'credentialSubject.statusPurpose' field.");
             }
             return instance;

--- a/spi/common/verifiable-credentials-spi/src/main/java/org/eclipse/edc/iam/verifiablecredentials/spi/model/statuslist/StatusListStatus.java
+++ b/spi/common/verifiable-credentials-spi/src/main/java/org/eclipse/edc/iam/verifiablecredentials/spi/model/statuslist/StatusListStatus.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialStatus;
 import java.util.Map;
 
 import static java.util.Optional.ofNullable;
+import static org.eclipse.edc.iam.verifiablecredentials.spi.VcConstants.STATUSLIST_2021_PREFIX;
 
 /**
  * Specialized {@code credentialStatus}, that contains information mandated by the StatusList2021 standard.
@@ -38,12 +39,12 @@ public class StatusListStatus {
                 .map(Object::toString)
                 .orElseThrow(() -> new IllegalArgumentException(missingProperty(StatusList2021Credential.STATUS_LIST_CREDENTIAL)));
 
-        instance.statusListIndex = ofNullable(status.additionalProperties().get(StatusList2021Credential.STATUS_LIST_INDEX))
+        instance.statusListIndex = ofNullable(status.getProperty(STATUSLIST_2021_PREFIX, StatusList2021Credential.STATUS_LIST_INDEX_LITERAL))
                 .map(Object::toString)
                 .map(Integer::parseInt)
                 .orElseThrow(() -> new IllegalArgumentException(missingProperty(StatusList2021Credential.STATUS_LIST_INDEX)));
 
-        instance.statusListPurpose = ofNullable(status.additionalProperties().get(StatusList2021Credential.STATUS_LIST_PURPOSE))
+        instance.statusListPurpose = ofNullable(status.getProperty(STATUSLIST_2021_PREFIX, StatusList2021Credential.STATUS_LIST_PURPOSE_LITERAL))
                 .map(Object::toString)
                 .orElseThrow(() -> new IllegalArgumentException(missingProperty(StatusList2021Credential.STATUS_LIST_PURPOSE)));
 
@@ -51,7 +52,7 @@ public class StatusListStatus {
     }
 
     private static Object getId(CredentialStatus status) {
-        var credentialId = status.additionalProperties().get(StatusList2021Credential.STATUS_LIST_CREDENTIAL);
+        var credentialId = status.getProperty(STATUSLIST_2021_PREFIX, StatusList2021Credential.STATUS_LIST_CREDENTIAL_LITERAL);
         if (credentialId instanceof Map<?, ?> map) {
             return map.get("@id");
         }

--- a/spi/common/verifiable-credentials-spi/src/test/java/org/eclipse/edc/iam/verifiablecredentials/spi/model/CredentialSubjectTest.java
+++ b/spi/common/verifiable-credentials-spi/src/test/java/org/eclipse/edc/iam/verifiablecredentials/spi/model/CredentialSubjectTest.java
@@ -55,4 +55,17 @@ class CredentialSubjectTest {
                 .containsKey("complex")
                 .hasEntrySatisfying("complex", o -> assertThat(o).isInstanceOf(Map.class));
     }
+
+    @Test
+    void getClaim() {
+        var namespace = "http://namespace#";
+        var cred = CredentialSubject.Builder.newInstance()
+                .claim("key", "val")
+                .claim(namespace + "key1", "val1")
+                .build();
+
+
+        assertThat(cred.getClaim(namespace, "key")).isEqualTo("val");
+        assertThat(cred.getClaim(namespace, "key1")).isEqualTo("val1");
+    }
 }

--- a/spi/common/verifiable-credentials-spi/src/test/java/org/eclipse/edc/iam/verifiablecredentials/spi/model/statuslist/BitStringTest.java
+++ b/spi/common/verifiable-credentials-spi/src/test/java/org/eclipse/edc/iam/verifiablecredentials/spi/model/statuslist/BitStringTest.java
@@ -1,0 +1,92 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.iam.verifiablecredentials.spi.model.statuslist;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class BitStringTest {
+
+    @ParameterizedTest
+    @ArgumentsSource(ValidEncodedListProvider.class)
+    void parse(String list, int size, int[] revoked, Base64.Decoder decoder, boolean leftToRightIndexing) {
+
+        var result = BitString.Parser.newInstance().decoder(decoder).leftToRightIndexing(leftToRightIndexing).parse(list);
+
+        assertThat(result.succeeded()).isTrue();
+        assertThat(result.getContent()).satisfies(bitString -> {
+            assertThat(bitString.length()).isEqualTo(size);
+            Arrays.stream(revoked).forEach((idx) -> assertThat(bitString.get(idx)).isTrue());
+        });
+    }
+
+    @Test
+    void get_whenOutOfBound() {
+
+        var bitString = BitString.Parser.newInstance().parse("H4sIAAAAAAAAA+3BMQEAAADCoPVPbQsvoAAAAAAAAAAAAAAAAP4GcwM92tQwAAA=").getContent();
+
+        assertThatThrownBy(() -> bitString.get(200_000)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> bitString.get(-10)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void parse_invalidBas64() {
+
+        var result = BitString.Parser.newInstance().parse("invalid-");
+        assertThat(result.failed()).isTrue();
+        assertThat(result.getFailureDetail()).contains("Illegal base64 character");
+    }
+
+    @Test
+    void parse_invalidGzip() {
+
+        var result = BitString.Parser.newInstance().parse("invalid/gzip");
+        assertThat(result.failed()).isTrue();
+        assertThat(result.getFailureDetail()).contains("Failed to ungzip encoded list: Not in GZIP format");
+    }
+
+    private static class ValidEncodedListProvider implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                    // Base64 decoder
+                    Arguments.of("H4sIAAAAAAAAA+3BMQEAAADCoPVPbQsvoAAAAAAAAAAAAAAAAP4GcwM92tQwAAA=", 100_000, new int[]{}, Base64.getDecoder(), true),
+                    Arguments.of("H4sIAAAAAAAAA+3BIQEAAAACIP+vcKozLEADAAAAAAAAAAAAAAAAAAAAvA0cOP65AEAAAA", 131072, new int[]{ 0, 2 }, Base64.getDecoder(), true),
+                    Arguments.of("H4sIAAAAAAAAA+3OMQ0AAAgDsElHOh72EJJWQRMAAAAAAIDWXAcAAAAAAIDHFvRitn7UMAAA", 100_000, new int[]{ 50_000 }, Base64.getDecoder(), true),
+                    Arguments.of("H4sIAAAAAAAAA+3BIQEAAAACIP1/2hkWoAEAAAAAAAAAAAAAAAAAAADeBjn7xTYAQAAA", 131072, new int[]{ 7 }, Base64.getDecoder(), true),
+                    // Base64 URL decoder
+                    Arguments.of("H4sIAAAAAAAAA-3BMQEAAADCoPVPbQsvoAAAAAAAAAAAAAAAAP4GcwM92tQwAAA", 100_000, new int[]{}, Base64.getUrlDecoder(), true),
+                    Arguments.of("H4sIAAAAAAAAA-3BIQEAAAACIP-vcKozLEADAAAAAAAAAAAAAAAAAAAAvA0cOP65AEAAAA", 131072, new int[]{ 0, 2 }, Base64.getUrlDecoder(), true),
+                    Arguments.of("H4sIAAAAAAAAA-3OMQ0AAAgDsElHOh72EJJWQRMAAAAAAIDWXAcAAAAAAIDHFvRitn7UMAAA", 100_000, new int[]{ 50_000 }, Base64.getUrlDecoder(), true),
+                    Arguments.of("H4sIAAAAAAAAA-3BIQEAAAACIP1_2hkWoAEAAAAAAAAAAAAAAAAAAADeBjn7xTYAQAAA", 131072, new int[]{ 7 }, Base64.getUrlDecoder(), true),
+
+                    // Left to right = false
+                    Arguments.of("H4sIAAAAAAAA_-3AIQEAAAACIIv_LzvDAg0AAAAAAAAAAAAAAAAAAADwNgZXEi0AQAAA", 131072, new int[]{ 0, 2 }, Base64.getUrlDecoder(), false)
+            );
+        }
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

- Adds the API for fetching properties from CredentialSubject and CredentialStatus with the tuple (namespace, property)
- Removes the usage of Bitset and implemented custom Bitstring for parsing the bitstring encoded list and checking if an index is `1`


