### PR TITLE
fix: remove unused parentPermission field that caused stack overflow exceptions

### DIFF
--- a/core/common/lib/policy-engine-lib/src/main/java/org/eclipse/edc/policy/engine/ScopeFilter.java
+++ b/core/common/lib/policy-engine-lib/src/main/java/org/eclipse/edc/policy/engine/ScopeFilter.java
@@ -97,7 +97,6 @@ public class ScopeFilter {
         return Duty.Builder.newInstance()
                 .action(duty.getAction())
                 .constraints(filteredConstraints)
-                .parentPermission(duty.getParentPermission())
                 .consequences(filteredConsequences)
                 .build();
     }

--- a/spi/common/policy-model/src/main/java/org/eclipse/edc/policy/model/Duty.java
+++ b/spi/common/policy-model/src/main/java/org/eclipse/edc/policy/model/Duty.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,23 +32,10 @@ import static java.util.stream.Collectors.joining;
 @JsonTypeName("dataspaceconnector:duty")
 public class Duty extends Rule {
 
-    private Permission parentPermission;
     private final List<Duty> consequences = new ArrayList<>();
-
-    /**
-     * If this duty is part of a permission, returns the parent permission; otherwise returns null.
-     */
-    @Nullable
-    public Permission getParentPermission() {
-        return parentPermission;
-    }
 
     public List<Duty> getConsequences() {
         return consequences;
-    }
-
-    void setParentPermission(Permission permission) {
-        parentPermission = permission;
     }
 
     @Override
@@ -72,11 +58,6 @@ public class Duty extends Rule {
         @JsonCreator
         public static Builder newInstance() {
             return new Builder();
-        }
-
-        public Builder parentPermission(Permission parentPermission) {
-            rule.parentPermission = parentPermission;
-            return this;
         }
 
         public Builder consequence(Duty consequence) {

--- a/spi/common/policy-model/src/main/java/org/eclipse/edc/policy/model/Permission.java
+++ b/spi/common/policy-model/src/main/java/org/eclipse/edc/policy/model/Permission.java
@@ -60,15 +60,11 @@ public class Permission extends Rule {
         }
 
         public Builder duty(Duty duty) {
-            duty.setParentPermission(rule);
             rule.duties.add(duty);
             return this;
         }
 
         public Builder duties(List<Duty> duties) {
-            for (var duty : duties) {
-                duty.setParentPermission(rule);
-            }
             rule.duties.addAll(duties);
             return this;
         }


### PR DESCRIPTION
## What this PR changes/adds

Remove unneeded `parentPermission` from `Duty` that caused `StackOverflowException` in json serialization.

## Why it does that

cleanup

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #3830 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
