### PR TITLE
feat(api): add additional scopes to the CatalogRequest

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -136,7 +136,7 @@ maven/mavencentral/io.prometheus/simpleclient_tracer_otel/0.16.0, Apache-2.0, ap
 maven/mavencentral/io.prometheus/simpleclient_tracer_otel_agent/0.16.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.rest-assured/json-path/5.5.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.rest-assured/rest-assured-common/5.5.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.rest-assured/rest-assured/5.5.0, Apache-2.0, restricted, clearlydefined
+maven/mavencentral/io.rest-assured/rest-assured/5.5.0, Apache-2.0, approved, #15676
 maven/mavencentral/io.rest-assured/xml-path/5.5.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.setl/rdf-urdna/1.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.22, Apache-2.0, approved, #5947

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -108,9 +108,9 @@ maven/mavencentral/io.cloudevents/cloudevents-core/4.0.1, Apache-2.0, approved, 
 maven/mavencentral/io.cloudevents/cloudevents-http-basic/4.0.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.github.classgraph/classgraph/4.8.154, MIT, approved, CQ22530
 maven/mavencentral/io.github.classgraph/classgraph/4.8.165, MIT, approved, CQ22530
-maven/mavencentral/io.micrometer/micrometer-commons/1.13.1, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #14826
-maven/mavencentral/io.micrometer/micrometer-core/1.13.1, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #14827
-maven/mavencentral/io.micrometer/micrometer-observation/1.13.1, Apache-2.0, approved, #14829
+maven/mavencentral/io.micrometer/micrometer-commons/1.13.2, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #14826
+maven/mavencentral/io.micrometer/micrometer-core/1.13.2, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #14827
+maven/mavencentral/io.micrometer/micrometer-observation/1.13.2, Apache-2.0, approved, #14829
 maven/mavencentral/io.netty/netty-buffer/4.1.86.Final, Apache-2.0, approved, CQ21842
 maven/mavencentral/io.netty/netty-codec-http/4.1.86.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-codec-http2/4.1.86.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
@@ -188,6 +188,7 @@ maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.15, Apache-2.0, approved,
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.1, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.15, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.16, Apache-2.0 AND BSD-3-Clause, approved, #7163
+maven/mavencentral/net.bytebuddy/byte-buddy/1.14.18, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.java.dev.jna/jna/5.13.0, Apache-2.0 AND LGPL-2.1-or-later, approved, #15196
 maven/mavencentral/net.javacrumbs.json-unit/json-unit-core/2.36.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/net.minidev/accessors-smart/2.4.7, Apache-2.0, approved, #7515
@@ -228,6 +229,7 @@ maven/mavencentral/org.apache.velocity/velocity-engine-scripting/2.3, Apache-2.0
 maven/mavencentral/org.apache.xbean/xbean-reflect/3.7, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.assertj/assertj-core/3.26.0, Apache-2.0, approved, #14886
+maven/mavencentral/org.assertj/assertj-core/3.26.3, Apache-2.0, approved, #14886
 maven/mavencentral/org.awaitility/awaitility/4.2.1, Apache-2.0, approved, #14178
 maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.72, MIT, approved, #3789
 maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.78.1, MIT, approved, #14434

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/catalog/CatalogServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/catalog/CatalogServiceImpl.java
@@ -33,12 +33,13 @@ public class CatalogServiceImpl implements CatalogService {
     }
 
     @Override
-    public CompletableFuture<StatusResult<byte[]>> requestCatalog(String counterPartyId, String counterPartyAddress, String protocol, QuerySpec querySpec) {
+    public CompletableFuture<StatusResult<byte[]>> requestCatalog(String counterPartyId, String counterPartyAddress, String protocol, QuerySpec querySpec, String... additionalScopes) {
         var request = CatalogRequestMessage.Builder.newInstance()
                 .protocol(protocol)
                 .counterPartyId(counterPartyId)
                 .counterPartyAddress(counterPartyAddress)
                 .querySpec(querySpec)
+                .additionalScopes(additionalScopes)
                 .build();
 
         return dispatcher.dispatch(byte[].class, request);

--- a/data-protocols/dsp/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/http/dispatcher/DspHttpRemoteMessageDispatcherImpl.java
+++ b/data-protocols/dsp/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/http/dispatcher/DspHttpRemoteMessageDispatcherImpl.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.protocol.dsp.http.dispatcher;
 
 import okhttp3.Response;
 import okhttp3.ResponseBody;
+import org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequestMessage;
 import org.eclipse.edc.http.spi.EdcHttpClient;
 import org.eclipse.edc.policy.engine.spi.PolicyContextImpl;
 import org.eclipse.edc.policy.engine.spi.PolicyEngine;
@@ -107,6 +108,11 @@ public class DspHttpRemoteMessageDispatcherImpl implements DspHttpRemoteMessageD
                     .build();
             var policyProvider = (Function<M, Policy>) policyScope.policyProvider;
             policyEngine.evaluate(policyScope.scope, policyProvider.apply(message), context);
+
+            // catalog request messages can carry additional, user-supplied scopes
+            if (message instanceof CatalogRequestMessage catalogRequestMessage) {
+                catalogRequestMessage.getAdditionalScopes().forEach(requestScopeBuilder::scope);
+            }
 
             var scopes = requestScopeBuilder.build().getScopes();
 

--- a/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
+++ b/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
@@ -8,7 +8,7 @@
   {
     "version": "3.1.0-alpha",
     "urlPath": "/v3.1alpha",
-    "lastUpdated": "2024-07-09T09:17:00Z",
+    "lastUpdated": "2024-07-10T09:17:00Z",
     "maturity": "alpha"
   }
 ]

--- a/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/catalog/BaseCatalogApiController.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/catalog/BaseCatalogApiController.java
@@ -50,7 +50,8 @@ public abstract class BaseCatalogApiController {
         var request = transformerRegistry.transform(requestBody, CatalogRequest.class)
                 .orElseThrow(InvalidRequestException::new);
 
-        service.requestCatalog(request.getCounterPartyId(), request.getCounterPartyAddress(), request.getProtocol(), request.getQuerySpec())
+        var scopes = request.getAdditionalScopes().toArray(new String[0]);
+        service.requestCatalog(request.getCounterPartyId(), request.getCounterPartyAddress(), request.getProtocol(), request.getQuerySpec(), scopes)
                 .whenComplete((result, throwable) -> {
                     try {
                         response.resume(toResponse(result, throwable));

--- a/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/catalog/CatalogApiExtension.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/catalog/CatalogApiExtension.java
@@ -18,6 +18,7 @@ import org.eclipse.edc.connector.controlplane.api.management.catalog.transform.J
 import org.eclipse.edc.connector.controlplane.api.management.catalog.transform.JsonObjectToDatasetRequestTransformer;
 import org.eclipse.edc.connector.controlplane.api.management.catalog.v2.CatalogApiV2Controller;
 import org.eclipse.edc.connector.controlplane.api.management.catalog.v3.CatalogApiV3Controller;
+import org.eclipse.edc.connector.controlplane.api.management.catalog.v31alpha.CatalogApiV31AlphaController;
 import org.eclipse.edc.connector.controlplane.api.management.catalog.validation.CatalogRequestValidator;
 import org.eclipse.edc.connector.controlplane.api.management.catalog.validation.DatasetRequestValidator;
 import org.eclipse.edc.connector.controlplane.services.spi.catalog.CatalogService;
@@ -67,6 +68,7 @@ public class CatalogApiExtension implements ServiceExtension {
         var managementApiTransformerRegistry = transformerRegistry.forContext("management-api");
         webService.registerResource(ApiContext.MANAGEMENT, new CatalogApiV2Controller(service, managementApiTransformerRegistry, validatorRegistry, context.getMonitor()));
         webService.registerResource(ApiContext.MANAGEMENT, new CatalogApiV3Controller(service, managementApiTransformerRegistry, validatorRegistry));
+        webService.registerResource(ApiContext.MANAGEMENT, new CatalogApiV31AlphaController(service, managementApiTransformerRegistry, validatorRegistry));
 
         validatorRegistry.register(CATALOG_REQUEST_TYPE, CatalogRequestValidator.instance(criterionOperatorRegistry));
         validatorRegistry.register(DATASET_REQUEST_TYPE, DatasetRequestValidator.instance());

--- a/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/catalog/v31alpha/CatalogApiV31AlphaController.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/catalog/v31alpha/CatalogApiV31AlphaController.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.api.management.catalog.v31alpha;
+
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.container.AsyncResponse;
+import jakarta.ws.rs.container.Suspended;
+import org.eclipse.edc.connector.controlplane.api.management.catalog.BaseCatalogApiController;
+import org.eclipse.edc.connector.controlplane.services.spi.catalog.CatalogService;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
+@Path("/v3.1alpha/catalog")
+public class CatalogApiV31AlphaController extends BaseCatalogApiController implements CatalogApiV31alpha {
+    public CatalogApiV31AlphaController(CatalogService service, TypeTransformerRegistry transformerRegistry, JsonObjectValidatorRegistry validatorRegistry) {
+        super(service, transformerRegistry, validatorRegistry);
+    }
+
+    @POST
+    @Path("/request")
+    @Override
+    public void requestCatalogV31alpha(JsonObject request, @Suspended AsyncResponse response) {
+        requestCatalog(request, response);
+    }
+
+    @POST
+    @Path("dataset/request")
+    @Override
+    public void getDatasetV31alpha(JsonObject request, @Suspended AsyncResponse response) {
+        getDataset(request, response);
+    }
+}

--- a/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/catalog/v31alpha/CatalogApiV31alpha.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/catalog/v31alpha/CatalogApiV31alpha.java
@@ -1,0 +1,252 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.api.management.catalog.v31alpha;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.container.AsyncResponse;
+import jakarta.ws.rs.container.Suspended;
+import org.eclipse.edc.api.model.ApiCoreSchema;
+
+import java.util.List;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+import static org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequest.CATALOG_REQUEST_TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+
+@OpenAPIDefinition(info = @Info(version = "v3"))
+@Tag(name = "Catalog V3")
+public interface CatalogApiV31alpha {
+
+    @Operation(
+            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = CatalogRequestSchema.class))),
+            responses = { @ApiResponse(
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CatalogSchema.class)
+                    ),
+                    description = "Gets contract offers (=catalog) of a single connector") }
+    )
+    void requestCatalogV31alpha(JsonObject request, @Suspended AsyncResponse response);
+
+    @Operation(
+            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = DatasetRequestSchema.class))),
+            responses = { @ApiResponse(
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = DatasetSchema.class)
+                    ),
+                    description = "Gets single dataset from a connector") }
+    )
+    void getDatasetV31alpha(JsonObject request, @Suspended AsyncResponse response);
+
+    @Schema(name = "CatalogRequest", example = CatalogRequestSchema.CATALOG_REQUEST_EXAMPLE)
+    record CatalogRequestSchema(
+            @Schema(name = CONTEXT, requiredMode = REQUIRED)
+            Object context,
+            @Schema(name = TYPE, example = CATALOG_REQUEST_TYPE)
+            String type,
+            @Schema(requiredMode = REQUIRED)
+            String counterPartyAddress,
+            // Switch to required in the next API iteration
+            @Schema(requiredMode = NOT_REQUIRED)
+            String counterPartyId,
+            @Schema(requiredMode = REQUIRED)
+            String protocol,
+            @Schema(requiredMode = NOT_REQUIRED)
+            List<String> additionalScopes,
+            ApiCoreSchema.QuerySpecSchema querySpec) {
+
+        public static final String CATALOG_REQUEST_EXAMPLE = """
+                {
+                    "@context": { "@vocab": "https://w3id.org/edc/v0.0.1/ns/" },
+                    "@type": "CatalogRequest",
+                    "counterPartyAddress": "http://provider-address",
+                    "counterPartyId": "providerId",
+                    "protocol": "dataspace-protocol-http",
+                    "additionalScopes": [ "org.eclipse.edc.vc.type:SomeCredential:read", "org.eclipse.edc.vc.type:AnotherCredential:write" ],
+                    "querySpec": {
+                        "offset": 0,
+                        "limit": 50,
+                        "sortOrder": "DESC",
+                        "sortField": "fieldName",
+                        "filterExpression": []
+                    }
+                }
+                """;
+    }
+
+    @Schema(name = "DatasetRequest", example = DatasetRequestSchema.DATASET_REQUEST_EXAMPLE)
+    record DatasetRequestSchema(
+            @Schema(name = TYPE, example = CATALOG_REQUEST_TYPE)
+            String type,
+            String counterPartyAddress,
+            String counterPartyId,
+            String protocol,
+            ApiCoreSchema.QuerySpecSchema querySpec) {
+
+        public static final String DATASET_REQUEST_EXAMPLE = """
+                {
+                    "@context": { "@vocab": "https://w3id.org/edc/v0.0.1/ns/" },
+                    "@type": "DatasetRequest",
+                    "@id": "dataset-id",
+                    "counterPartyAddress": "http://counter-party-address",
+                    "counterPartyId": "counter-party-id",
+                    "protocol": "dataspace-protocol-http"
+                }
+                """;
+    }
+
+    @Schema(name = "Catalog", description = "DCAT catalog", example = CatalogSchema.CATALOG_EXAMPLE)
+    record CatalogSchema(
+    ) {
+        public static final String CATALOG_EXAMPLE = """
+                {
+                    "@id": "7df65569-8c59-4013-b1c0-fa14f6641bf2",
+                    "@type": "dcat:Catalog",
+                    "dcat:dataset": {
+                        "@id": "bcca61be-e82e-4da6-bfec-9716a56cef35",
+                        "@type": "dcat:Dataset",
+                        "odrl:hasPolicy": {
+                            "@id": "OGU0ZTMzMGMtODQ2ZS00ZWMxLThmOGQtNWQxNWM0NmI2NmY4:YmNjYTYxYmUtZTgyZS00ZGE2LWJmZWMtOTcxNmE1NmNlZjM1:NDY2ZTZhMmEtNjQ1Yy00ZGQ0LWFlZDktMjdjNGJkZTU4MDNj",
+                            "@type": "odrl:Set",
+                            "odrl:permission": {
+                                "odrl:target": "bcca61be-e82e-4da6-bfec-9716a56cef35",
+                                "odrl:action": {
+                                    "odrl:type": "http://www.w3.org/ns/odrl/2/use"
+                                },
+                                "odrl:constraint": {
+                                    "odrl:and": [
+                                        {
+                                            "odrl:leftOperand": "https://w3id.org/edc/v0.0.1/ns/inForceDate",
+                                            "odrl:operator": {
+                                                "@id": "odrl:gteq"
+                                            },
+                                            "odrl:rightOperand": "2023-07-07T07:19:58.585601395Z"
+                                        },
+                                        {
+                                            "odrl:leftOperand": "https://w3id.org/edc/v0.0.1/ns/inForceDate",
+                                            "odrl:operator": {
+                                                "@id": "odrl:lteq"
+                                            },
+                                            "odrl:rightOperand": "2023-07-12T07:19:58.585601395Z"
+                                        }
+                                    ]
+                                }
+                            },
+                            "odrl:prohibition": [],
+                            "odrl:obligation": []
+                        },
+                        "dcat:distribution": [
+                            {
+                                "@type": "dcat:Distribution",
+                                "dct:format": {
+                                    "@id": "HttpData"
+                                },
+                                "dcat:accessService": "5e839777-d93e-4785-8972-1005f51cf367"
+                            }
+                        ],
+                        "description": "description",
+                        "id": "bcca61be-e82e-4da6-bfec-9716a56cef35"
+                    },
+                    "dcat:service": {
+                        "@id": "5e839777-d93e-4785-8972-1005f51cf367",
+                        "@type": "dcat:DataService",
+                        "dct:terms": "connector",
+                        "dct:endpointUrl": "http://localhost:16806/protocol"
+                    },
+                    "dspace:participantId": "urn:connector:provider",
+                    "@context": {
+                        "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
+                        "dct": "http://purl.org/dc/terms/",
+                        "edc": "https://w3id.org/edc/v0.0.1/ns/",
+                        "dcat": "http://www.w3.org/ns/dcat#",
+                        "odrl": "http://www.w3.org/ns/odrl/2/",
+                        "dspace": "https://w3id.org/dspace/v0.8/"
+                    }
+                }
+                """;
+    }
+
+    @Schema(name = "Dataset", description = "DCAT dataset", example = DatasetSchema.DATASET_EXAMPLE)
+    record DatasetSchema(
+    ) {
+        public static final String DATASET_EXAMPLE = """
+                {
+                    "@id": "bcca61be-e82e-4da6-bfec-9716a56cef35",
+                    "@type": "dcat:Dataset",
+                    "odrl:hasPolicy": {
+                        "@id": "OGU0ZTMzMGMtODQ2ZS00ZWMxLThmOGQtNWQxNWM0NmI2NmY4:YmNjYTYxYmUtZTgyZS00ZGE2LWJmZWMtOTcxNmE1NmNlZjM1:NDY2ZTZhMmEtNjQ1Yy00ZGQ0LWFlZDktMjdjNGJkZTU4MDNj",
+                        "@type": "odrl:Set",
+                        "odrl:permission": {
+                            "odrl:target": "bcca61be-e82e-4da6-bfec-9716a56cef35",
+                            "odrl:action": {
+                                "odrl:type": "http://www.w3.org/ns/odrl/2/use"
+                            },
+                            "odrl:constraint": {
+                                "odrl:and": [
+                                    {
+                                        "odrl:leftOperand": "https://w3id.org/edc/v0.0.1/ns/inForceDate",
+                                        "odrl:operator": {
+                                            "@id": "odrl:gteq"
+                                        },
+                                        "odrl:rightOperand": "2023-07-07T07:19:58.585601395Z"
+                                    },
+                                    {
+                                        "odrl:leftOperand": "https://w3id.org/edc/v0.0.1/ns/inForceDate",
+                                        "odrl:operator": {
+                                            "@id": "odrl:lteq"
+                                        },
+                                        "odrl:rightOperand": "2023-07-12T07:19:58.585601395Z"
+                                    }
+                                ]
+                            }
+                        },
+                        "odrl:prohibition": [],
+                        "odrl:obligation": [],
+                        "odrl:target": "bcca61be-e82e-4da6-bfec-9716a56cef35"
+                    },
+                    "dcat:distribution": [
+                        {
+                            "@type": "dcat:Distribution",
+                            "dct:format": {
+                                "@id": "HttpData"
+                            },
+                            "dcat:accessService": "5e839777-d93e-4785-8972-1005f51cf367"
+                        }
+                    ],
+                    "description": "description",
+                    "id": "bcca61be-e82e-4da6-bfec-9716a56cef35",
+                    "@context": {
+                        "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
+                        "dct": "http://purl.org/dc/terms/",
+                        "edc": "https://w3id.org/edc/v0.0.1/ns/",
+                        "dcat": "http://www.w3.org/ns/dcat#",
+                        "odrl": "http://www.w3.org/ns/odrl/2/",
+                        "dspace": "https://w3id.org/dspace/v0.8/"
+                    }
+                }
+                """;
+    }
+}

--- a/extensions/control-plane/api/management-api/catalog-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/catalog/CatalogApiExtensionTest.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/catalog/CatalogApiExtensionTest.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.controlplane.api.management.catalog;
 
 import org.eclipse.edc.connector.controlplane.api.management.catalog.v2.CatalogApiV2Controller;
 import org.eclipse.edc.connector.controlplane.api.management.catalog.v3.CatalogApiV3Controller;
+import org.eclipse.edc.connector.controlplane.api.management.catalog.v31alpha.CatalogApiV31AlphaController;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
@@ -58,5 +59,6 @@ class CatalogApiExtensionTest {
 
         verify(webService).registerResource(any(), isA(CatalogApiV2Controller.class));
         verify(webService).registerResource(any(), isA(CatalogApiV3Controller.class));
+        verify(webService).registerResource(any(), isA(CatalogApiV31AlphaController.class));
     }
 }

--- a/extensions/control-plane/api/management-api/catalog-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/catalog/v31alpha/CatalogApiV31AlphaControllerTest.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/catalog/v31alpha/CatalogApiV31AlphaControllerTest.java
@@ -1,0 +1,76 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.api.management.catalog.v31alpha;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.controlplane.api.management.catalog.BaseCatalogApiControllerTest;
+import org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequest;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.validator.spi.ValidationResult;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CatalogApiV31AlphaControllerTest extends BaseCatalogApiControllerTest {
+
+    @Test
+    void requestCatalog_withAdditionalScopes() {
+        var request = CatalogRequest.Builder.newInstance().counterPartyAddress("http://url").build();
+        when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
+        when(transformerRegistry.transform(argThat(o -> o instanceof JsonObject jo && jo.containsKey(CatalogRequest.CATALOG_REQUEST_ADDITIONAL_SCOPES)), eq(CatalogRequest.class))).thenReturn(Result.success(request));
+        when(service.requestCatalog(any(), any(), any(), any())).thenReturn(completedFuture(StatusResult.success("{}".getBytes())));
+        var requestBody = Json.createObjectBuilder()
+                .add(CatalogRequest.CATALOG_REQUEST_PROTOCOL, "any")
+                .add(CatalogRequest.CATALOG_REQUEST_ADDITIONAL_SCOPES, Json.createArrayBuilder(List.of("scope1", "scope2")).build())
+                .build();
+
+        given()
+                .port(port)
+                .contentType(JSON)
+                .body(requestBody)
+                .post(baseUrl() + "/request")
+                .then()
+                .statusCode(200)
+                .contentType(JSON);
+        var captor = ArgumentCaptor.forClass(JsonObject.class);
+        verify(transformerRegistry).transform(captor.capture(), eq(CatalogRequest.class));
+
+        var jo = captor.getValue();
+        assertThat(jo).containsKey(CatalogRequest.CATALOG_REQUEST_ADDITIONAL_SCOPES);
+    }
+
+    @Override
+    protected String baseUrl() {
+        return "/v3.1alpha/catalog";
+    }
+
+    @Override
+    protected Object controller() {
+        return new CatalogApiV31AlphaController(service, transformerRegistry, validatorRegistry);
+    }
+}

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/iam/RequestScope.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/iam/RequestScope.java
@@ -24,11 +24,10 @@ import java.util.Set;
  */
 public class RequestScope {
 
-    private RequestScope() {
-    }
-
     private Set<String> scopes = new HashSet<>();
 
+    private RequestScope() {
+    }
 
     public Set<String> getScopes() {
         return scopes;

--- a/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/CatalogRequest.java
+++ b/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/CatalogRequest.java
@@ -36,6 +36,7 @@ public class CatalogRequest {
     private String counterPartyAddress;
     private String counterPartyId;
     private String protocol;
+
     private CatalogRequest() {
     }
 

--- a/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/CatalogRequest.java
+++ b/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/CatalogRequest.java
@@ -18,6 +18,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.eclipse.edc.spi.query.QuerySpec;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 
 public class CatalogRequest {
@@ -27,13 +30,17 @@ public class CatalogRequest {
     public static final String CATALOG_REQUEST_COUNTER_PARTY_ADDRESS = EDC_NAMESPACE + "counterPartyAddress";
     public static final String CATALOG_REQUEST_COUNTER_PARTY_ID = EDC_NAMESPACE + "counterPartyId";
     public static final String CATALOG_REQUEST_QUERY_SPEC = EDC_NAMESPACE + "querySpec";
-
+    public static final String CATALOG_REQUEST_ADDITIONAL_SCOPES = EDC_NAMESPACE + "additionalScopes";
+    private List<String> additionalScopes = new ArrayList<>();
     private QuerySpec querySpec;
     private String counterPartyAddress;
     private String counterPartyId;
     private String protocol;
-
     private CatalogRequest() {
+    }
+
+    public List<String> getAdditionalScopes() {
+        return additionalScopes;
     }
 
     public String getCounterPartyAddress() {
@@ -82,6 +89,16 @@ public class CatalogRequest {
 
         public Builder protocol(String protocol) {
             instance.protocol = protocol;
+            return this;
+        }
+
+        public Builder additionalScopes(List<String> additionalScopes) {
+            instance.additionalScopes = additionalScopes;
+            return this;
+        }
+
+        public Builder additionalScope(String additionalScope) {
+            instance.additionalScopes.add(additionalScope);
             return this;
         }
 

--- a/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/CatalogRequestMessage.java
+++ b/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/CatalogRequestMessage.java
@@ -21,6 +21,9 @@ import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -30,6 +33,7 @@ import java.util.Objects;
 public class CatalogRequestMessage implements RemoteMessage {
 
     private final Policy policy;
+    private List<String> additionalScopes = new ArrayList<>();
     private String protocol = "unknown";
     private String counterPartyAddress;
     private String counterPartyId;
@@ -77,6 +81,10 @@ public class CatalogRequestMessage implements RemoteMessage {
         return policy;
     }
 
+    public List<String> getAdditionalScopes() {
+        return additionalScopes;
+    }
+
     public static class Builder {
         private final CatalogRequestMessage message;
 
@@ -106,6 +114,11 @@ public class CatalogRequestMessage implements RemoteMessage {
 
         public CatalogRequestMessage.Builder querySpec(QuerySpec querySpec) {
             this.message.querySpec = querySpec;
+            return this;
+        }
+
+        public CatalogRequestMessage.Builder additionalScopes(String... additionalScopes) {
+            this.message.additionalScopes = Arrays.asList(additionalScopes);
             return this;
         }
 

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/controlplane/services/spi/catalog/CatalogService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/controlplane/services/spi/catalog/CatalogService.java
@@ -27,9 +27,10 @@ public interface CatalogService {
      * @param counterPartyAddress the url of the provider.
      * @param protocol            the protocol id string.
      * @param querySpec           the {@link QuerySpec} object.
+     * @param additionalScopes    optional list of additional scope values that are intended for use with the IAM subsystem
      * @return the provider's catalog
      */
-    CompletableFuture<StatusResult<byte[]>> requestCatalog(String counterPartyId, String counterPartyAddress, String protocol, QuerySpec querySpec);
+    CompletableFuture<StatusResult<byte[]>> requestCatalog(String counterPartyId, String counterPartyAddress, String protocol, QuerySpec querySpec, String... additionalScopes);
 
     /**
      * Return the dataset


### PR DESCRIPTION
## What this PR changes/adds

adds an optional list `additionalScopes` to the `CatalogRequest` (CatalogApi DTO) and the `CatalogRequestMessage` (DSP message).
These additional scopes can be used by certain implementations of the `IdentityService` to enrich the generated token.

For example, in DCP we can use this to attach additional scope strings to the `access_token`, effectively giving permissions to request more credentials from the CredentialService.

## Why it does that

being able to request additional VerifiableCredentials from the wallet

## Further notes

- Since this is an alpha feature, it will be made available under the `/v3.1alpha` context url path
- the `instanceof` check in the `DspHttpRemoteMessageDispatcherImpl` might not be the most elegant solution, but it is the least impactful, and considering that we don't really foresee additionalScopes for any other DSP message, it seemed good enough.

## Linked Issue(s)

Closes #4322

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
