### PR TITLE
feat: add alias for issuance date

### DIFF
--- a/extensions/common/iam/verifiable-credentials/src/test/java/org/eclipse/edc/iam/verifiablecredentials/TestData.java
+++ b/extensions/common/iam/verifiable-credentials/src/test/java/org/eclipse/edc/iam/verifiablecredentials/TestData.java
@@ -16,7 +16,7 @@ package org.eclipse.edc.iam.verifiablecredentials;
 
 public class TestData {
     // test data taken from https://www.w3.org/TR/2023/WD-vc-status-list-20230427/#example-example-statuslist2021credential-0
-    public static final String STATUS_LIST_CREDENTIAL_SUBJECT_IS_ARRAY = """
+    public static final String STATUS_LIST_CREDENTIAL_SUBJECT_IS_ARRAY_INTERMEDIATE = """
             {
               "@context": [
                 "https://www.w3.org/2018/credentials/v1",
@@ -37,7 +37,7 @@ public class TestData {
             }
             """;
 
-    public static final String STATUS_LIST_CREDENTIAL_SINGLE_SUBJECT = """
+    public static final String STATUS_LIST_CREDENTIAL_SINGLE_SUBJECT_INTERMEDIATE = """
             {
               "@context": [
                 "https://www.w3.org/2018/credentials/v1",
@@ -47,6 +47,87 @@ public class TestData {
               "type": ["VerifiableCredential", "StatusList2021Credential"],
               "issuer": "did:example:12345",
               "issued": "2021-04-05T14:27:40Z",
+              "credentialSubject": {
+                "id": "https://example.com/status/3#list",
+                "type": "StatusList2021",
+                "https://w3id.org/vc/status-list#statusPurpose": "revocation",
+                "https://w3id.org/vc/status-list#encodedList": "H4sIAAAAAAAAA+3BIQEAAAACIP+vcKozLEADAAAAAAAAAAAAAAAAAAAAvA0cOP65AEAAAA"
+              }
+            }
+            """;
+
+    public static final String STATUS_LIST_CREDENTIAL_SUBJECT_IS_ARRAY_2_0 = """
+            {
+              "@context": [
+                "https://www.w3.org/2018/credentials/v1",
+                "https://w3id.org/vc/status-list/2021/v1"
+              ],
+              "id": "https://example.com/credentials/status/3",
+              "type": ["VerifiableCredential", "StatusList2021Credential"],
+              "issuer": "did:example:12345",
+              "validFrom": "2021-04-05T14:27:40Z",
+              "credentialSubject": [
+              {
+                "id": "https://example.com/status/3#list",
+                "type": "StatusList2021",
+                "https://w3id.org/vc/status-list#statusPurpose": "revocation",
+                "https://w3id.org/vc/status-list#encodedList": "H4sIAAAAAAAAA+3BIQEAAAACIP+vcKozLEADAAAAAAAAAAAAAAAAAAAAvA0cOP65AEAAAA"
+              }
+              ]
+            }
+            """;
+
+    public static final String STATUS_LIST_CREDENTIAL_SINGLE_SUBJECT_2_0 = """
+            {
+              "@context": [
+                "https://www.w3.org/2018/credentials/v1",
+                "https://w3id.org/vc/status-list/2021/v1"
+              ],
+              "id": "https://example.com/credentials/status/3",
+              "type": ["VerifiableCredential", "StatusList2021Credential"],
+              "issuer": "did:example:12345",
+              "validFrom": "2021-04-05T14:27:40Z",
+              "credentialSubject": {
+                "id": "https://example.com/status/3#list",
+                "type": "StatusList2021",
+                "https://w3id.org/vc/status-list#statusPurpose": "revocation",
+                "https://w3id.org/vc/status-list#encodedList": "H4sIAAAAAAAAA+3BIQEAAAACIP+vcKozLEADAAAAAAAAAAAAAAAAAAAAvA0cOP65AEAAAA"
+              }
+            }
+            """;
+
+
+    public static final String STATUS_LIST_CREDENTIAL_SUBJECT_IS_ARRAY_1_0 = """
+            {
+              "@context": [
+                "https://www.w3.org/2018/credentials/v1",
+                "https://w3id.org/vc/status-list/2021/v1"
+              ],
+              "id": "https://example.com/credentials/status/3",
+              "type": ["VerifiableCredential", "StatusList2021Credential"],
+              "issuer": "did:example:12345",
+              "issuanceDate": "2021-04-05T14:27:40Z",
+              "credentialSubject": [
+              {
+                "id": "https://example.com/status/3#list",
+                "type": "StatusList2021",
+                "https://w3id.org/vc/status-list#statusPurpose": "revocation",
+                "https://w3id.org/vc/status-list#encodedList": "H4sIAAAAAAAAA+3BIQEAAAACIP+vcKozLEADAAAAAAAAAAAAAAAAAAAAvA0cOP65AEAAAA"
+              }
+              ]
+            }
+            """;
+
+    public static final String STATUS_LIST_CREDENTIAL_SINGLE_SUBJECT_1_0 = """
+            {
+              "@context": [
+                "https://www.w3.org/2018/credentials/v1",
+                "https://w3id.org/vc/status-list/2021/v1"
+              ],
+              "id": "https://example.com/credentials/status/3",
+              "type": ["VerifiableCredential", "StatusList2021Credential"],
+              "issuer": "did:example:12345",
+              "issuanceDate": "2021-04-05T14:27:40Z",
               "credentialSubject": {
                 "id": "https://example.com/status/3#list",
                 "type": "StatusList2021",

--- a/spi/common/verifiable-credentials-spi/src/main/java/org/eclipse/edc/iam/verifiablecredentials/spi/model/VerifiableCredential.java
+++ b/spi/common/verifiable-credentials-spi/src/main/java/org/eclipse/edc/iam/verifiablecredentials/spi/model/VerifiableCredential.java
@@ -71,12 +71,13 @@ public class VerifiableCredential {
         return issuer;
     }
 
-    @JsonAlias({ "issued" }) // some credentials like StatusList2021 don't adhere to the spec
+    @JsonAlias({ "issued", "validFrom" }) // some credentials like StatusList2021 don't adhere to the spec
     @NotNull
     public Instant getIssuanceDate() {
         return issuanceDate;
     }
 
+    @JsonAlias({ "validUntil" })
     public Instant getExpirationDate() {
         return expirationDate;
     }


### PR DESCRIPTION
## What this PR changes/adds

Adds a JSON alias `validFrom` for the issuance date of a `VerifiableCredential` to compensate a vagueness in the StatusList2021 spec:

- VC Datamodel 1.1 requires a `issuanceDate` field
- VC Datamodel 2.0 requires a `validFrom` field
- StatusList2021 explicitly mentions the VC Datamodel 1.1 as normative reference
- StatusList2021 requires a `validFrom` field, which would violate the previous spec
- StatusList2021 uses yet another option, an `issued` field in its examples

This is quite inconsistent, and so far EDC could accomodate `issuanceDate` and `issued`, but not `validFrom`. This PR changes that.

## Why it does that

VCs are not always parsed using the Json-LD transformers: when we fetch a `StatusList2021Credential` it is parsed using standard Jackson features.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
