### PR TITLE
fix: serialize the leftOperand as an @id

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -125,7 +125,7 @@ maven/mavencentral/io.netty/netty-tcnative-classes/2.0.56.Final, Apache-2.0, app
 maven/mavencentral/io.netty/netty-transport-native-unix-common/4.1.86.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-transport/4.1.86.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations/1.32.0, Apache-2.0, approved, #11684
-maven/mavencentral/io.opentelemetry.proto/opentelemetry-proto/1.3.1-alpha, None, restricted, #14688
+maven/mavencentral/io.opentelemetry.proto/opentelemetry-proto/1.3.1-alpha, Apache-2.0, approved, #14688
 maven/mavencentral/io.opentelemetry/opentelemetry-api/1.32.0, Apache-2.0, approved, #11682
 maven/mavencentral/io.opentelemetry/opentelemetry-context/1.32.0, Apache-2.0, approved, #11683
 maven/mavencentral/io.prometheus/simpleclient/0.16.0, Apache-2.0, approved, clearlydefined

--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/odrl/from/JsonObjectFromPolicyTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/odrl/from/JsonObjectFromPolicyTransformer.java
@@ -133,7 +133,8 @@ public class JsonObjectFromPolicyTransformer extends AbstractJsonLdTransformer<P
         public JsonObject visitAtomicConstraint(AtomicConstraint atomicConstraint) {
             var constraintBuilder = jsonFactory.createObjectBuilder();
 
-            constraintBuilder.add(ODRL_LEFT_OPERAND_ATTRIBUTE, atomicConstraint.getLeftExpression().accept(this));
+            var leftOperand = atomicConstraint.getLeftExpression().accept((expression) -> expression.getValue().toString());
+            constraintBuilder.add(ODRL_LEFT_OPERAND_ATTRIBUTE, jsonFactory.createArrayBuilder().add(jsonFactory.createObjectBuilder().add(ID, leftOperand)));
             var operator = atomicConstraint.getOperator().getOdrlRepresentation();
             constraintBuilder.add(ODRL_OPERATOR_ATTRIBUTE, jsonFactory.createArrayBuilder().add(jsonFactory.createObjectBuilder().add(ID, operator)));
             constraintBuilder.add(ODRL_RIGHT_OPERAND_ATTRIBUTE, atomicConstraint.getRightExpression().accept(this));

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/odrl/from/JsonObjectFromPolicyTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/odrl/from/JsonObjectFromPolicyTransformerTest.java
@@ -181,7 +181,7 @@ class JsonObjectFromPolicyTransformerTest {
         assertThat(actionJson.getJsonObject(ODRL_REFINEMENT_ATTRIBUTE)).isNotNull();
 
         var constraintJson = actionJson.getJsonObject(ODRL_REFINEMENT_ATTRIBUTE);
-        assertThat(constraintJson.getJsonObject(ODRL_LEFT_OPERAND_ATTRIBUTE).getJsonString(VALUE).getString())
+        assertThat(constraintJson.getJsonArray(ODRL_LEFT_OPERAND_ATTRIBUTE).getJsonObject(0).getString(ID))
                 .isEqualTo(((LiteralExpression) constraint.getLeftExpression()).getValue());
         assertThat(constraintJson.getJsonArray(ODRL_OPERATOR_ATTRIBUTE).getJsonObject(0).getString(ID))
                 .isEqualTo(constraint.getOperator().getOdrlRepresentation());
@@ -221,7 +221,7 @@ class JsonObjectFromPolicyTransformerTest {
         assertThat(permissionJson.getJsonArray(ODRL_DUTY_ATTRIBUTE)).hasSize(1);
 
         var constraintJson = permissionJson.getJsonArray(ODRL_CONSTRAINT_ATTRIBUTE).get(0).asJsonObject();
-        assertThat(constraintJson.getJsonObject(ODRL_LEFT_OPERAND_ATTRIBUTE).getJsonString(VALUE).getString())
+        assertThat(constraintJson.getJsonArray(ODRL_LEFT_OPERAND_ATTRIBUTE).getJsonObject(0).getString(ID))
                 .isEqualTo(((LiteralExpression) constraint.getLeftExpression()).getValue());
         assertThat(constraintJson.getJsonArray(ODRL_OPERATOR_ATTRIBUTE).getJsonObject(0).getString(ID))
                 .isEqualTo(constraint.getOperator().getOdrlRepresentation());
@@ -253,7 +253,7 @@ class JsonObjectFromPolicyTransformerTest {
         assertThat(prohibitionJson.getJsonArray(ODRL_CONSTRAINT_ATTRIBUTE)).hasSize(1);
 
         var constraintJson = prohibitionJson.getJsonArray(ODRL_CONSTRAINT_ATTRIBUTE).get(0).asJsonObject();
-        assertThat(constraintJson.getJsonObject(ODRL_LEFT_OPERAND_ATTRIBUTE).getJsonString(VALUE).getString())
+        assertThat(constraintJson.getJsonArray(ODRL_LEFT_OPERAND_ATTRIBUTE).getJsonObject(0).getString(ID))
                 .isEqualTo(((LiteralExpression) constraint.getLeftExpression()).getValue());
         assertThat(constraintJson.getJsonArray(ODRL_OPERATOR_ATTRIBUTE).getJsonObject(0).getString(ID))
                 .isEqualTo(constraint.getOperator().getOdrlRepresentation());
@@ -289,7 +289,7 @@ class JsonObjectFromPolicyTransformerTest {
         assertThat(dutyJson.getJsonArray(ODRL_CONSTRAINT_ATTRIBUTE)).hasSize(1);
 
         var constraintJson = dutyJson.getJsonArray(ODRL_CONSTRAINT_ATTRIBUTE).get(0).asJsonObject();
-        assertThat(constraintJson.getJsonObject(ODRL_LEFT_OPERAND_ATTRIBUTE).getJsonString(VALUE).getString())
+        assertThat(constraintJson.getJsonArray(ODRL_LEFT_OPERAND_ATTRIBUTE).getJsonObject(0).getString(ID))
                 .isEqualTo(((LiteralExpression) constraint.getLeftExpression()).getValue());
         assertThat(constraintJson.getJsonArray(ODRL_OPERATOR_ATTRIBUTE).getJsonObject(0).getString(ID))
                 .isEqualTo(constraint.getOperator().getOdrlRepresentation());


### PR DESCRIPTION
## What this PR changes/adds

serialize the `leftOperand` of a constraint as an @id

The breaking change only affects management API, since at protocol level EDC in input can handle both `@value` and `@id` as expanded form

## Linked Issue(s)

Closes #4179 
