### PR TITLE
fix: replace File.separator with forward-slash

### DIFF
--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/JsonLdExtension.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/JsonLdExtension.java
@@ -93,7 +93,7 @@ public class JsonLdExtension implements ServiceExtension {
         Stream.of(
                 new JsonLdContext("odrl.jsonld", "http://www.w3.org/ns/odrl.jsonld"),
                 new JsonLdContext("dspace.jsonld", "https://w3id.org/dspace/2024/1/context.json")
-        ).forEach(jsonLdContext -> getResourceUri("document" + File.separator + jsonLdContext.fileName())
+        ).forEach(jsonLdContext -> getResourceUri("document/" + jsonLdContext.fileName())
                 .onSuccess(uri -> service.registerCachedDocument(jsonLdContext.url(), uri))
                 .onFailure(failure -> monitor.warning("Failed to register cached json-ld document: " + failure.getFailureDetail()))
         );
@@ -131,6 +131,7 @@ public class JsonLdExtension implements ServiceExtension {
         }
     }
 
-    record JsonLdContext(String fileName, String url) { }
+    record JsonLdContext(String fileName, String url) {
+    }
 
 }


### PR DESCRIPTION
## What this PR changes/adds

Replaces the `File.separator` with a hard-coded forward slash, to avoid path errors on Windows.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

- no tests - Windows is not a supported platform.

## Linked Issue(s)

Closes #4219

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
