### PR TITLE
chore: correct null check message to corresponding field

### DIFF
--- a/spi/common/edr-store-spi/src/main/java/org/eclipse/edc/edr/spi/types/EndpointDataReferenceEntry.java
+++ b/spi/common/edr-store-spi/src/main/java/org/eclipse/edc/edr/spi/types/EndpointDataReferenceEntry.java
@@ -23,8 +23,7 @@ import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 /**
  * Represents metadata associated with an EDR
  */
-public class
-EndpointDataReferenceEntry extends Entity {
+public class EndpointDataReferenceEntry extends Entity {
 
     public static final String SIMPLE_TYPE = "EndpointDataReferenceEntry";
     public static final String EDR_ENTRY_TYPE = EDC_NAMESPACE + SIMPLE_TYPE;
@@ -114,6 +113,7 @@ EndpointDataReferenceEntry extends Entity {
             return this;
         }
 
+        @Override
         public EndpointDataReferenceEntry build() {
             super.build();
             requireNonNull(entity.assetId, ASSET_ID);

--- a/spi/common/edr-store-spi/src/main/java/org/eclipse/edc/edr/spi/types/EndpointDataReferenceEntry.java
+++ b/spi/common/edr-store-spi/src/main/java/org/eclipse/edc/edr/spi/types/EndpointDataReferenceEntry.java
@@ -23,7 +23,8 @@ import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 /**
  * Represents metadata associated with an EDR
  */
-public class EndpointDataReferenceEntry extends Entity {
+public class
+EndpointDataReferenceEntry extends Entity {
 
     public static final String SIMPLE_TYPE = "EndpointDataReferenceEntry";
     public static final String EDR_ENTRY_TYPE = EDC_NAMESPACE + SIMPLE_TYPE;
@@ -118,7 +119,7 @@ public class EndpointDataReferenceEntry extends Entity {
             requireNonNull(entity.assetId, ASSET_ID);
             requireNonNull(entity.agreementId, AGREEMENT_ID);
             requireNonNull(entity.transferProcessId, TRANSFER_PROCESS_ID);
-            requireNonNull(entity.providerId, TRANSFER_PROCESS_ID);
+            requireNonNull(entity.providerId, PROVIDER_ID);
             // The id is always equals to transfer process id
             entity.id = entity.transferProcessId;
             return entity;


### PR DESCRIPTION
## What this PR changes/adds

This PR corrects the null check error message for the providerId within the EDREntry. 

## Why it does that

Wrong validation message was given for the providerId field.

## Linked Issue(s)

Closes #4250 
