### PR TITLE
build(deps): switch to new namespace for jakarta.json-api library

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -4,7 +4,7 @@ maven/mavencentral/com.apicatalog/copper-multicodec/0.1.1, Apache-2.0, approved,
 maven/mavencentral/com.apicatalog/iron-ed25519-cryptosuite-2020/0.14.0, Apache-2.0, approved, #14503
 maven/mavencentral/com.apicatalog/iron-verifiable-credentials/0.14.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.apicatalog/titanium-json-ld/1.0.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.apicatalog/titanium-json-ld/1.4.0, Apache-2.0, approved, #13683
+maven/mavencentral/com.apicatalog/titanium-json-ld/1.4.0, Apache-2.0, approved, #15200
 maven/mavencentral/com.atomikos/atomikos-util/6.0.0, Apache-2.0, approved, #9326
 maven/mavencentral/com.atomikos/transactions-api/6.0.0, Apache-2.0, approved, #10351
 maven/mavencentral/com.atomikos/transactions-jdbc/6.0.0, Apache-2.0, approved, #9273
@@ -45,9 +45,9 @@ maven/mavencentral/com.github.cliftonlabs/json-simple/3.0.2, Apache-2.0, approve
 maven/mavencentral/com.github.docker-java/docker-java-api/3.3.6, Apache-2.0, approved, #10346
 maven/mavencentral/com.github.docker-java/docker-java-transport-zerodep/3.3.6, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #7946
 maven/mavencentral/com.github.docker-java/docker-java-transport/3.3.6, Apache-2.0, approved, #7942
-maven/mavencentral/com.github.java-json-tools/btf/1.3, Apache-2.0 OR LGPL-3.0-or-later, approved, #2721
+maven/mavencentral/com.github.java-json-tools/btf/1.3, Apache-2.0 AND GPL-1.0-or-later AND LGPL-3.0-only AND Apache-2.0 AND LGPL-3.0-only, restricted, #15201
 maven/mavencentral/com.github.java-json-tools/jackson-coreutils-equivalence/1.0, LGPL-3.0 OR Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.github.java-json-tools/jackson-coreutils/2.0, Apache-2.0 OR LGPL-3.0-or-later, approved, #2719
+maven/mavencentral/com.github.java-json-tools/jackson-coreutils/2.0, Apache-2.0 AND LGPL-2.1-or-later AND LGPL-3.0-only AND (Apache-2.0 AND GPL-1.0-or-later AND LGPL-3.0-only) AND Apache-2.0 AND LGPL-3.0-only, restricted, #15186
 maven/mavencentral/com.github.java-json-tools/json-patch/1.13, Apache-2.0 OR LGPL-3.0-or-later, approved, CQ23929
 maven/mavencentral/com.github.java-json-tools/json-schema-core/1.2.14, Apache-2.0 OR LGPL-3.0-or-later, approved, #2722
 maven/mavencentral/com.github.java-json-tools/json-schema-validator/2.2.14, Apache-2.0 OR LGPL-3.0-or-later, approved, CQ20779
@@ -96,11 +96,11 @@ maven/mavencentral/commons-beanutils/commons-beanutils/1.8.3, Apache-2.0, approv
 maven/mavencentral/commons-beanutils/commons-beanutils/1.9.4, Apache-2.0, approved, CQ12654
 maven/mavencentral/commons-codec/commons-codec/1.11, Apache-2.0 AND BSD-3-Clause, approved, CQ15971
 maven/mavencentral/commons-codec/commons-codec/1.15, Apache-2.0 AND BSD-3-Clause AND LicenseRef-Public-Domain, approved, CQ22641
-maven/mavencentral/commons-collections/commons-collections/3.2.2, Apache-2.0, approved, CQ10385
+maven/mavencentral/commons-collections/commons-collections/3.2.2, Apache-2.0, approved, #15185
 maven/mavencentral/commons-io/commons-io/2.11.0, Apache-2.0, approved, CQ23745
 maven/mavencentral/commons-logging/commons-logging/1.1.1, Apache-2.0, approved, CQ1907
 maven/mavencentral/commons-logging/commons-logging/1.2, Apache-2.0, approved, CQ10162
-maven/mavencentral/dev.failsafe/failsafe-okhttp/3.3.2, Apache-2.0, approved, #9178
+maven/mavencentral/dev.failsafe/failsafe-okhttp/3.3.2, Apache-2.0, approved, #15208
 maven/mavencentral/dev.failsafe/failsafe/3.3.2, Apache-2.0, approved, #9268
 maven/mavencentral/info.picocli/picocli/4.7.6, Apache-2.0, approved, #4365
 maven/mavencentral/io.cloudevents/cloudevents-api/3.0.0, Apache-2.0, approved, #14228
@@ -136,7 +136,7 @@ maven/mavencentral/io.prometheus/simpleclient_tracer_otel/0.16.0, Apache-2.0, ap
 maven/mavencentral/io.prometheus/simpleclient_tracer_otel_agent/0.16.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.rest-assured/json-path/5.4.0, Apache-2.0, approved, #12042
 maven/mavencentral/io.rest-assured/rest-assured-common/5.4.0, Apache-2.0, approved, #12039
-maven/mavencentral/io.rest-assured/rest-assured/5.4.0, Apache-2.0, approved, #12040
+maven/mavencentral/io.rest-assured/rest-assured/5.4.0, Apache-2.0, approved, #15190
 maven/mavencentral/io.rest-assured/xml-path/5.4.0, Apache-2.0, approved, #12038
 maven/mavencentral/io.setl/rdf-urdna/1.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.21, Apache-2.0, approved, #5947
@@ -189,7 +189,7 @@ maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.15, Apache-2.0, approved,
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.1, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.15, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.16, Apache-2.0 AND BSD-3-Clause, approved, #7163
-maven/mavencentral/net.java.dev.jna/jna/5.13.0, Apache-2.0 AND LGPL-2.1-or-later, approved, #6709
+maven/mavencentral/net.java.dev.jna/jna/5.13.0, Apache-2.0 AND LGPL-2.1-or-later, approved, #15196
 maven/mavencentral/net.javacrumbs.json-unit/json-unit-core/2.36.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/net.minidev/accessors-smart/2.4.7, Apache-2.0, approved, #7515
 maven/mavencentral/net.minidev/json-smart/2.4.7, Apache-2.0, approved, #3288
@@ -270,6 +270,7 @@ maven/mavencentral/org.eclipse.jetty/jetty-servlet/11.0.21, EPL-2.0 OR Apache-2.
 maven/mavencentral/org.eclipse.jetty/jetty-util/11.0.21, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty/jetty-webapp/11.0.21, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty/jetty-xml/11.0.21, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.parsson/parsson/1.1.6, EPL-2.0, approved, ee4j.parsson
 maven/mavencentral/org.glassfish.hk2.external/aopalliance-repackaged/3.0.6, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/hk2-api/3.0.6, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/hk2-locator/3.0.6, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,5 +57,4 @@ allprojects {
         configDirectory.set(rootProject.file("resources"))
     }
 
-
 }

--- a/core/common/lib/json-ld-lib/build.gradle.kts
+++ b/core/common/lib/json-ld-lib/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
 }
 
 dependencies {
-    api(libs.jakartaJson)
+    api(libs.jakarta.json.api)
     api(libs.jackson.datatype.jakarta.jsonp)
     api(libs.titaniumJsonLd)
     implementation(libs.jackson.datatype.jsr310)

--- a/core/common/lib/transform-lib/build.gradle.kts
+++ b/core/common/lib/transform-lib/build.gradle.kts
@@ -23,8 +23,6 @@ dependencies {
     api(project(":spi:common:transform-spi"))
     api(project(":spi:data-plane-selector:data-plane-selector-spi"))
 
-    api(libs.jakartaJson)
-
     testImplementation(project(":tests:junit-base"));
     testImplementation(project(":core:common:lib:json-ld-lib"))
 }

--- a/core/common/lib/validator-lib/build.gradle.kts
+++ b/core/common/lib/validator-lib/build.gradle.kts
@@ -22,8 +22,6 @@ dependencies {
     api(project(":spi:common:json-ld-spi"))
     api(project(":spi:common:validator-spi"))
 
-    api(libs.jakartaJson)
-
     testImplementation(project(":tests:junit-base"));
 
 }

--- a/core/control-plane/control-plane-transform/build.gradle.kts
+++ b/core/control-plane/control-plane-transform/build.gradle.kts
@@ -22,8 +22,6 @@ dependencies {
     api(project(":spi:common:json-ld-spi"))
     api(project(":spi:control-plane:asset-spi"))
 
-    api(libs.jakartaJson)
-
     testImplementation(project(":tests:junit-base"));
     testImplementation(project(":core:common:lib:json-ld-lib"))
     testImplementation(project(":core:common:lib:transform-lib"))

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/build.gradle.kts
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/build.gradle.kts
@@ -23,7 +23,5 @@ dependencies {
     api(project(":extensions:common:json-ld"))
     api(project(":spi:control-plane:catalog-spi"))
 
-    api(libs.jakartaJson)
-
     testImplementation(testFixtures(project(":data-protocols:dsp:dsp-http-spi")))
 }

--- a/data-protocols/dsp/dsp-http-spi/build.gradle.kts
+++ b/data-protocols/dsp/dsp-http-spi/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
     api(project(":data-protocols:dsp:dsp-spi"))
 
     api(libs.okhttp)
-    api(libs.jakartaJson)
+    api(libs.jakarta.json.api)
     api(libs.jakarta.rsApi)
 
     testFixturesApi(project(":core:common:junit"))

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-dispatcher/build.gradle.kts
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-dispatcher/build.gradle.kts
@@ -23,7 +23,5 @@ dependencies {
     api(project(":extensions:common:json-ld"))
     api(project(":spi:control-plane:contract-spi"))
 
-    api(libs.jakartaJson)
-
     testImplementation(testFixtures(project(":data-protocols:dsp:dsp-http-spi")))
 }

--- a/extensions/common/crypto/lib/jws2020-lib/build.gradle.kts
+++ b/extensions/common/crypto/lib/jws2020-lib/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     implementation(libs.nimbus.jwt)
     // used for the Ed25519 Verifier in conjunction with OctetKeyPairs (OKP)
     runtimeOnly(libs.tink)
-    implementation(libs.jakartaJson)
+    implementation(libs.jakarta.json.api)
 
     api("com.apicatalog:iron-verifiable-credentials:0.14.0") {
         exclude("com.github.multiformats")

--- a/extensions/common/json-ld/build.gradle.kts
+++ b/extensions/common/json-ld/build.gradle.kts
@@ -17,7 +17,6 @@ plugins {
 }
 
 dependencies {
-    api(libs.jakartaJson)
     api(libs.jackson.datatype.jakarta.jsonp)
     api(libs.titaniumJsonLd)
 

--- a/extensions/common/vault/vault-hashicorp/build.gradle.kts
+++ b/extensions/common/vault/vault-hashicorp/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
     testImplementation(project(":core:common:connector-core"))
     testImplementation(testFixtures(project(":core:common:lib:http-lib")))
     testImplementation(project(":core:common:junit"))
-    testImplementation(libs.jakartaJson)
+    testImplementation(libs.jakarta.json.api)
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.testcontainers.vault)
     implementation(libs.bouncyCastle.bcpkixJdk18on)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ edc = "0.7.1-SNAPSHOT"
 failsafe = "3.3.2"
 h2 = "2.2.224"
 httpMockServer = "5.15.0"
-jakarta-json = "2.0.1"
+jakarta-json = "2.1.3"
 jakarta-transaction = "2.0.1"
 jackson = "2.17.1"
 jersey = "3.1.7"
@@ -28,6 +28,7 @@ nimbus = "9.40"
 okhttp = "4.12.0"
 opentelemetry = "1.32.0"
 opentelemetry-proto = "1.3.1-alpha"
+parsson = "1.1.6"
 postgres = "42.7.3"
 restAssured = "5.4.0"
 rsApi = "4.0.0"
@@ -54,9 +55,9 @@ jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
 jackson-datatype-jakarta-jsonp = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jakarta-jsonp", version.ref = "jackson" }
 jackson-datatype-jsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310", version.ref = "jackson" }
+jakarta-json-api = { module = "jakarta.json:jakarta.json-api", version.ref = "jakarta-json" }
 jakarta-rsApi = { module = "jakarta.ws.rs:jakarta.ws.rs-api", version.ref = "rsApi" }
 jakarta-transaction-api = { module = "jakarta.transaction:jakarta.transaction-api", version.ref = "jakarta-transaction" }
-jakartaJson = { module = "org.glassfish:jakarta.json", version.ref = "jakarta-json" }
 jersey-common = { module = "org.glassfish.jersey.core:jersey-common", version.ref = "jersey" }
 jersey-inject = { module = "org.glassfish.jersey.inject:jersey-hk2", version.ref = "jersey" }
 jersey-jackson = { module = "org.glassfish.jersey.media:jersey-media-json-jackson", version.ref = "jersey" }
@@ -81,6 +82,7 @@ okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 opentelemetry-api = { module = "io.opentelemetry:opentelemetry-api", version.ref = "opentelemetry" }
 opentelemetry-instrumentation-annotations = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations", version.ref = "opentelemetry" }
 opentelemetry-proto = { module = "io.opentelemetry.proto:opentelemetry-proto", version.ref = "opentelemetry-proto" }
+parsson = { module = "org.eclipse.parsson:parsson", version.ref = "parsson" }
 restAssured = { module = "io.rest-assured:rest-assured", version.ref = "restAssured" }
 swagger-annotations-jakarta = { module = "io.swagger.core.v3:swagger-annotations-jakarta", version.ref = "swagger" }
 titaniumJsonLd = { module = "com.apicatalog:titanium-json-ld", version.ref = "titanium" }

--- a/spi/common/json-ld-spi/build.gradle.kts
+++ b/spi/common/json-ld-spi/build.gradle.kts
@@ -18,9 +18,11 @@ plugins {
 }
 
 dependencies {
-    api(libs.jakartaJson)
+    api(libs.jakarta.json.api)
 
     api(project(":spi:common:transform-spi"))
+
+    implementation(libs.parsson)
 }
 
 

--- a/spi/common/validator-spi/build.gradle.kts
+++ b/spi/common/validator-spi/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 dependencies {
     api(project(":spi:common:core-spi"))
 
-    api(libs.jakartaJson)
+    api(libs.jakarta.json.api)
 }
 
 

--- a/system-tests/e2e-dataplane-tests/tests/build.gradle.kts
+++ b/system-tests/e2e-dataplane-tests/tests/build.gradle.kts
@@ -27,7 +27,6 @@ dependencies {
     testImplementation(project(":core:common:junit"))
     testImplementation(project(":core:common:lib:keys-lib"))
     testImplementation(project(":extensions:common:json-ld"))
-    testImplementation(libs.jakartaJson)
 
     testImplementation(libs.restAssured)
     testImplementation(libs.assertj)

--- a/system-tests/e2e-transfer-test/runner/build.gradle.kts
+++ b/system-tests/e2e-transfer-test/runner/build.gradle.kts
@@ -27,7 +27,6 @@ dependencies {
     testImplementation(testFixtures(project(":extensions:common:sql:sql-core")))
     testImplementation(testFixtures(project(":extensions:control-plane:api:management-api:management-api-test-fixtures")))
     testImplementation(project(":extensions:common:json-ld"))
-    testImplementation(libs.jakartaJson)
 
     testImplementation(libs.postgres)
     testImplementation(libs.restAssured)

--- a/system-tests/management-api/management-api-test-runner/build.gradle.kts
+++ b/system-tests/management-api/management-api-test-runner/build.gradle.kts
@@ -38,7 +38,6 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(libs.awaitility)
     testImplementation(libs.junit.jupiter.api)
-    testImplementation(libs.jakartaJson)
     testImplementation(testFixtures(project(":extensions:common:sql:sql-core")))
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.testcontainers.postgres)

--- a/system-tests/sts-api/sts-api-test-runner/build.gradle.kts
+++ b/system-tests/sts-api/sts-api-test-runner/build.gradle.kts
@@ -26,7 +26,6 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(libs.awaitility)
     testImplementation(libs.junit.jupiter.api)
-    testImplementation(libs.jakartaJson)
 
     testCompileOnly(project(":system-tests:sts-api:sts-api-test-runtime"))
     testImplementation(testFixtures(project(":spi:common:identity-trust-sts-spi")))

--- a/system-tests/telemetry/telemetry-test-runner/build.gradle.kts
+++ b/system-tests/telemetry/telemetry-test-runner/build.gradle.kts
@@ -27,7 +27,6 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(libs.awaitility)
     testImplementation(libs.junit.jupiter.api)
-    testImplementation(libs.jakartaJson)
     testImplementation(libs.mockserver.netty)
     testImplementation(libs.mockserver.client)
     testImplementation(libs.opentelemetry.proto)

--- a/system-tests/version-api/version-api-test-runner/build.gradle.kts
+++ b/system-tests/version-api/version-api-test-runner/build.gradle.kts
@@ -41,7 +41,6 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(libs.awaitility)
     testImplementation(libs.junit.jupiter.api)
-    testImplementation(libs.jakartaJson)
     testImplementation(testFixtures(project(":extensions:common:sql:sql-core")))
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.testcontainers.postgres)


### PR DESCRIPTION
## What this PR changes/adds

Changes the group id fo the `jakarta.json` api library.
To do that I had to add a `parsson` implementation, because from version 2.1.0 api and implementation have been separated (ref. https://github.com/jakartaee/jsonp-api/releases/tag/2.1.0-RELEASE)

## Why it does that

_Briefly state why the change was necessary._

## Further notes

- took the opportunity to rename the reference in the version catalog to the standard notation
- speed up `DataPlaneSelectorEndToEndTest` and remove related deprecation usages

## Linked Issue(s)

Closes #4271 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
