### PR TITLE
docs(api): fix request and response types

### DIFF
--- a/extensions/common/api/version-api/src/main/java/org/eclipse/edc/connector/api/management/version/v1/VersionApi.java
+++ b/extensions/common/api/version-api/src/main/java/org/eclipse/edc/connector/api/management/version/v1/VersionApi.java
@@ -39,7 +39,6 @@ import static org.eclipse.edc.spi.types.domain.secret.Secret.EDC_SECRET_VALUE;
 public interface VersionApi {
 
     @Operation(description = "Gets the exact SemVer string of the Management API",
-            operationId = "getVersion",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The secret",
                             content = @Content(schema = @Schema(implementation = SecretOutputSchema.class)))

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/asset/v3/AssetApi.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/asset/v3/AssetApi.java
@@ -40,7 +40,6 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 @Tag(name = "Asset V3")
 public interface AssetApi {
     @Operation(description = "Creates a new asset together with a data address",
-            operationId = "createAssetV3",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = AssetInputSchema.class))),
             responses = {
                     @ApiResponse(responseCode = "200", description = "Asset was created successfully. Returns the asset Id and created timestamp",
@@ -50,10 +49,9 @@ public interface AssetApi {
                     @ApiResponse(responseCode = "409", description = "Could not create asset, because an asset with that ID already exists",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))) }
     )
-    JsonObject createAsset(JsonObject asset);
+    JsonObject createAssetV3(JsonObject asset);
 
     @Operation(description = "Request all assets according to a particular query",
-            operationId = "requestAssetV3",
             requestBody = @RequestBody(
                     content = @Content(schema = @Schema(implementation = ApiCoreSchema.QuerySpecSchema.class))
             ),
@@ -63,10 +61,9 @@ public interface AssetApi {
                     @ApiResponse(responseCode = "400", description = "Request body was malformed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             })
-    JsonArray requestAssets(JsonObject querySpecJson);
+    JsonArray requestAssetsV3(JsonObject querySpecJson);
 
     @Operation(description = "Gets an asset with the given ID",
-            operationId = "getAssetV3",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The asset",
                             content = @Content(schema = @Schema(implementation = AssetOutputSchema.class))),
@@ -76,12 +73,11 @@ public interface AssetApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             }
     )
-    JsonObject getAsset(String id);
+    JsonObject getAssetV3(String id);
 
     @Operation(description = "Removes an asset with the given ID if possible. Deleting an asset is only possible if that asset is not yet referenced " +
             "by a contract agreement, in which case an error is returned. " +
             "DANGER ZONE: Note that deleting assets can have unexpected results, especially for contract offers that have been sent out or ongoing or contract negotiations.",
-            operationId = "removeAssetV3",
             responses = {
                     @ApiResponse(responseCode = "204", description = "Asset was deleted successfully"),
                     @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
@@ -91,11 +87,10 @@ public interface AssetApi {
                     @ApiResponse(responseCode = "409", description = "The asset cannot be deleted, because it is referenced by a contract agreement",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             })
-    void removeAsset(String id);
+    void removeAssetV3(String id);
 
     @Operation(description = "Updates an asset with the given ID if it exists. If the asset is not found, no further action is taken. " +
             "DANGER ZONE: Note that updating assets can have unexpected results, especially for contract offers that have been sent out or are ongoing in contract negotiations.",
-            operationId = "updateAssetV3",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = AssetInputSchema.class))),
             responses = {
                     @ApiResponse(responseCode = "204", description = "Asset was updated successfully"),
@@ -103,7 +98,7 @@ public interface AssetApi {
                     @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
             })
-    void updateAsset(JsonObject asset);
+    void updateAssetV3(JsonObject asset);
 
     @Schema(name = "AssetInput", example = AssetInputSchema.ASSET_INPUT_EXAMPLE)
     record AssetInputSchema(

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/asset/v3/AssetApiController.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/asset/v3/AssetApiController.java
@@ -63,7 +63,7 @@ public class AssetApiController implements AssetApi {
 
     @POST
     @Override
-    public JsonObject createAsset(JsonObject assetJson) {
+    public JsonObject createAssetV3(JsonObject assetJson) {
         validator.validate(EDC_ASSET_TYPE, assetJson).orElseThrow(ValidationFailureException::new);
 
         var asset = transformerRegistry.transform(assetJson, Asset.class)
@@ -83,7 +83,7 @@ public class AssetApiController implements AssetApi {
     @POST
     @Path("/request")
     @Override
-    public JsonArray requestAssets(JsonObject querySpecJson) {
+    public JsonArray requestAssetsV3(JsonObject querySpecJson) {
         QuerySpec querySpec;
         if (querySpecJson == null) {
             querySpec = QuerySpec.Builder.newInstance().build();
@@ -105,7 +105,7 @@ public class AssetApiController implements AssetApi {
     @GET
     @Path("{id}")
     @Override
-    public JsonObject getAsset(@PathParam("id") String id) {
+    public JsonObject getAssetV3(@PathParam("id") String id) {
         var asset = of(id)
                 .map(it -> service.findById(id))
                 .orElseThrow(() -> new ObjectNotFoundException(Asset.class, id));
@@ -118,13 +118,13 @@ public class AssetApiController implements AssetApi {
     @DELETE
     @Path("{id}")
     @Override
-    public void removeAsset(@PathParam("id") String id) {
+    public void removeAssetV3(@PathParam("id") String id) {
         service.delete(id).orElseThrow(exceptionMapper(Asset.class, id));
     }
 
     @PUT
     @Override
-    public void updateAsset(JsonObject assetJson) {
+    public void updateAssetV3(JsonObject assetJson) {
         validator.validate(EDC_ASSET_TYPE, assetJson).orElseThrow(ValidationFailureException::new);
 
         var assetResult = transformerRegistry.transform(assetJson, Asset.class)

--- a/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/catalog/BaseCatalogApiController.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/catalog/BaseCatalogApiController.java
@@ -15,12 +15,7 @@
 package org.eclipse.edc.connector.controlplane.api.management.catalog;
 
 import jakarta.json.JsonObject;
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.POST;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.container.AsyncResponse;
-import jakarta.ws.rs.container.Suspended;
 import org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequest;
 import org.eclipse.edc.connector.controlplane.catalog.spi.DatasetRequest;
 import org.eclipse.edc.connector.controlplane.services.spi.catalog.CatalogService;
@@ -32,12 +27,10 @@ import org.eclipse.edc.web.spi.exception.BadGatewayException;
 import org.eclipse.edc.web.spi.exception.InvalidRequestException;
 import org.eclipse.edc.web.spi.exception.ValidationFailureException;
 
-import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequest.CATALOG_REQUEST_TYPE;
 import static org.eclipse.edc.connector.controlplane.catalog.spi.DatasetRequest.DATASET_REQUEST_TYPE;
 
-@Consumes(APPLICATION_JSON)
-@Produces(APPLICATION_JSON)
+
 public abstract class BaseCatalogApiController {
 
     private final CatalogService service;
@@ -51,9 +44,7 @@ public abstract class BaseCatalogApiController {
         this.validatorRegistry = validatorRegistry;
     }
 
-    @POST
-    @Path("/request")
-    public void requestCatalog(JsonObject requestBody, @Suspended AsyncResponse response) {
+    public void requestCatalog(JsonObject requestBody, AsyncResponse response) {
         validatorRegistry.validate(CATALOG_REQUEST_TYPE, requestBody).orElseThrow(ValidationFailureException::new);
 
         var request = transformerRegistry.transform(requestBody, CatalogRequest.class)
@@ -69,9 +60,7 @@ public abstract class BaseCatalogApiController {
                 });
     }
 
-    @POST
-    @Path("dataset/request")
-    public void getDataset(JsonObject requestBody, @Suspended AsyncResponse response) {
+    public void getDataset(JsonObject requestBody, AsyncResponse response) {
         validatorRegistry.validate(DATASET_REQUEST_TYPE, requestBody).orElseThrow(ValidationFailureException::new);
 
         var request = transformerRegistry.transform(requestBody, DatasetRequest.class)

--- a/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/catalog/v2/CatalogApiV2.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/catalog/v2/CatalogApiV2.java
@@ -39,7 +39,6 @@ public interface CatalogApiV2 {
 
     @Operation(
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = CatalogRequestSchema.class))),
-            operationId = "requestCatalogV2",
             responses = { @ApiResponse(
                     content = @Content(
                             mediaType = "application/json",
@@ -49,11 +48,10 @@ public interface CatalogApiV2 {
             deprecated = true
     )
     @Deprecated(since = "0.7.0")
-    void requestCatalog(JsonObject request, @Suspended AsyncResponse response);
+    void requestCatalogV2(JsonObject request, @Suspended AsyncResponse response);
 
     @Operation(
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = DatasetRequestSchema.class))),
-            operationId = "getDatasetV2",
             responses = { @ApiResponse(
                     content = @Content(
                             mediaType = "application/json",
@@ -63,7 +61,7 @@ public interface CatalogApiV2 {
             deprecated = true
     )
     @Deprecated(since = "0.7.0")
-    void getDataset(JsonObject request, @Suspended AsyncResponse response);
+    void getDatasetV2(JsonObject request, @Suspended AsyncResponse response);
 
     @Schema(name = "CatalogRequest", example = CatalogRequestSchema.CATALOG_REQUEST_EXAMPLE)
     record CatalogRequestSchema(

--- a/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/catalog/v2/CatalogApiV2Controller.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/catalog/v2/CatalogApiV2Controller.java
@@ -15,15 +15,23 @@
 package org.eclipse.edc.connector.controlplane.api.management.catalog.v2;
 
 import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.container.AsyncResponse;
-import org.eclipse.edc.api.ApiWarnings;
+import jakarta.ws.rs.container.Suspended;
 import org.eclipse.edc.connector.controlplane.api.management.catalog.BaseCatalogApiController;
 import org.eclipse.edc.connector.controlplane.services.spi.catalog.CatalogService;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.eclipse.edc.api.ApiWarnings.deprecationWarning;
+
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
 @Path("/v2/catalog")
 public class CatalogApiV2Controller extends BaseCatalogApiController implements CatalogApiV2 {
     private final Monitor monitor;
@@ -33,15 +41,19 @@ public class CatalogApiV2Controller extends BaseCatalogApiController implements 
         this.monitor = monitor;
     }
 
+    @POST
+    @Path("/request")
     @Override
-    public void requestCatalog(JsonObject requestBody, AsyncResponse response) {
-        monitor.warning(ApiWarnings.deprecationWarning("/v2", "/v3"));
-        super.requestCatalog(requestBody, response);
+    public void requestCatalogV2(JsonObject requestBody, @Suspended AsyncResponse response) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        requestCatalog(requestBody, response);
     }
 
+    @POST
+    @Path("dataset/request")
     @Override
-    public void getDataset(JsonObject requestBody, AsyncResponse response) {
-        monitor.warning(ApiWarnings.deprecationWarning("/v2", "/v3"));
-        super.getDataset(requestBody, response);
+    public void getDatasetV2(JsonObject requestBody, @Suspended AsyncResponse response) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        getDataset(requestBody, response);
     }
 }

--- a/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/catalog/v3/CatalogApiV3.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/catalog/v3/CatalogApiV3.java
@@ -39,7 +39,6 @@ public interface CatalogApiV3 {
 
     @Operation(
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = CatalogRequestSchema.class))),
-            operationId = "requestCatalogV3",
             responses = { @ApiResponse(
                     content = @Content(
                             mediaType = "application/json",
@@ -47,11 +46,10 @@ public interface CatalogApiV3 {
                     ),
                     description = "Gets contract offers (=catalog) of a single connector") }
     )
-    void requestCatalog(JsonObject request, @Suspended AsyncResponse response);
+    void requestCatalogV3(JsonObject request, @Suspended AsyncResponse response);
 
     @Operation(
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = DatasetRequestSchema.class))),
-            operationId = "getDatasetV3",
             responses = { @ApiResponse(
                     content = @Content(
                             mediaType = "application/json",
@@ -59,7 +57,7 @@ public interface CatalogApiV3 {
                     ),
                     description = "Gets single dataset from a connector") }
     )
-    void getDataset(JsonObject request, @Suspended AsyncResponse response);
+    void getDatasetV3(JsonObject request, @Suspended AsyncResponse response);
 
     @Schema(name = "CatalogRequest", example = CatalogRequestSchema.CATALOG_REQUEST_EXAMPLE)
     record CatalogRequestSchema(

--- a/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/catalog/v3/CatalogApiV3Controller.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/catalog/v3/CatalogApiV3Controller.java
@@ -14,15 +14,39 @@
 
 package org.eclipse.edc.connector.controlplane.api.management.catalog.v3;
 
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.container.AsyncResponse;
+import jakarta.ws.rs.container.Suspended;
 import org.eclipse.edc.connector.controlplane.api.management.catalog.BaseCatalogApiController;
 import org.eclipse.edc.connector.controlplane.services.spi.catalog.CatalogService;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
 @Path("/v3/catalog")
 public class CatalogApiV3Controller extends BaseCatalogApiController implements CatalogApiV3 {
     public CatalogApiV3Controller(CatalogService service, TypeTransformerRegistry transformerRegistry, JsonObjectValidatorRegistry validatorRegistry) {
         super(service, transformerRegistry, validatorRegistry);
+    }
+
+    @POST
+    @Path("/request")
+    @Override
+    public void requestCatalogV3(JsonObject request, @Suspended AsyncResponse response) {
+        requestCatalog(request, response);
+    }
+
+    @POST
+    @Path("dataset/request")
+    @Override
+    public void getDatasetV3(JsonObject request, @Suspended AsyncResponse response) {
+        getDataset(request, response);
     }
 }

--- a/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractagreement/BaseContractAgreementApiController.java
+++ b/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractagreement/BaseContractAgreementApiController.java
@@ -16,13 +16,6 @@ package org.eclipse.edc.connector.controlplane.api.management.contractagreement;
 
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.POST;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.core.MediaType;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractDefinition;
 import org.eclipse.edc.connector.controlplane.services.spi.contractagreement.ContractAgreementService;
@@ -42,8 +35,6 @@ import static jakarta.json.stream.JsonCollectors.toJsonArray;
 import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE;
 import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMapper;
 
-@Consumes({ MediaType.APPLICATION_JSON })
-@Produces({ MediaType.APPLICATION_JSON })
 public abstract class BaseContractAgreementApiController {
     protected final Monitor monitor;
     private final ContractAgreementService service;
@@ -58,8 +49,6 @@ public abstract class BaseContractAgreementApiController {
         this.validatorRegistry = validatorRegistry;
     }
 
-    @POST
-    @Path("/request")
     public JsonArray queryAgreements(JsonObject querySpecJson) {
         QuerySpec querySpec;
         if (querySpecJson == null) {
@@ -79,9 +68,7 @@ public abstract class BaseContractAgreementApiController {
                 .collect(toJsonArray());
     }
 
-    @GET
-    @Path("{id}")
-    public JsonObject getAgreementById(@PathParam("id") String id) {
+    public JsonObject getAgreementById(String id) {
         return Optional.of(id)
                 .map(service::findById)
                 .map(it -> transformerRegistry.transform(it, JsonObject.class)
@@ -89,9 +76,7 @@ public abstract class BaseContractAgreementApiController {
                 .orElseThrow(() -> new ObjectNotFoundException(ContractAgreement.class, id));
     }
 
-    @GET
-    @Path("{id}/negotiation")
-    public JsonObject getNegotiationByAgreementId(@PathParam("id") String id) {
+    public JsonObject getNegotiationByAgreementId(String id) {
         return Optional.of(id)
                 .map(service::findNegotiation)
                 .map(it -> transformerRegistry.transform(it, JsonObject.class)

--- a/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractagreement/v2/ContractAgreementApiV2.java
+++ b/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractagreement/v2/ContractAgreementApiV2.java
@@ -34,7 +34,6 @@ public interface ContractAgreementApiV2 {
 
     @Operation(description = "Gets all contract agreements according to a particular query",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ApiCoreSchema.QuerySpecSchema.class))),
-            operationId = "queryAgreementsV2",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The contract agreements matching the query",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ManagementApiSchema.ContractAgreementSchema.class)))),
@@ -44,10 +43,9 @@ public interface ContractAgreementApiV2 {
             deprecated = true
     )
     @Deprecated(since = "0.7.0")
-    JsonArray queryAgreements(JsonObject querySpecJson);
+    JsonArray queryAgreementsV2(JsonObject querySpecJson);
 
     @Operation(description = "Gets an contract agreement with the given ID",
-            operationId = "getAgreementByIdV2",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The contract agreement",
                             content = @Content(schema = @Schema(implementation = ManagementApiSchema.ContractAgreementSchema.class))),
@@ -59,11 +57,10 @@ public interface ContractAgreementApiV2 {
             deprecated = true
     )
     @Deprecated(since = "0.7.0")
-    JsonObject getAgreementById(String id);
+    JsonObject getAgreementByIdV2(String id);
 
 
     @Operation(description = "Gets a contract negotiation with the given contract agreement ID",
-            operationId = "getNegotiationByAgreementIdV2",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The contract negotiation",
                             content = @Content(schema = @Schema(implementation = ManagementApiSchema.ContractNegotiationSchema.class))),
@@ -75,6 +72,6 @@ public interface ContractAgreementApiV2 {
             deprecated = true
     )
     @Deprecated(since = "0.7.0")
-    JsonObject getNegotiationByAgreementId(String id);
+    JsonObject getNegotiationByAgreementIdV2(String id);
 
 }

--- a/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractagreement/v2/ContractAgreementApiV2Controller.java
+++ b/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractagreement/v2/ContractAgreementApiV2Controller.java
@@ -16,34 +16,50 @@ package org.eclipse.edc.connector.controlplane.api.management.contractagreement.
 
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
-import org.eclipse.edc.api.ApiWarnings;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
 import org.eclipse.edc.connector.controlplane.api.management.contractagreement.BaseContractAgreementApiController;
 import org.eclipse.edc.connector.controlplane.services.spi.contractagreement.ContractAgreementService;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.eclipse.edc.api.ApiWarnings.deprecationWarning;
+
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
 @Path("/v2/contractagreements")
 public class ContractAgreementApiV2Controller extends BaseContractAgreementApiController implements ContractAgreementApiV2 {
     public ContractAgreementApiV2Controller(ContractAgreementService service, TypeTransformerRegistry transformerRegistry, Monitor monitor, JsonObjectValidatorRegistry validatorRegistry) {
         super(service, transformerRegistry, monitor, validatorRegistry);
     }
 
+    @POST
+    @Path("/request")
     @Override
-    public JsonArray queryAgreements(JsonObject querySpecJson) {
-        return super.queryAgreements(querySpecJson);
+    public JsonArray queryAgreementsV2(JsonObject querySpecJson) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        return queryAgreements(querySpecJson);
     }
 
+    @GET
+    @Path("{id}")
     @Override
-    public JsonObject getAgreementById(String id) {
-        monitor.warning(ApiWarnings.deprecationWarning("/v2", "/v3"));
-        return super.getAgreementById(id);
+    public JsonObject getAgreementByIdV2(@PathParam("id") String id) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        return getAgreementById(id);
     }
 
+    @GET
+    @Path("{id}/negotiation")
     @Override
-    public JsonObject getNegotiationByAgreementId(String id) {
-        monitor.warning(ApiWarnings.deprecationWarning("/v2", "/v3"));
-        return super.getNegotiationByAgreementId(id);
+    public JsonObject getNegotiationByAgreementIdV2(@PathParam("id") String id) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        return getNegotiationByAgreementId(id);
     }
 }

--- a/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractagreement/v3/ContractAgreementApiV3.java
+++ b/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractagreement/v3/ContractAgreementApiV3.java
@@ -34,7 +34,6 @@ public interface ContractAgreementApiV3 {
 
     @Operation(description = "Gets all contract agreements according to a particular query",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ApiCoreSchema.QuerySpecSchema.class))),
-            operationId = "queryAgreementsV3",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The contract agreements matching the query",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ManagementApiSchema.ContractAgreementSchema.class)))),
@@ -42,10 +41,9 @@ public interface ContractAgreementApiV3 {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             }
     )
-    JsonArray queryAgreements(JsonObject querySpecJson);
+    JsonArray queryAgreementsV3(JsonObject querySpecJson);
 
     @Operation(description = "Gets an contract agreement with the given ID",
-            operationId = "getAgreementByIdV3",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The contract agreement",
                             content = @Content(schema = @Schema(implementation = ManagementApiSchema.ContractAgreementSchema.class))),
@@ -55,11 +53,10 @@ public interface ContractAgreementApiV3 {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             }
     )
-    JsonObject getAgreementById(String id);
+    JsonObject getAgreementByIdV3(String id);
 
 
     @Operation(description = "Gets a contract negotiation with the given contract agreement ID",
-            operationId = "getNegotiationByAgreementIdV3",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The contract negotiation",
                             content = @Content(schema = @Schema(implementation = ManagementApiSchema.ContractNegotiationSchema.class))),
@@ -69,6 +66,6 @@ public interface ContractAgreementApiV3 {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             }
     )
-    JsonObject getNegotiationByAgreementId(String id);
+    JsonObject getNegotiationByAgreementIdV3(String id);
 
 }

--- a/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractagreement/v3/ContractAgreementApiV3Controller.java
+++ b/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractagreement/v3/ContractAgreementApiV3Controller.java
@@ -14,16 +14,48 @@
 
 package org.eclipse.edc.connector.controlplane.api.management.contractagreement.v3;
 
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
 import org.eclipse.edc.connector.controlplane.api.management.contractagreement.BaseContractAgreementApiController;
 import org.eclipse.edc.connector.controlplane.services.spi.contractagreement.ContractAgreementService;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
 @Path("/v3/contractagreements")
 public class ContractAgreementApiV3Controller extends BaseContractAgreementApiController implements ContractAgreementApiV3 {
     public ContractAgreementApiV3Controller(ContractAgreementService service, TypeTransformerRegistry transformerRegistry, Monitor monitor, JsonObjectValidatorRegistry validatorRegistry) {
         super(service, transformerRegistry, monitor, validatorRegistry);
+    }
+
+    @POST
+    @Path("/request")
+    @Override
+    public JsonArray queryAgreementsV3(JsonObject querySpecJson) {
+        return queryAgreements(querySpecJson);
+    }
+
+    @GET
+    @Path("{id}")
+    @Override
+    public JsonObject getAgreementByIdV3(@PathParam("id") String id) {
+        return getAgreementById(id);
+    }
+
+    @GET
+    @Path("{id}/negotiation")
+    @Override
+    public JsonObject getNegotiationByAgreementIdV3(@PathParam("id") String id) {
+        return getNegotiationByAgreementId(id);
     }
 }

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/BaseContractDefinitionApiController.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/BaseContractDefinitionApiController.java
@@ -16,15 +16,6 @@ package org.eclipse.edc.connector.controlplane.api.management.contractdefinition
 
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.DELETE;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.POST;
-import jakarta.ws.rs.PUT;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.core.MediaType;
 import org.eclipse.edc.api.model.IdResponse;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractDefinition;
 import org.eclipse.edc.connector.controlplane.services.spi.contractdefinition.ContractDefinitionService;
@@ -45,8 +36,6 @@ import static org.eclipse.edc.connector.controlplane.contract.spi.types.offer.Co
 import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMapper;
 
 
-@Consumes({ MediaType.APPLICATION_JSON })
-@Produces({ MediaType.APPLICATION_JSON })
 public abstract class BaseContractDefinitionApiController {
     protected final TypeTransformerRegistry transformerRegistry;
     protected final ContractDefinitionService service;
@@ -61,8 +50,6 @@ public abstract class BaseContractDefinitionApiController {
         this.validatorRegistry = validatorRegistry;
     }
 
-    @POST
-    @Path("/request")
     public JsonArray queryContractDefinitions(JsonObject querySpecJson) {
         QuerySpec querySpec;
         if (querySpecJson == null) {
@@ -83,9 +70,7 @@ public abstract class BaseContractDefinitionApiController {
                 .collect(toJsonArray());
     }
 
-    @GET
-    @Path("{id}")
-    public JsonObject getContractDefinition(@PathParam("id") String id) {
+    public JsonObject getContractDefinition(String id) {
         return Optional.ofNullable(id)
                 .map(service::findById)
                 .map(it -> transformerRegistry.transform(it, JsonObject.class))
@@ -93,7 +78,6 @@ public abstract class BaseContractDefinitionApiController {
                 .orElseThrow(() -> new ObjectNotFoundException(ContractDefinition.class, id));
     }
 
-    @POST
     public JsonObject createContractDefinition(JsonObject createObject) {
         validatorRegistry.validate(CONTRACT_DEFINITION_TYPE, createObject)
                 .orElseThrow(ValidationFailureException::new);
@@ -112,13 +96,10 @@ public abstract class BaseContractDefinitionApiController {
                 .orElseThrow(f -> new EdcException("Error creating response body: " + f.getFailureDetail()));
     }
 
-    @DELETE
-    @Path("{id}")
-    public void deleteContractDefinition(@PathParam("id") String id) {
+    public void deleteContractDefinition(String id) {
         service.delete(id).orElseThrow(exceptionMapper(ContractDefinition.class, id));
     }
 
-    @PUT
     public void updateContractDefinition(JsonObject updateObject) {
         validatorRegistry.validate(CONTRACT_DEFINITION_TYPE, updateObject)
                 .orElseThrow(ValidationFailureException::new);

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/v2/ContractDefinitionApiV2.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/v2/ContractDefinitionApiV2.java
@@ -43,7 +43,6 @@ public interface ContractDefinitionApiV2 {
 
     @Operation(description = "Returns all contract definitions according to a query",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ApiCoreSchema.QuerySpecSchema.class))),
-            operationId = "queryContractDefV2",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The contract definitions matching the query",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ContractDefinitionOutputSchema.class)))),
@@ -53,10 +52,9 @@ public interface ContractDefinitionApiV2 {
             deprecated = true
     )
     @Deprecated(since = "0.7.0")
-    JsonArray queryContractDefinitions(JsonObject querySpecJson);
+    JsonArray queryContractDefinitionsV2(JsonObject querySpecJson);
 
     @Operation(description = "Gets an contract definition with the given ID",
-            operationId = "getContractDefV2",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The contract definition",
                             content = @Content(schema = @Schema(implementation = ContractDefinitionOutputSchema.class))),
@@ -68,11 +66,10 @@ public interface ContractDefinitionApiV2 {
             deprecated = true
     )
     @Deprecated(since = "0.7.0")
-    JsonObject getContractDefinition(String id);
+    JsonObject getContractDefinitionV2(String id);
 
     @Operation(description = "Creates a new contract definition",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ContractDefinitionInputSchema.class))),
-            operationId = "createContractDefinitionV2",
             responses = {
                     @ApiResponse(responseCode = "200", description = "contract definition was created successfully. Returns the Contract Definition Id and created timestamp",
                             content = @Content(schema = @Schema(implementation = ApiCoreSchema.IdResponseSchema.class))),
@@ -83,11 +80,10 @@ public interface ContractDefinitionApiV2 {
             deprecated = true
     )
     @Deprecated(since = "0.7.0")
-    JsonObject createContractDefinition(JsonObject createObject);
+    JsonObject createContractDefinitionV2(JsonObject createObject);
 
     @Operation(description = "Removes a contract definition with the given ID if possible. " +
             "DANGER ZONE: Note that deleting contract definitions can have unexpected results, especially for contract offers that have been sent out or ongoing or contract negotiations.",
-            operationId = "deleteContractDefV2",
             responses = {
                     @ApiResponse(responseCode = "204", description = "Contract definition was deleted successfully"),
                     @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
@@ -98,11 +94,10 @@ public interface ContractDefinitionApiV2 {
             deprecated = true
     )
     @Deprecated(since = "0.7.0")
-    void deleteContractDefinition(String id);
+    void deleteContractDefinitionV2(String id);
 
     @Operation(description = "Updated a contract definition with the given ID. The supplied JSON structure must be a valid JSON-LD object",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ContractDefinitionInputSchema.class))),
-            operationId = "updateContractDefV2",
             responses = {
                     @ApiResponse(responseCode = "204", description = "Contract definition was updated successfully"),
                     @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
@@ -113,7 +108,7 @@ public interface ContractDefinitionApiV2 {
             deprecated = true
     )
     @Deprecated(since = "0.7.0")
-    void updateContractDefinition(JsonObject updateObject);
+    void updateContractDefinitionV2(JsonObject updateObject);
 
     @Schema(name = "ContractDefinitionInput", example = CONTRACT_DEFINITION_INPUT_EXAMPLE)
     record ContractDefinitionInputSchema(

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/v2/ContractDefinitionApiV2Controller.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/v2/ContractDefinitionApiV2Controller.java
@@ -14,24 +14,68 @@
 
 package org.eclipse.edc.connector.controlplane.api.management.contractdefinition.v2;
 
+import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
-import org.eclipse.edc.api.ApiWarnings;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
 import org.eclipse.edc.connector.controlplane.api.management.contractdefinition.BaseContractDefinitionApiController;
 import org.eclipse.edc.connector.controlplane.services.spi.contractdefinition.ContractDefinitionService;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.eclipse.edc.api.ApiWarnings.deprecationWarning;
+
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
 @Path("/v2/contractdefinitions")
-public class ContractDefinitionApiV2Controller extends BaseContractDefinitionApiController {
+public class ContractDefinitionApiV2Controller extends BaseContractDefinitionApiController implements ContractDefinitionApiV2 {
     public ContractDefinitionApiV2Controller(TypeTransformerRegistry transformerRegistry, ContractDefinitionService service, Monitor monitor, JsonObjectValidatorRegistry validatorRegistry) {
         super(transformerRegistry, service, monitor, validatorRegistry);
     }
 
+    @POST
+    @Path("/request")
     @Override
-    public JsonObject createContractDefinition(JsonObject createObject) {
-        monitor.warning(ApiWarnings.deprecationWarning("/v2", "/v3"));
-        return super.createContractDefinition(createObject);
+    public JsonArray queryContractDefinitionsV2(JsonObject querySpecJson) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        return queryContractDefinitions(querySpecJson);
+    }
+
+    @GET
+    @Path("{id}")
+    @Override
+    public JsonObject getContractDefinitionV2(@PathParam("id") String id) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        return getContractDefinition(id);
+    }
+
+    @POST
+    @Override
+    public JsonObject createContractDefinitionV2(JsonObject createObject) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        return createContractDefinition(createObject);
+    }
+
+    @DELETE
+    @Path("{id}")
+    @Override
+    public void deleteContractDefinitionV2(@PathParam("id") String id) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        deleteContractDefinition(id);
+    }
+
+    @PUT
+    @Override
+    public void updateContractDefinitionV2(JsonObject updateObject) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        updateContractDefinition(updateObject);
     }
 }

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/v3/ContractDefinitionApiV3.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/v3/ContractDefinitionApiV3.java
@@ -43,7 +43,6 @@ public interface ContractDefinitionApiV3 {
 
     @Operation(description = "Returns all contract definitions according to a query",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ApiCoreSchema.QuerySpecSchema.class))),
-            operationId = "queryContractDefV3",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The contract definitions matching the query",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ContractDefinitionOutputSchema.class)))),
@@ -51,10 +50,9 @@ public interface ContractDefinitionApiV3 {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             }
     )
-    JsonArray queryContractDefinitions(JsonObject querySpecJson);
+    JsonArray queryContractDefinitionsV3(JsonObject querySpecJson);
 
     @Operation(description = "Gets an contract definition with the given ID",
-            operationId = "getContractDefV3",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The contract definition",
                             content = @Content(schema = @Schema(implementation = ContractDefinitionOutputSchema.class))),
@@ -64,11 +62,10 @@ public interface ContractDefinitionApiV3 {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             }
     )
-    JsonObject getContractDefinition(String id);
+    JsonObject getContractDefinitionV3(String id);
 
     @Operation(description = "Creates a new contract definition",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ContractDefinitionInputSchema.class))),
-            operationId = "createContractDefinitionV3",
             responses = {
                     @ApiResponse(responseCode = "200", description = "contract definition was created successfully. Returns the Contract Definition Id and created timestamp",
                             content = @Content(schema = @Schema(implementation = ApiCoreSchema.IdResponseSchema.class))),
@@ -77,11 +74,10 @@ public interface ContractDefinitionApiV3 {
                     @ApiResponse(responseCode = "409", description = "Could not create contract definition, because a contract definition with that ID already exists",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))) }
     )
-    JsonObject createContractDefinition(JsonObject createObject);
+    JsonObject createContractDefinitionV3(JsonObject createObject);
 
     @Operation(description = "Removes a contract definition with the given ID if possible. " +
             "DANGER ZONE: Note that deleting contract definitions can have unexpected results, especially for contract offers that have been sent out or ongoing or contract negotiations.",
-            operationId = "deleteContractDefV3",
             responses = {
                     @ApiResponse(responseCode = "204", description = "Contract definition was deleted successfully"),
                     @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
@@ -90,11 +86,10 @@ public interface ContractDefinitionApiV3 {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             }
     )
-    void deleteContractDefinition(String id);
+    void deleteContractDefinitionV3(String id);
 
     @Operation(description = "Updated a contract definition with the given ID. The supplied JSON structure must be a valid JSON-LD object",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ContractDefinitionInputSchema.class))),
-            operationId = "updateContractDefV3",
             responses = {
                     @ApiResponse(responseCode = "204", description = "Contract definition was updated successfully"),
                     @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
@@ -103,7 +98,7 @@ public interface ContractDefinitionApiV3 {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             }
     )
-    void updateContractDefinition(JsonObject updateObject);
+    void updateContractDefinitionV3(JsonObject updateObject);
 
     @Schema(name = "ContractDefinitionInput", example = CONTRACT_DEFINITION_INPUT_EXAMPLE)
     record ContractDefinitionInputSchema(

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/v3/ContractDefinitionApiV3Controller.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/v3/ContractDefinitionApiV3Controller.java
@@ -14,22 +14,62 @@
 
 package org.eclipse.edc.connector.controlplane.api.management.contractdefinition.v3;
 
+import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
 import org.eclipse.edc.connector.controlplane.api.management.contractdefinition.BaseContractDefinitionApiController;
 import org.eclipse.edc.connector.controlplane.services.spi.contractdefinition.ContractDefinitionService;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
 @Path("/v3/contractdefinitions")
 public class ContractDefinitionApiV3Controller extends BaseContractDefinitionApiController implements ContractDefinitionApiV3 {
     public ContractDefinitionApiV3Controller(TypeTransformerRegistry transformerRegistry, ContractDefinitionService service, Monitor monitor, JsonObjectValidatorRegistry validatorRegistry) {
         super(transformerRegistry, service, monitor, validatorRegistry);
     }
 
+    @POST
+    @Path("/request")
     @Override
-    public JsonObject createContractDefinition(JsonObject createObject) {
-        return super.createContractDefinition(createObject);
+    public JsonArray queryContractDefinitionsV3(JsonObject querySpecJson) {
+        return queryContractDefinitions(querySpecJson);
+    }
+
+    @GET
+    @Path("{id}")
+    @Override
+    public JsonObject getContractDefinitionV3(@PathParam("id") String id) {
+        return getContractDefinition(id);
+    }
+
+    @POST
+    @Override
+    public JsonObject createContractDefinitionV3(JsonObject createObject) {
+        return createContractDefinition(createObject);
+    }
+
+    @DELETE
+    @Path("{id}")
+    @Override
+    public void deleteContractDefinitionV3(@PathParam("id") String id) {
+        deleteContractDefinition(id);
+    }
+
+    @PUT
+    @Override
+    public void updateContractDefinitionV3(JsonObject updateObject) {
+        updateContractDefinition(updateObject);
     }
 }

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/BaseContractNegotiationApiController.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/BaseContractNegotiationApiController.java
@@ -16,13 +16,6 @@ package org.eclipse.edc.connector.controlplane.api.management.contractnegotiatio
 
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.POST;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.core.MediaType;
 import org.eclipse.edc.api.model.IdResponse;
 import org.eclipse.edc.connector.controlplane.api.management.contractnegotiation.model.NegotiationState;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.command.TerminateNegotiationCommand;
@@ -47,8 +40,6 @@ import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiat
 import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE;
 import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMapper;
 
-@Consumes({ MediaType.APPLICATION_JSON })
-@Produces({ MediaType.APPLICATION_JSON })
 public class BaseContractNegotiationApiController {
     protected final ContractNegotiationService service;
     protected final TypeTransformerRegistry transformerRegistry;
@@ -63,8 +54,6 @@ public class BaseContractNegotiationApiController {
         this.validatorRegistry = validatorRegistry;
     }
 
-    @POST
-    @Path("/request")
     public JsonArray queryNegotiations(JsonObject querySpecJson) {
         QuerySpec querySpec;
         if (querySpecJson == null) {
@@ -85,9 +74,7 @@ public class BaseContractNegotiationApiController {
                 .collect(toJsonArray());
     }
 
-    @GET
-    @Path("/{id}")
-    public JsonObject getNegotiation(@PathParam("id") String id) {
+    public JsonObject getNegotiation(String id) {
 
         return Optional.of(id)
                 .map(service::findbyId)
@@ -96,9 +83,7 @@ public class BaseContractNegotiationApiController {
                 .orElseThrow(() -> new ObjectNotFoundException(ContractNegotiation.class, id));
     }
 
-    @GET
-    @Path("/{id}/state")
-    public JsonObject getNegotiationState(@PathParam("id") String id) {
+    public JsonObject getNegotiationState(String id) {
         return Optional.of(id)
                 .map(service::getState)
                 .map(NegotiationState::new)
@@ -107,9 +92,7 @@ public class BaseContractNegotiationApiController {
                 .orElseThrow(failure -> new EdcException(failure.getFailureDetail()));
     }
 
-    @GET
-    @Path("/{id}/agreement")
-    public JsonObject getAgreementForNegotiation(@PathParam("id") String negotiationId) {
+    public JsonObject getAgreementForNegotiation(String negotiationId) {
         return Optional.of(negotiationId)
                 .map(service::getForNegotiation)
                 .map(it -> transformerRegistry.transform(it, JsonObject.class)
@@ -117,7 +100,6 @@ public class BaseContractNegotiationApiController {
                 .orElseThrow(() -> new ObjectNotFoundException(ContractNegotiation.class, negotiationId));
     }
 
-    @POST
     public JsonObject initiateContractNegotiation(JsonObject requestObject) {
         validatorRegistry.validate(CONTRACT_REQUEST_TYPE, requestObject)
                 .orElseThrow(ValidationFailureException::new);
@@ -136,9 +118,7 @@ public class BaseContractNegotiationApiController {
                 .orElseThrow(f -> new EdcException("Error creating response body: " + f.getFailureDetail()));
     }
 
-    @POST
-    @Path("/{id}/terminate")
-    public void terminateNegotiation(@PathParam("id") String id, JsonObject terminateNegotiation) {
+    public void terminateNegotiation(String id, JsonObject terminateNegotiation) {
         validatorRegistry.validate(TERMINATE_NEGOTIATION_TYPE, terminateNegotiation)
                 .orElseThrow(ValidationFailureException::new);
 

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v2/ContractNegotiationApiV2.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v2/ContractNegotiationApiV2.java
@@ -47,7 +47,6 @@ public interface ContractNegotiationApiV2 {
 
     @Operation(description = "Returns all contract negotiations according to a query",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ApiCoreSchema.QuerySpecSchema.class))),
-            operationId = "queryNegotiationsV2",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The contract negotiations that match the query",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ManagementApiSchema.ContractNegotiationSchema.class)))),
@@ -56,10 +55,9 @@ public interface ContractNegotiationApiV2 {
             deprecated = true
     )
     @Deprecated(since = "0.7.0")
-    JsonArray queryNegotiations(JsonObject querySpecJson);
+    JsonArray queryNegotiationsV2(JsonObject querySpecJson);
 
     @Operation(description = "Gets a contract negotiation with the given ID",
-            operationId = "getNegotiationV2",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The contract negotiation",
                             content = @Content(schema = @Schema(implementation = ManagementApiSchema.ContractNegotiationSchema.class))),
@@ -71,10 +69,9 @@ public interface ContractNegotiationApiV2 {
             deprecated = true
     )
     @Deprecated(since = "0.7.0")
-    JsonObject getNegotiation(String id);
+    JsonObject getNegotiationV2(String id);
 
     @Operation(description = "Gets the state of a contract negotiation with the given ID",
-            operationId = "getNegotiationStateV2",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The contract negotiation's state",
                             content = @Content(schema = @Schema(implementation = NegotiationState.class))),
@@ -86,7 +83,7 @@ public interface ContractNegotiationApiV2 {
             deprecated = true
     )
     @Deprecated(since = "0.7.0")
-    JsonObject getNegotiationState(String id);
+    JsonObject getNegotiationStateV2(String id);
 
     @Operation(description = "Gets a contract agreement for a contract negotiation with the given ID",
             responses = {
@@ -97,20 +94,18 @@ public interface ContractNegotiationApiV2 {
                     @ApiResponse(responseCode = "404", description = "An contract negotiation with the given ID does not exist",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             },
-            operationId = "getAgreementForNegotiationV2",
             deprecated = true
     )
     @Deprecated(since = "0.7.0")
-    JsonObject getAgreementForNegotiation(String negotiationId);
+    JsonObject getAgreementForNegotiationV2(String negotiationId);
 
     @Operation(description = "Initiates a contract negotiation for a given offer and with the given counter part. Please note that successfully invoking this endpoint " +
             "only means that the negotiation was initiated. Clients must poll the /{id}/state endpoint to track the state",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ContractRequestSchema.class))),
-            operationId = "initiateNegotiationV2",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The negotiation was successfully initiated. Returns the contract negotiation ID and created timestamp",
                             content = @Content(schema = @Schema(implementation = ApiCoreSchema.IdResponseSchema.class)),
-                            links = @Link(name = "poll-state", operationId = "getNegotiationState", parameters = {
+                            links = @Link(name = "poll-state", operationId = "getNegotiationStateV2", parameters = {
                                     @LinkParameter(name = "id", expression = "$response.body#/id")
                             })
                     ),
@@ -119,14 +114,13 @@ public interface ContractNegotiationApiV2 {
             },
             deprecated = true)
     @Deprecated(since = "0.7.0")
-    JsonObject initiateContractNegotiation(JsonObject requestDto);
+    JsonObject initiateContractNegotiationV2(JsonObject requestDto);
 
     @Operation(description = "Terminates the contract negotiation.",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = TerminateNegotiationSchema.class))),
-            operationId = "terminateNegotiationV2",
             responses = {
                     @ApiResponse(responseCode = "200", description = "ContractNegotiation is terminating",
-                            links = @Link(name = "poll-state", operationId = "getNegotiationState")),
+                            links = @Link(name = "poll-state", operationId = "getNegotiationStateV2")),
                     @ApiResponse(responseCode = "400", description = "Request was malformed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
                     @ApiResponse(responseCode = "404", description = "A contract negotiation with the given ID does not exist",
@@ -135,7 +129,7 @@ public interface ContractNegotiationApiV2 {
             deprecated = true
     )
     @Deprecated(since = "0.7.0")
-    void terminateNegotiation(String id, JsonObject terminateNegotiation);
+    void terminateNegotiationV2(String id, JsonObject terminateNegotiation);
 
     @Schema(name = "ContractRequest", example = ContractRequestSchema.CONTRACT_REQUEST_EXAMPLE)
     record ContractRequestSchema(

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v2/ContractNegotiationApiV2Controller.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v2/ContractNegotiationApiV2Controller.java
@@ -16,54 +16,73 @@ package org.eclipse.edc.connector.controlplane.api.management.contractnegotiatio
 
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
-import org.eclipse.edc.api.ApiWarnings;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
 import org.eclipse.edc.connector.controlplane.api.management.contractnegotiation.BaseContractNegotiationApiController;
 import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationService;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.eclipse.edc.api.ApiWarnings.deprecationWarning;
 
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
 @Path("/v2/contractnegotiations")
 public class ContractNegotiationApiV2Controller extends BaseContractNegotiationApiController implements ContractNegotiationApiV2 {
     public ContractNegotiationApiV2Controller(ContractNegotiationService service, TypeTransformerRegistry transformerRegistry, Monitor monitor, JsonObjectValidatorRegistry validatorRegistry) {
         super(service, transformerRegistry, monitor, validatorRegistry);
     }
 
+    @POST
+    @Path("/request")
     @Override
-    public JsonArray queryNegotiations(JsonObject querySpecJson) {
-        monitor.warning(ApiWarnings.deprecationWarning("/v2", "/v3"));
-        return super.queryNegotiations(querySpecJson);
+    public JsonArray queryNegotiationsV2(JsonObject querySpecJson) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        return queryNegotiations(querySpecJson);
     }
 
+    @GET
+    @Path("/{id}")
     @Override
-    public JsonObject getNegotiation(String id) {
-        monitor.warning(ApiWarnings.deprecationWarning("/v2", "/v3"));
-        return super.getNegotiation(id);
+    public JsonObject getNegotiationV2(@PathParam("id") String id) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        return getNegotiation(id);
     }
 
+    @GET
+    @Path("/{id}/state")
     @Override
-    public JsonObject getNegotiationState(String id) {
-        monitor.warning(ApiWarnings.deprecationWarning("/v2", "/v3"));
-        return super.getNegotiationState(id);
+    public JsonObject getNegotiationStateV2(@PathParam("id") String id) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        return getNegotiationState(id);
     }
 
+    @GET
+    @Path("/{id}/agreement")
     @Override
-    public JsonObject getAgreementForNegotiation(String negotiationId) {
-        monitor.warning(ApiWarnings.deprecationWarning("/v2", "/v3"));
-        return super.getAgreementForNegotiation(negotiationId);
+    public JsonObject getAgreementForNegotiationV2(@PathParam("id") String negotiationId) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        return getAgreementForNegotiation(negotiationId);
     }
 
+    @POST
     @Override
-    public JsonObject initiateContractNegotiation(JsonObject requestObject) {
-        monitor.warning(ApiWarnings.deprecationWarning("/v2", "/v3"));
-        return super.initiateContractNegotiation(requestObject);
+    public JsonObject initiateContractNegotiationV2(JsonObject requestObject) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        return initiateContractNegotiation(requestObject);
     }
 
+    @POST
+    @Path("/{id}/terminate")
     @Override
-    public void terminateNegotiation(String id, JsonObject terminateNegotiation) {
-        monitor.warning(ApiWarnings.deprecationWarning("/v2", "/v3"));
-        super.terminateNegotiation(id, terminateNegotiation);
+    public void terminateNegotiationV2(@PathParam("id") String id, JsonObject terminateNegotiation) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        terminateNegotiation(id, terminateNegotiation);
     }
 }

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v3/ContractNegotiationApiV3.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v3/ContractNegotiationApiV3.java
@@ -47,17 +47,15 @@ public interface ContractNegotiationApiV3 {
 
     @Operation(description = "Returns all contract negotiations according to a query",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ApiCoreSchema.QuerySpecSchema.class))),
-            operationId = "queryNegotiationsV3",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The contract negotiations that match the query",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ManagementApiSchema.ContractNegotiationSchema.class)))),
                     @ApiResponse(responseCode = "400", description = "Request was malformed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))) }
     )
-    JsonArray queryNegotiations(JsonObject querySpecJson);
+    JsonArray queryNegotiationsV3(JsonObject querySpecJson);
 
     @Operation(description = "Gets a contract negotiation with the given ID",
-            operationId = "getNegotiationsV3",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The contract negotiation",
                             content = @Content(schema = @Schema(implementation = ManagementApiSchema.ContractNegotiationSchema.class))),
@@ -67,10 +65,9 @@ public interface ContractNegotiationApiV3 {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             }
     )
-    JsonObject getNegotiation(String id);
+    JsonObject getNegotiationV3(String id);
 
     @Operation(description = "Gets the state of a contract negotiation with the given ID",
-            operationId = "getNegotiationStateV3",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The contract negotiation's state",
                             content = @Content(schema = @Schema(implementation = NegotiationState.class))),
@@ -80,10 +77,9 @@ public interface ContractNegotiationApiV3 {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             }
     )
-    JsonObject getNegotiationState(String id);
+    JsonObject getNegotiationStateV3(String id);
 
     @Operation(description = "Gets a contract agreement for a contract negotiation with the given ID",
-            operationId = "getAgreementForNegotiationV3",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The contract agreement that is attached to the negotiation, or null",
                             content = @Content(schema = @Schema(implementation = ManagementApiSchema.ContractAgreementSchema.class))),
@@ -93,37 +89,35 @@ public interface ContractNegotiationApiV3 {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             }
     )
-    JsonObject getAgreementForNegotiation(String negotiationId);
+    JsonObject getAgreementForNegotiationV3(String negotiationId);
 
     @Operation(description = "Initiates a contract negotiation for a given offer and with the given counter part. Please note that successfully invoking this endpoint " +
             "only means that the negotiation was initiated. Clients must poll the /{id}/state endpoint to track the state",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ContractRequestSchema.class))),
-            operationId = "initiateNegotiationV3",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The negotiation was successfully initiated. Returns the contract negotiation ID and created timestamp",
                             content = @Content(schema = @Schema(implementation = ApiCoreSchema.IdResponseSchema.class)),
-                            links = @Link(name = "poll-state", operationId = "getNegotiationState", parameters = {
+                            links = @Link(name = "poll-state", operationId = "getNegotiationStateV3", parameters = {
                                     @LinkParameter(name = "id", expression = "$response.body#/id")
                             })
                     ),
                     @ApiResponse(responseCode = "400", description = "Request body was malformed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
             })
-    JsonObject initiateContractNegotiation(JsonObject requestDto);
+    JsonObject initiateContractNegotiationV3(JsonObject requestDto);
 
     @Operation(description = "Terminates the contract negotiation.",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = TerminateNegotiationSchema.class))),
-            operationId = "terminateNegotiationV3",
             responses = {
                     @ApiResponse(responseCode = "200", description = "ContractNegotiation is terminating",
-                            links = @Link(name = "poll-state", operationId = "getNegotiationState")),
+                            links = @Link(name = "poll-state", operationId = "getNegotiationStateV3")),
                     @ApiResponse(responseCode = "400", description = "Request was malformed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
                     @ApiResponse(responseCode = "404", description = "A contract negotiation with the given ID does not exist",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             }
     )
-    void terminateNegotiation(String id, JsonObject terminateNegotiation);
+    void terminateNegotiationV3(String id, JsonObject terminateNegotiation);
 
     @Schema(name = "ContractRequest", example = ContractRequestSchema.CONTRACT_REQUEST_EXAMPLE)
     record ContractRequestSchema(

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v3/ContractNegotiationApiV3Controller.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v3/ContractNegotiationApiV3Controller.java
@@ -14,16 +14,68 @@
 
 package org.eclipse.edc.connector.controlplane.api.management.contractnegotiation.v3;
 
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
 import org.eclipse.edc.connector.controlplane.api.management.contractnegotiation.BaseContractNegotiationApiController;
 import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationService;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
 @Path("/v3/contractnegotiations")
 public class ContractNegotiationApiV3Controller extends BaseContractNegotiationApiController implements ContractNegotiationApiV3 {
     public ContractNegotiationApiV3Controller(ContractNegotiationService service, TypeTransformerRegistry transformerRegistry, Monitor monitor, JsonObjectValidatorRegistry validatorRegistry) {
         super(service, transformerRegistry, monitor, validatorRegistry);
+    }
+
+    @POST
+    @Path("/request")
+    @Override
+    public JsonArray queryNegotiationsV3(JsonObject querySpecJson) {
+        return queryNegotiations(querySpecJson);
+    }
+
+    @GET
+    @Path("/{id}")
+    @Override
+    public JsonObject getNegotiationV3(@PathParam("id") String id) {
+        return getNegotiation(id);
+    }
+
+    @GET
+    @Path("/{id}/state")
+    @Override
+    public JsonObject getNegotiationStateV3(@PathParam("id") String id) {
+        return getNegotiationState(id);
+    }
+
+    @GET
+    @Path("/{id}/agreement")
+    @Override
+    public JsonObject getAgreementForNegotiationV3(@PathParam("id") String negotiationId) {
+        return getAgreementForNegotiation(negotiationId);
+    }
+
+    @POST
+    @Override
+    public JsonObject initiateContractNegotiationV3(JsonObject requestObject) {
+        return initiateContractNegotiation(requestObject);
+    }
+
+    @POST
+    @Path("/{id}/terminate")
+    @Override
+    public void terminateNegotiationV3(@PathParam("id") String id, JsonObject terminateNegotiation) {
+        terminateNegotiation(id, terminateNegotiation);
     }
 }

--- a/extensions/control-plane/api/management-api/edr-cache-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/edr/BaseEdrCacheApiController.java
+++ b/extensions/control-plane/api/management-api/edr-cache-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/edr/BaseEdrCacheApiController.java
@@ -16,13 +16,6 @@ package org.eclipse.edc.connector.controlplane.api.management.edr;
 
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.DELETE;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.POST;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
 import org.eclipse.edc.edr.spi.store.EndpointDataReferenceStore;
 import org.eclipse.edc.edr.spi.types.EndpointDataReferenceEntry;
 import org.eclipse.edc.spi.EdcException;
@@ -36,12 +29,9 @@ import org.eclipse.edc.web.spi.exception.InvalidRequestException;
 import org.eclipse.edc.web.spi.exception.ValidationFailureException;
 
 import static jakarta.json.stream.JsonCollectors.toJsonArray;
-import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE;
 import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMapper;
 
-@Consumes(APPLICATION_JSON)
-@Produces(APPLICATION_JSON)
 public class BaseEdrCacheApiController {
     protected final EndpointDataReferenceStore edrStore;
     protected final TypeTransformerRegistry transformerRegistry;
@@ -55,8 +45,6 @@ public class BaseEdrCacheApiController {
         this.monitor = monitor;
     }
 
-    @POST
-    @Path("/request")
     public JsonArray requestEdrEntries(JsonObject querySpecJson) {
         QuerySpec querySpec;
         if (querySpecJson == null) {
@@ -78,9 +66,7 @@ public class BaseEdrCacheApiController {
                 .collect(toJsonArray());
     }
 
-    @GET
-    @Path("{transferProcessId}/dataaddress")
-    public JsonObject getEdrEntryDataAddress(@PathParam("transferProcessId") String transferProcessId) {
+    public JsonObject getEdrEntryDataAddress(String transferProcessId) {
         var dataAddress = edrStore.resolveByTransferProcess(transferProcessId)
                 .flatMap(ServiceResult::from)
                 .orElseThrow(exceptionMapper(EndpointDataReferenceEntry.class, transferProcessId));
@@ -91,9 +77,7 @@ public class BaseEdrCacheApiController {
 
     }
 
-    @DELETE
-    @Path("{transferProcessId}")
-    public void removeEdrEntry(@PathParam("transferProcessId") String transferProcessId) {
+    public void removeEdrEntry(String transferProcessId) {
         edrStore.delete(transferProcessId)
                 .flatMap(ServiceResult::from)
                 .orElseThrow(exceptionMapper(EndpointDataReferenceEntry.class, transferProcessId));

--- a/extensions/control-plane/api/management-api/edr-cache-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/edr/v1/EdrCacheApiV1.java
+++ b/extensions/control-plane/api/management-api/edr-cache-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/edr/v1/EdrCacheApiV1.java
@@ -39,7 +39,6 @@ public interface EdrCacheApiV1 {
             requestBody = @RequestBody(
                     content = @Content(schema = @Schema(implementation = ApiCoreSchema.QuerySpecSchema.class))
             ),
-            operationId = "requestEdrEntriesV1",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The edr entries matching the query",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = EndpointDataReferenceEntrySchema.class)))),
@@ -47,10 +46,9 @@ public interface EdrCacheApiV1 {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             }, deprecated = true)
     @Deprecated(since = "0.7.0")
-    JsonArray requestEdrEntries(JsonObject querySpecJson);
+    JsonArray requestEdrEntriesV1(JsonObject querySpecJson);
 
     @Operation(description = "Gets the EDR data address with the given transfer process ID",
-            operationId = "getEdrEndryDataAddressV1",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The data address",
                             content = @Content(schema = @Schema(implementation = ApiCoreSchema.DataAddressSchema.class))),
@@ -62,10 +60,9 @@ public interface EdrCacheApiV1 {
             deprecated = true
     )
     @Deprecated(since = "0.7.0")
-    JsonObject getEdrEntryDataAddress(String transferProcessId);
+    JsonObject getEdrEntryDataAddressV1(String transferProcessId);
 
     @Operation(description = "Removes an EDR entry given the transfer process ID",
-            operationId = "removeEdrEntryV1",
             responses = {
                     @ApiResponse(responseCode = "204", description = "EDR entry was deleted successfully"),
                     @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
@@ -74,8 +71,7 @@ public interface EdrCacheApiV1 {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             }, deprecated = true)
     @Deprecated(since = "0.7.0")
-    void removeEdrEntry(String transferProcessId);
-
+    void removeEdrEntryV1(String transferProcessId);
 
     @ArraySchema()
     @Schema(name = "EndpointDataReferenceEntry", example = EndpointDataReferenceEntrySchema.EDR_ENTRY_OUTPUT_EXAMPLE)

--- a/extensions/control-plane/api/management-api/edr-cache-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/edr/v1/EdrCacheApiV1Controller.java
+++ b/extensions/control-plane/api/management-api/edr-cache-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/edr/v1/EdrCacheApiV1Controller.java
@@ -17,36 +17,51 @@ package org.eclipse.edc.connector.controlplane.api.management.edr.v1;
 
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
-import org.eclipse.edc.api.ApiWarnings;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
 import org.eclipse.edc.connector.controlplane.api.management.edr.BaseEdrCacheApiController;
 import org.eclipse.edc.edr.spi.store.EndpointDataReferenceStore;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.eclipse.edc.api.ApiWarnings.deprecationWarning;
 
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
 @Path("/v1/edrs")
 public class EdrCacheApiV1Controller extends BaseEdrCacheApiController implements EdrCacheApiV1 {
     public EdrCacheApiV1Controller(EndpointDataReferenceStore edrStore, TypeTransformerRegistry transformerRegistry, JsonObjectValidatorRegistry validator, Monitor monitor) {
         super(edrStore, transformerRegistry, validator, monitor);
     }
 
+    @POST
+    @Path("/request")
     @Override
-    public JsonArray requestEdrEntries(JsonObject querySpecJson) {
-        monitor.warning(ApiWarnings.deprecationWarning("/v1", "/v3"));
-        return super.requestEdrEntries(querySpecJson);
+    public JsonArray requestEdrEntriesV1(JsonObject querySpecJson) {
+        monitor.warning(deprecationWarning("/v1", "/v3"));
+        return requestEdrEntries(querySpecJson);
     }
 
+    @GET
+    @Path("{transferProcessId}/dataaddress")
     @Override
-    public JsonObject getEdrEntryDataAddress(String transferProcessId) {
-        monitor.warning(ApiWarnings.deprecationWarning("/v1", "/v3"));
-        return super.getEdrEntryDataAddress(transferProcessId);
+    public JsonObject getEdrEntryDataAddressV1(@PathParam("transferProcessId") String transferProcessId) {
+        monitor.warning(deprecationWarning("/v1", "/v3"));
+        return getEdrEntryDataAddress(transferProcessId);
     }
 
+    @DELETE
+    @Path("{transferProcessId}")
     @Override
-    public void removeEdrEntry(String transferProcessId) {
-        monitor.warning(ApiWarnings.deprecationWarning("/v1", "/v3"));
-        super.removeEdrEntry(transferProcessId);
+    public void removeEdrEntryV1(@PathParam("transferProcessId") String transferProcessId) {
+        monitor.warning(deprecationWarning("/v1", "/v3"));
+        removeEdrEntry(transferProcessId);
     }
 }

--- a/extensions/control-plane/api/management-api/edr-cache-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/edr/v3/EdrCacheApiV3.java
+++ b/extensions/control-plane/api/management-api/edr-cache-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/edr/v3/EdrCacheApiV3.java
@@ -39,17 +39,15 @@ public interface EdrCacheApiV3 {
             requestBody = @RequestBody(
                     content = @Content(schema = @Schema(implementation = ApiCoreSchema.QuerySpecSchema.class))
             ),
-            operationId = "requestEdrEntriesV3",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The edr entries matching the query",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = EndpointDataReferenceEntrySchema.class)))),
                     @ApiResponse(responseCode = "400", description = "Request body was malformed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             })
-    JsonArray requestEdrEntries(JsonObject querySpecJson);
+    JsonArray requestEdrEntriesV3(JsonObject querySpecJson);
 
     @Operation(description = "Gets the EDR data address with the given transfer process ID",
-            operationId = "getEdrEndryDataAddressV3",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The data address",
                             content = @Content(schema = @Schema(implementation = ApiCoreSchema.DataAddressSchema.class))),
@@ -60,10 +58,9 @@ public interface EdrCacheApiV3 {
             },
             deprecated = true
     )
-    JsonObject getEdrEntryDataAddress(String transferProcessId);
+    JsonObject getEdrEntryDataAddressV3(String transferProcessId);
 
     @Operation(description = "Removes an EDR entry given the transfer process ID",
-            operationId = "removeEdrEntryV3",
             responses = {
                     @ApiResponse(responseCode = "204", description = "EDR entry was deleted successfully"),
                     @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
@@ -71,8 +68,7 @@ public interface EdrCacheApiV3 {
                     @ApiResponse(responseCode = "404", description = "An EDR entry with the given ID does not exist",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             })
-    void removeEdrEntry(String transferProcessId);
-
+    void removeEdrEntryV3(String transferProcessId);
 
     @ArraySchema()
     @Schema(name = "EndpointDataReferenceEntry", example = EndpointDataReferenceEntrySchema.EDR_ENTRY_OUTPUT_EXAMPLE)

--- a/extensions/control-plane/api/management-api/edr-cache-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/edr/v3/EdrCacheApiV3Controller.java
+++ b/extensions/control-plane/api/management-api/edr-cache-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/edr/v3/EdrCacheApiV3Controller.java
@@ -15,16 +15,49 @@
 package org.eclipse.edc.connector.controlplane.api.management.edr.v3;
 
 
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
 import org.eclipse.edc.connector.controlplane.api.management.edr.BaseEdrCacheApiController;
 import org.eclipse.edc.edr.spi.store.EndpointDataReferenceStore;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
 @Path("/v3/edrs")
 public class EdrCacheApiV3Controller extends BaseEdrCacheApiController implements EdrCacheApiV3 {
     public EdrCacheApiV3Controller(EndpointDataReferenceStore edrStore, TypeTransformerRegistry transformerRegistry, JsonObjectValidatorRegistry validator, Monitor monitor) {
         super(edrStore, transformerRegistry, validator, monitor);
+    }
+
+    @POST
+    @Path("/request")
+    @Override
+    public JsonArray requestEdrEntriesV3(JsonObject querySpecJson) {
+        return requestEdrEntries(querySpecJson);
+    }
+
+    @GET
+    @Path("{transferProcessId}/dataaddress")
+    @Override
+    public JsonObject getEdrEntryDataAddressV3(@PathParam("transferProcessId") String transferProcessId) {
+        return getEdrEntryDataAddress(transferProcessId);
+    }
+
+    @DELETE
+    @Path("{transferProcessId}")
+    @Override
+    public void removeEdrEntryV3(@PathParam("transferProcessId") String transferProcessId) {
+        removeEdrEntry(transferProcessId);
     }
 }

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/BasePolicyDefinitionApiController.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/BasePolicyDefinitionApiController.java
@@ -16,14 +16,6 @@ package org.eclipse.edc.connector.controlplane.api.management.policy;
 
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.DELETE;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.POST;
-import jakarta.ws.rs.PUT;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
 import org.eclipse.edc.api.model.IdResponse;
 import org.eclipse.edc.connector.controlplane.policy.spi.PolicyDefinition;
 import org.eclipse.edc.connector.controlplane.services.spi.policydefinition.PolicyDefinitionService;
@@ -38,14 +30,11 @@ import org.eclipse.edc.web.spi.exception.ObjectNotFoundException;
 import org.eclipse.edc.web.spi.exception.ValidationFailureException;
 
 import static jakarta.json.stream.JsonCollectors.toJsonArray;
-import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static java.lang.String.format;
 import static org.eclipse.edc.connector.controlplane.policy.spi.PolicyDefinition.EDC_POLICY_DEFINITION_TYPE;
 import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE;
 import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMapper;
 
-@Consumes(APPLICATION_JSON)
-@Produces(APPLICATION_JSON)
 public abstract class BasePolicyDefinitionApiController {
 
     protected final Monitor monitor;
@@ -61,8 +50,6 @@ public abstract class BasePolicyDefinitionApiController {
         this.validatorRegistry = validatorRegistry;
     }
 
-    @POST
-    @Path("request")
     public JsonArray queryPolicyDefinitions(JsonObject querySpecJson) {
         QuerySpec querySpec;
         if (querySpecJson == null) {
@@ -81,9 +68,7 @@ public abstract class BasePolicyDefinitionApiController {
                 .collect(toJsonArray());
     }
 
-    @GET
-    @Path("{id}")
-    public JsonObject getPolicyDefinition(@PathParam("id") String id) {
+    public JsonObject getPolicyDefinition(String id) {
         var definition = service.findById(id);
         if (definition == null) {
             throw new ObjectNotFoundException(PolicyDefinition.class, id);
@@ -93,7 +78,6 @@ public abstract class BasePolicyDefinitionApiController {
                 .orElseThrow(failure -> new ObjectNotFoundException(PolicyDefinition.class, id));
     }
 
-    @POST
     public JsonObject createPolicyDefinition(JsonObject request) {
         validatorRegistry.validate(EDC_POLICY_DEFINITION_TYPE, request).orElseThrow(ValidationFailureException::new);
 
@@ -113,17 +97,13 @@ public abstract class BasePolicyDefinitionApiController {
                 .orElseThrow(f -> new EdcException("Error creating response body: " + f.getFailureDetail()));
     }
 
-    @DELETE
-    @Path("{id}")
-    public void deletePolicyDefinition(@PathParam("id") String id) {
+    public void deletePolicyDefinition(String id) {
         service.deleteById(id)
                 .onSuccess(d -> monitor.debug(format("Policy Definition deleted %s", d.getId())))
                 .orElseThrow(exceptionMapper(PolicyDefinition.class, id));
     }
 
-    @PUT
-    @Path("{id}")
-    public void updatePolicyDefinition(@PathParam("id") String id, JsonObject input) {
+    public void updatePolicyDefinition(String id, JsonObject input) {
         validatorRegistry.validate(EDC_POLICY_DEFINITION_TYPE, input).orElseThrow(ValidationFailureException::new);
 
         var policyDefinition = transformerRegistry.transform(input, PolicyDefinition.class)

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/v2/PolicyDefinitionApiV2.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/v2/PolicyDefinitionApiV2.java
@@ -40,7 +40,6 @@ public interface PolicyDefinitionApiV2 {
 
     @Operation(description = "Returns all policy definitions according to a query",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ApiCoreSchema.QuerySpecSchema.class))),
-            operationId = "queryPolicyDefinitionsV2",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The policy definitions matching the query",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = PolicyDefinitionOutputSchema.class)))),
@@ -49,10 +48,9 @@ public interface PolicyDefinitionApiV2 {
             deprecated = true
     )
     @Deprecated(since = "0.7.0")
-    JsonArray queryPolicyDefinitions(JsonObject querySpecJson);
+    JsonArray queryPolicyDefinitionsV2(JsonObject querySpecJson);
 
     @Operation(description = "Gets a policy definition with the given ID",
-            operationId = "getPolicyDefinitionV2",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The  policy definition",
                             content = @Content(schema = @Schema(implementation = PolicyDefinitionOutputSchema.class))),
@@ -64,11 +62,10 @@ public interface PolicyDefinitionApiV2 {
             deprecated = true
     )
     @Deprecated(since = "0.7.0")
-    JsonObject getPolicyDefinition(String id);
+    JsonObject getPolicyDefinitionV2(String id);
 
     @Operation(description = "Creates a new policy definition",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = PolicyDefinitionInputSchema.class))),
-            operationId = "createPolicyDefinitionV2",
             responses = {
                     @ApiResponse(responseCode = "200", description = "policy definition was created successfully. Returns the Policy Definition Id and created timestamp",
                             content = @Content(schema = @Schema(implementation = ApiCoreSchema.IdResponseSchema.class))),
@@ -79,12 +76,11 @@ public interface PolicyDefinitionApiV2 {
             deprecated = true
     )
     @Deprecated(since = "0.7.0")
-    JsonObject createPolicyDefinition(JsonObject policyDefinition);
+    JsonObject createPolicyDefinitionV2(JsonObject policyDefinition);
 
     @Operation(description = "Removes a policy definition with the given ID if possible. Deleting a policy definition is " +
             "only possible if that policy definition is not yet referenced by a contract definition, in which case an error is returned. " +
             "DANGER ZONE: Note that deleting policy definitions can have unexpected results, do this at your own risk!",
-            operationId = "deletePolicyDefinitionV2",
             responses = {
                     @ApiResponse(responseCode = "204", description = "Policy definition was deleted successfully"),
                     @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
@@ -97,11 +93,10 @@ public interface PolicyDefinitionApiV2 {
             deprecated = true
     )
     @Deprecated(since = "0.7.0")
-    void deletePolicyDefinition(String id);
+    void deletePolicyDefinitionV2(String id);
 
     @Operation(description = "Updates an existing Policy, If the Policy is not found, an error is reported",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = PolicyDefinitionInputSchema.class))),
-            operationId = "updatePolicyDefinitionV2",
             responses = {
                     @ApiResponse(responseCode = "204", description = "policy definition was updated successfully."),
                     @ApiResponse(responseCode = "400", description = "Request body was malformed",
@@ -112,7 +107,7 @@ public interface PolicyDefinitionApiV2 {
             deprecated = true
     )
     @Deprecated(since = "0.7.0")
-    void updatePolicyDefinition(String id, JsonObject policyDefinition);
+    void updatePolicyDefinitionV2(String id, JsonObject policyDefinition);
 
     @Schema(name = "PolicyDefinitionInput", example = PolicyDefinitionInputSchema.POLICY_DEFINITION_INPUT_EXAMPLE)
     record PolicyDefinitionInputSchema(

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/v2/PolicyDefinitionApiV2Controller.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/v2/PolicyDefinitionApiV2Controller.java
@@ -16,47 +16,67 @@ package org.eclipse.edc.connector.controlplane.api.management.policy.v2;
 
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
-import org.eclipse.edc.api.ApiWarnings;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
 import org.eclipse.edc.connector.controlplane.api.management.policy.BasePolicyDefinitionApiController;
 import org.eclipse.edc.connector.controlplane.services.spi.policydefinition.PolicyDefinitionService;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.eclipse.edc.api.ApiWarnings.deprecationWarning;
+
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
 @Path("/v2/policydefinitions")
 public class PolicyDefinitionApiV2Controller extends BasePolicyDefinitionApiController implements PolicyDefinitionApiV2 {
     public PolicyDefinitionApiV2Controller(Monitor monitor, TypeTransformerRegistry transformerRegistry, PolicyDefinitionService service, JsonObjectValidatorRegistry validatorRegistry) {
         super(monitor, transformerRegistry, service, validatorRegistry);
     }
 
+    @POST
+    @Path("request")
     @Override
-    public JsonArray queryPolicyDefinitions(JsonObject querySpecJson) {
-        monitor.warning(ApiWarnings.deprecationWarning("/v2", "/v3"));
-        return super.queryPolicyDefinitions(querySpecJson);
+    public JsonArray queryPolicyDefinitionsV2(JsonObject querySpecJson) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        return queryPolicyDefinitions(querySpecJson);
     }
 
+    @GET
+    @Path("{id}")
     @Override
-    public JsonObject getPolicyDefinition(String id) {
-        monitor.warning(ApiWarnings.deprecationWarning("/v2", "/v3"));
-        return super.getPolicyDefinition(id);
+    public JsonObject getPolicyDefinitionV2(@PathParam("id") String id) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        return getPolicyDefinition(id);
     }
 
+    @POST
     @Override
-    public JsonObject createPolicyDefinition(JsonObject request) {
-        monitor.warning(ApiWarnings.deprecationWarning("/v2", "/v3"));
-        return super.createPolicyDefinition(request);
+    public JsonObject createPolicyDefinitionV2(JsonObject request) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        return createPolicyDefinition(request);
     }
 
+    @DELETE
+    @Path("{id}")
     @Override
-    public void deletePolicyDefinition(String id) {
-        monitor.warning(ApiWarnings.deprecationWarning("/v2", "/v3"));
-        super.deletePolicyDefinition(id);
+    public void deletePolicyDefinitionV2(@PathParam("id") String id) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        deletePolicyDefinition(id);
     }
 
+    @PUT
+    @Path("{id}")
     @Override
-    public void updatePolicyDefinition(String id, JsonObject input) {
-        monitor.warning(ApiWarnings.deprecationWarning("/v2", "/v3"));
-        super.updatePolicyDefinition(id, input);
+    public void updatePolicyDefinitionV2(@PathParam("id") String id, JsonObject input) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        updatePolicyDefinition(id, input);
     }
 }

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/v3/PolicyDefinitionApiV3.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/v3/PolicyDefinitionApiV3.java
@@ -40,17 +40,15 @@ public interface PolicyDefinitionApiV3 {
 
     @Operation(description = "Returns all policy definitions according to a query",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ApiCoreSchema.QuerySpecSchema.class))),
-            operationId = "queryPolicyDefinitionsV3",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The policy definitions matching the query",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = PolicyDefinitionOutputSchema.class)))),
                     @ApiResponse(responseCode = "400", description = "Request was malformed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))) }
     )
-    JsonArray queryPolicyDefinitions(JsonObject querySpecJson);
+    JsonArray queryPolicyDefinitionsV3(JsonObject querySpecJson);
 
     @Operation(description = "Gets a policy definition with the given ID",
-            operationId = "getPolicyDefinitionV3",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The  policy definition",
                             content = @Content(schema = @Schema(implementation = PolicyDefinitionOutputSchema.class))),
@@ -60,11 +58,10 @@ public interface PolicyDefinitionApiV3 {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             }
     )
-    JsonObject getPolicyDefinition(String id);
+    JsonObject getPolicyDefinitionV3(String id);
 
     @Operation(description = "Creates a new policy definition",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = PolicyDefinitionInputSchema.class))),
-            operationId = "createPolicyDefinitionV3",
             responses = {
                     @ApiResponse(responseCode = "200", description = "policy definition was created successfully. Returns the Policy Definition Id and created timestamp",
                             content = @Content(schema = @Schema(implementation = ApiCoreSchema.IdResponseSchema.class))),
@@ -73,12 +70,11 @@ public interface PolicyDefinitionApiV3 {
                     @ApiResponse(responseCode = "409", description = "Could not create policy definition, because a contract definition with that ID already exists",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))) }
     )
-    JsonObject createPolicyDefinition(JsonObject policyDefinition);
+    JsonObject createPolicyDefinitionV3(JsonObject policyDefinition);
 
     @Operation(description = "Removes a policy definition with the given ID if possible. Deleting a policy definition is " +
             "only possible if that policy definition is not yet referenced by a contract definition, in which case an error is returned. " +
             "DANGER ZONE: Note that deleting policy definitions can have unexpected results, do this at your own risk!",
-            operationId = "deletePolicyDefinitionV3",
             responses = {
                     @ApiResponse(responseCode = "204", description = "Policy definition was deleted successfully"),
                     @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
@@ -89,11 +85,10 @@ public interface PolicyDefinitionApiV3 {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             }
     )
-    void deletePolicyDefinition(String id);
+    void deletePolicyDefinitionV3(String id);
 
     @Operation(description = "Updates an existing Policy, If the Policy is not found, an error is reported",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = PolicyDefinitionInputSchema.class))),
-            operationId = "updatePolicyDefinitionV3",
             responses = {
                     @ApiResponse(responseCode = "204", description = "policy definition was updated successfully."),
                     @ApiResponse(responseCode = "400", description = "Request body was malformed",
@@ -102,7 +97,7 @@ public interface PolicyDefinitionApiV3 {
                             content = @Content(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))
             }
     )
-    void updatePolicyDefinition(String id, JsonObject policyDefinition);
+    void updatePolicyDefinitionV3(String id, JsonObject policyDefinition);
 
     @Schema(name = "PolicyDefinitionInput", example = PolicyDefinitionInputSchema.POLICY_DEFINITION_INPUT_EXAMPLE)
     record PolicyDefinitionInputSchema(

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/v3/PolicyDefinitionApiV3Controller.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/v3/PolicyDefinitionApiV3Controller.java
@@ -14,16 +14,69 @@
 
 package org.eclipse.edc.connector.controlplane.api.management.policy.v3;
 
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
 import org.eclipse.edc.connector.controlplane.api.management.policy.BasePolicyDefinitionApiController;
 import org.eclipse.edc.connector.controlplane.services.spi.policydefinition.PolicyDefinitionService;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.eclipse.edc.api.ApiWarnings.deprecationWarning;
+
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
 @Path("/v3/policydefinitions")
-public class PolicyDefinitionApiV3Controller extends BasePolicyDefinitionApiController {
+public class PolicyDefinitionApiV3Controller extends BasePolicyDefinitionApiController implements PolicyDefinitionApiV3 {
     public PolicyDefinitionApiV3Controller(Monitor monitor, TypeTransformerRegistry transformerRegistry, PolicyDefinitionService service, JsonObjectValidatorRegistry validatorRegistry) {
         super(monitor, transformerRegistry, service, validatorRegistry);
+    }
+
+    @POST
+    @Path("request")
+    @Override
+    public JsonArray queryPolicyDefinitionsV3(JsonObject querySpecJson) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        return queryPolicyDefinitions(querySpecJson);
+    }
+
+    @GET
+    @Path("{id}")
+    @Override
+    public JsonObject getPolicyDefinitionV3(@PathParam("id") String id) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        return getPolicyDefinition(id);
+    }
+
+    @POST
+    @Override
+    public JsonObject createPolicyDefinitionV3(JsonObject request) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        return createPolicyDefinition(request);
+    }
+
+    @DELETE
+    @Path("{id}")
+    @Override
+    public void deletePolicyDefinitionV3(@PathParam("id") String id) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        deletePolicyDefinition(id);
+    }
+
+    @PUT
+    @Path("{id}")
+    @Override
+    public void updatePolicyDefinitionV3(@PathParam("id") String id, JsonObject input) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        updatePolicyDefinition(id, input);
     }
 }

--- a/extensions/control-plane/api/management-api/secrets-api/src/main/java/org/eclipse/edc/connector/api/management/secret/BaseSecretsApiController.java
+++ b/extensions/control-plane/api/management-api/secrets-api/src/main/java/org/eclipse/edc/connector/api/management/secret/BaseSecretsApiController.java
@@ -15,14 +15,6 @@
 package org.eclipse.edc.connector.api.management.secret;
 
 import jakarta.json.JsonObject;
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.DELETE;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.POST;
-import jakarta.ws.rs.PUT;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
 import org.eclipse.edc.api.model.IdResponse;
 import org.eclipse.edc.connector.spi.service.SecretService;
 import org.eclipse.edc.spi.EdcException;
@@ -33,13 +25,10 @@ import org.eclipse.edc.web.spi.exception.InvalidRequestException;
 import org.eclipse.edc.web.spi.exception.ObjectNotFoundException;
 import org.eclipse.edc.web.spi.exception.ValidationFailureException;
 
-import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static java.util.Optional.of;
 import static org.eclipse.edc.spi.types.domain.secret.Secret.EDC_SECRET_TYPE;
 import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMapper;
 
-@Consumes(APPLICATION_JSON)
-@Produces(APPLICATION_JSON)
 public abstract class BaseSecretsApiController {
     private final TypeTransformerRegistry transformerRegistry;
     private final SecretService service;
@@ -51,7 +40,6 @@ public abstract class BaseSecretsApiController {
         this.validator = validator;
     }
 
-    @POST
     public JsonObject createSecret(JsonObject secretJson) {
         validator.validate(EDC_SECRET_TYPE, secretJson).orElseThrow(ValidationFailureException::new);
 
@@ -69,9 +57,7 @@ public abstract class BaseSecretsApiController {
                 .orElseThrow(f -> new EdcException(f.getFailureDetail()));
     }
 
-    @GET
-    @Path("{id}")
-    public JsonObject getSecret(@PathParam("id") String id) {
+    public JsonObject getSecret(String id) {
         var secret = of(id)
                 .map(it -> service.findById(id))
                 .orElseThrow(() -> new ObjectNotFoundException(Secret.class, id));
@@ -80,13 +66,10 @@ public abstract class BaseSecretsApiController {
                 .orElseThrow(f -> new EdcException(f.getFailureDetail()));
     }
 
-    @DELETE
-    @Path("{id}")
-    public void removeSecret(@PathParam("id") String id) {
+    public void removeSecret(String id) {
         service.delete(id).orElseThrow(exceptionMapper(Secret.class, id));
     }
 
-    @PUT
     public void updateSecret(JsonObject secretJson) {
         validator.validate(EDC_SECRET_TYPE, secretJson).orElseThrow(ValidationFailureException::new);
 

--- a/extensions/control-plane/api/management-api/secrets-api/src/main/java/org/eclipse/edc/connector/api/management/secret/v1/SecretsApiV1.java
+++ b/extensions/control-plane/api/management-api/secrets-api/src/main/java/org/eclipse/edc/connector/api/management/secret/v1/SecretsApiV1.java
@@ -38,7 +38,7 @@ import static org.eclipse.edc.spi.types.domain.secret.Secret.EDC_SECRET_TYPE;
 public interface SecretsApiV1 {
 
     @Operation(description = "Creates a new secret.",
-            deprecated = true, operationId = "createSecretV1",
+            deprecated = true,
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = SecretInputSchema.class))),
             responses = {
                     @ApiResponse(responseCode = "200", description = "Secret was created successfully. Returns the secret Id and created timestamp",
@@ -49,10 +49,10 @@ public interface SecretsApiV1 {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))) }
     )
     @Deprecated(since = "0.7.0")
-    JsonObject createSecret(JsonObject secret);
+    JsonObject createSecretV1(JsonObject secret);
 
     @Operation(description = "Gets a secret with the given ID",
-            deprecated = true, operationId = "getSecretV1",
+            deprecated = true,
             responses = {
                     @ApiResponse(responseCode = "200", description = "The secret",
                             content = @Content(schema = @Schema(implementation = SecretOutputSchema.class))),
@@ -63,10 +63,10 @@ public interface SecretsApiV1 {
             }
     )
     @Deprecated(since = "0.7.0")
-    JsonObject getSecret(String id);
+    JsonObject getSecretV1(String id);
 
     @Operation(description = "Removes a secret with the given ID if possible.",
-            deprecated = true, operationId = "removeSecretV1",
+            deprecated = true,
             responses = {
                     @ApiResponse(responseCode = "204", description = "Secret was deleted successfully"),
                     @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
@@ -75,10 +75,10 @@ public interface SecretsApiV1 {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             })
     @Deprecated(since = "0.7.0")
-    void removeSecret(String id);
+    void removeSecretV1(String id);
 
     @Operation(description = "Updates a secret with the given ID if it exists. If the secret is not found, no further action is taken. ",
-            deprecated = true, operationId = "updateSecretV1",
+            deprecated = true,
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = SecretInputSchema.class))),
             responses = {
                     @ApiResponse(responseCode = "204", description = "Secret was updated successfully"),
@@ -87,7 +87,7 @@ public interface SecretsApiV1 {
                     @ApiResponse(responseCode = "404", description = "Secret could not be updated, because it does not exist.")
             })
     @Deprecated(since = "0.7.0")
-    void updateSecret(JsonObject secret);
+    void updateSecretV1(JsonObject secret);
 
     @Schema(name = "SecretInput", example = SecretInputSchema.SECRET_INPUT_EXAMPLE)
     record SecretInputSchema(

--- a/extensions/control-plane/api/management-api/secrets-api/src/main/java/org/eclipse/edc/connector/api/management/secret/v1/SecretsApiV1Controller.java
+++ b/extensions/control-plane/api/management-api/secrets-api/src/main/java/org/eclipse/edc/connector/api/management/secret/v1/SecretsApiV1Controller.java
@@ -15,16 +15,27 @@
 package org.eclipse.edc.connector.api.management.secret.v1;
 
 import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
-import org.eclipse.edc.api.ApiWarnings;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
 import org.eclipse.edc.connector.api.management.secret.BaseSecretsApiController;
 import org.eclipse.edc.connector.spi.service.SecretService;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.eclipse.edc.api.ApiWarnings.deprecationWarning;
+
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
 @Path("/v1/secrets")
-public class SecretsApiV1Controller extends BaseSecretsApiController {
+public class SecretsApiV1Controller extends BaseSecretsApiController implements SecretsApiV1 {
     private final Monitor monitor;
 
     public SecretsApiV1Controller(SecretService service, TypeTransformerRegistry transformerRegistry, JsonObjectValidatorRegistry validator, Monitor monitor) {
@@ -32,27 +43,33 @@ public class SecretsApiV1Controller extends BaseSecretsApiController {
         this.monitor = monitor;
     }
 
+    @POST
     @Override
-    public JsonObject createSecret(JsonObject secretJson) {
-        monitor.warning(ApiWarnings.deprecationWarning("/v1", "/v3"));
-        return super.createSecret(secretJson);
+    public JsonObject createSecretV1(JsonObject secretJson) {
+        monitor.warning(deprecationWarning("/v1", "/v3"));
+        return createSecret(secretJson);
     }
 
+    @GET
+    @Path("{id}")
     @Override
-    public JsonObject getSecret(String id) {
-        monitor.warning(ApiWarnings.deprecationWarning("/v1", "/v3"));
-        return super.getSecret(id);
+    public JsonObject getSecretV1(@PathParam("id") String id) {
+        monitor.warning(deprecationWarning("/v1", "/v3"));
+        return getSecret(id);
     }
 
+    @DELETE
+    @Path("{id}")
     @Override
-    public void removeSecret(String id) {
-        monitor.warning(ApiWarnings.deprecationWarning("/v1", "/v3"));
-        super.removeSecret(id);
+    public void removeSecretV1(@PathParam("id") String id) {
+        monitor.warning(deprecationWarning("/v1", "/v3"));
+        removeSecret(id);
     }
 
+    @PUT
     @Override
-    public void updateSecret(JsonObject secretJson) {
-        monitor.warning(ApiWarnings.deprecationWarning("/v1", "/v3"));
-        super.updateSecret(secretJson);
+    public void updateSecretV1(JsonObject secretJson) {
+        monitor.warning(deprecationWarning("/v1", "/v3"));
+        updateSecret(secretJson);
     }
 }

--- a/extensions/control-plane/api/management-api/secrets-api/src/main/java/org/eclipse/edc/connector/api/management/secret/v3/SecretsApiV3.java
+++ b/extensions/control-plane/api/management-api/secrets-api/src/main/java/org/eclipse/edc/connector/api/management/secret/v3/SecretsApiV3.java
@@ -38,7 +38,6 @@ import static org.eclipse.edc.spi.types.domain.secret.Secret.EDC_SECRET_TYPE;
 public interface SecretsApiV3 {
 
     @Operation(description = "Creates a new secret.",
-            operationId = "createSecretV3",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = SecretInputSchema.class))),
             responses = {
                     @ApiResponse(responseCode = "200", description = "Secret was created successfully. Returns the secret Id and created timestamp",
@@ -48,10 +47,9 @@ public interface SecretsApiV3 {
                     @ApiResponse(responseCode = "409", description = "Could not create secret, because a secret with that ID already exists",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))) }
     )
-    JsonObject createSecret(JsonObject secret);
+    JsonObject createSecretV3(JsonObject secret);
 
     @Operation(description = "Gets a secret with the given ID",
-            operationId = "getSecretV3",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The secret",
                             content = @Content(schema = @Schema(implementation = SecretOutputSchema.class))),
@@ -61,10 +59,9 @@ public interface SecretsApiV3 {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             }
     )
-    JsonObject getSecret(String id);
+    JsonObject getSecretV3(String id);
 
     @Operation(description = "Removes a secret with the given ID if possible.",
-            operationId = "removeSecretV3",
             responses = {
                     @ApiResponse(responseCode = "204", description = "Secret was deleted successfully"),
                     @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
@@ -72,10 +69,9 @@ public interface SecretsApiV3 {
                     @ApiResponse(responseCode = "404", description = "A secret with the given ID does not exist",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             })
-    void removeSecret(String id);
+    void removeSecretV3(String id);
 
     @Operation(description = "Updates a secret with the given ID if it exists. If the secret is not found, no further action is taken. ",
-            operationId = "updateSecretV3",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = SecretInputSchema.class))),
             responses = {
                     @ApiResponse(responseCode = "204", description = "Secret was updated successfully"),
@@ -83,7 +79,7 @@ public interface SecretsApiV3 {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
                     @ApiResponse(responseCode = "404", description = "Secret could not be updated, because it does not exist.")
             })
-    void updateSecret(JsonObject secret);
+    void updateSecretV3(JsonObject secret);
 
     @Schema(name = "SecretInput", example = SecretInputSchema.SECRET_INPUT_EXAMPLE)
     record SecretInputSchema(

--- a/extensions/control-plane/api/management-api/secrets-api/src/main/java/org/eclipse/edc/connector/api/management/secret/v3/SecretsApiV3Controller.java
+++ b/extensions/control-plane/api/management-api/secrets-api/src/main/java/org/eclipse/edc/connector/api/management/secret/v3/SecretsApiV3Controller.java
@@ -14,16 +14,54 @@
 
 package org.eclipse.edc.connector.api.management.secret.v3;
 
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
 import org.eclipse.edc.connector.api.management.secret.BaseSecretsApiController;
 import org.eclipse.edc.connector.spi.service.SecretService;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
 @Path("/v3/secrets")
-public class SecretsApiV3Controller extends BaseSecretsApiController {
+public class SecretsApiV3Controller extends BaseSecretsApiController implements SecretsApiV3 {
 
     public SecretsApiV3Controller(SecretService service, TypeTransformerRegistry transformerRegistry, JsonObjectValidatorRegistry validator) {
         super(service, transformerRegistry, validator);
+    }
+
+    @POST
+    @Override
+    public JsonObject createSecretV3(JsonObject secretJson) {
+        return createSecret(secretJson);
+    }
+
+    @GET
+    @Path("{id}")
+    @Override
+    public JsonObject getSecretV3(@PathParam("id") String id) {
+        return getSecret(id);
+    }
+
+    @DELETE
+    @Path("{id}")
+    @Override
+    public void removeSecretV3(@PathParam("id") String id) {
+        removeSecret(id);
+    }
+
+    @PUT
+    @Override
+    public void updateSecretV3(JsonObject secretJson) {
+        updateSecret(secretJson);
     }
 }

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/v2/TransferProcessApiV2.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/v2/TransferProcessApiV2.java
@@ -53,7 +53,7 @@ public interface TransferProcessApiV2 {
 
     @Operation(description = "Returns all transfer process according to a query",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ApiCoreSchema.QuerySpecSchema.class))),
-            operationId = "queryTransferProcessesV2", deprecated = true,
+            deprecated = true,
             responses = {
                     @ApiResponse(responseCode = "200", description = "The transfer processes matching the query",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = TransferProcessSchema.class)))),
@@ -61,10 +61,10 @@ public interface TransferProcessApiV2 {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))) }
     )
     @Deprecated(since = "0.7.0")
-    JsonArray queryTransferProcesses(JsonObject querySpecJson);
+    JsonArray queryTransferProcessesV2(JsonObject querySpecJson);
 
     @Operation(description = "Gets an transfer process with the given ID",
-            operationId = "getTransferProcessV2", deprecated = true,
+            deprecated = true,
             responses = {
                     @ApiResponse(responseCode = "200", description = "The transfer process",
                             content = @Content(schema = @Schema(implementation = TransferProcessSchema.class))),
@@ -75,10 +75,10 @@ public interface TransferProcessApiV2 {
             }
     )
     @Deprecated(since = "0.7.0")
-    JsonObject getTransferProcess(String id);
+    JsonObject getTransferProcessV2(String id);
 
     @Operation(description = "Gets the state of a transfer process with the given ID",
-            operationId = "getTransferProcessStateV2", deprecated = true,
+            deprecated = true,
             responses = {
                     @ApiResponse(responseCode = "200", description = "The  transfer process's state",
                             content = @Content(schema = @Schema(implementation = TransferStateSchema.class))),
@@ -89,15 +89,15 @@ public interface TransferProcessApiV2 {
             }
     )
     @Deprecated(since = "0.7.0")
-    JsonObject getTransferProcessState(String id);
+    JsonObject getTransferProcessStateV2(String id);
 
     @Operation(description = "Initiates a data transfer with the given parameters. " + ASYNC_WARNING,
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = TransferRequestSchema.class))),
-            operationId = "initiateTransferProcessV2", deprecated = true,
+            deprecated = true,
             responses = {
                     @ApiResponse(responseCode = "200", description = "The transfer was successfully initiated. Returns the transfer process ID and created timestamp",
                             content = @Content(schema = @Schema(implementation = ApiCoreSchema.IdResponseSchema.class)),
-                            links = @Link(name = "poll-state", operationId = "getTransferProcessState", parameters = {
+                            links = @Link(name = "poll-state", operationId = "getTransferProcessStateV2", parameters = {
                                     @LinkParameter(name = "id", expression = "$response.body#/id")
                             })
                     ),
@@ -105,27 +105,27 @@ public interface TransferProcessApiV2 {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
             })
     @Deprecated(since = "0.7.0")
-    JsonObject initiateTransferProcess(JsonObject transferRequest);
+    JsonObject initiateTransferProcessV2(JsonObject transferRequest);
 
     @Operation(description = "Requests the deprovisioning of resources associated with a transfer process. " + ASYNC_WARNING,
-            operationId = "deprovisionTransferProcessV2", deprecated = true,
+            deprecated = true,
             responses = {
                     @ApiResponse(responseCode = "204", description = "Request to deprovision the transfer process was successfully received",
-                            links = @Link(name = "poll-state", operationId = "deprovisionTransferProcess")),
+                            links = @Link(name = "poll-state", operationId = "deprovisionTransferProcessV2")),
                     @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
                     @ApiResponse(responseCode = "404", description = "A transfer process with the given ID does not exist",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             })
     @Deprecated(since = "0.7.0")
-    void deprovisionTransferProcess(String id);
+    void deprovisionTransferProcessV2(String id);
 
     @Operation(description = "Requests the termination of a transfer process. " + ASYNC_WARNING,
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = TerminateTransferSchema.class))),
-            operationId = "terminateTransferProcessV2", deprecated = true,
+            deprecated = true,
             responses = {
                     @ApiResponse(responseCode = "204", description = "Request to terminate the transfer process was successfully received",
-                            links = @Link(name = "poll-state", operationId = "terminateTransferProcess")),
+                            links = @Link(name = "poll-state", operationId = "terminateTransferProcessV2")),
                     @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
                     @ApiResponse(responseCode = "404", description = "A transfer process with the given ID does not exist",
@@ -134,14 +134,14 @@ public interface TransferProcessApiV2 {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             })
     @Deprecated(since = "0.7.0")
-    void terminateTransferProcess(String id, JsonObject terminateTransfer);
+    void terminateTransferProcessV2(String id, JsonObject terminateTransfer);
 
     @Operation(description = "Requests the suspension of a transfer process. " + ASYNC_WARNING,
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = SuspendTransferSchema.class))),
-            operationId = "suspendTransferProcessV2", deprecated = true,
+            deprecated = true,
             responses = {
                     @ApiResponse(responseCode = "204", description = "Request to suspend the transfer process was successfully received",
-                            links = @Link(name = "poll-state", operationId = "suspendTransferProcess")),
+                            links = @Link(name = "poll-state", operationId = "suspendTransferProcessV2")),
                     @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
                     @ApiResponse(responseCode = "404", description = "A transfer process with the given ID does not exist",
@@ -150,20 +150,20 @@ public interface TransferProcessApiV2 {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             })
     @Deprecated(since = "0.7.0")
-    void suspendTransferProcess(String id, JsonObject suspendTransfer);
+    void suspendTransferProcessV2(String id, JsonObject suspendTransfer);
 
     @Operation(description = "Requests the resumption of a suspended transfer process. " + ASYNC_WARNING,
-            operationId = "resumeTransferProcessV2", deprecated = true,
+            deprecated = true,
             responses = {
                     @ApiResponse(responseCode = "204", description = "Request to resume the transfer process was successfully received",
-                            links = @Link(name = "poll-state", operationId = "resumeTransferProcess")),
+                            links = @Link(name = "poll-state", operationId = "resumeTransferProcessV2")),
                     @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
                     @ApiResponse(responseCode = "404", description = "A transfer process with the given ID does not exist",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             })
     @Deprecated(since = "0.7.0")
-    void resumeTransferProcess(String id);
+    void resumeTransferProcessV2(String id);
 
     @Schema(name = "TransferRequest", example = TransferRequestSchema.TRANSFER_REQUEST_EXAMPLE)
     record TransferRequestSchema(

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/v2/TransferProcessApiV2Controller.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/v2/TransferProcessApiV2Controller.java
@@ -14,16 +14,91 @@
 
 package org.eclipse.edc.connector.controlplane.api.management.transferprocess.v2;
 
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
 import org.eclipse.edc.connector.controlplane.api.management.transferprocess.BaseTransferProcessApiController;
 import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessService;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.eclipse.edc.api.ApiWarnings.deprecationWarning;
+
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
 @Path("/v2/transferprocesses")
 public class TransferProcessApiV2Controller extends BaseTransferProcessApiController implements TransferProcessApiV2 {
     public TransferProcessApiV2Controller(Monitor monitor, TransferProcessService service, TypeTransformerRegistry transformerRegistry, JsonObjectValidatorRegistry validatorRegistry) {
         super(monitor, service, transformerRegistry, validatorRegistry);
+    }
+
+    @POST
+    @Path("request")
+    @Override
+    public JsonArray queryTransferProcessesV2(JsonObject querySpecJson) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        return queryTransferProcesses(querySpecJson);
+    }
+
+    @GET
+    @Path("{id}")
+    @Override
+    public JsonObject getTransferProcessV2(@PathParam("id") String id) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        return getTransferProcess(id);
+    }
+
+    @GET
+    @Path("/{id}/state")
+    @Override
+    public JsonObject getTransferProcessStateV2(@PathParam("id") String id) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        return getTransferProcessState(id);
+    }
+
+    @POST
+    @Override
+    public JsonObject initiateTransferProcessV2(JsonObject transferRequest) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        return initiateTransferProcess(transferRequest);
+    }
+
+    @POST
+    @Path("/{id}/deprovision")
+    @Override
+    public void deprovisionTransferProcessV2(@PathParam("id") String id) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        deprovisionTransferProcess(id);
+    }
+
+    @POST
+    @Path("/{id}/terminate")
+    @Override
+    public void terminateTransferProcessV2(@PathParam("id") String id, JsonObject terminateTransfer) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        terminateTransferProcess(id, terminateTransfer);
+    }
+
+    @POST
+    @Path("/{id}/suspend")
+    @Override
+    public void suspendTransferProcessV2(@PathParam("id") String id, JsonObject suspendTransfer) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        suspendTransferProcess(id, suspendTransfer);
+    }
+
+    @POST
+    @Path("/{id}/resume")
+    @Override
+    public void resumeTransferProcessV2(@PathParam("id") String id) {
+        monitor.warning(deprecationWarning("/v2", "/v3"));
+        resumeTransferProcess(id);
     }
 }

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/v3/TransferProcessApiV3.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/v3/TransferProcessApiV3.java
@@ -53,17 +53,15 @@ public interface TransferProcessApiV3 {
 
     @Operation(description = "Returns all transfer process according to a query",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ApiCoreSchema.QuerySpecSchema.class))),
-            operationId = "queryTransferProcessesV3",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The transfer processes matching the query",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = TransferProcessSchema.class)))),
                     @ApiResponse(responseCode = "400", description = "Request was malformed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))) }
     )
-    JsonArray queryTransferProcesses(JsonObject querySpecJson);
+    JsonArray queryTransferProcessesV3(JsonObject querySpecJson);
 
     @Operation(description = "Gets an transfer process with the given ID",
-            operationId = "getTransferProcessV3",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The transfer process",
                             content = @Content(schema = @Schema(implementation = TransferProcessSchema.class))),
@@ -73,10 +71,9 @@ public interface TransferProcessApiV3 {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             }
     )
-    JsonObject getTransferProcess(String id);
+    JsonObject getTransferProcessV3(String id);
 
     @Operation(description = "Gets the state of a transfer process with the given ID",
-            operationId = "getTransferProcessStateV3",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The  transfer process's state",
                             content = @Content(schema = @Schema(implementation = TransferStateSchema.class))),
@@ -86,41 +83,38 @@ public interface TransferProcessApiV3 {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             }
     )
-    JsonObject getTransferProcessState(String id);
+    JsonObject getTransferProcessStateV3(String id);
 
     @Operation(description = "Initiates a data transfer with the given parameters. " + ASYNC_WARNING,
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = TransferRequestSchema.class))),
-            operationId = "initiateTransferProcessV3",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The transfer was successfully initiated. Returns the transfer process ID and created timestamp",
                             content = @Content(schema = @Schema(implementation = ApiCoreSchema.IdResponseSchema.class)),
-                            links = @Link(name = "poll-state", operationId = "getTransferProcessState", parameters = {
+                            links = @Link(name = "poll-state", operationId = "getTransferProcessStateV3", parameters = {
                                     @LinkParameter(name = "id", expression = "$response.body#/id")
                             })
                     ),
                     @ApiResponse(responseCode = "400", description = "Request body was malformed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
             })
-    JsonObject initiateTransferProcess(JsonObject transferRequest);
+    JsonObject initiateTransferProcessV3(JsonObject transferRequest);
 
     @Operation(description = "Requests the deprovisioning of resources associated with a transfer process. " + ASYNC_WARNING,
-            operationId = "deprovisionTransferProcessV3",
             responses = {
                     @ApiResponse(responseCode = "204", description = "Request to deprovision the transfer process was successfully received",
-                            links = @Link(name = "poll-state", operationId = "deprovisionTransferProcess")),
+                            links = @Link(name = "poll-state", operationId = "deprovisionTransferProcessV3")),
                     @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
                     @ApiResponse(responseCode = "404", description = "A transfer process with the given ID does not exist",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             })
-    void deprovisionTransferProcess(String id);
+    void deprovisionTransferProcessV3(String id);
 
     @Operation(description = "Requests the termination of a transfer process. " + ASYNC_WARNING,
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = TerminateTransferSchema.class))),
-            operationId = "terminateTransferProcessV3",
             responses = {
                     @ApiResponse(responseCode = "204", description = "Request to terminate the transfer process was successfully received",
-                            links = @Link(name = "poll-state", operationId = "terminateTransferProcess")),
+                            links = @Link(name = "poll-state", operationId = "terminateTransferProcessV3")),
                     @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
                     @ApiResponse(responseCode = "404", description = "A transfer process with the given ID does not exist",
@@ -128,14 +122,13 @@ public interface TransferProcessApiV3 {
                     @ApiResponse(responseCode = "409", description = "Could not terminate transfer process, because it is already completed or terminated.",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             })
-    void terminateTransferProcess(String id, JsonObject terminateTransfer);
+    void terminateTransferProcessV3(String id, JsonObject terminateTransfer);
 
     @Operation(description = "Requests the suspension of a transfer process. " + ASYNC_WARNING,
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = SuspendTransferSchema.class))),
-            operationId = "suspendTransferProcessV3",
             responses = {
                     @ApiResponse(responseCode = "204", description = "Request to suspend the transfer process was successfully received",
-                            links = @Link(name = "poll-state", operationId = "suspendTransferProcess")),
+                            links = @Link(name = "poll-state", operationId = "suspendTransferProcessV3")),
                     @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
                     @ApiResponse(responseCode = "404", description = "A transfer process with the given ID does not exist",
@@ -143,19 +136,18 @@ public interface TransferProcessApiV3 {
                     @ApiResponse(responseCode = "409", description = "Could not suspend the transfer process, because it is already completed or terminated.",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             })
-    void suspendTransferProcess(String id, JsonObject suspendTransfer);
+    void suspendTransferProcessV3(String id, JsonObject suspendTransfer);
 
     @Operation(description = "Requests the resumption of a suspended transfer process. " + ASYNC_WARNING,
-            operationId = "resumeTransferProcessV3",
             responses = {
                     @ApiResponse(responseCode = "204", description = "Request to resume the transfer process was successfully received",
-                            links = @Link(name = "poll-state", operationId = "resumeTransferProcess")),
+                            links = @Link(name = "poll-state", operationId = "resumeTransferProcessV3")),
                     @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
                     @ApiResponse(responseCode = "404", description = "A transfer process with the given ID does not exist",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             })
-    void resumeTransferProcess(String id);
+    void resumeTransferProcessV3(String id);
 
     @Schema(name = "TransferRequest", example = TransferRequestSchema.TRANSFER_REQUEST_EXAMPLE)
     record TransferRequestSchema(

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/v3/TransferProcessApiV3Controller.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/v3/TransferProcessApiV3Controller.java
@@ -14,16 +14,83 @@
 
 package org.eclipse.edc.connector.controlplane.api.management.transferprocess.v3;
 
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
 import org.eclipse.edc.connector.controlplane.api.management.transferprocess.BaseTransferProcessApiController;
 import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessService;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
 @Path("/v3/transferprocesses")
 public class TransferProcessApiV3Controller extends BaseTransferProcessApiController implements TransferProcessApiV3 {
+
     public TransferProcessApiV3Controller(Monitor monitor, TransferProcessService service, TypeTransformerRegistry transformerRegistry, JsonObjectValidatorRegistry validatorRegistry) {
         super(monitor, service, transformerRegistry, validatorRegistry);
+    }
+
+    @POST
+    @Path("request")
+    @Override
+    public JsonArray queryTransferProcessesV3(JsonObject querySpecJson) {
+        return queryTransferProcesses(querySpecJson);
+    }
+
+    @GET
+    @Path("{id}")
+    @Override
+    public JsonObject getTransferProcessV3(@PathParam("id") String id) {
+        return getTransferProcess(id);
+    }
+
+    @GET
+    @Path("/{id}/state")
+    @Override
+    public JsonObject getTransferProcessStateV3(@PathParam("id") String id) {
+        return getTransferProcessState(id);
+    }
+
+    @POST
+    @Override
+    public JsonObject initiateTransferProcessV3(JsonObject transferRequest) {
+        return initiateTransferProcess(transferRequest);
+    }
+
+    @POST
+    @Path("/{id}/deprovision")
+    @Override
+    public void deprovisionTransferProcessV3(@PathParam("id") String id) {
+        deprovisionTransferProcess(id);
+    }
+
+    @POST
+    @Path("/{id}/terminate")
+    @Override
+    public void terminateTransferProcessV3(@PathParam("id") String id, JsonObject terminateTransfer) {
+        terminateTransferProcess(id, terminateTransfer);
+    }
+
+    @POST
+    @Path("/{id}/suspend")
+    @Override
+    public void suspendTransferProcessV3(@PathParam("id") String id, JsonObject suspendTransfer) {
+        suspendTransferProcess(id, suspendTransfer);
+    }
+
+    @POST
+    @Path("/{id}/resume")
+    @Override
+    public void resumeTransferProcessV3(@PathParam("id") String id) {
+        resumeTransferProcess(id);
     }
 }

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/model/SelectionRequest.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/model/SelectionRequest.java
@@ -20,7 +20,7 @@ import org.eclipse.edc.spi.types.domain.DataAddress;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 
 /**
- * Represents the request body that the {@link DataplaneSelectorApiV2#selectDataPlaneInstance(jakarta.json.JsonObject)} endpoint requires
+ * Represents the request body that the {@link DataplaneSelectorApiV2#selectDataPlaneInstanceV2(jakarta.json.JsonObject)} endpoint requires
  * Contains source and destination address and optionally the name of a selection strategy
  */
 public class SelectionRequest {

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/DataplaneSelectorApiV2.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/DataplaneSelectorApiV2.java
@@ -37,7 +37,6 @@ public interface DataplaneSelectorApiV2 {
 
     @Operation(method = "POST",
             deprecated = true,
-            operationId = "selectDataPlaneInstanceV2",
             description = "Finds the best fitting data plane instance for a particular query",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = SelectionRequestSchema.class))),
             responses = {
@@ -49,11 +48,10 @@ public interface DataplaneSelectorApiV2 {
             })
     @Deprecated(since = "0.6.4")
     @POST
-    JsonObject selectDataPlaneInstance(JsonObject request);
+    JsonObject selectDataPlaneInstanceV2(JsonObject request);
 
 
     @Operation(method = "POST",
-            operationId = "addDataPlaneInstanceV2",
             description = "Adds one dataplane instance to the internal database of the selector. DEPRECATED: dataplanes should register themselves through control-api",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = DataPlaneInstanceSchema.class))),
             responses = {
@@ -64,10 +62,9 @@ public interface DataplaneSelectorApiV2 {
     )
     @POST
     @Deprecated(since = "0.6.2")
-    JsonObject addDataPlaneInstance(JsonObject instance);
+    JsonObject addDataPlaneInstanceV2(JsonObject instance);
 
     @Operation(method = "GET",
-            operationId = "getAllDataPlaneInstancesV2",
             description = "Returns a list of all currently registered data plane instances",
             responses = {
                     @ApiResponse(responseCode = "200", description = "A (potentially empty) list of currently registered data plane instances",
@@ -77,6 +74,6 @@ public interface DataplaneSelectorApiV2 {
     )
     @GET
     @Deprecated(since = "0.7.0")
-    JsonArray getAllDataPlaneInstances();
+    JsonArray getAllDataPlaneInstancesV2();
 
 }

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/DataplaneSelectorApiV2Controller.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v2/DataplaneSelectorApiV2Controller.java
@@ -61,7 +61,7 @@ public class DataplaneSelectorApiV2Controller implements DataplaneSelectorApiV2 
     @Override
     @POST
     @Path("select")
-    public JsonObject selectDataPlaneInstance(JsonObject requestObject) {
+    public JsonObject selectDataPlaneInstanceV2(JsonObject requestObject) {
         var request = transformerRegistry.transform(requestObject, SelectionRequest.class)
                 .orElseThrow(InvalidRequestException::new);
 
@@ -76,7 +76,7 @@ public class DataplaneSelectorApiV2Controller implements DataplaneSelectorApiV2 
 
     @Override
     @POST
-    public JsonObject addDataPlaneInstance(JsonObject jsonObject) {
+    public JsonObject addDataPlaneInstanceV2(JsonObject jsonObject) {
         validatorRegistry.validate(DATAPLANE_INSTANCE_TYPE, jsonObject).orElseThrow(ValidationFailureException::new);
 
         var instance = transformerRegistry.transform(jsonObject, DataPlaneInstance.class)
@@ -96,7 +96,7 @@ public class DataplaneSelectorApiV2Controller implements DataplaneSelectorApiV2 
 
     @Override
     @GET
-    public JsonArray getAllDataPlaneInstances() {
+    public JsonArray getAllDataPlaneInstancesV2() {
         var instances = selectionService.getAll().orElseThrow(exceptionMapper(DataPlaneInstance.class));
         return instances.stream()
                 .map(i -> transformerRegistry.transform(i, JsonObject.class))

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v3/DataplaneSelectorApiV3.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v3/DataplaneSelectorApiV3.java
@@ -31,7 +31,6 @@ import org.eclipse.edc.connector.dataplane.selector.api.schemas.DataPlaneInstanc
 public interface DataplaneSelectorApiV3 {
 
     @Operation(method = "GET",
-            operationId = "getAllDataPlaneInstancesV3",
             description = "Returns a list of all currently registered data plane instances",
             responses = {
                     @ApiResponse(responseCode = "200", description = "A (potentially empty) list of currently registered data plane instances",
@@ -39,6 +38,6 @@ public interface DataplaneSelectorApiV3 {
             }
     )
     @GET
-    JsonArray getAllDataPlaneInstances();
+    JsonArray getAllDataPlaneInstancesV3();
 
 }

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v3/DataplaneSelectorApiV3Controller.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/v3/DataplaneSelectorApiV3Controller.java
@@ -44,7 +44,7 @@ public class DataplaneSelectorApiV3Controller implements DataplaneSelectorApiV3 
 
     @Override
     @GET
-    public JsonArray getAllDataPlaneInstances() {
+    public JsonArray getAllDataPlaneInstancesV3() {
         var instances = selectionService.getAll().orElseThrow(exceptionMapper(DataPlaneInstance.class));
         return instances.stream()
                 .map(i -> transformerRegistry.transform(i, JsonObject.class))

--- a/extensions/data-plane-selector/data-plane-selector-control-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/control/api/DataplaneSelectorControlApi.java
+++ b/extensions/data-plane-selector/data-plane-selector-control-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/control/api/DataplaneSelectorControlApi.java
@@ -42,7 +42,6 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 public interface DataplaneSelectorControlApi {
 
     @Operation(method = HttpMethod.POST,
-            operationId = "registerDataplane",
             description = "Register new Dataplane",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = DataPlaneInstanceSchema.class))),
             responses = {
@@ -56,7 +55,6 @@ public interface DataplaneSelectorControlApi {
     JsonObject registerDataplane(JsonObject request);
 
     @Operation(method = HttpMethod.DELETE,
-            operationId = "unregisterDataplane",
             description = "Unregister existing Dataplane",
             responses = {
                     @ApiResponse(responseCode = "204", description = "Dataplane successfully unregistered"),
@@ -69,7 +67,6 @@ public interface DataplaneSelectorControlApi {
     void unregisterDataplane(String id);
 
     @Operation(method = "POST",
-            operationId = "selectDataplane",
             description = "Finds the best fitting data plane instance for a particular query",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = SelectionRequestSchema.class))),
             responses = {
@@ -82,7 +79,6 @@ public interface DataplaneSelectorControlApi {
     JsonObject selectDataplane(JsonObject request);
 
     @Operation(method = "GET",
-            operationId = "getAllDataPlaneInstances",
             description = "Returns a list of all currently registered data plane instances",
             responses = {
                     @ApiResponse(responseCode = "200", description = "A (potentially empty) list of currently registered data plane instances",
@@ -93,7 +89,6 @@ public interface DataplaneSelectorControlApi {
 
 
     @Operation(method = "GET",
-            operationId = "findDataPlaneById",
             description = "Returns the Data Plane Instance with the specified id.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The Data Plane Instance",


### PR DESCRIPTION
## What this PR changes/adds

- distinguish method names for different api versions
- push down all the jakarta.ws.rs annotation from abstract classes to implementations

## Why it does that

fix the api docs output (as outlined in #4243)

## Further notes

removed all the unnecessary `operationId` attributes from `@Operation` swagger annotations

## Linked Issue(s)

Closes #4243 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
