### PR TITLE
fix: action as @id if it's not refined

### DIFF
--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/odrl/from/JsonObjectFromPolicyTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/odrl/from/JsonObjectFromPolicyTransformer.java
@@ -48,7 +48,6 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ACTION_ATTRIBUTE;
-import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ACTION_TYPE_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_AND_CONSTRAINT_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ASSIGNEE_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ASSIGNER_ATTRIBUTE;
@@ -248,12 +247,16 @@ public class JsonObjectFromPolicyTransformer extends AbstractJsonLdTransformer<P
             if (action == null) {
                 return actionBuilder.build();
             }
-            actionBuilder.add(ODRL_ACTION_TYPE_ATTRIBUTE, action.getType());
-            if (action.getIncludedIn() != null) {
-                actionBuilder.add(ODRL_INCLUDED_IN_ATTRIBUTE, action.getIncludedIn());
-            }
-            if (action.getConstraint() != null) {
-                actionBuilder.add(ODRL_REFINEMENT_ATTRIBUTE, action.getConstraint().accept(this));
+            if (action.getIncludedIn() != null || action.getConstraint() != null) {
+                actionBuilder.add(ODRL_ACTION_ATTRIBUTE, jsonFactory.createObjectBuilder().add(ID, action.getType()));
+                if (action.getIncludedIn() != null) {
+                    actionBuilder.add(ODRL_INCLUDED_IN_ATTRIBUTE, action.getIncludedIn());
+                }
+                if (action.getConstraint() != null) {
+                    actionBuilder.add(ODRL_REFINEMENT_ATTRIBUTE, action.getConstraint().accept(this));
+                }
+            } else {
+                actionBuilder.add(ID, action.getType());
             }
             return actionBuilder.build();
         }

--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/odrl/to/JsonObjectToActionTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/odrl/to/JsonObjectToActionTransformer.java
@@ -25,6 +25,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
 
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ACTION_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ACTION_TYPE_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_INCLUDED_IN_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_REFINEMENT_ATTRIBUTE;
@@ -48,7 +49,10 @@ public class JsonObjectToActionTransformer extends AbstractJsonLdTransformer<Jso
     }
 
     private void transformProperties(String key, JsonValue value, Action.Builder builder, TransformerContext context) {
+        // we read the type for backward compatibility
         if (ODRL_ACTION_TYPE_ATTRIBUTE.equals(key)) {
+            transformString(value, builder::type, context);
+        } else if (ODRL_ACTION_ATTRIBUTE.equals(key)) {
             transformString(value, builder::type, context);
         } else if (ODRL_INCLUDED_IN_ATTRIBUTE.equals(key)) {
             transformString(value, builder::includedIn, context);

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/odrl/from/JsonObjectFromPolicyTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/odrl/from/JsonObjectFromPolicyTransformerTest.java
@@ -51,7 +51,6 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ACTION_ATTRIBUTE;
-import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ACTION_TYPE_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_AND_CONSTRAINT_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ASSIGNEE_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ASSIGNER_ATTRIBUTE;
@@ -176,7 +175,7 @@ class JsonObjectFromPolicyTransformerTest {
         assertThat(permissionJson.getJsonObject(ODRL_ACTION_ATTRIBUTE)).isNotNull();
 
         var actionJson = permissionJson.getJsonObject(ODRL_ACTION_ATTRIBUTE);
-        assertThat(actionJson.getJsonString(ODRL_ACTION_TYPE_ATTRIBUTE).getString()).isEqualTo(action.getType());
+        assertThat(actionJson.getJsonObject(ODRL_ACTION_ATTRIBUTE).getString(ID)).isEqualTo(action.getType());
         assertThat(actionJson.getJsonString(ODRL_INCLUDED_IN_ATTRIBUTE).getString()).isEqualTo(action.getIncludedIn());
         assertThat(actionJson.getJsonObject(ODRL_REFINEMENT_ATTRIBUTE)).isNotNull();
 
@@ -262,7 +261,7 @@ class JsonObjectFromPolicyTransformerTest {
 
         assertThat(prohibitionJson.getJsonArray(ODRL_REMEDY_ATTRIBUTE)).hasSize(1).first()
                 .extracting(JsonValue::asJsonObject).satisfies(remedyJson -> {
-                    assertThat(remedyJson.getJsonObject(ODRL_ACTION_ATTRIBUTE).getString(ODRL_ACTION_TYPE_ATTRIBUTE))
+                    assertThat(remedyJson.getJsonObject(ODRL_ACTION_ATTRIBUTE).getString(ID))
                             .isEqualTo("remedyAction");
                 });
 

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/odrl/to/JsonObjectToActionTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/odrl/to/JsonObjectToActionTransformerTest.java
@@ -105,7 +105,7 @@ class JsonObjectToActionTransformerTest {
     }
 
     @Test
-    void transform_allAttributes_returnAction() {
+    void transform_allAttributesWithType_returnAction() {
         var constraint = AtomicConstraint.Builder.newInstance()
                 .leftExpression(new LiteralExpression("left"))
                 .operator(Operator.EQ)
@@ -115,6 +115,32 @@ class JsonObjectToActionTransformerTest {
 
         var action = jsonFactory.createObjectBuilder()
                 .add(ODRL_ACTION_TYPE_ATTRIBUTE, "use")
+                .add(ODRL_INCLUDED_IN_ATTRIBUTE, "includedIn")
+                .add(ODRL_REFINEMENT_ATTRIBUTE, jsonFactory.createObjectBuilder().build())
+                .build();
+
+        var result = transformer.transform(TestInput.getExpanded(action), context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getType()).isEqualTo("use");
+        assertThat(result.getIncludedIn()).isEqualTo("includedIn");
+        assertThat(result.getConstraint()).isEqualTo(constraint);
+
+        verify(context, never()).reportProblem(anyString());
+        verify(context, times(1)).transform(any(JsonObject.class), eq(Constraint.class));
+    }
+
+    @Test
+    void transform_allAttributes_returnAction() {
+        var constraint = AtomicConstraint.Builder.newInstance()
+                .leftExpression(new LiteralExpression("left"))
+                .operator(Operator.EQ)
+                .rightExpression(new LiteralExpression("right"))
+                .build();
+        when(context.transform(any(JsonObject.class), eq(Constraint.class))).thenReturn(constraint);
+
+        var action = jsonFactory.createObjectBuilder()
+                .add(ODRL_ACTION_ATTRIBUTE, "use")
                 .add(ODRL_INCLUDED_IN_ATTRIBUTE, "includedIn")
                 .add(ODRL_REFINEMENT_ATTRIBUTE, jsonFactory.createObjectBuilder().build())
                 .build();

--- a/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/PropertyAndTypeNames.java
+++ b/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/PropertyAndTypeNames.java
@@ -61,6 +61,7 @@ public interface PropertyAndTypeNames {
     String ODRL_PROHIBITION_ATTRIBUTE = ODRL_SCHEMA + "prohibition";
     String ODRL_OBLIGATION_ATTRIBUTE = ODRL_SCHEMA + "obligation";
     String ODRL_ACTION_ATTRIBUTE = ODRL_SCHEMA + "action";
+    @Deprecated(since = "0.7.0")
     String ODRL_ACTION_TYPE_ATTRIBUTE = ODRL_SCHEMA + "type";
     String ODRL_CONSEQUENCE_ATTRIBUTE = ODRL_SCHEMA + "consequence";
     String ODRL_REMEDY_ATTRIBUTE = ODRL_SCHEMA + "remedy";

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/PolicyDefinitionApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/PolicyDefinitionApiEndToEndTest.java
@@ -113,7 +113,7 @@ public class PolicyDefinitionApiEndToEndTest {
                     .body(CONTEXT, hasEntry(EDC_PREFIX, EDC_NAMESPACE))
                     .body(CONTEXT, hasEntry(ODRL_PREFIX, ODRL_SCHEMA))
                     .body("policy.'odrl:permission'.'odrl:constraint'.'odrl:operator'.@id", is("odrl:eq"))
-                    .body("policy.'odrl:prohibition'.'odrl:remedy'.'odrl:action'.'odrl:type'", is(ODRL_SCHEMA + "anonymize"))
+                    .body("policy.'odrl:prohibition'.'odrl:remedy'.'odrl:action'.@id", is("odrl:anonymize"))
                     .body("policy.'odrl:obligation'.'odrl:consequence'.size()", is(2));
         }
 


### PR DESCRIPTION
## What this PR changes/adds

Fixes the serialization of an `Action`

Currently the output is when the action is not refined

```json
 "odrl:action": {
    "odrl:type": "http://www.w3.org/ns/odrl/2/use"
   }
```

Now it changes to :

```json
 "odrl:action": {
    "@id": "odrl:use"
   }
```

Since now the action is an `@id` in compaction phase:

`http://www.w3.org/ns/odrl/2/use` => `odrl:use`

## Why it does that

bug fix

## Further notes

This is a breaking change for the MGMT API mostly since at protocol level older EDC should be able to deal wit the `@id` syntax.

The patch also support in input the old wrong `type` when deserializing the action from json.

## Linked Issue(s)

Closes #4192 


