### PR TITLE
feat: add state field on DataPlaneInstance response

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -136,7 +136,7 @@ maven/mavencentral/io.prometheus/simpleclient_tracer_otel/0.16.0, Apache-2.0, ap
 maven/mavencentral/io.prometheus/simpleclient_tracer_otel_agent/0.16.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.rest-assured/json-path/5.5.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.rest-assured/rest-assured-common/5.5.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.rest-assured/rest-assured/5.5.0, Apache-2.0, restricted, clearlydefined
+maven/mavencentral/io.rest-assured/rest-assured/5.5.0, Apache-2.0, approved, #15676
 maven/mavencentral/io.rest-assured/xml-path/5.5.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.setl/rdf-urdna/1.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.22, Apache-2.0, approved, #5947
@@ -188,6 +188,7 @@ maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.15, Apache-2.0, approved,
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.1, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.15, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.16, Apache-2.0 AND BSD-3-Clause, approved, #7163
+maven/mavencentral/net.bytebuddy/byte-buddy/1.14.18, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.java.dev.jna/jna/5.13.0, Apache-2.0 AND LGPL-2.1-or-later, approved, #15196
 maven/mavencentral/net.javacrumbs.json-unit/json-unit-core/2.36.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/net.minidev/accessors-smart/2.4.7, Apache-2.0, approved, #7515
@@ -228,6 +229,7 @@ maven/mavencentral/org.apache.velocity/velocity-engine-scripting/2.3, Apache-2.0
 maven/mavencentral/org.apache.xbean/xbean-reflect/3.7, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.assertj/assertj-core/3.26.0, Apache-2.0, approved, #14886
+maven/mavencentral/org.assertj/assertj-core/3.26.3, Apache-2.0, approved, #14886
 maven/mavencentral/org.awaitility/awaitility/4.2.1, Apache-2.0, approved, #14178
 maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.72, MIT, approved, #3789
 maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.78.1, MIT, approved, #14434

--- a/core/common/lib/transform-lib/src/main/java/org/eclipse/edc/transform/transformer/edc/from/JsonObjectFromDataPlaneInstanceTransformer.java
+++ b/core/common/lib/transform-lib/src/main/java/org/eclipse/edc/transform/transformer/edc/from/JsonObjectFromDataPlaneInstanceTransformer.java
@@ -18,14 +18,19 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
+import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstanceStates;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Optional;
+
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_DEST_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_SOURCE_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_TRANSFER_TYPES;
+import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.DATAPLANE_INSTANCE_STATE;
+import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.DATAPLANE_INSTANCE_STATE_TIMESTAMP;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.LAST_ACTIVE;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.PROPERTIES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.TURN_COUNT;
@@ -68,6 +73,13 @@ public class JsonObjectFromDataPlaneInstanceTransformer extends AbstractJsonLdTr
         var transferTypesBldr = jsonFactory.createArrayBuilder(dataPlaneInstance.getAllowedTransferTypes());
         builder.add(ALLOWED_TRANSFER_TYPES, transferTypesBldr);
 
+        var state = Optional.ofNullable(DataPlaneInstanceStates.from(dataPlaneInstance.getState()))
+                .map(Enum::name)
+                .orElse(null);
+
+        addIfNotNull(state, DATAPLANE_INSTANCE_STATE, builder);
+
+        builder.add(DATAPLANE_INSTANCE_STATE_TIMESTAMP, dataPlaneInstance.getStateTimestamp());
 
         return builder.build();
     }

--- a/core/common/lib/transform-lib/src/main/java/org/eclipse/edc/transform/transformer/edc/to/JsonObjectToDataPlaneInstanceTransformer.java
+++ b/core/common/lib/transform-lib/src/main/java/org/eclipse/edc/transform/transformer/edc/to/JsonObjectToDataPlaneInstanceTransformer.java
@@ -34,6 +34,7 @@ import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlan
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_SOURCE_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_TRANSFER_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.Builder;
+import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.DATAPLANE_INSTANCE_STATE_TIMESTAMP;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.LAST_ACTIVE;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.PROPERTIES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.TURN_COUNT;
@@ -76,6 +77,7 @@ public class JsonObjectToDataPlaneInstanceTransformer extends AbstractJsonLdTran
                 var set = jsonValue.asJsonArray().stream().map(jv -> transformString(jv, context)).collect(Collectors.toSet());
                 builder.allowedTransferType(set);
             }
+            case DATAPLANE_INSTANCE_STATE_TIMESTAMP -> transformLong(context, jsonValue, builder::stateTimestamp);
             case PROPERTIES -> {
                 var props = jsonValue.asJsonArray().getJsonObject(0);
                 visitProperties(props, (k, val) -> transformProperties(k, val, builder, context));

--- a/core/common/lib/transform-lib/src/test/java/org/eclipse/edc/transform/transformer/edc/from/JsonObjectFromDataPlaneInstanceTransformerTest.java
+++ b/core/common/lib/transform-lib/src/test/java/org/eclipse/edc/transform/transformer/edc/from/JsonObjectFromDataPlaneInstanceTransformerTest.java
@@ -27,10 +27,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_DEST_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_SOURCE_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_TRANSFER_TYPES;
+import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.DATAPLANE_INSTANCE_STATE;
+import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.DATAPLANE_INSTANCE_STATE_TIMESTAMP;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.LAST_ACTIVE;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.PROPERTIES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.TURN_COUNT;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.URL;
+import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstanceStates.AVAILABLE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.util.JacksonJsonLd.createObjectMapper;
 import static org.mockito.Mockito.mock;
@@ -68,6 +71,36 @@ class JsonObjectFromDataPlaneInstanceTransformerTest {
         assertThat(jsonObject.getJsonArray(ALLOWED_TRANSFER_TYPES)).hasSize(1).allMatch(v -> ((JsonString) v).getString().equals("test-transfer-type"));
         assertThat(jsonObject.getJsonNumber(LAST_ACTIVE).intValue()).isEqualTo(15);
         assertThat(jsonObject.getJsonNumber(TURN_COUNT).intValue()).isEqualTo(42);
+        assertThat(jsonObject.getJsonObject(PROPERTIES).getJsonString("foo").getString()).isEqualTo("bar");
+
+    }
+
+    @Test
+    void transform_withState() {
+        var dpi = DataPlaneInstance.Builder.newInstance()
+                .id("test-id")
+                .url("http://foo.bar")
+                .allowedSourceType("test-source-type")
+                .allowedDestType("test-dest-type")
+                .allowedTransferType("test-transfer-type")
+                .lastActive(15)
+                .turnCount(42)
+                .state(AVAILABLE.code())
+                .property("foo", "bar")
+                .build();
+
+        var jsonObject = transformer.transform(dpi, context);
+
+        assertThat(jsonObject).isNotNull();
+        assertThat(jsonObject.getString(ID)).isEqualTo("test-id");
+        assertThat(jsonObject.getString(URL)).isEqualTo("http://foo.bar");
+        assertThat(jsonObject.getJsonArray(ALLOWED_SOURCE_TYPES)).hasSize(1).allMatch(v -> ((JsonString) v).getString().equals("test-source-type"));
+        assertThat(jsonObject.getJsonArray(ALLOWED_DEST_TYPES)).hasSize(1).allMatch(v -> ((JsonString) v).getString().equals("test-dest-type"));
+        assertThat(jsonObject.getJsonArray(ALLOWED_TRANSFER_TYPES)).hasSize(1).allMatch(v -> ((JsonString) v).getString().equals("test-transfer-type"));
+        assertThat(jsonObject.getJsonNumber(LAST_ACTIVE).intValue()).isEqualTo(15);
+        assertThat(jsonObject.getJsonNumber(TURN_COUNT).intValue()).isEqualTo(42);
+        assertThat(jsonObject.getString(DATAPLANE_INSTANCE_STATE)).isEqualTo(AVAILABLE.name());
+        assertThat(jsonObject.getJsonNumber(DATAPLANE_INSTANCE_STATE_TIMESTAMP).longValue()).isEqualTo(dpi.getStateTimestamp());
         assertThat(jsonObject.getJsonObject(PROPERTIES).getJsonString("foo").getString()).isEqualTo("bar");
 
     }

--- a/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
+++ b/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
@@ -1,8 +1,8 @@
 [
   {
-    "version": "3.0.1",
+    "version": "3.0.2",
     "urlPath": "/v3",
-    "lastUpdated": "2024-06-13T14:28:00Z",
+    "lastUpdated": "2024-07-10T09:17:00Z",
     "maturity": "stable"
   },
   {

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/schemas/DataPlaneInstanceSchema.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/schemas/DataPlaneInstanceSchema.java
@@ -40,7 +40,9 @@ public record DataPlaneInstanceSchema(
         @Schema(requiredMode = REQUIRED)
         Set<String> allowedDestTypes,
         Integer turnCount,
-        Long lastActive) {
+        Long lastActive,
+        String state,
+        Long stateTimestamp) {
     public static final String DATAPLANE_INSTANCE_EXAMPLE = """
             {
                 "@context": {
@@ -53,7 +55,9 @@ public record DataPlaneInstanceSchema(
                     "source-type2"
                 ],
                 "allowedDestTypes": ["your-dest-type"],
-                "allowedTransferTypes": ["transfer-type"]
+                "allowedTransferTypes": ["transfer-type"],
+                "state": "AVAILABLE",
+                "stateTimestamp": 1688465655
             }
             """;
 }

--- a/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/instance/DataPlaneInstance.java
+++ b/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/instance/DataPlaneInstance.java
@@ -54,6 +54,10 @@ public class DataPlaneInstance extends StatefulEntity<DataPlaneInstance> {
     @Deprecated(since = "0.7.0")
     public static final String ALLOWED_DEST_TYPES = EDC_NAMESPACE + "allowedDestTypes";
 
+    public static final String DATAPLANE_INSTANCE_STATE = EDC_NAMESPACE + "state";
+    public static final String DATAPLANE_INSTANCE_STATE_TIMESTAMP = EDC_NAMESPACE + "stateTimestamp";
+
+
     private Map<String, Object> properties = new HashMap<>();
     private Set<String> allowedTransferTypes = new HashSet<>();
     private Set<String> allowedSourceTypes = new HashSet<>();
@@ -91,7 +95,7 @@ public class DataPlaneInstance extends StatefulEntity<DataPlaneInstance> {
      * transferType against an internal list of allowed source and transfer types.
      *
      * @param sourceAddress the sourceAddress
-     * @param transferType the transferType
+     * @param transferType  the transferType
      * @return true if it can handle, false otherwise.
      */
     public boolean canHandle(DataAddress sourceAddress, @Nullable String transferType) {

--- a/system-tests/version-api/version-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/versionapi/VersionApiEndToEndTest.java
+++ b/system-tests/version-api/version-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/versionapi/VersionApiEndToEndTest.java
@@ -55,7 +55,7 @@ public class VersionApiEndToEndTest {
 
             assertThat(result).containsKeys("management", "version", "control", "observability", "sts");
             assertThat(result.get("management")).hasSize(2)
-                    .anyMatch(vr -> vr.version().equals("3.0.1") && vr.maturity().equals("stable"))
+                    .anyMatch(vr -> vr.version().equals("3.0.2") && vr.maturity().equals("stable"))
                     .anyMatch(vr -> vr.version().equals("3.1.0-alpha") && vr.maturity().equals("alpha"));
             assertThat(result.get("version")).hasSize(1).anyMatch(vr -> vr.version().equals("1.0.0"));
             assertThat(result.get("observability")).hasSize(1).anyMatch(vr -> vr.version().equals("1.0.0"));


### PR DESCRIPTION
## What this PR changes/adds

add state field on `DataPlaneInstance` response

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #4335 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
