### PR TITLE
feat: make async test timeout overrideable

### DIFF
--- a/spi/data-plane/data-plane-spi/src/testFixtures/java/org/eclipse/edc/connector/dataplane/spi/testfixtures/store/DataPlaneStoreTestBase.java
+++ b/spi/data-plane/data-plane-spi/src/testFixtures/java/org/eclipse/edc/connector/dataplane/spi/testfixtures/store/DataPlaneStoreTestBase.java
@@ -55,6 +55,14 @@ public abstract class DataPlaneStoreTestBase {
 
     protected abstract boolean isLeasedBy(String entityId, String owner);
 
+    /**
+     * determines the amount of time (default = 500ms) before an async test using Awaitility fails. This may be useful if using remote
+     * or non-self-contained databases.
+     */
+    protected Duration getTestTimeout() {
+        return Duration.ofMillis(500);
+    }
+
     private DataFlow createDataFlow(String id, DataFlowStates state) {
         return DataFlow.Builder.newInstance()
                 .id(id)
@@ -149,7 +157,7 @@ public abstract class DataPlaneStoreTestBase {
 
             leaseEntity(dataFlow.getId(), CONNECTOR_NAME, Duration.ofMillis(100));
 
-            await().atMost(Duration.ofMillis(500))
+            await().atMost(getTestTimeout())
                     .until(() -> getStore().nextNotLeased(1, hasState(RECEIVED.code())), hasSize(1));
         }
 


### PR DESCRIPTION
## What this PR changes/adds

database tests that test the behaviour of leases now use a configurable/overrideable test timeout. That way, tests that use a remote database can increase the timeout.

## Why it does that

I noticed that some tests using CosmosDB (in the Technology-Azure repo) fail because 500ms is simply not enough for a cold connection to reliably return data.

## Further notes

- A subsequent PR in the tech repo will follow that then makes use of this feature.

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
