### PR TITLE
refactor(test): speed up e2e tests

### DIFF
--- a/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/ClasspathReader.java
+++ b/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/ClasspathReader.java
@@ -1,0 +1,97 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.junit.extensions;
+
+import org.eclipse.edc.junit.testfixtures.TestUtils;
+import org.eclipse.edc.spi.EdcException;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.stream.Stream;
+
+/**
+ * Read the classpath entries of the gradle modules.
+ */
+public class ClasspathReader {
+
+    private static final File PROJECT_ROOT = TestUtils.findBuildRoot();
+    private static final File GRADLE_WRAPPER = new File(PROJECT_ROOT, TestUtils.GRADLE_WRAPPER);
+
+    /**
+     * Get classpath entries for the passed modules
+     *
+     * @param modules the modules.
+     * @return the classpath entries.
+     */
+    public static URL[] classpathFor(String... modules) {
+        try {
+            // Run a Gradle custom task to determine the runtime classpath of the module to run
+            var printClasspath = Arrays.stream(modules).map(it -> it + ":printClasspath");
+            var commandStream = Stream.of(GRADLE_WRAPPER.getCanonicalPath(), "-q");
+            var command = Stream.concat(commandStream, printClasspath).toArray(String[]::new);
+
+            var exec = Runtime.getRuntime().exec(command);
+
+            try (var reader = exec.inputReader()) {
+                return reader.lines().map(line -> line.split(":|\\s"))
+                        .flatMap(Arrays::stream)
+                        .filter(s -> !s.isBlank())
+                        .map(File::new)
+                        .flatMap(ClasspathReader::resolveClasspathEntry)
+                        .toArray(URL[]::new);
+            }
+
+        } catch (IOException e) {
+            throw new EdcException(e);
+        }
+    }
+
+    /**
+     * Replace Gradle subproject JAR entries with subproject build directories in classpath. This ensures modified
+     * classes are picked up without needing to rebuild dependent JARs.
+     *
+     * @param classpathFile classpath entry file.
+     * @return resolved classpath entries for the input argument.
+     */
+    private static Stream<URL> resolveClasspathEntry(File classpathFile) {
+        try {
+            if (isJar(classpathFile) && isUnderRoot(classpathFile)) {
+                var buildDir = classpathFile.getCanonicalFile().getParentFile().getParentFile();
+                return Stream.of(
+                        new File(buildDir, "/classes/java/main").toURI().toURL(),
+                        new File(buildDir, "../src/main/resources").toURI().toURL()
+                );
+            } else {
+                var sanitizedClassPathEntry = classpathFile.getCanonicalPath().replace("build/resources/main", "src/main/resources");
+                return Stream.of(new File(sanitizedClassPathEntry).toURI().toURL());
+            }
+
+        } catch (IOException e) {
+            throw new EdcException(e);
+        }
+    }
+
+    private static boolean isUnderRoot(File classPathFile) throws IOException {
+        return classPathFile.getCanonicalPath().startsWith(ClasspathReader.PROJECT_ROOT.getCanonicalPath() + File.separator);
+    }
+
+    private static boolean isJar(File classPathFile) throws IOException {
+        return classPathFile.getCanonicalPath().toLowerCase(Locale.ROOT).endsWith(".jar");
+    }
+
+}

--- a/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/EmbeddedRuntime.java
+++ b/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/EmbeddedRuntime.java
@@ -15,7 +15,6 @@
 package org.eclipse.edc.junit.extensions;
 
 import org.eclipse.edc.boot.system.runtime.BaseRuntime;
-import org.eclipse.edc.junit.testfixtures.TestUtils;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.ConsoleMonitor;
 import org.eclipse.edc.spi.monitor.Monitor;
@@ -24,22 +23,16 @@ import org.eclipse.edc.spi.system.SystemExtension;
 import org.eclipse.edc.spi.system.configuration.Config;
 import org.jetbrains.annotations.NotNull;
 
-import java.io.File;
-import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.Arrays;
 import java.util.LinkedHashMap;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Stream;
 
-import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.eclipse.edc.boot.system.ExtensionLoader.loadMonitor;
 
@@ -52,52 +45,31 @@ public class EmbeddedRuntime extends BaseRuntime {
 
     private final String name;
     private final Map<String, String> properties;
-    private final String[] additionalModules;
     private final LinkedHashMap<Class<?>, Object> serviceMocks = new LinkedHashMap<>();
     private final ExecutorService executorService = Executors.newSingleThreadExecutor();
     private final MultiSourceServiceLocator serviceLocator;
+    private final URL[] classPathEntries;
 
     public EmbeddedRuntime(String name, Map<String, String> properties, String... additionalModules) {
-        this(new MultiSourceServiceLocator(), name, properties, additionalModules);
+        this(new MultiSourceServiceLocator(), name, properties, ClasspathReader.classpathFor(additionalModules));
     }
 
-    private EmbeddedRuntime(MultiSourceServiceLocator serviceLocator, String name, Map<String, String> properties, String... additionalModules) {
+    public EmbeddedRuntime(String name, Map<String, String> properties, URL[] classpathEntries) {
+        this(new MultiSourceServiceLocator(), name, properties, classpathEntries);
+    }
+
+    private EmbeddedRuntime(MultiSourceServiceLocator serviceLocator, String name, Map<String, String> properties, URL[] classPathEntries) {
         super(serviceLocator);
         this.serviceLocator = serviceLocator;
         this.name = name;
         this.properties = properties;
-        this.additionalModules = additionalModules;
+        this.classPathEntries = classPathEntries;
     }
 
     @Override
     public void boot(boolean addShutdownHook) {
         try {
-            // Find the project root directory, moving up the directory tree
-            var root = TestUtils.findBuildRoot();
-
-            // Run a Gradle custom task to determine the runtime classpath of the module to run
-            var printClasspath = Arrays.stream(additionalModules).map(it -> it + ":printClasspath");
-            var commandStream = Stream.of(new File(root, TestUtils.GRADLE_WRAPPER).getCanonicalPath(), "-q");
-            var command = Stream.concat(commandStream, printClasspath).toArray(String[]::new);
-
-            var exec = Runtime.getRuntime().exec(command);
-            var classpathString = new String(exec.getInputStream().readAllBytes());
-            var errorOutput = new String(exec.getErrorStream().readAllBytes());
-            if (exec.waitFor() != 0) {
-                throw new EdcException(format("Failed to run gradle command: [%s]. Output: %s %s",
-                        String.join(" ", command), classpathString, errorOutput));
-            }
-
-            // Replace subproject JAR entries with subproject build directories in classpath.
-            // This ensures modified classes are picked up without needing to rebuild dependent JARs.
-            var classPathEntries = Arrays.stream(classpathString.split(":|\\s"))
-                    .filter(s -> !s.isBlank())
-                    .flatMap(p -> resolveClassPathEntry(root, p))
-                    .toArray(URL[]::new);
-
-            // Create a ClassLoader that only has the target module class path, and is not
-            // parented with the current ClassLoader.
-            var classLoader = URLClassLoader.newInstance(classPathEntries);
+            MONITOR.info("Starting runtime %s".formatted(name));
 
             // Temporarily inject system properties.
             var savedProperties = (Properties) System.getProperties().clone();
@@ -106,10 +78,10 @@ public class EmbeddedRuntime extends BaseRuntime {
             var runtimeException = new AtomicReference<Exception>();
             var latch = new CountDownLatch(1);
 
-            MONITOR.info("Starting runtime %s with additional modules: [%s]".formatted(name, String.join(",", additionalModules)));
-
             executorService.execute(() -> {
                 try {
+                    var classLoader = URLClassLoader.newInstance(classPathEntries);
+
                     Thread.currentThread().setContextClassLoader(classLoader);
 
                     super.boot(false);
@@ -172,35 +144,5 @@ public class EmbeddedRuntime extends BaseRuntime {
 
     public ServiceExtensionContext getContext() {
         return context;
-    }
-
-    /**
-     * Replace Gradle subproject JAR entries with subproject build directories in classpath. This ensures modified
-     * classes are picked up without needing to rebuild dependent JARs.
-     *
-     * @param root           project root directory.
-     * @param classPathEntry class path entry to resolve.
-     * @return resolved class path entries for the input argument.
-     */
-    private Stream<URL> resolveClassPathEntry(File root, String classPathEntry) {
-        try {
-            var f = new File(classPathEntry).getCanonicalFile();
-
-            // If class path entry is not a JAR under the root (i.e. a sub-project), do not transform it
-            var isUnderRoot = f.getCanonicalPath().startsWith(root.getCanonicalPath() + File.separator);
-            if (!classPathEntry.toLowerCase(Locale.ROOT).endsWith(".jar") || !isUnderRoot) {
-                var sanitizedClassPathEntry = classPathEntry.replace("build/resources/main", "src/main/resources");
-                return Stream.of(new File(sanitizedClassPathEntry).toURI().toURL());
-            }
-
-            // Replace JAR entry with the resolved classes and resources folder
-            var buildDir = f.getParentFile().getParentFile();
-            return Stream.of(
-                    new File(buildDir, "/classes/java/main").toURI().toURL(),
-                    new File(buildDir, "../src/main/resources").toURI().toURL()
-            );
-        } catch (IOException e) {
-            throw new EdcException(e);
-        }
     }
 }

--- a/extensions/control-plane/transfer/transfer-data-plane-signaling/build.gradle.kts
+++ b/extensions/control-plane/transfer/transfer-data-plane-signaling/build.gradle.kts
@@ -29,11 +29,4 @@ dependencies {
     testImplementation(project(":core:common:junit"))
 }
 
-edcBuild {
-    swagger {
-        apiGroup.set("control-api")
-    }
-}
-
-
 

--- a/system-tests/e2e-transfer-test/control-plane/build.gradle.kts
+++ b/system-tests/e2e-transfer-test/control-plane/build.gradle.kts
@@ -17,15 +17,22 @@ plugins {
 }
 
 dependencies {
+    implementation(project(":core:common:edr-store-core"))
     implementation(project(":core:common:token-core"))
     implementation(project(":core:control-plane:control-plane-core"))
     implementation(project(":data-protocols:dsp"))
     implementation(project(":extensions:common:http"))
-    implementation(project(":extensions:common:iam:iam-mock"))
-    implementation(project(":extensions:control-plane:api:control-plane-api"))
-    implementation(project(":extensions:control-plane:api:management-api"))
     implementation(project(":extensions:common:api:control-api-configuration"))
     implementation(project(":extensions:common:api:management-api-configuration"))
+    implementation(project(":extensions:common:iam:iam-mock"))
+
+    implementation(project(":extensions:control-plane:api:control-plane-api"))
+    implementation(project(":extensions:control-plane:api:management-api"))
+    implementation(project(":extensions:control-plane:api:management-api:edr-cache-api"))
+    implementation(project(":extensions:control-plane:callback:callback-event-dispatcher"))
+    implementation(project(":extensions:control-plane:callback:callback-http-dispatcher"))
+    implementation(project(":extensions:control-plane:edr:edr-store-receiver"))
+    implementation(project(":extensions:control-plane:transfer:transfer-data-plane-signaling"))
 
     implementation(project(":core:data-plane-selector:data-plane-selector-core"))
     implementation(project(":extensions:data-plane-selector:data-plane-selector-api"))

--- a/system-tests/e2e-transfer-test/data-plane/build.gradle.kts
+++ b/system-tests/e2e-transfer-test/data-plane/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     implementation(project(":extensions:data-plane:data-plane-kafka"))
     implementation(project(":extensions:data-plane:data-plane-http-oauth2"))
     implementation(project(":extensions:data-plane:data-plane-control-api"))
+    implementation(project(":extensions:data-plane:data-plane-public-api-v2"))
     implementation(project(":extensions:data-plane:data-plane-signaling:data-plane-signaling-api"))
 }
 

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/Runtimes.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/Runtimes.java
@@ -14,81 +14,66 @@
 
 package org.eclipse.edc.test.e2e;
 
+import org.eclipse.edc.junit.extensions.ClasspathReader;
 import org.eclipse.edc.junit.extensions.EmbeddedRuntime;
 
+import java.net.URL;
 import java.util.Map;
 
-public interface Runtimes {
+/**
+ * Runtimes for E2E transfer test.
+ * The usage of this pattern permits to initialize the classpath once for runtime in a lazy manner.
+ * Tests will be quite faster this way because classpath loading (that requires interaction with gradlew) is a pretty slow activity.
+ */
+public enum Runtimes {
 
-    interface InMemory {
+    BACKEND_SERVICE(
+            ":system-tests:e2e-transfer-test:backend-service"
+    ),
 
-        static EmbeddedRuntime controlPlane(String name, Map<String, String> configuration) {
-            return new EmbeddedRuntime(name, configuration,
-                    ":system-tests:e2e-transfer-test:control-plane",
-                    ":core:common:edr-store-core",
-                    ":extensions:control-plane:transfer:transfer-data-plane-signaling",
-                    ":extensions:control-plane:api:management-api:edr-cache-api",
-                    ":extensions:control-plane:edr:edr-store-receiver",
-                    ":extensions:data-plane:data-plane-signaling:data-plane-signaling-client",
-                    ":extensions:control-plane:callback:callback-event-dispatcher",
-                    ":extensions:control-plane:callback:callback-http-dispatcher"
-            );
-        }
+    IN_MEMORY_CONTROL_PLANE(
+            ":system-tests:e2e-transfer-test:control-plane",
+            ":extensions:data-plane:data-plane-signaling:data-plane-signaling-client"
+    ),
 
-        static EmbeddedRuntime controlPlaneEmbeddedDataPlane(String name, Map<String, String> configuration) {
-            return new EmbeddedRuntime(name, configuration,
-                    ":system-tests:e2e-transfer-test:control-plane",
-                    ":system-tests:e2e-transfer-test:data-plane",
-                    ":extensions:control-plane:transfer:transfer-data-plane-signaling",
-                    ":extensions:data-plane:data-plane-self-registration",
-                    ":extensions:data-plane:data-plane-public-api-v2"
-            );
-        }
+    IN_MEMORY_CONTROL_PLANE_EMBEDDED_DATA_PLANE(
+            ":system-tests:e2e-transfer-test:control-plane",
+            ":system-tests:e2e-transfer-test:data-plane"
+    ),
 
-        static EmbeddedRuntime dataPlane(String name, Map<String, String> configuration) {
-            return new EmbeddedRuntime(name, configuration,
-                    ":system-tests:e2e-transfer-test:data-plane",
-                    ":extensions:data-plane:data-plane-public-api-v2",
-                    ":extensions:data-plane-selector:data-plane-selector-client"
-            );
-        }
+    IN_MEMORY_DATA_PLANE(
+            ":system-tests:e2e-transfer-test:data-plane",
+            ":extensions:data-plane-selector:data-plane-selector-client"
+    ),
+
+    POSTGRES_CONTROL_PLANE(
+            ":system-tests:e2e-transfer-test:control-plane",
+            ":extensions:common:store:sql:edr-index-sql",
+            ":extensions:common:sql:sql-pool:sql-pool-apache-commons",
+            ":extensions:common:transaction:transaction-local",
+            ":extensions:control-plane:store:sql:control-plane-sql",
+            ":extensions:data-plane:data-plane-signaling:data-plane-signaling-client"
+    ),
+
+    POSTGRES_DATA_PLANE(
+            ":system-tests:e2e-transfer-test:data-plane",
+            ":extensions:data-plane:store:sql:data-plane-store-sql",
+            ":extensions:common:sql:sql-pool:sql-pool-apache-commons",
+            ":extensions:common:transaction:transaction-local",
+            ":extensions:data-plane-selector:data-plane-selector-client"
+    );
+
+    private URL[] classpathEntries;
+    private final String[] modules;
+
+    Runtimes(String... modules) {
+        this.modules = modules;
     }
 
-    interface Postgres {
-
-        static EmbeddedRuntime controlPlane(String name, Map<String, String> configuration) {
-            return new EmbeddedRuntime(name, configuration,
-                    ":system-tests:e2e-transfer-test:control-plane",
-                    ":core:common:edr-store-core",
-                    ":extensions:common:store:sql:edr-index-sql",
-                    ":extensions:common:sql:sql-pool:sql-pool-apache-commons",
-                    ":extensions:common:transaction:transaction-local",
-                    ":extensions:control-plane:transfer:transfer-data-plane-signaling",
-                    ":extensions:control-plane:api:management-api:edr-cache-api",
-                    ":extensions:control-plane:edr:edr-store-receiver",
-                    ":extensions:control-plane:store:sql:control-plane-sql",
-                    ":extensions:data-plane:data-plane-signaling:data-plane-signaling-client",
-                    ":extensions:control-plane:callback:callback-event-dispatcher",
-                    ":extensions:control-plane:callback:callback-http-dispatcher"
-            );
+    public EmbeddedRuntime create(String name, Map<String, String> configuration) {
+        if (classpathEntries == null) {
+            classpathEntries = ClasspathReader.classpathFor(modules);
         }
-
-        static EmbeddedRuntime dataPlane(String name, Map<String, String> configuration) {
-            return new EmbeddedRuntime(name, configuration,
-                    ":system-tests:e2e-transfer-test:data-plane",
-                    ":extensions:data-plane:store:sql:data-plane-store-sql",
-                    ":extensions:common:sql:sql-pool:sql-pool-apache-commons",
-                    ":extensions:common:transaction:transaction-local",
-                    ":extensions:data-plane:data-plane-public-api-v2",
-                    ":extensions:data-plane-selector:data-plane-selector-client"
-            );
-        }
-
-    }
-
-    static EmbeddedRuntime backendService(String name, Map<String, String> configuration) {
-        return new EmbeddedRuntime(name, configuration,
-                ":system-tests:e2e-transfer-test:backend-service"
-        );
+        return new EmbeddedRuntime(name, configuration, classpathEntries);
     }
 }

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferEndToEndTestBase.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferEndToEndTestBase.java
@@ -15,13 +15,16 @@
 package org.eclipse.edc.test.e2e;
 
 import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates;
 import org.eclipse.edc.junit.extensions.RuntimeExtension;
 import org.eclipse.edc.spi.security.Vault;
 
 import java.time.Duration;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 
+import static org.awaitility.Awaitility.await;
 import static org.eclipse.edc.connector.controlplane.test.system.utils.PolicyFixtures.noConstraintPolicy;
 import static org.eclipse.edc.junit.testfixtures.TestUtils.getResourceFileContentAsString;
 
@@ -54,6 +57,13 @@ public abstract class TransferEndToEndTestBase {
         var accessPolicyId = PROVIDER.createPolicyDefinition(noConstraintPolicy());
         var contractPolicyId = PROVIDER.createPolicyDefinition(contractPolicy);
         PROVIDER.createContractDefinition(assetId, UUID.randomUUID().toString(), accessPolicyId, contractPolicyId);
+    }
+
+    protected void awaitTransferToBeInState(String transferProcessId, TransferProcessStates state) {
+        await().atMost(timeout).until(
+                () -> CONSUMER.getTransferProcessState(transferProcessId),
+                it -> Objects.equals(it, state.name())
+        );
     }
 
 }


### PR DESCRIPTION
## What this PR changes/adds

Export classpath loading from `EmbeddedRuntime`

## Why it does that

Classpath loading is a time consuming operation (approx 14 seconds first time it runs, 4-5 seconds other times) as it needs to invoke gradle wrapper and the `printClasspath` task. By doing it just once for every runtime in the `e2e-transfer-test` makes tests run faster (approx 1 minute less than before)

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
