### PR TITLE
feat(vault): implements custom secret folder config

### DIFF
--- a/extensions/common/vault/vault-hashicorp/src/main/java/org/eclipse/edc/vault/hashicorp/HashicorpVaultExtension.java
+++ b/extensions/common/vault/vault-hashicorp/src/main/java/org/eclipse/edc/vault/hashicorp/HashicorpVaultExtension.java
@@ -71,7 +71,7 @@ public class HashicorpVaultExtension implements ServiceExtension {
     @Setting(value = "The URL path of the vault's /secret endpoint", defaultValue = VAULT_API_SECRET_PATH_DEFAULT)
     public static final String VAULT_API_SECRET_PATH = "edc.vault.hashicorp.api.secret.path";
 
-    @Setting(value = "The path of the folder that the secret is stored in", required = false, defaultValue = "")
+    @Setting(value = "The path of the folder that the secret is stored in, relative to VAULT_FOLDER_PATH")
     public static final String VAULT_FOLDER_PATH = "edc.vault.hashicorp.folder";
 
     @Inject
@@ -147,7 +147,7 @@ public class HashicorpVaultExtension implements ServiceExtension {
         var ttl = context.getSetting(VAULT_TOKEN_TTL, VAULT_TOKEN_TTL_DEFAULT);
         var renewBuffer = context.getSetting(VAULT_TOKEN_RENEW_BUFFER, VAULT_TOKEN_RENEW_BUFFER_DEFAULT);
         var secretPath = context.getSetting(VAULT_API_SECRET_PATH, VAULT_API_SECRET_PATH_DEFAULT);
-        var folderPath = context.getSetting(VAULT_FOLDER_PATH, "");
+        var folderPath = context.getSetting(VAULT_FOLDER_PATH, null);
 
         return HashicorpVaultSettings.Builder.newInstance()
                 .url(url)

--- a/extensions/common/vault/vault-hashicorp/src/main/java/org/eclipse/edc/vault/hashicorp/HashicorpVaultExtension.java
+++ b/extensions/common/vault/vault-hashicorp/src/main/java/org/eclipse/edc/vault/hashicorp/HashicorpVaultExtension.java
@@ -71,6 +71,9 @@ public class HashicorpVaultExtension implements ServiceExtension {
     @Setting(value = "The URL path of the vault's /secret endpoint", defaultValue = VAULT_API_SECRET_PATH_DEFAULT)
     public static final String VAULT_API_SECRET_PATH = "edc.vault.hashicorp.api.secret.path";
 
+    @Setting(value = "The path of the folder that the secret is stored in", required = false, defaultValue = "")
+    public static final String VAULT_FOLDER_PATH = "edc.vault.hashicorp.folder";
+
     @Inject
     private EdcHttpClient httpClient;
 
@@ -144,6 +147,7 @@ public class HashicorpVaultExtension implements ServiceExtension {
         var ttl = context.getSetting(VAULT_TOKEN_TTL, VAULT_TOKEN_TTL_DEFAULT);
         var renewBuffer = context.getSetting(VAULT_TOKEN_RENEW_BUFFER, VAULT_TOKEN_RENEW_BUFFER_DEFAULT);
         var secretPath = context.getSetting(VAULT_API_SECRET_PATH, VAULT_API_SECRET_PATH_DEFAULT);
+        var folderPath = context.getSetting(VAULT_FOLDER_PATH, "");
 
         return HashicorpVaultSettings.Builder.newInstance()
                 .url(url)
@@ -155,6 +159,7 @@ public class HashicorpVaultExtension implements ServiceExtension {
                 .ttl(ttl)
                 .renewBuffer(renewBuffer)
                 .secretPath(secretPath)
+                .folderPath(folderPath)
                 .build();
     }
 }

--- a/extensions/common/vault/vault-hashicorp/src/main/java/org/eclipse/edc/vault/hashicorp/client/HashicorpVaultClient.java
+++ b/extensions/common/vault/vault-hashicorp/src/main/java/org/eclipse/edc/vault/hashicorp/client/HashicorpVaultClient.java
@@ -279,7 +279,12 @@ public class HashicorpVaultClient {
         var folderPath = settings.getFolderPath();
 
         if (folderPath == null) {
-            folderPath = "";
+            return settings.url()
+                    .newBuilder()
+                    .addPathSegments(PathUtil.trimLeadingOrEndingSlash(vaultApiPath))
+                    .addPathSegment(entryType)
+                    .addPathSegments(key)
+                    .build();
         }
 
         return settings.url()

--- a/extensions/common/vault/vault-hashicorp/src/main/java/org/eclipse/edc/vault/hashicorp/client/HashicorpVaultClient.java
+++ b/extensions/common/vault/vault-hashicorp/src/main/java/org/eclipse/edc/vault/hashicorp/client/HashicorpVaultClient.java
@@ -276,11 +276,17 @@ public class HashicorpVaultClient {
         key = key.replace("%2F", "/");
 
         var vaultApiPath = settings.secretPath();
+        var folderPath = settings.getFolderPath();
+
+        if (folderPath == null) {
+            folderPath = "";
+        }
 
         return settings.url()
                 .newBuilder()
                 .addPathSegments(PathUtil.trimLeadingOrEndingSlash(vaultApiPath))
                 .addPathSegment(entryType)
+                .addPathSegments(PathUtil.trimLeadingOrEndingSlash(folderPath))
                 .addPathSegments(key)
                 .build();
     }

--- a/extensions/common/vault/vault-hashicorp/src/main/java/org/eclipse/edc/vault/hashicorp/client/HashicorpVaultClient.java
+++ b/extensions/common/vault/vault-hashicorp/src/main/java/org/eclipse/edc/vault/hashicorp/client/HashicorpVaultClient.java
@@ -278,20 +278,16 @@ public class HashicorpVaultClient {
         var vaultApiPath = settings.secretPath();
         var folderPath = settings.getFolderPath();
 
-        if (folderPath == null) {
-            return settings.url()
-                    .newBuilder()
-                    .addPathSegments(PathUtil.trimLeadingOrEndingSlash(vaultApiPath))
-                    .addPathSegment(entryType)
-                    .addPathSegments(key)
-                    .build();
-        }
-
-        return settings.url()
+        var builder = settings.url()
                 .newBuilder()
                 .addPathSegments(PathUtil.trimLeadingOrEndingSlash(vaultApiPath))
-                .addPathSegment(entryType)
-                .addPathSegments(PathUtil.trimLeadingOrEndingSlash(folderPath))
+                .addPathSegment(entryType);
+
+        if (folderPath != null) {
+            builder.addPathSegments(PathUtil.trimLeadingOrEndingSlash(folderPath));
+        }
+
+        return builder
                 .addPathSegments(key)
                 .build();
     }

--- a/extensions/common/vault/vault-hashicorp/src/main/java/org/eclipse/edc/vault/hashicorp/client/HashicorpVaultSettings.java
+++ b/extensions/common/vault/vault-hashicorp/src/main/java/org/eclipse/edc/vault/hashicorp/client/HashicorpVaultSettings.java
@@ -33,6 +33,8 @@ public class HashicorpVaultSettings {
     private long renewBuffer;
     private String secretPath;
 
+    private String folderPath;
+
     private HashicorpVaultSettings() {
     }
 
@@ -70,6 +72,10 @@ public class HashicorpVaultSettings {
 
     public String secretPath() {
         return secretPath;
+    }
+
+    public String getFolderPath() {
+        return folderPath;
     }
 
     public static class Builder {
@@ -126,6 +132,11 @@ public class HashicorpVaultSettings {
 
         public Builder secretPath(String secretPath) {
             values.secretPath = secretPath;
+            return this;
+        }
+
+        public Builder folderPath(String folderPath) {
+            values.folderPath = folderPath;
             return this;
         }
 

--- a/extensions/common/vault/vault-hashicorp/src/test/java/org/eclipse/edc/vault/hashicorp/client/HashicorpVaultSettingsTest.java
+++ b/extensions/common/vault/vault-hashicorp/src/test/java/org/eclipse/edc/vault/hashicorp/client/HashicorpVaultSettingsTest.java
@@ -48,6 +48,7 @@ class HashicorpVaultSettingsTest {
         assertThat(settings.ttl()).isEqualTo(VAULT_TOKEN_TTL_DEFAULT);
         assertThat(settings.renewBuffer()).isEqualTo(VAULT_TOKEN_RENEW_BUFFER_DEFAULT);
         assertThat(settings.secretPath()).isEqualTo(SECRET_PATH);
+        assertThat(settings.getFolderPath()).isNull();
     }
 
     @Test


### PR DESCRIPTION
## What this PR changes/adds

Adds the possibility to configure a folder for the storage of secrets inside Hashicorp Vault.

## Why it does that

Additional feature, as described in the discussion and issue.

## Linked Issue(s)

Closes #4384 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
