### PR TITLE
feat: add component ID

### DIFF
--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/BootServicesExtension.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/BootServicesExtension.java
@@ -42,8 +42,11 @@ public class BootServicesExtension implements ServiceExtension {
     @Setting(value = "Configures the participant id this runtime is operating on behalf of")
     public static final String PARTICIPANT_ID = "edc.participant.id";
 
-    @Setting(value = "Configures the runtime id", defaultValue = "<random UUID>")
+    @Setting(value = "Configures the runtime id. This should be fully or partly randomized, and need not be stable across restarts. It is recommended to leave this value blank.", defaultValue = "<random UUID>")
     public static final String RUNTIME_ID = "edc.runtime.id";
+
+    @Setting(value = "Configures this component's ID. This should be a unique, stable and deterministic identifier.", defaultValue = "<random UUID>")
+    public static final String COMPONENT_ID = "edc.component.id";
 
     private HealthCheckServiceImpl healthCheckService;
 

--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/DefaultServiceExtensionContext.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/DefaultServiceExtensionContext.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+import static org.eclipse.edc.boot.BootServicesExtension.COMPONENT_ID;
 import static org.eclipse.edc.boot.BootServicesExtension.RUNTIME_ID;
 
 /**
@@ -33,14 +34,13 @@ import static org.eclipse.edc.boot.BootServicesExtension.RUNTIME_ID;
  */
 public class DefaultServiceExtensionContext implements ServiceExtensionContext {
 
-    @Deprecated(since = "0.6.2")
-    private static final String EDC_CONNECTOR_NAME = "edc.connector.name";
 
     private final Map<Class<?>, Object> services = new HashMap<>();
     private final Config config;
     private boolean isReadOnly = false;
     private String participantId;
     private String runtimeId;
+    private String componentId;
 
     public DefaultServiceExtensionContext(Monitor monitor, Config config) {
         this.config = config;
@@ -66,6 +66,11 @@ public class DefaultServiceExtensionContext implements ServiceExtensionContext {
     @Override
     public String getRuntimeId() {
         return runtimeId;
+    }
+
+    @Override
+    public String getComponentId() {
+        return componentId;
     }
 
     @Override
@@ -108,20 +113,21 @@ public class DefaultServiceExtensionContext implements ServiceExtensionContext {
             getMonitor().warning("The runtime is configured as an anonymous participant. DO NOT DO THIS IN PRODUCTION.");
         }
 
-        var connectorName = getSetting(EDC_CONNECTOR_NAME, null);
-        if (connectorName != null) {
-            getMonitor().warning("Setting %s has been deprecated, please use %s instead".formatted(EDC_CONNECTOR_NAME, RUNTIME_ID));
+        runtimeId = getSetting(RUNTIME_ID, null);
+        if (runtimeId != null) {
+            getMonitor().warning("A configuration value for '%s' was found. The runtime ID should be left blank to use a random one.".formatted(RUNTIME_ID));
         }
 
-        runtimeId = getSetting(RUNTIME_ID, null);
-        if (runtimeId == null) {
-            if (connectorName == null) {
-                getMonitor().warning("%s is not configured so a random UUID is used. It is recommended to provide a static one.".formatted(RUNTIME_ID));
-                runtimeId = UUID.randomUUID().toString();
+        componentId = getSetting(COMPONENT_ID, null);
+        if (componentId == null) {
+            if (runtimeId != null) {
+                getMonitor().warning("'%s' is not configured, but '%s' is. The value used for '%s' will be used for '%s', and a random string will be used for '%s'".formatted(COMPONENT_ID, RUNTIME_ID, RUNTIME_ID, COMPONENT_ID, RUNTIME_ID));
+                componentId = runtimeId;
             } else {
-                getMonitor().warning("%s is not configured and it will fallback to the deprecated %s value".formatted(RUNTIME_ID, EDC_CONNECTOR_NAME));
-                runtimeId = connectorName;
+                getMonitor().warning("%s is not configured so a random UUID is used. It is recommended to provide a static one.".formatted(COMPONENT_ID));
+                componentId = UUID.randomUUID().toString();
             }
+            runtimeId = UUID.randomUUID().toString();
         }
 
     }

--- a/core/common/boot/src/test/java/org/eclipse/edc/boot/system/DefaultServiceExtensionContextTest.java
+++ b/core/common/boot/src/test/java/org/eclipse/edc/boot/system/DefaultServiceExtensionContextTest.java
@@ -29,12 +29,14 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.eclipse.edc.boot.BootServicesExtension.COMPONENT_ID;
 import static org.eclipse.edc.boot.BootServicesExtension.RUNTIME_ID;
 import static org.mockito.AdditionalMatchers.and;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -83,24 +85,62 @@ class DefaultServiceExtensionContextTest {
     @Nested
     class GetRuntimeId {
         @Test
-        void shouldReturnRandomUuid_whenNotConfigured() {
+        void shouldReturnRandomUuid_whenNotConfigured_andComponentIdNull() {
             when(config.getConfig(any())).thenReturn(ConfigFactory.empty());
             context.initialize();
 
             var runtimeId = context.getRuntimeId();
-
             assertThat(UUID.fromString(runtimeId)).isNotNull();
-            verify(monitor).warning(and(isA(String.class), argThat(message -> message.startsWith(RUNTIME_ID))));
+
+            verify(monitor, times(2)).warning(and(isA(String.class), argThat(message -> !message.contains(RUNTIME_ID))));
         }
 
+
         @Test
-        void shouldReturnConfiguredId_whenConfigured() {
+        void shouldReturnRandomId_whenComponentIdNotConfigured() {
             when(config.getConfig(any())).thenReturn(ConfigFactory.fromMap(Map.of(RUNTIME_ID, "runtime-id")));
             context.initialize();
 
             var runtimeId = context.getRuntimeId();
 
+            assertThat(UUID.fromString(runtimeId)).isNotNull();
+        }
+    }
+
+    @Nested
+    class GetComponentId {
+        @Test
+        void shouldReturnRandomUuid_whenNotConfigured() {
+            when(config.getConfig(any())).thenReturn(ConfigFactory.empty());
+            context.initialize();
+
+            var componentId = context.getComponentId();
+            assertThat(UUID.fromString(componentId)).isNotNull();
+
+            verify(monitor).warning(and(isA(String.class), argThat(message -> !message.contains(COMPONENT_ID))));
+        }
+
+
+        @Test
+        void shouldUseRuntimeId_whenComponentIdNotConfigured() {
+            when(config.getConfig(any())).thenReturn(ConfigFactory.fromMap(Map.of(RUNTIME_ID, "runtime-id")));
+            context.initialize();
+            var componentId = context.getComponentId();
+            assertThat(componentId).isEqualTo("runtime-id");
+        }
+
+
+        @Test
+        void shouldUseConfiguredValue_whenBothAreConfigured() {
+            when(config.getConfig(any())).thenReturn(ConfigFactory.fromMap(Map.of(RUNTIME_ID, "runtime-id", COMPONENT_ID, "component-id")));
+
+            context.initialize();
+            var componentId = context.getComponentId();
+            var runtimeId = context.getRuntimeId();
+
             assertThat(runtimeId).isEqualTo("runtime-id");
+            assertThat(componentId).isEqualTo("component-id");
+            verify(monitor).warning(and(isA(String.class), argThat(message -> !message.contains(RUNTIME_ID))));
         }
     }
 

--- a/core/common/boot/src/test/java/org/eclipse/edc/boot/system/DefaultServiceExtensionContextTest.java
+++ b/core/common/boot/src/test/java/org/eclipse/edc/boot/system/DefaultServiceExtensionContextTest.java
@@ -138,7 +138,7 @@ class DefaultServiceExtensionContextTest {
             var componentId = context.getComponentId();
             var runtimeId = context.getRuntimeId();
 
-            assertThat(runtimeId).isEqualTo("runtime-id");
+            assertThat(UUID.fromString(runtimeId)).isNotNull();
             assertThat(componentId).isEqualTo("component-id");
             verify(monitor).warning(and(isA(String.class), argThat(message -> !message.contains(RUNTIME_ID))));
         }

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceExtension.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceExtension.java
@@ -173,7 +173,7 @@ public class Oauth2ServiceExtension implements ServiceExtension {
     }
 
     private Oauth2ServiceConfiguration createConfig(ServiceExtensionContext context) {
-        var providerAudience = context.getSetting(PROVIDER_AUDIENCE, context.getRuntimeId());
+        var providerAudience = context.getSetting(PROVIDER_AUDIENCE, context.getComponentId());
         var endpointAudience = context.getSetting(ENDPOINT_AUDIENCE, providerAudience);
         var tokenUrl = context.getConfig().getString(TOKEN_URL);
         var publicCertificateAlias = context.getConfig().getString(PUBLIC_CERTIFICATE_ALIAS);

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/store/SqlContractNegotiationStore.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/store/SqlContractNegotiationStore.java
@@ -59,12 +59,12 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
 
     public SqlContractNegotiationStore(DataSourceRegistry dataSourceRegistry, String dataSourceName,
                                        TransactionContext transactionContext, ObjectMapper objectMapper,
-                                       ContractNegotiationStatements statements, String connectorId, Clock clock,
+                                       ContractNegotiationStatements statements, String leaseHolderName, Clock clock,
                                        QueryExecutor queryExecutor) {
         super(dataSourceRegistry, dataSourceName, transactionContext, objectMapper, queryExecutor);
         this.statements = statements;
         this.clock = clock;
-        leaseContext = SqlLeaseContextBuilder.with(transactionContext, connectorId, statements, clock, queryExecutor);
+        leaseContext = SqlLeaseContextBuilder.with(transactionContext, leaseHolderName, statements, clock, queryExecutor);
     }
 
     @Override

--- a/extensions/data-plane/data-plane-self-registration/src/main/java/org/eclipse/edc/connector/dataplane/registration/DataplaneSelfRegistrationExtension.java
+++ b/extensions/data-plane/data-plane-self-registration/src/main/java/org/eclipse/edc/connector/dataplane/registration/DataplaneSelfRegistrationExtension.java
@@ -46,15 +46,12 @@ import static org.eclipse.edc.spi.types.domain.transfer.FlowType.PUSH;
 @Extension(NAME)
 public class DataplaneSelfRegistrationExtension implements ServiceExtension {
 
-    public static final String NAME = "Dataplane Self Registration";
-    private final AtomicBoolean isRegistered = new AtomicBoolean(false);
-    private final AtomicReference<String> registrationError = new AtomicReference<>("Data plane self registration not complete");
-
     private static final boolean DEFAULT_SELF_UNREGISTRATION = false;
-
+    public static final String NAME = "Dataplane Self Registration";
     @Setting(value = "Enable data-plane un-registration at shutdown (not suggested for clustered environments)", type = "boolean", defaultValue = DEFAULT_SELF_UNREGISTRATION + "")
     static final String SELF_UNREGISTRATION = "edc.data.plane.self.unregistration";
-
+    private final AtomicBoolean isRegistered = new AtomicBoolean(false);
+    private final AtomicReference<String> registrationError = new AtomicReference<>("Data plane self registration not complete");
     @Inject
     private DataPlaneSelectorService dataPlaneSelectorService;
     @Inject
@@ -86,7 +83,7 @@ public class DataplaneSelfRegistrationExtension implements ServiceExtension {
         );
 
         var instance = DataPlaneInstance.Builder.newInstance()
-                .id(context.getRuntimeId())
+                .id(context.getComponentId())
                 .url(controlApiUrl.get().toString() + "/v1/dataflows")
                 .allowedSourceTypes(pipelineService.supportedSourceTypes())
                 .allowedDestTypes(pipelineService.supportedSinkTypes())
@@ -112,7 +109,7 @@ public class DataplaneSelfRegistrationExtension implements ServiceExtension {
     @Override
     public void shutdown() {
         if (context.getConfig().getBoolean(SELF_UNREGISTRATION, DEFAULT_SELF_UNREGISTRATION)) {
-            dataPlaneSelectorService.unregister(context.getRuntimeId())
+            dataPlaneSelectorService.unregister(context.getComponentId())
                     .onSuccess(it -> context.getMonitor().info("data plane successfully unregistered"))
                     .onFailure(failure -> context.getMonitor().severe("error during data plane de-registration. %s: %s"
                             .formatted(failure.getReason(), failure.getFailureDetail())));

--- a/extensions/data-plane/data-plane-self-registration/src/test/java/org/eclipse/edc/connector/dataplane/registration/DataplaneSelfRegistrationExtensionTest.java
+++ b/extensions/data-plane/data-plane-self-registration/src/test/java/org/eclipse/edc/connector/dataplane/registration/DataplaneSelfRegistrationExtensionTest.java
@@ -63,14 +63,14 @@ class DataplaneSelfRegistrationExtensionTest {
         context.registerService(PipelineService.class, pipelineService);
         context.registerService(PublicEndpointGeneratorService.class, publicEndpointGeneratorService);
         var monitor = mock(Monitor.class);
-        when(monitor.withPrefix(anyString())).thenReturn(mock());
+        when(monitor.withPrefix(anyString())).thenReturn(monitor);
         context.registerService(Monitor.class, monitor);
         context.registerService(HealthCheckService.class, healthCheckService);
     }
 
     @Test
     void shouldRegisterInstanceAtStartup(DataplaneSelfRegistrationExtension extension, ServiceExtensionContext context) throws MalformedURLException {
-        when(context.getRuntimeId()).thenReturn("runtimeId");
+        when(context.getComponentId()).thenReturn("componentId");
         when(controlApiUrl.get()).thenReturn(URI.create("http://control/api/url"));
         when(pipelineService.supportedSinkTypes()).thenReturn(Set.of("sinkType", "anotherSinkType"));
         when(pipelineService.supportedSourceTypes()).thenReturn(Set.of("sourceType", "anotherSourceType"));
@@ -83,7 +83,7 @@ class DataplaneSelfRegistrationExtensionTest {
         var captor = ArgumentCaptor.forClass(DataPlaneInstance.class);
         verify(dataPlaneSelectorService).addInstance(captor.capture());
         var dataPlaneInstance = captor.getValue();
-        assertThat(dataPlaneInstance.getId()).isEqualTo("runtimeId");
+        assertThat(dataPlaneInstance.getId()).isEqualTo("componentId");
         assertThat(dataPlaneInstance.getUrl()).isEqualTo(new URL("http://control/api/url/v1/dataflows"));
         assertThat(dataPlaneInstance.getAllowedSourceTypes()).containsExactlyInAnyOrder("sourceType", "anotherSourceType");
         assertThat(dataPlaneInstance.getAllowedDestTypes()).containsExactlyInAnyOrder("sinkType", "anotherSinkType");
@@ -107,7 +107,7 @@ class DataplaneSelfRegistrationExtensionTest {
 
     @Test
     void shouldNotUnregisterInstanceAtShutdown(DataplaneSelfRegistrationExtension extension, ServiceExtensionContext context) {
-        when(context.getRuntimeId()).thenReturn("runtimeId");
+        when(context.getComponentId()).thenReturn("componentId");
         when(dataPlaneSelectorService.unregister(any())).thenReturn(ServiceResult.success());
         extension.initialize(context);
 
@@ -118,13 +118,13 @@ class DataplaneSelfRegistrationExtensionTest {
 
     @Test
     void shouldUnregisterInstanceAtShutdown_whenConfigured(DataplaneSelfRegistrationExtension extension, ServiceExtensionContext context) {
-        when(context.getRuntimeId()).thenReturn("runtimeId");
+        when(context.getComponentId()).thenReturn("componentId");
         when(context.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of(SELF_UNREGISTRATION, "true")));
         when(dataPlaneSelectorService.unregister(any())).thenReturn(ServiceResult.success());
         extension.initialize(context);
 
         extension.shutdown();
 
-        verify(dataPlaneSelectorService).unregister("runtimeId");
+        verify(dataPlaneSelectorService).unregister("componentId");
     }
 }

--- a/spi/common/boot-spi/src/main/java/org/eclipse/edc/spi/system/ServiceExtensionContext.java
+++ b/spi/common/boot-spi/src/main/java/org/eclipse/edc/spi/system/ServiceExtensionContext.java
@@ -40,22 +40,24 @@ public interface ServiceExtensionContext extends SettingResolver {
     String getParticipantId();
 
     /**
-     * Return the id of the runtime. If not configured a random UUID is used.
+     * Return the id of the runtime. A runtime is a physical process. If {@code edc.runtime.id} is not configured, a random UUID is used.
+     * <br/><em>It is recommended to leave this configuration blank..</em>
      *
      * @return the runtime id.
      */
     String getRuntimeId();
 
     /**
-     * Fetches the unique ID of the connector. If the {@code dataspaceconnector.connector.name} config value has been set, that value is returned; otherwise  a random
-     * name is chosen.
+     * Returns the id of the component. A component is a logical unit of deployment, consisting of 1...N runtimes. If it is not
+     * configured, but the runtime ID is configured, then the value of the runtime ID will be used. If neither runtime ID
+     * nor component ID are used, (individual) random values are generated.
+     * <p>
+     * <br/><em>It is recommended to provide a stable value for this configuration.</em>
      *
-     * @deprecated use {{@link #getRuntimeId()}} instead.
+     * @return the component id.
      */
-    @Deprecated(since = "0.6.2")
-    default String getConnectorId() {
-        return getRuntimeId();
-    }
+    String getComponentId();
+
 
     /**
      * Returns the system monitor.


### PR DESCRIPTION
## What this PR changes/adds

This PR adds the `edc.component.id` property with the following logic:

- if `edc.runtime.id` is configured, a warning is issued
- if `edc.component.id` is not configured, a warning is issued. 
  - if `edc.runtime.id` is configured, its value is used for `edc.component.id`, and `edc.runtime.id` receives a random UUID
  - if `edc.runtime.id` is not configured, a random UUID is used for `edc.component.id`

This way, backwards compatibility can be provided for deployments that previously had configured a static `edc.runtime.id`.

In addition, Dataplane Self Registration was modified to use the `edc.component.id` property.

## Why it does that

component IDs are used for idempotent processes, such as data plane registration. runtime IDs are used for lease acquisition.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #4399

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
