### PR TITLE
refactor: separate sql stores from datasources

### DIFF
--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -11,6 +11,7 @@
 ## Guides
 - [Customize Policy Engine](policy-engine.md)
 - [Performance Tuning](performance-tuning.md)
+- [Sql persistence](sql-persistence.md)
 
 ## Build and testing
 - [OpenApi Spec Generation](openapi.md)

--- a/docs/developer/sql-persistence.md
+++ b/docs/developer/sql-persistence.md
@@ -1,0 +1,41 @@
+# SQL persistence
+
+Every store in the EDC, intended as persistence for state, comes out of the box with two implementations:
+- in-memory
+- sql (postgresql dialect)
+
+By default, the `in-memory` stores are provided by the dependency injection, the `sql` implementations can be used by
+simply registering the relative extensions (e.g. `asset-index-sql`, `contract-negotiation-store-sql`, ...).
+
+## Configuration
+
+### DataSources
+
+For using `sql` extensions, a `DataSource` is needed, and it should be registered on the `DataSourceRegistry` service.
+
+The `sql-pool-apache-commons` extension takes care to create and register pooled data sources starting from configuration.
+It expects at least one data source called `default` that can be configured with `Vault` keys:
+```
+edc.datasource.default.url=...
+edc.datasource.default.name=...
+edc.datasource.default.password=...
+```
+(note: if no vault entries are found for such keys, they will be obtained from the configuration).
+
+Other datasources can be defined using the same settings structure:
+```
+edc.datasource.<datasource-name>.url=...
+edc.datasource.<datasource-name>.name=...
+edc.datasource.<datasource-name>.password=...
+```
+
+`<datasource-name>` can be a string that then can be used by the stores configuration to use specific data sources.
+
+### Using custom datasource in stores
+
+Using a custom datasource in a store can be done by configuring the setting:
+```
+edc.sql.store.<store-context>.datasource=<datasource-name>
+```
+
+This way the `<store-context>` (that could be `asset`, `contractnegotiation`...) will use the `<datasource-name>` datasource.

--- a/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/configuration/DataSourceName.java
+++ b/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/configuration/DataSourceName.java
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.sql.configuration;
+
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.system.configuration.Config;
+
+import static org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry.DEFAULT_DATASOURCE;
+
+/**
+ * This interface is only functional to the migration from the old format to the new one.
+ * Ref. <a href="https://github.com/eclipse-edc/Connector/issues/3811">https://github.com/eclipse-edc/Connector/issues/3811</a>
+ */
+public interface DataSourceName {
+
+    /**
+     * Extracts datasource name from configuration considering deprecated key as fallback.
+     *
+     * @param key the setting key.
+     * @param deprecatedKey the deprecate setting key.
+     * @param config the config.
+     * @param monitor the monitor.
+     * @return the datasource name
+     * @deprecated will be removed together with the deprecated settings.
+     */
+    @Deprecated(since = "0.8.1")
+    static String getDataSourceName(String key, String deprecatedKey, Config config, Monitor monitor) {
+        var datasourceName = config.getString(key, null);
+
+        if (datasourceName != null) {
+            return datasourceName;
+        }
+
+        var name = config.getString(deprecatedKey, null);
+
+        if (name != null) {
+            monitor.warning("Datasource name setting key %s has been deprecated, please switch to %s".formatted(deprecatedKey, key));
+            return name;
+        }
+
+        return DEFAULT_DATASOURCE;
+    }
+
+}

--- a/extensions/common/store/sql/edr-index-sql/src/main/java/org/eclipse/edc/edr/store/index/SqlEndpointDataReferenceEntryIndexExtension.java
+++ b/extensions/common/store/sql/edr-index-sql/src/main/java/org/eclipse/edc/edr/store/index/SqlEndpointDataReferenceEntryIndexExtension.java
@@ -27,6 +27,7 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.sql.QueryExecutor;
 import org.eclipse.edc.sql.bootstrapper.SqlSchemaBootstrapper;
+import org.eclipse.edc.sql.configuration.DataSourceName;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 
@@ -34,11 +35,11 @@ import org.eclipse.edc.transaction.spi.TransactionContext;
 @Extension(value = "SQL edr entry store")
 public class SqlEndpointDataReferenceEntryIndexExtension implements ServiceExtension {
 
-    /**
-     * Name of the datasource to use for accessing edr entries.
-     */
-    @Setting(required = true)
+    @Deprecated(since = "0.8.1")
     public static final String DATASOURCE_SETTING_NAME = "edc.datasource.edr.name";
+
+    @Setting(value = "The datasource to be used", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE)
+    public static final String DATASOURCE_NAME = "edc.sql.store.edr.datasource";
 
     @Inject
     private DataSourceRegistry dataSourceRegistry;
@@ -60,7 +61,7 @@ public class SqlEndpointDataReferenceEntryIndexExtension implements ServiceExten
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var dataSourceName = context.getConfig().getString(DATASOURCE_SETTING_NAME, DataSourceRegistry.DEFAULT_DATASOURCE);
+        var dataSourceName = DataSourceName.getDataSourceName(DATASOURCE_NAME, DATASOURCE_SETTING_NAME, context.getConfig(), context.getMonitor());
 
         var sqlStore = new SqlEndpointDataReferenceEntryIndex(dataSourceRegistry, dataSourceName, transactionContext, typeManager.getMapper(),
                 getStatementImpl(), queryExecutor);

--- a/extensions/common/store/sql/edr-index-sql/src/test/java/org/eclipse/edc/edr/store/index/sql/SqlEndpointDataReferenceEntryIndexExtensionTest.java
+++ b/extensions/common/store/sql/edr-index-sql/src/test/java/org/eclipse/edc/edr/store/index/sql/SqlEndpointDataReferenceEntryIndexExtensionTest.java
@@ -22,21 +22,20 @@ import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.configuration.Config;
 import org.eclipse.edc.spi.types.TypeManager;
-import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.edr.store.index.SqlEndpointDataReferenceEntryIndexExtension.DATASOURCE_SETTING_NAME;
+import static org.eclipse.edc.edr.store.index.SqlEndpointDataReferenceEntryIndexExtension.DATASOURCE_NAME;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(DependencyInjectionExtension.class)
 public class SqlEndpointDataReferenceEntryIndexExtensionTest {
-
 
     @BeforeEach
     void setUp(ServiceExtensionContext context) {
@@ -54,6 +53,6 @@ public class SqlEndpointDataReferenceEntryIndexExtensionTest {
         var service = context.getService(EndpointDataReferenceEntryIndex.class);
         assertThat(service).isInstanceOf(SqlEndpointDataReferenceEntryIndex.class);
 
-        verify(config).getString(DATASOURCE_SETTING_NAME, DataSourceRegistry.DEFAULT_DATASOURCE);
+        verify(config).getString(eq(DATASOURCE_NAME), any());
     }
 }

--- a/extensions/control-plane/store/sql/asset-index-sql/README.md
+++ b/extensions/control-plane/store/sql/asset-index-sql/README.md
@@ -37,12 +37,6 @@ edc_asset ||--o{ edc_asset_property
 ```
 -->
 
-## Configuration
-
-| Key                       | Description                       | Mandatory | 
-|:--------------------------|:----------------------------------|-----------|
-| edc.datasource.asset.name | Datasource used by this extension | X         |
-
 ## Migrate from 0.3.1 to 0.3.2
 
 This table structure has been changed, from 3 tables (one for the asset, one for properties and one for data address) to

--- a/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/assetindex/SqlAssetIndexServiceExtension.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/assetindex/SqlAssetIndexServiceExtension.java
@@ -28,6 +28,7 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.sql.QueryExecutor;
 import org.eclipse.edc.sql.bootstrapper.SqlSchemaBootstrapper;
+import org.eclipse.edc.sql.configuration.DataSourceName;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 
@@ -35,11 +36,11 @@ import org.eclipse.edc.transaction.spi.TransactionContext;
 @Extension(value = "SQL asset index")
 public class SqlAssetIndexServiceExtension implements ServiceExtension {
 
-    /**
-     * Name of the datasource to use for accessing assets.
-     */
-    @Setting(required = true)
+    @Deprecated(since = "0.8.1")
     public static final String DATASOURCE_SETTING_NAME = "edc.datasource.asset.name";
+
+    @Setting(value = "The datasource to be used", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE)
+    public static final String DATASOURCE_NAME = "edc.sql.store.asset.datasource";
 
     @Inject
     private DataSourceRegistry dataSourceRegistry;
@@ -61,7 +62,7 @@ public class SqlAssetIndexServiceExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var dataSourceName = context.getConfig().getString(DATASOURCE_SETTING_NAME, DataSourceRegistry.DEFAULT_DATASOURCE);
+        var dataSourceName = DataSourceName.getDataSourceName(DATASOURCE_NAME, DATASOURCE_SETTING_NAME, context.getConfig(), context.getMonitor());
 
         var sqlAssetLoader = new SqlAssetIndex(dataSourceRegistry, dataSourceName, transactionContext, typeManager.getMapper(), getDialect(), queryExecutor);
 

--- a/extensions/control-plane/store/sql/asset-index-sql/src/test/java/org/eclipse/edc/connector/controlplane/store/sql/assetindex/SqlAssetIndexServiceExtensionTest.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/test/java/org/eclipse/edc/connector/controlplane/store/sql/assetindex/SqlAssetIndexServiceExtensionTest.java
@@ -21,14 +21,14 @@ import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.configuration.Config;
 import org.eclipse.edc.spi.types.TypeManager;
-import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.connector.controlplane.store.sql.assetindex.SqlAssetIndexServiceExtension.DATASOURCE_SETTING_NAME;
+import static org.eclipse.edc.connector.controlplane.store.sql.assetindex.SqlAssetIndexServiceExtension.DATASOURCE_NAME;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -55,6 +55,6 @@ public class SqlAssetIndexServiceExtensionTest {
         var dataAddressResolver = context.getService(DataAddressResolver.class);
         assertThat(dataAddressResolver).isInstanceOf(SqlAssetIndex.class);
 
-        verify(config).getString(DATASOURCE_SETTING_NAME, DataSourceRegistry.DEFAULT_DATASOURCE);
+        verify(config).getString(eq(DATASOURCE_NAME), any());
     }
 }

--- a/extensions/control-plane/store/sql/contract-definition-store-sql/README.md
+++ b/extensions/control-plane/store/sql/contract-definition-store-sql/README.md
@@ -10,12 +10,6 @@ Please apply this [schema](src/main/resources/contract-definition-schema.sql) to
 
 ![ER Diagram](docs/er.png)
 
-## Configuration
-
-| Key                                    | Description                       | Mandatory | 
-|:---------------------------------------|:----------------------------------|-----------|
-| edc.datasource.contractdefinition.name | Datasource used by this extension | X         |
-
 ## Create a flexible query API to accommodate `QuerySpec`
 
 _For the first version, only the `limit` and `offset` arguments from the `QuerySpec` will be used._

--- a/extensions/control-plane/store/sql/contract-definition-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractdefinition/SqlContractDefinitionStoreExtension.java
+++ b/extensions/control-plane/store/sql/contract-definition-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractdefinition/SqlContractDefinitionStoreExtension.java
@@ -28,6 +28,7 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.sql.QueryExecutor;
 import org.eclipse.edc.sql.bootstrapper.SqlSchemaBootstrapper;
+import org.eclipse.edc.sql.configuration.DataSourceName;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 
@@ -35,11 +36,11 @@ import org.eclipse.edc.transaction.spi.TransactionContext;
 @Extension(value = "SQL contract definition store")
 public class SqlContractDefinitionStoreExtension implements ServiceExtension {
 
-    /**
-     * Name of the datasource to use for accessing contract definitions.
-     */
-    @Setting(required = true)
+    @Deprecated(since = "0.8.1")
     public static final String DATASOURCE_SETTING_NAME = "edc.datasource.contractdefinition.name";
+
+    @Setting(value = "The datasource to be used", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE)
+    public static final String DATASOURCE_NAME = "edc.sql.store.contractdefinition.datasource";
 
     @Inject
     private DataSourceRegistry dataSourceRegistry;
@@ -61,7 +62,7 @@ public class SqlContractDefinitionStoreExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var dataSourceName = context.getConfig().getString(DATASOURCE_SETTING_NAME, DataSourceRegistry.DEFAULT_DATASOURCE);
+        var dataSourceName = DataSourceName.getDataSourceName(DATASOURCE_NAME, DATASOURCE_SETTING_NAME, context.getConfig(), context.getMonitor());
 
         var sqlContractDefinitionStore = new SqlContractDefinitionStore(dataSourceRegistry, dataSourceName, transactionContext,
                 getStatementImpl(), typeManager.getMapper(), queryExecutor);

--- a/extensions/control-plane/store/sql/contract-definition-store-sql/src/test/java/org/eclipse/edc/connector/controlplane/store/sql/contractdefinition/SqlContractDefinitionStoreExtensionTest.java
+++ b/extensions/control-plane/store/sql/contract-definition-store-sql/src/test/java/org/eclipse/edc/connector/controlplane/store/sql/contractdefinition/SqlContractDefinitionStoreExtensionTest.java
@@ -20,21 +20,20 @@ import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.configuration.Config;
 import org.eclipse.edc.spi.types.TypeManager;
-import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.connector.controlplane.store.sql.contractdefinition.SqlContractDefinitionStoreExtension.DATASOURCE_SETTING_NAME;
+import static org.eclipse.edc.connector.controlplane.store.sql.contractdefinition.SqlContractDefinitionStoreExtension.DATASOURCE_NAME;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(DependencyInjectionExtension.class)
 public class SqlContractDefinitionStoreExtensionTest {
-
 
     @BeforeEach
     void setUp(ServiceExtensionContext context) {
@@ -52,6 +51,6 @@ public class SqlContractDefinitionStoreExtensionTest {
         var service = context.getService(ContractDefinitionStore.class);
         assertThat(service).isInstanceOf(ContractDefinitionStore.class);
 
-        verify(config).getString(DATASOURCE_SETTING_NAME, DataSourceRegistry.DEFAULT_DATASOURCE);
+        verify(config).getString(eq(DATASOURCE_NAME), any());
     }
 }

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/SqlContractNegotiationStoreExtension.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/SqlContractNegotiationStoreExtension.java
@@ -21,11 +21,13 @@ import org.eclipse.edc.connector.controlplane.store.sql.contractnegotiation.stor
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provides;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.sql.QueryExecutor;
 import org.eclipse.edc.sql.bootstrapper.SqlSchemaBootstrapper;
+import org.eclipse.edc.sql.configuration.DataSourceName;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 
@@ -35,7 +37,11 @@ import java.time.Clock;
 @Extension(value = "SQL contract negotiation store")
 public class SqlContractNegotiationStoreExtension implements ServiceExtension {
 
-    public static final String DATASOURCE_NAME_SETTING = "edc.datasource.contractnegotiation.name";
+    @Deprecated(since = "0.8.1")
+    public static final String DATASOURCE_SETTING_NAME = "edc.datasource.contractnegotiation.name";
+
+    @Setting(value = "The datasource to be used", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE)
+    public static final String DATASOURCE_NAME = "edc.sql.store.contractnegotiation.datasource";
 
     @Inject
     private DataSourceRegistry dataSourceRegistry;
@@ -60,7 +66,8 @@ public class SqlContractNegotiationStoreExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var dataSourceName = getDataSourceName(context);
+        var dataSourceName = DataSourceName.getDataSourceName(DATASOURCE_NAME, DATASOURCE_SETTING_NAME, context.getConfig(), context.getMonitor());
+
         var sqlStore = new SqlContractNegotiationStore(dataSourceRegistry, dataSourceName, trxContext,
                 typeManager.getMapper(), getStatementImpl(), context.getRuntimeId(), clock, queryExecutor);
         context.registerService(ContractNegotiationStore.class, sqlStore);
@@ -76,6 +83,6 @@ public class SqlContractNegotiationStoreExtension implements ServiceExtension {
     }
 
     private String getDataSourceName(ServiceExtensionContext context) {
-        return context.getConfig().getString(DATASOURCE_NAME_SETTING, DataSourceRegistry.DEFAULT_DATASOURCE);
+        return context.getConfig().getString(DATASOURCE_SETTING_NAME, DataSourceRegistry.DEFAULT_DATASOURCE);
     }
 }

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/test/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/SqlContractNegotiationStoreExtensionTest.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/test/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/SqlContractNegotiationStoreExtensionTest.java
@@ -33,7 +33,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.eclipse.edc.connector.controlplane.store.sql.contractnegotiation.SqlContractNegotiationStoreExtension.DATASOURCE_NAME_SETTING;
+import static org.eclipse.edc.connector.controlplane.store.sql.contractnegotiation.SqlContractNegotiationStoreExtension.DATASOURCE_NAME;
+import static org.eclipse.edc.connector.controlplane.store.sql.contractnegotiation.SqlContractNegotiationStoreExtension.DATASOURCE_SETTING_NAME;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -47,7 +50,7 @@ class SqlContractNegotiationStoreExtensionTest {
     void initialize(ServiceExtensionContext context, ObjectFactory factory) {
         var config = mock(Config.class);
         when(context.getConfig()).thenReturn(config);
-        when(config.getString(DATASOURCE_NAME_SETTING, DataSourceRegistry.DEFAULT_DATASOURCE)).thenReturn("test");
+        when(config.getString(DATASOURCE_SETTING_NAME, DataSourceRegistry.DEFAULT_DATASOURCE)).thenReturn("test");
 
         context.registerService(DataSourceRegistry.class, mock(DataSourceRegistry.class));
         context.registerService(TransactionContext.class, mock(TransactionContext.class));
@@ -61,7 +64,7 @@ class SqlContractNegotiationStoreExtensionTest {
         var service = context.getService(ContractNegotiationStore.class);
         assertThat(service).isInstanceOf(SqlContractNegotiationStore.class);
         assertThat(service).extracting("statements").isInstanceOf(BaseSqlDialectStatements.class);
-        verify(config).getString(DATASOURCE_NAME_SETTING, DataSourceRegistry.DEFAULT_DATASOURCE);
+        verify(config).getString(eq(DATASOURCE_NAME), any());
 
     }
 

--- a/extensions/control-plane/store/sql/policy-definition-store-sql/README.md
+++ b/extensions/control-plane/store/sql/policy-definition-store-sql/README.md
@@ -34,9 +34,3 @@ entity edc_policydefinitions {
 @enduml
 ```
 -->
-
-## Configuration
-
-| Key                        | Description                       | Mandatory | 
-|:---------------------------|:----------------------------------|-----------|
-| edc.datasource.policy.name | Datasource used by this extension | X         |

--- a/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/policydefinition/SqlPolicyStoreExtension.java
+++ b/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/policydefinition/SqlPolicyStoreExtension.java
@@ -27,6 +27,7 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.sql.QueryExecutor;
 import org.eclipse.edc.sql.bootstrapper.SqlSchemaBootstrapper;
+import org.eclipse.edc.sql.configuration.DataSourceName;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 
@@ -34,8 +35,11 @@ import org.eclipse.edc.transaction.spi.TransactionContext;
 @Extension("SQL policy store")
 public class SqlPolicyStoreExtension implements ServiceExtension {
 
-    @Setting(required = true)
+    @Deprecated(since = "0.8.1")
     public static final String DATASOURCE_SETTING_NAME = "edc.datasource.policy.name";
+
+    @Setting(value = "The datasource to be used", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE)
+    public static final String DATASOURCE_NAME = "edc.sql.store.policy.datasource";
 
     @Inject
     private DataSourceRegistry dataSourceRegistry;
@@ -56,7 +60,8 @@ public class SqlPolicyStoreExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var dataSourceName = getDataSourceName(context);
+        var dataSourceName = DataSourceName.getDataSourceName(DATASOURCE_NAME, DATASOURCE_SETTING_NAME, context.getConfig(), context.getMonitor());
+
         var sqlPolicyStore = new SqlPolicyDefinitionStore(dataSourceRegistry, dataSourceName, transactionContext,
                 typeManager.getMapper(), getStatementImpl(), queryExecutor);
 

--- a/extensions/control-plane/store/sql/policy-definition-store-sql/src/test/java/org/eclipse/edc/connector/controlplane/store/sql/policydefinition/SqlPolicyDefinitionStoreExtensionTest.java
+++ b/extensions/control-plane/store/sql/policy-definition-store-sql/src/test/java/org/eclipse/edc/connector/controlplane/store/sql/policydefinition/SqlPolicyDefinitionStoreExtensionTest.java
@@ -21,14 +21,14 @@ import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.configuration.Config;
 import org.eclipse.edc.spi.types.TypeManager;
-import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.connector.controlplane.store.sql.policydefinition.SqlPolicyStoreExtension.DATASOURCE_SETTING_NAME;
+import static org.eclipse.edc.connector.controlplane.store.sql.policydefinition.SqlPolicyStoreExtension.DATASOURCE_NAME;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -53,6 +53,6 @@ public class SqlPolicyDefinitionStoreExtensionTest {
         var service = context.getService(PolicyDefinitionStore.class);
         assertThat(service).isInstanceOf(SqlPolicyDefinitionStore.class);
 
-        verify(config).getString(DATASOURCE_SETTING_NAME, DataSourceRegistry.DEFAULT_DATASOURCE);
+        verify(config).getString(eq(DATASOURCE_NAME), any());
     }
 }

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/test/java/org/eclipse/edc/connector/controlplane/store/sql/transferprocess/SqlTransferProcessStoreExtensionTest.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/test/java/org/eclipse/edc/connector/controlplane/store/sql/transferprocess/SqlTransferProcessStoreExtensionTest.java
@@ -21,14 +21,14 @@ import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.configuration.Config;
 import org.eclipse.edc.spi.types.TypeManager;
-import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.connector.controlplane.store.sql.transferprocess.SqlTransferProcessStoreExtension.DATASOURCE_NAME_SETTING;
+import static org.eclipse.edc.connector.controlplane.store.sql.transferprocess.SqlTransferProcessStoreExtension.DATASOURCE_NAME;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -52,6 +52,6 @@ public class SqlTransferProcessStoreExtensionTest {
         var service = context.getService(TransferProcessStore.class);
         assertThat(service).isInstanceOf(SqlTransferProcessStore.class);
 
-        verify(config).getString(DATASOURCE_NAME_SETTING, DataSourceRegistry.DEFAULT_DATASOURCE);
+        verify(config).getString(eq(DATASOURCE_NAME), any());
     }
 }

--- a/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/src/test/java/org/eclipse/edc/connector/dataplane/selector/store/sql/SqlDataPlaneInstanceStoreExtensionTest.java
+++ b/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/src/test/java/org/eclipse/edc/connector/dataplane/selector/store/sql/SqlDataPlaneInstanceStoreExtensionTest.java
@@ -19,14 +19,14 @@ import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.configuration.Config;
 import org.eclipse.edc.spi.types.TypeManager;
-import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.connector.dataplane.selector.store.sql.SqlDataPlaneInstanceStoreExtension.DATASOURCE_SETTING_NAME;
+import static org.eclipse.edc.connector.dataplane.selector.store.sql.SqlDataPlaneInstanceStoreExtension.DATASOURCE_NAME;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -48,6 +48,6 @@ public class SqlDataPlaneInstanceStoreExtensionTest {
         var store = extension.dataPlaneInstanceStore(context);
         assertThat(store).isInstanceOf(SqlDataPlaneInstanceStore.class);
 
-        verify(config).getString(DATASOURCE_SETTING_NAME, DataSourceRegistry.DEFAULT_DATASOURCE);
+        verify(config).getString(eq(DATASOURCE_NAME), any());
     }
 }

--- a/extensions/data-plane/store/sql/data-plane-store-sql/README.md
+++ b/extensions/data-plane/store/sql/data-plane-store-sql/README.md
@@ -20,9 +20,3 @@ entity edc_data_plane {
 ```
 
 -->
-
-## Configuration
-
-| Key                           | Description                       | Mandatory | 
-|:------------------------------|:----------------------------------|-----------|
-| edc.datasource.dataplane.name | Datasource used by this extension | X         |

--- a/extensions/policy-monitor/store/sql/policy-monitor-store-sql/src/main/java/org/eclipse/edc/connector/policy/monitor/store/sql/SqlPolicyMonitorStoreExtension.java
+++ b/extensions/policy-monitor/store/sql/policy-monitor-store-sql/src/main/java/org/eclipse/edc/connector/policy/monitor/store/sql/SqlPolicyMonitorStoreExtension.java
@@ -25,6 +25,7 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.sql.QueryExecutor;
 import org.eclipse.edc.sql.bootstrapper.SqlSchemaBootstrapper;
+import org.eclipse.edc.sql.configuration.DataSourceName;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 
@@ -34,8 +35,12 @@ import static org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry.DEFA
 
 public class SqlPolicyMonitorStoreExtension implements ServiceExtension {
 
+    @Deprecated(since = "0.8.1")
     @Setting(value = "Name of the datasource to use for accessing policy monitor store", defaultValue = DEFAULT_DATASOURCE)
     private static final String DATASOURCE_SETTING_NAME = "edc.datasource.policy-monitor.name";
+
+    @Setting(value = "The datasource to be used", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE)
+    public static final String DATASOURCE_NAME = "edc.sql.store.policy-monitor.datasource";
 
     @Inject
     private DataSourceRegistry dataSourceRegistry;
@@ -60,7 +65,8 @@ public class SqlPolicyMonitorStoreExtension implements ServiceExtension {
 
     @Provider
     public PolicyMonitorStore policyMonitorStore(ServiceExtensionContext context) {
-        var dataSourceName = context.getConfig().getString(DATASOURCE_SETTING_NAME, DEFAULT_DATASOURCE);
+        var dataSourceName = DataSourceName.getDataSourceName(DATASOURCE_NAME, DATASOURCE_SETTING_NAME, context.getConfig(), context.getMonitor());
+
         sqlSchemaBootstrapper.addStatementFromResource(dataSourceName, "policy-monitor-schema.sql");
 
         return new SqlPolicyMonitorStore(dataSourceRegistry, dataSourceName, transactionContext,

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/sql/configuration/DataSourceNameTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/sql/configuration/DataSourceNameTest.java
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.sql.configuration;
+
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+class DataSourceNameTest {
+
+    private final Monitor monitor = mock();
+
+    @Test
+    void shouldReturnDefaultDatasource_whenNoConfiguration() {
+        var config = ConfigFactory.empty();
+
+        var datasourceName = DataSourceName.getDataSourceName("key", "deprecatedKey", config, monitor);
+
+        assertThat(datasourceName).isEqualTo(DataSourceRegistry.DEFAULT_DATASOURCE);
+        verifyNoInteractions(monitor);
+    }
+
+    @Test
+    void shouldReturnDatasource_whenIsInConfiguration() {
+        var config = ConfigFactory.fromMap(Map.of("key", "value"));
+
+        var datasourceName = DataSourceName.getDataSourceName("key", "deprecatedKey", config, monitor);
+
+        assertThat(datasourceName).isEqualTo("value");
+        verifyNoInteractions(monitor);
+    }
+
+    @Test
+    void shouldLogWarning_whenDeprecatedKeyIsUsed() {
+        var config = ConfigFactory.fromMap(Map.of("deprecatedKey", "value"));
+
+        var datasourceName = DataSourceName.getDataSourceName("key", "deprecatedKey", config, monitor);
+
+        assertThat(datasourceName).isEqualTo("value");
+        verify(monitor).warning(anyString());
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

Separate stores and datasources configurations, making configuration easier and clearer:
- `edc.datasource` represents the datasource configuration, that by default requires only one `default` datasource, but there's the possibility to define multiple of them
- `edc.sql.store.<name>.datasource` will associate the store to a datasource, that by default will be `default`

this will not break the existent configuration, but a `warning` log will be printed to spur adopters to migrate.

## Why it does that

simplify configuration

## Further notes

- some deserved refactoring to `CommonsConnectionPoolServiceExtension`
- added some documentation explaining how the datasource configuration works

## Linked Issue(s)

Closes #3811

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
