### PR TITLE
docs: remove deprecation typo

### DIFF
--- a/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
+++ b/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
@@ -1,8 +1,8 @@
 [
   {
-    "version": "3.0.2",
+    "version": "3.0.3",
     "urlPath": "/v3",
-    "lastUpdated": "2024-07-10T09:17:00Z",
+    "lastUpdated": "2024-07-12T10:14:00Z",
     "maturity": "stable"
   },
   {

--- a/extensions/control-plane/api/management-api/edr-cache-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/edr/v3/EdrCacheApiV3.java
+++ b/extensions/control-plane/api/management-api/edr-cache-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/edr/v3/EdrCacheApiV3.java
@@ -55,8 +55,7 @@ public interface EdrCacheApiV3 {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
                     @ApiResponse(responseCode = "404", description = "An EDR data address with the given transfer process ID does not exist",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
-            },
-            deprecated = true
+            }
     )
     JsonObject getEdrEntryDataAddressV3(String transferProcessId);
 

--- a/system-tests/version-api/version-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/versionapi/VersionApiEndToEndTest.java
+++ b/system-tests/version-api/version-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/versionapi/VersionApiEndToEndTest.java
@@ -36,9 +36,6 @@ public class VersionApiEndToEndTest {
 
     abstract static class Tests {
 
-        Tests() {
-        }
-
         @Test
         void getVersion() {
 
@@ -55,7 +52,7 @@ public class VersionApiEndToEndTest {
 
             assertThat(result).containsKeys("management", "version", "control", "observability", "sts");
             assertThat(result.get("management")).hasSize(2)
-                    .anyMatch(vr -> vr.version().equals("3.0.2") && vr.maturity().equals("stable"))
+                    .anyMatch(vr -> vr.version().startsWith("3.") && vr.maturity().equals("stable"))
                     .anyMatch(vr -> vr.version().equals("3.1.0-alpha") && vr.maturity().equals("alpha"));
             assertThat(result.get("version")).hasSize(1).anyMatch(vr -> vr.version().equals("1.0.0"));
             assertThat(result.get("observability")).hasSize(1).anyMatch(vr -> vr.version().equals("1.0.0"));


### PR DESCRIPTION
## What this PR changes/adds

Remove deprecation attribute from a not-deprecated api

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #4358 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
