### PR TITLE
test: avoid getFreePort collisions

### DIFF
--- a/core/common/lib/util-lib/src/main/java/org/eclipse/edc/util/io/Ports.java
+++ b/core/common/lib/util-lib/src/main/java/org/eclipse/edc/util/io/Ports.java
@@ -16,9 +16,9 @@ package org.eclipse.edc.util.io;
 
 import java.io.IOException;
 import java.net.ServerSocket;
+import java.util.HashSet;
 import java.util.Random;
-
-import static java.lang.String.format;
+import java.util.Set;
 
 /**
  * Utilities for assigning ports.
@@ -26,22 +26,22 @@ import static java.lang.String.format;
 public final class Ports {
     public static final int MAX_TCP_PORT = 65_535;
     private static final Random RANDOM = new Random();
+    private static final Set<Integer> ALREADY_RETURNED = new HashSet<>();
 
     /**
-     * Gets a free port in the range 1024 - 65535 by trying them in ascending order.
+     * Gets a free port in the range 1024 - 65535 by trying them randomly.
      *
-     * @return the first free port
+     * @return the lower bound.
      * @throws IllegalArgumentException if no free port is available
      */
     public static int getFreePort() {
-        var rnd = 1024 + RANDOM.nextInt(MAX_TCP_PORT - 1024);
-        return getFreePort(rnd);
+        return getFreePort(1024);
     }
 
     /**
-     * Gets a free port in the range lowerBound - 65535 by trying them in ascending order.
+     * Gets a free port in the range lowerBound - 65535 by trying them randomly.
      *
-     * @return the first free port
+     * @return the lower bound.
      * @throws IllegalArgumentException if no free port is available
      */
     public static int getFreePort(int lowerBound) {
@@ -52,7 +52,7 @@ public final class Ports {
     }
 
     /**
-     * Gets a free port in the range lowerBound - upperBound by trying them in ascending order.
+     * Gets a free port in the range lowerBound - upperBound randomly. Will not return ports already returned.
      *
      * @return the first free port
      * @throws IllegalArgumentException if no free port is available or if the bounds are invalid.
@@ -65,25 +65,21 @@ public final class Ports {
         if (upperBound > MAX_TCP_PORT) {
             throw new IllegalArgumentException("Upper bound must be < " + MAX_TCP_PORT);
         }
-        var port = lowerBound;
-        boolean found = false;
 
-        while (!found && port <= upperBound) {
-            try (ServerSocket serverSocket = new ServerSocket(port)) {
-                serverSocket.setReuseAddress(true);
-                port = serverSocket.getLocalPort();
+        do {
+            var tryPort = lowerBound + RANDOM.nextInt(upperBound - lowerBound);
+            if (!ALREADY_RETURNED.contains(tryPort)) {
+                ALREADY_RETURNED.add(tryPort);
 
-                found = true;
-            } catch (IOException e) {
-                found = false;
-                port++;
+                try (var serverSocket = new ServerSocket(tryPort)) {
+                    serverSocket.setReuseAddress(true);
+
+                    return tryPort;
+                } catch (IOException ignored) {
+                    // port already used by external service, try another one
+                }
             }
-        }
-
-        if (!found) {
-            throw new IllegalArgumentException(format("No free ports in the range [%d - %d]", lowerBound, upperBound));
-        }
-        return port;
+        } while (true);
     }
 
     private Ports() {

--- a/core/common/lib/util-lib/src/test/java/org/eclipse/edc/util/io/PortsTest.java
+++ b/core/common/lib/util-lib/src/test/java/org/eclipse/edc/util/io/PortsTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.net.ServerSocket;
 
+import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -52,11 +53,22 @@ class PortsTest {
     }
 
     @Test
+    void getFreePortAvoidDuplicated() {
+        var lowerBound = 6000;
+        var portsToBeGenerated = 10;
+        var ports = range(0, portsToBeGenerated)
+                .mapToObj(i -> Ports.getFreePort(lowerBound, lowerBound + portsToBeGenerated))
+                .distinct().toList();
+
+        assertThat(ports.size()).isEqualTo(portsToBeGenerated);
+    }
+
+    @Test
     void getFreePort_whenOccupied() throws IOException {
         var port = Ports.getFreePort(MIN_PORT);
 
         try (var socket = new ServerSocket(port)) {
-            assertThat(Ports.getFreePort(MIN_PORT)).describedAs("Next free port").isGreaterThan(socket.getLocalPort());
+            assertThat(Ports.getFreePort(MIN_PORT)).describedAs("Next free port").isNotEqualTo(socket.getLocalPort());
         }
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Add an `ALREADY_RETURNED` `HashSet` to ensure that the port generated by `getFreePort` is not already returned.

## Why it does that

Avoid possible collisions.

## Further notes

- changed the "incremental" port generation to the complete randomic. Looking at the tests they are always calling the `getFreePort` without arguments, that is generating a random number anyway, so the "efficiency" of using the next number instead is pretty negligible.

## Linked Issue(s)

Closes #4365

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
