### PR TITLE
feat: data-plane self unregistration

### DIFF
--- a/core/data-plane-selector/data-plane-selector-core/src/main/java/org/eclipse/edc/connector/dataplane/selector/manager/DataPlaneSelectorManagerImpl.java
+++ b/core/data-plane-selector/data-plane-selector-core/src/main/java/org/eclipse/edc/connector/dataplane/selector/manager/DataPlaneSelectorManagerImpl.java
@@ -66,7 +66,7 @@ public class DataPlaneSelectorManagerImpl extends AbstractStateEntityManager<Dat
         } else {
             instance.transitionToUnavailable();
         }
-        store.save(instance);
+        update(instance);
         return true;
     }
 

--- a/extensions/common/http/jersey-core/src/testFixtures/java/org/eclipse/edc/web/jersey/testfixtures/RestControllerTestBase.java
+++ b/extensions/common/http/jersey-core/src/testFixtures/java/org/eclipse/edc/web/jersey/testfixtures/RestControllerTestBase.java
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.mock;
  * Base utility class that permits to test Rest controllers deploying a bare bone instance of Jetty
  * with Jersey. The controller returned by the {@link #controller()} method gets registered on a test api context.
  */
-public abstract class RestControllerTestBase {
+public abstract class RestControllerTestBase { // TODO: can it be started once for class?
 
     protected final int port = getFreePort();
     protected final Monitor monitor = mock(Monitor.class);

--- a/extensions/data-plane-selector/data-plane-selector-client/src/main/java/org/eclipse/edc/connector/dataplane/selector/RemoteDataPlaneSelectorService.java
+++ b/extensions/data-plane-selector/data-plane-selector-client/src/main/java/org/eclipse/edc/connector/dataplane/selector/RemoteDataPlaneSelectorService.java
@@ -39,6 +39,7 @@ import java.util.Optional;
 
 import static jakarta.json.Json.createObjectBuilder;
 import static java.lang.String.format;
+import static okhttp3.internal.Util.EMPTY_REQUEST;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
@@ -121,6 +122,13 @@ public class RemoteDataPlaneSelectorService implements DataPlaneSelectorService 
     @Override
     public ServiceResult<Void> delete(String instanceId) {
         var requestBuilder = new Request.Builder().delete().url(url + "/" + instanceId);
+
+        return request(requestBuilder).mapEmpty();
+    }
+
+    @Override
+    public ServiceResult<Void> unregister(String instanceId) {
+        var requestBuilder = new Request.Builder().put(EMPTY_REQUEST).url("%s/%s/unregister".formatted(url, instanceId));
 
         return request(requestBuilder).mapEmpty();
     }

--- a/extensions/data-plane-selector/data-plane-selector-client/src/test/java/org/eclipse/edc/connector/dataplane/selector/RemoteDataPlaneSelectorServiceTest.java
+++ b/extensions/data-plane-selector/data-plane-selector-client/src/test/java/org/eclipse/edc/connector/dataplane/selector/RemoteDataPlaneSelectorServiceTest.java
@@ -46,6 +46,7 @@ import java.util.UUID;
 
 import static org.eclipse.edc.http.client.testfixtures.HttpTestUtils.testHttpClient;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.spi.result.ServiceFailure.Reason.CONFLICT;
 import static org.eclipse.edc.spi.result.ServiceFailure.Reason.NOT_FOUND;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -102,6 +103,30 @@ class RemoteDataPlaneSelectorServiceTest extends RestControllerTestBase {
         assertThat(result).isSucceeded().usingRecursiveComparison()
                 .ignoringFields(FIELDS_TO_BE_IGNORED).isEqualTo(expected);
         verify(authenticationProvider).authenticationHeaders();
+    }
+
+    @Nested
+    class Unregister {
+        @Test
+        void shouldUnregister() {
+            var instanceId = UUID.randomUUID().toString();
+            when(serverService.unregister(any())).thenReturn(ServiceResult.success());
+
+            var result = service.unregister(instanceId);
+
+            assertThat(result).isSucceeded();
+            verify(serverService).unregister(instanceId);
+        }
+
+        @Test
+        void shouldFail_whenServiceFails() {
+            var instanceId = UUID.randomUUID().toString();
+            when(serverService.unregister(any())).thenReturn(ServiceResult.conflict("conflict"));
+
+            var result = service.unregister(instanceId);
+
+            assertThat(result).isFailed().extracting(ServiceFailure::getReason).isEqualTo(CONFLICT);
+        }
     }
 
     @Nested

--- a/extensions/data-plane-selector/data-plane-selector-control-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/control/api/DataplaneSelectorControlApi.java
+++ b/extensions/data-plane-selector/data-plane-selector-control-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/control/api/DataplaneSelectorControlApi.java
@@ -54,17 +54,33 @@ public interface DataplaneSelectorControlApi {
             })
     JsonObject registerDataplane(JsonObject request);
 
-    @Operation(method = HttpMethod.DELETE,
+    @Operation(method = HttpMethod.POST,
             description = "Unregister existing Dataplane",
             responses = {
                     @ApiResponse(responseCode = "204", description = "Dataplane successfully unregistered"),
                     @ApiResponse(responseCode = "400", description = "Request body was malformed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
                     @ApiResponse(responseCode = "404", description = "Resource not found",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
+                    @ApiResponse(responseCode = "409", description = "Conflict",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             }
     )
     void unregisterDataplane(String id);
+
+    @Operation(method = HttpMethod.DELETE,
+            description = "Delete existing Dataplane",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "Dataplane successfully deleted"),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
+                    @ApiResponse(responseCode = "404", description = "Resource not found",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
+                    @ApiResponse(responseCode = "409", description = "Conflict",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
+            }
+    )
+    void deleteDataplane(String id);
 
     @Operation(method = "POST",
             description = "Finds the best fitting data plane instance for a particular query",

--- a/extensions/data-plane-selector/data-plane-selector-control-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/control/api/DataplaneSelectorControlApiController.java
+++ b/extensions/data-plane-selector/data-plane-selector-control-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/control/api/DataplaneSelectorControlApiController.java
@@ -20,6 +20,7 @@ import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
@@ -79,10 +80,17 @@ public class DataplaneSelectorControlApiController implements DataplaneSelectorC
                 .orElseThrow(f -> new EdcException(f.getFailureDetail()));
     }
 
+    @PUT
+    @Path("/{id}/unregister")
     @Override
+    public void unregisterDataplane(@PathParam("id") String id) {
+        service.unregister(id).orElseThrow(exceptionMapper(DataPlaneInstance.class));
+    }
+
     @DELETE
     @Path("/{id}")
-    public void unregisterDataplane(@PathParam("id") String id) {
+    @Override
+    public void deleteDataplane(@PathParam("id") String id) {
         service.delete(id).orElseThrow(exceptionMapper(DataPlaneInstance.class));
     }
 

--- a/extensions/data-plane-selector/data-plane-selector-control-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/control/api/DataplaneSelectorControlApiControllerTest.java
+++ b/extensions/data-plane-selector/data-plane-selector-control-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/control/api/DataplaneSelectorControlApiControllerTest.java
@@ -148,6 +148,36 @@ class DataplaneSelectorControlApiControllerTest extends RestControllerTestBase {
     class Unregister {
 
         @Test
+        void shouldUnregisterInstance() {
+            when(service.unregister(any())).thenReturn(ServiceResult.success());
+            var instanceId = UUID.randomUUID().toString();
+
+            given()
+                    .port(port)
+                    .put("/v1/dataplanes/{id}/unregister", instanceId)
+                    .then()
+                    .statusCode(204);
+
+            verify(service).unregister(instanceId);
+        }
+
+        @Test
+        void shouldReturnNotFound_whenServiceReturnsNotFound() {
+            when(service.unregister(any())).thenReturn(ServiceResult.notFound("not found"));
+            var instanceId = UUID.randomUUID().toString();
+
+            given()
+                    .port(port)
+                    .put("/v1/dataplanes/{id}/unregister", instanceId)
+                    .then()
+                    .statusCode(404);
+        }
+    }
+
+    @Nested
+    class Delete {
+
+        @Test
         void shouldDeleteInstance() {
             when(service.delete(any())).thenReturn(ServiceResult.success());
             var instanceId = UUID.randomUUID().toString();

--- a/extensions/data-plane/data-plane-self-registration/src/main/java/org/eclipse/edc/connector/dataplane/registration/DataplaneSelfRegistrationExtension.java
+++ b/extensions/data-plane/data-plane-self-registration/src/main/java/org/eclipse/edc/connector/dataplane/registration/DataplaneSelfRegistrationExtension.java
@@ -58,6 +58,7 @@ public class DataplaneSelfRegistrationExtension implements ServiceExtension {
     private PublicEndpointGeneratorService publicEndpointGeneratorService;
     @Inject
     private HealthCheckService healthCheckService;
+
     private ServiceExtensionContext context;
 
     @Override
@@ -86,7 +87,6 @@ public class DataplaneSelfRegistrationExtension implements ServiceExtension {
                 .build();
 
 
-        // register the data plane
         var monitor = context.getMonitor().withPrefix("DataPlaneHealthCheck");
         var check = new DataPlaneHealthCheck();
         healthCheckService.addReadinessProvider(check);
@@ -105,7 +105,7 @@ public class DataplaneSelfRegistrationExtension implements ServiceExtension {
 
     @Override
     public void shutdown() {
-        dataPlaneSelectorService.delete(context.getRuntimeId())
+        dataPlaneSelectorService.unregister(context.getRuntimeId())
                 .onSuccess(it -> context.getMonitor().info("data plane successfully unregistered"))
                 .onFailure(failure -> context.getMonitor().severe("error during data plane de-registration. %s: %s"
                         .formatted(failure.getReason(), failure.getFailureDetail())));

--- a/extensions/data-plane/data-plane-self-registration/src/test/java/org/eclipse/edc/connector/dataplane/registration/DataplaneSelfRegistrationExtensionTest.java
+++ b/extensions/data-plane/data-plane-self-registration/src/test/java/org/eclipse/edc/connector/dataplane/registration/DataplaneSelfRegistrationExtensionTest.java
@@ -104,11 +104,11 @@ class DataplaneSelfRegistrationExtensionTest {
     @Test
     void shouldUnregisterInstanceAtShutdown(DataplaneSelfRegistrationExtension extension, ServiceExtensionContext context) {
         when(context.getRuntimeId()).thenReturn("runtimeId");
-        when(dataPlaneSelectorService.delete(any())).thenReturn(ServiceResult.success());
+        when(dataPlaneSelectorService.unregister(any())).thenReturn(ServiceResult.success());
         extension.initialize(context);
 
         extension.shutdown();
 
-        verify(dataPlaneSelectorService).delete("runtimeId");
+        verify(dataPlaneSelectorService).unregister("runtimeId");
     }
 }

--- a/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/DataPlaneSelectorService.java
+++ b/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/DataPlaneSelectorService.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.connector.dataplane.selector.spi;
 
 import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
+import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstanceStates;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.types.domain.DataAddress;
@@ -57,6 +58,14 @@ public interface DataPlaneSelectorService {
      * @return successful result if operation completed, failure otherwise.
      */
     ServiceResult<Void> delete(String instanceId);
+
+    /**
+     * Unregister a Data Plane instance. The state will transition to {@link DataPlaneInstanceStates#UNREGISTERED}.
+     *
+     * @param instanceId the instance id.
+     * @return successful result if operation completed, failure otherwise.
+     */
+    ServiceResult<Void> unregister(String instanceId);
 
     /**
      * Find a Data Plane instance by id.

--- a/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/instance/DataPlaneInstance.java
+++ b/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/instance/DataPlaneInstance.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstanceStates.AVAILABLE;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstanceStates.REGISTERED;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstanceStates.UNAVAILABLE;
+import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstanceStates.UNREGISTERED;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 
 /**
@@ -139,6 +140,10 @@ public class DataPlaneInstance extends StatefulEntity<DataPlaneInstance> {
 
     public void transitionToUnavailable() {
         transitionTo(UNAVAILABLE.code());
+    }
+
+    public void transitionToUnregistered() {
+        transitionTo(UNREGISTERED.code());
     }
 
     @JsonPOJOBuilder(withPrefix = "")


### PR DESCRIPTION
## What this PR changes/adds

Make the data plane "unregister" itself instead of "delete".

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #4238 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
