### PR TITLE
refactor(remote STS): lazy fetch the secret from the vault before request

### DIFF
--- a/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-remote-client/src/main/java/org/eclipse/edc/iam/identitytrust/sts/remote/client/StsRemoteClientConfigurationExtension.java
+++ b/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-remote-client/src/main/java/org/eclipse/edc/iam/identitytrust/sts/remote/client/StsRemoteClientConfigurationExtension.java
@@ -23,10 +23,6 @@ import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 
-import java.util.Objects;
-
-import static java.lang.String.format;
-
 /**
  * Configuration Extension for the STS OAuth2 client
  */
@@ -58,10 +54,8 @@ public class StsRemoteClientConfigurationExtension implements ServiceExtension {
         var tokenUrl = context.getConfig().getString(TOKEN_URL);
         var clientId = context.getConfig().getString(CLIENT_ID);
         var clientSecretAlias = context.getConfig().getString(CLIENT_SECRET_ALIAS);
-        var clientSecret = vault.resolveSecret(clientSecretAlias);
-        Objects.requireNonNull(clientSecret, format("Client secret could not be retrieved from the vault with alias %s", clientSecretAlias));
 
-        return new StsRemoteClientConfiguration(tokenUrl, clientId, clientSecret);
+        return new StsRemoteClientConfiguration(tokenUrl, clientId, clientSecretAlias);
     }
 
 }

--- a/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-remote-client/src/main/java/org/eclipse/edc/iam/identitytrust/sts/remote/client/StsRemoteClientExtension.java
+++ b/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-remote-client/src/main/java/org/eclipse/edc/iam/identitytrust/sts/remote/client/StsRemoteClientExtension.java
@@ -21,6 +21,7 @@ import org.eclipse.edc.iam.oauth2.spi.client.Oauth2Client;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.system.ServiceExtension;
 
 /**
@@ -37,6 +38,9 @@ public class StsRemoteClientExtension implements ServiceExtension {
     @Inject
     private Oauth2Client oauth2Client;
 
+    @Inject
+    private Vault vault;
+
     @Override
     public String name() {
         return NAME;
@@ -44,6 +48,6 @@ public class StsRemoteClientExtension implements ServiceExtension {
 
     @Provider
     public SecureTokenService secureTokenService() {
-        return new RemoteSecureTokenService(oauth2Client, clientConfiguration);
+        return new RemoteSecureTokenService(oauth2Client, clientConfiguration, vault);
     }
 }

--- a/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-remote-client/src/test/java/org/eclipse/edc/iam/identitytrust/sts/remote/client/StsRemoteClientConfigurationExtensionTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-remote-client/src/test/java/org/eclipse/edc/iam/identitytrust/sts/remote/client/StsRemoteClientConfigurationExtensionTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.edc.iam.identitytrust.sts.remote.client.StsRemoteClientConfigurationExtension.CLIENT_ID;
 import static org.eclipse.edc.iam.identitytrust.sts.remote.client.StsRemoteClientConfigurationExtension.CLIENT_SECRET_ALIAS;
 import static org.eclipse.edc.iam.identitytrust.sts.remote.client.StsRemoteClientConfigurationExtension.TOKEN_URL;
@@ -41,13 +40,11 @@ public class StsRemoteClientConfigurationExtensionTest {
     }
 
     @Test
-    void initialize(StsRemoteClientConfigurationExtension extension, ServiceExtensionContext context, Vault vault) {
+    void initialize(StsRemoteClientConfigurationExtension extension, ServiceExtensionContext context) {
 
         var tokenUrl = "http://tokenUrl";
         var clientId = "clientId";
         var secretAlias = "secretAlias";
-
-        when(vault.resolveSecret(secretAlias)).thenReturn(secretAlias);
 
         var configMap = Map.of(TOKEN_URL, tokenUrl, CLIENT_ID, clientId, CLIENT_SECRET_ALIAS, secretAlias);
         var config = ConfigFactory.fromMap(configMap);
@@ -62,19 +59,5 @@ public class StsRemoteClientConfigurationExtensionTest {
                     assertThat(configuration.clientSecretAlias()).isEqualTo(secretAlias);
                 });
     }
-
-    @Test
-    void initialize_fail_withVaultSecretResolutionError(StsRemoteClientConfigurationExtension extension, ServiceExtensionContext context, Vault vault) {
-
-        var tokenUrl = "http://tokenUrl";
-        var clientId = "clientId";
-        var secretAlias = "secretAlias";
-
-        var configMap = Map.of(TOKEN_URL, tokenUrl, CLIENT_ID, clientId, CLIENT_SECRET_ALIAS, secretAlias);
-        var config = ConfigFactory.fromMap(configMap);
-
-        when(context.getConfig()).thenReturn(config);
-
-        assertThatThrownBy(() -> extension.clientConfiguration(context)).isInstanceOf(NullPointerException.class);
-    }
+    
 }

--- a/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-remote-client/src/test/java/org/eclipse/edc/iam/identitytrust/sts/remote/client/StsRemoteClientConfigurationExtensionTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-remote-client/src/test/java/org/eclipse/edc/iam/identitytrust/sts/remote/client/StsRemoteClientConfigurationExtensionTest.java
@@ -59,7 +59,7 @@ public class StsRemoteClientConfigurationExtensionTest {
                 .satisfies(configuration -> {
                     assertThat(configuration.tokenUrl()).isEqualTo(tokenUrl);
                     assertThat(configuration.clientId()).isEqualTo(clientId);
-                    assertThat(configuration.clientSecret()).isEqualTo(secretAlias);
+                    assertThat(configuration.clientSecretAlias()).isEqualTo(secretAlias);
                 });
     }
 

--- a/extensions/common/iam/identity-trust/identity-trust-sts/lib/identity-trust-sts-remote-lib/src/main/java/org/eclipse/edc/iam/identitytrust/sts/remote/RemoteSecureTokenService.java
+++ b/extensions/common/iam/identity-trust/identity-trust-sts/lib/identity-trust-sts-remote-lib/src/main/java/org/eclipse/edc/iam/identitytrust/sts/remote/RemoteSecureTokenService.java
@@ -20,6 +20,7 @@ import org.eclipse.edc.iam.oauth2.spi.client.Oauth2CredentialsRequest;
 import org.eclipse.edc.iam.oauth2.spi.client.SharedSecretOauth2CredentialsRequest;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.security.Vault;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -41,35 +42,46 @@ public class RemoteSecureTokenService implements SecureTokenService {
 
     private final Oauth2Client oauth2Client;
     private final StsRemoteClientConfiguration configuration;
+    private final Vault vault;
 
-    public RemoteSecureTokenService(Oauth2Client oauth2Client, StsRemoteClientConfiguration configuration) {
+    public RemoteSecureTokenService(Oauth2Client oauth2Client, StsRemoteClientConfiguration configuration, Vault vault) {
         this.oauth2Client = oauth2Client;
         this.configuration = configuration;
+        this.vault = vault;
     }
 
     @Override
     public Result<TokenRepresentation> createToken(Map<String, String> claims, @Nullable String bearerAccessScope) {
-        return oauth2Client.requestToken(createRequest(claims, bearerAccessScope));
+        return createRequest(claims, bearerAccessScope)
+                .compose(oauth2Client::requestToken);
     }
 
     @NotNull
-    private Oauth2CredentialsRequest createRequest(Map<String, String> claims, @Nullable String bearerAccessScope) {
-        var builder = SharedSecretOauth2CredentialsRequest.Builder.newInstance()
-                .url(configuration.tokenUrl())
-                .clientId(configuration.clientId())
-                .clientSecret(configuration.clientSecret())
-                .grantType(GRANT_TYPE);
+    private Result<Oauth2CredentialsRequest> createRequest(Map<String, String> claims, @Nullable String bearerAccessScope) {
 
-        var additionalParams = claims.entrySet().stream()
-                .filter(entry -> CLAIM_MAPPING.containsKey(entry.getKey()))
-                .map(entry -> Map.entry(CLAIM_MAPPING.get(entry.getKey()), entry.getValue()))
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        var secret = vault.resolveSecret(configuration.clientSecretAlias());
+        if (secret != null) {
+            var builder = SharedSecretOauth2CredentialsRequest.Builder.newInstance()
+                    .url(configuration.tokenUrl())
+                    .clientId(configuration.clientId())
+                    .clientSecret(secret)
+                    .grantType(GRANT_TYPE);
 
-        if (bearerAccessScope != null) {
-            additionalParams.put(BEARER_ACCESS_SCOPE, bearerAccessScope);
+            var additionalParams = claims.entrySet().stream()
+                    .filter(entry -> CLAIM_MAPPING.containsKey(entry.getKey()))
+                    .map(entry -> Map.entry(CLAIM_MAPPING.get(entry.getKey()), entry.getValue()))
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+            if (bearerAccessScope != null) {
+                additionalParams.put(BEARER_ACCESS_SCOPE, bearerAccessScope);
+            }
+
+            builder.params(additionalParams);
+            return Result.success(builder.build());
+        } else {
+            return Result.failure("Failed to fetch client secret from the vault with alias: %s".formatted(configuration.clientSecretAlias()));
         }
 
-        builder.params(additionalParams);
-        return builder.build();
+
     }
 }

--- a/extensions/common/iam/identity-trust/identity-trust-sts/lib/identity-trust-sts-remote-lib/src/main/java/org/eclipse/edc/iam/identitytrust/sts/remote/StsRemoteClientConfiguration.java
+++ b/extensions/common/iam/identity-trust/identity-trust-sts/lib/identity-trust-sts-remote-lib/src/main/java/org/eclipse/edc/iam/identitytrust/sts/remote/StsRemoteClientConfiguration.java
@@ -17,6 +17,6 @@ package org.eclipse.edc.iam.identitytrust.sts.remote;
 /**
  * Configuration of the OAuth2 client
  */
-public record StsRemoteClientConfiguration(String tokenUrl, String clientId, String clientSecret) {
-    
+public record StsRemoteClientConfiguration(String tokenUrl, String clientId, String clientSecretAlias) {
+
 }

--- a/extensions/common/iam/identity-trust/identity-trust-sts/lib/identity-trust-sts-remote-lib/src/test/java/org/eclipse/edc/iam/identitytrust/sts/remote/RemoteSecureTokenServiceTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-sts/lib/identity-trust-sts-remote-lib/src/test/java/org/eclipse/edc/iam/identitytrust/sts/remote/RemoteSecureTokenServiceTest.java
@@ -18,12 +18,14 @@ import org.eclipse.edc.iam.oauth2.spi.client.Oauth2Client;
 import org.eclipse.edc.iam.oauth2.spi.client.SharedSecretOauth2CredentialsRequest;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.security.Vault;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.util.Map;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.iam.identitytrust.spi.SelfIssuedTokenConstants.BEARER_ACCESS_SCOPE;
 import static org.eclipse.edc.iam.identitytrust.spi.SelfIssuedTokenConstants.PRESENTATION_TOKEN_CLAIM;
@@ -38,19 +40,23 @@ import static org.mockito.Mockito.when;
 
 public class RemoteSecureTokenServiceTest {
 
-    private final StsRemoteClientConfiguration configuration = new StsRemoteClientConfiguration("id", "secret", "url");
+    private final StsRemoteClientConfiguration configuration = new StsRemoteClientConfiguration("url", "id", "secretAlias");
     private final Oauth2Client oauth2Client = mock();
+    private final Vault vault = mock();
     private RemoteSecureTokenService secureTokenService;
 
     @BeforeEach
     void setup() {
-        secureTokenService = new RemoteSecureTokenService(oauth2Client, configuration);
+        secureTokenService = new RemoteSecureTokenService(oauth2Client, configuration, vault);
     }
 
     @Test
     void createToken() {
         var audience = "aud";
+        var secret = "secret";
         when(oauth2Client.requestToken(any())).thenReturn(Result.success(TokenRepresentation.Builder.newInstance().build()));
+        when(vault.resolveSecret(configuration.clientSecretAlias())).thenReturn(secret);
+
         assertThat(secureTokenService.createToken(Map.of(AUDIENCE, audience), null)).isSucceeded();
 
         var captor = ArgumentCaptor.forClass(SharedSecretOauth2CredentialsRequest.class);
@@ -60,7 +66,7 @@ public class RemoteSecureTokenServiceTest {
             assertThat(request.getUrl()).isEqualTo(configuration.tokenUrl());
             assertThat(request.getClientId()).isEqualTo(configuration.clientId());
             assertThat(request.getGrantType()).isEqualTo(GRANT_TYPE);
-            assertThat(request.getClientSecret()).isEqualTo(configuration.clientSecret());
+            assertThat(request.getClientSecret()).isEqualTo(secret);
             assertThat(request.getParams())
                     .containsEntry(AUDIENCE_PARAM, audience);
         });
@@ -70,7 +76,11 @@ public class RemoteSecureTokenServiceTest {
     void createToken_withAccessScope() {
         var audience = "aud";
         var bearerAccessScope = "scope";
+        var secret = "secret";
+
         when(oauth2Client.requestToken(any())).thenReturn(Result.success(TokenRepresentation.Builder.newInstance().build()));
+        when(vault.resolveSecret(configuration.clientSecretAlias())).thenReturn(secret);
+
         assertThat(secureTokenService.createToken(Map.of(AUDIENCE, audience), bearerAccessScope)).isSucceeded();
 
         var captor = ArgumentCaptor.forClass(SharedSecretOauth2CredentialsRequest.class);
@@ -80,7 +90,7 @@ public class RemoteSecureTokenServiceTest {
             assertThat(request.getUrl()).isEqualTo(configuration.tokenUrl());
             assertThat(request.getClientId()).isEqualTo(configuration.clientId());
             assertThat(request.getGrantType()).isEqualTo(GRANT_TYPE);
-            assertThat(request.getClientSecret()).isEqualTo(configuration.clientSecret());
+            assertThat(request.getClientSecret()).isEqualTo(secret);
             assertThat(request.getParams())
                     .containsEntry(AUDIENCE_PARAM, audience)
                     .containsEntry(BEARER_ACCESS_SCOPE, bearerAccessScope);
@@ -91,7 +101,11 @@ public class RemoteSecureTokenServiceTest {
     void createToken_withAccessToken() {
         var audience = "aud";
         var accessToken = "accessToken";
+        var secret = "secret";
+
         when(oauth2Client.requestToken(any())).thenReturn(Result.success(TokenRepresentation.Builder.newInstance().build()));
+        when(vault.resolveSecret(configuration.clientSecretAlias())).thenReturn(secret);
+
         assertThat(secureTokenService.createToken(Map.of(AUDIENCE, audience, PRESENTATION_TOKEN_CLAIM, accessToken), null)).isSucceeded();
 
         var captor = ArgumentCaptor.forClass(SharedSecretOauth2CredentialsRequest.class);
@@ -101,11 +115,25 @@ public class RemoteSecureTokenServiceTest {
             assertThat(request.getUrl()).isEqualTo(configuration.tokenUrl());
             assertThat(request.getClientId()).isEqualTo(configuration.clientId());
             assertThat(request.getGrantType()).isEqualTo(GRANT_TYPE);
-            assertThat(request.getClientSecret()).isEqualTo(configuration.clientSecret());
+            assertThat(request.getClientSecret()).isEqualTo(secret);
             assertThat(request.getParams())
                     .containsEntry(AUDIENCE_PARAM, audience)
                     .containsEntry(PRESENTATION_TOKEN_CLAIM, accessToken);
         });
+    }
+
+    @Test
+    void createToken_shouldFail_whenSecretIsNotPresent() {
+        var audience = "aud";
+        var accessToken = "accessToken";
+
+        when(oauth2Client.requestToken(any())).thenReturn(Result.success(TokenRepresentation.Builder.newInstance().build()));
+        when(vault.resolveSecret(configuration.clientSecretAlias())).thenReturn(null);
+        
+        assertThat(secureTokenService.createToken(Map.of(AUDIENCE, audience, PRESENTATION_TOKEN_CLAIM, accessToken), null))
+                .isFailed()
+                .detail().isEqualTo(format("Failed to fetch client secret from the vault with alias: %s", configuration.clientSecretAlias()));
+
     }
 
 }

--- a/system-tests/sts-api/sts-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/sts/api/RemoteStsEndToEndTest.java
+++ b/system-tests/sts-api/sts-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/sts/api/RemoteStsEndToEndTest.java
@@ -50,7 +50,8 @@ public class RemoteStsEndToEndTest extends StsEndToEndTestBase {
 
     public static final int PORT = getFreePort();
     public static final String STS_TOKEN_PATH = "http://localhost:" + PORT + "/sts/token";
-    private final static String SECRET = "secret";
+    private static final String SECRET = "secret";
+
     @RegisterExtension
     static RuntimePerClassExtension sts = new RuntimePerClassExtension(new EmbeddedRuntime(
             "sts",

--- a/system-tests/sts-api/sts-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/sts/api/StsApiEndToEndTest.java
+++ b/system-tests/sts-api/sts-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/sts/api/StsApiEndToEndTest.java
@@ -17,7 +17,8 @@ package org.eclipse.edc.test.e2e.sts.api;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
-import org.eclipse.edc.junit.extensions.EdcRuntimeExtension;
+import org.eclipse.edc.junit.extensions.EmbeddedRuntime;
+import org.eclipse.edc.junit.extensions.RuntimePerClassExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -49,9 +50,9 @@ public class StsApiEndToEndTest extends StsEndToEndTestBase {
     public static final String BASE_STS = "http://localhost:" + PORT + "/sts";
     private static final String GRANT_TYPE = "client_credentials";
 
+
     @RegisterExtension
-    static EdcRuntimeExtension sts = new EdcRuntimeExtension(
-            ":system-tests:sts-api:sts-api-test-runtime",
+    static RuntimePerClassExtension sts = new RuntimePerClassExtension(new EmbeddedRuntime(
             "sts",
             new HashMap<>() {
                 {
@@ -60,8 +61,9 @@ public class StsApiEndToEndTest extends StsEndToEndTestBase {
                     put("web.http.sts.path", "/sts");
                     put("web.http.sts.port", String.valueOf(PORT));
                 }
-            }
-    );
+            },
+            ":system-tests:sts-api:sts-api-test-runtime"
+    ));
 
     @Test
     void requestToken() throws ParseException {
@@ -203,7 +205,7 @@ public class StsApiEndToEndTest extends StsEndToEndTestBase {
     }
 
     @Override
-    protected EdcRuntimeExtension getRuntime() {
+    protected RuntimePerClassExtension getRuntime() {
         return sts;
     }
 

--- a/system-tests/sts-api/sts-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/sts/api/StsEndToEndTestBase.java
+++ b/system-tests/sts-api/sts-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/sts/api/StsEndToEndTestBase.java
@@ -17,7 +17,7 @@ package org.eclipse.edc.test.e2e.sts.api;
 import com.nimbusds.jwt.SignedJWT;
 import org.eclipse.edc.iam.identitytrust.sts.spi.model.StsClient;
 import org.eclipse.edc.iam.identitytrust.sts.spi.store.StsClientStore;
-import org.eclipse.edc.junit.extensions.EdcRuntimeExtension;
+import org.eclipse.edc.junit.extensions.RuntimePerClassExtension;
 import org.eclipse.edc.spi.security.Vault;
 
 import java.text.ParseException;
@@ -32,7 +32,7 @@ import static org.eclipse.edc.iam.identitytrust.sts.spi.store.fixtures.TestFunct
  */
 public abstract class StsEndToEndTestBase {
 
-    protected abstract EdcRuntimeExtension getRuntime();
+    protected abstract RuntimePerClassExtension getRuntime();
 
     protected StsClient initClient(String clientId, String clientSecret) {
         var store = getClientStore();


### PR DESCRIPTION
## What this PR changes/adds

The `StsRemoteClientConfiguration` now holds the secret alias instead of the secret itself.

The `RemoteSecureTokenService` before sending the request fetches the secret from the vault with the configured secret alias.


## Linked Issue(s)

Closes #4412 