### PR TITLE
fix: always record dataplane ID

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProtocolServiceImpl.java
@@ -182,7 +182,7 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
         if (transferProcess.getType() == CONSUMER && transferProcess.canBeStartedConsumer()) {
             observable.invokeForEach(l -> l.preStarted(transferProcess));
             transferProcess.protocolMessageReceived(message.getId());
-            transferProcess.transitionStarted();
+            transferProcess.transitionStarted(transferProcess.getDataPlaneId());
             update(transferProcess);
             var transferStartedData = TransferProcessStartedData.Builder.newInstance()
                     .dataAddress(message.getDataAddress())

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferProcess.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferProcess.java
@@ -291,10 +291,6 @@ public class TransferProcess extends StatefulEntity<TransferProcess> {
         return currentStateIsOneOf(STARTED, REQUESTED, STARTING, RESUMED);
     }
 
-    public void transitionStarted() {
-        transitionStarted(null);
-    }
-
     public void transitionStarted(String dataPlaneId) {
         if (type == CONSUMER) {
             transition(STARTED, state -> canBeStartedConsumer());


### PR DESCRIPTION

## What this PR changes/adds

When sending the STARTED notification, the data plane ID should always be recorded.

## Why it does that

consistency

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
