### PR TITLE
feat: Enhancing debug information for HttpDataSource transfers

### DIFF
--- a/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImplTest.java
+++ b/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImplTest.java
@@ -57,6 +57,7 @@ import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.spi.persistence.StateEntityStore.hasState;
 import static org.eclipse.edc.spi.response.ResponseStatus.ERROR_RETRY;
 import static org.eclipse.edc.spi.response.ResponseStatus.FATAL_ERROR;
+import static org.eclipse.edc.spi.result.StoreFailure.Reason.GENERAL_ERROR;
 import static org.mockito.AdditionalMatchers.aryEq;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -373,7 +374,7 @@ class DataPlaneManagerImplTest {
 
             await().untilAsserted(() -> {
                 verify(transferService).transfer(isA(DataFlowStartMessage.class));
-                verify(store, atLeastOnce()).save(argThat(it -> it.getState() == FAILED.code() && it.getErrorDetail().equals("an error")));
+                verify(store, atLeastOnce()).save(argThat(it -> it.getState() == FAILED.code() && it.getErrorDetail().equals(GENERAL_ERROR + ": an error")));
             });
         }
 

--- a/extensions/control-plane/api/control-plane-api-client/src/test/java/org/eclipse/edc/connector/controlplane/api/client/transferprocess/TransferProcessHttpClientIntegrationTest.java
+++ b/extensions/control-plane/api/control-plane-api-client/src/test/java/org/eclipse/edc/connector/controlplane/api/client/transferprocess/TransferProcessHttpClientIntegrationTest.java
@@ -125,7 +125,7 @@ public class TransferProcessHttpClientIntegrationTest {
             var transferProcess = store.findById("tp-id");
             assertThat(transferProcess).isNotNull().satisfies(process -> {
                 assertThat(process.getState()).isGreaterThanOrEqualTo(TERMINATED.code());
-                assertThat(process.getErrorDetail()).isEqualTo(GENERAL_ERROR + "error");
+                assertThat(process.getErrorDetail()).isEqualTo(GENERAL_ERROR + ": error");
             });
         });
     }

--- a/extensions/control-plane/api/control-plane-api-client/src/test/java/org/eclipse/edc/connector/controlplane/api/client/transferprocess/TransferProcessHttpClientIntegrationTest.java
+++ b/extensions/control-plane/api/control-plane-api-client/src/test/java/org/eclipse/edc/connector/controlplane/api/client/transferprocess/TransferProcessHttpClientIntegrationTest.java
@@ -56,6 +56,7 @@ import static org.assertj.core.api.InstanceOfAssertFactories.INTEGER;
 import static org.awaitility.Awaitility.await;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.COMPLETED;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.TERMINATED;
+import static org.eclipse.edc.connector.dataplane.spi.pipeline.StreamFailure.Reason.GENERAL_ERROR;
 import static org.eclipse.edc.util.io.Ports.getFreePort;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -124,7 +125,7 @@ public class TransferProcessHttpClientIntegrationTest {
             var transferProcess = store.findById("tp-id");
             assertThat(transferProcess).isNotNull().satisfies(process -> {
                 assertThat(process.getState()).isGreaterThanOrEqualTo(TERMINATED.code());
-                assertThat(process.getErrorDetail()).isEqualTo("error");
+                assertThat(process.getErrorDetail()).isEqualTo(GENERAL_ERROR + "error");
             });
         });
     }

--- a/extensions/data-plane/data-plane-public-api-v2/src/test/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlanePublicApiV2ControllerTest.java
+++ b/extensions/data-plane/data-plane-public-api-v2/src/test/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlanePublicApiV2ControllerTest.java
@@ -117,7 +117,7 @@ class DataPlanePublicApiV2ControllerTest extends RestControllerTestBase {
                 .then()
                 .statusCode(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode())
                 .contentType(JSON)
-                .body("errors[0]", is(GENERAL_ERROR + ": " +errorMsg));
+                .body("errors[0]", is(GENERAL_ERROR + ": " + errorMsg));
     }
 
     @Test

--- a/extensions/data-plane/data-plane-public-api-v2/src/test/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlanePublicApiV2ControllerTest.java
+++ b/extensions/data-plane/data-plane-public-api-v2/src/test/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlanePublicApiV2ControllerTest.java
@@ -45,6 +45,7 @@ import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.CompletableFuture.failedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.connector.dataplane.spi.pipeline.StreamFailure.Reason.GENERAL_ERROR;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.mockito.ArgumentMatchers.any;
@@ -116,7 +117,7 @@ class DataPlanePublicApiV2ControllerTest extends RestControllerTestBase {
                 .then()
                 .statusCode(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode())
                 .contentType(JSON)
-                .body("errors[0]", is(errorMsg));
+                .body("errors[0]", is(GENERAL_ERROR + ": " +errorMsg));
     }
 
     @Test

--- a/extensions/data-plane/data-plane-public-api/src/test/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlanePublicApiControllerTest.java
+++ b/extensions/data-plane/data-plane-public-api/src/test/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlanePublicApiControllerTest.java
@@ -93,7 +93,7 @@ class DataPlanePublicApiControllerTest extends RestControllerTestBase {
     @Test
     void should_returnInternalServerError_if_transferFails() {
         var token = UUID.randomUUID().toString();
-        var errorMsg = GENERAL_ERROR + ": " + UUID.randomUUID().toString();
+        var errorMsg = UUID.randomUUID().toString();
         when(dataAddressResolver.resolve(any())).thenReturn(Result.success(testDestAddress()));
         when(pipelineService.transfer(any(), any()))
                 .thenReturn(completedFuture(StreamResult.error(errorMsg)));
@@ -105,7 +105,7 @@ class DataPlanePublicApiControllerTest extends RestControllerTestBase {
                 .then()
                 .statusCode(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode())
                 .contentType(JSON)
-                .body("errors[0]", is(errorMsg));
+                .body("errors[0]", is(GENERAL_ERROR + ": " + errorMsg));
     }
 
     @Test

--- a/extensions/data-plane/data-plane-public-api/src/test/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlanePublicApiControllerTest.java
+++ b/extensions/data-plane/data-plane-public-api/src/test/java/org/eclipse/edc/connector/dataplane/api/controller/DataPlanePublicApiControllerTest.java
@@ -43,6 +43,7 @@ import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.CompletableFuture.failedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.connector.dataplane.spi.pipeline.StreamFailure.Reason.GENERAL_ERROR;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.mockito.ArgumentMatchers.any;
@@ -92,7 +93,7 @@ class DataPlanePublicApiControllerTest extends RestControllerTestBase {
     @Test
     void should_returnInternalServerError_if_transferFails() {
         var token = UUID.randomUUID().toString();
-        var errorMsg = UUID.randomUUID().toString();
+        var errorMsg = GENERAL_ERROR + ": " + UUID.randomUUID().toString();
         when(dataAddressResolver.resolve(any())).thenReturn(Result.success(testDestAddress()));
         when(pipelineService.transfer(any(), any()))
                 .thenReturn(completedFuture(StreamResult.error(errorMsg)));

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/pipeline/StreamFailure.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/pipeline/StreamFailure.java
@@ -29,6 +29,12 @@ public class StreamFailure extends Failure {
         this.reason = reason;
     }
 
+    @Override
+    public String getFailureDetail() {
+        var str = super.getFailureDetail();
+        return (str != null && !str.isEmpty()) ? (reason + ": " + str) : (reason + "");
+    }
+
     public Reason getReason() {
         return reason;
     }

--- a/spi/data-plane/data-plane-spi/src/test/java/org/eclipse/edc/connector/dataplane/spi/pipeline/StreamFailureTest.java
+++ b/spi/data-plane/data-plane-spi/src/test/java/org/eclipse/edc/connector/dataplane/spi/pipeline/StreamFailureTest.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.spi.pipeline;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.connector.dataplane.spi.pipeline.StreamFailure.Reason.NOT_FOUND;
+
+public class StreamFailureTest {
+    private final String failureMessage = "failure message";
+
+    @Test
+    void verify_with_failureDetail_message_starts_with_reason() {
+        assertThat(new StreamFailure(List.of(failureMessage), NOT_FOUND)
+                .getFailureDetail()
+                .startsWith(NOT_FOUND.toString())
+        ).isTrue();
+    }
+
+    @Test
+    void verify_with_failureDetail_message_only_contains_reason_when_message_is_empty() {
+        assertThat(new StreamFailure(Collections.emptyList(), NOT_FOUND)
+                .getFailureDetail()
+                .equals(NOT_FOUND.toString())
+        ).isTrue();
+    }
+}

--- a/spi/data-plane/data-plane-spi/src/test/java/org/eclipse/edc/connector/dataplane/spi/pipeline/StreamFailureTest.java
+++ b/spi/data-plane/data-plane-spi/src/test/java/org/eclipse/edc/connector/dataplane/spi/pipeline/StreamFailureTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.dataplane.spi.pipeline.StreamFailure.Reason.NOT_FOUND;
 
 public class StreamFailureTest {
-    private final String failureMessage = "failure message";
+    private static final String failureMessage = "failure message";
 
     @Test
     void verify_with_failureDetail_message_starts_with_reason() {

--- a/spi/data-plane/data-plane-spi/src/test/java/org/eclipse/edc/connector/dataplane/spi/pipeline/StreamFailureTest.java
+++ b/spi/data-plane/data-plane-spi/src/test/java/org/eclipse/edc/connector/dataplane/spi/pipeline/StreamFailureTest.java
@@ -23,21 +23,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.dataplane.spi.pipeline.StreamFailure.Reason.NOT_FOUND;
 
 public class StreamFailureTest {
-    private static final String failureMessage = "failure message";
+    private static final String FAILURE_MESSAGE = "failure message";
 
     @Test
     void verify_with_failureDetail_message_starts_with_reason() {
-        assertThat(new StreamFailure(List.of(failureMessage), NOT_FOUND)
-                .getFailureDetail()
-                .startsWith(NOT_FOUND.toString())
-        ).isTrue();
+        var failure = new StreamFailure(List.of(FAILURE_MESSAGE), NOT_FOUND);
+        assertThat(failure.getFailureDetail()).startsWith(NOT_FOUND.toString());
     }
 
     @Test
     void verify_with_failureDetail_message_only_contains_reason_when_message_is_empty() {
-        assertThat(new StreamFailure(Collections.emptyList(), NOT_FOUND)
-                .getFailureDetail()
-                .equals(NOT_FOUND.toString())
-        ).isTrue();
+        var failure = new StreamFailure(Collections.emptyList(), NOT_FOUND);
+        assertThat(failure.getFailureDetail()).startsWith(NOT_FOUND.toString());
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Appends the reason for the error to the message that will be sent to the user when the transfer fails

## Why it does that

To improve the user experience by returning some feedback when the `StreamResult` has no message associated with it

## Linked Issue(s)

Closes #4280