### PR TITLE
fix: correct DataService json-ld attributes

### DIFF
--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/DspCatalogApiExtension.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/DspCatalogApiExtension.java
@@ -82,7 +82,7 @@ public class DspCatalogApiExtension implements ServiceExtension {
         webService.registerResource(apiConfiguration.getContextAlias(), new DspCatalogApiController20241(service, dspRequestHandler, catalogPaginationResponseDecoratorFactory));
 
         dataServiceRegistry.register(DataService.Builder.newInstance()
-                .terms("connector")
+                .endpointDescription("dspace:connector")
                 .endpointUrl(apiConfiguration.getDspCallbackAddress())
                 .build());
 

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/main/java/org/eclipse/edc/protocol/dsp/catalog/transform/from/JsonObjectFromDataServiceTransformer.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/main/java/org/eclipse/edc/protocol/dsp/catalog/transform/from/JsonObjectFromDataServiceTransformer.java
@@ -25,6 +25,8 @@ import org.jetbrains.annotations.Nullable;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DATA_SERVICE_TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_ENDPOINT_DESCRIPTION_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_ENDPOINT_URL_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCT_ENDPOINT_URL_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCT_TERMS_ATTRIBUTE;
 
@@ -42,17 +44,16 @@ public class JsonObjectFromDataServiceTransformer extends AbstractJsonLdTransfor
 
     @Override
     public @Nullable JsonObject transform(@NotNull DataService dataService, @NotNull TransformerContext context) {
-        var objectBuilder = jsonFactory.createObjectBuilder();
-        objectBuilder.add(ID, dataService.getId());
-        objectBuilder.add(TYPE, DCAT_DATA_SERVICE_TYPE);
+        var objectBuilder = jsonFactory.createObjectBuilder()
+                .add(ID, dataService.getId())
+                .add(TYPE, DCAT_DATA_SERVICE_TYPE);
 
-        if (dataService.getTerms() != null) {
-            objectBuilder.add(DCT_TERMS_ATTRIBUTE, dataService.getTerms());
-        }
+        addIfNotNull(dataService.getEndpointDescription(), DCAT_ENDPOINT_DESCRIPTION_ATTRIBUTE, objectBuilder);
+        addIfNotNull(dataService.getEndpointUrl(), DCAT_ENDPOINT_URL_ATTRIBUTE, objectBuilder);
 
-        if (dataService.getEndpointUrl() != null) {
-            objectBuilder.add(DCT_ENDPOINT_URL_ATTRIBUTE, dataService.getEndpointUrl());
-        }
+        // deprecated attributes, to be removed
+        addIfNotNull(dataService.getEndpointDescription(), DCT_TERMS_ATTRIBUTE, objectBuilder);
+        addIfNotNull(dataService.getEndpointUrl(), DCT_ENDPOINT_URL_ATTRIBUTE, objectBuilder);
 
         return objectBuilder.build();
     }

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/test/java/org/eclipse/edc/protocol/dsp/catalog/transform/from/JsonObjectFromDataServiceTransformerTest.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/test/java/org/eclipse/edc/protocol/dsp/catalog/transform/from/JsonObjectFromDataServiceTransformerTest.java
@@ -27,14 +27,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DATA_SERVICE_TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_ENDPOINT_DESCRIPTION_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_ENDPOINT_URL_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCT_ENDPOINT_URL_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCT_TERMS_ATTRIBUTE;
 import static org.mockito.Mockito.mock;
 
 class JsonObjectFromDataServiceTransformerTest {
 
-    private JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
-    private TransformerContext context = mock(TransformerContext.class);
+    private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
+    private final TransformerContext context = mock();
 
     private JsonObjectFromDataServiceTransformer transformer;
 
@@ -47,15 +49,34 @@ class JsonObjectFromDataServiceTransformerTest {
     void transform_returnJsonObject() {
         var dataService = DataService.Builder.newInstance()
                 .id("dataServiceId")
-                .terms("terms")
+                .endpointDescription("description")
                 .endpointUrl("url")
                 .build();
+
         var result = transformer.transform(dataService, context);
 
         assertThat(result).isNotNull();
         assertThat(result.getJsonString(ID).getString()).isEqualTo(dataService.getId());
         assertThat(result.getJsonString(TYPE).getString()).isEqualTo(DCAT_DATA_SERVICE_TYPE);
-        assertThat(result.getJsonString(DCT_TERMS_ATTRIBUTE).getString()).isEqualTo(dataService.getTerms());
-        assertThat(result.getJsonString(DCT_ENDPOINT_URL_ATTRIBUTE).getString()).isEqualTo(dataService.getEndpointUrl());
+        assertThat(result.getJsonString(DCAT_ENDPOINT_DESCRIPTION_ATTRIBUTE).getString()).isEqualTo("description");
+        assertThat(result.getJsonString(DCAT_ENDPOINT_URL_ATTRIBUTE).getString()).isEqualTo("url");
+    }
+
+    @Deprecated
+    @Test
+    void deprecated_attributes() {
+        var dataService = DataService.Builder.newInstance()
+                .id("dataServiceId")
+                .endpointDescription("description")
+                .endpointUrl("url")
+                .build();
+
+        var result = transformer.transform(dataService, context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getJsonString(ID).getString()).isEqualTo(dataService.getId());
+        assertThat(result.getJsonString(TYPE).getString()).isEqualTo(DCAT_DATA_SERVICE_TYPE);
+        assertThat(result.getJsonString(DCT_TERMS_ATTRIBUTE).getString()).isEqualTo("description");
+        assertThat(result.getJsonString(DCT_ENDPOINT_URL_ATTRIBUTE).getString()).isEqualTo("url");
     }
 }

--- a/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/PropertyAndTypeNames.java
+++ b/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/PropertyAndTypeNames.java
@@ -33,6 +33,8 @@ public interface PropertyAndTypeNames {
     String DCAT_DATASET_ATTRIBUTE = DCAT_SCHEMA + "dataset";
     String DCAT_DISTRIBUTION_ATTRIBUTE = DCAT_SCHEMA + "distribution";
     String DCAT_ACCESS_SERVICE_ATTRIBUTE = DCAT_SCHEMA + "accessService";
+    String DCAT_ENDPOINT_URL_ATTRIBUTE = DCAT_SCHEMA + "endpointUrl";
+    String DCAT_ENDPOINT_DESCRIPTION_ATTRIBUTE = DCAT_SCHEMA + "endpointDescription";
 
     //EDC
     String EDC_CREATED_AT = EDC_NAMESPACE + "createdAt";
@@ -41,7 +43,9 @@ public interface PropertyAndTypeNames {
     @Deprecated(since = "0.5.1")
     String DEPRECATED_DCT_FORMAT_ATTRIBUTE = "https://purl.org/dc/terms/format";
     String DCT_FORMAT_ATTRIBUTE = DCT_SCHEMA + "format";
+    @Deprecated(since = "0.6.2")
     String DCT_TERMS_ATTRIBUTE = DCT_SCHEMA + "terms";
+    @Deprecated(since = "0.6.2")
     String DCT_ENDPOINT_URL_ATTRIBUTE = DCT_SCHEMA + "endpointUrl";
 
     String ODRL_POLICY_ATTRIBUTE = ODRL_SCHEMA + "hasPolicy";

--- a/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/DataService.java
+++ b/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/DataService.java
@@ -46,7 +46,7 @@ public class DataService {
         return id;
     }
 
-    public String getTerms() {
+    public String getEndpointDescription() {
         return terms;
     }
 
@@ -69,7 +69,7 @@ public class DataService {
         }
 
         var dataService = (DataService) o;
-        return id.equals(dataService.getId()) && terms.equals(dataService.getTerms()) && endpointUrl.equals(dataService.getEndpointUrl());
+        return id.equals(dataService.getId()) && terms.equals(dataService.getEndpointDescription()) && endpointUrl.equals(dataService.getEndpointUrl());
     }
 
     @JsonPOJOBuilder(withPrefix = "")
@@ -90,7 +90,7 @@ public class DataService {
             return this;
         }
 
-        public Builder terms(String terms) {
+        public Builder endpointDescription(String terms) {
             dataService.terms = terms;
             return this;
         }


### PR DESCRIPTION
## What this PR changes/adds

replace `dct:endpointUrl` and `dct:forms` with `dcat:endpointUrl` and `dcat:endpointDescription`

## Why it does that

stick to the specs

## Further notes

- the erratic attributes have been maintained to avoid breaking changes, they will be removed in the future

## Linked Issue(s)

Closes #4145

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
