### PR TITLE
feat(keys): add functionality to extract public key to KeyParsers

### DIFF
--- a/core/common/connector-core/src/test/java/org/eclipse/edc/connector/core/LocalPublicKeyDefaultExtensionTest.java
+++ b/core/common/connector-core/src/test/java/org/eclipse/edc/connector/core/LocalPublicKeyDefaultExtensionTest.java
@@ -58,7 +58,7 @@ class LocalPublicKeyDefaultExtensionTest {
                 "key1.id", "key1",
                 "key1.value", "value");
 
-        when(keyParserRegistry.parse("value")).thenReturn(Result.success(mock(PublicKey.class)));
+        when(keyParserRegistry.parsePublic("value")).thenReturn(Result.success(mock(PublicKey.class)));
         when(context.getConfig(EDC_PUBLIC_KEYS_PREFIX)).thenReturn(ConfigFactory.fromMap(keys));
         var localPublicKeyService = extension.localPublicKeyService();
         extension.initialize(context);
@@ -75,7 +75,7 @@ class LocalPublicKeyDefaultExtensionTest {
                 "key1.id", "key1",
                 "key1.path", path.getPath());
 
-        when(keyParserRegistry.parse(value)).thenReturn(Result.success(mock(PublicKey.class)));
+        when(keyParserRegistry.parsePublic(value)).thenReturn(Result.success(mock(PublicKey.class)));
         when(context.getConfig(EDC_PUBLIC_KEYS_PREFIX)).thenReturn(ConfigFactory.fromMap(keys));
         var localPublicKeyService = extension.localPublicKeyService();
         extension.initialize(context);

--- a/core/common/lib/keys-lib/src/main/java/org/eclipse/edc/keys/KeyParserRegistryImpl.java
+++ b/core/common/lib/keys-lib/src/main/java/org/eclipse/edc/keys/KeyParserRegistryImpl.java
@@ -37,4 +37,12 @@ public class KeyParserRegistryImpl implements KeyParserRegistry {
                 .map(kp -> kp.parse(encoded))
                 .orElseGet(() -> Result.failure("No parser found that can handle that format."));
     }
+
+    @Override
+    public Result<Key> parsePublic(String encoded) {
+        return parsers.stream().filter(kp -> kp.canHandle(encoded))
+                .findFirst()
+                .map(kp -> kp.parsePublic(encoded))
+                .orElseGet(() -> Result.failure("No parser found that can handle that format."));
+    }
 }

--- a/core/common/lib/keys-lib/src/main/java/org/eclipse/edc/keys/KeyParserRegistryImpl.java
+++ b/core/common/lib/keys-lib/src/main/java/org/eclipse/edc/keys/KeyParserRegistryImpl.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.keys.spi.KeyParserRegistry;
 import org.eclipse.edc.spi.result.Result;
 
 import java.security.Key;
+import java.security.PublicKey;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -39,10 +40,10 @@ public class KeyParserRegistryImpl implements KeyParserRegistry {
     }
 
     @Override
-    public Result<Key> parsePublic(String encoded) {
+    public Result<PublicKey> parsePublic(String encoded) {
         return parsers.stream().filter(kp -> kp.canHandle(encoded))
                 .findFirst()
-                .map(kp -> kp.parsePublic(encoded))
+                .map(kp -> kp.parsePublic(encoded).compose(k -> Result.success((PublicKey) k)))
                 .orElseGet(() -> Result.failure("No parser found that can handle that format."));
     }
 }

--- a/core/common/lib/keys-lib/src/main/java/org/eclipse/edc/keys/LocalPublicKeyServiceImpl.java
+++ b/core/common/lib/keys-lib/src/main/java/org/eclipse/edc/keys/LocalPublicKeyServiceImpl.java
@@ -48,6 +48,10 @@ public class LocalPublicKeyServiceImpl implements LocalPublicKeyService {
                 .orElseGet(() -> Result.failure("No public key could be resolved for key-ID '%s'".formatted(id)));
     }
 
+    public Result<Void> addRawKey(String id, String rawKey) {
+        return parseKey(rawKey).onSuccess((pk) -> cachedKeys.put(id, pk)).mapEmpty();
+    }
+
     private Optional<String> resolveFromVault(String id) {
         return Optional.ofNullable(vault.resolveSecret(id));
     }
@@ -57,16 +61,12 @@ public class LocalPublicKeyServiceImpl implements LocalPublicKeyService {
     }
 
     private Result<PublicKey> parseKey(String encodedKey) {
-        return registry.parse(encodedKey).compose(pk -> {
+        return registry.parsePublic(encodedKey).compose(pk -> {
             if (pk instanceof PublicKey publicKey) {
                 return Result.success(publicKey);
             } else {
                 return Result.failure("The specified resource did not contain public key material.");
             }
         });
-    }
-
-    public Result<Void> addRawKey(String id, String rawKey) {
-        return parseKey(rawKey).onSuccess((pk) -> cachedKeys.put(id, pk)).mapTo();
     }
 }

--- a/core/common/lib/keys-lib/src/main/java/org/eclipse/edc/keys/LocalPublicKeyServiceImpl.java
+++ b/core/common/lib/keys-lib/src/main/java/org/eclipse/edc/keys/LocalPublicKeyServiceImpl.java
@@ -61,12 +61,6 @@ public class LocalPublicKeyServiceImpl implements LocalPublicKeyService {
     }
 
     private Result<PublicKey> parseKey(String encodedKey) {
-        return registry.parsePublic(encodedKey).compose(pk -> {
-            if (pk instanceof PublicKey publicKey) {
-                return Result.success(publicKey);
-            } else {
-                return Result.failure("The specified resource did not contain public key material.");
-            }
-        });
+        return registry.parsePublic(encodedKey).compose(Result::success);
     }
 }

--- a/core/common/lib/keys-lib/src/main/java/org/eclipse/edc/keys/LocalPublicKeyServiceImpl.java
+++ b/core/common/lib/keys-lib/src/main/java/org/eclipse/edc/keys/LocalPublicKeyServiceImpl.java
@@ -61,6 +61,6 @@ public class LocalPublicKeyServiceImpl implements LocalPublicKeyService {
     }
 
     private Result<PublicKey> parseKey(String encodedKey) {
-        return registry.parsePublic(encodedKey).compose(Result::success);
+        return registry.parsePublic(encodedKey);
     }
 }

--- a/core/common/lib/keys-lib/src/test/java/org/eclipse/edc/keys/LocalPublicKeyServiceImplTest.java
+++ b/core/common/lib/keys-lib/src/test/java/org/eclipse/edc/keys/LocalPublicKeyServiceImplTest.java
@@ -31,9 +31,9 @@ import static org.mockito.Mockito.when;
 
 class LocalPublicKeyServiceImplTest {
 
-    private LocalPublicKeyServiceImpl localPublicKeyService;
     private final Vault vault = mock();
     private final KeyParserRegistry keyParserRegistry = mock();
+    private LocalPublicKeyServiceImpl localPublicKeyService;
 
     @BeforeEach
     void setup() {
@@ -42,7 +42,7 @@ class LocalPublicKeyServiceImplTest {
 
     @Test
     void resolve_withCache() {
-        when(keyParserRegistry.parse("value")).thenReturn(Result.success(mock(PublicKey.class)));
+        when(keyParserRegistry.parsePublic("value")).thenReturn(Result.success(mock(PublicKey.class)));
         localPublicKeyService.addRawKey("id", "value");
         AbstractResultAssert.assertThat(localPublicKeyService.resolveKey("id")).isSucceeded();
         Mockito.verifyNoInteractions(vault);
@@ -51,7 +51,7 @@ class LocalPublicKeyServiceImplTest {
     @Test
     void resolve_withVault() {
         when(vault.resolveSecret("id")).thenReturn("value");
-        when(keyParserRegistry.parse("value")).thenReturn(Result.success(mock(PublicKey.class)));
+        when(keyParserRegistry.parsePublic("value")).thenReturn(Result.success(mock(PublicKey.class)));
         AbstractResultAssert.assertThat(localPublicKeyService.resolveKey("id")).isSucceeded();
 
         verify(vault).resolveSecret("id");
@@ -66,7 +66,7 @@ class LocalPublicKeyServiceImplTest {
     @Test
     void resolve_wrongKeyType() {
         when(vault.resolveSecret("id")).thenReturn("value");
-        when(keyParserRegistry.parse("value")).thenReturn(Result.success(mock(PrivateKey.class)));
+        when(keyParserRegistry.parsePublic("value")).thenReturn(Result.success(mock(PrivateKey.class)));
 
         AbstractResultAssert.assertThat(localPublicKeyService.resolveKey("id")).isFailed();
         verify(vault).resolveSecret("id");
@@ -75,7 +75,7 @@ class LocalPublicKeyServiceImplTest {
     @Test
     void resolve_wrongKeyFormat() {
         when(vault.resolveSecret("id")).thenReturn("value");
-        when(keyParserRegistry.parse("value")).thenReturn(Result.failure("failure"));
+        when(keyParserRegistry.parsePublic("value")).thenReturn(Result.failure("failure"));
 
         AbstractResultAssert.assertThat(localPublicKeyService.resolveKey("id")).isFailed();
         verify(vault).resolveSecret("id");

--- a/core/common/lib/keys-lib/src/test/java/org/eclipse/edc/keys/LocalPublicKeyServiceImplTest.java
+++ b/core/common/lib/keys-lib/src/test/java/org/eclipse/edc/keys/LocalPublicKeyServiceImplTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import java.security.PrivateKey;
 import java.security.PublicKey;
 
 import static org.mockito.Mockito.mock;
@@ -59,15 +58,6 @@ class LocalPublicKeyServiceImplTest {
 
     @Test
     void resolve_notFound() {
-        AbstractResultAssert.assertThat(localPublicKeyService.resolveKey("id")).isFailed();
-        verify(vault).resolveSecret("id");
-    }
-
-    @Test
-    void resolve_wrongKeyType() {
-        when(vault.resolveSecret("id")).thenReturn("value");
-        when(keyParserRegistry.parsePublic("value")).thenReturn(Result.success(mock(PrivateKey.class)));
-
         AbstractResultAssert.assertThat(localPublicKeyService.resolveKey("id")).isFailed();
         verify(vault).resolveSecret("id");
     }

--- a/core/common/lib/keys-lib/src/test/java/org/eclipse/edc/keys/keyparsers/JwkParserTest.java
+++ b/core/common/lib/keys-lib/src/test/java/org/eclipse/edc/keys/keyparsers/JwkParserTest.java
@@ -63,6 +63,23 @@ class JwkParserTest {
         assertThat(result).isSucceeded().isInstanceOf(PublicKey.class);
     }
 
+
+    @ParameterizedTest
+    @ArgumentsSource(KeyProvider.class)
+    void parsePublic_withPublicKey(JWK jwk) {
+        var publickey = jwk.toPublicJWK();
+        var result = parser.parsePublic(publickey.toJSONString());
+        assertThat(result).isSucceeded().isInstanceOf(PublicKey.class);
+    }
+
+
+    @ParameterizedTest
+    @ArgumentsSource(KeyProvider.class)
+    void parsePublic_withPrivateKey(JWK jwk) {
+        var result = parser.parsePublic(jwk.toJSONString());
+        assertThat(result).isSucceeded().isInstanceOf(PublicKey.class);
+    }
+
     private static class KeyProvider implements ArgumentsProvider {
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) {

--- a/core/common/lib/keys-lib/src/test/java/org/eclipse/edc/keys/keyparsers/PemParserTest.java
+++ b/core/common/lib/keys-lib/src/test/java/org/eclipse/edc/keys/keyparsers/PemParserTest.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.keys.keyparsers;
 import org.assertj.core.api.Assertions;
 import org.eclipse.edc.junit.testfixtures.TestUtils;
 import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -74,6 +75,38 @@ class PemParserTest {
                 .isInstanceOf(PublicKey.class);
     }
 
+
+    @ParameterizedTest
+    @ArgumentsSource(PemConvertiblePrivateKeyProvider.class)
+    void parsePublic_withPrivateKey(String pem) {
+        var result = parser.parsePublic(pem);
+        assertThat(result)
+                .isSucceeded()
+                .isNotNull()
+                .isInstanceOf(PublicKey.class);
+
+    }
+
+    @Test
+    void parsePublic_withPrivateKey_whenEd25519_shouldFail() {
+        var pem = TestUtils.getResourceFileContentAsString("ed25519.pem");
+        var result = parser.parsePublic(pem);
+        assertThat(result)
+                .isFailed()
+                .detail().isEqualTo("PEM-encoded structure did not contain a public key.");
+    }
+
+
+    @ParameterizedTest
+    @ArgumentsSource(PemPublicKeyProvider.class)
+    void parsePublic_withPublicKey(String pem) {
+
+        assertThat(parser.parsePublic(pem))
+                .isSucceeded()
+                .isNotNull()
+                .isInstanceOf(PublicKey.class);
+    }
+
     private static class PemPrivateKeyProvider implements ArgumentsProvider {
 
         @Override
@@ -84,6 +117,19 @@ class PemParserTest {
                     Arguments.of(Named.named("EC PrivateKey (P384)", TestUtils.getResourceFileContentAsString("ec_p384.pem"))),
                     Arguments.of(Named.named("EC PrivateKey (P512)", TestUtils.getResourceFileContentAsString("ec_p512.pem"))),
                     Arguments.of(Named.named("Ed25519 PrivateKey", TestUtils.getResourceFileContentAsString("ed25519.pem")))
+            );
+        }
+    }
+
+    private static class PemConvertiblePrivateKeyProvider implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                    Arguments.of(Named.named("RSA PrivateKey", TestUtils.getResourceFileContentAsString("rsa_2048.pem"))),
+                    Arguments.of(Named.named("EC PrivateKey (P256)", TestUtils.getResourceFileContentAsString("ec_p256.pem"))),
+                    Arguments.of(Named.named("EC PrivateKey (P384)", TestUtils.getResourceFileContentAsString("ec_p384.pem"))),
+                    Arguments.of(Named.named("EC PrivateKey (P512)", TestUtils.getResourceFileContentAsString("ec_p512.pem")))
             );
         }
     }

--- a/spi/common/keys-spi/src/main/java/org/eclipse/edc/keys/spi/KeyParser.java
+++ b/spi/common/keys-spi/src/main/java/org/eclipse/edc/keys/spi/KeyParser.java
@@ -49,4 +49,20 @@ public interface KeyParser {
      * @return Either a {@link java.security.PrivateKey}, a {@link java.security.PublicKey} or a failure.
      */
     Result<Key> parse(String encoded);
+
+    /**
+     * Parses the encoded key as public key. If the encoded string is invalid, or the parser can't handle the input,
+     * it must return a {@link Result#failure(String)}, it must never throw an exception.
+     * <p>
+     * If the given key material contains public and private key data, the parser attempts to remove the private key data,
+     * returning only the public part of the key as {@link java.security.PublicKey}.
+     * If the given key material does not contain private key data, just public key data, returns a {@link java.security.PublicKey}. In all
+     * other cases, a {@link Result#failure(String)} is returned, for example, when a private key cannot be converted into a public key.
+     *
+     * @param encoded serialized/encoded key material.
+     * @return Either a {@link java.security.PublicKey} or a failure.
+     */
+    default Result<Key> parsePublic(String encoded) {
+        return parse(encoded);
+    }
 }

--- a/spi/common/keys-spi/src/main/java/org/eclipse/edc/keys/spi/KeyParserRegistry.java
+++ b/spi/common/keys-spi/src/main/java/org/eclipse/edc/keys/spi/KeyParserRegistry.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.keys.spi;
 import org.eclipse.edc.spi.result.Result;
 
 import java.security.Key;
+import java.security.PublicKey;
 
 /**
  * Registry that holds multiple {@link KeyParser} instances that are used to deserialize a private key from their
@@ -45,5 +46,5 @@ public interface KeyParserRegistry {
      * @param encoded The private key in encoded format (PEM, OpenSSH, JWK, PKCS8,...)
      * @return a success result containing the public key, a failure if the encoded public key could not be deserialized.
      */
-    Result<Key> parsePublic(String encoded);
+    Result<PublicKey> parsePublic(String encoded);
 }

--- a/spi/common/keys-spi/src/main/java/org/eclipse/edc/keys/spi/KeyParserRegistry.java
+++ b/spi/common/keys-spi/src/main/java/org/eclipse/edc/keys/spi/KeyParserRegistry.java
@@ -17,7 +17,6 @@ package org.eclipse.edc.keys.spi;
 import org.eclipse.edc.spi.result.Result;
 
 import java.security.Key;
-import java.security.PrivateKey;
 
 /**
  * Registry that holds multiple {@link KeyParser} instances that are used to deserialize a private key from their
@@ -30,11 +29,21 @@ public interface KeyParserRegistry {
     void register(KeyParser parser);
 
     /**
-     * Attempts to parse the String representation of a private key into a {@link PrivateKey}. If no parser can handle
+     * Attempts to parse the String representation of a private key into a {@link Key}. If no parser can handle
      * the encoded format, or it is corrupt etc. then a failure is returned.
      *
      * @param encoded The private key in encoded format (PEM, OpenSSH, JWK, PKCS8,...)
      * @return a success result containing the private key, a failure if the encoded private key could not be deserialized.
      */
     Result<Key> parse(String encoded);
+
+    /**
+     * Attempts to parse the String representation of a public or private key into a {@link Key}. If no parser can handle
+     * the encoded format, if the encoded format contains a private key that cannot be converted to a public key,
+     * or if the input is corrupt etc. then a failure is returned.
+     *
+     * @param encoded The private key in encoded format (PEM, OpenSSH, JWK, PKCS8,...)
+     * @return a success result containing the public key, a failure if the encoded public key could not be deserialized.
+     */
+    Result<Key> parsePublic(String encoded);
 }


### PR DESCRIPTION
## What this PR changes/adds

Adds a `parsePublic` method to they keyparsers, that attempt to extract the public key from an encoded string, leaving behind any potential private key parts.
## Why it does that

LocalPublicKeyServiceImpl should be able to extract a public key from any serialized format

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
