### PR TITLE
fix: adds checks on prefixes post JSON-LD expansion process

### DIFF
--- a/core/common/lib/json-ld-lib/build.gradle.kts
+++ b/core/common/lib/json-ld-lib/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     api(libs.titaniumJsonLd)
     implementation(libs.jackson.datatype.jsr310)
 
+    implementation(project(":core:common:lib:validator-lib"))
     implementation(project(":spi:common:core-spi"))
     implementation(project(":spi:common:json-ld-spi"))
     testImplementation(project(":core:common:lib:util-lib"))

--- a/core/common/lib/json-ld-lib/src/main/java/org/eclipse/edc/jsonld/JsonLdConfiguration.java
+++ b/core/common/lib/json-ld-lib/src/main/java/org/eclipse/edc/jsonld/JsonLdConfiguration.java
@@ -32,7 +32,7 @@ public class JsonLdConfiguration {
         return httpsEnabled;
     }
 
-    public boolean isCheckPrefixes() {
+    public boolean shouldCheckPrefixes() {
         return checkPrefixes;
     }
 

--- a/core/common/lib/json-ld-lib/src/main/java/org/eclipse/edc/jsonld/JsonLdConfiguration.java
+++ b/core/common/lib/json-ld-lib/src/main/java/org/eclipse/edc/jsonld/JsonLdConfiguration.java
@@ -18,6 +18,7 @@ public class JsonLdConfiguration {
 
     private boolean httpEnabled = false;
     private boolean httpsEnabled = false;
+    private boolean checkPrefixes = true;
 
     private JsonLdConfiguration() {
 
@@ -29,6 +30,10 @@ public class JsonLdConfiguration {
 
     public boolean isHttpsEnabled() {
         return httpsEnabled;
+    }
+
+    public boolean isCheckPrefixes() {
+        return checkPrefixes;
     }
 
     public static class Builder {
@@ -46,6 +51,11 @@ public class JsonLdConfiguration {
 
         public Builder httpsEnabled(boolean httpsEnabled) {
             configuration.httpsEnabled = httpsEnabled;
+            return this;
+        }
+
+        public Builder checkPrefixes(boolean checkPrefixes) {
+            configuration.checkPrefixes = checkPrefixes;
             return this;
         }
 

--- a/core/common/lib/json-ld-lib/src/main/java/org/eclipse/edc/jsonld/TitaniumJsonLd.java
+++ b/core/common/lib/json-ld-lib/src/main/java/org/eclipse/edc/jsonld/TitaniumJsonLd.java
@@ -74,7 +74,7 @@ public class TitaniumJsonLd implements JsonLd {
     public TitaniumJsonLd(Monitor monitor, JsonLdConfiguration configuration) {
         this.monitor = monitor;
         this.documentLoader = new CachedDocumentLoader(configuration, monitor);
-        this.shouldCheckPrefixes = configuration.isCheckPrefixes();
+        this.shouldCheckPrefixes = configuration.shouldCheckPrefixes();
         this.validator = JsonObjectValidator.newValidator()
                 .verify((path) -> new MissingPrefixes(path, this::getAllPrefixes))
                 .build();

--- a/core/common/lib/json-ld-lib/src/test/java/org/eclipse/edc/jsonld/TitaniumJsonLdTest.java
+++ b/core/common/lib/json-ld-lib/src/test/java/org/eclipse/edc/jsonld/TitaniumJsonLdTest.java
@@ -77,6 +77,36 @@ class TitaniumJsonLdTest {
     }
 
     @Test
+    void expand_shouldFail_whenMissingRegisteredPrefix() {
+        var jsonObject = createObjectBuilder()
+                .add(JsonLdKeywords.CONTEXT, createObjectBuilder().build())
+                .add("custom:item", "foo")
+                .build();
+        var jsonLd = defaultService(JsonLdConfiguration.Builder.newInstance().checkPrefixes(false).build());
+
+        jsonLd.registerNamespace("custom", "https://custom.namespace.org/schema/");
+
+        var expanded = jsonLd.expand(jsonObject);
+
+        AbstractResultAssert.assertThat(expanded).isSucceeded();
+    }
+
+    @Test
+    void expand_shouldSucceed_whenMissingRegisteredPrefix() {
+        var jsonObject = createObjectBuilder()
+                .add(JsonLdKeywords.CONTEXT, createObjectBuilder().build())
+                .add("custom:item", "foo")
+                .build();
+        var jsonLd = defaultService();
+
+        jsonLd.registerNamespace("custom", "https://custom.namespace.org/schema/");
+
+        var expanded = jsonLd.expand(jsonObject);
+
+        AbstractResultAssert.assertThat(expanded).isFailed();
+    }
+
+    @Test
     void expand_withCustomContext() {
         var jsonObject = createObjectBuilder()
                 .add(JsonLdKeywords.CONTEXT, createObjectBuilder().add("custom", "https://custom.namespace.org/schema/").build())
@@ -96,6 +126,7 @@ class TitaniumJsonLdTest {
                 .contains("https://custom.namespace.org/schema/key2")
                 .contains("@value\":\"value2\"");
     }
+
 
     @Test
     void compact() {
@@ -313,6 +344,10 @@ class TitaniumJsonLdTest {
     }
 
     private JsonLd defaultService() {
-        return new TitaniumJsonLd(monitor);
+        return defaultService(JsonLdConfiguration.Builder.newInstance().build());
+    }
+
+    private JsonLd defaultService(JsonLdConfiguration configuration) {
+        return new TitaniumJsonLd(monitor, configuration);
     }
 }

--- a/core/common/lib/json-ld-lib/src/test/java/org/eclipse/edc/jsonld/TitaniumJsonLdTest.java
+++ b/core/common/lib/json-ld-lib/src/test/java/org/eclipse/edc/jsonld/TitaniumJsonLdTest.java
@@ -77,7 +77,7 @@ class TitaniumJsonLdTest {
     }
 
     @Test
-    void expand_shouldFail_whenMissingRegisteredPrefix() {
+    void expand_shouldSucceed_whenChecksDisabledOnMissingContext() {
         var jsonObject = createObjectBuilder()
                 .add(JsonLdKeywords.CONTEXT, createObjectBuilder().build())
                 .add("custom:item", "foo")
@@ -88,11 +88,11 @@ class TitaniumJsonLdTest {
 
         var expanded = jsonLd.expand(jsonObject);
 
-        AbstractResultAssert.assertThat(expanded).isSucceeded();
+        assertThat(expanded).isSucceeded();
     }
 
     @Test
-    void expand_shouldSucceed_whenMissingRegisteredPrefix() {
+    void expand_shouldFail_whenMissingContext() {
         var jsonObject = createObjectBuilder()
                 .add(JsonLdKeywords.CONTEXT, createObjectBuilder().build())
                 .add("custom:item", "foo")
@@ -103,7 +103,7 @@ class TitaniumJsonLdTest {
 
         var expanded = jsonLd.expand(jsonObject);
 
-        AbstractResultAssert.assertThat(expanded).isFailed();
+        assertThat(expanded).isFailed();
     }
 
     @Test

--- a/core/common/lib/validator-lib/src/main/java/org/eclipse/edc/validator/jsonobject/validators/MissingPrefixes.java
+++ b/core/common/lib/validator-lib/src/main/java/org/eclipse/edc/validator/jsonobject/validators/MissingPrefixes.java
@@ -1,0 +1,150 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.validator.jsonobject.validators;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonString;
+import jakarta.json.JsonValue;
+import org.eclipse.edc.validator.jsonobject.JsonLdPath;
+import org.eclipse.edc.validator.spi.ValidationResult;
+import org.eclipse.edc.validator.spi.Validator;
+import org.eclipse.edc.validator.spi.Violation;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+
+/**
+ * Verifies that after expansion all the properties are not prefixed with the configured prefixes for the runtime.
+ */
+public class MissingPrefixes implements Validator<JsonObject> {
+
+    private final JsonLdPath path;
+
+    private final Supplier<Set<String>> prefixesSupplier;
+
+    public MissingPrefixes(JsonLdPath path, Supplier<Set<String>> prefixesSupplier) {
+        this.path = path;
+        this.prefixesSupplier = prefixesSupplier;
+    }
+
+    @Override
+    public ValidationResult validate(JsonObject input) {
+        var prefixes = prefixesSupplier.get();
+        return Optional.ofNullable(input.getJsonArray(path.last()))
+                .filter(it -> !it.isEmpty())
+                .map(it -> it.getJsonObject(0))
+                .or(() -> Optional.of(input))
+                .map(it -> validateObject(it, path, prefixes))
+                .orElseGet(ValidationResult::success);
+    }
+
+    private ValidationResult validateObject(JsonObject input, JsonLdPath path, Set<String> prefixes) {
+        return input.entrySet().stream().map(entry -> validateField(entry.getKey(), entry.getValue(), path, prefixes))
+                .reduce(ValidationResult::merge)
+                .orElse(ValidationResult.success());
+    }
+
+    private ValidationResult validateArray(JsonArray array, JsonLdPath path, Set<String> prefixes) {
+        return array.stream().filter(f -> f instanceof JsonObject)
+                .map(JsonObject.class::cast)
+                .map(object -> validateObject(object, path, prefixes))
+                .reduce(ValidationResult::merge)
+                .orElse(ValidationResult.success());
+    }
+
+    private ValidationResult validateField(String name, JsonValue value, JsonLdPath path, Set<String> prefixes) {
+        return switch (name) {
+            case TYPE -> validateTypeValue(value, path, prefixes);
+            case ID -> validateIdValue(value, path, prefixes);
+            default -> validateGenericField(name, value, path, prefixes);
+        };
+
+    }
+
+    private ValidationResult validateTypeValue(JsonValue value, JsonLdPath path, Set<String> prefixes) {
+        if (value instanceof JsonArray array) {
+            return array.stream()
+                    .filter(it -> it.getValueType() == JsonValue.ValueType.STRING)
+                    .map(JsonString.class::cast)
+                    .map(JsonString::getString)
+                    .map(type -> validateType(type, path, prefixes))
+                    .reduce(ValidationResult::merge)
+                    .orElseGet(ValidationResult::success);
+        } else if (value instanceof JsonString type) {
+            return validateType(type.getString(), path, prefixes);
+        } else {
+            return ValidationResult.success();
+        }
+    }
+
+    private ValidationResult validateType(String type, JsonLdPath path, Set<String> prefixes) {
+        var msg = "Value of @type contains a prefix '%s' which was not expended correctly. Ensure to attach the namespace definition in the input JSON-LD.";
+        return validate(type, path, prefixes, msg::formatted);
+    }
+
+    private ValidationResult validate(String input, JsonLdPath path, Set<String> prefixes, Function<String, String> formatter) {
+        return Arrays.stream(input.split(":"))
+                .findFirst()
+                .map(prefix -> validatePrefix(prefix, path, prefixes, formatter))
+                .orElseGet(ValidationResult::success);
+    }
+
+    private ValidationResult validatePrefix(String prefix, JsonLdPath path, Set<String> prefixes, Function<String, String> formatter) {
+        if (prefixes.contains(prefix)) {
+            var msg = formatter.apply(prefix);
+            return ValidationResult.failure(Violation.violation(msg, path.toString()));
+        } else {
+            return ValidationResult.success();
+        }
+    }
+
+    private ValidationResult validateId(String id, JsonLdPath path, Set<String> prefixes) {
+        var msg = "Value of @id contains a prefix '%s' which was not expended correctly. Ensure to attach the namespace definition in the input JSON-LD.";
+        return validate(id, path, prefixes, msg::formatted);
+    }
+
+    private ValidationResult validateIdValue(JsonValue value, JsonLdPath path, Set<String> prefixes) {
+        if (value instanceof JsonString id) {
+            return validateId(id.getString(), path, prefixes);
+        } else {
+            return ValidationResult.success();
+        }
+    }
+
+    private ValidationResult validateGenericField(String name, JsonValue value, JsonLdPath path, Set<String> prefixes) {
+        var newPath = path.append(name);
+        var msg = "Property %s, contains a prefix '%s' which was not expended correctly. Ensure to attach the namespace definition in the input JSON-LD.";
+        var result = validate(name, newPath, prefixes, (prefix) -> msg.formatted(name, prefix));
+
+        if (result.failed()) {
+            return result;
+        } else {
+            if (value instanceof JsonObject object) {
+                return validateObject(object, newPath, prefixes);
+            } else if (value instanceof JsonArray array) {
+                return validateArray(array, newPath, prefixes);
+            } else {
+                return ValidationResult.success();
+            }
+        }
+    }
+}

--- a/core/common/lib/validator-lib/src/test/java/org/eclipse/edc/validator/jsonobject/MissingPrefixesTest.java
+++ b/core/common/lib/validator-lib/src/test/java/org/eclipse/edc/validator/jsonobject/MissingPrefixesTest.java
@@ -26,6 +26,10 @@ import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 
 class MissingPrefixesTest {
 
+
+    private final JsonObjectValidator validator = JsonObjectValidator.newValidator()
+            .verify(path -> new MissingPrefixes(path, () -> Set.of("prefix"))).build();
+
     @Test
     void shouldValidateObjectMissingPrefixes_success() {
         var input = createObjectBuilder()
@@ -36,7 +40,7 @@ class MissingPrefixesTest {
                                 .add("subProperty", ""))
                 );
 
-        var result = JsonObjectValidator.newValidator().verify(path -> new MissingPrefixes(path, () -> Set.of("prefix"))).build().validate(input.build());
+        var result = validator.validate(input.build());
 
         assertThat(result).isSucceeded();
     }
@@ -49,7 +53,7 @@ class MissingPrefixesTest {
                                 .add("subProperty", ""))
                 );
 
-        var result = JsonObjectValidator.newValidator().verify(path -> new MissingPrefixes(path, () -> Set.of("prefix"))).build().validate(input.build());
+        var result = validator.validate(input.build());
 
         assertThat(result).isFailed().satisfies(failure -> {
             assertThat(failure.getViolations()).anySatisfy(violation -> {
@@ -66,7 +70,7 @@ class MissingPrefixesTest {
                                 .add("prefix:subProperty", ""))
                 );
 
-        var result = JsonObjectValidator.newValidator().verify(path -> new MissingPrefixes(path, () -> Set.of("prefix"))).build().validate(input.build());
+        var result = validator.validate(input.build());
 
         assertThat(result).isFailed().satisfies(failure -> {
             assertThat(failure.getViolations()).anySatisfy(violation -> {
@@ -84,7 +88,7 @@ class MissingPrefixesTest {
                                 .add("@id", "prefix:subProperty"))
                 );
 
-        var result = JsonObjectValidator.newValidator().verify("mandatoryObject", path -> new MissingPrefixes(path, () -> Set.of("prefix"))).build().validate(input.build());
+        var result = validator.validate(input.build());
 
         assertThat(result).isFailed().satisfies(failure -> {
             assertThat(failure.getViolations()).anySatisfy(violation -> {
@@ -102,7 +106,7 @@ class MissingPrefixesTest {
                                 .add("@type", createArrayBuilder().add("prefix:subProperty")))
                 );
 
-        var result = JsonObjectValidator.newValidator().verify("mandatoryObject", path -> new MissingPrefixes(path, () -> Set.of("prefix"))).build().validate(input.build());
+        var result = validator.validate(input.build());
 
         assertThat(result).isFailed().satisfies(failure -> {
             assertThat(failure.getViolations()).anySatisfy(violation -> {

--- a/core/common/lib/validator-lib/src/test/java/org/eclipse/edc/validator/jsonobject/MissingPrefixesTest.java
+++ b/core/common/lib/validator-lib/src/test/java/org/eclipse/edc/validator/jsonobject/MissingPrefixesTest.java
@@ -1,0 +1,114 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.validator.jsonobject;
+
+import org.eclipse.edc.validator.jsonobject.validators.MissingPrefixes;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static jakarta.json.Json.createArrayBuilder;
+import static jakarta.json.Json.createObjectBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+
+class MissingPrefixesTest {
+
+    @Test
+    void shouldValidateObjectMissingPrefixes_success() {
+        var input = createObjectBuilder()
+                .add("mandatoryObject", createArrayBuilder()
+                        .add(createObjectBuilder()
+                                .add("@id", "id")
+                                .add("@type", createArrayBuilder().add("type"))
+                                .add("subProperty", ""))
+                );
+
+        var result = JsonObjectValidator.newValidator().verify(path -> new MissingPrefixes(path, () -> Set.of("prefix"))).build().validate(input.build());
+
+        assertThat(result).isSucceeded();
+    }
+
+    @Test
+    void shouldValidateObjectMissingPrefixes_failure() {
+        var input = createObjectBuilder()
+                .add("prefix:mandatoryObject", createArrayBuilder()
+                        .add(createObjectBuilder()
+                                .add("subProperty", ""))
+                );
+
+        var result = JsonObjectValidator.newValidator().verify(path -> new MissingPrefixes(path, () -> Set.of("prefix"))).build().validate(input.build());
+
+        assertThat(result).isFailed().satisfies(failure -> {
+            assertThat(failure.getViolations()).anySatisfy(violation -> {
+                assertThat(violation.path()).contains("prefix:mandatoryObject");
+            });
+        });
+    }
+
+    @Test
+    void shouldValidateMissingPrefixes_whenNestedProperty_failure() {
+        var input = createObjectBuilder()
+                .add("mandatoryObject", createArrayBuilder()
+                        .add(createObjectBuilder()
+                                .add("prefix:subProperty", ""))
+                );
+
+        var result = JsonObjectValidator.newValidator().verify(path -> new MissingPrefixes(path, () -> Set.of("prefix"))).build().validate(input.build());
+
+        assertThat(result).isFailed().satisfies(failure -> {
+            assertThat(failure.getViolations()).anySatisfy(violation -> {
+                assertThat(violation.path()).contains("prefix:subProperty");
+            });
+        });
+    }
+
+
+    @Test
+    void shouldValidateNestedMissingPrefixes_whenPrefixedId_failure() {
+        var input = createObjectBuilder()
+                .add("mandatoryObject", createArrayBuilder()
+                        .add(createObjectBuilder()
+                                .add("@id", "prefix:subProperty"))
+                );
+
+        var result = JsonObjectValidator.newValidator().verify("mandatoryObject", path -> new MissingPrefixes(path, () -> Set.of("prefix"))).build().validate(input.build());
+
+        assertThat(result).isFailed().satisfies(failure -> {
+            assertThat(failure.getViolations()).anySatisfy(violation -> {
+                assertThat(violation.path()).contains("mandatoryObject");
+                assertThat(violation.message()).contains("Value of @id contains a prefix");
+            });
+        });
+    }
+
+    @Test
+    void shouldValidateNestedMissingPrefixes_whenPrefixedType_failure() {
+        var input = createObjectBuilder()
+                .add("mandatoryObject", createArrayBuilder()
+                        .add(createObjectBuilder()
+                                .add("@type", createArrayBuilder().add("prefix:subProperty")))
+                );
+
+        var result = JsonObjectValidator.newValidator().verify("mandatoryObject", path -> new MissingPrefixes(path, () -> Set.of("prefix"))).build().validate(input.build());
+
+        assertThat(result).isFailed().satisfies(failure -> {
+            assertThat(failure.getViolations()).anySatisfy(violation -> {
+                assertThat(violation.path()).contains("mandatoryObject");
+                assertThat(violation.message()).contains("Value of @type contains a prefix");
+            });
+        });
+    }
+}

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/JsonLdExtension.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/JsonLdExtension.java
@@ -63,6 +63,10 @@ public class JsonLdExtension implements ServiceExtension {
     private static final String DEFAULT_AVOID_VOCAB_CONTEXT = "false";
     @Setting(value = "If true disable the @vocab context definition. This could be used to avoid api breaking changes", type = "boolean", defaultValue = DEFAULT_AVOID_VOCAB_CONTEXT)
     private static final String AVOID_VOCAB_CONTEXT = "edc.jsonld.vocab.disable";
+    private static final boolean DEFAULT_CHECK_PREFIXES = true;
+    @Setting(value = "If true a validation on expended object will be made against configured prefixes", type = "boolean", defaultValue = DEFAULT_CHECK_PREFIXES + "")
+    private static final String CHECK_PREFIXES = "edc.jsonld.prefixes.check";
+
     @Inject
     private TypeManager typeManager;
 
@@ -82,6 +86,7 @@ public class JsonLdExtension implements ServiceExtension {
         var configuration = JsonLdConfiguration.Builder.newInstance()
                 .httpEnabled(config.getBoolean(HTTP_ENABLE_SETTING, DEFAULT_HTTP_HTTPS_RESOLUTION))
                 .httpsEnabled(config.getBoolean(HTTPS_ENABLE_SETTING, DEFAULT_HTTP_HTTPS_RESOLUTION))
+                .checkPrefixes(config.getBoolean(CHECK_PREFIXES, DEFAULT_CHECK_PREFIXES))
                 .build();
         var monitor = context.getMonitor();
         var service = new TitaniumJsonLd(monitor, configuration);


### PR DESCRIPTION
## What this PR changes/adds

A new JSON-LD validator has been introduced in order to walk the input JsonObject after the expansion process
and check if some `property` name or `@id`/`@type` values still contains prefixed notation and checks those prefixes against the configured ones for the runtime. 
This can happen on custom properties (that we have in almost all entities) when the input JSON-LD object does not contains the prefix alias in the `@context`.

For example like in the #4160  issue if a user post a property `dct:type` without explicitly  mapping `dct` in the context :

```json
{
    "@context": {
        "dct": "http://purl.org/dc/terms/"
    },
    "dct:type": "mytype"
}
``` 

It will cause the property to be stored as `dct:type` instead of the expanded form. This is not always an issue but it can lead to JsonLD error  in compaction as `Absolute IRI  confused with prefix`. 

Since there are multiple places where we support custom properties in our entities, almost in every entities
the prefix check is added directly after the expansion process in the default JSON-LD service implementation.

The prefixes checker can be disabled with the setting `edc.jsonld.prefixes.check`, but it's activated by default

## Why it does that

Fixes eventual compaction issue when returning JSON-LD objects

## Further notes


## Linked Issue(s)

Closes #4160 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
