### PR TITLE
feat: make TransferRequest transferType mandatory and dataDestination optional

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
@@ -57,6 +57,7 @@ import org.eclipse.edc.connector.controlplane.services.transferprocess.TransferP
 import org.eclipse.edc.connector.controlplane.services.transferprocess.TransferProcessServiceImpl;
 import org.eclipse.edc.connector.controlplane.transfer.spi.TransferProcessManager;
 import org.eclipse.edc.connector.controlplane.transfer.spi.flow.DataFlowManager;
+import org.eclipse.edc.connector.controlplane.transfer.spi.flow.FlowTypeExtractor;
 import org.eclipse.edc.connector.controlplane.transfer.spi.observe.TransferProcessObservable;
 import org.eclipse.edc.connector.controlplane.transfer.spi.store.TransferProcessStore;
 import org.eclipse.edc.policy.engine.spi.PolicyEngine;
@@ -163,6 +164,9 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     @Inject
     private DataFlowManager dataFlowManager;
 
+    @Inject
+    private FlowTypeExtractor flowTypeExtractor;
+
     @Override
     public String name() {
         return NAME;
@@ -220,7 +224,7 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     @Provider
     public TransferProcessService transferProcessService() {
         return new TransferProcessServiceImpl(transferProcessStore, transferProcessManager, transactionContext,
-                dataAddressValidator, commandHandlerRegistry);
+                dataAddressValidator, commandHandlerRegistry, flowTypeExtractor);
     }
 
     @Provider

--- a/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/TransferProcessDefaultServicesExtension.java
+++ b/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/TransferProcessDefaultServicesExtension.java
@@ -15,11 +15,13 @@
 package org.eclipse.edc.connector.controlplane.transfer;
 
 import org.eclipse.edc.connector.controlplane.transfer.flow.DataFlowManagerImpl;
+import org.eclipse.edc.connector.controlplane.transfer.flow.FlowTypeExtractorImpl;
 import org.eclipse.edc.connector.controlplane.transfer.observe.TransferProcessObservableImpl;
 import org.eclipse.edc.connector.controlplane.transfer.provision.ProvisionManagerImpl;
 import org.eclipse.edc.connector.controlplane.transfer.provision.ResourceManifestGeneratorImpl;
 import org.eclipse.edc.connector.controlplane.transfer.spi.TransferProcessPendingGuard;
 import org.eclipse.edc.connector.controlplane.transfer.spi.flow.DataFlowManager;
+import org.eclipse.edc.connector.controlplane.transfer.spi.flow.FlowTypeExtractor;
 import org.eclipse.edc.connector.controlplane.transfer.spi.observe.TransferProcessObservable;
 import org.eclipse.edc.connector.controlplane.transfer.spi.provision.ProvisionManager;
 import org.eclipse.edc.connector.controlplane.transfer.spi.provision.ResourceManifestGenerator;
@@ -66,6 +68,11 @@ public class TransferProcessDefaultServicesExtension implements ServiceExtension
     @Provider(isDefault = true)
     public TransferProcessPendingGuard pendingGuard() {
         return it -> false;
+    }
+
+    @Provider
+    public FlowTypeExtractor flowTypeExtractor() {
+        return new FlowTypeExtractorImpl();
     }
 
 }

--- a/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/flow/FlowTypeExtractorImpl.java
+++ b/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/flow/FlowTypeExtractorImpl.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.transfer.flow;
+
+import org.eclipse.edc.connector.controlplane.transfer.spi.flow.FlowTypeExtractor;
+import org.eclipse.edc.spi.response.ResponseStatus;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.types.domain.transfer.FlowType;
+
+import java.util.Optional;
+
+public class FlowTypeExtractorImpl implements FlowTypeExtractor {
+    @Override
+    public StatusResult<FlowType> extract(String transferType) {
+        return Optional.ofNullable(transferType)
+                .map(type -> type.split("-"))
+                .filter(tokens -> tokens.length == 2)
+                .map(tokens -> parseFlowType(tokens[1]))
+                .orElse(StatusResult.failure(ResponseStatus.FATAL_ERROR, "Failed to extract flow type from transferType %s".formatted(transferType)));
+    }
+
+    private StatusResult<FlowType> parseFlowType(String flowType) {
+        try {
+            return StatusResult.success(FlowType.valueOf(flowType));
+        } catch (Exception e) {
+            return StatusResult.failure(ResponseStatus.FATAL_ERROR, "Unknown flow type %s".formatted(flowType));
+        }
+    }
+}

--- a/core/control-plane/control-plane-transfer/src/test/java/org/eclipse/edc/connector/controlplane/transfer/flow/FlowTypeExtractorImplTest.java
+++ b/core/control-plane/control-plane-transfer/src/test/java/org/eclipse/edc/connector/controlplane/transfer/flow/FlowTypeExtractorImplTest.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.transfer.flow;
+
+import org.eclipse.edc.connector.controlplane.transfer.spi.flow.FlowTypeExtractor;
+import org.junit.jupiter.api.Test;
+
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.spi.types.domain.transfer.FlowType.PULL;
+import static org.eclipse.edc.spi.types.domain.transfer.FlowType.PUSH;
+
+class FlowTypeExtractorImplTest {
+
+    private final FlowTypeExtractor extractor = new FlowTypeExtractorImpl();
+
+    @Test
+    void shouldExtractPull() {
+        var result = extractor.extract("Any-PULL");
+
+        assertThat(result).isSucceeded().isEqualTo(PULL);
+    }
+
+    @Test
+    void shouldExtractPush() {
+        var result = extractor.extract("Any-PUSH");
+
+        assertThat(result).isSucceeded().isEqualTo(PUSH);
+    }
+
+    @Test
+    void shouldReturnFatalError_whenTypeIsUnknown() {
+        var result = extractor.extract("Any-NOT_KNOWN");
+
+        assertThat(result).isFailed();
+    }
+
+    @Test
+    void shouldReturnFatalError_whenFormatIsNotCorrect() {
+        var result = extractor.extract("not_correct");
+
+        assertThat(result).isFailed();
+    }
+}

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/validation/ContractRequestValidator.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/validation/ContractRequestValidator.java
@@ -43,9 +43,9 @@ import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIB
 public class ContractRequestValidator {
     public static Validator<JsonObject> instance(Monitor monitor) {
         return JsonObjectValidator.newValidator()
-                .verify(path -> new LogDeprecatedValue(path.append(PROVIDER_ID), CONTRACT_REQUEST_TYPE, ODRL_ASSIGNER_ATTRIBUTE, monitor))
-                .verify(path -> new LogDeprecatedValue(path.append(OFFER), CONTRACT_REQUEST_TYPE, POLICY, monitor))
-                .verify(path -> new LogDeprecatedValue(path.append(CONNECTOR_ADDRESS), CONTRACT_REQUEST_TYPE, CONTRACT_REQUEST_COUNTER_PARTY_ADDRESS, monitor))
+                .verify(PROVIDER_ID, path -> new LogDeprecatedValue(path, CONTRACT_REQUEST_TYPE, ODRL_ASSIGNER_ATTRIBUTE, monitor))
+                .verify(OFFER, path -> new LogDeprecatedValue(path, CONTRACT_REQUEST_TYPE, POLICY, monitor))
+                .verify(CONNECTOR_ADDRESS, path -> new LogDeprecatedValue(path, CONTRACT_REQUEST_TYPE, CONTRACT_REQUEST_COUNTER_PARTY_ADDRESS, monitor))
                 .verify(path -> new MandatoryCounterPartyAddressOrConnectorAddress(path, monitor))
                 .verify(PROTOCOL, MandatoryValue::new)
                 .verify(path -> new MandatoryOfferOrPolicy(path, monitor))

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/TransferProcessApi.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/TransferProcessApi.java
@@ -170,9 +170,8 @@ public interface TransferProcessApi {
             @Schema(requiredMode = REQUIRED)
             String assetId,
             @Schema(requiredMode = REQUIRED)
+            String transferType,
             ManagementApiSchema.DataAddressSchema dataDestination,
-            @Schema(deprecated = true, description = "Deprecated as this field is not used anymore, please use privateProperties instead")
-            ManagementApiSchema.FreeFormPropertiesSchema properties,
             @Schema(additionalProperties = Schema.AdditionalPropertiesValue.TRUE)
             ManagementApiSchema.FreeFormPropertiesSchema privateProperties,
             List<ManagementApiSchema.CallbackAddressSchema> callbackAddresses) {
@@ -185,6 +184,7 @@ public interface TransferProcessApi {
                     "counterPartyAddress": "http://provider-address",
                     "contractId": "contract-id",
                     "assetId": "asset-id",
+                    "transferType": "transferType",
                     "dataDestination": {
                         "type": "data-destination-type"
                     },
@@ -215,9 +215,6 @@ public interface TransferProcessApi {
             String state,
             String contractAgreementId,
             String errorDetail,
-            @Deprecated(since = "0.2.0")
-            @Schema(deprecated = true)
-            ManagementApiSchema.FreeFormPropertiesSchema properties,
             ManagementApiSchema.DataAddressSchema dataDestination,
             ManagementApiSchema.FreeFormPropertiesSchema privateProperties,
             List<ManagementApiSchema.CallbackAddressSchema> callbackAddresses

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/transform/JsonObjectToTransferRequestTransformer.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/transform/JsonObjectToTransferRequestTransformer.java
@@ -39,7 +39,6 @@ import static org.eclipse.edc.connector.controlplane.transfer.spi.types.Transfer
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_COUNTER_PARTY_ADDRESS;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_DATA_DESTINATION;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_PRIVATE_PROPERTIES;
-import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_PROPERTIES;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_PROTOCOL;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_TRANSFER_TYPE;
 
@@ -60,7 +59,6 @@ public class JsonObjectToTransferRequestTransformer extends AbstractJsonLdTransf
             case TRANSFER_REQUEST_CONTRACT_ID -> (v) -> builder.contractId(transformString(v, context));
             case TRANSFER_REQUEST_DATA_DESTINATION ->
                     v -> builder.dataDestination(transformObject(v, DataAddress.class, context));
-            case TRANSFER_REQUEST_PROPERTIES -> (v) -> transformStringProperties(v, builder::properties, context);
             case TRANSFER_REQUEST_CALLBACK_ADDRESSES -> (v) -> {
                 var addresses = new ArrayList<CallbackAddress>();
                 transformArrayOrObject(v, CallbackAddress.class, addresses::add, context);
@@ -97,24 +95,4 @@ public class JsonObjectToTransferRequestTransformer extends AbstractJsonLdTransf
         consumer.accept(properties);
     }
 
-    @Deprecated(since = "0.2.0")
-    private void transformStringProperties(JsonValue jsonValue, Consumer<Map<String, String>> consumer, TransformerContext context) {
-        JsonObject jsonObject;
-        if (jsonValue instanceof JsonArray) {
-            jsonObject = jsonValue.asJsonArray().getJsonObject(0);
-        } else if (jsonValue instanceof JsonObject) {
-            jsonObject = (JsonObject) jsonValue;
-        } else {
-            context.problem()
-                    .unexpectedType()
-                    .actual(jsonValue.getValueType())
-                    .expected(OBJECT)
-                    .expected(ARRAY)
-                    .report();
-            return;
-        }
-        var properties = new HashMap<String, String>();
-        visitProperties(jsonObject, (k, v) -> properties.put(k, transformString(v, context)));
-        consumer.accept(properties);
-    }
 }

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/validation/TransferRequestValidator.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/validation/TransferRequestValidator.java
@@ -19,19 +19,19 @@ import org.eclipse.edc.api.validation.DataAddressValidator;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.validator.jsonobject.JsonLdPath;
 import org.eclipse.edc.validator.jsonobject.JsonObjectValidator;
-import org.eclipse.edc.validator.jsonobject.validators.MandatoryObject;
+import org.eclipse.edc.validator.jsonobject.validators.LogDeprecatedValue;
 import org.eclipse.edc.validator.jsonobject.validators.MandatoryValue;
 import org.eclipse.edc.validator.jsonobject.validators.OptionalIdNotBlank;
 import org.eclipse.edc.validator.spi.ValidationResult;
 import org.eclipse.edc.validator.spi.Validator;
 
-import static java.lang.String.format;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_ASSET_ID;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_CONNECTOR_ADDRESS;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_CONTRACT_ID;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_COUNTER_PARTY_ADDRESS;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_DATA_DESTINATION;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_PROTOCOL;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_TRANSFER_TYPE;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_TYPE;
 
 public class TransferRequestValidator {
@@ -39,11 +39,12 @@ public class TransferRequestValidator {
     public static Validator<JsonObject> instance(Monitor monitor) {
         return JsonObjectValidator.newValidator()
                 .verifyId(OptionalIdNotBlank::new)
-                .verify(path -> new MandatoryCounterPartyAddressOrConnectorAddress(path, monitor))
+                .verify(MandatoryCounterPartyAddressOrConnectorAddress::new)
+                .verify(TRANSFER_REQUEST_CONNECTOR_ADDRESS, path -> new LogDeprecatedValue(path, TRANSFER_REQUEST_TYPE, TRANSFER_REQUEST_COUNTER_PARTY_ADDRESS, monitor))
                 .verify(TRANSFER_REQUEST_CONTRACT_ID, MandatoryValue::new)
                 .verify(TRANSFER_REQUEST_PROTOCOL, MandatoryValue::new)
                 .verify(TRANSFER_REQUEST_ASSET_ID, MandatoryValue::new)
-                .verify(TRANSFER_REQUEST_DATA_DESTINATION, MandatoryObject::new)
+                .verify(TRANSFER_REQUEST_TRANSFER_TYPE, MandatoryValue::new)
                 .verifyObject(TRANSFER_REQUEST_DATA_DESTINATION, DataAddressValidator::instance)
                 .build();
     }
@@ -51,7 +52,7 @@ public class TransferRequestValidator {
     /**
      * This custom validator can be removed once `connectorAddress` is deleted and exists only for legacy reasons
      */
-    private record MandatoryCounterPartyAddressOrConnectorAddress(JsonLdPath path, Monitor monitor) implements Validator<JsonObject> {
+    private record MandatoryCounterPartyAddressOrConnectorAddress(JsonLdPath path) implements Validator<JsonObject> {
 
         @Override
         public ValidationResult validate(JsonObject input) {
@@ -63,8 +64,6 @@ public class TransferRequestValidator {
             var connectorAddress = new MandatoryValue(path.append(TRANSFER_REQUEST_CONNECTOR_ADDRESS));
             var validateConnectorAddress = connectorAddress.validate(input);
             if (validateConnectorAddress.succeeded()) {
-                monitor.warning(format("The attribute %s has been deprecated in type %s, please use %s",
-                        TRANSFER_REQUEST_CONNECTOR_ADDRESS, TRANSFER_REQUEST_TYPE, TRANSFER_REQUEST_COUNTER_PARTY_ADDRESS));
                 return ValidationResult.success();
             }
             return validateCounterParty;

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/transform/JsonObjectToTransferRequestTransformerTest.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/transform/JsonObjectToTransferRequestTransformerTest.java
@@ -30,7 +30,6 @@ import static org.eclipse.edc.connector.controlplane.transfer.spi.types.Transfer
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_COUNTER_PARTY_ADDRESS;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_DATA_DESTINATION;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_PRIVATE_PROPERTIES;
-import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_PROPERTIES;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_PROTOCOL;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_TRANSFER_TYPE;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_TYPE;
@@ -57,10 +56,8 @@ class JsonObjectToTransferRequestTransformerTest {
     @Test
     void transform() {
         var dataDestinationJson = Json.createObjectBuilder().build();
-        var propertiesJson = Json.createObjectBuilder().add("foo", "bar").build();
         var privatePropertiesJson = Json.createObjectBuilder().add("fooPrivate", "bar").build();
         var dataDestination = DataAddress.Builder.newInstance().type("type").build();
-        var properties = Map.of("foo", "bar");
         var privateProperties = Map.of("fooPrivate", "bar");
 
         when(context.transform(any(), eq(DataAddress.class))).thenReturn(dataDestination);
@@ -71,7 +68,6 @@ class JsonObjectToTransferRequestTransformerTest {
                 .add(TRANSFER_REQUEST_COUNTER_PARTY_ADDRESS, "address")
                 .add(TRANSFER_REQUEST_CONTRACT_ID, "contractId")
                 .add(TRANSFER_REQUEST_DATA_DESTINATION, dataDestinationJson)
-                .add(TRANSFER_REQUEST_PROPERTIES, propertiesJson)
                 .add(TRANSFER_REQUEST_PRIVATE_PROPERTIES, privatePropertiesJson)
                 .add(TRANSFER_REQUEST_TRANSFER_TYPE, "Http-Pull")
                 .add(TRANSFER_REQUEST_PROTOCOL, "protocol")
@@ -85,7 +81,6 @@ class JsonObjectToTransferRequestTransformerTest {
         assertThat(result.getCounterPartyAddress()).isEqualTo("address");
         assertThat(result.getContractId()).isEqualTo("contractId");
         assertThat(result.getDataDestination()).isSameAs(dataDestination);
-        assertThat(result.getProperties()).containsAllEntriesOf(properties);
         assertThat(result.getPrivateProperties()).containsAllEntriesOf(privateProperties);
         assertThat(result.getProtocol()).isEqualTo("protocol");
         assertThat(result.getAssetId()).isEqualTo("assetId");

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/validation/TransferRequestValidatorTest.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/validation/TransferRequestValidatorTest.java
@@ -33,6 +33,7 @@ import static org.eclipse.edc.connector.controlplane.transfer.spi.types.Transfer
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_COUNTER_PARTY_ADDRESS;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_DATA_DESTINATION;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_PROTOCOL;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_TRANSFER_TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
@@ -53,6 +54,7 @@ class TransferRequestValidatorTest {
                 .add(TRANSFER_REQUEST_CONTRACT_ID, value("contract-id"))
                 .add(TRANSFER_REQUEST_PROTOCOL, value("protocol"))
                 .add(TRANSFER_REQUEST_ASSET_ID, value("assetId"))
+                .add(TRANSFER_REQUEST_TRANSFER_TYPE, value("transferType"))
                 .add(TRANSFER_REQUEST_DATA_DESTINATION, createArrayBuilder().add(createObjectBuilder()
                         .add(EDC_DATA_ADDRESS_TYPE_PROPERTY, value("type"))
                 ))
@@ -64,12 +66,29 @@ class TransferRequestValidatorTest {
     }
 
     @Test
+    void shouldSucceed_whenDataDestinationIsMissing() {
+        var input = Json.createObjectBuilder()
+                .add(TRANSFER_REQUEST_COUNTER_PARTY_ADDRESS, value("http://connector-address"))
+                .add(TRANSFER_REQUEST_CONTRACT_ID, value("contract-id"))
+                .add(TRANSFER_REQUEST_PROTOCOL, value("protocol"))
+                .add(TRANSFER_REQUEST_ASSET_ID, value("assetId"))
+                .add(TRANSFER_REQUEST_TRANSFER_TYPE, value("transferType"))
+                .build();
+
+        var result = validator.validate(input);
+
+        assertThat(result).isSucceeded();
+    }
+
+    @Test
+    @Deprecated(since = "0.3.2")
     void shouldSucceed_whenDeprecatedConnectorAddressIsUsed() {
         var input = Json.createObjectBuilder()
                 .add(TRANSFER_REQUEST_CONNECTOR_ADDRESS, value("http://connector-address"))
                 .add(TRANSFER_REQUEST_CONTRACT_ID, value("contract-id"))
                 .add(TRANSFER_REQUEST_PROTOCOL, value("protocol"))
                 .add(TRANSFER_REQUEST_ASSET_ID, value("assetId"))
+                .add(TRANSFER_REQUEST_TRANSFER_TYPE, value("transferType"))
                 .add(TRANSFER_REQUEST_DATA_DESTINATION, createArrayBuilder().add(createObjectBuilder()
                         .add(EDC_DATA_ADDRESS_TYPE_PROPERTY, value("type"))
                 ))
@@ -107,7 +126,7 @@ class TransferRequestValidatorTest {
                 .anySatisfy(violation -> assertThat(violation.path()).isEqualTo(TRANSFER_REQUEST_CONTRACT_ID))
                 .anySatisfy(violation -> assertThat(violation.path()).isEqualTo(TRANSFER_REQUEST_PROTOCOL))
                 .anySatisfy(violation -> assertThat(violation.path()).isEqualTo(TRANSFER_REQUEST_ASSET_ID))
-                .anySatisfy(violation -> assertThat(violation.path()).isEqualTo(TRANSFER_REQUEST_DATA_DESTINATION));
+                .anySatisfy(violation -> assertThat(violation.path()).isEqualTo(TRANSFER_REQUEST_TRANSFER_TYPE));
     }
 
     private JsonArrayBuilder value(String value) {

--- a/extensions/control-plane/transfer/transfer-data-plane-signaling/src/main/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/TransferDataPlaneSignalingExtension.java
+++ b/extensions/control-plane/transfer/transfer-data-plane-signaling/src/main/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/TransferDataPlaneSignalingExtension.java
@@ -18,6 +18,7 @@ import org.eclipse.edc.connector.controlplane.transfer.dataplane.flow.DataPlaneS
 import org.eclipse.edc.connector.controlplane.transfer.spi.callback.ControlApiUrl;
 import org.eclipse.edc.connector.controlplane.transfer.spi.flow.DataFlowManager;
 import org.eclipse.edc.connector.controlplane.transfer.spi.flow.DataFlowPropertiesProvider;
+import org.eclipse.edc.connector.controlplane.transfer.spi.flow.FlowTypeExtractor;
 import org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService;
 import org.eclipse.edc.connector.dataplane.selector.spi.client.DataPlaneClientFactory;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
@@ -40,8 +41,10 @@ public class TransferDataPlaneSignalingExtension implements ServiceExtension {
 
     @Setting(value = "Defines strategy for Data Plane instance selection in case Data Plane is not embedded in current runtime", defaultValue = DEFAULT_DATAPLANE_SELECTOR_STRATEGY)
     private static final String DPF_SELECTOR_STRATEGY = "edc.dataplane.client.selector.strategy";
+
     @Inject
     private DataFlowManager dataFlowManager;
+
     @Inject(required = false)
     private ControlApiUrl callbackUrl;
 
@@ -54,10 +57,15 @@ public class TransferDataPlaneSignalingExtension implements ServiceExtension {
     @Inject(required = false)
     private DataFlowPropertiesProvider propertiesProvider;
 
+    @Inject
+    private FlowTypeExtractor flowTypeExtractor;
+
     @Override
     public void initialize(ServiceExtensionContext context) {
         var selectionStrategy = context.getSetting(DPF_SELECTOR_STRATEGY, DEFAULT_DATAPLANE_SELECTOR_STRATEGY);
-        dataFlowManager.register(new DataPlaneSignalingFlowController(callbackUrl, selectorService, getPropertiesProvider(), clientFactory, selectionStrategy));
+        var controller = new DataPlaneSignalingFlowController(callbackUrl, selectorService, getPropertiesProvider(),
+                clientFactory, selectionStrategy, flowTypeExtractor);
+        dataFlowManager.register(controller);
     }
 
     private DataFlowPropertiesProvider getPropertiesProvider() {

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/flow/FlowTypeExtractor.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/flow/FlowTypeExtractor.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.transfer.spi.flow;
+
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.types.domain.transfer.FlowType;
+
+/**
+ * Extract the {@link FlowType} from the transfer type
+ */
+@FunctionalInterface
+public interface FlowTypeExtractor {
+
+    /**
+     * Return the {@link FlowType} associated to the transfer type.
+     *
+     * @param transferType the transfer type.
+     * @return the {@link FlowType}, failure if the operation failed.
+     */
+    StatusResult<FlowType> extract(String transferType);
+}

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferRequest.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferRequest.java
@@ -34,8 +34,6 @@ public class TransferRequest {
     public static final String TRANSFER_REQUEST_CONTRACT_ID = EDC_NAMESPACE + "contractId";
     public static final String TRANSFER_REQUEST_DATA_DESTINATION = EDC_NAMESPACE + "dataDestination";
     public static final String TRANSFER_REQUEST_TRANSFER_TYPE = EDC_NAMESPACE + "transferType";
-    @Deprecated(since = "0.2.0")
-    public static final String TRANSFER_REQUEST_PROPERTIES = EDC_NAMESPACE + "properties";
     public static final String TRANSFER_REQUEST_PRIVATE_PROPERTIES = EDC_NAMESPACE + "privateProperties";
     public static final String TRANSFER_REQUEST_PROTOCOL = EDC_NAMESPACE + "protocol";
     @Deprecated(since = "0.3.2")
@@ -50,8 +48,6 @@ public class TransferRequest {
     private String assetId;
     private String transferType;
     private DataAddress dataDestination;
-    @Deprecated(since = "0.2.0")
-    private Map<String, String> properties = new HashMap<>();
     private Map<String, Object> privateProperties = new HashMap<>();
     private List<CallbackAddress> callbackAddresses = new ArrayList<>();
 
@@ -69,11 +65,6 @@ public class TransferRequest {
 
     public DataAddress getDataDestination() {
         return dataDestination;
-    }
-
-    @Deprecated(since = "0.2.0")
-    public Map<String, String> getProperties() {
-        return properties;
     }
 
     public Map<String, Object> getPrivateProperties() {
@@ -129,12 +120,6 @@ public class TransferRequest {
 
         public Builder dataDestination(DataAddress dataDestination) {
             request.dataDestination = dataDestination;
-            return this;
-        }
-
-        @Deprecated(since = "0.2.0")
-        public Builder properties(Map<String, String> properties) {
-            request.properties = properties;
             return this;
         }
 

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TransferProcessApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TransferProcessApiEndToEndTest.java
@@ -151,6 +151,7 @@ public class TransferProcessApiEndToEndTest {
                                     .build())
                             .build()
                     )
+                    .add("transferType", "HttpData-PUSH")
                     .add("callbackAddresses", createCallbackAddress())
                     .add("protocol", "dataspace-protocol-http")
                     .add("counterPartyAddress", "http://connector-address")


### PR DESCRIPTION
## What this PR changes/adds

in `TransferRequest`:
- `transferType` becomes mandatory
- `dataDestination` becomes optional (only validated if `FlowType` is PUSH

## Why it does that

`transferType` needs to be used to discriminate which dataplane to choose

## Further notes

- added a `FlowTypeExtractor` service that takes care of extracting the `FlowType` from the `transferType`
- in the `Participant` test class, added a `RequestAsset` inner class that helps defining a request asset operation in a fluent way (instead of having multiple methods with different parameters)
- removed `properties` field in `TransferProcess` that was deprecated in 0.2.0

## Linked Issue(s)

Part of #4031

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
