### PR TITLE
feat: implement Asset/Dataset specialization pt. 2

### DIFF
--- a/core/control-plane/control-plane-catalog/build.gradle.kts
+++ b/core/control-plane/control-plane-catalog/build.gradle.kts
@@ -22,7 +22,8 @@ dependencies {
     api(project(":spi:control-plane:transfer-spi"))
     api(project(":spi:control-plane:asset-spi"))
 
-    testImplementation(project(":tests:junit-base"));
+    implementation(project(":spi:common:data-address:data-address-http-data-spi"))
+    testImplementation(project(":tests:junit-base"))
 
     testImplementation(project(":core:common:connector-core"))
     testImplementation(project(":core:control-plane:control-plane-core"))

--- a/core/control-plane/control-plane-catalog/src/main/java/org/eclipse/edc/connector/controlplane/catalog/DatasetResolverImpl.java
+++ b/core/control-plane/control-plane-catalog/src/main/java/org/eclipse/edc/connector/controlplane/catalog/DatasetResolverImpl.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.controlplane.catalog;
 
 import org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset;
 import org.eclipse.edc.connector.controlplane.asset.spi.index.AssetIndex;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
 import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
 import org.eclipse.edc.connector.controlplane.catalog.spi.DatasetResolver;
 import org.eclipse.edc.connector.controlplane.catalog.spi.DistributionResolver;
@@ -78,7 +79,7 @@ public class DatasetResolverImpl implements DatasetResolver {
     private Dataset toDataset(List<ContractDefinition> contractDefinitions, Asset asset) {
 
         var distributions = distributionResolver.getDistributions(asset);
-        var datasetBuilder = Dataset.Builder.newInstance()
+        var datasetBuilder = asset.isCatalog() ? Catalog.Builder.newInstance() : Dataset.Builder.newInstance()
                 .id(asset.getId())
                 .distributions(distributions)
                 .properties(asset.getProperties());

--- a/core/control-plane/control-plane-catalog/src/main/java/org/eclipse/edc/connector/controlplane/catalog/DatasetResolverImpl.java
+++ b/core/control-plane/control-plane-catalog/src/main/java/org/eclipse/edc/connector/controlplane/catalog/DatasetResolverImpl.java
@@ -79,7 +79,7 @@ public class DatasetResolverImpl implements DatasetResolver {
                 .orElse(null);
     }
 
-    private Dataset.Builder createCatalog(Asset asset) {
+    private Dataset.Builder buildDataset(Asset asset) {
         if (!asset.isCatalog()) {
             return Dataset.Builder.newInstance();
         }
@@ -95,7 +95,7 @@ public class DatasetResolverImpl implements DatasetResolver {
     private Dataset toDataset(List<ContractDefinition> contractDefinitions, Asset asset) {
 
         var distributions = distributionResolver.getDistributions(asset);
-        var datasetBuilder = createCatalog(asset)
+        var datasetBuilder = buildDataset(asset)
                 .id(asset.getId())
                 .distributions(distributions)
                 .properties(asset.getProperties());

--- a/core/control-plane/control-plane-catalog/src/main/java/org/eclipse/edc/connector/controlplane/catalog/DatasetResolverImpl.java
+++ b/core/control-plane/control-plane-catalog/src/main/java/org/eclipse/edc/connector/controlplane/catalog/DatasetResolverImpl.java
@@ -79,7 +79,8 @@ public class DatasetResolverImpl implements DatasetResolver {
     private Dataset toDataset(List<ContractDefinition> contractDefinitions, Asset asset) {
 
         var distributions = distributionResolver.getDistributions(asset);
-        var datasetBuilder = asset.isCatalog() ? Catalog.Builder.newInstance() : Dataset.Builder.newInstance()
+        var datasetBuilder = asset.isCatalog() ? Catalog.Builder.newInstance() : Dataset.Builder.newInstance();
+        datasetBuilder
                 .id(asset.getId())
                 .distributions(distributions)
                 .properties(asset.getProperties());

--- a/core/control-plane/control-plane-catalog/src/main/java/org/eclipse/edc/connector/controlplane/catalog/DefaultDistributionResolver.java
+++ b/core/control-plane/control-plane-catalog/src/main/java/org/eclipse/edc/connector/controlplane/catalog/DefaultDistributionResolver.java
@@ -21,8 +21,8 @@ import org.eclipse.edc.connector.controlplane.catalog.spi.DataServiceRegistry;
 import org.eclipse.edc.connector.controlplane.catalog.spi.Distribution;
 import org.eclipse.edc.connector.controlplane.catalog.spi.DistributionResolver;
 import org.eclipse.edc.connector.controlplane.transfer.spi.flow.DataFlowManager;
-import org.eclipse.edc.dataaddress.httpdata.spi.HttpDataAddressSchema;
 
+import java.util.Base64;
 import java.util.List;
 
 public class DefaultDistributionResolver implements DistributionResolver {
@@ -41,8 +41,7 @@ public class DefaultDistributionResolver implements DistributionResolver {
             return List.of(Distribution.Builder.newInstance()
                     .format(asset.getDataAddress().getType())
                     .dataService(DataService.Builder.newInstance()
-                            .endpointDescription(asset.getDescription())
-                            .endpointUrl(asset.getDataAddress().getStringProperty(HttpDataAddressSchema.BASE_URL, null))
+                            .id(Base64.getUrlEncoder().encodeToString(asset.getId().getBytes()))
                             .build())
                     .build());
         }

--- a/core/control-plane/control-plane-catalog/src/main/java/org/eclipse/edc/connector/controlplane/catalog/DefaultDistributionResolver.java
+++ b/core/control-plane/control-plane-catalog/src/main/java/org/eclipse/edc/connector/controlplane/catalog/DefaultDistributionResolver.java
@@ -16,10 +16,12 @@
 package org.eclipse.edc.connector.controlplane.catalog;
 
 import org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset;
+import org.eclipse.edc.connector.controlplane.catalog.spi.DataService;
 import org.eclipse.edc.connector.controlplane.catalog.spi.DataServiceRegistry;
 import org.eclipse.edc.connector.controlplane.catalog.spi.Distribution;
 import org.eclipse.edc.connector.controlplane.catalog.spi.DistributionResolver;
 import org.eclipse.edc.connector.controlplane.transfer.spi.flow.DataFlowManager;
+import org.eclipse.edc.dataaddress.httpdata.spi.HttpDataAddressSchema;
 
 import java.util.List;
 
@@ -35,6 +37,15 @@ public class DefaultDistributionResolver implements DistributionResolver {
 
     @Override
     public List<Distribution> getDistributions(Asset asset) {
+        if (asset.isCatalog()) {
+            return List.of(Distribution.Builder.newInstance()
+                    .format(asset.getDataAddress().getType())
+                    .dataService(DataService.Builder.newInstance()
+                            .endpointDescription(asset.getDescription())
+                            .endpointUrl(asset.getDataAddress().getStringProperty(HttpDataAddressSchema.BASE_URL, null))
+                            .build())
+                    .build());
+        }
         return dataFlowManager.transferTypesFor(asset).stream().map(this::createDistribution).toList();
     }
 

--- a/core/control-plane/control-plane-catalog/src/test/java/org/eclipse/edc/connector/controlplane/catalog/DatasetResolverImplTest.java
+++ b/core/control-plane/control-plane-catalog/src/test/java/org/eclipse/edc/connector/controlplane/catalog/DatasetResolverImplTest.java
@@ -36,6 +36,7 @@ import org.eclipse.edc.spi.agent.ParticipantAgent;
 import org.eclipse.edc.spi.message.Range;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -232,7 +233,10 @@ class DatasetResolverImplTest {
                 .format(HttpDataAddressSchema.HTTP_DATA_TYPE).build();
 
         when(contractDefinitionResolver.definitionsFor(any())).thenReturn(Stream.of(contractDefinition));
-        when(assetIndex.queryAssets(isA(QuerySpec.class))).thenReturn(Stream.of(createAsset("assetId").property(Asset.PROPERTY_IS_CATALOG, true).build()));
+        when(assetIndex.queryAssets(isA(QuerySpec.class))).thenReturn(Stream.of(createAsset("assetId")
+                .property(Asset.PROPERTY_IS_CATALOG, true)
+                .dataAddress(DataAddress.Builder.newInstance().type(HttpDataAddressSchema.HTTP_DATA_TYPE).build())
+                .build()));
         when(policyStore.findById("contractPolicyId")).thenReturn(PolicyDefinition.Builder.newInstance().policy(contractPolicy).build());
         when(distributionResolver.getDistributions(isA(Asset.class))).thenReturn(List.of(distribution));
 

--- a/core/control-plane/control-plane-catalog/src/test/java/org/eclipse/edc/connector/controlplane/catalog/DefaultDistributionResolverTest.java
+++ b/core/control-plane/control-plane-catalog/src/test/java/org/eclipse/edc/connector/controlplane/catalog/DefaultDistributionResolverTest.java
@@ -79,8 +79,7 @@ class DefaultDistributionResolverTest {
         assertThat(distributions).hasSize(1)
                 .anySatisfy(distribution -> {
                     assertThat(distribution.getFormat()).isEqualTo("HttpData");
-                    assertThat(distribution.getDataService().getEndpointDescription()).isEqualTo(asset.getDescription());
-                    assertThat(distribution.getDataService().getEndpointUrl()).isEqualTo("http://quizzqua.zz/buzz");
+                    assertThat(distribution.getDataService().getId()).isNotNull();
                 });
     }
 }

--- a/core/control-plane/control-plane-catalog/src/test/java/org/eclipse/edc/connector/controlplane/catalog/DefaultDistributionResolverTest.java
+++ b/core/control-plane/control-plane-catalog/src/test/java/org/eclipse/edc/connector/controlplane/catalog/DefaultDistributionResolverTest.java
@@ -18,6 +18,7 @@ import org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset;
 import org.eclipse.edc.connector.controlplane.catalog.spi.DataService;
 import org.eclipse.edc.connector.controlplane.catalog.spi.DataServiceRegistry;
 import org.eclipse.edc.connector.controlplane.transfer.spi.flow.DataFlowManager;
+import org.eclipse.edc.dataaddress.httpdata.spi.HttpDataAddressSchema;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.junit.jupiter.api.Test;
 
@@ -55,6 +56,31 @@ class DefaultDistributionResolverTest {
                 .anySatisfy(distribution -> {
                     assertThat(distribution.getFormat()).isEqualTo("type2");
                     assertThat(distribution.getDataService()).isSameAs(dataService);
+                });
+    }
+
+    @Test
+    void shouldReturnDistribution_whenAssetIsCatalog() {
+        when(dataServiceRegistry.getDataServices()).thenReturn(List.of(dataService));
+        when(dataFlowManager.transferTypesFor(any())).thenReturn(Set.of("type1", "type2"));
+
+        var dataAddress = DataAddress.Builder.newInstance()
+                .type("HttpData")
+                .property(HttpDataAddressSchema.BASE_URL, "http://quizzqua.zz/buzz")
+                .build();
+        var asset = Asset.Builder.newInstance()
+                .dataAddress(dataAddress)
+                .property(Asset.PROPERTY_IS_CATALOG, true)
+                .description("test description")
+                .build();
+
+        var distributions = resolver.getDistributions(asset);
+
+        assertThat(distributions).hasSize(1)
+                .anySatisfy(distribution -> {
+                    assertThat(distribution.getFormat()).isEqualTo("HttpData");
+                    assertThat(distribution.getDataService().getEndpointDescription()).isEqualTo(asset.getDescription());
+                    assertThat(distribution.getDataService().getEndpointUrl()).isEqualTo("http://quizzqua.zz/buzz");
                 });
     }
 }

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/main/java/org/eclipse/edc/protocol/dsp/catalog/transform/from/JsonObjectFromCatalogTransformer.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/main/java/org/eclipse/edc/protocol/dsp/catalog/transform/from/JsonObjectFromCatalogTransformer.java
@@ -25,11 +25,13 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import static jakarta.json.stream.JsonCollectors.toJsonArray;
+import static java.util.Optional.ofNullable;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_CATALOG_TYPE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DATASET_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DATA_SERVICE_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DISTRIBUTION_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DSPACE_PROPERTY_PARTICIPANT_ID;
 
 /**
@@ -57,12 +59,18 @@ public class JsonObjectFromCatalogTransformer extends AbstractJsonLdTransformer<
                 .map(service -> context.transform(service, JsonObject.class))
                 .collect(toJsonArray());
 
+        var distributions = catalog.getDistributions().stream()
+                .map(distro -> context.transform(distro, JsonObject.class))
+                .collect(toJsonArray());
+
         var objectBuilder = jsonFactory.createObjectBuilder()
                 .add(ID, catalog.getId())
                 .add(TYPE, DCAT_CATALOG_TYPE)
-                .add(DSPACE_PROPERTY_PARTICIPANT_ID, participantIdMapper.toIri(catalog.getParticipantId()))
                 .add(DCAT_DATASET_ATTRIBUTE, datasets)
+                .add(DCAT_DISTRIBUTION_ATTRIBUTE, distributions)
                 .add(DCAT_DATA_SERVICE_ATTRIBUTE, dataServices);
+
+        ofNullable(catalog.getParticipantId()).ifPresent(pid -> objectBuilder.add(DSPACE_PROPERTY_PARTICIPANT_ID, participantIdMapper.toIri(pid)));
 
         transformProperties(catalog.getProperties(), objectBuilder, mapper, context);
 

--- a/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/Catalog.java
+++ b/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/Catalog.java
@@ -27,7 +27,7 @@ import java.util.List;
 @JsonDeserialize(builder = Catalog.Builder.class)
 public class Catalog extends Dataset {
     protected final List<Dataset> datasets = new ArrayList<>();
-    protected List<DataService> dataServices;
+    protected List<DataService> dataServices = new ArrayList<>();
     protected String participantId;
 
     public List<Dataset> getDatasets() {

--- a/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/Catalog.java
+++ b/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/Catalog.java
@@ -19,26 +19,16 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-
-import static java.util.UUID.randomUUID;
 
 /**
  * Entity representing a Catalog
  */
 @JsonDeserialize(builder = Catalog.Builder.class)
-public class Catalog {
-    private String id;
-    private List<Dataset> datasets = new ArrayList<>();
-    private List<DataService> dataServices;
-    private Map<String, Object> properties;
-    private String participantId;
-
-    public String getId() {
-        return id;
-    }
+public class Catalog extends Dataset {
+    protected final List<Dataset> datasets = new ArrayList<>();
+    protected List<DataService> dataServices;
+    protected String participantId;
 
     public List<Dataset> getDatasets() {
         return datasets;
@@ -48,78 +38,47 @@ public class Catalog {
         return dataServices;
     }
 
-    public Map<String, Object> getProperties() {
-        return properties;
-    }
-
     public String getParticipantId() {
         return participantId;
     }
 
     @JsonPOJOBuilder(withPrefix = "")
-    public static class Builder {
-        private final Catalog catalog;
+    public static class Builder extends Dataset.Builder<Catalog, Catalog.Builder> {
 
         private Builder() {
-            catalog = new Catalog();
+            super(new Catalog());
         }
 
         public static Builder newInstance() {
             return new Builder();
         }
 
-        public Builder id(String id) {
-            catalog.id = id;
-            return this;
-        }
-
         public Builder datasets(List<Dataset> datasets) {
-            catalog.datasets.addAll(datasets);
+            dataset.datasets.addAll(datasets);
             return this;
         }
 
         public Builder dataset(Dataset dataset) {
-            catalog.datasets.add(dataset);
+            this.dataset.datasets.add(dataset);
             return this;
         }
 
         public Builder dataServices(List<DataService> dataServices) {
-            catalog.dataServices = dataServices;
+            this.dataset.dataServices = dataServices;
             return this;
         }
 
         public Builder dataService(DataService dataService) {
-            if (catalog.dataServices == null) {
-                catalog.dataServices = new ArrayList<>();
+            if (this.dataset.dataServices == null) {
+                this.dataset.dataServices = new ArrayList<>();
             }
-            catalog.dataServices.add(dataService);
-            return this;
-        }
-
-        public Builder properties(Map<String, Object> properties) {
-            catalog.properties = properties;
-            return this;
-        }
-
-        public Builder property(String key, Object value) {
-            if (catalog.properties == null) {
-                catalog.properties = new HashMap<>();
-            }
-            catalog.properties.put(key, value);
+            this.dataset.dataServices.add(dataService);
             return this;
         }
 
         public Builder participantId(String participantId) {
-            catalog.participantId = participantId;
+            this.dataset.participantId = participantId;
             return this;
-        }
-
-        public Catalog build() {
-            if (catalog.id == null) {
-                catalog.id = randomUUID().toString();
-            }
-
-            return catalog;
         }
     }
 }

--- a/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/Dataset.java
+++ b/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/Dataset.java
@@ -43,7 +43,7 @@ public class Dataset {
     /**
      * Representations of this Dataset.
      */
-    protected List<Distribution> distributions;
+    protected List<Distribution> distributions = new ArrayList<>();
 
     /**
      * Properties for describing the Dataset.

--- a/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/Dataset.java
+++ b/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/Dataset.java
@@ -35,22 +35,20 @@ import static java.util.UUID.randomUUID;
 @JsonDeserialize(builder = Dataset.Builder.class)
 public class Dataset {
 
-    private String id;
-
     /**
      * Policies under which this Dataset is available.
      */
-    private final Map<String, Policy> offers = new HashMap<>();
-
+    protected final Map<String, Policy> offers = new HashMap<>();
+    protected String id;
     /**
      * Representations of this Dataset.
      */
-    private List<Distribution> distributions;
+    protected List<Distribution> distributions;
 
     /**
      * Properties for describing the Dataset.
      */
-    private Map<String, Object> properties = new HashMap<>();
+    protected Map<String, Object> properties = new HashMap<>();
 
     public String getId() {
         return id;
@@ -78,60 +76,65 @@ public class Dataset {
     }
 
     @JsonPOJOBuilder(withPrefix = "")
-    public static class Builder {
-        private final Dataset dataset;
+    public static class Builder<T extends Dataset, B extends Builder<T, B>> {
+        protected final T dataset;
 
-        private Builder() {
-            dataset = new Dataset();
+        protected Builder(T dataset) {
+            this.dataset = dataset;
         }
 
+        @SuppressWarnings({ "rawtypes", "unchecked" })
         @JsonCreator
         public static Builder newInstance() {
-            return new Builder();
+            return new Builder(new Dataset());
         }
 
-        public Builder id(String id) {
+        public B id(String id) {
             dataset.id = id;
-            return this;
+            return self();
         }
 
-        public Builder offer(String offerId, Policy policy) {
+        public B offer(String offerId, Policy policy) {
             dataset.offers.put(offerId, policy);
-            return this;
+            return self();
         }
 
-        public Builder distribution(Distribution distribution) {
+        public B distribution(Distribution distribution) {
             if (dataset.distributions == null) {
                 dataset.distributions = new ArrayList<>();
             }
             dataset.distributions.add(distribution);
-            return this;
+            return self();
         }
 
-        public Builder distributions(List<Distribution> distributions) {
+        public B distributions(List<Distribution> distributions) {
             if (dataset.distributions == null) {
                 dataset.distributions = new ArrayList<>();
             }
             dataset.distributions.addAll(distributions);
-            return this;
+            return self();
         }
 
-        public Builder properties(Map<String, Object> properties) {
+        public B properties(Map<String, Object> properties) {
             dataset.properties = properties;
-            return this;
+            return self();
         }
 
-        public Builder property(String key, Object value) {
+        public B property(String key, Object value) {
             dataset.properties.put(key, value);
-            return this;
+            return self();
         }
 
-        public Dataset build() {
+        public T build() {
             if (dataset.id == null) {
                 dataset.id = randomUUID().toString();
             }
 
             return dataset;
+        }
+
+        public B self() {
+            return (B) this;
         }
     }
 

--- a/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/Distribution.java
+++ b/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/Distribution.java
@@ -71,7 +71,6 @@ public class Distribution {
 
         public Distribution build() {
             Objects.requireNonNull(distribution.dataService, "DataService must not be null");
-            Objects.requireNonNull(distribution.format, "Format must not be null");
 
             return distribution;
         }


### PR DESCRIPTION
## What this PR changes/adds

implements the second part of the preparatory work for Management Domains, specifically:

- makes `Catalog` extend `Dataset`
- improves the `DatasetResolver` and `DistributionResolver` so that they can handle `CatalogAsset`s
- updates the JSON-LD transformers, so they can handle `CatalogAsset`s

## Why it does that

Management Domain feature, specifically handling distributed catalogs

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #4296

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
