### PR TITLE
fix: enforce consistency of contract negotiation request and transfer request

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -80,7 +80,7 @@ maven/mavencentral/com.jcraft/jzlib/1.1.3, BSD-2-Clause, approved, CQ6218
 maven/mavencentral/com.lmax/disruptor/3.4.4, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.networknt/json-schema-validator/1.0.76, Apache-2.0, approved, CQ22638
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.28, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.40, , restricted, clearlydefined
+maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.40, Apache-2.0, approved, #15156
 maven/mavencentral/com.puppycrawl.tools/checkstyle/10.17.0, LGPL-2.1-or-later AND (Apache-2.0 AND LGPL-2.1-or-later) AND Apache-2.0, approved, #15077
 maven/mavencentral/com.samskivert/jmustache/1.15, BSD-2-Clause, approved, clearlydefined
 maven/mavencentral/com.squareup.okhttp3/okhttp-dnsoverhttps/4.12.0, Apache-2.0, approved, #11159

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
@@ -237,7 +237,7 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     @Provider
     public TransferProcessService transferProcessService() {
         return new TransferProcessServiceImpl(transferProcessStore, transferProcessManager, transactionContext,
-                dataAddressValidator, commandHandlerRegistry, flowTypeExtractor);
+                dataAddressValidator, commandHandlerRegistry, flowTypeExtractor, contractNegotiationStore);
     }
 
     @Provider

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessEventDispatchTest.java
@@ -137,21 +137,21 @@ public class TransferProcessEventDispatchTest {
 
         when(identityService.verifyJwtToken(eq(tokenRepresentation), isA(VerificationContext.class))).thenReturn(Result.success(token));
 
+        var transferRequest = createTransferRequest();
         var agent = mock(ParticipantAgent.class);
         var agreement = mock(ContractAgreement.class);
         var providerId = "ProviderId";
 
+        when(agreement.getAssetId()).thenReturn(transferRequest.getAssetId());
         when(agreement.getProviderId()).thenReturn(providerId);
         when(agreement.getPolicy()).thenReturn(Policy.Builder.newInstance().build());
         when(agent.getIdentity()).thenReturn(providerId);
 
         dispatcherRegistry.register(getTestDispatcher());
-        when(policyArchive.findPolicyForContract(matches("contractId"))).thenReturn(mock(Policy.class));
-        when(negotiationStore.findContractAgreement("contractId")).thenReturn(agreement);
+        when(policyArchive.findPolicyForContract(matches(transferRequest.getContractId()))).thenReturn(Policy.Builder.newInstance().target(transferRequest.getAssetId()).build());
+        when(negotiationStore.findContractAgreement(transferRequest.getContractId())).thenReturn(agreement);
         when(agentService.createFor(token)).thenReturn(agent);
         eventRouter.register(TransferProcessEvent.class, eventSubscriber);
-
-        var transferRequest = createTransferRequest();
 
         var initiateResult = service.initiateTransfer(transferRequest);
 
@@ -196,10 +196,13 @@ public class TransferProcessEventDispatchTest {
     }
 
     @Test
-    void shouldTerminateOnInvalidPolicy(TransferProcessService service, EventRouter eventRouter, RemoteMessageDispatcherRegistry dispatcherRegistry) {
+    void shouldTerminateOnInvalidPolicy(TransferProcessService service, EventRouter eventRouter, RemoteMessageDispatcherRegistry dispatcherRegistry, ContractNegotiationStore negotiationStore) {
         dispatcherRegistry.register(getTestDispatcher());
         eventRouter.register(TransferProcessEvent.class, eventSubscriber);
         var transferRequest = createTransferRequest();
+        var agreement = mock(ContractAgreement.class);
+        when(agreement.getAssetId()).thenReturn(transferRequest.getAssetId());
+        when(negotiationStore.findContractAgreement(transferRequest.getContractId())).thenReturn(agreement);
 
         service.initiateTransfer(transferRequest);
 
@@ -213,12 +216,16 @@ public class TransferProcessEventDispatchTest {
     void shouldDispatchEventOnTransferProcessTerminated(TransferProcessService service,
                                                         EventRouter eventRouter,
                                                         RemoteMessageDispatcherRegistry dispatcherRegistry,
-                                                        PolicyArchive policyArchive) {
+                                                        PolicyArchive policyArchive,
+                                                        ContractNegotiationStore negotiationStore) {
 
-        when(policyArchive.findPolicyForContract(matches("contractId"))).thenReturn(mock(Policy.class));
+        var transferRequest = createTransferRequest();
+        when(policyArchive.findPolicyForContract(matches("contractId"))).thenReturn(Policy.Builder.newInstance().target(transferRequest.getAssetId()).build());
+        var agreement = mock(ContractAgreement.class);
+        when(agreement.getAssetId()).thenReturn(transferRequest.getAssetId());
+        when(negotiationStore.findContractAgreement(transferRequest.getContractId())).thenReturn(agreement);
         dispatcherRegistry.register(getTestDispatcher());
         eventRouter.register(TransferProcessEvent.class, eventSubscriber);
-        var transferRequest = createTransferRequest();
 
         var initiateResult = service.initiateTransfer(transferRequest);
 
@@ -234,10 +241,13 @@ public class TransferProcessEventDispatchTest {
     }
 
     @Test
-    void shouldDispatchEventOnTransferProcessFailure(TransferProcessService service, EventRouter eventRouter, RemoteMessageDispatcherRegistry dispatcherRegistry) {
+    void shouldDispatchEventOnTransferProcessFailure(TransferProcessService service, EventRouter eventRouter, RemoteMessageDispatcherRegistry dispatcherRegistry, ContractNegotiationStore negotiationStore) {
         dispatcherRegistry.register(getTestDispatcher());
         eventRouter.register(TransferProcessEvent.class, eventSubscriber);
         var transferRequest = createTransferRequest();
+        var agreement = mock(ContractAgreement.class);
+        when(agreement.getAssetId()).thenReturn(transferRequest.getAssetId());
+        when(negotiationStore.findContractAgreement(transferRequest.getContractId())).thenReturn(agreement);
 
         service.initiateTransfer(transferRequest);
 

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TransferProcessApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TransferProcessApiEndToEndTest.java
@@ -19,11 +19,15 @@ import jakarta.json.Json;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.controlplane.transfer.spi.store.TransferProcessStore;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.jsonld.util.JacksonJsonLd;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.junit.annotations.PostgresqlIntegrationTest;
+import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 import org.junit.jupiter.api.Nested;
@@ -106,7 +110,18 @@ public class TransferProcessApiEndToEndTest {
         }
 
         @Test
-        void create(ManagementEndToEndTestContext context, TransferProcessStore store) {
+        void create(ManagementEndToEndTestContext context, TransferProcessStore transferProcessStore, ContractNegotiationStore contractNegotiationStore) {
+            var assetId = UUID.randomUUID().toString();
+            var contractId = UUID.randomUUID().toString();
+            var contractNegotiation = ContractNegotiation.Builder.newInstance()
+                    .id(UUID.randomUUID().toString())
+                    .counterPartyId("counterPartyId")
+                    .counterPartyAddress("http://counterparty")
+                    .protocol("dataspace-protocol-http")
+                    .contractAgreement(createContractAgreement(contractId, assetId).build())
+                    .build();
+            contractNegotiationStore.save(contractNegotiation);
+
             var requestBody = createObjectBuilder()
                     .add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
                     .add(TYPE, "TransferRequest")
@@ -122,8 +137,8 @@ public class TransferProcessApiEndToEndTest {
                     .add("callbackAddresses", createCallbackAddress())
                     .add("protocol", "dataspace-protocol-http")
                     .add("counterPartyAddress", "http://connector-address")
-                    .add("contractId", "contractId")
-                    .add("assetId", "assetId")
+                    .add("contractId", contractId)
+                    .add("assetId", assetId)
                     .build();
 
             var id = context.baseRequest()
@@ -135,7 +150,7 @@ public class TransferProcessApiEndToEndTest {
                     .statusCode(200)
                     .extract().jsonPath().getString(ID);
 
-            assertThat(store.findById(id)).isNotNull();
+            assertThat(transferProcessStore.findById(id)).isNotNull();
         }
 
         @Test
@@ -277,16 +292,27 @@ public class TransferProcessApiEndToEndTest {
                     .add(URI, "http://test.local/")
                     .add(EVENTS, Json.createArrayBuilder().build()));
         }
+
+        private ContractAgreement.Builder createContractAgreement(String contractId, String assetId) {
+            return ContractAgreement.Builder.newInstance()
+                    .id(contractId)
+                    .providerId("providerId")
+                    .consumerId("consumerId")
+                    .policy(Policy.Builder.newInstance().target(assetId).build())
+                    .assetId(assetId);
+        }
     }
 
     @Nested
     @EndToEndTest
     @ExtendWith(ManagementEndToEndExtension.InMemory.class)
-    class InMemory extends Tests { }
+    class InMemory extends Tests {
+    }
 
     @Nested
     @PostgresqlIntegrationTest
     @ExtendWith(ManagementEndToEndExtension.Postgres.class)
-    class Postgres extends Tests { }
+    class Postgres extends Tests {
+    }
 
 }


### PR DESCRIPTION
## What this PR changes/adds

This PR fixes two issues of the current implementation:
- in contract negotiation request, the asset id part of the offer id can be different from the asset id provided in the `target` field of the `Policy`.
- in transfer request, the asset id provided in the request can be different to the one referred by the contract id also provided in this same request. This leads to inconsistent `EndpointDataReferenceEntry` being generated.

## Why it does that

Fix.

## Linked Issue(s)

Closes #4239 
Closes #4240 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
