### PR TITLE
docs(api): fix secrets api doc

### DIFF
--- a/extensions/control-plane/api/management-api/secrets-api/src/main/java/org/eclipse/edc/connector/api/management/secret/SecretsApi.java
+++ b/extensions/control-plane/api/management-api/secrets-api/src/main/java/org/eclipse/edc/connector/api/management/secret/SecretsApi.java
@@ -31,7 +31,6 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.spi.types.domain.secret.Secret.EDC_SECRET_TYPE;
-import static org.eclipse.edc.spi.types.domain.secret.Secret.EDC_SECRET_VALUE;
 
 @OpenAPIDefinition(
         info = @Info(description = "This contains the secret management API, which allows to add, remove and update secrets in the Vault.", title = "Secret API"))
@@ -94,7 +93,7 @@ public interface SecretsApi {
             String id,
             @Schema(name = TYPE, example = EDC_SECRET_TYPE)
             String type,
-            @Schema(name = EDC_SECRET_VALUE, requiredMode = REQUIRED)
+            @Schema(requiredMode = REQUIRED)
             String value
     ) {
         public static final String SECRET_INPUT_EXAMPLE = """
@@ -113,7 +112,7 @@ public interface SecretsApi {
             String id,
             @Schema(name = TYPE, example = EDC_SECRET_TYPE)
             String type,
-            @Schema(name = EDC_SECRET_VALUE, requiredMode = REQUIRED)
+            @Schema(requiredMode = REQUIRED)
             String value
     ) {
         public static final String SECRET_OUTPUT_EXAMPLE = """


### PR DESCRIPTION
## What this PR changes/adds

nothing fancy, just removing the overloaded `name` value, because as it was done it reported the full namespaced parameter name on the schema, but we usually report only the "compacted" version attribute name (in this case simply `value`).

## Why it does that

documentation consistency

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
