### PR TITLE
feat: bump the Dataplane Selector management API endpoints to `v3`

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -68,7 +68,7 @@ maven/mavencentral/com.google.guava/guava/28.1-android, Apache-2.0, approved, cl
 maven/mavencentral/com.google.guava/guava/28.2-android, Apache-2.0 AND LicenseRef-Public-Domain, approved, CQ22437
 maven/mavencentral/com.google.guava/guava/31.0.1-android, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.guava/guava/31.1-jre, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.guava/guava/33.1.0-jre, Apache-2.0 AND CC0-1.0, approved, #13675
+maven/mavencentral/com.google.guava/guava/33.2.0-jre, Apache-2.0 AND CC0-1.0 AND (Apache-2.0 AND CC-PDDC), approved, #14607
 maven/mavencentral/com.google.guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava, Apache-2.0, approved, CQ22657
 maven/mavencentral/com.google.j2objc/j2objc-annotations/1.3, Apache-2.0, approved, CQ21195
 maven/mavencentral/com.google.protobuf/protobuf-java/3.23.4, BSD-3-Clause, approved, #8634
@@ -81,7 +81,7 @@ maven/mavencentral/com.lmax/disruptor/3.4.4, Apache-2.0, approved, clearlydefine
 maven/mavencentral/com.networknt/json-schema-validator/1.0.76, Apache-2.0, approved, CQ22638
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.28, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.39.1, Apache-2.0, approved, #14830
-maven/mavencentral/com.puppycrawl.tools/checkstyle/10.16.0, LGPL-2.1-or-later AND (Apache-2.0 AND LGPL-2.1-or-later) AND Apache-2.0, approved, #14689
+maven/mavencentral/com.puppycrawl.tools/checkstyle/10.17.0, , restricted, clearlydefined
 maven/mavencentral/com.samskivert/jmustache/1.15, BSD-2-Clause, approved, clearlydefined
 maven/mavencentral/com.squareup.okhttp3/okhttp-dnsoverhttps/4.12.0, Apache-2.0, approved, #11159
 maven/mavencentral/com.squareup.okhttp3/okhttp/4.12.0, Apache-2.0, approved, #11156
@@ -102,7 +102,7 @@ maven/mavencentral/commons-logging/commons-logging/1.1.1, Apache-2.0, approved, 
 maven/mavencentral/commons-logging/commons-logging/1.2, Apache-2.0, approved, CQ10162
 maven/mavencentral/dev.failsafe/failsafe-okhttp/3.3.2, Apache-2.0, approved, #9178
 maven/mavencentral/dev.failsafe/failsafe/3.3.2, Apache-2.0, approved, #9268
-maven/mavencentral/info.picocli/picocli/4.7.5, Apache-2.0, approved, #4365
+maven/mavencentral/info.picocli/picocli/4.7.6, Apache-2.0, approved, #4365
 maven/mavencentral/io.cloudevents/cloudevents-api/3.0.0, Apache-2.0, approved, #14228
 maven/mavencentral/io.cloudevents/cloudevents-core/3.0.0, Apache-2.0, approved, #14227
 maven/mavencentral/io.cloudevents/cloudevents-http-basic/3.0.0, Apache-2.0, approved, #14229
@@ -189,6 +189,7 @@ maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.15, Apache-2.0, approved,
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.1, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.11, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.15, Apache-2.0 AND BSD-3-Clause, approved, #7163
+maven/mavencentral/net.bytebuddy/byte-buddy/1.14.16, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.java.dev.jna/jna/5.13.0, Apache-2.0 AND LGPL-2.1-or-later, approved, #6709
 maven/mavencentral/net.javacrumbs.json-unit/json-unit-core/2.36.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/net.minidev/accessors-smart/2.4.7, Apache-2.0, approved, #7515
@@ -229,6 +230,7 @@ maven/mavencentral/org.apache.velocity/velocity-engine-scripting/2.3, Apache-2.0
 maven/mavencentral/org.apache.xbean/xbean-reflect/3.7, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.assertj/assertj-core/3.25.3, Apache-2.0, approved, #12585
+maven/mavencentral/org.assertj/assertj-core/3.26.0, Apache-2.0, approved, #14886
 maven/mavencentral/org.awaitility/awaitility/4.2.1, Apache-2.0, approved, #14178
 maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.72, MIT, approved, #3789
 maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.78.1, MIT, approved, #14434
@@ -239,6 +241,7 @@ maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.78.1, MIT, approved, #14435
 maven/mavencentral/org.ccil.cowan.tagsoup/tagsoup/1.2.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.checkerframework/checker-qual/3.12.0, MIT, approved, clearlydefined
 maven/mavencentral/org.checkerframework/checker-qual/3.42.0, MIT, approved, clearlydefined
+maven/mavencentral/org.checkerframework/checker-qual/3.43.0, MIT, approved, clearlydefined
 maven/mavencentral/org.codehaus.plexus/plexus-classworlds/2.6.0, Apache-2.0 AND Plexus, approved, CQ22821
 maven/mavencentral/org.codehaus.plexus/plexus-component-annotations/2.1.0, Apache-2.0, approved, #809
 maven/mavencentral/org.codehaus.plexus/plexus-container-default/2.1.0, Apache-2.0, approved, clearlydefined

--- a/extensions/data-plane-selector/data-plane-selector-api/build.gradle.kts
+++ b/extensions/data-plane-selector/data-plane-selector-api/build.gradle.kts
@@ -37,6 +37,8 @@ dependencies {
     testImplementation(project(":extensions:common:http"))
 
     testImplementation(libs.restAssured)
+    testImplementation(testFixtures(project(":extensions:common:http:jersey-core")))
+
 }
 
 edcBuild {

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/DataPlaneSelectorApiExtension.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/DataPlaneSelectorApiExtension.java
@@ -15,8 +15,9 @@
 package org.eclipse.edc.connector.dataplane.selector;
 
 import org.eclipse.edc.connector.api.management.configuration.ManagementApiConfiguration;
-import org.eclipse.edc.connector.dataplane.selector.api.v2.DataplaneSelectorApiController;
-import org.eclipse.edc.connector.dataplane.selector.api.v2.validation.DataPlaneInstanceValidator;
+import org.eclipse.edc.connector.dataplane.selector.api.v2.DataplaneSelectorApiV2Controller;
+import org.eclipse.edc.connector.dataplane.selector.api.v3.DataplaneSelectorApiV3Controller;
+import org.eclipse.edc.connector.dataplane.selector.api.validation.DataPlaneInstanceValidator;
 import org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService;
 import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
 import org.eclipse.edc.connector.dataplane.selector.transformer.JsonObjectToSelectionRequestTransformer;
@@ -71,8 +72,8 @@ public class DataPlaneSelectorApiExtension implements ServiceExtension {
         managementApiTransformerRegistry.register(new JsonObjectToSelectionRequestTransformer());
         managementApiTransformerRegistry.register(new JsonObjectToDataPlaneInstanceTransformer());
         managementApiTransformerRegistry.register(new JsonObjectFromDataPlaneInstanceTransformer(createBuilderFactory(Map.of()), typeManager.getMapper(JSON_LD)));
-        var controller = new DataplaneSelectorApiController(selectionService, managementApiTransformerRegistry, validatorRegistry, clock);
 
-        webservice.registerResource(managementApiConfiguration.getContextAlias(), controller);
+        webservice.registerResource(managementApiConfiguration.getContextAlias(), new DataplaneSelectorApiV2Controller(selectionService, managementApiTransformerRegistry, validatorRegistry, clock));
+        webservice.registerResource(managementApiConfiguration.getContextAlias(), new DataplaneSelectorApiV3Controller(selectionService, managementApiTransformerRegistry));
     }
 }

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/model/SelectionRequest.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/model/SelectionRequest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -12,15 +12,15 @@
  *
  */
 
-package org.eclipse.edc.connector.dataplane.selector.api.v2.model;
+package org.eclipse.edc.connector.dataplane.selector.api.model;
 
-import org.eclipse.edc.connector.dataplane.selector.api.v2.DataplaneSelectorApi;
+import org.eclipse.edc.connector.dataplane.selector.api.v2.DataplaneSelectorApiV2;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 
 /**
- * Represents the request body that the {@link DataplaneSelectorApi#selectDataPlaneInstance(jakarta.json.JsonObject)} endpoint requires
+ * Represents the request body that the {@link DataplaneSelectorApiV2#selectDataPlaneInstance(jakarta.json.JsonObject)} endpoint requires
  * Contains source and destination address and optionally the name of a selection strategy
  */
 public class SelectionRequest {

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/schemas/DataPlaneInstanceSchema.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/schemas/DataPlaneInstanceSchema.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.connector.dataplane.selector.api.v2.schemas;
+package org.eclipse.edc.connector.dataplane.selector.api.schemas;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/schemas/SelectionRequestSchema.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/schemas/SelectionRequestSchema.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -12,12 +12,12 @@
  *
  */
 
-package org.eclipse.edc.connector.dataplane.selector.api.v2.schemas;
+package org.eclipse.edc.connector.dataplane.selector.api.schemas;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.eclipse.edc.api.model.ApiCoreSchema;
 
-import static org.eclipse.edc.connector.dataplane.selector.api.v2.model.SelectionRequest.SELECTION_REQUEST_TYPE;
+import static org.eclipse.edc.connector.dataplane.selector.api.model.SelectionRequest.SELECTION_REQUEST_TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 
 @Schema(example = SelectionRequestSchema.SELECTION_REQUEST_INPUT_EXAMPLE)

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/DataplaneSelectorApiV2.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/DataplaneSelectorApiV2.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.dataplane.selector.api.v2;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -27,16 +28,16 @@ import jakarta.json.JsonObject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import org.eclipse.edc.api.model.ApiCoreSchema;
-import org.eclipse.edc.connector.dataplane.selector.api.v2.schemas.DataPlaneInstanceSchema;
-import org.eclipse.edc.connector.dataplane.selector.api.v2.schemas.SelectionRequestSchema;
+import org.eclipse.edc.connector.dataplane.selector.api.schemas.DataPlaneInstanceSchema;
+import org.eclipse.edc.connector.dataplane.selector.api.schemas.SelectionRequestSchema;
 
-@OpenAPIDefinition
-@Tag(name = "Dataplane Selector")
-public interface DataplaneSelectorApi {
+@OpenAPIDefinition(info = @Info(version = "v2"))
+@Tag(name = "Dataplane Selector V2")
+public interface DataplaneSelectorApiV2 {
 
     @Operation(method = "POST",
             deprecated = true,
-            operationId = "selectDataPlaneInstance",
+            operationId = "selectDataPlaneInstanceV2",
             description = "Finds the best fitting data plane instance for a particular query",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = SelectionRequestSchema.class))),
             responses = {
@@ -52,7 +53,7 @@ public interface DataplaneSelectorApi {
 
 
     @Operation(method = "POST",
-            operationId = "addDataPlaneInstance",
+            operationId = "addDataPlaneInstanceV2",
             description = "Adds one dataplane instance to the internal database of the selector. DEPRECATED: dataplanes should register themselves through control-api",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = DataPlaneInstanceSchema.class))),
             responses = {
@@ -66,14 +67,16 @@ public interface DataplaneSelectorApi {
     JsonObject addDataPlaneInstance(JsonObject instance);
 
     @Operation(method = "GET",
-            operationId = "getAllDataPlaneInstances",
+            operationId = "getAllDataPlaneInstancesV2",
             description = "Returns a list of all currently registered data plane instances",
             responses = {
                     @ApiResponse(responseCode = "200", description = "A (potentially empty) list of currently registered data plane instances",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = DataPlaneInstanceSchema.class))))
-            }
+            },
+            deprecated = true
     )
     @GET
+    @Deprecated(since = "0.7.0")
     JsonArray getAllDataPlaneInstances();
 
 }

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/DataplaneSelectorApiV2Controller.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/DataplaneSelectorApiV2Controller.java
@@ -23,7 +23,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import org.eclipse.edc.api.model.IdResponse;
-import org.eclipse.edc.connector.dataplane.selector.api.v2.model.SelectionRequest;
+import org.eclipse.edc.connector.dataplane.selector.api.model.SelectionRequest;
 import org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService;
 import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
 import org.eclipse.edc.spi.EdcException;
@@ -34,16 +34,15 @@ import org.eclipse.edc.web.spi.exception.InvalidRequestException;
 import org.eclipse.edc.web.spi.exception.ValidationFailureException;
 
 import java.time.Clock;
-import java.util.function.Supplier;
 
 import static jakarta.json.stream.JsonCollectors.toJsonArray;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.DATAPLANE_INSTANCE_TYPE;
 import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMapper;
 
-@Consumes({MediaType.APPLICATION_JSON})
-@Produces({MediaType.APPLICATION_JSON})
+@Consumes({ MediaType.APPLICATION_JSON })
+@Produces({ MediaType.APPLICATION_JSON })
 @Path("/v2/dataplanes")
-public class DataplaneSelectorApiController implements DataplaneSelectorApi {
+public class DataplaneSelectorApiV2Controller implements DataplaneSelectorApiV2 {
 
     private final DataPlaneSelectorService selectionService;
     private final TypeTransformerRegistry transformerRegistry;
@@ -52,7 +51,7 @@ public class DataplaneSelectorApiController implements DataplaneSelectorApi {
 
     private final Clock clock;
 
-    public DataplaneSelectorApiController(DataPlaneSelectorService selectionService, TypeTransformerRegistry transformerRegistry, JsonObjectValidatorRegistry validatorRegistry, Clock clock) {
+    public DataplaneSelectorApiV2Controller(DataPlaneSelectorService selectionService, TypeTransformerRegistry transformerRegistry, JsonObjectValidatorRegistry validatorRegistry, Clock clock) {
         this.selectionService = selectionService;
         this.transformerRegistry = transformerRegistry;
         this.validatorRegistry = validatorRegistry;
@@ -106,11 +105,4 @@ public class DataplaneSelectorApiController implements DataplaneSelectorApi {
                 .collect(toJsonArray());
     }
 
-    private DataPlaneInstance catchException(Supplier<DataPlaneInstance> supplier) {
-        try {
-            return supplier.get();
-        } catch (IllegalArgumentException ex) {
-            throw new InvalidRequestException(ex.getMessage());
-        }
-    }
 }

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v3/DataplaneSelectorApiV3.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v3/DataplaneSelectorApiV3.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.selector.api.v3;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.json.JsonArray;
+import jakarta.ws.rs.GET;
+import org.eclipse.edc.connector.dataplane.selector.api.schemas.DataPlaneInstanceSchema;
+
+@OpenAPIDefinition(info = @Info(version = "v3"))
+@Tag(name = "Dataplane Selector V3")
+public interface DataplaneSelectorApiV3 {
+
+    @Operation(method = "GET",
+            operationId = "getAllDataPlaneInstancesV3",
+            description = "Returns a list of all currently registered data plane instances",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "A (potentially empty) list of currently registered data plane instances",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = DataPlaneInstanceSchema.class))))
+            }
+    )
+    @GET
+    JsonArray getAllDataPlaneInstances();
+
+}

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v3/DataplaneSelectorApiV3Controller.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v3/DataplaneSelectorApiV3Controller.java
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.selector.api.v3;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService;
+import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+
+import static jakarta.json.stream.JsonCollectors.toJsonArray;
+import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMapper;
+
+@Consumes({ MediaType.APPLICATION_JSON })
+@Produces({ MediaType.APPLICATION_JSON })
+@Path("/v3/dataplanes")
+public class DataplaneSelectorApiV3Controller implements DataplaneSelectorApiV3 {
+
+    private final DataPlaneSelectorService selectionService;
+    private final TypeTransformerRegistry transformerRegistry;
+
+    public DataplaneSelectorApiV3Controller(DataPlaneSelectorService selectionService, TypeTransformerRegistry transformerRegistry) {
+        this.selectionService = selectionService;
+        this.transformerRegistry = transformerRegistry;
+    }
+
+    @Override
+    @GET
+    public JsonArray getAllDataPlaneInstances() {
+        var instances = selectionService.getAll().orElseThrow(exceptionMapper(DataPlaneInstance.class));
+        return instances.stream()
+                .map(i -> transformerRegistry.transform(i, JsonObject.class))
+                .filter(Result::succeeded)
+                .map(Result::getContent)
+                .collect(toJsonArray());
+    }
+
+}

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/validation/DataPlaneInstanceValidator.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/validation/DataPlaneInstanceValidator.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.connector.dataplane.selector.api.v2.validation;
+package org.eclipse.edc.connector.dataplane.selector.api.validation;
 
 import jakarta.json.JsonObject;
 import org.eclipse.edc.validator.jsonobject.JsonObjectValidator;

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/transformer/JsonObjectToSelectionRequestTransformer.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/transformer/JsonObjectToSelectionRequestTransformer.java
@@ -15,7 +15,7 @@
 package org.eclipse.edc.connector.dataplane.selector.transformer;
 
 import jakarta.json.JsonObject;
-import org.eclipse.edc.connector.dataplane.selector.api.v2.model.SelectionRequest;
+import org.eclipse.edc.connector.dataplane.selector.api.model.SelectionRequest;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.transform.spi.TransformerContext;

--- a/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/DataPlaneSelectorApiExtensionTest.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/DataPlaneSelectorApiExtensionTest.java
@@ -17,7 +17,8 @@ package org.eclipse.edc.connector.dataplane.selector;
 import org.eclipse.edc.boot.system.DefaultServiceExtensionContext;
 import org.eclipse.edc.boot.system.injection.ObjectFactory;
 import org.eclipse.edc.connector.api.management.configuration.ManagementApiConfiguration;
-import org.eclipse.edc.connector.dataplane.selector.api.v2.DataplaneSelectorApiController;
+import org.eclipse.edc.connector.dataplane.selector.api.v2.DataplaneSelectorApiV2Controller;
+import org.eclipse.edc.connector.dataplane.selector.api.v3.DataplaneSelectorApiV3Controller;
 import org.eclipse.edc.connector.dataplane.selector.service.EmbeddedDataPlaneSelectorService;
 import org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService;
 import org.eclipse.edc.connector.dataplane.selector.spi.store.DataPlaneInstanceStore;
@@ -77,10 +78,21 @@ class DataPlaneSelectorApiExtensionTest {
         when(managementApiConfiguration.getContextAlias()).thenReturn("management");
 
         extension.initialize(contextWithConfig(config));
-        verify(webService).registerResource(eq("management"), isA(DataplaneSelectorApiController.class));
+        verify(webService).registerResource(eq("management"), isA(DataplaneSelectorApiV2Controller.class));
         verify(transformerRegistry).register(isA(JsonObjectFromDataPlaneInstanceTransformer.class));
         verify(transformerRegistry).register(isA(JsonObjectToDataPlaneInstanceTransformer.class));
         verify(transformerRegistry).register(isA(JsonObjectToSelectionRequestTransformer.class));
+    }
+
+    @Test
+    void shouldRegisterControllers() {
+        var config = ConfigFactory.fromMap(Collections.emptyMap());
+        when(managementApiConfiguration.getContextAlias()).thenReturn("management");
+
+        extension.initialize(contextWithConfig(config));
+
+        verify(webService).registerResource(eq("management"), isA(DataplaneSelectorApiV2Controller.class));
+        verify(webService).registerResource(eq("management"), isA(DataplaneSelectorApiV3Controller.class));
     }
 
     @NotNull

--- a/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/api/DataPlaneApiSelectorTest.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/api/DataPlaneApiSelectorTest.java
@@ -17,7 +17,7 @@ package org.eclipse.edc.connector.dataplane.selector.api;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.json.JsonObject;
-import org.eclipse.edc.connector.dataplane.selector.api.v2.model.SelectionRequest;
+import org.eclipse.edc.connector.dataplane.selector.api.model.SelectionRequest;
 import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
 import org.eclipse.edc.connector.dataplane.selector.transformer.JsonObjectToSelectionRequestTransformer;
 import org.eclipse.edc.jsonld.TitaniumJsonLd;
@@ -33,8 +33,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.connector.dataplane.selector.api.v2.schemas.DataPlaneInstanceSchema.DATAPLANE_INSTANCE_EXAMPLE;
-import static org.eclipse.edc.connector.dataplane.selector.api.v2.schemas.SelectionRequestSchema.SELECTION_REQUEST_INPUT_EXAMPLE;
+import static org.eclipse.edc.connector.dataplane.selector.api.schemas.DataPlaneInstanceSchema.DATAPLANE_INSTANCE_EXAMPLE;
+import static org.eclipse.edc.connector.dataplane.selector.api.schemas.SelectionRequestSchema.SELECTION_REQUEST_INPUT_EXAMPLE;
 import static org.mockito.Mockito.mock;
 
 public class DataPlaneApiSelectorTest {

--- a/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/api/v2/DataPlaneSelectorApiV2ControllerTest.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/api/v2/DataPlaneSelectorApiV2ControllerTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -12,14 +12,14 @@
  *
  */
 
-package org.eclipse.edc.connector.dataplane.selector.api;
+package org.eclipse.edc.connector.dataplane.selector.api.v2;
 
 import io.restassured.specification.RequestSpecification;
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
-import org.eclipse.edc.connector.dataplane.selector.api.v2.model.SelectionRequest;
+import org.eclipse.edc.connector.dataplane.selector.api.model.SelectionRequest;
 import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
 import org.eclipse.edc.connector.dataplane.selector.spi.store.DataPlaneInstanceStore;
 import org.eclipse.edc.connector.dataplane.selector.spi.strategy.SelectionStrategy;
@@ -47,7 +47,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 @ComponentTest
 @ExtendWith(EdcExtension.class)
-public class DataPlaneSelectorApiControllerTest {
+public class DataPlaneSelectorApiV2ControllerTest {
 
     private static final int PORT = 8181;
 
@@ -220,7 +220,7 @@ public class DataPlaneSelectorApiControllerTest {
         var myCustomStrategy = new SelectionStrategy() {
             @Override
             public DataPlaneInstance apply(List<DataPlaneInstance> instances) {
-                return instances.stream().filter(i -> i.getId().equals("test-id1")).findFirst().get();
+                return instances.stream().filter(i -> i.getId().equals("test-id1")).findFirst().orElseThrow();
             }
 
             @Override
@@ -245,13 +245,6 @@ public class DataPlaneSelectorApiControllerTest {
         assertThat(result.getString(ID)).isEqualTo("test-id1");
     }
 
-    protected RequestSpecification baseRequest() {
-        return given()
-                .port(PORT)
-                .baseUri("http://localhost:" + PORT + "/api/v2/dataplanes")
-                .when();
-    }
-
     public JsonObject createSelectionRequestJson(String srcType, String destType, String strategy, String transferType) {
         var builder = createObjectBuilder()
                 .add(SelectionRequest.SOURCE_ADDRESS, createDataAddress(srcType))
@@ -262,6 +255,13 @@ public class DataPlaneSelectorApiControllerTest {
             builder.add(SelectionRequest.STRATEGY, strategy);
         }
         return builder.build();
+    }
+
+    protected RequestSpecification baseRequest() {
+        return given()
+                .port(PORT)
+                .baseUri("http://localhost:" + PORT + "/api/v2/dataplanes")
+                .when();
     }
 
     private JsonObjectBuilder createDataAddress(String type) {

--- a/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/api/v3/DataPlaneSelectorApiV3ControllerTest.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/api/v3/DataPlaneSelectorApiV3ControllerTest.java
@@ -1,0 +1,103 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.selector.api.v3;
+
+import io.restassured.specification.RequestSpecification;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import org.eclipse.edc.connector.dataplane.selector.api.model.SelectionRequest;
+import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
+import org.eclipse.edc.connector.dataplane.selector.spi.store.DataPlaneInstanceStore;
+import org.eclipse.edc.junit.annotations.ComponentTest;
+import org.eclipse.edc.junit.extensions.EdcExtension;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+import static jakarta.json.Json.createObjectBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.connector.dataplane.selector.TestFunctions.createInstance;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+
+@ComponentTest
+@ExtendWith(EdcExtension.class)
+public class DataPlaneSelectorApiV3ControllerTest {
+
+    private static final int PORT = 8181;
+
+    @Test
+    void getAll(DataPlaneInstanceStore store) {
+        var list = List.of(createInstance("test-id1"), createInstance("test-id2"), createInstance("test-id3"));
+        saveInstances(list, store);
+
+        var array = baseRequest()
+                .get()
+                .then()
+                .statusCode(200)
+                .extract().body().as(JsonArray.class);
+
+        assertThat(array).hasSize(3)
+                .allSatisfy(jo -> assertThat(jo.asJsonObject().getString(ID))
+                        .isIn("test-id1", "test-id2", "test-id3"));
+    }
+
+    @Test
+    void getAll_noneExist() {
+        var array = baseRequest()
+                .get()
+                .then()
+                .statusCode(200)
+                .extract().body().as(JsonArray.class);
+
+        assertThat(array).isNotNull().isEmpty();
+    }
+
+    public JsonObject createSelectionRequestJson(String srcType, String destType, String strategy, String transferType) {
+        var builder = createObjectBuilder()
+                .add(SelectionRequest.SOURCE_ADDRESS, createDataAddress(srcType))
+                .add(SelectionRequest.DEST_ADDRESS, createDataAddress(destType))
+                .add(SelectionRequest.TRANSFER_TYPE, transferType);
+
+        if (strategy != null) {
+            builder.add(SelectionRequest.STRATEGY, strategy);
+        }
+        return builder.build();
+    }
+
+    protected RequestSpecification baseRequest() {
+        return given()
+                .port(PORT)
+                .baseUri("http://localhost:" + PORT + "/api/v3/dataplanes")
+                .when();
+    }
+
+    private JsonObjectBuilder createDataAddress(String type) {
+        return createObjectBuilder()
+                .add(TYPE, EDC_NAMESPACE + "DataAddress")
+                .add(DataAddress.EDC_DATA_ADDRESS_TYPE_PROPERTY, type);
+    }
+
+    private void saveInstances(List<DataPlaneInstance> instances, DataPlaneInstanceStore store) {
+        for (var instance : instances) {
+            store.create(instance);
+        }
+    }
+}

--- a/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/transformer/JsonObjectToSelectionRequestTransformerTest.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/transformer/JsonObjectToSelectionRequestTransformerTest.java
@@ -25,10 +25,10 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import static jakarta.json.Json.createObjectBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.connector.dataplane.selector.api.v2.model.SelectionRequest.DEST_ADDRESS;
-import static org.eclipse.edc.connector.dataplane.selector.api.v2.model.SelectionRequest.SOURCE_ADDRESS;
-import static org.eclipse.edc.connector.dataplane.selector.api.v2.model.SelectionRequest.STRATEGY;
-import static org.eclipse.edc.connector.dataplane.selector.api.v2.model.SelectionRequest.TRANSFER_TYPE;
+import static org.eclipse.edc.connector.dataplane.selector.api.model.SelectionRequest.DEST_ADDRESS;
+import static org.eclipse.edc.connector.dataplane.selector.api.model.SelectionRequest.SOURCE_ADDRESS;
+import static org.eclipse.edc.connector.dataplane.selector.api.model.SelectionRequest.STRATEGY;
+import static org.eclipse.edc.connector.dataplane.selector.api.model.SelectionRequest.TRANSFER_TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;

--- a/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/validation/DataPlaneInstanceValidatorTest.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/validation/DataPlaneInstanceValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -12,17 +12,18 @@
  *
  */
 
-package org.eclipse.edc.connector.dataplane.selector.api.v2.validation;
+package org.eclipse.edc.connector.dataplane.selector.validation;
 
 import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
-import org.assertj.core.api.Assertions;
+import org.eclipse.edc.connector.dataplane.selector.api.validation.DataPlaneInstanceValidator;
 import org.eclipse.edc.validator.spi.Validator;
 import org.eclipse.edc.validator.spi.Violation;
 import org.junit.jupiter.api.Test;
 
 import static jakarta.json.Json.createArrayBuilder;
 import static jakarta.json.Json.createObjectBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_DEST_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_SOURCE_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.URL;
@@ -57,11 +58,7 @@ public class DataPlaneInstanceValidatorTest {
 
         var result = validator.validate(input);
 
-        assertThat(result).isFailed().satisfies(failure -> {
-            Assertions.assertThat(failure.getViolations()).hasSize(1).anySatisfy(v -> {
-                Assertions.assertThat(v.path()).isEqualTo(ID);
-            });
-        });
+        assertThat(result).isFailed().satisfies(failure -> assertThat(failure.getViolations()).hasSize(1).anySatisfy(v -> assertThat(v.path()).isEqualTo(ID)));
     }
 
     @Test
@@ -74,11 +71,7 @@ public class DataPlaneInstanceValidatorTest {
 
         var result = validator.validate(input);
 
-        assertThat(result).isFailed().satisfies(failure -> {
-            Assertions.assertThat(failure.getViolations()).hasSize(1).anySatisfy(v -> {
-                Assertions.assertThat(v.path()).isEqualTo(URL);
-            });
-        });
+        assertThat(result).isFailed().satisfies(failure -> assertThat(failure.getViolations()).hasSize(1).anySatisfy(v -> assertThat(v.path()).isEqualTo(URL)));
     }
 
     @Test
@@ -92,11 +85,9 @@ public class DataPlaneInstanceValidatorTest {
 
         var result = validator.validate(input);
 
-        assertThat(result).isFailed().satisfies(failure -> {
-            Assertions.assertThat(failure.getViolations()).hasSize(2)
-                    .map(Violation::path)
-                    .contains(ALLOWED_DEST_TYPES, ALLOWED_SOURCE_TYPES);
-        });
+        assertThat(result).isFailed().satisfies(failure -> assertThat(failure.getViolations()).hasSize(2)
+                .map(Violation::path)
+                .contains(ALLOWED_DEST_TYPES, ALLOWED_SOURCE_TYPES));
     }
 
     private JsonArrayBuilder value(String value) {


### PR DESCRIPTION
## What this PR changes/adds

Bumps the `DataPlaneSelectorApi` from `/v2 -> /v3`, deprecating `/v2`.

the V3 Controller does **not** contain deprecated methods of the V2 Controller!

## Why it does that

_Briefly state why the change was necessary._

## Further notes

- updates the `operationId` property of endpoints - **this is a breaking change**

## Linked Issue(s)

Closes #4208

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
