### PR TITLE
feat: add not-equals (!=) operator

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -16,27 +16,34 @@ maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.14.0, Apache
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.14.1, Apache-2.0, approved, #5303
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.15.1, Apache-2.0, approved, #7947
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.17.0, Apache-2.0, approved, #13672
+maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.17.1, Apache-2.0, approved, #13672
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.14.1, Apache-2.0 AND MIT, approved, #4303
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.15.1, MIT AND Apache-2.0, approved, #7932
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.17.0, , approved, #13665
+maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.17.1, , approved, #13665
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.11.0, Apache-2.0, approved, CQ23093
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.14.0, Apache-2.0, approved, #4105
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.14.1, Apache-2.0, approved, #4105
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.15.1, Apache-2.0, approved, #7934
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.17.0, Apache-2.0, approved, #13671
+maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.17.1, Apache-2.0, approved, #13671
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.14.0, Apache-2.0, approved, #5933
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.15.1, Apache-2.0, approved, #8802
-maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.17.0, Apache-2.0, approved, #13669
+maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.17.1, Apache-2.0, approved, #13669
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jakarta-jsonp/2.17.0, Apache-2.0, approved, #14161
+maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jakarta-jsonp/2.17.1, Apache-2.0, approved, #14161
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.14.0, Apache-2.0, approved, #4699
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.15.1, Apache-2.0, approved, #7930
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.17.0, Apache-2.0, approved, #14160
-maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/2.17.0, Apache-2.0, approved, #14194
+maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.17.1, Apache-2.0, approved, #14160
+maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/2.17.1, Apache-2.0, approved, #14194
 maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.15.1, Apache-2.0, approved, #9236
-maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.17.0, Apache-2.0, approved, #14195
+maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.17.1, Apache-2.0, approved, #14195
 maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.17.0, Apache-2.0, approved, #13668
+maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.17.1, Apache-2.0, approved, #13668
 maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.15.1, Apache-2.0, approved, #7929
 maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.17.0, Apache-2.0, approved, #14162
+maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.17.1, Apache-2.0, approved, #14162
 maven/mavencentral/com.fasterxml.uuid/java-uuid-generator/4.1.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.github.cliftonlabs/json-simple/3.0.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.github.docker-java/docker-java-api/3.3.6, Apache-2.0, approved, #10346
@@ -78,7 +85,7 @@ maven/mavencentral/com.lmax/disruptor/3.4.4, Apache-2.0, approved, clearlydefine
 maven/mavencentral/com.networknt/json-schema-validator/1.0.76, Apache-2.0, approved, CQ22638
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.28, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.37.3, Apache-2.0, approved, #11701
-maven/mavencentral/com.puppycrawl.tools/checkstyle/10.15.0, LGPL-2.1-or-later, restricted, clearlydefined
+maven/mavencentral/com.puppycrawl.tools/checkstyle/10.16.0, , restricted, clearlydefined
 maven/mavencentral/com.samskivert/jmustache/1.15, BSD-2-Clause, approved, clearlydefined
 maven/mavencentral/com.squareup.okhttp3/okhttp-dnsoverhttps/4.12.0, Apache-2.0, approved, #11159
 maven/mavencentral/com.squareup.okhttp3/okhttp/4.12.0, Apache-2.0, approved, #11156

--- a/core/common/lib/query-lib/src/main/java/org/eclipse/edc/query/CriterionOperatorRegistryImpl.java
+++ b/core/common/lib/query-lib/src/main/java/org/eclipse/edc/query/CriterionOperatorRegistryImpl.java
@@ -44,6 +44,7 @@ public class CriterionOperatorRegistryImpl implements CriterionOperatorRegistry 
         registry.registerOperatorPredicate(LIKE, new LikeOperatorPredicate());
         registry.registerOperatorPredicate(ILIKE, new IlikeOperatorPredicate());
         registry.registerOperatorPredicate(CONTAINS, new ContainsOperatorPredicate());
+        registry.registerOperatorPredicate(NOT_EQUAL, new NotEqualOperatorPredicate());
         return registry;
     }
 
@@ -60,11 +61,6 @@ public class CriterionOperatorRegistryImpl implements CriterionOperatorRegistry 
     @Override
     public void unregister(String operator) {
         operatorPredicates.remove(operator.toLowerCase());
-    }
-
-    @Override
-    public boolean isSupported(String operator) {
-        return operatorPredicates.containsKey(operator.toLowerCase());
     }
 
     @Override
@@ -91,6 +87,11 @@ public class CriterionOperatorRegistryImpl implements CriterionOperatorRegistry 
             return predicate.test(property, criterion.getOperandRight());
         };
 
+    }
+
+    @Override
+    public boolean isSupported(String operator) {
+        return operatorPredicates.containsKey(operator.toLowerCase());
     }
 
 }

--- a/core/common/lib/query-lib/src/main/java/org/eclipse/edc/query/EqualOperatorPredicate.java
+++ b/core/common/lib/query-lib/src/main/java/org/eclipse/edc/query/EqualOperatorPredicate.java
@@ -23,6 +23,9 @@ public class EqualOperatorPredicate implements OperatorPredicate {
 
     @Override
     public boolean test(Object property, Object operandRight) {
+        if (property == null) {
+            return operandRight == null;
+        }
         if (property.getClass().isEnum()) {
             var enumProperty = (Enum<?>) property;
             if (operandRight instanceof String) {

--- a/core/common/lib/query-lib/src/main/java/org/eclipse/edc/query/NotEqualOperatorPredicate.java
+++ b/core/common/lib/query-lib/src/main/java/org/eclipse/edc/query/NotEqualOperatorPredicate.java
@@ -1,0 +1,23 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.query;
+
+public class NotEqualOperatorPredicate extends EqualOperatorPredicate {
+
+    @Override
+    public boolean test(Object property, Object operandRight) {
+        return !super.test(property, operandRight);
+    }
+}

--- a/core/common/lib/query-lib/src/test/java/org/eclipse/edc/query/EqualOperatorPredicateTest.java
+++ b/core/common/lib/query-lib/src/test/java/org/eclipse/edc/query/EqualOperatorPredicateTest.java
@@ -32,6 +32,8 @@ class EqualOperatorPredicateTest {
         assertThat(predicate.test("any", "any")).isTrue();
         assertThat(predicate.test("other", "any")).isFalse();
         assertThat(predicate.test("", "any")).isFalse();
+        assertThat(predicate.test(null, "any")).isFalse();
+        assertThat(predicate.test(null, null)).isTrue();
         assertThat(predicate.test(42, 42)).isTrue();
     }
 

--- a/core/common/lib/query-lib/src/test/java/org/eclipse/edc/query/NotEqualOperatorPredicateTest.java
+++ b/core/common/lib/query-lib/src/test/java/org/eclipse/edc/query/NotEqualOperatorPredicateTest.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.query;
+
+import org.eclipse.edc.spi.query.OperatorPredicate;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.query.NotEqualOperatorPredicateTest.TestEnum.ENTRY1;
+import static org.eclipse.edc.query.NotEqualOperatorPredicateTest.TestEnum.ENTRY2;
+
+class NotEqualOperatorPredicateTest {
+    private final OperatorPredicate predicate = new NotEqualOperatorPredicate();
+
+    @Test
+    void shouldReturnTrue_whenObjectsAreEqual() {
+        assertThat(predicate.test("any", "any")).isFalse();
+        assertThat(predicate.test("other", "any")).isTrue();
+        assertThat(predicate.test("", "any")).isTrue();
+        assertThat(predicate.test(null, "any")).isTrue();
+        assertThat(predicate.test(null, null)).isFalse();
+        assertThat(predicate.test(42, 42)).isFalse();
+        assertThat(predicate.test(42, 69)).isTrue();
+    }
+
+    @Test
+    void shouldCheckName_whenPropertyIsEnum() {
+        assertThat(predicate.test(ENTRY2, "ENTRY2")).isFalse();
+        assertThat(predicate.test(ENTRY1, "ENTRY2")).isTrue();
+    }
+
+    @Test
+    void shouldCheckOrdinal_whenPropertyIsEnumAndOperandRightIsNumber() {
+        assertThat(predicate.test(ENTRY2, ENTRY2.ordinal())).isFalse();
+        assertThat(predicate.test(ENTRY1, ENTRY2.ordinal())).isTrue();
+        assertThat(predicate.test(ENTRY2, -42)).isTrue();
+    }
+
+    @Test
+    void shouldMatchPredicate_whenObjectIsList() {
+        assertThat(predicate.test(List.of("one", "two"), "two")).isFalse();
+        assertThat(predicate.test(List.of("one", "two"), "three")).isTrue();
+    }
+
+    public enum TestEnum {
+        ENTRY1, ENTRY2
+    }
+}

--- a/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/PostgresqlOperatorTranslator.java
+++ b/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/PostgresqlOperatorTranslator.java
@@ -21,6 +21,7 @@ import static org.eclipse.edc.spi.query.CriterionOperatorRegistry.EQUAL;
 import static org.eclipse.edc.spi.query.CriterionOperatorRegistry.ILIKE;
 import static org.eclipse.edc.spi.query.CriterionOperatorRegistry.IN;
 import static org.eclipse.edc.spi.query.CriterionOperatorRegistry.LIKE;
+import static org.eclipse.edc.spi.query.CriterionOperatorRegistry.NOT_EQUAL;
 
 /**
  * Postgresql's implementation of the operator translator
@@ -31,6 +32,7 @@ public class PostgresqlOperatorTranslator implements SqlOperatorTranslator {
     public SqlOperator translate(String operator) {
         return switch (operator) {
             case EQUAL -> new SqlOperator("=", Object.class);
+            case NOT_EQUAL -> new SqlOperator("!=", Object.class);
             case LIKE -> new SqlOperator("like", String.class);
             case ILIKE -> new SqlOperator("ilike", String.class);
             case IN -> new SqlOperator("in", Collection.class);

--- a/extensions/common/sql/sql-core/src/test/java/org/eclipse/edc/sql/translation/PostgresqlOperatorTranslatorTest.java
+++ b/extensions/common/sql/sql-core/src/test/java/org/eclipse/edc/sql/translation/PostgresqlOperatorTranslatorTest.java
@@ -33,6 +33,14 @@ class PostgresqlOperatorTranslatorTest {
     }
 
     @Test
+    void shouldTranslate_notEqual() {
+        var operator = translator.translate("!=");
+
+        assertThat(operator.representation()).isEqualTo("!=");
+        assertThat(operator.rightOperandClass()).isEqualTo(Object.class);
+    }
+
+    @Test
     void shouldTranslate_like() {
         var operator = translator.translate("like");
 

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/CriterionOperatorRegistry.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/CriterionOperatorRegistry.java
@@ -22,6 +22,7 @@ import java.util.function.Predicate;
 public interface CriterionOperatorRegistry {
 
     String EQUAL = "=";
+    String NOT_EQUAL = "!=";
     String IN = "in";
     String LIKE = "like";
     String ILIKE = "ilike";
@@ -30,7 +31,7 @@ public interface CriterionOperatorRegistry {
     /**
      * Register an operator with the related operator predicate.
      *
-     * @param operator the operator, case-insensitive.
+     * @param operator  the operator, case-insensitive.
      * @param predicate the operator predicate.
      */
     void registerOperatorPredicate(String operator, OperatorPredicate predicate);


### PR DESCRIPTION
## What this PR changes/adds

Adds the "not-equals" or "!=" operator to our default operator portfolio

## Why it does that

General functional completeness, but there is one particular use case: when querying for VerifiableCredentials, we only want those where the status is not `"REVOKED"` and not `"EXPIRED"`.

If we wanted to "cross all t's and dot all i's" we'd also have to add a "not-in" operator, but this seems good enough for now and keeps the complexity down.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #4163

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
