### PR TITLE
fix: correctly reset HealthStatus of BaseRuntime

### DIFF
--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/runtime/BaseRuntime.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/runtime/BaseRuntime.java
@@ -184,12 +184,9 @@ public class BaseRuntime {
             }
 
             if (context.hasService(HealthCheckService.class)) {
-                var statusbuilder = HealthCheckResult.Builder.newInstance().component("BaseRuntime");
-                var startupStatus = new AtomicReference<>(statusbuilder.failure("Startup not complete").build());
+                var startupStatusRef = new AtomicReference<>(HealthCheckResult.Builder.newInstance().component("BaseRuntime").success().build());
                 var healthCheckService = context.getService(HealthCheckService.class);
-                healthCheckService.addStartupStatusProvider(startupStatus::get);
-
-                startupStatus.set(statusbuilder.success().build());
+                healthCheckService.addStartupStatusProvider(startupStatusRef::get);
             }
 
         } catch (Exception e) {


### PR DESCRIPTION
## What this PR changes/adds

This correctly sets the HealthCheckResult of the base runtime to `succeeeded`, where previously it was initially set to failure, but later
the builder method `success()` was called, which caused the resulting result to contain a failure and a `success=true` flag.

This in turn was interpreted as failure by the HealthCheckService.

## Why it does that

Docker images never became healthy, causing our nightly builds to fail, specifically IdentityHub and FederatedCatalog.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
