### PR TITLE
feat: supports filtering by createdAt

### DIFF
--- a/extensions/common/store/sql/edr-index-sql/src/main/java/org/eclipse/edc/edr/store/index/sql/schema/postgres/EndpointDataReferenceEntryMapping.java
+++ b/extensions/common/store/sql/edr-index-sql/src/main/java/org/eclipse/edc/edr/store/index/sql/schema/postgres/EndpointDataReferenceEntryMapping.java
@@ -29,5 +29,6 @@ public class EndpointDataReferenceEntryMapping extends TranslationMapping {
         add("transferProcessId", statements.getTransferProcessIdColumn());
         add("providerId", statements.getProviderIdColumn());
         add("contractNegotiationId", statements.getContractNegotiationIdColumn());
+        add("createdAt", statements.getCreatedAtColumn());
     }
 }

--- a/spi/common/edr-store-spi/src/testFixtures/java/org/eclipse/edc/edr/spi/store/EndpointDataReferenceEntryIndexTestBase.java
+++ b/spi/common/edr-store-spi/src/testFixtures/java/org/eclipse/edc/edr/spi/store/EndpointDataReferenceEntryIndexTestBase.java
@@ -18,6 +18,7 @@ import org.eclipse.edc.edr.spi.TestFunctions;
 import org.eclipse.edc.edr.spi.types.EndpointDataReferenceEntry;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.query.SortOrder;
 import org.eclipse.edc.spi.result.StoreFailure;
 import org.eclipse.edc.spi.result.StoreResult;
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
+import java.util.Comparator;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -116,6 +118,20 @@ public abstract class EndpointDataReferenceEntryIndexTestBase {
 
         assertThat(results.succeeded()).isTrue();
         assertThat(results.getContent()).usingRecursiveFieldByFieldElementComparator().containsOnly(entry);
+
+    }
+
+    @Test
+    void query_withOrderBy() {
+        IntStream.range(0, 10)
+                .mapToObj(i -> TestFunctions.edrEntry("assetId" + i, "agreementId" + i, "tpId" + i, "cnId" + i))
+                .forEach(entry -> getStore().save(entry));
+
+        var results = getStore().query(QuerySpec.Builder.newInstance().sortField("createdAt").sortOrder(SortOrder.DESC).build());
+
+        assertThat(results.succeeded()).isTrue();
+        assertThat(results.getContent())
+                .isSortedAccordingTo(Comparator.comparing(EndpointDataReferenceEntry::getCreatedAt).reversed());
 
     }
 


### PR DESCRIPTION
## What this PR changes/adds

Adds support for filtering by `createdAt` property when querying the EDRs 

## Linked Issue(s)

Closes #4305 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
