### PR TITLE
feat: define runtime id as a configurable setting

### DIFF
--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/BootServicesExtension.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/BootServicesExtension.java
@@ -51,6 +51,9 @@ public class BootServicesExtension implements ServiceExtension {
     @Setting(value = "Configures the participant id this runtime is operating on behalf of")
     public static final String PARTICIPANT_ID = "edc.participant.id";
 
+    @Setting(value = "Configures the runtime id", defaultValue = "<random UUID>")
+    public static final String RUNTIME_ID = "edc.runtime.id";
+
     private static final long DEFAULT_DURATION = 60;
     private static final int DEFAULT_TP_SIZE = 3;
 

--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/DefaultServiceExtensionContext.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/DefaultServiceExtensionContext.java
@@ -118,15 +118,22 @@ public class DefaultServiceExtensionContext implements ServiceExtensionContext {
             getMonitor().warning("The runtime is configured as an anonymous participant. DO NOT DO THIS IN PRODUCTION.");
         }
 
-        runtimeId = getSetting(RUNTIME_ID, null);
-        if (runtimeId == null) {
-            getMonitor().warning("Runtime id is not configured so a random UUID is used. It is recommended to provide a static one.");
-            runtimeId = UUID.randomUUID().toString();
-        }
-
-        if (getSetting(EDC_CONNECTOR_NAME, null) != null) {
+        var connectorName = getSetting(EDC_CONNECTOR_NAME, null);
+        if (connectorName != null) {
             getMonitor().warning("Setting %s has been deprecated, please use %s instead".formatted(EDC_CONNECTOR_NAME, RUNTIME_ID));
         }
+
+        runtimeId = getSetting(RUNTIME_ID, null);
+        if (runtimeId == null) {
+            if (connectorName == null) {
+                getMonitor().warning("%s is not configured so a random UUID is used. It is recommended to provide a static one.".formatted(RUNTIME_ID));
+                runtimeId = UUID.randomUUID().toString();
+            } else {
+                getMonitor().warning("%s is not configured and it will fallback to the deprecated %s value".formatted(RUNTIME_ID, EDC_CONNECTOR_NAME));
+                runtimeId = connectorName;
+            }
+        }
+
     }
 
     // this method exists so that getting env vars can be mocked during testing

--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/runtime/BaseRuntime.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/runtime/BaseRuntime.java
@@ -123,14 +123,6 @@ public class BaseRuntime {
     }
 
     /**
-     * The name of this runtime. This string is solely used for cosmetic/display/logging purposes.
-     * By default, {@link ServiceExtensionContext#getConnectorId()} is used.
-     */
-    protected String getRuntimeName(ServiceExtensionContext context) {
-        return context.getConnectorId();
-    }
-
-    /**
      * Callback for any error that happened during runtime initialization
      */
     protected void onError(Exception e) {
@@ -189,7 +181,6 @@ public class BaseRuntime {
         monitor = createMonitor();
         var context = createServiceExtensionContext();
 
-        var name = getRuntimeName(context);
         try {
             var newExtensions = createExtensions(context);
             bootExtensions(context, newExtensions);
@@ -213,7 +204,7 @@ public class BaseRuntime {
             onError(e);
         }
 
-        monitor.info(format("%s ready", name));
+        monitor.info(format("Runtime %s ready", context.getRuntimeId()));
     }
 
 }

--- a/core/common/boot/src/test/java/org/eclipse/edc/boot/system/DefaultServiceExtensionContextTest.java
+++ b/core/common/boot/src/test/java/org/eclipse/edc/boot/system/DefaultServiceExtensionContextTest.java
@@ -190,7 +190,7 @@ class DefaultServiceExtensionContextTest {
             var runtimeId = context.getRuntimeId();
 
             assertThat(UUID.fromString(runtimeId)).isNotNull();
-            verify(monitor).warning(and(isA(String.class), argThat(message -> message.startsWith("Runtime id"))));
+            verify(monitor).warning(and(isA(String.class), argThat(message -> message.startsWith(RUNTIME_ID))));
         }
 
         @Test

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceExtension.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceExtension.java
@@ -173,7 +173,7 @@ public class Oauth2ServiceExtension implements ServiceExtension {
     }
 
     private Oauth2ServiceConfiguration createConfig(ServiceExtensionContext context) {
-        var providerAudience = context.getSetting(PROVIDER_AUDIENCE, context.getConnectorId());
+        var providerAudience = context.getSetting(PROVIDER_AUDIENCE, context.getRuntimeId());
         var endpointAudience = context.getSetting(ENDPOINT_AUDIENCE, providerAudience);
         var tokenUrl = context.getConfig().getString(TOKEN_URL);
         var publicCertificateAlias = context.getConfig().getString(PUBLIC_CERTIFICATE_ALIAS);

--- a/extensions/common/transaction/transaction-atomikos/src/main/java/org/eclipse/edc/transaction/atomikos/AtomikosTransactionExtension.java
+++ b/extensions/common/transaction/transaction-atomikos/src/main/java/org/eclipse/edc/transaction/atomikos/AtomikosTransactionExtension.java
@@ -19,7 +19,6 @@ import org.eclipse.edc.runtime.metamodel.annotation.Provides;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
-import org.eclipse.edc.spi.system.configuration.Config;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 import org.jetbrains.annotations.NotNull;
@@ -122,8 +121,8 @@ public class AtomikosTransactionExtension implements ServiceExtension {
     private TransactionManagerConfiguration getTransactionManagerConfiguration(ServiceExtensionContext context) {
         var builder = TransactionManagerConfiguration.Builder.newInstance();
 
-        Config config = context.getConfig();
-        var name = context.getConnectorId().replace(":", "_");
+        var config = context.getConfig();
+        var name = context.getRuntimeId().replace(":", "_");
         builder.name(name);
 
         setIfProvidedInt(CHECKPOINT_INTERVAL, builder::checkPointInterval, config);

--- a/extensions/common/transaction/transaction-atomikos/src/test/java/org/eclipse/edc/transaction/atomikos/AtomikosTransactionExtensionTest.java
+++ b/extensions/common/transaction/transaction-atomikos/src/test/java/org/eclipse/edc/transaction/atomikos/AtomikosTransactionExtensionTest.java
@@ -45,7 +45,7 @@ class AtomikosTransactionExtensionTest {
     @Test
     void verifyEndToEndTransactions() {
         var extensionContext = mock(ServiceExtensionContext.class);
-        when(extensionContext.getConnectorId()).thenReturn(randomUUID().toString());
+        when(extensionContext.getRuntimeId()).thenReturn(randomUUID().toString());
         when(extensionContext.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of(AtomikosTransactionExtension.LOGGING, "false")));
 
         when(extensionContext.getConfig(isA(String.class))).thenAnswer(a -> JdbcTestFixtures.createDataSourceConfig());

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/SqlContractNegotiationStoreExtension.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/SqlContractNegotiationStoreExtension.java
@@ -57,7 +57,7 @@ public class SqlContractNegotiationStoreExtension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
         var sqlStore = new SqlContractNegotiationStore(dataSourceRegistry, getDataSourceName(context), trxContext,
-                typeManager.getMapper(), getStatementImpl(), context.getConnectorId(), clock, queryExecutor);
+                typeManager.getMapper(), getStatementImpl(), context.getRuntimeId(), clock, queryExecutor);
         context.registerService(ContractNegotiationStore.class, sqlStore);
     }
 

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/transferprocess/SqlTransferProcessStoreExtension.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/transferprocess/SqlTransferProcessStoreExtension.java
@@ -57,7 +57,7 @@ public class SqlTransferProcessStoreExtension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
         var store = new SqlTransferProcessStore(dataSourceRegistry, getDataSourceName(context), trxContext,
-                typeManager.getMapper(), getStatementImpl(), context.getConnectorId(), clock, queryExecutor);
+                typeManager.getMapper(), getStatementImpl(), context.getRuntimeId(), clock, queryExecutor);
         context.registerService(TransferProcessStore.class, store);
     }
 

--- a/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/SqlDataPlaneStoreExtension.java
+++ b/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/SqlDataPlaneStoreExtension.java
@@ -67,7 +67,7 @@ public class SqlDataPlaneStoreExtension implements ServiceExtension {
     @Provider
     public DataPlaneStore dataPlaneStore(ServiceExtensionContext context) {
         return new SqlDataPlaneStore(dataSourceRegistry, getDataSourceName(context), transactionContext,
-                getStatementImpl(), typeManager.getMapper(), clock, queryExecutor, context.getConnectorId());
+                getStatementImpl(), typeManager.getMapper(), clock, queryExecutor, context.getRuntimeId());
     }
 
     /**

--- a/extensions/policy-monitor/store/sql/policy-monitor-store-sql/src/main/java/org/eclipse/edc/connector/policy/monitor/store/sql/SqlPolicyMonitorStoreExtension.java
+++ b/extensions/policy-monitor/store/sql/policy-monitor-store-sql/src/main/java/org/eclipse/edc/connector/policy/monitor/store/sql/SqlPolicyMonitorStoreExtension.java
@@ -58,7 +58,7 @@ public class SqlPolicyMonitorStoreExtension implements ServiceExtension {
     public PolicyMonitorStore policyMonitorStore(ServiceExtensionContext context) {
         var dataSourceName = context.getConfig().getString(DATASOURCE_SETTING_NAME, DEFAULT_DATASOURCE);
         return new SqlPolicyMonitorStore(dataSourceRegistry, dataSourceName, transactionContext,
-                getStatementImpl(), typeManager.getMapper(), clock, queryExecutor, context.getConnectorId());
+                getStatementImpl(), typeManager.getMapper(), clock, queryExecutor, context.getRuntimeId());
     }
 
     /**

--- a/spi/common/boot-spi/src/main/java/org/eclipse/edc/spi/system/ServiceExtensionContext.java
+++ b/spi/common/boot-spi/src/main/java/org/eclipse/edc/spi/system/ServiceExtensionContext.java
@@ -40,10 +40,22 @@ public interface ServiceExtensionContext extends SettingResolver {
     String getParticipantId();
 
     /**
+     * Return the id of the runtime. If not configured a random UUID is used.
+     *
+     * @return the runtime id.
+     */
+    String getRuntimeId();
+
+    /**
      * Fetches the unique ID of the connector. If the {@code dataspaceconnector.connector.name} config value has been set, that value is returned; otherwise  a random
      * name is chosen.
+     *
+     * @deprecated use {{@link #getRuntimeId()}} instead.
      */
-    String getConnectorId();
+    @Deprecated(since = "0.6.2")
+    default String getConnectorId() {
+        return getRuntimeId();
+    }
 
     /**
      * Returns the system monitor.


### PR DESCRIPTION
## What this PR changes/adds

Add a new configuration setting called `edc.runtime.id`, that will replace `edc.connector.name`

## Why it does that
`edc.connector.name` was not really used for its purpose, instead of being the name of the connector was used as `leaseHolder` for sql lease, so I generalized its concept calling it `edc.runtime.id` because its an Id that represent a specific runtime, that could be used in clustered environments to allow idempotence.
Specifically, it will be used by data-planes for self-registration. (see #4031)


## Further notes

- the way the configuration is loaded inside the `DefaultServiceContext` is not optimal, there could be a dedicated component that could do that (like the `ExtensionLoader`) so the context could be instantiated with a `Config` instance passed. This will untangle some knots and will improve testing (issue will come)  

## Linked Issue(s)

Closes #4156

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
