### PR TITLE
refactor(api): deprecate TransferRequest assetId

### DIFF
--- a/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/RuntimeExtension.java
+++ b/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/RuntimeExtension.java
@@ -66,19 +66,22 @@ public abstract class RuntimeExtension implements ParameterResolver {
      *
      * @param mock the service mock
      */
-    public <T> void registerServiceMock(Class<T> type, T mock) {
+    public <T> RuntimeExtension registerServiceMock(Class<T> type, T mock) {
         runtime.registerServiceMock(type, mock);
+        return this;
     }
 
     /**
      * Registers a service extension with the runtime.
      */
-    public <T extends SystemExtension> void registerSystemExtension(Class<T> type, SystemExtension extension) {
+    public <T extends SystemExtension> RuntimeExtension registerSystemExtension(Class<T> type, SystemExtension extension) {
         runtime.registerSystemExtension(type, extension);
+        return this;
     }
 
-    public void setConfiguration(Map<String, String> configuration) {
+    public RuntimeExtension setConfiguration(Map<String, String> configuration) {
         registerSystemExtension(ConfigurationExtension.class, (ConfigurationExtension) () -> ConfigFactory.fromMap(configuration));
+        return this;
     }
 
     public <T> T getService(Class<T> clazz) {

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessServiceImpl.java
@@ -132,10 +132,6 @@ public class TransferProcessServiceImpl implements TransferProcessService {
             return ServiceResult.badRequest("Contract agreement with id %s not found".formatted(request.getContractId()));
         }
 
-        if (!agreement.getAssetId().equals(request.getAssetId())) {
-            return ServiceResult.badRequest("Asset id %s in contract agreement does not match asset id in transfer request %s".formatted(agreement.getAssetId(), request.getAssetId()));
-        }
-
         var flowType = flowTypeExtractor.extract(request.getTransferType()).getContent();
 
         if (flowType == FlowType.PUSH) {

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessEventDispatchTest.java
@@ -36,7 +36,8 @@ import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.Transf
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferStartMessage;
 import org.eclipse.edc.connector.core.event.EventExecutorServiceContainer;
 import org.eclipse.edc.connector.dataplane.selector.spi.client.DataPlaneClientFactory;
-import org.eclipse.edc.junit.extensions.EdcExtension;
+import org.eclipse.edc.junit.extensions.RuntimeExtension;
+import org.eclipse.edc.junit.extensions.RuntimePerClassExtension;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.agent.ParticipantAgent;
@@ -47,19 +48,15 @@ import org.eclipse.edc.spi.event.EventSubscriber;
 import org.eclipse.edc.spi.iam.ClaimToken;
 import org.eclipse.edc.spi.iam.IdentityService;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
-import org.eclipse.edc.spi.iam.VerificationContext;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcher;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.protocol.ProtocolWebhook;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.eclipse.edc.validator.spi.DataAddressValidatorRegistry;
-import org.eclipse.edc.validator.spi.ValidationResult;
 import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentCaptor;
 
 import java.time.Duration;
@@ -67,61 +64,40 @@ import java.util.Map;
 import java.util.UUID;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 import static java.util.concurrent.Executors.newSingleThreadExecutor;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.junit.matchers.EventEnvelopeMatcher.isEnvelopeOf;
-import static org.eclipse.edc.util.io.Ports.getFreePort;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.ArgumentMatchers.matches;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(EdcExtension.class)
 public class TransferProcessEventDispatchTest {
 
     public static final Duration TIMEOUT = Duration.ofSeconds(30);
     private final EventSubscriber eventSubscriber = mock();
-    private final IdentityService identityService = mock();
 
-    @NotNull
-    private static RemoteMessageDispatcher getTestDispatcher() {
-        var testDispatcher = mock(RemoteMessageDispatcher.class);
-        when(testDispatcher.protocol()).thenReturn("test");
-        var ack = TransferProcessAck.Builder.newInstance().build();
-        when(testDispatcher.dispatch(any(), any())).thenReturn(completedFuture(StatusResult.success(ack)));
-        return testDispatcher;
-    }
-
-    @BeforeEach
-    void setUp(EdcExtension extension) {
-        var configuration = Map.of(
-                "edc.transfer.send.retry.limit", "0",
-                "edc.transfer.send.retry.base-delay.ms", "0",
-                "web.http.port", String.valueOf(getFreePort()),
-                "web.http.path", "/api"
-        );
-
-        extension.setConfiguration(configuration);
-        extension.registerServiceMock(TransferWaitStrategy.class, () -> 1);
-        extension.registerServiceMock(EventExecutorServiceContainer.class, new EventExecutorServiceContainer(newSingleThreadExecutor()));
-        extension.registerServiceMock(IdentityService.class, identityService);
-        extension.registerServiceMock(ProtocolWebhook.class, () -> "http://dummy");
-        extension.registerServiceMock(PolicyArchive.class, mock());
-        extension.registerServiceMock(ContractNegotiationStore.class, mock());
-        extension.registerServiceMock(ParticipantAgentService.class, mock());
-        extension.registerServiceMock(DataPlaneClientFactory.class, mock());
-        var dataAddressValidatorRegistry = mock(DataAddressValidatorRegistry.class);
-        when(dataAddressValidatorRegistry.validateSource(any())).thenReturn(ValidationResult.success());
-        when(dataAddressValidatorRegistry.validateDestination(any())).thenReturn(ValidationResult.success());
-        extension.registerServiceMock(DataAddressValidatorRegistry.class, dataAddressValidatorRegistry);
-    }
+    @RegisterExtension
+    static final RuntimeExtension RUNTIME = new RuntimePerClassExtension()
+            .setConfiguration(Map.of(
+                    "edc.transfer.send.retry.limit", "0",
+                    "edc.transfer.send.retry.base-delay.ms", "0"
+            ))
+            .registerServiceMock(TransferWaitStrategy.class, () -> 1)
+            .registerServiceMock(EventExecutorServiceContainer.class, new EventExecutorServiceContainer(newSingleThreadExecutor()))
+            .registerServiceMock(IdentityService.class, mock())
+            .registerServiceMock(ProtocolWebhook.class, () -> "http://dummy")
+            .registerServiceMock(PolicyArchive.class, mock())
+            .registerServiceMock(ContractNegotiationStore.class, mock())
+            .registerServiceMock(ParticipantAgentService.class, mock())
+            .registerServiceMock(DataPlaneClientFactory.class, mock());
 
     @Test
     void shouldDispatchEventsOnTransferProcessStateChanges(TransferProcessService service,
@@ -130,31 +106,35 @@ public class TransferProcessEventDispatchTest {
                                                            RemoteMessageDispatcherRegistry dispatcherRegistry,
                                                            PolicyArchive policyArchive,
                                                            ContractNegotiationStore negotiationStore,
-                                                           ParticipantAgentService agentService) {
+                                                           ParticipantAgentService agentService,
+                                                           IdentityService identityService) {
 
         var token = ClaimToken.Builder.newInstance().build();
         var tokenRepresentation = TokenRepresentation.Builder.newInstance().token(UUID.randomUUID().toString()).build();
 
-        when(identityService.verifyJwtToken(eq(tokenRepresentation), isA(VerificationContext.class))).thenReturn(Result.success(token));
+        when(identityService.verifyJwtToken(any(), any())).thenReturn(Result.success(token));
 
         var transferRequest = createTransferRequest();
         var agent = mock(ParticipantAgent.class);
-        var agreement = mock(ContractAgreement.class);
         var providerId = "ProviderId";
+        var agreement = ContractAgreement.Builder.newInstance()
+                .assetId("assetId")
+                .providerId(providerId)
+                .consumerId("consumerId")
+                .policy(Policy.Builder.newInstance().build())
+                .build();
 
-        when(agreement.getAssetId()).thenReturn(transferRequest.getAssetId());
-        when(agreement.getProviderId()).thenReturn(providerId);
-        when(agreement.getPolicy()).thenReturn(Policy.Builder.newInstance().build());
         when(agent.getIdentity()).thenReturn(providerId);
 
         dispatcherRegistry.register(getTestDispatcher());
-        when(policyArchive.findPolicyForContract(matches(transferRequest.getContractId()))).thenReturn(Policy.Builder.newInstance().target(transferRequest.getAssetId()).build());
+        when(policyArchive.findPolicyForContract(matches(transferRequest.getContractId()))).thenReturn(Policy.Builder.newInstance().target("assetId").build());
         when(negotiationStore.findContractAgreement(transferRequest.getContractId())).thenReturn(agreement);
         when(agentService.createFor(token)).thenReturn(agent);
         eventRouter.register(TransferProcessEvent.class, eventSubscriber);
 
         var initiateResult = service.initiateTransfer(transferRequest);
 
+        assertThat(initiateResult).isSucceeded();
         await().atMost(TIMEOUT).untilAsserted(() -> {
             verify(eventSubscriber).on(argThat(isEnvelopeOf(TransferProcessInitiated.class)));
             verify(eventSubscriber).on(argThat(isEnvelopeOf(TransferProcessProvisioned.class)));
@@ -169,15 +149,16 @@ public class TransferProcessEventDispatchTest {
                 .dataAddress(dataAddress)
                 .build();
 
-        protocolService.notifyStarted(startMessage, tokenRepresentation);
+        var startedResult = protocolService.notifyStarted(startMessage, tokenRepresentation);
 
+        assertThat(startedResult).isSucceeded();
         await().atMost(TIMEOUT).untilAsserted(() -> {
-            ArgumentCaptor<EventEnvelope<TransferProcessStarted>> captor = ArgumentCaptor.forClass(EventEnvelope.class);
-            verify(eventSubscriber, times(4)).on(captor.capture());
-            assertThat(captor.getValue()).isNotNull()
-                    .extracting(EventEnvelope::getPayload)
-                    .extracting(TransferProcessStarted::getDataAddress)
-                    .usingRecursiveComparison().isEqualTo(dataAddress);
+            var captor = ArgumentCaptor.forClass(EventEnvelope.class);
+            verify(eventSubscriber, atLeast(3)).on(captor.capture());
+            var payload = captor.getAllValues().stream().map(EventEnvelope::getPayload).filter(TransferProcessStarted.class::isInstance).findFirst();
+            assertThat(payload).isPresent().get().isInstanceOfSatisfying(TransferProcessStarted.class, s -> {
+                assertThat(s.getDataAddress()).usingRecursiveComparison().isEqualTo(dataAddress);
+            });
         });
 
         var transferProcess = initiateResult.getContent();
@@ -196,23 +177,6 @@ public class TransferProcessEventDispatchTest {
     }
 
     @Test
-    void shouldTerminateOnInvalidPolicy(TransferProcessService service, EventRouter eventRouter, RemoteMessageDispatcherRegistry dispatcherRegistry, ContractNegotiationStore negotiationStore) {
-        dispatcherRegistry.register(getTestDispatcher());
-        eventRouter.register(TransferProcessEvent.class, eventSubscriber);
-        var transferRequest = createTransferRequest();
-        var agreement = mock(ContractAgreement.class);
-        when(agreement.getAssetId()).thenReturn(transferRequest.getAssetId());
-        when(negotiationStore.findContractAgreement(transferRequest.getContractId())).thenReturn(agreement);
-
-        service.initiateTransfer(transferRequest);
-
-        await().atMost(TIMEOUT).untilAsserted(() -> {
-            verify(eventSubscriber).on(argThat(isEnvelopeOf(TransferProcessInitiated.class)));
-            verify(eventSubscriber).on(argThat(isEnvelopeOf(TransferProcessTerminated.class)));
-        });
-    }
-
-    @Test
     void shouldDispatchEventOnTransferProcessTerminated(TransferProcessService service,
                                                         EventRouter eventRouter,
                                                         RemoteMessageDispatcherRegistry dispatcherRegistry,
@@ -220,9 +184,13 @@ public class TransferProcessEventDispatchTest {
                                                         ContractNegotiationStore negotiationStore) {
 
         var transferRequest = createTransferRequest();
-        when(policyArchive.findPolicyForContract(matches("contractId"))).thenReturn(Policy.Builder.newInstance().target(transferRequest.getAssetId()).build());
-        var agreement = mock(ContractAgreement.class);
-        when(agreement.getAssetId()).thenReturn(transferRequest.getAssetId());
+        when(policyArchive.findPolicyForContract(matches("contractId"))).thenReturn(Policy.Builder.newInstance().target("assetId").build());
+        var agreement = ContractAgreement.Builder.newInstance()
+                .assetId("assetId")
+                .providerId("providerId")
+                .consumerId("consumerId")
+                .policy(Policy.Builder.newInstance().build())
+                .build();
         when(negotiationStore.findContractAgreement(transferRequest.getContractId())).thenReturn(agreement);
         dispatcherRegistry.register(getTestDispatcher());
         eventRouter.register(TransferProcessEvent.class, eventSubscriber);
@@ -241,23 +209,45 @@ public class TransferProcessEventDispatchTest {
     }
 
     @Test
-    void shouldDispatchEventOnTransferProcessFailure(TransferProcessService service, EventRouter eventRouter, RemoteMessageDispatcherRegistry dispatcherRegistry, ContractNegotiationStore negotiationStore) {
-        dispatcherRegistry.register(getTestDispatcher());
+    void shouldDispatchEventOnTransferProcessFailure(TransferProcessService service, EventRouter eventRouter, RemoteMessageDispatcherRegistry dispatcherRegistry,
+                                                     ContractNegotiationStore negotiationStore, PolicyArchive policyArchive) {
+        dispatcherRegistry.register(getFailingDispatcher());
         eventRouter.register(TransferProcessEvent.class, eventSubscriber);
         var transferRequest = createTransferRequest();
-        var agreement = mock(ContractAgreement.class);
-        when(agreement.getAssetId()).thenReturn(transferRequest.getAssetId());
+        var agreement = ContractAgreement.Builder.newInstance()
+                .assetId("assetId")
+                .providerId("providerId")
+                .consumerId("consumerId")
+                .policy(Policy.Builder.newInstance().build())
+                .build();
         when(negotiationStore.findContractAgreement(transferRequest.getContractId())).thenReturn(agreement);
+        when(policyArchive.findPolicyForContract(any())).thenReturn(Policy.Builder.newInstance().build());
 
         service.initiateTransfer(transferRequest);
 
         await().atMost(TIMEOUT).untilAsserted(() -> verify(eventSubscriber).on(argThat(isEnvelopeOf(TransferProcessTerminated.class))));
     }
 
+    @NotNull
+    private RemoteMessageDispatcher getTestDispatcher() {
+        var testDispatcher = mock(RemoteMessageDispatcher.class);
+        when(testDispatcher.protocol()).thenReturn("test");
+        var ack = TransferProcessAck.Builder.newInstance().build();
+        when(testDispatcher.dispatch(any(), any())).thenReturn(completedFuture(StatusResult.success(ack)));
+        return testDispatcher;
+    }
+
+    @NotNull
+    private RemoteMessageDispatcher getFailingDispatcher() {
+        var testDispatcher = mock(RemoteMessageDispatcher.class);
+        when(testDispatcher.protocol()).thenReturn("test");
+        when(testDispatcher.dispatch(any(), any())).thenReturn(failedFuture(new EdcException("cannot send message")));
+        return testDispatcher;
+    }
+
     private TransferRequest createTransferRequest() {
         return TransferRequest.Builder.newInstance()
                 .id("dataRequestId")
-                .assetId("assetId")
                 .dataDestination(DataAddress.Builder.newInstance().type("any").build())
                 .protocol("test")
                 .counterPartyAddress("http://an/address")

--- a/extensions/common/api/management-api-configuration/src/main/resources/version.json
+++ b/extensions/common/api/management-api-configuration/src/main/resources/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.0",
+  "version": "3.0.1",
   "urlPath": "/v3",
-  "lastUpdated": "2024-05-23T15:52:00Z"
+  "lastUpdated": "2024-06-13T14:28:00Z"
 }

--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/Participant.java
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/Participant.java
@@ -339,14 +339,13 @@ public class Participant {
      *
      * @param provider            data provider
      * @param contractAgreementId contract agreement id
-     * @param assetId             asset id
      * @param privateProperties   private properties
      * @param destination         data destination address
      * @param transferType        type of transfer
      * @return id of the transfer process.
      */
-    public String initiateTransfer(Participant provider, String contractAgreementId, String assetId, JsonObject privateProperties, JsonObject destination, String transferType) {
-        return initiateTransfer(provider, contractAgreementId, assetId, privateProperties, destination, transferType, null);
+    public String initiateTransfer(Participant provider, String contractAgreementId, JsonObject privateProperties, JsonObject destination, String transferType) {
+        return initiateTransfer(provider, contractAgreementId, privateProperties, destination, transferType, null);
     }
 
     /**
@@ -354,19 +353,17 @@ public class Participant {
      *
      * @param provider            data provider
      * @param contractAgreementId contract agreement id
-     * @param assetId             asset id
      * @param privateProperties   private properties
      * @param destination         data destination address
      * @param transferType        type of transfer
      * @param callbacks           callbacks for the transfer process
      * @return id of the transfer process.
      */
-    public String initiateTransfer(Participant provider, String contractAgreementId, String assetId, JsonObject privateProperties, JsonObject destination, String transferType, JsonArray callbacks) {
+    public String initiateTransfer(Participant provider, String contractAgreementId, JsonObject privateProperties, JsonObject destination, String transferType, JsonArray callbacks) {
         var requestBodyBuilder = createObjectBuilder()
                 .add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
                 .add(TYPE, "TransferRequest")
                 .add("protocol", protocol)
-                .add("assetId", assetId)
                 .add("contractId", contractAgreementId)
                 .add("connectorId", provider.id)
                 .add("counterPartyAddress", provider.protocolEndpoint.url.toString());
@@ -731,7 +728,7 @@ public class Participant {
         public String execute() {
             var offer = getOfferForAsset(counterPart, assetId);
             var contractAgreementId = negotiateContract(counterPart, offer);
-            var transferProcessId = initiateTransfer(counterPart, contractAgreementId, assetId, privateProperties, destination, transferType, callbacks);
+            var transferProcessId = initiateTransfer(counterPart, contractAgreementId, privateProperties, destination, transferType, callbacks);
             assertThat(transferProcessId).isNotNull();
             return transferProcessId;
         }

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/TransferProcessApiExtension.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/TransferProcessApiExtension.java
@@ -72,7 +72,7 @@ public class TransferProcessApiExtension implements ServiceExtension {
         managementApiTransformerRegistry.register(new JsonObjectToSuspendTransferTransformer());
         managementApiTransformerRegistry.register(new JsonObjectToTransferRequestTransformer());
 
-        validatorRegistry.register(TRANSFER_REQUEST_TYPE, TransferRequestValidator.instance());
+        validatorRegistry.register(TRANSFER_REQUEST_TYPE, TransferRequestValidator.instance(context.getMonitor()));
         validatorRegistry.register(TERMINATE_TRANSFER_TYPE, TerminateTransferValidator.instance());
 
         webService.registerResource(ApiContext.MANAGEMENT, new TransferProcessApiV2Controller(context.getMonitor(), service, managementApiTransformerRegistry, validatorRegistry));

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/transform/JsonObjectToTransferRequestTransformer.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/transform/JsonObjectToTransferRequestTransformer.java
@@ -32,7 +32,6 @@ import java.util.function.Consumer;
 
 import static jakarta.json.JsonValue.ValueType.ARRAY;
 import static jakarta.json.JsonValue.ValueType.OBJECT;
-import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_ASSET_ID;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_CALLBACK_ADDRESSES;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_CONTRACT_ID;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_COUNTER_PARTY_ADDRESS;
@@ -67,7 +66,6 @@ public class JsonObjectToTransferRequestTransformer extends AbstractJsonLdTransf
                     (v) -> transformProperties(v, builder::privateProperties, context);
             case TRANSFER_REQUEST_PROTOCOL -> (v) -> builder.protocol(transformString(v, context));
             case TRANSFER_REQUEST_TRANSFER_TYPE -> (v) -> builder.transferType(transformString(v, context));
-            case TRANSFER_REQUEST_ASSET_ID -> (v) -> builder.assetId(transformString(v, context));
             default -> doNothing();
         });
 

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/v3/TransferProcessApiV3.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/v3/TransferProcessApiV3.java
@@ -161,7 +161,7 @@ public interface TransferProcessApiV3 {
             String counterPartyAddress,
             @Schema(requiredMode = REQUIRED)
             String contractId,
-            @Schema(requiredMode = REQUIRED)
+            @Schema(deprecated = true)
             String assetId,
             @Schema(requiredMode = REQUIRED)
             String transferType,
@@ -177,7 +177,6 @@ public interface TransferProcessApiV3 {
                     "protocol": "dataspace-protocol-http",
                     "counterPartyAddress": "http://provider-address",
                     "contractId": "contract-id",
-                    "assetId": "asset-id",
                     "transferType": "transferType",
                     "dataDestination": {
                         "type": "data-destination-type"

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/validation/TransferRequestValidator.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/validation/TransferRequestValidator.java
@@ -16,7 +16,9 @@ package org.eclipse.edc.connector.controlplane.api.management.transferprocess.va
 
 import jakarta.json.JsonObject;
 import org.eclipse.edc.api.validation.DataAddressValidator;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.validator.jsonobject.JsonObjectValidator;
+import org.eclipse.edc.validator.jsonobject.validators.LogDeprecatedValue;
 import org.eclipse.edc.validator.jsonobject.validators.MandatoryValue;
 import org.eclipse.edc.validator.jsonobject.validators.OptionalIdNotBlank;
 import org.eclipse.edc.validator.spi.Validator;
@@ -30,13 +32,13 @@ import static org.eclipse.edc.connector.controlplane.transfer.spi.types.Transfer
 
 public class TransferRequestValidator {
 
-    public static Validator<JsonObject> instance() {
+    public static Validator<JsonObject> instance(Monitor monitor) {
         return JsonObjectValidator.newValidator()
                 .verifyId(OptionalIdNotBlank::new)
+                .verify(TRANSFER_REQUEST_ASSET_ID, path -> new LogDeprecatedValue(path, TRANSFER_REQUEST_ASSET_ID, "no attribute, as %s already provide such information".formatted(TRANSFER_REQUEST_CONTRACT_ID), monitor))
                 .verify(TRANSFER_REQUEST_COUNTER_PARTY_ADDRESS, MandatoryValue::new)
                 .verify(TRANSFER_REQUEST_CONTRACT_ID, MandatoryValue::new)
                 .verify(TRANSFER_REQUEST_PROTOCOL, MandatoryValue::new)
-                .verify(TRANSFER_REQUEST_ASSET_ID, MandatoryValue::new)
                 .verify(TRANSFER_REQUEST_TRANSFER_TYPE, MandatoryValue::new)
                 .verifyObject(TRANSFER_REQUEST_DATA_DESTINATION, DataAddressValidator::instance)
                 .build();

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/TransferProcessApiTest.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/TransferProcessApiTest.java
@@ -63,6 +63,7 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.junit.extensions.TestServiceExtensionContext.testServiceExtensionContext;
+import static org.mockito.Mockito.mock;
 
 class TransferProcessApiTest {
 
@@ -82,7 +83,7 @@ class TransferProcessApiTest {
 
     @Test
     void transferRequestExample() throws JsonProcessingException {
-        var validator = TransferRequestValidator.instance();
+        var validator = TransferRequestValidator.instance(mock());
 
         var jsonObject = objectMapper.readValue(TRANSFER_REQUEST_EXAMPLE, JsonObject.class);
         assertThat(jsonObject).isNotNull();
@@ -96,7 +97,6 @@ class TransferProcessApiTest {
                             assertThat(transformed.getCounterPartyAddress()).isNotBlank();
                             assertThat(transformed.getContractId()).isNotBlank();
                             assertThat(transformed.getProtocol()).isNotBlank();
-                            assertThat(transformed.getAssetId()).isNotBlank();
                             assertThat(transformed.getDataDestination()).isNotNull();
                             assertThat(transformed.getPrivateProperties()).asInstanceOf(map(String.class, Object.class)).isNotEmpty();
                             assertThat(transformed.getCallbackAddresses()).asList().isNotEmpty();

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/transform/JsonObjectToTransferRequestTransformerTest.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/transform/JsonObjectToTransferRequestTransformerTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_ASSET_ID;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_CONTRACT_ID;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_COUNTER_PARTY_ADDRESS;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_DATA_DESTINATION;
@@ -71,7 +70,6 @@ class JsonObjectToTransferRequestTransformerTest {
                 .add(TRANSFER_REQUEST_PRIVATE_PROPERTIES, privatePropertiesJson)
                 .add(TRANSFER_REQUEST_TRANSFER_TYPE, "Http-Pull")
                 .add(TRANSFER_REQUEST_PROTOCOL, "protocol")
-                .add(TRANSFER_REQUEST_ASSET_ID, "assetId")
                 .build();
 
         var result = transformer.transform(json, context);
@@ -83,7 +81,6 @@ class JsonObjectToTransferRequestTransformerTest {
         assertThat(result.getDataDestination()).isSameAs(dataDestination);
         assertThat(result.getPrivateProperties()).containsAllEntriesOf(privateProperties);
         assertThat(result.getProtocol()).isEqualTo("protocol");
-        assertThat(result.getAssetId()).isEqualTo("assetId");
         assertThat(result.getTransferType()).isEqualTo("Http-Pull");
     }
 

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/validation/TransferRequestValidatorTest.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/validation/TransferRequestValidatorTest.java
@@ -26,7 +26,6 @@ import static jakarta.json.Json.createArrayBuilder;
 import static jakarta.json.Json.createObjectBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.list;
-import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_ASSET_ID;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_CONTRACT_ID;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_COUNTER_PARTY_ADDRESS;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_DATA_DESTINATION;
@@ -36,10 +35,11 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.spi.types.domain.DataAddress.EDC_DATA_ADDRESS_TYPE_PROPERTY;
+import static org.mockito.Mockito.mock;
 
 class TransferRequestValidatorTest {
 
-    private final Validator<JsonObject> validator = TransferRequestValidator.instance();
+    private final Validator<JsonObject> validator = TransferRequestValidator.instance(mock());
 
     @Test
     void shouldSucceed_whenObjectIsValid() {
@@ -47,7 +47,6 @@ class TransferRequestValidatorTest {
                 .add(TRANSFER_REQUEST_COUNTER_PARTY_ADDRESS, value("http://connector-address"))
                 .add(TRANSFER_REQUEST_CONTRACT_ID, value("contract-id"))
                 .add(TRANSFER_REQUEST_PROTOCOL, value("protocol"))
-                .add(TRANSFER_REQUEST_ASSET_ID, value("assetId"))
                 .add(TRANSFER_REQUEST_TRANSFER_TYPE, value("transferType"))
                 .add(TRANSFER_REQUEST_DATA_DESTINATION, createArrayBuilder().add(createObjectBuilder()
                         .add(EDC_DATA_ADDRESS_TYPE_PROPERTY, value("type"))
@@ -65,7 +64,6 @@ class TransferRequestValidatorTest {
                 .add(TRANSFER_REQUEST_COUNTER_PARTY_ADDRESS, value("http://connector-address"))
                 .add(TRANSFER_REQUEST_CONTRACT_ID, value("contract-id"))
                 .add(TRANSFER_REQUEST_PROTOCOL, value("protocol"))
-                .add(TRANSFER_REQUEST_ASSET_ID, value("assetId"))
                 .add(TRANSFER_REQUEST_TRANSFER_TYPE, value("transferType"))
                 .build();
 
@@ -99,7 +97,6 @@ class TransferRequestValidatorTest {
                 .anySatisfy(violation -> assertThat(violation.path()).isEqualTo(TRANSFER_REQUEST_COUNTER_PARTY_ADDRESS))
                 .anySatisfy(violation -> assertThat(violation.path()).isEqualTo(TRANSFER_REQUEST_CONTRACT_ID))
                 .anySatisfy(violation -> assertThat(violation.path()).isEqualTo(TRANSFER_REQUEST_PROTOCOL))
-                .anySatisfy(violation -> assertThat(violation.path()).isEqualTo(TRANSFER_REQUEST_ASSET_ID))
                 .anySatisfy(violation -> assertThat(violation.path()).isEqualTo(TRANSFER_REQUEST_TRANSFER_TYPE));
     }
 

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferRequest.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferRequest.java
@@ -34,6 +34,7 @@ public class TransferRequest {
     public static final String TRANSFER_REQUEST_TRANSFER_TYPE = EDC_NAMESPACE + "transferType";
     public static final String TRANSFER_REQUEST_PRIVATE_PROPERTIES = EDC_NAMESPACE + "privateProperties";
     public static final String TRANSFER_REQUEST_PROTOCOL = EDC_NAMESPACE + "protocol";
+    @Deprecated(since = "0.7.0")
     public static final String TRANSFER_REQUEST_ASSET_ID = EDC_NAMESPACE + "assetId";
     public static final String TRANSFER_REQUEST_CALLBACK_ADDRESSES = EDC_NAMESPACE + "callbackAddresses";
 
@@ -41,7 +42,6 @@ public class TransferRequest {
     private String protocol;
     private String counterPartyAddress;
     private String contractId;
-    private String assetId;
     private String transferType;
     private DataAddress dataDestination;
     private Map<String, Object> privateProperties = new HashMap<>();
@@ -69,10 +69,6 @@ public class TransferRequest {
 
     public String getProtocol() {
         return protocol;
-    }
-
-    public String getAssetId() {
-        return assetId;
     }
 
     public List<CallbackAddress> getCallbackAddresses() {
@@ -126,11 +122,6 @@ public class TransferRequest {
 
         public Builder protocol(String protocol) {
             request.protocol = protocol;
-            return this;
-        }
-
-        public Builder assetId(String assetId) {
-            request.assetId = assetId;
             return this;
         }
 

--- a/system-tests/protocol-test/src/test/java/org/eclipse/edc/test/e2e/protocol/DspCatalogApiEndToEndTest.java
+++ b/system-tests/protocol-test/src/test/java/org/eclipse/edc/test/e2e/protocol/DspCatalogApiEndToEndTest.java
@@ -23,7 +23,9 @@ import org.eclipse.edc.connector.controlplane.policy.spi.PolicyDefinition;
 import org.eclipse.edc.connector.controlplane.policy.spi.store.PolicyDefinitionStore;
 import org.eclipse.edc.connector.controlplane.services.spi.protocol.ProtocolVersionRegistry;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
-import org.eclipse.edc.junit.extensions.EdcRuntimeExtension;
+import org.eclipse.edc.junit.extensions.EmbeddedRuntime;
+import org.eclipse.edc.junit.extensions.RuntimeExtension;
+import org.eclipse.edc.junit.extensions.RuntimePerClassExtension;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.util.io.Ports;
@@ -56,7 +58,7 @@ public class DspCatalogApiEndToEndTest {
     private static final int PROTOCOL_PORT = Ports.getFreePort();
 
     @RegisterExtension
-    static EdcRuntimeExtension runtime = new EdcRuntimeExtension(
+    static RuntimeExtension runtime = new RuntimePerClassExtension(new EmbeddedRuntime(
             "runtime",
             Map.of(
                     "web.http.protocol.path", "/protocol",
@@ -70,7 +72,7 @@ public class DspCatalogApiEndToEndTest {
             ":core:control-plane:control-plane-aggregate-services",
             ":core:control-plane:control-plane-core",
             ":extensions:common:http"
-    );
+    ));
 
     @Test
     void shouldExposeVersion2024_1() {

--- a/system-tests/protocol-test/src/test/java/org/eclipse/edc/test/e2e/protocol/DspNegotiationApiEndToEndTest.java
+++ b/system-tests/protocol-test/src/test/java/org/eclipse/edc/test/e2e/protocol/DspNegotiationApiEndToEndTest.java
@@ -19,7 +19,9 @@ import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.Con
 import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.controlplane.services.spi.protocol.ProtocolVersionRegistry;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
-import org.eclipse.edc.junit.extensions.EdcRuntimeExtension;
+import org.eclipse.edc.junit.extensions.EmbeddedRuntime;
+import org.eclipse.edc.junit.extensions.RuntimeExtension;
+import org.eclipse.edc.junit.extensions.RuntimePerClassExtension;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.util.io.Ports;
 import org.junit.jupiter.api.Test;
@@ -40,7 +42,7 @@ public class DspNegotiationApiEndToEndTest {
     private static final int PROTOCOL_PORT = Ports.getFreePort();
 
     @RegisterExtension
-    static EdcRuntimeExtension runtime = new EdcRuntimeExtension(
+    static RuntimeExtension runtime = new RuntimePerClassExtension(new EmbeddedRuntime(
             "runtime",
             Map.of(
                     "web.http.protocol.path", "/protocol",
@@ -54,7 +56,7 @@ public class DspNegotiationApiEndToEndTest {
             ":core:control-plane:control-plane-aggregate-services",
             ":core:control-plane:control-plane-core",
             ":extensions:common:http"
-    );
+    ));
 
     @Test
     void shouldExposeVersion2024_1() {

--- a/system-tests/protocol-test/src/test/java/org/eclipse/edc/test/e2e/protocol/DspTransferApiEndToEndTest.java
+++ b/system-tests/protocol-test/src/test/java/org/eclipse/edc/test/e2e/protocol/DspTransferApiEndToEndTest.java
@@ -23,7 +23,9 @@ import org.eclipse.edc.connector.controlplane.services.spi.protocol.ProtocolVers
 import org.eclipse.edc.connector.controlplane.transfer.spi.store.TransferProcessStore;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
-import org.eclipse.edc.junit.extensions.EdcRuntimeExtension;
+import org.eclipse.edc.junit.extensions.EmbeddedRuntime;
+import org.eclipse.edc.junit.extensions.RuntimeExtension;
+import org.eclipse.edc.junit.extensions.RuntimePerClassExtension;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.util.io.Ports;
@@ -45,7 +47,7 @@ public class DspTransferApiEndToEndTest {
     private static final int PROTOCOL_PORT = Ports.getFreePort();
 
     @RegisterExtension
-    static EdcRuntimeExtension runtime = new EdcRuntimeExtension(
+    static RuntimeExtension runtime = new RuntimePerClassExtension(new EmbeddedRuntime(
             "runtime",
             Map.of(
                     "web.http.protocol.path", "/protocol",
@@ -59,7 +61,7 @@ public class DspTransferApiEndToEndTest {
             ":core:control-plane:control-plane-aggregate-services",
             ":core:control-plane:control-plane-core",
             ":extensions:common:http"
-    );
+    ));
 
     @Test
     void shouldExposeVersion2024_1() {

--- a/system-tests/protocol-test/src/test/java/org/eclipse/edc/test/e2e/protocol/DspVersionApiEndToEndTest.java
+++ b/system-tests/protocol-test/src/test/java/org/eclipse/edc/test/e2e/protocol/DspVersionApiEndToEndTest.java
@@ -22,7 +22,9 @@ import org.eclipse.edc.connector.controlplane.services.spi.protocol.ProtocolVers
 import org.eclipse.edc.jsonld.TitaniumJsonLd;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
-import org.eclipse.edc.junit.extensions.EdcRuntimeExtension;
+import org.eclipse.edc.junit.extensions.EmbeddedRuntime;
+import org.eclipse.edc.junit.extensions.RuntimeExtension;
+import org.eclipse.edc.junit.extensions.RuntimePerClassExtension;
 import org.eclipse.edc.spi.monitor.ConsoleMonitor;
 import org.eclipse.edc.util.io.Ports;
 import org.junit.jupiter.api.Test;
@@ -45,7 +47,7 @@ public class DspVersionApiEndToEndTest {
     private final JsonLd jsonLd = new TitaniumJsonLd(new ConsoleMonitor());
 
     @RegisterExtension
-    static EdcRuntimeExtension runtime = new EdcRuntimeExtension(
+    static RuntimeExtension runtime = new RuntimePerClassExtension(new EmbeddedRuntime(
             "runtime",
             Map.of(
                     "web.http.protocol.path", "/protocol",
@@ -58,7 +60,7 @@ public class DspVersionApiEndToEndTest {
             ":core:control-plane:control-plane-aggregate-services",
             ":core:control-plane:control-plane-core",
             ":extensions:common:http"
-    );
+    ));
 
     @Test
     void shouldReturnValidJsonLd() {


### PR DESCRIPTION
## What this PR changes/adds

Deprecates `TransferRequest.assetId` attribute on management api.
Upgrades api version to 3.0.1.
Remove `assetId` from the `TransferRequest` value object and replace its usages with the policy target (that has the same value)

## Why it does that

cleanup

## Further notes

- improve RuntimeExtension a little, to permit better usage of the `RuntimePerClassExtension` (as shown in the `TransferProcessEventDispatchTest`)
- replaced some `EdcRuntimeExtension` occurrencies

## Linked Issue(s)

Closes #4267

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
