### PR TITLE
fix: adds order by timestamp 

### DIFF
--- a/core/policy-monitor/policy-monitor-core/src/test/java/org/eclipse/edc/connector/policy/monitor/manager/PolicyMonitorManagerImplTest.java
+++ b/core/policy-monitor/policy-monitor-core/src/test/java/org/eclipse/edc/connector/policy/monitor/manager/PolicyMonitorManagerImplTest.java
@@ -149,6 +149,8 @@ class PolicyMonitorManagerImplTest {
                 .state(STARTED.code())
                 .build();
         var policy = Policy.Builder.newInstance().build();
+
+        var stateTimestamp = entry.getStateTimestamp();
         when(store.nextNotLeased(anyInt(), stateIs(STARTED.code()))).thenReturn(List.of(entry)).thenReturn(emptyList());
         when(transferProcessService.findById(entry.getId()))
                 .thenReturn(TransferProcess.Builder.newInstance().state(TransferProcessStates.STARTED.code()).build());
@@ -159,7 +161,7 @@ class PolicyMonitorManagerImplTest {
 
         await().untilAsserted(() -> {
             verify(transferProcessService, never()).terminate(any());
-            verify(store).save(argThat(it -> it.getState() == STARTED.code()));
+            verify(store).save(argThat(it -> it.getState() == STARTED.code() && stateTimestamp < it.getStateTimestamp()));
         });
     }
 

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/docs/schema.sql
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/docs/schema.sql
@@ -80,3 +80,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS contract_negotiation_id_uindex
 
 CREATE UNIQUE INDEX IF NOT EXISTS contract_agreement_id_uindex
     ON edc_contract_agreement (agr_id);
+
+
+-- This will help to identify states that needs to be transition without table scan when the entries start to grow
+CREATE INDEX IF NOT EXISTS contract_negotiation_state ON edc_contract_negotiation (state,state_timestamp);

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/docs/schema.sql
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/docs/schema.sql
@@ -82,5 +82,5 @@ CREATE UNIQUE INDEX IF NOT EXISTS contract_agreement_id_uindex
     ON edc_contract_agreement (agr_id);
 
 
--- This will help to identify states that needs to be transition without table scan when the entries start to grow
+-- This will help to identify states that need to be transitioned without a table scan when the entries grow
 CREATE INDEX IF NOT EXISTS contract_negotiation_state ON edc_contract_negotiation (state,state_timestamp);

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/docs/schema.sql
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/docs/schema.sql
@@ -65,3 +65,6 @@ CREATE UNIQUE INDEX IF NOT EXISTS transfer_process_id_uindex
 
 CREATE UNIQUE INDEX IF NOT EXISTS lease_lease_id_uindex
     ON edc_lease (lease_id);
+
+-- This will help to identify states that needs to be transition without table scan when the entries start to grow
+CREATE INDEX IF NOT EXISTS transfer_process_state ON edc_transfer_process (state,state_time_stamp);

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/docs/schema.sql
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/docs/schema.sql
@@ -66,5 +66,5 @@ CREATE UNIQUE INDEX IF NOT EXISTS transfer_process_id_uindex
 CREATE UNIQUE INDEX IF NOT EXISTS lease_lease_id_uindex
     ON edc_lease (lease_id);
 
--- This will help to identify states that needs to be transition without table scan when the entries start to grow
+-- This will help to identify states that need to be transitioned without a table scan when the entries grow
 CREATE INDEX IF NOT EXISTS transfer_process_state ON edc_transfer_process (state,state_time_stamp);

--- a/extensions/data-plane/store/sql/data-plane-store-sql/docs/schema.sql
+++ b/extensions/data-plane/store/sql/data-plane-store-sql/docs/schema.sql
@@ -39,5 +39,5 @@ COMMENT ON COLUMN edc_data_plane.source IS 'DataAddress serialized as JSON';
 COMMENT ON COLUMN edc_data_plane.destination IS 'DataAddress serialized as JSON';
 COMMENT ON COLUMN edc_data_plane.properties IS 'Java Map serialized as JSON';
 
--- This will help to identify states that needs to be transition without table scan when the entries start to grow
+-- This will help to identify states that need to be transitioned without a table scan when the entries grow
 CREATE INDEX IF NOT EXISTS data_plane_state ON edc_data_plane (state,state_time_stamp);

--- a/extensions/data-plane/store/sql/data-plane-store-sql/docs/schema.sql
+++ b/extensions/data-plane/store/sql/data-plane-store-sql/docs/schema.sql
@@ -38,3 +38,6 @@ COMMENT ON COLUMN edc_data_plane.trace_context IS 'Java Map serialized as JSON';
 COMMENT ON COLUMN edc_data_plane.source IS 'DataAddress serialized as JSON';
 COMMENT ON COLUMN edc_data_plane.destination IS 'DataAddress serialized as JSON';
 COMMENT ON COLUMN edc_data_plane.properties IS 'Java Map serialized as JSON';
+
+-- This will help to identify states that needs to be transition without table scan when the entries start to grow
+CREATE INDEX IF NOT EXISTS data_plane_state ON edc_data_plane (state,state_time_stamp);

--- a/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/SqlDataPlaneStore.java
+++ b/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/SqlDataPlaneStore.java
@@ -81,7 +81,7 @@ public class SqlDataPlaneStore extends AbstractSqlStore implements DataPlaneStor
     public @NotNull List<DataFlow> nextNotLeased(int max, Criterion... criteria) {
         return transactionContext.execute(() -> {
             var filter = Arrays.stream(criteria).collect(toList());
-            var querySpec = QuerySpec.Builder.newInstance().filter(filter).limit(max).build();
+            var querySpec = QuerySpec.Builder.newInstance().filter(filter).sortField("stateTimestamp").limit(max).build();
             var statement = statements.createQuery(querySpec)
                     .addWhereClause(statements.getNotLeasedFilter(), clock.millis());
 

--- a/extensions/policy-monitor/store/sql/policy-monitor-store-sql/docs/schema.sql
+++ b/extensions/policy-monitor/store/sql/policy-monitor-store-sql/docs/schema.sql
@@ -30,3 +30,7 @@ CREATE TABLE IF NOT EXISTS edc_policy_monitor
     properties           JSON,
     contract_id          VARCHAR
 );
+
+
+-- This will help to identify states that needs to be transition without table scan when the entries start to grow
+CREATE INDEX IF NOT EXISTS policy_monitor_state ON edc_policy_monitor (state,state_time_stamp);

--- a/extensions/policy-monitor/store/sql/policy-monitor-store-sql/docs/schema.sql
+++ b/extensions/policy-monitor/store/sql/policy-monitor-store-sql/docs/schema.sql
@@ -32,5 +32,5 @@ CREATE TABLE IF NOT EXISTS edc_policy_monitor
 );
 
 
--- This will help to identify states that needs to be transition without table scan when the entries start to grow
+-- This will help to identify states that need to be transitioned without a table scan when the entries grow
 CREATE INDEX IF NOT EXISTS policy_monitor_state ON edc_policy_monitor (state,state_time_stamp);

--- a/extensions/policy-monitor/store/sql/policy-monitor-store-sql/src/main/java/org/eclipse/edc/connector/policy/monitor/store/sql/SqlPolicyMonitorStore.java
+++ b/extensions/policy-monitor/store/sql/policy-monitor-store-sql/src/main/java/org/eclipse/edc/connector/policy/monitor/store/sql/SqlPolicyMonitorStore.java
@@ -74,7 +74,7 @@ public class SqlPolicyMonitorStore extends AbstractSqlStore implements PolicyMon
     public @NotNull List<PolicyMonitorEntry> nextNotLeased(int max, Criterion... criteria) {
         return transactionContext.execute(() -> {
             var filter = Arrays.stream(criteria).collect(toList());
-            var querySpec = QuerySpec.Builder.newInstance().filter(filter).limit(max).build();
+            var querySpec = QuerySpec.Builder.newInstance().filter(filter).sortField("stateTimestamp").limit(max).build();
             var statement = statements.createQuery(querySpec)
                     .addWhereClause(statements.getNotLeasedFilter(), clock.millis());
 


### PR DESCRIPTION
## What this PR changes/adds

Adds a deterministic order by `stateTimestamp` field in `nextNotLeased` method of state machines:

- `PolicyMonitor`
- `DataPlane`
- `ContractNegotiation`
- `TransferProcess`


This will allow a consistent and fair processing order for entities based on their state.
By using an index on `state` + timestamp it will also speedup processing states that need to transition and it will also lower down the usage of the database which we constantly poll for next states to process. State machine should not poll final state or states that needs to be monitored for a long period of time.

While profiling state machine the `PolicyMonitor` was on of those which spikes the CPU usage of both connector and
database since basically it's constantly polling the database for the entries in `STARTED` state, which grows over time without transitioning. Also the `edc.policy.monitor.state-machine.iteration-wait-millis` didn't help since the state machine does not wait if at least  one entry has been process in a tick. To lower down the load to the database usage of the `PolicyMonitor` state machine the `processMonitoring` processor now return `false` if no state transition is made. In this way the `wait` configuration can be applied.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

We might think of reworking `PolicyMonitor` state machine, since it's a bit different from the other state machine and it needs constantly checking on transfer process states and policy evaluation. In the current form can be a CPU hog 

## Linked Issue(s)

Closes #4308 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
