### PR TITLE
chore: removes OAuth2 capabilities from the data sink

### DIFF
--- a/extensions/data-plane/data-plane-http-oauth2-core/src/main/java/org/eclipse/edc/connector/dataplane/http/oauth2/DataPlaneHttpOauth2Extension.java
+++ b/extensions/data-plane/data-plane-http-oauth2-core/src/main/java/org/eclipse/edc/connector/dataplane/http/oauth2/DataPlaneHttpOauth2Extension.java
@@ -58,7 +58,6 @@ public class DataPlaneHttpOauth2Extension implements ServiceExtension {
         var requestFactory = new Oauth2CredentialsRequestFactory(privateKeyResolver, clock, vault, context.getMonitor());
         var oauth2ParamsDecorator = new Oauth2HttpRequestParamsDecorator(requestFactory, oauth2Client);
 
-        paramsProvider.registerSinkDecorator(oauth2ParamsDecorator);
         paramsProvider.registerSourceDecorator(oauth2ParamsDecorator);
     }
 

--- a/extensions/data-plane/data-plane-http-oauth2-core/src/test/java/org/eclipse/edc/connector/dataplane/http/oauth2/DataPlaneHttpOauth2ExtensionTest.java
+++ b/extensions/data-plane/data-plane-http-oauth2-core/src/test/java/org/eclipse/edc/connector/dataplane/http/oauth2/DataPlaneHttpOauth2ExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2023 Amadeus
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Amadeus - initial API and implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
  *
  */
 
@@ -35,7 +35,7 @@ class DataPlaneHttpOauth2ExtensionTest {
     void setUp(ServiceExtensionContext context) {
         context.registerService(HttpRequestParamsProvider.class, paramsProvider);
     }
-    
+
     @Test
     void verifyRegisterKafkaSource(DataPlaneHttpOauth2Extension extension, ServiceExtensionContext context) {
         extension.initialize(context);

--- a/extensions/data-plane/data-plane-http-oauth2-core/src/test/java/org/eclipse/edc/connector/dataplane/http/oauth2/DataPlaneHttpOauth2ExtensionTest.java
+++ b/extensions/data-plane/data-plane-http-oauth2-core/src/test/java/org/eclipse/edc/connector/dataplane/http/oauth2/DataPlaneHttpOauth2ExtensionTest.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2023 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.http.oauth2;
+
+import org.eclipse.edc.connector.dataplane.http.spi.HttpRequestParamsProvider;
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(DependencyInjectionExtension.class)
+class DataPlaneHttpOauth2ExtensionTest {
+
+    private final HttpRequestParamsProvider paramsProvider = mock();
+
+    @BeforeEach
+    void setUp(ServiceExtensionContext context) {
+        context.registerService(HttpRequestParamsProvider.class, paramsProvider);
+    }
+    
+    @Test
+    void verifyRegisterKafkaSource(DataPlaneHttpOauth2Extension extension, ServiceExtensionContext context) {
+        extension.initialize(context);
+
+        verify(paramsProvider).registerSourceDecorator(isA(Oauth2HttpRequestParamsDecorator.class));
+        verify(paramsProvider, never()).registerSinkDecorator(isA(Oauth2HttpRequestParamsDecorator.class));
+    }
+
+}


### PR DESCRIPTION
## What this PR changes/adds

removes OAuth2 capabilities from the data sink

