### PR TITLE
feat: Support filter expressions for additional numberic types

### DIFF
--- a/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/JsonFieldTranslator.java
+++ b/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/JsonFieldTranslator.java
@@ -84,10 +84,6 @@ public class JsonFieldTranslator implements FieldTranslator {
             return format("(%s)::long", statement);
         }
 
-        if (type.equals(Byte.class)) {
-            return format("(%s)::byte", statement);
-        }
-
         if (type.equals(Short.class)) {
             return format("(%s)::short", statement);
         }

--- a/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/JsonFieldTranslator.java
+++ b/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/JsonFieldTranslator.java
@@ -44,7 +44,7 @@ public class JsonFieldTranslator implements FieldTranslator {
         statementBuilder.append(" ->> '%s'".formatted(path.get(length - 1)));
         var statement = statementBuilder.toString();
 
-        return checkStatementByType(type, statement);
+        return createStatementForType(type, statement);
     }
 
     @Override
@@ -63,7 +63,7 @@ public class JsonFieldTranslator implements FieldTranslator {
         );
     }
 
-    private String checkStatementByType(Class<?> type, String statement) {
+    private String createStatementForType(Class<?> type, String statement) {
         if (type.equals(Boolean.class)) {
             return format("(%s)::boolean", statement);
         }

--- a/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/JsonFieldTranslator.java
+++ b/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/JsonFieldTranslator.java
@@ -44,12 +44,28 @@ public class JsonFieldTranslator implements FieldTranslator {
         statementBuilder.append(" ->> '%s'".formatted(path.get(length - 1)));
         var statement = statementBuilder.toString();
 
+        return checkStatementByType(type, statement);
+    }
+
+    private String checkStatementByType(Class<?> type, String statement) {
         if (type.equals(Boolean.class)) {
             return format("(%s)::boolean", statement);
         }
 
         if (type.equals(Integer.class)) {
             return format("(%s)::integer", statement);
+        }
+
+        if (type.equals(Double.class)) {
+            return format("(%s)::double", statement);
+        }
+
+        if (type.equals(Float.class)) {
+            return format("(%s)::float", statement);
+        }
+
+        if (type.equals(Long.class)) {
+            return format("(%s)::long", statement);
         }
 
         return statement;

--- a/extensions/common/sql/sql-core/src/test/java/org/eclipse/edc/sql/translation/JsonFieldTranslatorTest.java
+++ b/extensions/common/sql/sql-core/src/test/java/org/eclipse/edc/sql/translation/JsonFieldTranslatorTest.java
@@ -131,6 +131,28 @@ class JsonFieldTranslatorTest {
         }
 
         @Test
+        void shouldParseWhereClause_whenRightOperandIsByte() {
+            var operator = new SqlOperator("=", Object.class);
+            var criterion = criterion("json.field", "=", (byte) 1);
+
+            var result = translator.toWhereClause(PathItem.parse("field"), criterion, operator);
+
+            assertThat(result.sql()).isEqualTo("(column_name ->> 'field')::byte = ?");
+            assertThat(result.parameters()).containsExactly((byte) 1);
+        }
+
+        @Test
+        void shouldParseWhereClause_whenRightOperandIsShort() {
+            var operator = new SqlOperator("=", Object.class);
+            var criterion = criterion("json.field", "=", (short) 1);
+
+            var result = translator.toWhereClause(PathItem.parse("field"), criterion, operator);
+
+            assertThat(result.sql()).isEqualTo("(column_name ->> 'field')::short = ?");
+            assertThat(result.parameters()).containsExactly((short) 1);
+        }
+
+        @Test
         void shouldConvertToJsonB_whenOperatorIsContains() {
             var operator = new SqlOperator("??", Object.class);
             var criterion = criterion("json.array", "contains", "value");

--- a/extensions/common/sql/sql-core/src/test/java/org/eclipse/edc/sql/translation/JsonFieldTranslatorTest.java
+++ b/extensions/common/sql/sql-core/src/test/java/org/eclipse/edc/sql/translation/JsonFieldTranslatorTest.java
@@ -131,17 +131,6 @@ class JsonFieldTranslatorTest {
         }
 
         @Test
-        void shouldParseWhereClause_whenRightOperandIsByte() {
-            var operator = new SqlOperator("=", Object.class);
-            var criterion = criterion("json.field", "=", (byte) 1);
-
-            var result = translator.toWhereClause(PathItem.parse("field"), criterion, operator);
-
-            assertThat(result.sql()).isEqualTo("(column_name ->> 'field')::byte = ?");
-            assertThat(result.parameters()).containsExactly((byte) 1);
-        }
-
-        @Test
         void shouldParseWhereClause_whenRightOperandIsShort() {
             var operator = new SqlOperator("=", Object.class);
             var criterion = criterion("json.field", "=", (short) 1);

--- a/extensions/common/sql/sql-core/src/test/java/org/eclipse/edc/sql/translation/JsonFieldTranslatorTest.java
+++ b/extensions/common/sql/sql-core/src/test/java/org/eclipse/edc/sql/translation/JsonFieldTranslatorTest.java
@@ -98,6 +98,39 @@ class JsonFieldTranslatorTest {
         }
 
         @Test
+        void shouldParseWhereClause_whenRightOperandIsDouble() {
+            var operator = new SqlOperator("=", Object.class);
+            var criterion = criterion("json.field", "=", 100.0);
+
+            var result = translator.toWhereClause(PathItem.parse("field"), criterion, operator);
+
+            assertThat(result.sql()).isEqualTo("(column_name ->> 'field')::double = ?");
+            assertThat(result.parameters()).containsExactly(100.0);
+        }
+
+        @Test
+        void shouldParseWhereClause_whenRightOperandIsFloat() {
+            var operator = new SqlOperator("=", Object.class);
+            var criterion = criterion("json.field", "=", 100.0F);
+
+            var result = translator.toWhereClause(PathItem.parse("field"), criterion, operator);
+
+            assertThat(result.sql()).isEqualTo("(column_name ->> 'field')::float = ?");
+            assertThat(result.parameters()).containsExactly(100.0F);
+        }
+
+        @Test
+        void shouldParseWhereClause_whenRightOperandIsLong() {
+            var operator = new SqlOperator("=", Object.class);
+            var criterion = criterion("json.field", "=", 100L);
+
+            var result = translator.toWhereClause(PathItem.parse("field"), criterion, operator);
+
+            assertThat(result.sql()).isEqualTo("(column_name ->> 'field')::long = ?");
+            assertThat(result.parameters()).containsExactly(100L);
+        }
+
+        @Test
         void shouldConvertToJsonB_whenOperatorIsContains() {
             var operator = new SqlOperator("??", Object.class);
             var criterion = criterion("json.array", "contains", "value");


### PR DESCRIPTION
## What this PR changes/adds

Allow different types of numeric field with postgresql database.

## Why it does that

AS done for other types (Boolean, Integer), add the same validation for other numeric types to avoid additional logging errors that should not be reflected with expected user behaviour.

## Further notes

UT's were added to reflect new scenarios.
Took the opportunity of extending with primitive java types to include more potential query usages.


## Linked Issue(s)

Closes https://github.com/eclipse-edc/Connector/issues/3688
