### PR TITLE
feat(dsp): support implicit Offer policy type

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -122,7 +122,7 @@ maven/mavencentral/io.netty/netty-tcnative-classes/2.0.56.Final, Apache-2.0, app
 maven/mavencentral/io.netty/netty-transport-native-unix-common/4.1.86.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-transport/4.1.86.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations/1.32.0, Apache-2.0, approved, #11684
-maven/mavencentral/io.opentelemetry.proto/opentelemetry-proto/1.2.0-alpha, , restricted, clearlydefined
+maven/mavencentral/io.opentelemetry.proto/opentelemetry-proto/1.2.0-alpha, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.opentelemetry/opentelemetry-api/1.32.0, Apache-2.0, approved, #11682
 maven/mavencentral/io.opentelemetry/opentelemetry-context/1.32.0, Apache-2.0, approved, #11683
 maven/mavencentral/io.prometheus/simpleclient/0.16.0, Apache-2.0, approved, clearlydefined

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/odrl/to/JsonObjectToPolicyTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/odrl/to/JsonObjectToPolicyTransformerTest.java
@@ -21,6 +21,7 @@ import jakarta.json.JsonValue;
 import org.eclipse.edc.connector.controlplane.transform.TestInput;
 import org.eclipse.edc.policy.model.Duty;
 import org.eclipse.edc.policy.model.Permission;
+import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.policy.model.PolicyType;
 import org.eclipse.edc.policy.model.Prohibition;
 import org.eclipse.edc.spi.agent.ParticipantIdMapper;
@@ -85,7 +86,6 @@ class JsonObjectToPolicyTransformerTest {
 
     @Test
     void transform_withAllRuleTypesAsObjects_returnPolicy() {
-        var jsonFactory = Json.createBuilderFactory(Map.of());
         var permissionJson = jsonFactory.createObjectBuilder().add(TYPE, "permission").build();
         var prohibitionJson = jsonFactory.createObjectBuilder().add(TYPE, "prohibition").build();
         var dutyJson = jsonFactory.createObjectBuilder().add(TYPE, "duty").build();
@@ -169,6 +169,20 @@ class JsonObjectToPolicyTransformerTest {
 
         assertThat(result).isNull();
         verify(context).reportProblem(anyString());
+    }
+
+    @Test
+    void shouldGetTypeFromContext_whenSet() {
+        when(context.consumeData(Policy.class, TYPE)).thenReturn(CONTRACT);
+
+        var policy = jsonFactory.createObjectBuilder()
+                .add(ODRL_TARGET_ATTRIBUTE, TARGET)
+                .build();
+
+        var result = transformer.transform(TestInput.getExpanded(policy), context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getType()).isEqualTo(CONTRACT);
     }
 
     private static class PolicyTypeArguments implements ArgumentsProvider {

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractOfferMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractOfferMessageTransformer.java
@@ -19,11 +19,13 @@ import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.Con
 import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
 import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.policy.model.PolicyType;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_OFFER_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS;
@@ -66,6 +68,7 @@ public class JsonObjectToContractOfferMessageTransformer extends AbstractJsonLdT
 
         var contractOffer = returnJsonObject(jsonObject.get(DSPACE_PROPERTY_OFFER), context, DSPACE_PROPERTY_OFFER, false);
         if (contractOffer != null) {
+            context.setData(Policy.class, TYPE, PolicyType.OFFER);
             var policy = transformObject(contractOffer, Policy.class, context);
             if (policy == null) {
                 reportMissingProperty(DSPACE_TYPE_CONTRACT_OFFER_MESSAGE, DSPACE_PROPERTY_OFFER, context);

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractOfferMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractOfferMessageTransformerTest.java
@@ -19,6 +19,7 @@ import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
 import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.policy.model.PolicyType;
 import org.eclipse.edc.transform.spi.ProblemBuilder;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,6 +29,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_OFFER_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS;
@@ -53,11 +55,10 @@ class JsonObjectToContractOfferMessageTransformerTest {
     private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
     private final TransformerContext context = mock();
 
-    private JsonObjectToContractOfferMessageTransformer transformer;
+    private final JsonObjectToContractOfferMessageTransformer transformer = new JsonObjectToContractOfferMessageTransformer();
 
     @BeforeEach
     void setUp() {
-        transformer = new JsonObjectToContractOfferMessageTransformer();
         when(context.problem()).thenReturn(new ProblemBuilder(context));
     }
 
@@ -92,6 +93,7 @@ class JsonObjectToContractOfferMessageTransformerTest {
         assertThat(contractOffer.getAssetId()).isEqualTo(ASSET_ID);
 
         verify(context, never()).reportProblem(anyString());
+        verify(context).setData(Policy.class, TYPE, PolicyType.OFFER);
     }
 
     @Deprecated(since = "0.4.1")


### PR DESCRIPTION
## What this PR changes/adds

Set "Offer" as implicit policy type on `JsonObjectToContractOfferMessageTransformer`

## Why it does that

because it's not mandatory in the `dspace:offer` type

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #4118

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
