### PR TITLE
refactor(api): merge signaling api context into control

### DIFF
--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/build.gradle.kts
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/build.gradle.kts
@@ -19,10 +19,10 @@ plugins {
 dependencies {
     api(project(":spi:control-plane:transfer-spi"))
     api(project(":spi:common:transform-spi"))
-    api(project(":core:common:lib:transform-lib"))
     api(project(":extensions:common:json-ld"))
     api(project(":data-protocols:dsp:dsp-spi"))
     api(project(":data-protocols:dsp:dsp-http-spi"))
+    implementation(project(":core:common:lib:transform-lib"))
 
     testImplementation(project(":core:common:lib:json-ld-lib"))
     testImplementation(project(":core:common:junit"))

--- a/extensions/common/api/control-api-configuration/src/main/java/org/eclipse/edc/connector/api/control/configuration/ControlApiConfigurationExtension.java
+++ b/extensions/common/api/control-api-configuration/src/main/java/org/eclipse/edc/connector/api/control/configuration/ControlApiConfigurationExtension.java
@@ -36,6 +36,10 @@ import org.eclipse.edc.web.spi.configuration.WebServiceSettings;
 import java.net.URI;
 
 import static java.lang.String.format;
+import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_PREFIX;
+import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+import static org.eclipse.edc.policy.model.OdrlNamespace.ODRL_PREFIX;
+import static org.eclipse.edc.policy.model.OdrlNamespace.ODRL_SCHEMA;
 import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
 
 /**
@@ -93,6 +97,9 @@ public class ControlApiConfigurationExtension implements ServiceExtension {
         var jsonLdMapper = typeManager.getMapper(JSON_LD);
         context.registerService(ControlApiConfiguration.class, new ControlApiConfiguration(config));
         context.registerService(ControlApiUrl.class, callbackAddress);
+
+        jsonLd.registerNamespace(ODRL_PREFIX, ODRL_SCHEMA, CONTROL_SCOPE);
+        jsonLd.registerNamespace(DSPACE_PREFIX, DSPACE_SCHEMA, CONTROL_SCOPE);
 
         webService.registerResource(SETTINGS.getContextAlias(), new ObjectMapperProvider(jsonLdMapper));
         webService.registerResource(SETTINGS.getContextAlias(), new JerseyJsonLdInterceptor(jsonLd, jsonLdMapper, CONTROL_SCOPE));

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-api-configuration/src/main/java/org/eclipse/edc/connector/api/signaling/configuration/SignalingApiConfiguration.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-api-configuration/src/main/java/org/eclipse/edc/connector/api/signaling/configuration/SignalingApiConfiguration.java
@@ -16,6 +16,12 @@ package org.eclipse.edc.connector.api.signaling.configuration;
 
 import org.eclipse.edc.web.spi.configuration.WebServiceConfiguration;
 
+/**
+ * Signaling api configuration
+ *
+ * @deprecated ControlApiConfiguration should be used instead.
+ */
+@Deprecated(since = "0.6.4")
 public class SignalingApiConfiguration extends WebServiceConfiguration {
 
     public SignalingApiConfiguration(String contextAlias) {

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-api-configuration/src/main/java/org/eclipse/edc/connector/api/signaling/configuration/SignalingApiConfigurationExtension.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-api-configuration/src/main/java/org/eclipse/edc/connector/api/signaling/configuration/SignalingApiConfigurationExtension.java
@@ -47,6 +47,7 @@ import static org.eclipse.edc.policy.model.OdrlNamespace.ODRL_PREFIX;
 import static org.eclipse.edc.policy.model.OdrlNamespace.ODRL_SCHEMA;
 import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
 
+@Deprecated(since = "0.6.4")
 @Provides(SignalingApiConfiguration.class)
 @Extension(value = NAME)
 public class SignalingApiConfigurationExtension implements ServiceExtension {
@@ -87,6 +88,11 @@ public class SignalingApiConfigurationExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
+        var warningMessage = """
+                The data-plane-signaling-api-configuration extension is deprecated as the related 'web.http.signaling'
+                settings, please exclude from your build and configure your endpoints to the control-api context
+                """;
+        context.getMonitor().warning(warningMessage);
         var webServiceConfiguration = configurer.configure(context, webServer, SETTINGS);
         context.registerService(SignalingApiConfiguration.class, new SignalingApiConfiguration(webServiceConfiguration));
 

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-api/build.gradle.kts
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-api/build.gradle.kts
@@ -23,10 +23,12 @@ dependencies {
     api(project(":spi:common:json-ld-spi"))
     api(project(":spi:data-plane:data-plane-spi"))
 
+    implementation(project(":core:common:lib:transform-lib"))
     implementation(project(":extensions:common:api:control-api-configuration"))
     implementation(project(":extensions:data-plane:data-plane-signaling:data-plane-signaling-transform"))
     implementation(project(":extensions:data-plane:data-plane-signaling:data-plane-signaling-api-configuration"))
     implementation(libs.jakarta.rsApi)
+
     testImplementation(libs.restAssured)
     testImplementation(testFixtures(project(":extensions:common:http:jersey-core")))
 

--- a/system-tests/e2e-dataplane-tests/runtimes/data-plane/build.gradle.kts
+++ b/system-tests/e2e-dataplane-tests/runtimes/data-plane/build.gradle.kts
@@ -16,10 +16,7 @@ plugins {
 }
 
 dependencies {
-    // these must be implementation dependencies as opposed to runtimeOnly, because otherwise
-    // this module isn't getting compiled when the :tests module is compiled
     implementation(project(":extensions:data-plane:data-plane-signaling:data-plane-signaling-api"))
-    implementation(project(":extensions:data-plane:data-plane-signaling:data-plane-signaling-api-configuration"))
     implementation(project(":core:data-plane:data-plane-core"))
     implementation(project(":extensions:control-plane:api:control-plane-api-client"))
     implementation(project(":extensions:data-plane:data-plane-http"))

--- a/system-tests/e2e-dataplane-tests/tests/src/test/java/org/eclipse/edc/test/e2e/DataPlaneSignalingApiEndToEndTest.java
+++ b/system-tests/e2e-dataplane-tests/tests/src/test/java/org/eclipse/edc/test/e2e/DataPlaneSignalingApiEndToEndTest.java
@@ -81,7 +81,7 @@ public class DataPlaneSignalingApiEndToEndTest extends AbstractDataPlaneTest {
         var flowMessage = createStartMessage(processId);
         var startMessage = registry.transform(flowMessage, JsonObject.class).orElseThrow(failTest());
 
-        var resultJson = DATAPLANE.getDataPlaneSignalingEndpoint()
+        var resultJson = DATAPLANE.getDataPlaneControlEndpoint()
                 .baseRequest()
                 .contentType(ContentType.JSON)
                 .body(startMessage)
@@ -121,7 +121,7 @@ public class DataPlaneSignalingApiEndToEndTest extends AbstractDataPlaneTest {
                 .build();
         runtime.getService(DataPlaneStore.class).save(flow);
 
-        var resultJson = DATAPLANE.getDataPlaneSignalingEndpoint()
+        var resultJson = DATAPLANE.getDataPlaneControlEndpoint()
                 .baseRequest()
                 .contentType(ContentType.JSON)
                 .get("/v1/dataflows/%s/state".formatted(dataFlowId))
@@ -153,7 +153,7 @@ public class DataPlaneSignalingApiEndToEndTest extends AbstractDataPlaneTest {
                 .add(DATA_FLOW_TERMINATE_MESSAGE_REASON, "test-reason")
                 .build();
 
-        DATAPLANE.getDataPlaneSignalingEndpoint()
+        DATAPLANE.getDataPlaneControlEndpoint()
                 .baseRequest()
                 .body(terminateMessage)
                 .contentType(ContentType.JSON)

--- a/system-tests/e2e-dataplane-tests/tests/src/test/java/org/eclipse/edc/test/e2e/participant/DataPlaneParticipant.java
+++ b/system-tests/e2e-dataplane-tests/tests/src/test/java/org/eclipse/edc/test/e2e/participant/DataPlaneParticipant.java
@@ -31,14 +31,13 @@ public class DataPlaneParticipant extends Participant {
     private final URI dataPlaneDefault = URI.create("http://localhost:" + getFreePort());
     private final URI dataPlaneControl = URI.create("http://localhost:" + getFreePort() + "/control");
     private final URI dataPlanePublic = URI.create("http://localhost:" + getFreePort() + "/public");
-    private final URI dataPlaneSignaling = URI.create("http://localhost:" + getFreePort() + "/api/signaling");
 
     private DataPlaneParticipant() {
         super();
     }
 
-    public Endpoint getDataPlaneSignalingEndpoint() {
-        return new Endpoint(dataPlaneSignaling);
+    public Endpoint getDataPlaneControlEndpoint() {
+        return new Endpoint(dataPlaneControl);
     }
 
     public Endpoint getDataPlanePublicEndpoint() {
@@ -54,8 +53,6 @@ public class DataPlaneParticipant extends Participant {
                 put("web.http.public.path", "/public");
                 put("web.http.control.port", String.valueOf(dataPlaneControl.getPort()));
                 put("web.http.control.path", dataPlaneControl.getPath());
-                put("web.http.signaling.port", String.valueOf(dataPlaneSignaling.getPort()));
-                put("web.http.signaling.path", dataPlaneSignaling.getPath());
                 put("edc.vault", resourceAbsolutePath(getName() + "-vault.properties"));
                 put("edc.keystore", resourceAbsolutePath("certs/cert.pfx"));
                 put("edc.keystore.password", "123456");

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferEndToEndParticipant.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferEndToEndParticipant.java
@@ -47,7 +47,6 @@ public class TransferEndToEndParticipant extends Participant {
     private final URI controlPlaneControl = URI.create("http://localhost:" + getFreePort() + "/control");
     private final URI dataPlaneDefault = URI.create("http://localhost:" + getFreePort());
     private final URI dataPlaneControl = URI.create("http://localhost:" + getFreePort() + "/control");
-    private final URI dataPlaneSignaling = URI.create("http://localhost:" + getFreePort() + "/signaling");
     private final URI dataPlanePublic = URI.create("http://localhost:" + getFreePort() + "/public");
     private final URI backendService = URI.create("http://localhost:" + getFreePort());
 
@@ -77,7 +76,7 @@ public class TransferEndToEndParticipant extends Participant {
      */
     @Deprecated(since = "0.6.3")
     public void registerDataPlane(Set<String> transferTypes) {
-        registerDataPlane(dataPlaneSignaling + "/v1/dataflows", Set.of("HttpData", "HttpProvision", "Kafka"), Set.of("HttpData", "HttpProvision", "HttpProxy", "Kafka"), transferTypes);
+        registerDataPlane(dataPlaneControl + "/v1/dataflows", Set.of("HttpData", "HttpProvision", "Kafka"), Set.of("HttpData", "HttpProvision", "HttpProxy", "Kafka"), transferTypes);
     }
 
     /**
@@ -159,8 +158,6 @@ public class TransferEndToEndParticipant extends Participant {
                 put("web.http.public.path", "/public");
                 put("web.http.control.port", String.valueOf(dataPlaneControl.getPort()));
                 put("web.http.control.path", dataPlaneControl.getPath());
-                put("web.http.signaling.port", String.valueOf(dataPlaneSignaling.getPort()));
-                put("web.http.signaling.path", dataPlaneSignaling.getPath());
                 put("edc.vault", resourceAbsolutePath(getName() + "-vault.properties"));
                 put("edc.keystore", resourceAbsolutePath("certs/cert.pfx"));
                 put("edc.keystore.password", "123456");


### PR DESCRIPTION
## What this PR changes/adds

Merge the `signaling-api` context into the `control-api` context

## Why it does that

we should keep the context number consistent to the ones described in this decision record:
https://github.com/eclipse-edc/Connector/blob/main/docs/developer/decision-records/2022-11-09-api-refactoring/renaming.md

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #4175 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
