### PR TITLE
chore: add test to presenationquery transformer

### DIFF
--- a/extensions/common/iam/identity-trust/identity-trust-transform/src/test/java/org/eclipse/edc/iam/identitytrust/transform/to/JsonObjectToPresentationQueryMessageTransformerTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-transform/src/test/java/org/eclipse/edc/iam/identitytrust/transform/to/JsonObjectToPresentationQueryMessageTransformerTest.java
@@ -78,6 +78,51 @@ class JsonObjectToPresentationQueryMessageTransformerTest {
         assertThat(query.getPresentationDefinition()).isNull();
     }
 
+
+    @Test
+    void transform_withEmptyScopes() throws JsonProcessingException {
+        var obj = """
+                {
+                  "@context": [
+                    "https://identity.foundation/presentation-exchange/submission/v1",
+                    "https://w3id.org/tractusx-trust/v0.8"
+                  ],
+                  "@type": "PresentationQueryMessage",
+                  "scope": []
+                }
+                """;
+        var json = mapper.readValue(obj, JsonObject.class);
+        var jo = jsonLd.expand(json);
+        assertThat(jo.succeeded()).withFailMessage(jo::getFailureDetail).isTrue();
+
+        var query = transformer.transform(jo.getContent(), context);
+        assertThat(query).isNotNull();
+        assertThat(query.getScopes()).isEmpty();
+        assertThat(query.getPresentationDefinition()).isNull();
+    }
+
+    @Test
+    void transform_withNullScopes() throws JsonProcessingException {
+        var obj = """
+                {
+                  "@context": [
+                    "https://identity.foundation/presentation-exchange/submission/v1",
+                    "https://w3id.org/tractusx-trust/v0.8"
+                  ],
+                  "@type": "PresentationQueryMessage"
+                }
+                """;
+        var json = mapper.readValue(obj, JsonObject.class);
+        var jo = jsonLd.expand(json);
+        assertThat(jo.succeeded()).withFailMessage(jo::getFailureDetail).isTrue();
+
+        var query = transformer.transform(jo.getContent(), context);
+        assertThat(query).isNotNull();
+        assertThat(query.getScopes()).isEmpty();
+        assertThat(query.getPresentationDefinition()).isNull();
+    }
+
+
     @Test
     void transform_withScopes_separatedByWhitespace() throws JsonProcessingException {
         var obj = """


### PR DESCRIPTION
## What this PR changes/adds

Adds two test cases to the `JsonObjectToPresentationQueryTransformer`, testing an empty array and a `null` array for the `scope` parameter

## Why it does that

test coverage


## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Contributes https://github.com/eclipse-edc/Connector/issues/4322

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
