### PR TITLE
fix(api): dataplane selector control API

### DIFF
--- a/extensions/data-plane-selector/data-plane-selector-control-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/control/api/DataplaneSelectorControlApiExtensionTest.java
+++ b/extensions/data-plane-selector/data-plane-selector-control-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/control/api/DataplaneSelectorControlApiExtensionTest.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - register missing transformer
  *
  */
 
@@ -18,6 +19,7 @@ import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstan
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.transform.transformer.edc.from.JsonObjectFromDataPlaneInstanceTransformer;
 import org.eclipse.edc.transform.transformer.edc.to.JsonObjectToDataPlaneInstanceTransformer;
 import org.eclipse.edc.validator.jsonobject.JsonObjectValidator;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
@@ -65,5 +67,6 @@ class DataplaneSelectorControlApiExtensionTest {
         extension.initialize(context);
 
         verify(typeTransformerRegistry).register(isA(JsonObjectToDataPlaneInstanceTransformer.class));
+        verify(typeTransformerRegistry).register(isA(JsonObjectFromDataPlaneInstanceTransformer.class));
     }
 }

--- a/system-tests/e2e-dataplane-tests/tests/src/test/java/org/eclipse/edc/test/e2e/DataplaneSelectorControlApiEndToEndTest.java
+++ b/system-tests/e2e-dataplane-tests/tests/src/test/java/org/eclipse/edc/test/e2e/DataplaneSelectorControlApiEndToEndTest.java
@@ -1,0 +1,88 @@
+/*
+ *  Copyright (c) 2024 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial implementation
+ *
+ */
+
+package org.eclipse.edc.test.e2e;
+
+import io.restassured.http.ContentType;
+import jakarta.json.JsonArray;
+import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.junit.extensions.EmbeddedRuntime;
+import org.eclipse.edc.junit.extensions.RuntimeExtension;
+import org.eclipse.edc.junit.extensions.RuntimePerMethodExtension;
+import org.eclipse.edc.spi.protocol.ProtocolWebhook;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.util.io.Ports.getFreePort;
+import static org.mockito.Mockito.mock;
+
+@EndToEndTest
+public class DataplaneSelectorControlApiEndToEndTest {
+
+    private final int controlPlaneControlPort = getFreePort();
+
+    @RegisterExtension
+    private final RuntimeExtension controlPlane = new RuntimePerMethodExtension(new EmbeddedRuntime(
+            "control-plane",
+            Map.of(
+                    "web.http.control.port", String.valueOf(controlPlaneControlPort),
+                    "web.http.control.path", "/control"
+            ),
+            ":core:control-plane:control-plane-core",
+            ":core:data-plane-selector:data-plane-selector-core",
+            ":extensions:control-plane:transfer:transfer-data-plane-signaling",
+            ":extensions:common:iam:iam-mock",
+            ":extensions:common:http",
+            ":extensions:common:api:control-api-configuration",
+            ":extensions:data-plane-selector:data-plane-selector-control-api"
+    )).registerServiceMock(ProtocolWebhook.class, mock());
+
+    @RegisterExtension
+    private final RuntimeExtension dataPlane = new RuntimePerMethodExtension(new EmbeddedRuntime(
+            "data-plane",
+            Map.of(
+                    "web.http.port", String.valueOf(getFreePort()),
+                    "web.http.path", "/api",
+                    "web.http.control.port", String.valueOf(getFreePort()),
+                    "web.http.control.path", "/control",
+                    "edc.dpf.selector.url", String.format("http://localhost:%d/control/v1/dataplanes", controlPlaneControlPort)
+            ),
+            ":core:data-plane:data-plane-core",
+            ":extensions:data-plane:data-plane-http",
+            ":extensions:data-plane:data-plane-signaling:data-plane-signaling-api",
+            ":extensions:common:api:control-api-configuration",
+            ":extensions:control-plane:api:control-plane-api-client",
+            ":extensions:data-plane:data-plane-self-registration",
+            ":extensions:data-plane-selector:data-plane-selector-client",
+            ":extensions:common:http"
+    ));
+
+    @Test
+    void shouldReturnSelfRegisteredDataplane() {
+        var result = given()
+                .baseUri("http://localhost:" + controlPlaneControlPort + "/control")
+                .when()
+                .get("/v1/dataplanes")
+                .then()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .extract().body().as(JsonArray.class);
+
+        assertThat(result).hasSize(1);
+    }
+}

--- a/system-tests/e2e-dataplane-tests/tests/src/test/java/org/eclipse/edc/test/e2e/DataplaneSelectorControlApiEndToEndTest.java
+++ b/system-tests/e2e-dataplane-tests/tests/src/test/java/org/eclipse/edc/test/e2e/DataplaneSelectorControlApiEndToEndTest.java
@@ -62,14 +62,9 @@ public class DataplaneSelectorControlApiEndToEndTest {
                     "web.http.control.path", "/control",
                     "edc.dpf.selector.url", String.format("http://localhost:%d/control/v1/dataplanes", controlPlaneControlPort)
             ),
-            ":core:data-plane:data-plane-core",
-            ":extensions:data-plane:data-plane-http",
-            ":extensions:data-plane:data-plane-signaling:data-plane-signaling-api",
-            ":extensions:common:api:control-api-configuration",
-            ":extensions:control-plane:api:control-plane-api-client",
+            ":system-tests:e2e-dataplane-tests:runtimes:data-plane",
             ":extensions:data-plane:data-plane-self-registration",
-            ":extensions:data-plane-selector:data-plane-selector-client",
-            ":extensions:common:http"
+            ":extensions:data-plane-selector:data-plane-selector-client"
     ));
 
     @Test


### PR DESCRIPTION
## What this PR changes/adds

Fixes a dataplane selector control API endpoint.

## Why it does that

Add a missing transformer.

## Further notes

/

## Linked Issue(s)

Closes #4245

