### PR TITLE
fix: add stateTimestamp to translation model

### DIFF
--- a/extensions/common/sql/sql-lease/src/main/java/org/eclipse/edc/sql/lease/StatefulEntityMapping.java
+++ b/extensions/common/sql/sql-lease/src/main/java/org/eclipse/edc/sql/lease/StatefulEntityMapping.java
@@ -27,6 +27,7 @@ public class StatefulEntityMapping extends TranslationMapping {
         add("id", statements.getIdColumn());
         add("state", statements.getStateColumn());
         add("stateCount", statements.getStateCountColumn());
+        add("stateTimestamp", statements.getStateTimestampColumn());
         add("createdAt", statements.getCreatedAtColumn());
         add("traceContext", new JsonFieldTranslator(statements.getTraceContextColumn()));
         add("errorDetail", statements.getErrorDetailColumn());

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TransferProcessApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TransferProcessApiEndToEndTest.java
@@ -19,7 +19,6 @@ import jakarta.json.Json;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
-import jakarta.json.JsonValue;
 import org.eclipse.edc.connector.controlplane.transfer.spi.store.TransferProcessStore;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.jsonld.util.JacksonJsonLd;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TransferProcessApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TransferProcessApiEndToEndTest.java
@@ -226,8 +226,6 @@ public class TransferProcessApiEndToEndTest {
                     .clock(Clock.fixed(Instant.now().plus(1, ChronoUnit.HOURS), ZoneId.systemDefault()))
                     .build();
             getStore().save(tp1);
-
-            tp2.updateStateTimestamp();
             getStore().save(tp2);
 
 
@@ -255,7 +253,7 @@ public class TransferProcessApiEndToEndTest {
                     .statusCode(200)
                     .extract().body().as(JsonArray.class);
 
-            assertThat(result).isNotEmpty().hasSize(2);
+            assertThat(result).isNotEmpty().hasSizeGreaterThanOrEqualTo(2);
             assertThat(result).isSortedAccordingTo((o1, o2) -> {
                 var l1 = o1.asJsonObject().getJsonNumber("stateTimestamp").longValue();
                 var l2 = o2.asJsonObject().getJsonNumber("stateTimestamp").longValue();


### PR DESCRIPTION
## What this PR changes/adds

adds the `stateTimestamp` to the translation model for stateful entities (`StatefulEntityMapping`).

## Why it does that

sorting stateful entities by `stateTimestamp` threw an IllegalArgumentException, because the translation model did not 
contain a corresponding mapping.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
