### PR TITLE
feat: publish workflow for management JSON-LD context

### DIFF
--- a/.github/workflows/publish-context.yaml
+++ b/.github/workflows/publish-context.yaml
@@ -1,0 +1,48 @@
+#################################################################################
+#  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+
+---
+name: Publish JSON-LD context
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+    paths:
+      - 'extensions/common/api/management-api-json-ld-context/src/main/resources/document/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: copy contexts into public folder
+        run: |
+          mkdir -p public/context
+          cp extensions/common/api/management-api-json-ld-context/src/main/resources/document/management-context-v1.jsonld public/context/
+      - name: deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public
+          keep_files: true


### PR DESCRIPTION
## What this PR changes/adds

 publish  workflow for management JSON-LD context in github pages

## Why it does that

public version of the JSON-LD context for the management api that will be used as repository
for w3id 


## Linked Issue(s)

Closes #4278 

