### PR TITLE
refactor: move configuration loading logic out of the extension context

### DIFF
--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/config/ConfigurationLoader.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/config/ConfigurationLoader.java
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.boot.config;
+
+import org.eclipse.edc.boot.system.ServiceLocator;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.system.ConfigurationExtension;
+import org.eclipse.edc.spi.system.configuration.Config;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+
+import java.util.Objects;
+
+/**
+ * Load configuration from configuration extensions, environment variables and system properties.
+ */
+public class ConfigurationLoader {
+    private final ServiceLocator serviceLocator;
+    private final EnvironmentVariables environmentVariables;
+    private final SystemProperties systemProperties;
+
+    public ConfigurationLoader(ServiceLocator serviceLocator, EnvironmentVariables environmentVariables, SystemProperties systemProperties) {
+        this.serviceLocator = serviceLocator;
+        this.environmentVariables = environmentVariables;
+        this.systemProperties = systemProperties;
+    }
+
+    /**
+     * Load configuration.
+     * Please note that Environment variables keys will be converted from the ENVIRONMENT_NOTATION to the dot.notation.
+     *
+     * @param monitor the monitor.
+     * @return the Config instance.
+     */
+    public Config loadConfiguration(Monitor monitor) {
+        var config = serviceLocator.loadImplementors(ConfigurationExtension.class, false)
+                .stream().peek(extension -> {
+                    extension.initialize(monitor);
+                    monitor.info("Initialized " + extension.name());
+                })
+                .map(ConfigurationExtension::getConfig)
+                .filter(Objects::nonNull)
+                .reduce(Config::merge)
+                .orElse(ConfigFactory.empty());
+
+        var environmentConfig = ConfigFactory.fromEnvironment(environmentVariables.get());
+        var systemPropertyConfig = ConfigFactory.fromProperties(systemProperties.get());
+
+        return config.merge(environmentConfig).merge(systemPropertyConfig);
+    }
+
+}

--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/config/EnvironmentVariables.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/config/EnvironmentVariables.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.boot.config;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+
+/**
+ * Wrapping interface that provides Environment Variables
+ */
+public interface EnvironmentVariables extends Supplier<Map<String, String>> {
+
+    /**
+     * Default implementation.
+     *
+     * @return the EnvironmentVariables default implementation.
+     */
+    static EnvironmentVariables ofDefault() {
+        return System::getenv;
+    }
+
+}

--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/config/SystemProperties.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/config/SystemProperties.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.boot.config;
+
+import java.util.Properties;
+import java.util.function.Supplier;
+
+/**
+ * Wrapping interface that provides System Properties
+ */
+public interface SystemProperties extends Supplier<Properties> {
+
+    /**
+     * Default implementation.
+     *
+     * @return the SystemProperties default implementation.
+     */
+    static SystemProperties ofDefault() {
+        return System::getProperties;
+    }
+}

--- a/core/common/boot/src/test/java/org/eclipse/edc/boot/config/ConfigurationLoaderTest.java
+++ b/core/common/boot/src/test/java/org/eclipse/edc/boot/config/ConfigurationLoaderTest.java
@@ -1,0 +1,140 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.boot.config;
+
+import org.eclipse.edc.boot.system.ServiceLocator;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.system.ConfigurationExtension;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ConfigurationLoaderTest {
+
+    private final ServiceLocator serviceLocator = mock();
+    private final Monitor monitor = mock();
+    private final ConfigurationExtension configurationExtension = mock();
+    private final EnvironmentVariables environmentVariables = mock();
+    private final SystemProperties systemProperties = mock();
+
+    private final ConfigurationLoader loader = new ConfigurationLoader(serviceLocator, environmentVariables, systemProperties);
+
+    @BeforeEach
+    void setUp() {
+        when(environmentVariables.get()).thenReturn(emptyMap());
+        when(systemProperties.get()).thenReturn(new Properties());
+        when(serviceLocator.loadImplementors(any(), anyBoolean())).thenReturn(List.of(configurationExtension));
+    }
+
+    @Test
+    void shouldInitializeConfigurationExtensions() {
+        loader.loadConfiguration(monitor);
+
+        verify(configurationExtension).initialize(monitor);
+    }
+
+    @Test
+    void shouldLoadEmptyConfiguration_whenNoConfigurationExtension() {
+        when(serviceLocator.loadImplementors(any(), anyBoolean())).thenReturn(emptyList());
+
+        var config = loader.loadConfiguration(monitor);
+
+        assertThat(config).isNotNull();
+        assertThat(config.getRelativeEntries()).isEmpty();
+        verify(serviceLocator).loadImplementors(ConfigurationExtension.class, false);
+    }
+
+    @Test
+    void shouldLoadConfigFromExtension() {
+        var extensionConfig = ConfigFactory.fromMap(Map.of("edc.test.entry1", "value1", "edc.test.entry2", "value2"));
+        when(configurationExtension.getConfig()).thenReturn(extensionConfig);
+
+        var config = loader.loadConfiguration(monitor);
+
+        assertThat(config.getString("edc.test.entry1")).isEqualTo("value1");
+        assertThat(config.getString("edc.test.entry2")).isEqualTo("value2");
+    }
+
+    @Test
+    void shouldLoadConfigFromSystemProperties() {
+        var properties = new Properties();
+        properties.put("edc.test.entry", "foo");
+        when(systemProperties.get()).thenReturn(properties);
+
+        var config = loader.loadConfiguration(monitor);
+
+        assertThat(config.getString("edc.test.entry")).isEqualTo("foo");
+    }
+
+    @Test
+    void shouldOverrideConfig_whenSystemPropertiesOverlap() {
+        var extensionConfig = ConfigFactory.fromMap(Map.of("edc.test.entry1", "value1", "edc.test.entry2", "value2"));
+        when(configurationExtension.getConfig()).thenReturn(extensionConfig);
+        var properties = new Properties();
+        properties.put("edc.test.entry2", "value override");
+        when(systemProperties.get()).thenReturn(properties);
+
+        var config = loader.loadConfiguration(monitor);
+
+        assertThat(config.getString("edc.test.entry1")).isEqualTo("value1");
+        assertThat(config.getString("edc.test.entry2")).isEqualTo("value override");
+    }
+
+    @Test
+    void shouldConvertCase_whenEnvironmentVariable() {
+        when(environmentVariables.get()).thenReturn(Map.of("EDC_TEST_ENTRY", "value"));
+
+        var config = loader.loadConfiguration(monitor);
+
+        assertThat(config.getString("edc.test.entry")).isEqualTo("value");
+    }
+
+    @Test
+    void shouldOverrideConfig_whenEnvironmentVariablesOverlap() {
+        var extensionConfig = ConfigFactory.fromMap(Map.of("edc.test.entry", "value"));
+        when(configurationExtension.getConfig()).thenReturn(extensionConfig);
+        when(environmentVariables.get()).thenReturn(Map.of("EDC_TEST_ENTRY", "value override"));
+
+        var config = loader.loadConfiguration(monitor);
+
+        assertThat(config.getString("edc.test.entry")).isEqualTo("value override");
+    }
+
+    @Test
+    void shouldOverrideEnvironmentVariablesWithSystemProperties() {
+        when(environmentVariables.get()).thenReturn(Map.of("EDC_TEST_ENTRY", "value"));
+        var properties = new Properties();
+        properties.put("edc.test.entry", "value override");
+        when(systemProperties.get()).thenReturn(properties);
+
+        var config = loader.loadConfiguration(monitor);
+
+        assertThat(config.getString("edc.test.entry")).isEqualTo("value override");
+    }
+
+}

--- a/core/common/boot/src/test/java/org/eclipse/edc/boot/system/DefaultServiceExtensionContextTest.java
+++ b/core/common/boot/src/test/java/org/eclipse/edc/boot/system/DefaultServiceExtensionContextTest.java
@@ -18,14 +18,12 @@ package org.eclipse.edc.boot.system;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.system.ConfigurationExtension;
+import org.eclipse.edc.spi.system.configuration.Config;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -33,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.edc.boot.BootServicesExtension.RUNTIME_ID;
 import static org.mockito.AdditionalMatchers.and;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
@@ -43,70 +42,17 @@ class DefaultServiceExtensionContextTest {
 
     private final ConfigurationExtension configuration = mock();
     private final Monitor monitor = mock();
+    private final Config config = mock();
     private DefaultServiceExtensionContext context;
 
     @BeforeEach
     void setUp() {
-        context = new DefaultServiceExtensionContext(monitor, List.of(configuration));
-    }
-
-    @Test
-    void getConfig_onlyFromConfig() {
-        var path = "edc.test";
-
-        var extensionConfig = ConfigFactory.fromMap(Map.of("edc.test.entry1", "value1", "edc.test.entry2", "value2"));
-        when(configuration.getConfig()).thenReturn(extensionConfig);
-        context.initialize();
-
-        var config = context.getConfig(path);
-
-        assertThat(config.getString("entry1")).isEqualTo("value1");
-        assertThat(config.getString("entry2")).isEqualTo("value2");
-    }
-
-    @Test
-    void getConfig_withOtherProperties() {
-        var path = "edc.test";
-
-        var extensionConfig = ConfigFactory.fromMap(Map.of("edc.test.entry1", "value1", "edc.test.entry2", "value2"));
-        when(configuration.getConfig()).thenReturn(extensionConfig);
-        System.setProperty("edc.test.entry3", "foo");
-
-        context.initialize();
-
-        var config = context.getConfig(path);
-        try {
-            assertThat(config.getString("entry1")).isEqualTo("value1");
-            assertThat(config.getString("entry2")).isEqualTo("value2");
-            assertThat(config.getString("entry3")).isEqualTo("foo");
-        } finally {
-            System.clearProperty("edc.test.entry3");
-        }
-    }
-
-    @Test
-    void getConfig_withOtherPropertiesOverlapping() {
-        var path = "edc.test";
-
-        var extensionConfig = ConfigFactory.fromMap(Map.of("edc.test.entry1", "value1", "edc.test.entry2", "value2"));
-        when(configuration.getConfig()).thenReturn(extensionConfig);
-        System.setProperty("edc.test.entry2", "foo");
-
-        context.initialize();
-
-        var config = context.getConfig(path);
-
-        try {
-            assertThat(config.getString("entry1")).isEqualTo("value1");
-            assertThat(config.getString("entry2")).isEqualTo("foo");
-        } finally {
-            System.clearProperty("edc.test.entry2");
-        }
+        context = new DefaultServiceExtensionContext(monitor, config);
     }
 
     @Test
     void get_setting_returns_the_setting_from_the_configuration_extension() {
-        when(configuration.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of("key", "value")));
+        when(config.getConfig(any())).thenReturn(ConfigFactory.fromMap(Map.of("key", "value")));
         context.initialize();
 
         var setting = context.getSetting("key", "default");
@@ -116,7 +62,7 @@ class DefaultServiceExtensionContextTest {
 
     @Test
     void get_setting_returns_default_value_if_setting_is_not_found() {
-        when(configuration.getConfig()).thenReturn(ConfigFactory.empty());
+        when(config.getConfig(any())).thenReturn(ConfigFactory.empty());
         context.initialize();
 
         var setting = context.getSetting("key", "default");
@@ -125,55 +71,8 @@ class DefaultServiceExtensionContextTest {
     }
 
     @Test
-    @DisplayName("An environment variable in UPPER_SNAKE_CASE gets converted to dot-notation")
-    void loadConfig_mapsSystemPropertyToJavaPropertyFormat() {
-        when(configuration.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of("key", "value")));
-        context = Mockito.spy(context);
-        when(context.getEnvironmentVariables()).thenReturn(Map.of("SOME_KEY", "env-val"));
-        context.initialize();
-
-        var setting = context.getSetting("key", "default");
-        var setting2 = context.getSetting("some.key", null);
-
-        assertThat(setting).isEqualTo("value");
-        assertThat(setting2).isEqualTo("env-val");
-    }
-
-    @Test
-    @DisplayName("An environment variable in UPPER_SNAKE_CASE should overwrite app config in dot-notation")
-    void loadConfig_envOverwritesAppConfig() {
-        when(configuration.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of("some.key", "value1")));
-        context = Mockito.spy(context);
-        when(context.getEnvironmentVariables()).thenReturn(Map.of("SOME_KEY", "value2"));
-        context.initialize();
-
-        var setting = context.getSetting("some.key", null);
-
-        assertThat(setting).isEqualTo("value2");
-    }
-
-    @Test
-    @DisplayName("An environment variable in UPPER_SNAKE_CASE should get overwritten by system config in dot-notation")
-    void loadConfig_systemPropOverwritesEnvVar() {
-
-        System.setProperty("some.key", "value3");
-        when(configuration.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of("some.key", "value1")));
-        context = Mockito.spy(context);
-        when(context.getEnvironmentVariables()).thenReturn(Map.of("SOME_KEY", "value2"));
-        context.initialize();
-
-        var setting = context.getSetting("some.key", null);
-
-        try {
-            assertThat(setting).isEqualTo("value3");
-        } finally {
-            System.clearProperty("some.key");
-        }
-    }
-
-    @Test
     void registerService_throwsWhenFrozen() {
-        when(configuration.getConfig()).thenReturn(ConfigFactory.empty());
+        when(config.getConfig(any())).thenReturn(ConfigFactory.empty());
         context.initialize();
 
         context.freeze();
@@ -185,6 +84,7 @@ class DefaultServiceExtensionContextTest {
     class GetRuntimeId {
         @Test
         void shouldReturnRandomUuid_whenNotConfigured() {
+            when(config.getConfig(any())).thenReturn(ConfigFactory.empty());
             context.initialize();
 
             var runtimeId = context.getRuntimeId();
@@ -195,7 +95,7 @@ class DefaultServiceExtensionContextTest {
 
         @Test
         void shouldReturnConfiguredId_whenConfigured() {
-            when(configuration.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of(RUNTIME_ID, "runtime-id")));
+            when(config.getConfig(any())).thenReturn(ConfigFactory.fromMap(Map.of(RUNTIME_ID, "runtime-id")));
             context.initialize();
 
             var runtimeId = context.getRuntimeId();

--- a/core/common/boot/src/test/java/org/eclipse/edc/boot/system/ExtensionLoaderTest.java
+++ b/core/common/boot/src/test/java/org/eclipse/edc/boot/system/ExtensionLoaderTest.java
@@ -33,6 +33,7 @@ import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.system.MonitorExtension;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -57,10 +58,10 @@ import static org.mockito.Mockito.when;
 
 class ExtensionLoaderTest {
 
-    private final ServiceLocator serviceLocator = mock(ServiceLocator.class);
+    private final ServiceLocator serviceLocator = mock();
     private final ServiceExtension coreExtension = new TestCoreExtension();
+    private final ServiceExtensionContext context = mock();
     private final ExtensionLoader loader = new ExtensionLoader(serviceLocator);
-    private final ServiceExtensionContext context = mock(ServiceExtensionContext.class);
 
     @BeforeAll
     public static void setup() {
@@ -295,7 +296,7 @@ class ExtensionLoaderTest {
         when(defaultProvider.testObject()).thenCallRealMethod();
 
 
-        var context = new DefaultServiceExtensionContext(mock(Monitor.class), List.of());
+        var context = new DefaultServiceExtensionContext(mock(Monitor.class), ConfigFactory.empty());
 
         var list = TestFunctions.createInjectionContainers(TestFunctions.createList(defaultProvider, dependentExtension), context);
 
@@ -314,7 +315,7 @@ class ExtensionLoaderTest {
         var nonDefaultProvider = (ProviderExtension) Mockito.spy(TestFunctions.createProviderExtension(false));
         when(nonDefaultProvider.testObject()).thenCallRealMethod();
 
-        var context = new DefaultServiceExtensionContext(mock(Monitor.class), List.of());
+        var context = new DefaultServiceExtensionContext(mock(Monitor.class), ConfigFactory.empty());
 
         var list = TestFunctions.createInjectionContainers(TestFunctions.createList(defaultProvider, dependentExtension, nonDefaultProvider), context);
 
@@ -332,7 +333,7 @@ class ExtensionLoaderTest {
         var nonDefaultProvider = (ProviderExtension) Mockito.spy(TestFunctions.createProviderExtension(false));
         when(nonDefaultProvider.testObject()).thenCallRealMethod();
 
-        var context = new DefaultServiceExtensionContext(mock(Monitor.class), List.of());
+        var context = new DefaultServiceExtensionContext(mock(Monitor.class), ConfigFactory.empty());
 
         var list = TestFunctions.createInjectionContainers(TestFunctions.createList(dependentExtension, nonDefaultProvider), context);
 
@@ -349,7 +350,7 @@ class ExtensionLoaderTest {
         var defaultProvider = (ProviderDefaultServicesExtension) Mockito.spy(TestFunctions.createProviderExtension(true));
         when(defaultProvider.testObject()).thenCallRealMethod();
 
-        var context = new DefaultServiceExtensionContext(mock(Monitor.class), List.of());
+        var context = new DefaultServiceExtensionContext(mock(Monitor.class), ConfigFactory.empty());
 
         var list = TestFunctions.createInjectionContainers(TestFunctions.createList(dependentExtension, defaultProvider), context);
 
@@ -370,7 +371,7 @@ class ExtensionLoaderTest {
         var provider = (ProviderExtension) Mockito.spy(TestFunctions.createProviderExtension(false));
         when(provider.testObject()).thenCallRealMethod();
 
-        var context = new DefaultServiceExtensionContext(mock(Monitor.class), List.of());
+        var context = new DefaultServiceExtensionContext(mock(Monitor.class), ConfigFactory.empty());
 
         var list = TestFunctions.createInjectionContainers(TestFunctions.createList(dependentExtension, defaultProvider, provider), context);
 

--- a/core/common/boot/src/test/java/org/eclipse/edc/boot/system/runtime/BaseRuntimeTest.java
+++ b/core/common/boot/src/test/java/org/eclipse/edc/boot/system/runtime/BaseRuntimeTest.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.boot.system.ServiceLocator;
 import org.eclipse.edc.boot.system.testextensions.BaseExtension;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.system.ConfigurationExtension;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.health.HealthCheckService;
@@ -76,6 +77,15 @@ public class BaseRuntimeTest {
 
         verify(healthCheckService).addStartupStatusProvider(any());
         verify(healthCheckService).refresh();
+    }
+
+    @Test
+    void shouldLoadConfiguration() {
+        when(serviceLocator.loadImplementors(eq(ServiceExtension.class), anyBoolean())).thenReturn(List.of(new BaseExtension()));
+
+        runtime.boot();
+
+        verify(serviceLocator).loadImplementors(ConfigurationExtension.class, false);
     }
 
     @NotNull

--- a/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/DependencyInjectionExtension.java
+++ b/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/DependencyInjectionExtension.java
@@ -21,7 +21,7 @@ import org.eclipse.edc.boot.system.injection.ReflectiveObjectFactory;
 import org.eclipse.edc.boot.system.runtime.BaseRuntime;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
-import org.jetbrains.annotations.NotNull;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
@@ -50,7 +50,7 @@ public class DependencyInjectionExtension extends BaseRuntime implements BeforeE
     @Override
     public void beforeEach(ExtensionContext extensionContext) {
         monitor = mock();
-        context = spy(super.createServiceExtensionContext());
+        context = spy(super.createServiceExtensionContext(ConfigFactory.empty()));
         context.initialize();
         factory = new ReflectiveObjectFactory(
                 new InjectorImpl(Mockito::mock),
@@ -91,8 +91,4 @@ public class DependencyInjectionExtension extends BaseRuntime implements BeforeE
         return null;
     }
 
-    @Override
-    protected @NotNull ServiceExtensionContext createServiceExtensionContext() {
-        return context;
-    }
 }

--- a/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/EdcExtension.java
+++ b/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/EdcExtension.java
@@ -24,6 +24,7 @@ import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.system.ConfigurationExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.SystemExtension;
+import org.eclipse.edc.spi.system.configuration.Config;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
@@ -125,8 +126,8 @@ public class EdcExtension extends BaseRuntime implements BeforeTestExecutionCall
     }
 
     @Override
-    protected @NotNull ServiceExtensionContext createContext(Monitor monitor) {
-        context = new TestServiceExtensionContext(monitor, loadConfigurationExtensions(), serviceMocks);
+    protected @NotNull ServiceExtensionContext createContext(Monitor monitor, Config config) {
+        context = new TestServiceExtensionContext(monitor, config, serviceMocks);
         return context;
     }
 

--- a/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/TestServiceExtensionContext.java
+++ b/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/TestServiceExtensionContext.java
@@ -16,12 +16,11 @@ package org.eclipse.edc.junit.extensions;
 
 import org.eclipse.edc.boot.system.DefaultServiceExtensionContext;
 import org.eclipse.edc.spi.monitor.Monitor;
-import org.eclipse.edc.spi.system.ConfigurationExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.system.configuration.Config;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
-import java.util.List;
 
 import static java.util.Optional.ofNullable;
 import static org.mockito.Mockito.mock;
@@ -42,13 +41,13 @@ public class TestServiceExtensionContext extends DefaultServiceExtensionContext 
     private final LinkedHashMap<Class<?>, Object> serviceMocks;
 
     public static ServiceExtensionContext testServiceExtensionContext() {
-        var context = new TestServiceExtensionContext(mock(), Collections.emptyList(), new LinkedHashMap<>());
+        var context = new TestServiceExtensionContext(mock(), ConfigFactory.empty(), new LinkedHashMap<>());
         context.initialize();
         return context;
     }
 
-    public TestServiceExtensionContext(Monitor monitor, List<ConfigurationExtension> configurationExtensions, LinkedHashMap<Class<?>, Object> serviceMocks) {
-        super(monitor, configurationExtensions);
+    public TestServiceExtensionContext(Monitor monitor, Config config, LinkedHashMap<Class<?>, Object> serviceMocks) {
+        super(monitor, config);
         this.serviceMocks = serviceMocks;
     }
 

--- a/extensions/common/api/management-api-configuration/src/test/java/org/eclipse/edc/connector/api/management/configuration/ManagementApiConfigurationExtensionTest.java
+++ b/extensions/common/api/management-api-configuration/src/test/java/org/eclipse/edc/connector/api/management/configuration/ManagementApiConfigurationExtensionTest.java
@@ -33,8 +33,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.util.List;
-
 import static org.eclipse.edc.connector.api.management.configuration.ManagementApiConfigurationExtension.SETTINGS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -77,7 +75,7 @@ class ManagementApiConfigurationExtensionTest {
 
     @NotNull
     private DefaultServiceExtensionContext contextWithConfig(Config config) {
-        var context = new DefaultServiceExtensionContext(monitor, List.of(() -> config));
+        var context = new DefaultServiceExtensionContext(monitor, config);
         context.initialize();
         return context;
     }

--- a/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-api/src/test/java/org/eclipse/edc/api/iam/identitytrust/sts/StsApiConfigurationExtensionTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-api/src/test/java/org/eclipse/edc/api/iam/identitytrust/sts/StsApiConfigurationExtensionTest.java
@@ -28,8 +28,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.util.List;
-
 import static org.eclipse.edc.api.iam.identitytrust.sts.StsApiConfigurationExtension.SETTINGS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -64,7 +62,7 @@ public class StsApiConfigurationExtensionTest {
 
     @NotNull
     private DefaultServiceExtensionContext contextWithConfig(Config config) {
-        var context = new DefaultServiceExtensionContext(monitor, List.of(() -> config));
+        var context = new DefaultServiceExtensionContext(monitor, config);
         context.initialize();
         return context;
     }

--- a/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/DataPlaneSelectorApiExtensionTest.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/DataPlaneSelectorApiExtensionTest.java
@@ -41,7 +41,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Collections;
-import java.util.List;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
@@ -86,7 +85,7 @@ class DataPlaneSelectorApiExtensionTest {
 
     @NotNull
     private DefaultServiceExtensionContext contextWithConfig(Config config) {
-        var context = new DefaultServiceExtensionContext(monitor, List.of(() -> config));
+        var context = new DefaultServiceExtensionContext(monitor, config);
         context.initialize();
         return context;
     }

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-api-configuration/src/test/java/org/eclipse/edc/connector/api/signaling/configuration/SignalingApiConfigurationExtensionTest.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-api-configuration/src/test/java/org/eclipse/edc/connector/api/signaling/configuration/SignalingApiConfigurationExtensionTest.java
@@ -31,8 +31,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.util.List;
-
 import static org.eclipse.edc.connector.api.signaling.configuration.SignalingApiConfigurationExtension.SETTINGS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -72,7 +70,7 @@ class SignalingApiConfigurationExtensionTest {
 
     @NotNull
     private DefaultServiceExtensionContext contextWithConfig(Config config) {
-        var context = new DefaultServiceExtensionContext(monitor, List.of(() -> config));
+        var context = new DefaultServiceExtensionContext(monitor, config);
         context.initialize();
         return context;
     }


### PR DESCRIPTION
## What this PR changes/adds

Add new `ConfigurationLoader` component that takes care of configuration loading (as `ExtensionLoader` is doing for extensions).

## Why it does that

refactor

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #4158 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
