### PR TITLE
refactor: cleanup DataPlaneSignalingFlowController

### DIFF
--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferPullEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferPullEndToEndTest.java
@@ -342,6 +342,7 @@ class TransferPullEndToEndTest {
 
         private static final EdcRuntimeExtension CONSUMER_RUNTIME = Runtimes.InMemory.controlPlane("consumer-control-plane", CONSUMER.controlPlaneConfiguration());
         private static final EdcRuntimeExtension PROVIDER_RUNTIME = Runtimes.InMemory.controlPlaneEmbeddedDataPlane("provider-control-plane", PROVIDER.controlPlaneEmbeddedDataPlaneConfiguration());
+
         @RegisterExtension
         static final EdcClassRuntimesExtension RUNTIMES = new EdcClassRuntimesExtension(
                 CONSUMER_RUNTIME,


### PR DESCRIPTION
## What this PR changes/adds

Resolved a TODO on `DataPlaneSignalingFlowController`. The original idea (described in the issue #4203) was to move dp selection into the client factory, but in fact now that data-planes can register themselves, this simple fix solves also the "embedded" case: a data-plane always need to be registered with the correct supported types, the only difference will be that for an embedded data-plane the `EmbeddedDataPlaneClient` will be used instead of the `Remote` one

## Why it does that

refactor

## Further notes

- `DataPlaneSelectorService` could offer a `findById` method, so the caller won't need to fetch all the dataplanes and apply the filter by itself. Issue will come.

## Linked Issue(s)

Closes #4203 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
