### PR TITLE
feat: add supportedType method on source and sink factories

### DIFF
--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/pipeline/PipelineServiceImpl.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/pipeline/PipelineServiceImpl.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import static java.lang.String.format;
@@ -141,12 +142,18 @@ public class PipelineServiceImpl implements PipelineService {
 
     @Nullable
     private DataSourceFactory getSourceFactory(DataFlowStartMessage request) {
-        return sourceFactories.stream().filter(s -> s.canHandle(request)).findFirst().orElse(null);
+        return sourceFactories.stream()
+                .filter(s -> Objects.equals(s.supportedType(), request.getSourceDataAddress().getType()))
+                .findFirst()
+                .orElse(null);
     }
 
     @Nullable
     private DataSinkFactory getSinkFactory(DataFlowStartMessage request) {
-        return sinkFactories.stream().filter(s -> s.canHandle(request)).findFirst().orElse(null);
+        return sinkFactories.stream()
+                .filter(s -> Objects.equals(s.supportedType(), request.getDestinationDataAddress().getType()))
+                .findFirst()
+                .orElse(null);
     }
 
     @NotNull

--- a/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/pipeline/PipelineServiceIntegrationTest.java
+++ b/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/pipeline/PipelineServiceIntegrationTest.java
@@ -90,6 +90,11 @@ public class PipelineServiceIntegrationTest {
         }
 
         @Override
+        public String supportedType() {
+            return "any";
+        }
+
+        @Override
         public boolean canHandle(DataFlowStartMessage request) {
             return true;
         }
@@ -114,6 +119,11 @@ public class PipelineServiceIntegrationTest {
 
         InputStreamDataFactory() {
             this("bytes");
+        }
+
+        @Override
+        public String supportedType() {
+            return "any";
         }
 
         @Override

--- a/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSinkFactory.java
+++ b/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSinkFactory.java
@@ -55,6 +55,11 @@ public class HttpDataSinkFactory implements DataSinkFactory {
     }
 
     @Override
+    public String supportedType() {
+        return HTTP_DATA_TYPE;
+    }
+
+    @Override
     public boolean canHandle(DataFlowStartMessage request) {
         return HTTP_DATA_TYPE.equals(request.getDestinationDataAddress().getType());
     }

--- a/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSourceFactory.java
+++ b/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSourceFactory.java
@@ -47,6 +47,11 @@ public class HttpDataSourceFactory implements DataSourceFactory {
     }
 
     @Override
+    public String supportedType() {
+        return HTTP_DATA_TYPE;
+    }
+
+    @Override
     public boolean canHandle(DataFlowStartMessage request) {
         return HTTP_DATA_TYPE.equals(request.getSourceDataAddress().getType());
     }

--- a/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSinkFactoryTest.java
+++ b/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSinkFactoryTest.java
@@ -65,11 +65,13 @@ class HttpDataSinkFactoryTest {
         factory = new HttpDataSinkFactory(httpClient, executorService, 5, monitor, provider, requestFactory);
     }
 
+    @Deprecated(since = "0.6.2")
     @Test
     void verifyCanHandle() {
         assertThat(factory.canHandle(TestFunctions.createRequest(HTTP_DATA_TYPE).build())).isTrue();
     }
 
+    @Deprecated(since = "0.6.2")
     @Test
     void verifyCannotHandle() {
         assertThat(factory.canHandle(TestFunctions.createRequest("dummy").build())).isFalse();

--- a/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSourceFactoryTest.java
+++ b/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSourceFactoryTest.java
@@ -51,11 +51,13 @@ class HttpDataSourceFactoryTest {
         factory = new HttpDataSourceFactory(httpClient, provider, monitor, requestFactory);
     }
 
+    @Deprecated(since = "0.6.2")
     @Test
     void verifyCanHandle() {
         assertThat(factory.canHandle(TestFunctions.createRequest(HTTP_DATA_TYPE).build())).isTrue();
     }
 
+    @Deprecated(since = "0.6.2")
     @Test
     void verifyCannotHandle() {
         assertThat(factory.canHandle(TestFunctions.createRequest("dummy").build())).isFalse();

--- a/extensions/data-plane/data-plane-kafka/src/main/java/org/eclipse/edc/connector/dataplane/kafka/pipeline/KafkaDataSinkFactory.java
+++ b/extensions/data-plane/data-plane-kafka/src/main/java/org/eclipse/edc/connector/dataplane/kafka/pipeline/KafkaDataSinkFactory.java
@@ -49,6 +49,11 @@ public class KafkaDataSinkFactory implements DataSinkFactory {
     }
 
     @Override
+    public String supportedType() {
+        return KAFKA_TYPE;
+    }
+
+    @Override
     public boolean canHandle(DataFlowStartMessage dataRequest) {
         return KAFKA_TYPE.equalsIgnoreCase(dataRequest.getDestinationDataAddress().getType());
     }

--- a/extensions/data-plane/data-plane-kafka/src/main/java/org/eclipse/edc/connector/dataplane/kafka/pipeline/KafkaDataSourceFactory.java
+++ b/extensions/data-plane/data-plane-kafka/src/main/java/org/eclipse/edc/connector/dataplane/kafka/pipeline/KafkaDataSourceFactory.java
@@ -55,6 +55,11 @@ public class KafkaDataSourceFactory implements DataSourceFactory {
     }
 
     @Override
+    public String supportedType() {
+        return KAFKA_TYPE;
+    }
+
+    @Override
     public boolean canHandle(DataFlowStartMessage dataRequest) {
         return KAFKA_TYPE.equalsIgnoreCase(dataRequest.getSourceDataAddress().getType());
     }

--- a/extensions/data-plane/data-plane-kafka/src/test/java/org/eclipse/edc/connector/dataplane/kafka/pipeline/KafkaDataSinkFactoryTest.java
+++ b/extensions/data-plane/data-plane-kafka/src/test/java/org/eclipse/edc/connector/dataplane/kafka/pipeline/KafkaDataSinkFactoryTest.java
@@ -47,6 +47,7 @@ class KafkaDataSinkFactoryTest {
         factory = new KafkaDataSinkFactory(mock(ExecutorService.class), mock(Monitor.class), propertiesFactory, 1);
     }
 
+    @Deprecated(since = "0.6.2")
     @Test
     void verifyCanHandle() {
         assertThat(factory.canHandle(createRequest("kafka", emptyMap()))).isTrue();

--- a/extensions/data-plane/data-plane-kafka/src/test/java/org/eclipse/edc/connector/dataplane/kafka/pipeline/KafkaDataSourceFactoryTest.java
+++ b/extensions/data-plane/data-plane-kafka/src/test/java/org/eclipse/edc/connector/dataplane/kafka/pipeline/KafkaDataSourceFactoryTest.java
@@ -47,6 +47,7 @@ class KafkaDataSourceFactoryTest {
         factory = new KafkaDataSourceFactory(mock(Monitor.class), propertiesFactory, mock(Clock.class));
     }
 
+    @Deprecated(since = "0.6.2")
     @Test
     void verifyCanHandle() {
         assertThat(factory.canHandle(createRequest("kafka", emptyMap()))).isTrue();

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/pipeline/DataSinkFactory.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/pipeline/DataSinkFactory.java
@@ -24,9 +24,21 @@ import org.jetbrains.annotations.NotNull;
 public interface DataSinkFactory {
 
     /**
-     * Returns true if this factory can create a {@link DataSink} for the request.
+     * Return the supported DataAddress type.
+     *
+     * @return supported DataAddress type.
      */
-    boolean canHandle(DataFlowStartMessage request);
+    String supportedType();
+
+    /**
+     * Returns true if this factory can create a {@link DataSink} for the request.
+     *
+     * @deprecated please use {@link #supportedType()} instead.
+     */
+    @Deprecated(since = "0.6.2")
+    default boolean canHandle(DataFlowStartMessage request) {
+        return false;
+    }
 
     /**
      * Creates a sink to send data to.

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/pipeline/DataSourceFactory.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/pipeline/DataSourceFactory.java
@@ -24,9 +24,21 @@ import org.jetbrains.annotations.NotNull;
 public interface DataSourceFactory {
 
     /**
-     * Returns true if this factory can create a {@link DataSource} for the request.
+     * Return the supported DataAddress type.
+     *
+     * @return supported DataAddress type.
      */
-    boolean canHandle(DataFlowStartMessage request);
+    String supportedType();
+
+    /**
+     * Returns true if this factory can create a {@link DataSource} for the request.
+     *
+     * @deprecated please use {@link #supportedType()} instead.
+     */
+    @Deprecated(since = "0.6.2")
+    default boolean canHandle(DataFlowStartMessage request) {
+        return false;
+    }
 
     /**
      * Creates a source to access data to be sent.


### PR DESCRIPTION
## What this PR changes/adds

Add `supportedType` on `DataSourceFactory` and `DataSinkFactory`

## Why it does that

permit the dataplane to tell which sources/sinks it can handle

## Further notes

- deprecated the now unused `canHandle`

## Linked Issue(s)

Closes #4150

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
