### PR TITLE
feat: add `findById` method on `DataPlaneSelectorService`

### DIFF
--- a/core/data-plane-selector/data-plane-selector-core/src/main/java/org/eclipse/edc/connector/dataplane/selector/service/EmbeddedDataPlaneSelectorService.java
+++ b/core/data-plane-selector/data-plane-selector-core/src/main/java/org/eclipse/edc/connector/dataplane/selector/service/EmbeddedDataPlaneSelectorService.java
@@ -68,7 +68,6 @@ public class EmbeddedDataPlaneSelectorService implements DataPlaneSelectorServic
         });
     }
 
-
     @Override
     public ServiceResult<Void> addInstance(DataPlaneInstance instance) {
         return transactionContext.execute(() -> {
@@ -85,5 +84,16 @@ public class EmbeddedDataPlaneSelectorService implements DataPlaneSelectorServic
     @Override
     public ServiceResult<Void> delete(String instanceId) {
         return transactionContext.execute(() -> ServiceResult.from(store.deleteById(instanceId))).mapEmpty();
+    }
+
+    @Override
+    public ServiceResult<DataPlaneInstance> findById(String id) {
+        return transactionContext.execute(() -> {
+            var instance = store.findById(id);
+            if (instance == null) {
+                return ServiceResult.notFound("Data Plane instance with id %s not found".formatted(id));
+            }
+            return ServiceResult.success(instance);
+        });
     }
 }

--- a/extensions/control-plane/transfer/transfer-data-plane-signaling/src/main/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/flow/DataPlaneSignalingFlowController.java
+++ b/extensions/control-plane/transfer/transfer-data-plane-signaling/src/main/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/flow/DataPlaneSignalingFlowController.java
@@ -110,7 +110,6 @@ public class DataPlaneSignalingFlowController implements DataFlowController {
                         .dataPlaneId(dataPlaneInstance.getId())
                         .build()
                 );
-
     }
 
     @Override
@@ -150,17 +149,10 @@ public class DataPlaneSignalingFlowController implements DataFlowController {
     }
 
     private StatusResult<DataPlaneClient> getClientForDataplane(String id) {
-        var result = selectorClient.getAll();
-        if (result.failed()) {
-            return StatusResult.failure(FATAL_ERROR, result.getFailureDetail());
-        }
-
-        return result.getContent().stream()
-                .filter(instance -> instance.getId().equals(id))
-                .findFirst()
+        return selectorClient.findById(id)
                 .map(clientFactory::createClient)
                 .map(StatusResult::success)
-                .orElseGet(() -> StatusResult.failure(FATAL_ERROR, "No data-plane found with id %s".formatted(id)));
+                .orElse(f -> StatusResult.failure(FATAL_ERROR, "No data-plane found with id %s. %s".formatted(id, f.getFailureDetail())));
     }
 
 }

--- a/extensions/control-plane/transfer/transfer-data-plane-signaling/src/test/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/flow/DataPlaneSignalingFlowControllerTest.java
+++ b/extensions/control-plane/transfer/transfer-data-plane-signaling/src/test/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/flow/DataPlaneSignalingFlowControllerTest.java
@@ -223,7 +223,6 @@ public class DataPlaneSignalingFlowControllerTest {
         @Test
         void shouldCallTerminateOnTheRightDataPlane() {
             var dataPlaneInstance = dataPlaneInstanceBuilder().id("dataPlaneId").build();
-            var anotherDataPlane = dataPlaneInstanceBuilder().id("anotherId").build();
             var transferProcess = transferProcessBuilder()
                     .id("transferProcessId")
                     .contentDataAddress(testDataAddress())
@@ -231,7 +230,7 @@ public class DataPlaneSignalingFlowControllerTest {
                     .build();
             when(dataPlaneClient.terminate(any())).thenReturn(StatusResult.success());
             when(dataPlaneClientFactory.createClient(any())).thenReturn(dataPlaneClient);
-            when(selectorService.getAll()).thenReturn(ServiceResult.success(List.of(dataPlaneInstance, anotherDataPlane)));
+            when(selectorService.findById(any())).thenReturn(ServiceResult.success(dataPlaneInstance));
 
             var result = flowController.terminate(transferProcess);
 
@@ -241,8 +240,7 @@ public class DataPlaneSignalingFlowControllerTest {
         }
 
         @Test
-        void shouldFail_withInvalidDataPlaneId() {
-            var dataPlaneInstance = createDataPlaneInstance();
+        void shouldFail_whenDataPlaneNotFound() {
             var transferProcess = transferProcessBuilder()
                     .id("transferProcessId")
                     .contentDataAddress(testDataAddress())
@@ -250,25 +248,11 @@ public class DataPlaneSignalingFlowControllerTest {
                     .build();
             when(dataPlaneClient.terminate(any())).thenReturn(StatusResult.success());
             when(dataPlaneClientFactory.createClient(any())).thenReturn(dataPlaneClient);
-            when(selectorService.getAll()).thenReturn(ServiceResult.success(List.of(dataPlaneInstance)));
+            when(selectorService.findById(any())).thenReturn(ServiceResult.notFound("not found"));
 
             var result = flowController.terminate(transferProcess);
 
             assertThat(result).isFailed().detail().contains("Failed to select the data plane for terminating the transfer process");
-        }
-
-        @Test
-        void shouldFail_whenCannotGetDataplaneInstances() {
-            var transferProcess = transferProcessBuilder()
-                    .id("transferProcessId")
-                    .contentDataAddress(testDataAddress())
-                    .dataPlaneId("invalid")
-                    .build();
-            when(selectorService.getAll()).thenReturn(ServiceResult.unexpected("error"));
-
-            var result = flowController.terminate(transferProcess);
-
-            assertThat(result).isFailed();
         }
     }
 
@@ -285,26 +269,7 @@ public class DataPlaneSignalingFlowControllerTest {
             when(dataPlaneClient.suspend(any())).thenReturn(StatusResult.success());
             var dataPlaneInstance = dataPlaneInstanceBuilder().id("dataPlaneId").build();
             when(dataPlaneClientFactory.createClient(any())).thenReturn(dataPlaneClient);
-            when(selectorService.getAll()).thenReturn(ServiceResult.success(List.of(dataPlaneInstance)));
-
-            var result = flowController.suspend(transferProcess);
-
-            assertThat(result).isSucceeded();
-            verify(dataPlaneClient).suspend("transferProcessId");
-        }
-
-        @Test
-        void shouldCallSuspendOnTheRightDataPlane() {
-            var dataPlaneInstance = dataPlaneInstanceBuilder().id("dataPlaneId").build();
-            var anotherDataPlane = dataPlaneInstanceBuilder().id("anotherDataPlaneId").build();
-            var transferProcess = TransferProcess.Builder.newInstance()
-                    .id("transferProcessId")
-                    .contentDataAddress(testDataAddress())
-                    .dataPlaneId(dataPlaneInstance.getId())
-                    .build();
-            when(dataPlaneClient.suspend(any())).thenReturn(StatusResult.success());
-            when(dataPlaneClientFactory.createClient(any())).thenReturn(dataPlaneClient);
-            when(selectorService.getAll()).thenReturn(ServiceResult.success(List.of(dataPlaneInstance, anotherDataPlane)));
+            when(selectorService.findById(any())).thenReturn(ServiceResult.success(dataPlaneInstance));
 
             var result = flowController.suspend(transferProcess);
 
@@ -314,8 +279,7 @@ public class DataPlaneSignalingFlowControllerTest {
         }
 
         @Test
-        void shouldFail_withInvalidDataPlaneId() {
-            var dataPlaneInstance = createDataPlaneInstance();
+        void shouldFail_whenDataPlaneDoesNotExist() {
             var transferProcess = TransferProcess.Builder.newInstance()
                     .id("transferProcessId")
                     .contentDataAddress(testDataAddress())
@@ -323,26 +287,13 @@ public class DataPlaneSignalingFlowControllerTest {
                     .build();
             when(dataPlaneClient.suspend(any())).thenReturn(StatusResult.success());
             when(dataPlaneClientFactory.createClient(any())).thenReturn(dataPlaneClient);
-            when(selectorService.getAll()).thenReturn(ServiceResult.success(List.of(dataPlaneInstance)));
+            when(selectorService.findById(any())).thenReturn(ServiceResult.notFound("not found"));
 
             var result = flowController.suspend(transferProcess);
 
             assertThat(result).isFailed().detail().contains("Failed to select the data plane for suspending the transfer process");
         }
 
-        @Test
-        void shouldFail_whenCannotGetDataplaneInstances() {
-            var transferProcess = transferProcessBuilder()
-                    .id("transferProcessId")
-                    .contentDataAddress(testDataAddress())
-                    .dataPlaneId("invalid")
-                    .build();
-            when(selectorService.getAll()).thenReturn(ServiceResult.unexpected("error"));
-
-            var result = flowController.suspend(transferProcess);
-
-            assertThat(result).isFailed();
-        }
     }
 
     @Nested

--- a/extensions/data-plane-selector/data-plane-selector-control-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/control/api/DataplaneSelectorControlApi.java
+++ b/extensions/data-plane-selector/data-plane-selector-control-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/control/api/DataplaneSelectorControlApi.java
@@ -24,9 +24,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
-import jakarta.ws.rs.GET;
 import jakarta.ws.rs.HttpMethod;
-import jakarta.ws.rs.POST;
 import org.eclipse.edc.api.model.ApiCoreSchema;
 
 import java.net.URL;
@@ -55,7 +53,6 @@ public interface DataplaneSelectorControlApi {
                     @ApiResponse(responseCode = "409", description = "Resource already exists",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             })
-    @POST
     JsonObject registerDataplane(JsonObject request);
 
     @Operation(method = HttpMethod.DELETE,
@@ -69,7 +66,6 @@ public interface DataplaneSelectorControlApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             }
     )
-    @POST
     void unregisterDataplane(String id);
 
     @Operation(method = "POST",
@@ -83,7 +79,6 @@ public interface DataplaneSelectorControlApi {
                     @ApiResponse(responseCode = "400", description = "Request body was malformed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             })
-    @POST
     JsonObject selectDataplane(JsonObject request);
 
     @Operation(method = "GET",
@@ -94,8 +89,20 @@ public interface DataplaneSelectorControlApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = DataPlaneInstanceSchema.class))))
             }
     )
-    @GET
     JsonArray getAllDataPlaneInstances();
+
+
+    @Operation(method = "GET",
+            operationId = "findDataPlaneById",
+            description = "Returns the Data Plane Instance with the specified id.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The Data Plane Instance",
+                            content = @Content(schema = @Schema(implementation = DataPlaneInstanceSchema.class))),
+                    @ApiResponse(responseCode = "404", description = "Resource not found",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
+            }
+    )
+    JsonObject findDataPlaneById(String id);
 
     @Schema(example = DataPlaneInstanceSchema.DATAPLANE_INSTANCE_EXAMPLE)
     record DataPlaneInstanceSchema(

--- a/extensions/data-plane-selector/data-plane-selector-control-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/control/api/DataplaneSelectorControlApiController.java
+++ b/extensions/data-plane-selector/data-plane-selector-control-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/control/api/DataplaneSelectorControlApiController.java
@@ -18,6 +18,7 @@ import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
@@ -100,6 +101,7 @@ public class DataplaneSelectorControlApiController implements DataplaneSelectorC
     }
 
     @Override
+    @GET
     public JsonArray getAllDataPlaneInstances() {
         var instances = service.getAll().orElseThrow(exceptionMapper(DataPlaneInstance.class));
 
@@ -108,6 +110,16 @@ public class DataplaneSelectorControlApiController implements DataplaneSelectorC
                 .filter(Result::succeeded)
                 .map(Result::getContent)
                 .collect(toJsonArray());
+    }
+
+    @Override
+    @GET
+    @Path("/{id}")
+    public JsonObject findDataPlaneById(@PathParam("id") String id) {
+        var instance = service.findById(id).orElseThrow(exceptionMapper(DataPlaneInstance.class, id));
+
+        return transformerRegistry.transform(instance, JsonObject.class)
+                .orElseThrow(f -> new EdcException(f.getFailureDetail()));
     }
 
 }

--- a/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/DataPlaneSelectorService.java
+++ b/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/DataPlaneSelectorService.java
@@ -46,6 +46,27 @@ public interface DataPlaneSelectorService {
     ServiceResult<DataPlaneInstance> select(DataAddress source, String transferType, @Nullable String selectionStrategy);
 
     /**
+     * Add a data plane instance
+     */
+    ServiceResult<Void> addInstance(DataPlaneInstance instance);
+
+    /**
+     * Delete a Data Plane instance.
+     *
+     * @param instanceId the instance id.
+     * @return successful result if operation completed, failure otherwise.
+     */
+    ServiceResult<Void> delete(String instanceId);
+
+    /**
+     * Find a Data Plane instance by id.
+     *
+     * @param id the id.
+     * @return the {@link DataPlaneInstance} if operation is successful, failure otherwise.
+     */
+    ServiceResult<DataPlaneInstance> findById(String id);
+
+    /**
      * Selects the {@link DataPlaneInstance} that can handle a source and destination {@link DataAddress} using the configured
      * strategy.
      *
@@ -83,17 +104,5 @@ public interface DataPlaneSelectorService {
         }
     }
 
-    /**
-     * Add a data plane instance
-     */
-    ServiceResult<Void> addInstance(DataPlaneInstance instance);
-
-    /**
-     * Delete a Data Plane instance.
-     *
-     * @param instanceId the instance id.
-     * @return successful result if operation completed, failure otherwise.
-     */
-    ServiceResult<Void> delete(String instanceId);
 
 }


### PR DESCRIPTION
## What this PR changes/adds

Add `findById` method on `DataPlaneSelectorService`

## Why it does that

Avoid unnecessary calls to `getAll`

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #4210 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
