### PR TITLE
fix: constructor arg and type hierarchy

### DIFF
--- a/extensions/common/crypto/ldp-verifiable-credentials/src/main/java/org/eclipse/edc/verifiablecredentials/linkeddata/DataIntegrityKeyPair.java
+++ b/extensions/common/crypto/ldp-verifiable-credentials/src/main/java/org/eclipse/edc/verifiablecredentials/linkeddata/DataIntegrityKeyPair.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.verifiablecredentials.linkeddata;
 
 
 import com.apicatalog.ld.signature.VerificationMethod;
+import com.apicatalog.ld.signature.key.VerificationKey;
 
 import java.net.URI;
 import java.util.Arrays;
@@ -24,24 +25,24 @@ import java.util.Objects;
 /**
  * Generic adapter object for a {@link VerificationMethod}
  */
-class DataIntegrityKeyPair implements VerificationMethod {
+class DataIntegrityKeyPair implements VerificationKey {
     private final URI id;
     private final URI type;
     private final URI controller;
     private final byte[] privateKey;
     private final byte[] publicKey;
 
-    DataIntegrityKeyPair(URI id, URI type, URI controller, byte[] privateKey, byte[] publicKey) {
+    DataIntegrityKeyPair(URI id, URI type, URI controller, byte[] publicKey, byte[] privateKey) {
         super();
         this.id = id;
         this.type = type;
         this.controller = controller;
-        this.privateKey = privateKey;
         this.publicKey = publicKey;
+        this.privateKey = privateKey;
     }
 
-    DataIntegrityKeyPair(URI id, URI type, URI controller, byte[] privateKey) {
-        this(id, type, controller, privateKey, null);
+    DataIntegrityKeyPair(URI id, URI type, URI controller, byte[] publicKey) {
+        this(id, type, controller, publicKey, null);
     }
 
     @Override
@@ -61,6 +62,11 @@ class DataIntegrityKeyPair implements VerificationMethod {
 
     public byte[] privateKey() {
         return privateKey;
+    }
+
+    @Override
+    public String algorithm() {
+        return type.toString();
     }
 
     public byte[] publicKey() {


### PR DESCRIPTION
## What this PR changes/adds

Fixes the type hierarchy of the `DataIntegrityKeyPair`

## Why it does that

- wrong type hierarchy leads to failing checks
- wrong constructor argument leads to NPE

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #4170

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
