### PR TITLE
refactor(test): move `QueryValidator` instantiation into `TransferProcessQueryValidatorFactory`

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
@@ -56,6 +56,7 @@ import org.eclipse.edc.connector.controlplane.services.spi.protocol.VersionProto
 import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessProtocolService;
 import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessService;
 import org.eclipse.edc.connector.controlplane.services.transferprocess.TransferProcessProtocolServiceImpl;
+import org.eclipse.edc.connector.controlplane.services.transferprocess.TransferProcessQueryValidatorFactory;
 import org.eclipse.edc.connector.controlplane.services.transferprocess.TransferProcessServiceImpl;
 import org.eclipse.edc.connector.controlplane.transfer.spi.TransferProcessManager;
 import org.eclipse.edc.connector.controlplane.transfer.spi.flow.DataFlowManager;
@@ -237,7 +238,7 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     @Provider
     public TransferProcessService transferProcessService() {
         return new TransferProcessServiceImpl(transferProcessStore, transferProcessManager, transactionContext,
-                dataAddressValidator, commandHandlerRegistry, transferTypeParser, contractNegotiationStore);
+                dataAddressValidator, commandHandlerRegistry, transferTypeParser, contractNegotiationStore, TransferProcessQueryValidatorFactory.createQueryValidator());
     }
 
     @Provider

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessQueryValidatorFactory.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessQueryValidatorFactory.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Contributors to the Eclipse Foundation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.services.transferprocess;
+
+import org.eclipse.edc.connector.controlplane.services.query.QueryValidator;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.ProvisionedContentResource;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.ProvisionedDataAddressResource;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.ProvisionedDataDestinationResource;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.ProvisionedResource;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Factory object that is used to generate a new instance of a {@link QueryValidator} for a service.
+ */
+public class TransferProcessQueryValidatorFactory {
+
+    /**
+     * Returns a {@link QueryValidator} validating {@link TransferProcess}
+     *
+     * @return a {@link QueryValidator} validating {@link TransferProcess}
+     */
+    public static QueryValidator createQueryValidator() {
+        return new QueryValidator(TransferProcess.class, Map.of(
+                ProvisionedResource.class, List.of(ProvisionedDataAddressResource.class),
+                ProvisionedDataAddressResource.class, List.of(ProvisionedDataDestinationResource.class, ProvisionedContentResource.class)
+        ));
+    }
+}

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessServiceImpl.java
@@ -47,6 +47,8 @@ import org.jetbrains.annotations.Nullable;
 import java.util.List;
 import java.util.Optional;
 
+import static java.lang.String.format;
+
 public class TransferProcessServiceImpl implements TransferProcessService {
     private final TransferProcessStore transferProcessStore;
     private final TransferProcessManager manager;

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessServiceImpl.java
@@ -23,10 +23,6 @@ import org.eclipse.edc.connector.controlplane.transfer.spi.flow.TransferTypePars
 import org.eclipse.edc.connector.controlplane.transfer.spi.store.TransferProcessStore;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.DeprovisionedResource;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.ProvisionResponse;
-import org.eclipse.edc.connector.controlplane.transfer.spi.types.ProvisionedContentResource;
-import org.eclipse.edc.connector.controlplane.transfer.spi.types.ProvisionedDataAddressResource;
-import org.eclipse.edc.connector.controlplane.transfer.spi.types.ProvisionedDataDestinationResource;
-import org.eclipse.edc.connector.controlplane.transfer.spi.types.ProvisionedResource;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest;
@@ -49,10 +45,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-
-import static java.lang.String.format;
 
 public class TransferProcessServiceImpl implements TransferProcessService {
     private final TransferProcessStore transferProcessStore;
@@ -67,7 +60,7 @@ public class TransferProcessServiceImpl implements TransferProcessService {
     public TransferProcessServiceImpl(TransferProcessStore transferProcessStore, TransferProcessManager manager,
                                       TransactionContext transactionContext, DataAddressValidatorRegistry dataAddressValidator,
                                       CommandHandlerRegistry commandHandlerRegistry, TransferTypeParser transferTypeParser,
-                                      ContractNegotiationStore contractNegotiationStore) {
+                                      ContractNegotiationStore contractNegotiationStore, QueryValidator queryValidator) {
         this.transferProcessStore = transferProcessStore;
         this.manager = manager;
         this.transactionContext = transactionContext;
@@ -75,7 +68,7 @@ public class TransferProcessServiceImpl implements TransferProcessService {
         this.commandHandlerRegistry = commandHandlerRegistry;
         this.transferTypeParser = transferTypeParser;
         this.contractNegotiationStore = contractNegotiationStore;
-        queryValidator = new QueryValidator(TransferProcess.class, getSubtypes());
+        this.queryValidator = queryValidator;
     }
 
     @Override
@@ -180,13 +173,6 @@ public class TransferProcessServiceImpl implements TransferProcessService {
 
     private ServiceResult<Void> execute(EntityCommand command) {
         return transactionContext.execute(() -> commandHandlerRegistry.execute(command).flatMap(ServiceResult::from));
-    }
-
-    private Map<Class<?>, List<Class<?>>> getSubtypes() {
-        return Map.of(
-                ProvisionedResource.class, List.of(ProvisionedDataAddressResource.class),
-                ProvisionedDataAddressResource.class, List.of(ProvisionedDataDestinationResource.class, ProvisionedContentResource.class)
-        );
     }
 
 }

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessQueryValidatorTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessQueryValidatorTest.java
@@ -1,0 +1,79 @@
+/*
+ *  Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Contributors to the Eclipse Foundation - Initial API and Implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.services.transferprocess;
+
+import org.eclipse.edc.connector.controlplane.services.query.QueryValidator;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+import static org.eclipse.edc.spi.query.Criterion.criterion;
+
+public class TransferProcessQueryValidatorTest {
+
+    private final QueryValidator queryValidator = TransferProcessQueryValidatorFactory.createQueryValidator();
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "deprovisionedResources.provisionedResourceId",
+            "provisionedResourceSet.resources.resourceDefinitionId",
+            "provisionedResourceSet.resources.hasToken",
+            "privateProperties.someKey", // path element with privateProperties and key
+            "privateProperties." + "'someKey'", // path element with privateProperties and 'key'
+            "privateProperties." + EDC_NAMESPACE + "someKey", // path element with privateProperties and edc_namespace key
+            "type",
+    })
+    void validate_shouldSucceed(String key) {
+        var query = QuerySpec.Builder.newInstance()
+                .filter(criterion(key, "=", "someval"))
+                .build();
+
+        var result = queryValidator.validate(query);
+        assertThat(result).isSucceeded();
+    }
+
+    @Test
+    public void validate_shouldFail_wrongCase() {
+        var query = QuerySpec.Builder.newInstance()
+                .filter(criterion("provisionedResourceSet.resources.hastoken", "=", "true"))
+                .build();
+
+        var result = queryValidator.validate(query);
+        assertThat(result).isFailed();
+    }
+
+    @Test
+    public void validate_shouldFail_wrongProperty() {
+        var query = QuerySpec.Builder.newInstance()
+                .filter(criterion("resourceManifest.definitions.notexist", "=", "foobar"))
+                .build();
+
+        var result = queryValidator.validate(query);
+        assertThat(result).isFailed();
+    }
+
+    @Test
+    public void validate_shouldFail_withMap() {
+        var query = QuerySpec.Builder.newInstance()
+                .filter(criterion("contentDataAddress.properties[*].someKey", "=", "someval"))
+                .build();
+
+        var result = queryValidator.validate(query);
+        assertThat(result).isFailed();
+    }
+}

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessServiceImplTest.java
@@ -51,6 +51,7 @@ import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Stream;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.spi.result.ServiceFailure.Reason.BAD_REQUEST;
 import static org.eclipse.edc.spi.result.ServiceFailure.Reason.NOT_FOUND;


### PR DESCRIPTION
## What this PR changes/adds

Introduce a Factory class to instantilize `QueryValidator` required by different services.

Add `PolicyDefinitionQueryValidatorFactory` to create policy definition specific to `PolicyDefinitionService`.

Add tests about these specific `QueryValidator`s (Currently only for `PolicyDefinition`). They are copied directly from `PolicyDefinitionServiceImplTest`.

## Why it does that

Makes `QueryValidator` injectable to services.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Related: #3731 <-- _insert Issue number if one exists_

