### PR TITLE
feat: prevent using SQL modules with the NoopTransactionContext

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -45,14 +45,14 @@ maven/mavencentral/com.github.cliftonlabs/json-simple/3.0.2, Apache-2.0, approve
 maven/mavencentral/com.github.docker-java/docker-java-api/3.3.6, Apache-2.0, approved, #10346
 maven/mavencentral/com.github.docker-java/docker-java-transport-zerodep/3.3.6, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #15251
 maven/mavencentral/com.github.docker-java/docker-java-transport/3.3.6, Apache-2.0, approved, #7942
-maven/mavencentral/com.github.java-json-tools/btf/1.3, Apache-2.0 AND GPL-1.0-or-later AND LGPL-3.0-only AND Apache-2.0 AND LGPL-3.0-only, restricted, #15201
+maven/mavencentral/com.github.java-json-tools/btf/1.3, Apache-2.0 OR LGPL-3.0-only, approved, #15201
 maven/mavencentral/com.github.java-json-tools/jackson-coreutils-equivalence/1.0, LGPL-3.0 OR Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.github.java-json-tools/jackson-coreutils/2.0, Apache-2.0 OR LGPL-3.0-or-later, approved, #15186
 maven/mavencentral/com.github.java-json-tools/json-patch/1.13, Apache-2.0 OR LGPL-3.0-or-later, approved, CQ23929
-maven/mavencentral/com.github.java-json-tools/json-schema-core/1.2.14, Apache-2.0 AND LGPL-2.1-or-later AND LGPL-3.0-only AND (Apache-2.0 AND GPL-1.0-or-later AND LGPL-3.0-only) AND Apache-2.0 AND LGPL-3.0-only, restricted, #15282
-maven/mavencentral/com.github.java-json-tools/json-schema-validator/2.2.14, Apache-2.0 OR LGPL-3.0-or-later, approved, CQ20779
-maven/mavencentral/com.github.java-json-tools/msg-simple/1.2, Apache-2.0 AND LGPL-2.1-or-later AND LGPL-3.0-only AND (Apache-2.0 AND GPL-1.0-or-later AND LGPL-3.0-only) AND Apache-2.0 AND LGPL-3.0-only, restricted, #15239
-maven/mavencentral/com.github.java-json-tools/uri-template/0.10, Apache-2.0 AND LGPL-3.0-only AND (Apache-2.0 AND GPL-1.0-or-later AND LGPL-3.0-only), restricted, #15288
+maven/mavencentral/com.github.java-json-tools/json-schema-core/1.2.14, Apache-2.0 OR LGPL-3.0-or-later, approved, #15282
+maven/mavencentral/com.github.java-json-tools/json-schema-validator/2.2.14, Apache-2.0 OR LGPL-3.0-or-later, approved, #15263
+maven/mavencentral/com.github.java-json-tools/msg-simple/1.2, Apache-2.0 OR LGPL-3.0-or-later, approved, #15239
+maven/mavencentral/com.github.java-json-tools/uri-template/0.10, , approved, #15288
 maven/mavencentral/com.github.luben/zstd-jni/1.5.6-3, BSD-2-Clause, approved, clearlydefined
 maven/mavencentral/com.github.stephenc.jcip/jcip-annotations/1.0-1, Apache-2.0, approved, CQ21949
 maven/mavencentral/com.google.code.findbugs/jsr305/2.0.1, BSD-3-Clause AND CC-BY-2.5 AND LGPL-2.1+, approved, CQ13390
@@ -356,7 +356,7 @@ maven/mavencentral/org.testcontainers/jdbc/1.19.8, Apache-2.0, approved, #10348
 maven/mavencentral/org.testcontainers/junit-jupiter/1.19.8, MIT, approved, #10344
 maven/mavencentral/org.testcontainers/kafka/1.19.8, MIT, approved, #14177
 maven/mavencentral/org.testcontainers/postgresql/1.19.8, MIT, approved, #10350
-maven/mavencentral/org.testcontainers/testcontainers/1.19.8, Apache-2.0 AND MIT, approved, #10347
+maven/mavencentral/org.testcontainers/testcontainers/1.19.8, MIT, approved, #15203
 maven/mavencentral/org.testcontainers/vault/1.19.8, MIT, approved, #10852
 maven/mavencentral/org.xerial.snappy/snappy-java/1.1.10.5, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #9098
 maven/mavencentral/org.xmlresolver/xmlresolver/5.2.2, Apache-2.0, approved, clearlydefined

--- a/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/SqlCoreExtension.java
+++ b/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/SqlCoreExtension.java
@@ -15,10 +15,14 @@
 package org.eclipse.edc.sql;
 
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.transaction.spi.NoopTransactionContext;
+import org.eclipse.edc.transaction.spi.TransactionContext;
 
 import static java.lang.Integer.parseInt;
 
@@ -31,9 +35,19 @@ public class SqlCoreExtension implements ServiceExtension {
     @Setting(value = "Fetch size value used in SQL queries", defaultValue = DEFAULT_EDC_SQL_FETCH_SIZE)
     public static final String EDC_SQL_FETCH_SIZE = "edc.sql.fetch.size";
 
+    @Inject
+    private TransactionContext transactionContext;
+
     @Override
     public String name() {
         return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        if (transactionContext instanceof NoopTransactionContext) {
+            throw new EdcException("The EDC SQL implementations cannot be used with a '%s'. Please provide a TransactionContext implementation.".formatted(NoopTransactionContext.class.getName()));
+        }
     }
 
     @Provider

--- a/extensions/common/sql/sql-core/src/test/java/org/eclipse/edc/sql/SqlCoreExtensionTest.java
+++ b/extensions/common/sql/sql-core/src/test/java/org/eclipse/edc/sql/SqlCoreExtensionTest.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.sql;
+
+import org.eclipse.edc.junit.annotations.ComponentTest;
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.transaction.spi.NoopTransactionContext;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ComponentTest
+@ExtendWith(DependencyInjectionExtension.class)
+class SqlCoreExtensionTest {
+    private ServiceExtensionContext context;
+
+    @BeforeEach
+    void setup(ServiceExtensionContext context) {
+        this.context = context;
+        context.registerService(TransactionContext.class, new NoopTransactionContext());
+    }
+
+    @Test
+    void initialize(SqlCoreExtension extension) {
+        assertThatThrownBy(() -> extension.initialize(context)).isInstanceOf(EdcException.class)
+                .hasMessage("The EDC SQL implementations cannot be used with a '%s'. Please provide a TransactionContext implementation.".formatted(NoopTransactionContext.class.getName()));
+    }
+}

--- a/system-tests/e2e-transfer-test/runner/build.gradle.kts
+++ b/system-tests/e2e-transfer-test/runner/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     testImplementation(project(":spi:control-plane:transfer-spi"))
     testImplementation(project(":spi:data-plane:data-plane-spi"))
     testImplementation(project(":extensions:common:sql:sql-core"))
+    testImplementation(project(":extensions:common:transaction:transaction-local"))
 
     testImplementation(project(":spi:common:web-spi"))
     testImplementation(project(":core:common:connector-core"))

--- a/system-tests/management-api/management-api-test-runner/build.gradle.kts
+++ b/system-tests/management-api/management-api-test-runner/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     testImplementation(libs.awaitility)
     testImplementation(libs.junit.jupiter.api)
     testImplementation(testFixtures(project(":extensions:common:sql:sql-core")))
+    testImplementation(project(":extensions:common:transaction:transaction-local"))
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.testcontainers.postgres)
 }

--- a/system-tests/version-api/version-api-test-runner/build.gradle.kts
+++ b/system-tests/version-api/version-api-test-runner/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
     testImplementation(libs.awaitility)
     testImplementation(libs.junit.jupiter.api)
     testImplementation(testFixtures(project(":extensions:common:sql:sql-core")))
+    testImplementation(project(":extensions:common:transaction:transaction-local"))
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.testcontainers.postgres)
 }


### PR DESCRIPTION
## What this PR changes/adds

throws an error when the SQL modules, in particular `sql-core` is on the classpath, but no `TransactionContext` implementation (other than `NoopTransactionContext`) was provided.

## Why it does that

avoid pitfalls, where downstream projects have to explicitly add the `transaction-local` module, but there is no warning if they don't do that.
In those cases, there could be sporadic exceptions thrown by the connection pool

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
