### PR TITLE
feat: implement Asset specialization

### DIFF
--- a/core/common/lib/query-lib/src/main/java/org/eclipse/edc/query/EqualOperatorPredicate.java
+++ b/core/common/lib/query-lib/src/main/java/org/eclipse/edc/query/EqualOperatorPredicate.java
@@ -19,6 +19,8 @@ import org.eclipse.edc.spi.query.OperatorPredicate;
 import java.util.List;
 import java.util.Objects;
 
+import static java.util.Optional.ofNullable;
+
 public class EqualOperatorPredicate implements OperatorPredicate {
 
     @Override
@@ -42,8 +44,13 @@ public class EqualOperatorPredicate implements OperatorPredicate {
 
         if (property instanceof List<?> list) {
             return list.stream().anyMatch(it -> Objects.equals(it, operandRight));
+        } else if (property instanceof Boolean booleanProperty) {
+            return ofNullable(operandRight)
+                    .map(Object::toString)
+                    .map(Boolean::parseBoolean)
+                    .map(booleanOperand -> booleanOperand == booleanProperty)
+                    .orElse(false);
         }
-
         return Objects.equals(property, operandRight);
     }
 }

--- a/core/common/lib/query-lib/src/test/java/org/eclipse/edc/query/EqualOperatorPredicateTest.java
+++ b/core/common/lib/query-lib/src/test/java/org/eclipse/edc/query/EqualOperatorPredicateTest.java
@@ -56,6 +56,17 @@ class EqualOperatorPredicateTest {
         assertThat(predicate.test(List.of("one", "two"), "three")).isFalse();
     }
 
+    @Test
+    void shouldCheckName_whenPropertyIsBoolean() {
+        assertThat(predicate.test(Boolean.TRUE, "ENTRY2")).isFalse();
+        assertThat(predicate.test(Boolean.TRUE, "true")).isTrue();
+        assertThat(predicate.test(Boolean.TRUE, true)).isTrue();
+        assertThat(predicate.test(Boolean.TRUE, false)).isFalse();
+        assertThat(predicate.test(Boolean.TRUE, null)).isFalse();
+        assertThat(predicate.test(Boolean.TRUE, "false")).isFalse();
+        assertThat(predicate.test(true, false)).isFalse();
+    }
+
     public enum TestEnum {
         ENTRY1, ENTRY2
     }

--- a/core/common/lib/query-lib/src/test/java/org/eclipse/edc/query/NotEqualOperatorPredicateTest.java
+++ b/core/common/lib/query-lib/src/test/java/org/eclipse/edc/query/NotEqualOperatorPredicateTest.java
@@ -56,6 +56,17 @@ class NotEqualOperatorPredicateTest {
         assertThat(predicate.test(List.of("one", "two"), "three")).isTrue();
     }
 
+    @Test
+    void shouldCheckName_whenPropertyIsBoolean() {
+        assertThat(predicate.test(Boolean.TRUE, "ENTRY2")).isTrue();
+        assertThat(predicate.test(Boolean.TRUE, "true")).isFalse();
+        assertThat(predicate.test(Boolean.TRUE, true)).isFalse();
+        assertThat(predicate.test(Boolean.TRUE, false)).isTrue();
+        assertThat(predicate.test(Boolean.TRUE, "false")).isTrue();
+        assertThat(predicate.test(Boolean.TRUE, null)).isTrue();
+        assertThat(predicate.test(true, false)).isTrue();
+    }
+
     public enum TestEnum {
         ENTRY1, ENTRY2
     }

--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/from/JsonObjectFromAssetTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/from/JsonObjectFromAssetTransformer.java
@@ -23,6 +23,7 @@ import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_CATALOG_ASSET_TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 
@@ -50,6 +51,10 @@ public class JsonObjectFromAssetTransformer extends AbstractJsonLdTransformer<As
             var privatePropBuilder = jsonFactory.createObjectBuilder();
             transformProperties(asset.getPrivateProperties(), privatePropBuilder, mapper, context);
             builder.add(Asset.EDC_ASSET_PRIVATE_PROPERTIES, privatePropBuilder);
+        }
+
+        if (asset.isCatalog()) {
+            builder.add(TYPE, EDC_CATALOG_ASSET_TYPE);
         }
 
         if (asset.getDataAddress() != null) {

--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/to/JsonObjectToAssetTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/to/JsonObjectToAssetTransformer.java
@@ -28,7 +28,7 @@ import java.util.function.BiConsumer;
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_ASSET_DATA_ADDRESS;
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_ASSET_PRIVATE_PROPERTIES;
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_ASSET_PROPERTIES;
-import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_CATALOG_TYPE;
+import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_CATALOG_ASSET_TYPE;
 import static org.eclipse.edc.jsonld.spi.TypeUtil.nodeType;
 
 /**
@@ -55,7 +55,7 @@ public class JsonObjectToAssetTransformer extends AbstractJsonLdTransformer<Json
         });
 
         // the asset is a Catalog Asset, i.e. it links to another catalog
-        if (DCAT_CATALOG_TYPE.equals(nodeType(jsonObject))) {
+        if (EDC_CATALOG_ASSET_TYPE.equals(nodeType(jsonObject))) {
             builder.privateProperty(Asset.PROPERTY_IS_CATALOG, true);
         }
 

--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/to/JsonObjectToAssetTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/to/JsonObjectToAssetTransformer.java
@@ -56,7 +56,7 @@ public class JsonObjectToAssetTransformer extends AbstractJsonLdTransformer<Json
 
         // the asset is a Catalog Asset, i.e. it links to another catalog
         if (EDC_CATALOG_ASSET_TYPE.equals(nodeType(jsonObject))) {
-            builder.privateProperty(Asset.PROPERTY_IS_CATALOG, true);
+            builder.property(Asset.PROPERTY_IS_CATALOG, "true");
         }
 
         return builderResult(builder::build, context);

--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/to/JsonObjectToAssetTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/to/JsonObjectToAssetTransformer.java
@@ -56,7 +56,7 @@ public class JsonObjectToAssetTransformer extends AbstractJsonLdTransformer<Json
 
         // the asset is a Catalog Asset, i.e. it links to another catalog
         if (EDC_CATALOG_ASSET_TYPE.equals(nodeType(jsonObject))) {
-            builder.property(Asset.PROPERTY_IS_CATALOG, "true");
+            builder.property(Asset.PROPERTY_IS_CATALOG, true);
         }
 
         return builderResult(builder::build, context);

--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/to/JsonObjectToAssetTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/to/JsonObjectToAssetTransformer.java
@@ -28,6 +28,8 @@ import java.util.function.BiConsumer;
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_ASSET_DATA_ADDRESS;
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_ASSET_PRIVATE_PROPERTIES;
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_ASSET_PROPERTIES;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_CATALOG_TYPE;
+import static org.eclipse.edc.jsonld.spi.TypeUtil.nodeType;
 
 /**
  * Converts from an {@link Asset} as a {@link JsonObject} in JSON-LD expanded form to an {@link Asset}.
@@ -43,11 +45,19 @@ public class JsonObjectToAssetTransformer extends AbstractJsonLdTransformer<Json
                 .id(nodeId(jsonObject));
 
         visitProperties(jsonObject, key -> switch (key) {
-            case EDC_ASSET_PROPERTIES -> value -> visitProperties(value.asJsonArray().getJsonObject(0), property(context, builder));
-            case EDC_ASSET_PRIVATE_PROPERTIES -> value -> visitProperties(value.asJsonArray().getJsonObject(0), privateProperty(context, builder));
-            case EDC_ASSET_DATA_ADDRESS -> value -> builder.dataAddress(transformObject(value, DataAddress.class, context));
+            case EDC_ASSET_PROPERTIES ->
+                    value -> visitProperties(value.asJsonArray().getJsonObject(0), property(context, builder));
+            case EDC_ASSET_PRIVATE_PROPERTIES ->
+                    value -> visitProperties(value.asJsonArray().getJsonObject(0), privateProperty(context, builder));
+            case EDC_ASSET_DATA_ADDRESS ->
+                    value -> builder.dataAddress(transformObject(value, DataAddress.class, context));
             default -> doNothing();
         });
+
+        // the asset is a Catalog Asset, i.e. it links to another catalog
+        if (DCAT_CATALOG_TYPE.equals(nodeType(jsonObject))) {
+            builder.privateProperty(Asset.PROPERTY_IS_CATALOG, true);
+        }
 
         return builderResult(builder::build, context);
     }

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/from/JsonObjectFromAssetTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/from/JsonObjectFromAssetTransformerTest.java
@@ -143,7 +143,7 @@ class JsonObjectFromAssetTransformerTest {
         var dataAddress = DataAddress.Builder.newInstance().type("address-type").build();
         var asset = createAssetBuilder()
                 .dataAddress(dataAddress)
-                .privateProperty(PROPERTY_IS_CATALOG, true)
+                .property(PROPERTY_IS_CATALOG, true)
                 .build();
 
         var jsonObject = transformer.transform(asset, context);

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/from/JsonObjectFromAssetTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/from/JsonObjectFromAssetTransformerTest.java
@@ -32,6 +32,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_ASSET_DATA_ADDRESS;
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_ASSET_PRIVATE_PROPERTIES;
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_ASSET_PROPERTIES;
+import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_CATALOG_ASSET_TYPE;
+import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.PROPERTY_IS_CATALOG;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
@@ -130,6 +132,24 @@ class JsonObjectFromAssetTransformerTest {
 
         assertThat(jsonObject).isNotNull();
         assertThat(jsonObject.getJsonObject(EDC_ASSET_PROPERTIES).getJsonObject("https://foo.bar.org/schema/payload")).isInstanceOf(JsonObject.class);
+    }
+
+    @Test
+    void transform_shouldSetType_whenAssetIsCatalog() {
+        when(context.transform(isA(DataAddress.class), eq(JsonObject.class)))
+                .thenReturn(createObjectBuilder()
+                        .add(EDC_DATA_ADDRESS_TYPE_PROPERTY, value("address-type"))
+                        .build());
+        var dataAddress = DataAddress.Builder.newInstance().type("address-type").build();
+        var asset = createAssetBuilder()
+                .dataAddress(dataAddress)
+                .privateProperty(PROPERTY_IS_CATALOG, true)
+                .build();
+
+        var jsonObject = transformer.transform(asset, context);
+
+        assertThat(jsonObject).isNotNull();
+        assertThat(jsonObject.getString(TYPE)).isEqualTo(EDC_CATALOG_ASSET_TYPE);
     }
 
     private Asset.Builder createAssetBuilder() {

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/to/JsonObjectToAssetTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/to/JsonObjectToAssetTransformerTest.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.InstanceOfAssertFactories.map;
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_ASSET_PRIVATE_PROPERTIES;
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_ASSET_PROPERTIES;
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_ASSET_TYPE;
+import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_CATALOG_ASSET_TYPE;
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.PROPERTY_CONTENT_TYPE;
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.PROPERTY_DESCRIPTION;
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.PROPERTY_ID;
@@ -45,7 +46,6 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
-import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_CATALOG_TYPE;
 import static org.eclipse.edc.jsonld.util.JacksonJsonLd.createObjectMapper;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
@@ -205,7 +205,7 @@ class JsonObjectToAssetTransformerTest {
     void shouldSetPrivateProperty_whenTypeIsCatalog() {
         var jsonObj = jsonFactory.createObjectBuilder()
                 .add(CONTEXT, createContextBuilder().build())
-                .add(TYPE, DCAT_CATALOG_TYPE)
+                .add(TYPE, EDC_CATALOG_ASSET_TYPE)
                 .add(ID, TEST_ASSET_ID)
                 .add(EDC_ASSET_PROPERTIES, createPropertiesBuilder().build())
                 .build();

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/to/JsonObjectToAssetTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/to/JsonObjectToAssetTransformerTest.java
@@ -202,7 +202,7 @@ class JsonObjectToAssetTransformerTest {
     }
 
     @Test
-    void shouldSetPrivateProperty_whenTypeIsCatalog() {
+    void shouldSetProperty_whenTypeIsCatalog() {
         var jsonObj = jsonFactory.createObjectBuilder()
                 .add(CONTEXT, createContextBuilder().build())
                 .add(TYPE, EDC_CATALOG_ASSET_TYPE)

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/to/JsonObjectToAssetTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/to/JsonObjectToAssetTransformerTest.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.map;
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_ASSET_PRIVATE_PROPERTIES;
+import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_ASSET_PROPERTIES;
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_ASSET_TYPE;
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.PROPERTY_CONTENT_TYPE;
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.PROPERTY_DESCRIPTION;
@@ -44,6 +45,7 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_CATALOG_TYPE;
 import static org.eclipse.edc.jsonld.util.JacksonJsonLd.createObjectMapper;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
@@ -197,6 +199,22 @@ class JsonObjectToAssetTransformerTest {
 
         assertThat(result).isSucceeded().extracting(Asset::getProperties)
                 .asInstanceOf(map(String.class, Object.class)).doesNotContainKey(EDC_NAMESPACE + "thisShouldBeIgnored");
+    }
+
+    @Test
+    void shouldSetPrivateProperty_whenTypeIsCatalog() {
+        var jsonObj = jsonFactory.createObjectBuilder()
+                .add(CONTEXT, createContextBuilder().build())
+                .add(TYPE, DCAT_CATALOG_TYPE)
+                .add(ID, TEST_ASSET_ID)
+                .add(EDC_ASSET_PROPERTIES, createPropertiesBuilder().build())
+                .build();
+
+        var asset = typeTransformerRegistry.transform(TestInput.getExpanded(jsonObj), Asset.class);
+
+        assertThat(asset).withFailMessage(asset::getFailureDetail).isSucceeded();
+        assertThat(asset).isSucceeded()
+                .satisfies(a -> assertThat(a.isCatalog()).isTrue());
     }
 
     private JsonObjectBuilder createPayloadBuilder() {

--- a/docs/developer/management-domains/management-domains.md
+++ b/docs/developer/management-domains/management-domains.md
@@ -172,7 +172,7 @@ The following implementation work will be done to support Management Domains.
 The following changes will be made:
 
 - A boolean subtype field will be introduced on `Asset` to indicate if it is a catalog. This field will be set to `true`
-  when an optional `@type` property is set to `dcat:Catalog` when an asset is created in the Management API.
+  when an optional `@type` property is set to `edc:CatalogAsset` when an asset is created in the Management API.
 - The Management API will be updated in a backward-compatible way to handle optionally specifying the `@type` property
   on `Asset`.
 - `Catalog` will extend `Dataset`.

--- a/spi/control-plane/asset-spi/src/main/java/org/eclipse/edc/connector/controlplane/asset/spi/domain/Asset.java
+++ b/spi/control-plane/asset-spi/src/main/java/org/eclipse/edc/connector/controlplane/asset/spi/domain/Asset.java
@@ -82,8 +82,8 @@ public class Asset extends Entity {
 
     @JsonIgnore
     public boolean isCatalog() {
-        return ofNullable(getPrivateProperty(PROPERTY_IS_CATALOG))
-                .map(o -> Boolean.parseBoolean(o.toString()))
+        return ofNullable(getPropertyAsString(PROPERTY_IS_CATALOG))
+                .map(Boolean::parseBoolean)
                 .orElse(false);
     }
 

--- a/spi/control-plane/asset-spi/src/main/java/org/eclipse/edc/connector/controlplane/asset/spi/domain/Asset.java
+++ b/spi/control-plane/asset-spi/src/main/java/org/eclipse/edc/connector/controlplane/asset/spi/domain/Asset.java
@@ -41,14 +41,14 @@ public class Asset extends Entity {
     public static final String PROPERTY_DESCRIPTION = EDC_NAMESPACE + "description";
     public static final String PROPERTY_VERSION = EDC_NAMESPACE + "version";
     public static final String PROPERTY_CONTENT_TYPE = EDC_NAMESPACE + "contenttype";
+    public static final String PROPERTY_IS_CATALOG = EDC_NAMESPACE + "isCatalog";
     public static final String EDC_ASSET_TYPE = EDC_NAMESPACE + "Asset";
     public static final String EDC_ASSET_PROPERTIES = EDC_NAMESPACE + "properties";
     public static final String EDC_ASSET_PRIVATE_PROPERTIES = EDC_NAMESPACE + "privateProperties";
     public static final String EDC_ASSET_DATA_ADDRESS = EDC_NAMESPACE + "dataAddress";
-
-    private DataAddress dataAddress;
     private final Map<String, Object> properties = new HashMap<>();
     private final Map<String, Object> privateProperties = new HashMap<>();
+    private DataAddress dataAddress;
 
     private Asset() {
     }
@@ -79,6 +79,13 @@ public class Asset extends Entity {
         return ofNullable(getPropertyAsString(PROPERTY_CONTENT_TYPE)).orElse(getPropertyAsString("contenttype"));
     }
 
+    @JsonIgnore
+    public boolean isCatalog() {
+        return ofNullable(getPrivateProperty(PROPERTY_IS_CATALOG))
+                .map(o -> Boolean.parseBoolean(o.toString()))
+                .orElse(false);
+    }
+
     public Map<String, Object> getProperties() {
         return properties;
     }
@@ -99,11 +106,6 @@ public class Asset extends Entity {
 
     public Object getPrivateProperty(String key) {
         return privateProperties.get(key);
-    }
-
-    private String getPropertyAsString(String key) {
-        var val = getProperty(key);
-        return val != null ? val.toString() : null;
     }
 
     public DataAddress getDataAddress() {
@@ -127,6 +129,11 @@ public class Asset extends Entity {
             return privateProperties.keySet().stream().distinct().anyMatch(properties::containsKey);
         }
         return true;
+    }
+
+    private String getPropertyAsString(String key) {
+        var val = getProperty(key);
+        return val != null ? val.toString() : null;
     }
 
     @JsonPOJOBuilder(withPrefix = "")
@@ -157,6 +164,17 @@ public class Asset extends Entity {
         @Override
         public Builder self() {
             return this;
+        }
+
+        @Override
+        public Asset build() {
+            super.build();
+
+            if (entity.getId() == null) {
+                id(UUID.randomUUID().toString());
+            }
+
+            return entity;
         }
 
         public Builder name(String title) {
@@ -204,17 +222,6 @@ public class Asset extends Entity {
         public Builder privateProperty(String key, Object value) {
             entity.privateProperties.put(key, value);
             return self();
-        }
-
-        @Override
-        public Asset build() {
-            super.build();
-
-            if (entity.getId() == null) {
-                id(UUID.randomUUID().toString());
-            }
-
-            return entity;
         }
     }
 

--- a/spi/control-plane/asset-spi/src/main/java/org/eclipse/edc/connector/controlplane/asset/spi/domain/Asset.java
+++ b/spi/control-plane/asset-spi/src/main/java/org/eclipse/edc/connector/controlplane/asset/spi/domain/Asset.java
@@ -43,6 +43,7 @@ public class Asset extends Entity {
     public static final String PROPERTY_CONTENT_TYPE = EDC_NAMESPACE + "contenttype";
     public static final String PROPERTY_IS_CATALOG = EDC_NAMESPACE + "isCatalog";
     public static final String EDC_ASSET_TYPE = EDC_NAMESPACE + "Asset";
+    public static final String EDC_CATALOG_ASSET_TYPE = EDC_NAMESPACE + "CatalogAsset";
     public static final String EDC_ASSET_PROPERTIES = EDC_NAMESPACE + "properties";
     public static final String EDC_ASSET_PRIVATE_PROPERTIES = EDC_NAMESPACE + "privateProperties";
     public static final String EDC_ASSET_DATA_ADDRESS = EDC_NAMESPACE + "dataAddress";

--- a/spi/control-plane/asset-spi/src/test/java/org/eclipse/edc/connector/controlplane/asset/spi/domain/AssetTest.java
+++ b/spi/control-plane/asset-spi/src/test/java/org/eclipse/edc/connector/controlplane/asset/spi/domain/AssetTest.java
@@ -79,4 +79,34 @@ class AssetTest {
         assertThat(asset.getName()).isNull();
         assertThat(asset.getVersion()).isNull();
     }
+
+    @Test
+    void isCatalog_whenNotPresent_shouldReturnFalse() {
+        var asset = Asset.Builder.newInstance().build();
+        assertThat(asset.isCatalog()).isFalse();
+    }
+
+    @Test
+    void isCatalog_whenFalse_shouldReturnFalse() {
+        var asset = Asset.Builder.newInstance().privateProperty(Asset.PROPERTY_IS_CATALOG, "false").build();
+        assertThat(asset.isCatalog()).isFalse();
+
+        var asset2 = Asset.Builder.newInstance().privateProperty(Asset.PROPERTY_IS_CATALOG, false).build();
+        assertThat(asset2.isCatalog()).isFalse();
+    }
+
+    @Test
+    void isCatalog_whenTrue_shouldReturnTrue() {
+        var asset = Asset.Builder.newInstance().privateProperty(Asset.PROPERTY_IS_CATALOG, "true").build();
+        assertThat(asset.isCatalog()).isTrue();
+
+        var asset2 = Asset.Builder.newInstance().privateProperty(Asset.PROPERTY_IS_CATALOG, true).build();
+        assertThat(asset2.isCatalog()).isTrue();
+    }
+
+    @Test
+    void isCatalog_whenInvalidValid_shoudReturnFalse() {
+        var asset = Asset.Builder.newInstance().privateProperty(Asset.PROPERTY_IS_CATALOG, "foobar").build();
+        assertThat(asset.isCatalog()).isFalse();
+    }
 }

--- a/spi/control-plane/asset-spi/src/test/java/org/eclipse/edc/connector/controlplane/asset/spi/domain/AssetTest.java
+++ b/spi/control-plane/asset-spi/src/test/java/org/eclipse/edc/connector/controlplane/asset/spi/domain/AssetTest.java
@@ -88,25 +88,25 @@ class AssetTest {
 
     @Test
     void isCatalog_whenFalse_shouldReturnFalse() {
-        var asset = Asset.Builder.newInstance().privateProperty(Asset.PROPERTY_IS_CATALOG, "false").build();
+        var asset = Asset.Builder.newInstance().property(Asset.PROPERTY_IS_CATALOG, "false").build();
         assertThat(asset.isCatalog()).isFalse();
 
-        var asset2 = Asset.Builder.newInstance().privateProperty(Asset.PROPERTY_IS_CATALOG, false).build();
+        var asset2 = Asset.Builder.newInstance().property(Asset.PROPERTY_IS_CATALOG, false).build();
         assertThat(asset2.isCatalog()).isFalse();
     }
 
     @Test
     void isCatalog_whenTrue_shouldReturnTrue() {
-        var asset = Asset.Builder.newInstance().privateProperty(Asset.PROPERTY_IS_CATALOG, "true").build();
+        var asset = Asset.Builder.newInstance().property(Asset.PROPERTY_IS_CATALOG, "true").build();
         assertThat(asset.isCatalog()).isTrue();
 
-        var asset2 = Asset.Builder.newInstance().privateProperty(Asset.PROPERTY_IS_CATALOG, true).build();
+        var asset2 = Asset.Builder.newInstance().property(Asset.PROPERTY_IS_CATALOG, true).build();
         assertThat(asset2.isCatalog()).isTrue();
     }
 
     @Test
     void isCatalog_whenInvalidValid_shoudReturnFalse() {
-        var asset = Asset.Builder.newInstance().privateProperty(Asset.PROPERTY_IS_CATALOG, "foobar").build();
+        var asset = Asset.Builder.newInstance().property(Asset.PROPERTY_IS_CATALOG, "foobar").build();
         assertThat(asset.isCatalog()).isFalse();
     }
 }

--- a/spi/control-plane/asset-spi/src/testFixtures/java/org/eclipse/edc/connector/controlplane/asset/spi/testfixtures/AssetIndexTestBase.java
+++ b/spi/control-plane/asset-spi/src/testFixtures/java/org/eclipse/edc/connector/controlplane/asset/spi/testfixtures/AssetIndexTestBase.java
@@ -147,7 +147,7 @@ public abstract class AssetIndexTestBase {
         @Test
         void shouldCreate_withPrivateProperty() {
             var asset = createAssetBuilder("test-asset").privateProperty("prop1", "val1")
-                    .privateProperty(Asset.PROPERTY_IS_CATALOG, true)
+                    .property(Asset.PROPERTY_IS_CATALOG, true)
                     .build();
 
             assertThat(getAssetIndex().create(asset).succeeded()).isTrue();

--- a/spi/control-plane/asset-spi/src/testFixtures/java/org/eclipse/edc/connector/controlplane/asset/spi/testfixtures/AssetIndexTestBase.java
+++ b/spi/control-plane/asset-spi/src/testFixtures/java/org/eclipse/edc/connector/controlplane/asset/spi/testfixtures/AssetIndexTestBase.java
@@ -143,6 +143,20 @@ public abstract class AssetIndexTestBase {
                     .usingRecursiveFieldByFieldElementComparator()
                     .contains(asset);
         }
+
+        @Test
+        void shouldCreate_withPrivateProperty() {
+            var asset = createAssetBuilder("test-asset").privateProperty("prop1", "val1")
+                    .privateProperty(Asset.PROPERTY_IS_CATALOG, true)
+                    .build();
+
+            assertThat(getAssetIndex().create(asset).succeeded()).isTrue();
+            var assetFound = getAssetIndex().findById("test-asset");
+
+            assertThat(assetFound).isNotNull();
+            assertThat(assetFound.isCatalog()).isTrue();
+
+        }
     }
 
     @Nested

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/AssetApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/AssetApiEndToEndTest.java
@@ -328,7 +328,7 @@ public class AssetApiEndToEndTest {
         void queryAsset_byCatalogProperty(ManagementEndToEndTestContext context, AssetIndex assetIndex) {
             var id = UUID.randomUUID().toString();
             assetIndex.create(Asset.Builder.newInstance()
-                    .property(Asset.PROPERTY_IS_CATALOG, "true")
+                    .property(Asset.PROPERTY_IS_CATALOG, true)
                     .id(id)
                     .contentType("application/octet-stream")
                     .dataAddress(createDataAddress().build())

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/AssetApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/AssetApiEndToEndTest.java
@@ -33,7 +33,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.jsonld.spi.Namespaces.DCAT_SCHEMA;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_PREFIX;
 import static org.eclipse.edc.spi.query.Criterion.criterion;
@@ -168,9 +167,8 @@ public class AssetApiEndToEndTest {
             var id = UUID.randomUUID().toString();
             var assetJson = createObjectBuilder()
                     .add(CONTEXT, createObjectBuilder()
-                            .add(EDC_PREFIX, EDC_NAMESPACE)
-                            .add("dcat", DCAT_SCHEMA))
-                    .add(TYPE, "dcat:Catalog")
+                            .add(EDC_PREFIX, EDC_NAMESPACE))
+                    .add(TYPE, "CatalogAsset")
                     .add(ID, id)
                     .add("properties", createPropertiesBuilder().build())
                     .add("dataAddress", createObjectBuilder()
@@ -282,6 +280,7 @@ public class AssetApiEndToEndTest {
                     .statusCode(200)
                     .body("size()", is(1));
         }
+
 
         @Test
         void updateAsset(ManagementEndToEndTestContext context, AssetIndex assetIndex) {

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/AssetApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/AssetApiEndToEndTest.java
@@ -44,16 +44,6 @@ import static org.hamcrest.Matchers.notNullValue;
  */
 public class AssetApiEndToEndTest {
 
-    @Nested
-    @EndToEndTest
-    @ExtendWith(ManagementEndToEndExtension.InMemory.class)
-    class InMemory extends Tests { }
-
-    @Nested
-    @PostgresqlIntegrationTest
-    @ExtendWith(ManagementEndToEndExtension.Postgres.class)
-    class Postgres extends Tests { }
-
     abstract static class Tests {
 
         @Test
@@ -90,6 +80,10 @@ public class AssetApiEndToEndTest {
                     .add(TYPE, "Asset")
                     .add(ID, id)
                     .add("properties", createPropertiesBuilder().build())
+                    .add("privateProperties", createObjectBuilder()
+                            .add("isCatalog", "true")
+                            .add("anotherProp", "anotherVal")
+                            .build())
                     .add("dataAddress", createObjectBuilder()
                             .add(TYPE, "DataAddress")
                             .add("type", "test-type")
@@ -105,7 +99,10 @@ public class AssetApiEndToEndTest {
                     .statusCode(200)
                     .body(ID, is(id));
 
-            assertThat(assetIndex.findById(id)).isNotNull();
+            var asset = assetIndex.findById(id);
+            assertThat(asset).isNotNull();
+            assertThat(asset.isCatalog()).isTrue();
+            assertThat(asset.getPrivateProperty(EDC_NAMESPACE + "anotherProp")).isEqualTo("anotherVal");
         }
 
         @Test
@@ -307,6 +304,18 @@ public class AssetApiEndToEndTest {
                     .add("contentType", "application/json");
         }
 
+    }
+
+    @Nested
+    @EndToEndTest
+    @ExtendWith(ManagementEndToEndExtension.InMemory.class)
+    class InMemory extends Tests {
+    }
+
+    @Nested
+    @PostgresqlIntegrationTest
+    @ExtendWith(ManagementEndToEndExtension.Postgres.class)
+    class Postgres extends Tests {
     }
 
 }


### PR DESCRIPTION
## What this PR changes/adds

- added a method `Asset#isCatalog()`
- Management API ingress: JSON-LD transformers parse the `@type` field and set the `Asset#properties['isCatalog']` flag
- Management API egress: JSON-LD transformers set the `@type` field on egress if `Asset#properties['isCatalog']` is `true`
- the information whether an Asset is a `CatalogAsset` is stored in `Asset#properties`

## Why it does that

prepare for the next iteration, where `Dataset` extends `Catalog`

## Further notes

- I had originally planned to store the information in the `privateProperties`, but that would have made querying for `CatalogAssets` impossible, because we currently can't query by private properties. **If we don't care about querying, I'd suggest moving the flag back to the `privateProperties`**
- the `EqualOperatorPredicate` can now handle booleans

## Linked Issue(s)

Closes #4295

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
