### PR TITLE
feat: fail validation if muliple operands in a Logical Constraint are found

### DIFF
--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/validation/PolicyDefinitionValidator.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/validation/PolicyDefinitionValidator.java
@@ -146,7 +146,15 @@ public class PolicyDefinitionValidator {
 
         @Override
         public ValidationResult validate(JsonObject input) {
-            if (LOGICAL_CONSTRAINTS.stream().anyMatch(input::containsKey)) {
+            var logicalOperands = input.keySet().stream().filter(LOGICAL_CONSTRAINTS::contains).toList();
+
+            if (logicalOperands.size() > 1) {
+                return ValidationResult.failure(
+                        violation("Cannot define multiple operands in a Logical Constraint: %s".formatted(logicalOperands),
+                                path.toString()));
+            }
+
+            if (logicalOperands.size() == 1) {
                 return ValidationResult.success();
             }
 

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/policy/validation/PolicyDefinitionValidatorTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/policy/validation/PolicyDefinitionValidatorTest.java
@@ -34,6 +34,7 @@ import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_AND_CONSTRAIN
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_CONSTRAINT_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_LEFT_OPERAND_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_OPERATOR_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_OR_CONSTRAINT_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_PERMISSION_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_SET;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_PROFILE_ATTRIBUTE;
@@ -200,6 +201,31 @@ class PolicyDefinitionValidatorTest {
         var result = validator.validate(policyDefinition);
 
         assertThat(result).isSucceeded();
+    }
+
+    @Test
+    void shouldFail_whenLogicalConstraintWithMultipleOperandsIsPresent() {
+        var permission = createArrayBuilder().add(createObjectBuilder()
+                .add(ODRL_ACTION_ATTRIBUTE, createValidAction())
+                .add(ODRL_CONSTRAINT_ATTRIBUTE, createArrayBuilder().add(createObjectBuilder()
+                        .add(ODRL_AND_CONSTRAINT_ATTRIBUTE, createArrayBuilder())
+                        .add(ODRL_OR_CONSTRAINT_ATTRIBUTE, createArrayBuilder())
+                )));
+        var policy = createObjectBuilder()
+                .add(TYPE, policySet())
+                .add(ODRL_PERMISSION_ATTRIBUTE, permission);
+        var policyDefinition = createObjectBuilder()
+                .add(EDC_POLICY_DEFINITION_POLICY, createArrayBuilder().add(policy))
+                .build();
+
+        var result = validator.validate(policyDefinition);
+
+        assertThat(result).isFailed().extracting(ValidationFailure::getViolations).asInstanceOf(list(Violation.class))
+                .hasSize(1)
+                .anySatisfy(violation -> {
+                    assertThat(violation.message()).contains("multiple operands");
+                    assertThat(violation.path()).endsWith(ODRL_CONSTRAINT_ATTRIBUTE);
+                });
     }
 
     @Test


### PR DESCRIPTION
## What this PR changes/adds

Add validation to avoid Logical Constraint with multiple operands

## Why it does that

ODRL compliance

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #4370 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
