### PR TITLE
build: openapi version link

### DIFF
--- a/resources/openapi/README.md
+++ b/resources/openapi/README.md
@@ -1,0 +1,5 @@
+# Openapi
+
+### .version files
+The `*.version` files contain the path for the `version.json` file that will be used by the openapi publish workflow to
+get the context api version to be published to github pages.

--- a/resources/openapi/control-api.version
+++ b/resources/openapi/control-api.version
@@ -1,0 +1,1 @@
+extensions/common/api/control-api-configuration/src/main/resources/version.json

--- a/resources/openapi/management-api.version
+++ b/resources/openapi/management-api.version
@@ -1,0 +1,1 @@
+extensions/common/api/management-api-configuration/src/main/resources/version.json

--- a/resources/openapi/observability-api.version
+++ b/resources/openapi/observability-api.version
@@ -1,0 +1,1 @@
+extensions/common/api/api-observability/src/main/resources/version.json

--- a/resources/openapi/sts-api.version
+++ b/resources/openapi/sts-api.version
@@ -1,0 +1,1 @@
+extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-api/src/main/resources/version.json

--- a/resources/openapi/version-api.version
+++ b/resources/openapi/version-api.version
@@ -1,0 +1,1 @@
+extensions/common/api/version-api/src/main/resources/version.json


### PR DESCRIPTION
## What this PR changes/adds

Add `resources/openapi/*.version` files, that contain each the path to the `version.json` that will be used by the [publish-openapi-ui workflow](https://github.com/eclipse-edc/.github/blob/main/.github/workflows/publish-openapi-ui.yml) to set the correct version in the published specs.

## Why it does that

api versioning

## Further notes

- an alternative would be to put all the `version.json` in the `resources/openapi` folder and have a build taks in the modules that require it as resource to take care of copying it in the `build` resource folder, but the current implementation was easier so for the moment it will be preferable

## Linked Issue(s)

Part of #4182 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
