### PR TITLE
chore: remove logging of entire request on exception

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,7 +1,7 @@
 maven/mavencentral/com.apicatalog/carbon-did/0.3.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.apicatalog/copper-multibase/0.5.0, , restricted, clearlydefined
-maven/mavencentral/com.apicatalog/copper-multicodec/0.1.1, , restricted, clearlydefined
-maven/mavencentral/com.apicatalog/iron-ed25519-cryptosuite-2020/0.14.0, , restricted, clearlydefined
+maven/mavencentral/com.apicatalog/copper-multibase/0.5.0, Apache-2.0, approved, #14501
+maven/mavencentral/com.apicatalog/copper-multicodec/0.1.1, Apache-2.0, approved, #14500
+maven/mavencentral/com.apicatalog/iron-ed25519-cryptosuite-2020/0.14.0, Apache-2.0, approved, #14503
 maven/mavencentral/com.apicatalog/iron-verifiable-credentials/0.14.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.apicatalog/titanium-json-ld/1.0.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.apicatalog/titanium-json-ld/1.4.0, Apache-2.0, approved, #13683
@@ -55,7 +55,7 @@ maven/mavencentral/com.github.stephenc.jcip/jcip-annotations/1.0-1, Apache-2.0, 
 maven/mavencentral/com.google.code.findbugs/jsr305/2.0.1, BSD-3-Clause AND CC-BY-2.5 AND LGPL-2.1+, approved, CQ13390
 maven/mavencentral/com.google.code.findbugs/jsr305/3.0.2, Apache-2.0, approved, #20
 maven/mavencentral/com.google.code.gson/gson/2.10.1, Apache-2.0, approved, #6159
-maven/mavencentral/com.google.crypto.tink/tink/1.13.0, , restricted, clearlydefined
+maven/mavencentral/com.google.crypto.tink/tink/1.13.0, Apache-2.0, approved, #14502
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.11.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.22.0, Apache-2.0, approved, #10661
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.26.1, Apache-2.0, approved, #13657

--- a/core/common/lib/http-lib/src/main/java/org/eclipse/edc/http/client/EdcHttpClientImpl.java
+++ b/core/common/lib/http-lib/src/main/java/org/eclipse/edc/http/client/EdcHttpClientImpl.java
@@ -69,7 +69,7 @@ public class EdcHttpClientImpl implements EdcHttpClient {
         try (var response = execute(request, fallbacks)) {
             return mappingFunction.apply(response);
         } catch (Throwable e) {
-            monitor.severe("HTTP client exception caught for request " + request, e);
+            monitor.severe("HTTP client exception caught for request [%s, %s]".formatted(request.method(), request.url()), e);
             return Result.failure(e.getMessage());
         }
     }


### PR DESCRIPTION
## What this PR changes/adds

Removes the logging of the entire request object when catching the exception


