### PR TITLE
refactor: extract control api client

### DIFF
--- a/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/CoreServicesExtension.java
+++ b/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/CoreServicesExtension.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.connector.core;
 
+import org.eclipse.edc.api.auth.spi.ControlClientAuthenticationProvider;
 import org.eclipse.edc.connector.core.agent.ParticipantAgentServiceImpl;
 import org.eclipse.edc.connector.core.command.CommandHandlerRegistryImpl;
 import org.eclipse.edc.connector.core.event.EventExecutorServiceContainer;
@@ -21,6 +22,9 @@ import org.eclipse.edc.connector.core.event.EventRouterImpl;
 import org.eclipse.edc.connector.core.message.RemoteMessageDispatcherRegistryImpl;
 import org.eclipse.edc.connector.core.validator.DataAddressValidatorRegistryImpl;
 import org.eclipse.edc.connector.core.validator.JsonObjectValidatorRegistryImpl;
+import org.eclipse.edc.http.client.ControlApiHttpClientImpl;
+import org.eclipse.edc.http.spi.ControlApiHttpClient;
+import org.eclipse.edc.http.spi.EdcHttpClient;
 import org.eclipse.edc.json.JacksonTypeManager;
 import org.eclipse.edc.policy.engine.PolicyEngineImpl;
 import org.eclipse.edc.policy.engine.RuleBindingRegistryImpl;
@@ -68,6 +72,12 @@ public class CoreServicesExtension implements ServiceExtension {
 
     @Inject(required = false)
     private TypeManager typeManager;
+
+    @Inject
+    private EdcHttpClient edcHttpClient;
+
+    @Inject
+    private ControlClientAuthenticationProvider controlClientAuthenticationProvider;
 
     private RuleBindingRegistry ruleBindingRegistry;
 
@@ -158,6 +168,11 @@ public class CoreServicesExtension implements ServiceExtension {
     @Provider
     public CriterionOperatorRegistry criterionOperatorRegistry() {
         return CriterionOperatorRegistryImpl.ofDefaults();
+    }
+
+    @Provider
+    public ControlApiHttpClient controlApiHttpClient() {
+        return new ControlApiHttpClientImpl(edcHttpClient, controlClientAuthenticationProvider);
     }
 
 }

--- a/core/common/lib/http-lib/build.gradle.kts
+++ b/core/common/lib/http-lib/build.gradle.kts
@@ -19,17 +19,18 @@ plugins {
 }
 
 dependencies {
+    api(project(":spi:common:auth-spi"))
     api(project(":spi:common:http-spi"))
 
     implementation(libs.okhttp)
     implementation(libs.dnsOverHttps)
 
+    testImplementation(project(":core:common:junit"))
     testImplementation(project(":core:common:lib:json-lib"))
     testImplementation(project(":core:common:lib:util-lib"))
+    testImplementation(libs.mockserver.netty)
 
     testFixturesImplementation(libs.mockito.core)
-
-    testImplementation(libs.mockserver.netty)
 }
 
 

--- a/core/common/lib/http-lib/src/main/java/org/eclipse/edc/http/client/ControlApiHttpClientImpl.java
+++ b/core/common/lib/http-lib/src/main/java/org/eclipse/edc/http/client/ControlApiHttpClientImpl.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.http.client;
+
+import okhttp3.Request;
+import org.eclipse.edc.api.auth.spi.ControlClientAuthenticationProvider;
+import org.eclipse.edc.http.spi.ControlApiHttpClient;
+import org.eclipse.edc.http.spi.EdcHttpClient;
+import org.eclipse.edc.http.spi.EdcHttpClientException;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.util.List;
+
+import static java.lang.String.format;
+import static org.eclipse.edc.http.spi.FallbackFactories.retryWhenStatusIsNotIn;
+
+public class ControlApiHttpClientImpl implements ControlApiHttpClient {
+
+    private final EdcHttpClient httpClient;
+    private final ControlClientAuthenticationProvider authenticationProvider;
+
+    public ControlApiHttpClientImpl(EdcHttpClient httpClient, ControlClientAuthenticationProvider authenticationProvider) {
+        this.httpClient = httpClient;
+        this.authenticationProvider = authenticationProvider;
+    }
+
+    @Override
+    public ServiceResult<Void> execute(Request.Builder requestBuilder) {
+        return request(requestBuilder).mapEmpty();
+    }
+
+    @Override
+    public ServiceResult<String> request(Request.Builder requestBuilder) {
+        authenticationProvider.authenticationHeaders().forEach(requestBuilder::header);
+        try (
+                var response = httpClient.execute(requestBuilder.build(), List.of(retryWhenStatusIsNotIn(200, 204)));
+                var responseBody = response.body();
+        ) {
+            var bodyAsString = responseBody == null ? null : responseBody.string();
+            if (response.isSuccessful()) {
+                return ServiceResult.success(bodyAsString);
+            } else {
+                return mapToFailure(response.code(), bodyAsString);
+            }
+        } catch (IOException exception) {
+            return ServiceResult.unexpected("Unexpected IOException. " + exception.getMessage());
+        } catch (EdcHttpClientException exception) {
+            return mapToFailure(exception.getStatusCode(), exception.getResponseBody());
+        }
+    }
+
+    private @NotNull ServiceResult<String> mapToFailure(int statusCode, String responseBody) {
+        return switch (statusCode) {
+            case 400 -> ServiceResult.badRequest("Remote API returned HTTP 400. " + responseBody);
+            case 401, 403 -> ServiceResult.unauthorized("Unauthorized. " + responseBody);
+            case 404 -> ServiceResult.notFound("Remote API returned HTTP 404. " + responseBody);
+            case 409 -> ServiceResult.conflict("Remote API returned HTTP 409. " + responseBody);
+            default ->
+                    ServiceResult.unexpected(format("An unknown error happened, HTTP Status = %d. Body %s", statusCode, responseBody));
+        };
+    }
+
+}

--- a/core/common/lib/http-lib/src/test/java/org/eclipse/edc/http/client/ControlApiHttpClientImplTest.java
+++ b/core/common/lib/http-lib/src/test/java/org/eclipse/edc/http/client/ControlApiHttpClientImplTest.java
@@ -1,0 +1,184 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.http.client;
+
+import okhttp3.Request;
+import org.eclipse.edc.api.auth.spi.ControlClientAuthenticationProvider;
+import org.eclipse.edc.http.spi.ControlApiHttpClient;
+import org.eclipse.edc.http.spi.EdcHttpClient;
+import org.eclipse.edc.spi.result.ServiceFailure;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.mockserver.integration.ClientAndServer;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.eclipse.edc.http.client.testfixtures.HttpTestUtils.testHttpClient;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.spi.result.ServiceFailure.Reason.BAD_REQUEST;
+import static org.eclipse.edc.spi.result.ServiceFailure.Reason.CONFLICT;
+import static org.eclipse.edc.spi.result.ServiceFailure.Reason.NOT_FOUND;
+import static org.eclipse.edc.spi.result.ServiceFailure.Reason.UNAUTHORIZED;
+import static org.eclipse.edc.spi.result.ServiceFailure.Reason.UNEXPECTED;
+import static org.eclipse.edc.util.io.Ports.getFreePort;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+import static org.mockserver.stop.Stop.stopQuietly;
+
+class ControlApiHttpClientImplTest {
+
+    private final int port = getFreePort();
+    private final EdcHttpClient http = testHttpClient();
+    private final ControlClientAuthenticationProvider authenticationProvider = mock();
+    private ClientAndServer server;
+
+    private final ControlApiHttpClient client = new ControlApiHttpClientImpl(http, authenticationProvider);
+
+    @BeforeEach
+    public void startServer() {
+        server = ClientAndServer.startClientAndServer(port);
+    }
+
+    @AfterEach
+    public void stopServer() {
+        stopQuietly(server);
+    }
+
+    @Nested
+    class Execute {
+        @Test
+        void shouldSucceed_whenServerResponseIsSuccessful() {
+            server.when(request()).respond(response().withStatusCode(204));
+
+            var request = new Request.Builder()
+                    .url("http://localhost:" + port);
+
+            var result = client.execute(request);
+
+            assertThat(result).isSucceeded();
+        }
+
+        @Test
+        void shouldIncludeAuthenticationHeaders() {
+            server.when(request()).respond(response().withStatusCode(204));
+            when(authenticationProvider.authenticationHeaders()).thenReturn(Map.of("Authorization", "authToken"));
+
+            var request = new Request.Builder()
+                    .url("http://localhost:" + port);
+
+            client.execute(request);
+
+            server.verify(request().withHeader("Authorization", "authToken"));
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(FailingResponses.class)
+        void shouldFail_whenServerResponseIsNotSuccessful(int statusCode, ServiceFailure.Reason reason) {
+            server.when(request()).respond(response().withStatusCode(statusCode));
+
+            var request = new Request.Builder()
+                    .url("http://localhost:" + port);
+
+            var result = client.execute(request);
+
+            assertThat(result).isFailed().extracting(ServiceFailure::getReason).isEqualTo(reason);
+        }
+
+        private static class FailingResponses implements ArgumentsProvider {
+
+            @Override
+            public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
+                return Stream.of(
+                        arguments(400, BAD_REQUEST),
+                        arguments(401, UNAUTHORIZED),
+                        arguments(403, UNAUTHORIZED),
+                        arguments(404, NOT_FOUND),
+                        arguments(409, CONFLICT),
+                        arguments(500, UNEXPECTED)
+                );
+            }
+        }
+    }
+
+    @Nested
+    class Response {
+
+        @Test
+        void shouldSucceed_whenServerResponseIsSuccessful() {
+            server.when(request()).respond(response().withStatusCode(200).withBody("response body"));
+
+            var request = new Request.Builder()
+                    .url("http://localhost:" + port);
+
+            var result = client.request(request);
+
+            assertThat(result).isSucceeded().isEqualTo("response body");
+        }
+
+        @Test
+        void shouldIncludeAuthenticationHeaders() {
+            server.when(request()).respond(response().withStatusCode(204));
+            when(authenticationProvider.authenticationHeaders()).thenReturn(Map.of("Authorization", "authToken"));
+
+            var request = new Request.Builder()
+                    .url("http://localhost:" + port);
+
+            client.request(request);
+
+            server.verify(request().withHeader("Authorization", "authToken"));
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(FailingResponses.class)
+        void shouldFail_whenServerResponseIsNotSuccessful(int statusCode, ServiceFailure.Reason reason) {
+            server.when(request()).respond(response().withStatusCode(statusCode));
+
+            var request = new Request.Builder()
+                    .url("http://localhost:" + port);
+
+            var result = client.request(request);
+
+            assertThat(result).isFailed().extracting(ServiceFailure::getReason).isEqualTo(reason);
+        }
+
+        private static class FailingResponses implements ArgumentsProvider {
+
+            @Override
+            public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
+                return Stream.of(
+                        arguments(400, BAD_REQUEST),
+                        arguments(401, UNAUTHORIZED),
+                        arguments(403, UNAUTHORIZED),
+                        arguments(404, NOT_FOUND),
+                        arguments(409, CONFLICT),
+                        arguments(500, UNEXPECTED)
+                );
+            }
+        }
+
+    }
+
+}

--- a/extensions/control-plane/api/control-plane-api-client/src/main/java/org/eclipse/edc/connector/controlplane/api/client/ControlPlaneApiClientExtension.java
+++ b/extensions/control-plane/api/control-plane-api-client/src/main/java/org/eclipse/edc/connector/controlplane/api/client/ControlPlaneApiClientExtension.java
@@ -14,11 +14,10 @@
 
 package org.eclipse.edc.connector.controlplane.api.client;
 
-import org.eclipse.edc.api.auth.spi.ControlClientAuthenticationProvider;
 import org.eclipse.edc.connector.controlplane.api.client.spi.transferprocess.TransferProcessApiClient;
 import org.eclipse.edc.connector.controlplane.api.client.transferprocess.TransferProcessHttpClient;
 import org.eclipse.edc.connector.controlplane.api.client.transferprocess.model.TransferProcessFailRequest;
-import org.eclipse.edc.http.spi.EdcHttpClient;
+import org.eclipse.edc.http.spi.ControlApiHttpClient;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
@@ -36,11 +35,9 @@ public class ControlPlaneApiClientExtension implements ServiceExtension {
     public static final String NAME = "Control Plane HTTP API client";
 
     @Inject
-    private EdcHttpClient httpClient;
-    @Inject
     private TypeManager typeManager;
     @Inject
-    private ControlClientAuthenticationProvider authenticationProvider;
+    private ControlApiHttpClient httpClient;
 
     @Override
     public String name() {
@@ -51,7 +48,7 @@ public class ControlPlaneApiClientExtension implements ServiceExtension {
     public TransferProcessApiClient transferProcessApiClient(ServiceExtensionContext context) {
         typeManager.registerTypes(TransferProcessFailRequest.class);
 
-        return new TransferProcessHttpClient(httpClient, typeManager.getMapper(), context.getMonitor(), authenticationProvider);
+        return new TransferProcessHttpClient(httpClient, typeManager.getMapper(), context.getMonitor());
     }
 
 }

--- a/extensions/control-plane/api/control-plane-api-client/src/test/java/org/eclipse/edc/connector/controlplane/api/client/transferprocess/TransferProcessHttpClientTest.java
+++ b/extensions/control-plane/api/control-plane-api-client/src/test/java/org/eclipse/edc/connector/controlplane/api/client/transferprocess/TransferProcessHttpClientTest.java
@@ -19,7 +19,8 @@ import okhttp3.Interceptor;
 import okhttp3.MediaType;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
-import org.eclipse.edc.api.auth.spi.ControlClientAuthenticationProvider;
+import org.eclipse.edc.http.client.ControlApiHttpClientImpl;
+import org.eclipse.edc.http.spi.ControlApiHttpClient;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
@@ -43,10 +44,10 @@ public class TransferProcessHttpClientTest {
 
     private final Interceptor interceptor = mock();
     private final Monitor monitor = mock();
-    private final ControlClientAuthenticationProvider authenticationProvider = mock();
+    private final ControlApiHttpClient httpClient = new ControlApiHttpClientImpl(testHttpClient(interceptor), mock());
 
     private final TransferProcessHttpClient transferProcessHttpClient = new TransferProcessHttpClient(
-            testHttpClient(interceptor), new ObjectMapper(), monitor, authenticationProvider);
+                httpClient, new ObjectMapper(), monitor);
 
     @Test
     void complete() throws IOException {
@@ -58,7 +59,6 @@ public class TransferProcessHttpClientTest {
 
         assertThat(result).isSucceeded();
         verifyNoInteractions(monitor);
-        verify(authenticationProvider).authenticationHeaders();
     }
 
     @Test
@@ -98,7 +98,7 @@ public class TransferProcessHttpClientTest {
 
         assertThat(result).isFailed();
 
-        verify(monitor).severe(anyString(), any());
+        verify(monitor).severe(anyString());
     }
 
     @Test
@@ -111,7 +111,6 @@ public class TransferProcessHttpClientTest {
 
         assertThat(result).isSucceeded();
         verifyNoInteractions(monitor);
-        verify(authenticationProvider).authenticationHeaders();
     }
 
     private DataFlowStartMessage.Builder createRequest() {

--- a/extensions/data-plane-selector/data-plane-selector-client/src/main/java/org/eclipse/edc/connector/dataplane/selector/DataPlaneSelectorClientExtension.java
+++ b/extensions/data-plane-selector/data-plane-selector-client/src/main/java/org/eclipse/edc/connector/dataplane/selector/DataPlaneSelectorClientExtension.java
@@ -15,9 +15,8 @@
 package org.eclipse.edc.connector.dataplane.selector;
 
 import jakarta.json.Json;
-import org.eclipse.edc.api.auth.spi.ControlClientAuthenticationProvider;
 import org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService;
-import org.eclipse.edc.http.spi.EdcHttpClient;
+import org.eclipse.edc.http.spi.ControlApiHttpClient;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
@@ -42,17 +41,14 @@ public class DataPlaneSelectorClientExtension implements ServiceExtension {
     @Setting(value = "Defines strategy for Data Plane instance selection in case Data Plane is not embedded in current runtime", defaultValue = DataPlaneSelectorService.DEFAULT_STRATEGY)
     private static final String DPF_SELECTOR_STRATEGY = "edc.dataplane.client.selector.strategy";
 
-    @Inject(required = false)
-    private EdcHttpClient httpClient;
+    @Inject
+    private ControlApiHttpClient httpClient;
 
     @Inject
     private TypeManager typeManager;
 
     @Inject
     private TypeTransformerRegistry typeTransformerRegistry;
-
-    @Inject
-    private ControlClientAuthenticationProvider authenticationProvider;
 
     @Override
     public String name() {
@@ -72,6 +68,6 @@ public class DataPlaneSelectorClientExtension implements ServiceExtension {
         var url = config.getString(DPF_SELECTOR_URL_SETTING);
         var selectionStrategy = config.getString(DPF_SELECTOR_STRATEGY, DataPlaneSelectorService.DEFAULT_STRATEGY);
         return new RemoteDataPlaneSelectorService(httpClient, url, typeManager.getMapper(), typeTransformerRegistry,
-                selectionStrategy, authenticationProvider);
+                selectionStrategy);
     }
 }

--- a/extensions/data-plane/data-plane-client/src/main/java/org/eclipse/edc/connector/dataplane/client/DataPlaneClientExtension.java
+++ b/extensions/data-plane/data-plane-client/src/main/java/org/eclipse/edc/connector/dataplane/client/DataPlaneClientExtension.java
@@ -14,10 +14,9 @@
 
 package org.eclipse.edc.connector.dataplane.client;
 
-import org.eclipse.edc.api.auth.spi.ControlClientAuthenticationProvider;
 import org.eclipse.edc.connector.dataplane.selector.spi.client.DataPlaneClientFactory;
 import org.eclipse.edc.connector.dataplane.spi.manager.DataPlaneManager;
-import org.eclipse.edc.http.spi.EdcHttpClient;
+import org.eclipse.edc.http.spi.ControlApiHttpClient;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
@@ -42,11 +41,9 @@ public class DataPlaneClientExtension implements ServiceExtension {
     @Inject(required = false)
     private DataPlaneManager dataPlaneManager;
     @Inject(required = false)
-    private EdcHttpClient httpClient;
+    private ControlApiHttpClient httpClient;
     @Inject
     private TypeManager typeManager;
-    @Inject
-    private ControlClientAuthenticationProvider authenticationProvider;
 
     @Override
     public String name() {
@@ -63,8 +60,8 @@ public class DataPlaneClientExtension implements ServiceExtension {
         }
 
         context.getMonitor().debug(() -> "Using remote Data Plane client.");
-        Objects.requireNonNull(httpClient, "To use remote Data Plane client, an EdcHttpClient instance must be registered");
-        return instance -> new RemoteDataPlaneClient(httpClient, typeManager.getMapper(), instance, authenticationProvider);
+        Objects.requireNonNull(httpClient, "To use remote Data Plane client, a ControlApiHttpClient instance must be registered");
+        return instance -> new RemoteDataPlaneClient(httpClient, typeManager.getMapper(), instance);
     }
 }
 

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/main/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClientExtension.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/main/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClientExtension.java
@@ -14,11 +14,10 @@
 
 package org.eclipse.edc.connector.dataplane.client;
 
-import org.eclipse.edc.api.auth.spi.ControlClientAuthenticationProvider;
 import org.eclipse.edc.connector.dataplane.selector.spi.client.DataPlaneClient;
 import org.eclipse.edc.connector.dataplane.selector.spi.client.DataPlaneClientFactory;
 import org.eclipse.edc.connector.dataplane.spi.manager.DataPlaneManager;
-import org.eclipse.edc.http.spi.EdcHttpClient;
+import org.eclipse.edc.http.spi.ControlApiHttpClient;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
@@ -40,7 +39,7 @@ public class DataPlaneSignalingClientExtension implements ServiceExtension {
     public static final String NAME = "Data Plane Signaling Client";
 
     @Inject(required = false)
-    private EdcHttpClient httpClient;
+    private ControlApiHttpClient httpClient;
     @Inject
     private TypeManager typeManager;
     @Inject
@@ -49,8 +48,6 @@ public class DataPlaneSignalingClientExtension implements ServiceExtension {
     private JsonLd jsonLd;
     @Inject(required = false)
     private DataPlaneManager dataPlaneManager;
-    @Inject
-    private ControlClientAuthenticationProvider authenticationProvider;
 
     @Override
     public String name() {
@@ -68,10 +65,10 @@ public class DataPlaneSignalingClientExtension implements ServiceExtension {
 
         var mapper = typeManager.getMapper(JSON_LD);
         context.getMonitor().debug(() -> "Using remote Data Plane client.");
-        Objects.requireNonNull(httpClient, "To use remote Data Plane client, an EdcHttpClient instance must be registered");
+        Objects.requireNonNull(httpClient, "To use remote Data Plane client, a ControlApiHttpClient instance must be registered");
         var signalingApiTypeTransformerRegistry = transformerRegistry.forContext("signaling-api");
         return instance -> new DataPlaneSignalingClient(httpClient, signalingApiTypeTransformerRegistry, jsonLd, mapper,
-                instance, authenticationProvider);
+                instance);
     }
 }
 

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/test/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClientTest.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/test/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClientTest.java
@@ -18,7 +18,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
-import org.eclipse.edc.api.auth.spi.ControlClientAuthenticationProvider;
 import org.eclipse.edc.connector.api.signaling.transform.from.JsonObjectFromDataFlowResponseMessageTransformer;
 import org.eclipse.edc.connector.api.signaling.transform.from.JsonObjectFromDataFlowStartMessageTransformer;
 import org.eclipse.edc.connector.api.signaling.transform.from.JsonObjectFromDataFlowSuspendMessageTransformer;
@@ -27,6 +26,8 @@ import org.eclipse.edc.connector.api.signaling.transform.to.JsonObjectToDataFlow
 import org.eclipse.edc.connector.dataplane.selector.spi.client.DataPlaneClient;
 import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
 import org.eclipse.edc.connector.dataplane.spi.response.TransferErrorResponse;
+import org.eclipse.edc.http.client.ControlApiHttpClientImpl;
+import org.eclipse.edc.http.spi.ControlApiHttpClient;
 import org.eclipse.edc.jsonld.TitaniumJsonLd;
 import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.spi.EdcException;
@@ -58,7 +59,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.http.client.testfixtures.HttpTestUtils.testHttpClient;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
@@ -68,7 +68,6 @@ import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 import static org.eclipse.edc.util.io.Ports.getFreePort;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 import static org.mockserver.matchers.Times.once;
@@ -90,10 +89,11 @@ class DataPlaneSignalingClientTest {
     private static final TypeTransformerRegistry TRANSFORMER_REGISTRY = new TypeTransformerRegistryImpl();
     private static final TitaniumJsonLd JSON_LD = new TitaniumJsonLd(mock(Monitor.class));
     private static ClientAndServer dataPlane;
-    private final ControlClientAuthenticationProvider authenticationProvider = mock();
     private final DataPlaneInstance instance = DataPlaneInstance.Builder.newInstance().url(DATA_PLANE_API_URI).build();
-    private final DataPlaneClient dataPlaneClient = new DataPlaneSignalingClient(testHttpClient(), TRANSFORMER_REGISTRY,
-            JSON_LD, MAPPER, instance, authenticationProvider);
+    private final ControlApiHttpClient httpClient = new ControlApiHttpClientImpl(testHttpClient(), mock());
+
+    private final DataPlaneClient dataPlaneClient = new DataPlaneSignalingClient(httpClient, TRANSFORMER_REGISTRY,
+            JSON_LD, MAPPER, instance);
 
     @BeforeAll
     public static void setUp() {
@@ -132,18 +132,16 @@ class DataPlaneSignalingClientTest {
                     .orElseThrow((e) -> new EdcException(e.getFailureDetail()));
 
             var httpRequest = new HttpRequest().withPath(DATA_PLANE_PATH).withBody(MAPPER.writeValueAsString(expected));
-            dataPlane.when(httpRequest, once()).respond(response().withStatusCode(HttpStatusCode.BAD_REQUEST_400.code()));
+            dataPlane.when(httpRequest).respond(response().withStatusCode(HttpStatusCode.BAD_REQUEST_400.code()));
 
             var result = dataPlaneClient.start(flowRequest);
 
-            dataPlane.verify(httpRequest, VerificationTimes.once());
+            dataPlane.verify(httpRequest);
 
             assertThat(result.failed()).isTrue();
             assertThat(result.getFailure().status()).isEqualTo(ResponseStatus.FATAL_ERROR);
             assertThat(result.getFailureMessages())
-                    .anySatisfy(s -> assertThat(s)
-                            .isEqualTo("Transfer request failed with status code 400 for request %s", flowRequest.getProcessId())
-                    );
+                    .anySatisfy(s -> assertThat(s).contains("400").contains(flowRequest.getProcessId()));
         }
 
         @Test
@@ -156,25 +154,22 @@ class DataPlaneSignalingClientTest {
 
             var httpRequest = new HttpRequest().withPath(DATA_PLANE_PATH).withBody(MAPPER.writeValueAsString(expected));
             var errorMsg = UUID.randomUUID().toString();
-            dataPlane.when(httpRequest, once()).respond(withResponse(errorMsg));
+            dataPlane.when(httpRequest).respond(withResponse(errorMsg));
 
             var result = dataPlaneClient.start(flowRequest);
 
-            dataPlane.verify(httpRequest, VerificationTimes.once());
+            dataPlane.verify(httpRequest);
 
             assertThat(result.failed()).isTrue();
             assertThat(result.getFailure().status()).isEqualTo(ResponseStatus.FATAL_ERROR);
-            assertThat(result.getFailureMessages())
-                    .anySatisfy(s -> assertThat(s)
-                            .isEqualTo(format("Transfer request failed with status code 400 for request %s", flowRequest.getProcessId()))
-                    );
+            assertThat(result.getFailureMessages()).anySatisfy(s -> assertThat(s).contains("400").contains(flowRequest.getProcessId()));
         }
 
         @Test
         void verifyReturnFatalErrorIfTransformFails() {
             var flowRequest = createDataFlowRequest();
             TypeTransformerRegistry registry = mock();
-            var dataPlaneClient = new DataPlaneSignalingClient(testHttpClient(), registry, JSON_LD, MAPPER, instance, authenticationProvider);
+            var dataPlaneClient = new DataPlaneSignalingClient(httpClient, registry, JSON_LD, MAPPER, instance);
 
             when(registry.transform(any(), any())).thenReturn(Result.failure("Transform Failure"));
 
@@ -232,7 +227,6 @@ class DataPlaneSignalingClientTest {
             dataPlane.verify(httpRequest, VerificationTimes.once());
 
             assertThat(result).isSucceeded().extracting(DataFlowResponseMessage::getDataAddress).isNotNull();
-            verify(authenticationProvider).authenticationHeaders();
         }
 
         @Test
@@ -293,7 +287,6 @@ class DataPlaneSignalingClientTest {
 
             assertThat(result).isSucceeded();
             dataPlane.verify(httpRequest, VerificationTimes.once());
-            verify(authenticationProvider).authenticationHeaders();
         }
 
         @Test
@@ -309,7 +302,7 @@ class DataPlaneSignalingClientTest {
         @Test
         void verifyReturnFatalErrorIfTransformFails() {
             TypeTransformerRegistry registry = mock();
-            var dataPlaneClient = new DataPlaneSignalingClient(testHttpClient(), registry, JSON_LD, MAPPER, instance, authenticationProvider);
+            var dataPlaneClient = new DataPlaneSignalingClient(httpClient, registry, JSON_LD, MAPPER, instance);
 
             when(registry.transform(any(), any())).thenReturn(Result.failure("Transform Failure"));
 
@@ -337,7 +330,6 @@ class DataPlaneSignalingClientTest {
 
             assertThat(result).isSucceeded();
             dataPlane.verify(httpRequest, VerificationTimes.once());
-            verify(authenticationProvider).authenticationHeaders();
         }
 
         @Test
@@ -353,7 +345,7 @@ class DataPlaneSignalingClientTest {
         @Test
         void verifyReturnFatalErrorIfTransformFails() {
             TypeTransformerRegistry registry = mock();
-            var dataPlaneClient = new DataPlaneSignalingClient(testHttpClient(), registry, JSON_LD, MAPPER, instance, authenticationProvider);
+            var dataPlaneClient = new DataPlaneSignalingClient(httpClient, registry, JSON_LD, MAPPER, instance);
 
             when(registry.transform(any(), any())).thenReturn(Result.failure("Transform Failure"));
 

--- a/spi/common/http-spi/src/main/java/org/eclipse/edc/http/spi/ControlApiHttpClient.java
+++ b/spi/common/http-spi/src/main/java/org/eclipse/edc/http/spi/ControlApiHttpClient.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.http.spi;
+
+import okhttp3.Request;
+import org.eclipse.edc.spi.result.ServiceResult;
+
+/**
+ * Http client that provides a way to communicate over the "control" api
+ */
+public interface ControlApiHttpClient {
+
+    /**
+     * Execute a http request without returning the response body.
+     *
+     * @param requestBuilder the request builder.
+     * @return a service result.
+     */
+    ServiceResult<Void> execute(Request.Builder requestBuilder);
+
+    /**
+     * Execute a http request and return the response body.
+     *
+     * @param requestBuilder the request builder.
+     * @return a service result.
+     */
+    ServiceResult<String> request(Request.Builder requestBuilder);
+
+}

--- a/spi/common/http-spi/src/main/java/org/eclipse/edc/http/spi/EdcHttpClientException.java
+++ b/spi/common/http-spi/src/main/java/org/eclipse/edc/http/spi/EdcHttpClientException.java
@@ -18,7 +18,20 @@ import org.eclipse.edc.spi.EdcException;
 
 public class EdcHttpClientException extends EdcException {
 
-    public EdcHttpClientException(String message) {
+    private final int statusCode;
+    private final String responseBody;
+
+    public EdcHttpClientException(String message, int statusCode, String responseBody) {
         super(message);
+        this.statusCode = statusCode;
+        this.responseBody = responseBody;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public String getResponseBody() {
+        return responseBody;
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Extract an HTTP client that can be used to implement "remote" services in an easier way.

## Why it does that

refactoring

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #4259 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
