### PR TITLE
feat: adds REST API for policy evaluation plan

### DIFF
--- a/core/common/lib/policy-engine-lib/src/main/java/org/eclipse/edc/policy/engine/PolicyEngineImpl.java
+++ b/core/common/lib/policy-engine-lib/src/main/java/org/eclipse/edc/policy/engine/PolicyEngineImpl.java
@@ -156,8 +156,7 @@ public class PolicyEngineImpl implements PolicyEngine {
 
     @Override
     public PolicyEvaluationPlan createEvaluationPlan(String scope, Policy policy) {
-        var delimitedScope = scope + DELIMITER;
-        var planner = PolicyEvaluationPlanner.Builder.newInstance(delimitedScope).ruleValidator(ruleValidator);
+        var planner = PolicyEvaluationPlanner.Builder.newInstance(scope).ruleValidator(ruleValidator);
 
         preValidators.forEach(planner::preValidators);
         postValidators.forEach(planner::postValidators);

--- a/core/common/lib/policy-engine-lib/src/test/java/org/eclipse/edc/policy/engine/PolicyEngineImplPlannerTest.java
+++ b/core/common/lib/policy-engine-lib/src/test/java/org/eclipse/edc/policy/engine/PolicyEngineImplPlannerTest.java
@@ -240,7 +240,7 @@ class PolicyEngineImplPlannerTest {
                 var prohibition = Prohibition.Builder.newInstance().constraint(constraint).action(action).build();
 
                 Function<PolicyEvaluationPlan, List<? extends RuleStep<? extends Rule>>> permissionSteps = PolicyEvaluationPlan::getPermissionSteps;
-                Function<PolicyEvaluationPlan, List<? extends RuleStep<? extends Rule>>> dutySteps = PolicyEvaluationPlan::getDutySteps;
+                Function<PolicyEvaluationPlan, List<? extends RuleStep<? extends Rule>>> dutySteps = PolicyEvaluationPlan::getObligationSteps;
                 Function<PolicyEvaluationPlan, List<? extends RuleStep<? extends Rule>>> prohibitionSteps = PolicyEvaluationPlan::getProhibitionSteps;
 
                 var permission = Permission.Builder.newInstance().constraint(constraint).action(action).build();
@@ -275,6 +275,7 @@ class PolicyEngineImplPlannerTest {
                     .first()
                     .satisfies(permissionStep -> {
                         assertThat(permissionStep.isFiltered()).isTrue();
+                        assertThat(permissionStep.getFilteringReasons()).hasSize(1);
                         assertThat(permissionStep.getConstraintSteps()).hasSize(1)
                                 .first()
                                 .isInstanceOfSatisfying(AtomicConstraintStep.class, constraintStep -> {
@@ -388,7 +389,7 @@ class PolicyEngineImplPlannerTest {
                         assertThat(ruleStep.getConstraintSteps()).hasSize(1)
                                 .first()
                                 .isInstanceOfSatisfying(MultiplicityConstraintStep.class, constraintStep -> {
-                                    assertThat(constraintStep.getSteps()).hasSize(2);
+                                    assertThat(constraintStep.getConstraintSteps()).hasSize(2);
                                     assertThat(constraintStep.getConstraint()).isNotNull();
                                 });
                     }));
@@ -414,7 +415,7 @@ class PolicyEngineImplPlannerTest {
                 var duty = Duty.Builder.newInstance().constraint(xoneConstraint).build();
 
                 Function<PolicyEvaluationPlan, List<? extends RuleStep<? extends Rule>>> permissionSteps = PolicyEvaluationPlan::getPermissionSteps;
-                Function<PolicyEvaluationPlan, List<? extends RuleStep<? extends Rule>>> dutySteps = PolicyEvaluationPlan::getDutySteps;
+                Function<PolicyEvaluationPlan, List<? extends RuleStep<? extends Rule>>> dutySteps = PolicyEvaluationPlan::getObligationSteps;
                 Function<PolicyEvaluationPlan, List<? extends RuleStep<? extends Rule>>> prohibitionSteps = PolicyEvaluationPlan::getProhibitionSteps;
 
                 return Stream.of(

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/policydefinition/PolicyDefinitionServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/policydefinition/PolicyDefinitionServiceImpl.java
@@ -21,6 +21,7 @@ import org.eclipse.edc.connector.controlplane.policy.spi.store.PolicyDefinitionS
 import org.eclipse.edc.connector.controlplane.services.query.QueryValidator;
 import org.eclipse.edc.connector.controlplane.services.spi.policydefinition.PolicyDefinitionService;
 import org.eclipse.edc.policy.engine.spi.PolicyEngine;
+import org.eclipse.edc.policy.engine.spi.plan.PolicyEvaluationPlan;
 import org.eclipse.edc.policy.model.AndConstraint;
 import org.eclipse.edc.policy.model.AtomicConstraint;
 import org.eclipse.edc.policy.model.Constraint;
@@ -31,7 +32,6 @@ import org.eclipse.edc.policy.model.OrConstraint;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.policy.model.XoneConstraint;
 import org.eclipse.edc.spi.query.QuerySpec;
-import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 import org.jetbrains.annotations.NotNull;
@@ -124,8 +124,17 @@ public class PolicyDefinitionServiceImpl implements PolicyDefinitionService {
     }
 
     @Override
-    public Result<Void> validate(Policy policy) {
-        return policyEngine.validate(policy);
+    public ServiceResult<Void> validate(Policy policy) {
+        var validationResult = policyEngine.validate(policy);
+        if (validationResult.failed()) {
+            return ServiceResult.badRequest(validationResult.getFailureMessages());
+        }
+        return ServiceResult.success();
+    }
+
+    @Override
+    public ServiceResult<PolicyEvaluationPlan> createEvaluationPlan(String scope, Policy policy) {
+        return ServiceResult.success(policyEngine.createEvaluationPlan(scope, policy));
     }
 
     private List<PolicyDefinition> queryPolicyDefinitions(QuerySpec query) {

--- a/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
+++ b/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
@@ -8,7 +8,7 @@
   {
     "version": "3.1.0-alpha",
     "urlPath": "/v3.1alpha",
-    "lastUpdated": "2024-08-30T10:17:00Z",
+    "lastUpdated": "2024-09-04T10:17:00Z",
     "maturity": "alpha"
   }
 ]

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/BasePolicyDefinitionApiController.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/BasePolicyDefinitionApiController.java
@@ -40,7 +40,7 @@ public abstract class BasePolicyDefinitionApiController {
     protected final Monitor monitor;
     protected final PolicyDefinitionService service;
     protected final TypeTransformerRegistry transformerRegistry;
-    private final JsonObjectValidatorRegistry validatorRegistry;
+    protected final JsonObjectValidatorRegistry validatorRegistry;
 
     public BasePolicyDefinitionApiController(Monitor monitor, TypeTransformerRegistry transformerRegistry,
                                              PolicyDefinitionService service, JsonObjectValidatorRegistry validatorRegistry) {

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/PolicyDefinitionApiExtension.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/PolicyDefinitionApiExtension.java
@@ -16,12 +16,15 @@ package org.eclipse.edc.connector.controlplane.api.management.policy;
 
 import jakarta.json.Json;
 import org.eclipse.edc.connector.controlplane.api.management.policy.transform.JsonObjectFromPolicyDefinitionTransformer;
+import org.eclipse.edc.connector.controlplane.api.management.policy.transform.JsonObjectFromPolicyEvaluationPlanTransformer;
 import org.eclipse.edc.connector.controlplane.api.management.policy.transform.JsonObjectFromPolicyValidationResultTransformer;
 import org.eclipse.edc.connector.controlplane.api.management.policy.transform.JsonObjectToPolicyDefinitionTransformer;
+import org.eclipse.edc.connector.controlplane.api.management.policy.transform.JsonObjectToPolicyEvaluationPlanRequestTransformer;
 import org.eclipse.edc.connector.controlplane.api.management.policy.v2.PolicyDefinitionApiV2Controller;
 import org.eclipse.edc.connector.controlplane.api.management.policy.v3.PolicyDefinitionApiV3Controller;
 import org.eclipse.edc.connector.controlplane.api.management.policy.v31alpha.PolicyDefinitionApiV31AlphaController;
 import org.eclipse.edc.connector.controlplane.api.management.policy.validation.PolicyDefinitionValidator;
+import org.eclipse.edc.connector.controlplane.api.management.policy.validation.PolicyEvaluationPlanRequestValidator;
 import org.eclipse.edc.connector.controlplane.services.spi.policydefinition.PolicyDefinitionService;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
@@ -35,6 +38,7 @@ import org.eclipse.edc.web.spi.configuration.ApiContext;
 
 import java.util.Map;
 
+import static org.eclipse.edc.connector.controlplane.api.management.policy.model.PolicyEvaluationPlanRequest.EDC_POLICY_EVALUATION_PLAN_REQUEST_TYPE;
 import static org.eclipse.edc.connector.controlplane.policy.spi.PolicyDefinition.EDC_POLICY_DEFINITION_TYPE;
 import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
 
@@ -69,11 +73,14 @@ public class PolicyDefinitionApiExtension implements ServiceExtension {
         var jsonBuilderFactory = Json.createBuilderFactory(Map.of());
         var managementApiTransformerRegistry = transformerRegistry.forContext("management-api");
         var mapper = typeManager.getMapper(JSON_LD);
+        managementApiTransformerRegistry.register(new JsonObjectToPolicyEvaluationPlanRequestTransformer());
         managementApiTransformerRegistry.register(new JsonObjectToPolicyDefinitionTransformer());
         managementApiTransformerRegistry.register(new JsonObjectFromPolicyDefinitionTransformer(jsonBuilderFactory, mapper));
         managementApiTransformerRegistry.register(new JsonObjectFromPolicyValidationResultTransformer(jsonBuilderFactory));
+        managementApiTransformerRegistry.register(new JsonObjectFromPolicyEvaluationPlanTransformer(jsonBuilderFactory));
 
         validatorRegistry.register(EDC_POLICY_DEFINITION_TYPE, PolicyDefinitionValidator.instance());
+        validatorRegistry.register(EDC_POLICY_EVALUATION_PLAN_REQUEST_TYPE, PolicyEvaluationPlanRequestValidator.instance());
 
         var monitor = context.getMonitor();
         webService.registerResource(ApiContext.MANAGEMENT, new PolicyDefinitionApiV2Controller(monitor, managementApiTransformerRegistry, service, validatorRegistry));

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/model/PolicyEvaluationPlanRequest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/model/PolicyEvaluationPlanRequest.java
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.api.management.policy.model;
+
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+
+public record PolicyEvaluationPlanRequest(String policyScope) {
+    public static final String EDC_POLICY_EVALUATION_PLAN_REQUEST_TYPE = EDC_NAMESPACE + "PolicyEvaluationPlanRequest";
+    public static final String EDC_POLICY_EVALUATION_PLAN_REQUEST_POLICY_SCOPE = EDC_NAMESPACE + "policyScope";
+}

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/transform/JsonObjectFromPolicyEvaluationPlanTransformer.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/transform/JsonObjectFromPolicyEvaluationPlanTransformer.java
@@ -1,0 +1,200 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.api.management.policy.transform;
+
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.policy.engine.spi.plan.PolicyEvaluationPlan;
+import org.eclipse.edc.policy.engine.spi.plan.step.AndConstraintStep;
+import org.eclipse.edc.policy.engine.spi.plan.step.AtomicConstraintStep;
+import org.eclipse.edc.policy.engine.spi.plan.step.ConstraintStep;
+import org.eclipse.edc.policy.engine.spi.plan.step.DutyStep;
+import org.eclipse.edc.policy.engine.spi.plan.step.MultiplicityConstraintStep;
+import org.eclipse.edc.policy.engine.spi.plan.step.OrConstraintStep;
+import org.eclipse.edc.policy.engine.spi.plan.step.PermissionStep;
+import org.eclipse.edc.policy.engine.spi.plan.step.ProhibitionStep;
+import org.eclipse.edc.policy.engine.spi.plan.step.RuleFunctionStep;
+import org.eclipse.edc.policy.engine.spi.plan.step.RuleStep;
+import org.eclipse.edc.policy.engine.spi.plan.step.ValidatorStep;
+import org.eclipse.edc.policy.engine.spi.plan.step.XoneConstraintStep;
+import org.eclipse.edc.policy.model.MultiplicityConstraint;
+import org.eclipse.edc.policy.model.Rule;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
+
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.policy.engine.spi.plan.PolicyEvaluationPlan.EDC_POLICY_EVALUATION_PLAN_OBLIGATION_STEPS;
+import static org.eclipse.edc.policy.engine.spi.plan.PolicyEvaluationPlan.EDC_POLICY_EVALUATION_PLAN_PERMISSION_STEPS;
+import static org.eclipse.edc.policy.engine.spi.plan.PolicyEvaluationPlan.EDC_POLICY_EVALUATION_PLAN_POST_VALIDATORS;
+import static org.eclipse.edc.policy.engine.spi.plan.PolicyEvaluationPlan.EDC_POLICY_EVALUATION_PLAN_PRE_VALIDATORS;
+import static org.eclipse.edc.policy.engine.spi.plan.PolicyEvaluationPlan.EDC_POLICY_EVALUATION_PLAN_PROHIBITION_STEPS;
+import static org.eclipse.edc.policy.engine.spi.plan.PolicyEvaluationPlan.EDC_POLICY_EVALUATION_PLAN_TYPE;
+import static org.eclipse.edc.policy.engine.spi.plan.step.AndConstraintStep.EDC_AND_CONSTRAINT_STEP_TYPE;
+import static org.eclipse.edc.policy.engine.spi.plan.step.AtomicConstraintStep.EDC_ATOMIC_CONSTRAINT_STEP_FILTERING_REASONS;
+import static org.eclipse.edc.policy.engine.spi.plan.step.AtomicConstraintStep.EDC_ATOMIC_CONSTRAINT_STEP_FUNCTION_NAME;
+import static org.eclipse.edc.policy.engine.spi.plan.step.AtomicConstraintStep.EDC_ATOMIC_CONSTRAINT_STEP_FUNCTION_PARAMS;
+import static org.eclipse.edc.policy.engine.spi.plan.step.AtomicConstraintStep.EDC_ATOMIC_CONSTRAINT_STEP_IS_FILTERED;
+import static org.eclipse.edc.policy.engine.spi.plan.step.AtomicConstraintStep.EDC_ATOMIC_CONSTRAINT_STEP_TYPE;
+import static org.eclipse.edc.policy.engine.spi.plan.step.DutyStep.EDC_DUTY_STEP_TYPE;
+import static org.eclipse.edc.policy.engine.spi.plan.step.MultiplicityConstraintStep.EDC_MULTIPLICITY_CONSTRAINT_STEPS;
+import static org.eclipse.edc.policy.engine.spi.plan.step.OrConstraintStep.EDC_OR_CONSTRAINT_STEP_TYPE;
+import static org.eclipse.edc.policy.engine.spi.plan.step.PermissionStep.EDC_PERMISSION_STEP_DUTY_STEPS;
+import static org.eclipse.edc.policy.engine.spi.plan.step.PermissionStep.EDC_PERMISSION_STEP_TYPE;
+import static org.eclipse.edc.policy.engine.spi.plan.step.ProhibitionStep.EDC_PROHIBITION_STEP_TYPE;
+import static org.eclipse.edc.policy.engine.spi.plan.step.RuleStep.EDC_RULE_CONSTRAINT_STEPS;
+import static org.eclipse.edc.policy.engine.spi.plan.step.RuleStep.EDC_RULE_FUNCTIONS;
+import static org.eclipse.edc.policy.engine.spi.plan.step.RuleStep.EDC_RULE_STEP_FILTERING_REASONS;
+import static org.eclipse.edc.policy.engine.spi.plan.step.RuleStep.EDC_RULE_STEP_IS_FILTERED;
+import static org.eclipse.edc.policy.engine.spi.plan.step.XoneConstraintStep.EDC_XONE_CONSTRAINT_STEP_TYPE;
+
+public class JsonObjectFromPolicyEvaluationPlanTransformer extends AbstractJsonLdTransformer<PolicyEvaluationPlan, JsonObject> {
+
+    private final JsonBuilderFactory jsonFactory;
+
+    public JsonObjectFromPolicyEvaluationPlanTransformer(JsonBuilderFactory jsonFactory) {
+        super(PolicyEvaluationPlan.class, JsonObject.class);
+        this.jsonFactory = jsonFactory;
+    }
+
+    @Override
+    public @Nullable JsonObject transform(@NotNull PolicyEvaluationPlan plan, @NotNull TransformerContext context) {
+        var objectBuilder = jsonFactory.createObjectBuilder();
+        objectBuilder.add(TYPE, EDC_POLICY_EVALUATION_PLAN_TYPE);
+
+        var preValidators = jsonFactory.createArrayBuilder();
+        plan.getPreValidators().stream().map(ValidatorStep::name).forEach(preValidators::add);
+
+        var postValidators = jsonFactory.createArrayBuilder();
+        plan.getPostValidators().stream().map(ValidatorStep::name).forEach(postValidators::add);
+
+        var permissionSteps = jsonFactory.createArrayBuilder();
+        plan.getPermissionSteps().stream().map(this::transformPermissionStep)
+                .forEach(permissionSteps::add);
+
+        var prohibitionSteps = jsonFactory.createArrayBuilder();
+        plan.getProhibitionSteps().stream().map(this::transformProhibitionStep)
+                .forEach(prohibitionSteps::add);
+
+        var dutySteps = jsonFactory.createArrayBuilder();
+        plan.getObligationSteps().stream().map(this::transformDutyStep)
+                .forEach(dutySteps::add);
+
+        objectBuilder.add(EDC_POLICY_EVALUATION_PLAN_PRE_VALIDATORS, preValidators);
+        objectBuilder.add(EDC_POLICY_EVALUATION_PLAN_PERMISSION_STEPS, permissionSteps);
+        objectBuilder.add(EDC_POLICY_EVALUATION_PLAN_PROHIBITION_STEPS, prohibitionSteps);
+        objectBuilder.add(EDC_POLICY_EVALUATION_PLAN_OBLIGATION_STEPS, dutySteps);
+        objectBuilder.add(EDC_POLICY_EVALUATION_PLAN_POST_VALIDATORS, postValidators);
+
+        return objectBuilder.build();
+    }
+
+    private JsonObjectBuilder transformDutyStep(DutyStep dutyStep) {
+        return transformRuleStep(dutyStep, EDC_DUTY_STEP_TYPE);
+    }
+
+    private JsonObjectBuilder transformPermissionStep(PermissionStep permissionStep) {
+        var dutySteps = jsonFactory.createArrayBuilder();
+
+        permissionStep.getDutySteps().stream().map(this::transformDutyStep)
+                .forEach(dutySteps::add);
+
+        return transformRuleStep(permissionStep, EDC_PERMISSION_STEP_TYPE)
+                .add(EDC_PERMISSION_STEP_DUTY_STEPS, dutySteps);
+    }
+
+    private JsonObjectBuilder transformProhibitionStep(ProhibitionStep prohibitionStep) {
+        return transformRuleStep(prohibitionStep, EDC_PROHIBITION_STEP_TYPE);
+    }
+
+    private <R extends Rule> JsonObjectBuilder transformRuleStep(RuleStep<R> ruleStep, String type) {
+
+        var builder = jsonFactory.createObjectBuilder();
+        var constraintSteps = jsonFactory.createArrayBuilder();
+        var ruleFunctionSteps = jsonFactory.createArrayBuilder();
+
+        ruleStep.getConstraintSteps().stream()
+                .map(this::transformConstraintStep)
+                .forEach(constraintSteps::add);
+
+        ruleStep.getRuleFunctions().stream()
+                .map(RuleFunctionStep::functionName)
+                .forEach(ruleFunctionSteps::add);
+
+        builder.add(TYPE, type);
+        builder.add(EDC_RULE_STEP_IS_FILTERED, ruleStep.isFiltered());
+        builder.add(EDC_RULE_STEP_FILTERING_REASONS, jsonFactory.createArrayBuilder(ruleStep.getFilteringReasons()));
+        builder.add(EDC_RULE_FUNCTIONS, ruleFunctionSteps);
+        builder.add(EDC_RULE_CONSTRAINT_STEPS, constraintSteps);
+
+        return builder;
+    }
+
+    private JsonObject transformConstraintStep(ConstraintStep constraintStep) {
+        // TODO replace with pattern matching once we move to JDK 21
+        if (constraintStep instanceof AtomicConstraintStep atomicConstraintStep) {
+            return transformAtomicConstraintStep(atomicConstraintStep);
+        } else if (constraintStep instanceof AndConstraintStep andConstraintStep) {
+            return transformAndConstraintStep(andConstraintStep);
+        } else if (constraintStep instanceof OrConstraintStep orConstraintStep) {
+            return transformOrConstraintStep(orConstraintStep);
+        } else if (constraintStep instanceof XoneConstraintStep xoneConstraintStep) {
+            return transformXoneConstraintStep(xoneConstraintStep);
+        }
+        return jsonFactory.createObjectBuilder().build();
+    }
+
+    private JsonObject transformAtomicConstraintStep(AtomicConstraintStep atomicConstraintStep) {
+        var builder = jsonFactory.createObjectBuilder();
+        builder.add(TYPE, EDC_ATOMIC_CONSTRAINT_STEP_TYPE);
+        builder.add(EDC_ATOMIC_CONSTRAINT_STEP_IS_FILTERED, atomicConstraintStep.isFiltered());
+        builder.add(EDC_ATOMIC_CONSTRAINT_STEP_FILTERING_REASONS, jsonFactory.createArrayBuilder(atomicConstraintStep.filteringReasons()));
+
+        Optional.ofNullable(atomicConstraintStep.functionName())
+                .ifPresent(name -> builder.add(EDC_ATOMIC_CONSTRAINT_STEP_FUNCTION_NAME, name));
+
+        builder.add(EDC_ATOMIC_CONSTRAINT_STEP_FUNCTION_PARAMS, jsonFactory.createArrayBuilder(atomicConstraintStep.functionParams()));
+        return builder.build();
+    }
+
+    private JsonObject transformOrConstraintStep(OrConstraintStep orConstraintStep) {
+        return transformMultiplicityConstraintStep(orConstraintStep, EDC_OR_CONSTRAINT_STEP_TYPE);
+    }
+
+    private JsonObject transformAndConstraintStep(AndConstraintStep andConstraintStep) {
+        return transformMultiplicityConstraintStep(andConstraintStep, EDC_AND_CONSTRAINT_STEP_TYPE);
+
+    }
+
+    private JsonObject transformXoneConstraintStep(XoneConstraintStep xoneConstraintStep) {
+        return transformMultiplicityConstraintStep(xoneConstraintStep, EDC_XONE_CONSTRAINT_STEP_TYPE);
+    }
+
+    private JsonObject transformMultiplicityConstraintStep(MultiplicityConstraintStep<? extends MultiplicityConstraint> multiplicityConstraintStep, String type) {
+        var builder = jsonFactory.createObjectBuilder();
+        var constraintSteps = jsonFactory.createArrayBuilder();
+
+        multiplicityConstraintStep.getConstraintSteps().stream().map(this::transformConstraintStep)
+                .forEach(constraintSteps::add);
+
+        builder.add(TYPE, type);
+        builder.add(EDC_MULTIPLICITY_CONSTRAINT_STEPS, constraintSteps);
+        return builder.build();
+    }
+}

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/transform/JsonObjectToPolicyEvaluationPlanRequestTransformer.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/transform/JsonObjectToPolicyEvaluationPlanRequestTransformer.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.api.management.policy.transform;
+
+import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.controlplane.api.management.policy.model.PolicyEvaluationPlanRequest;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static org.eclipse.edc.connector.controlplane.api.management.policy.model.PolicyEvaluationPlanRequest.EDC_POLICY_EVALUATION_PLAN_REQUEST_POLICY_SCOPE;
+
+public class JsonObjectToPolicyEvaluationPlanRequestTransformer extends AbstractJsonLdTransformer<JsonObject, PolicyEvaluationPlanRequest> {
+
+    public JsonObjectToPolicyEvaluationPlanRequestTransformer() {
+        super(JsonObject.class, PolicyEvaluationPlanRequest.class);
+    }
+
+    @Override
+    public @Nullable PolicyEvaluationPlanRequest transform(@NotNull JsonObject input, @NotNull TransformerContext context) {
+        var policyScope = transformString(input.get(EDC_POLICY_EVALUATION_PLAN_REQUEST_POLICY_SCOPE), context);
+        return new PolicyEvaluationPlanRequest(policyScope);
+    }
+
+}

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/v31alpha/PolicyDefinitionApiV31Alpha.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/v31alpha/PolicyDefinitionApiV31Alpha.java
@@ -104,11 +104,22 @@ public interface PolicyDefinitionApiV31Alpha {
     @Operation(description = "Validates an existing Policy, If the Policy is not found, an error is reported",
             responses = {
                     @ApiResponse(responseCode = "200", description = "Returns the validation result", content = @Content(schema = @Schema(implementation = PolicyValidationResultSchema.class))),
-                    @ApiResponse(responseCode = "404", description = "policy definition could not be updated, because it does not exists",
+                    @ApiResponse(responseCode = "404", description = "policy definition could not be validated, because it does not exists",
                             content = @Content(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))
             }
     )
     JsonObject validatePolicyDefinitionV3(String id);
+
+
+    @Operation(description = "Creates an execution plane for an existing Policy, If the Policy is not found, an error is reported",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = PolicyEvaluationPlanRequestSchema.class))),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Returns the evaluation plan", content = @Content(schema = @Schema(implementation = PolicyEvaluationPlanSchema.class))),
+                    @ApiResponse(responseCode = "404", description = "An evaluation plan could not be created, because the policy definition does not exists",
+                            content = @Content(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))
+            }
+    )
+    JsonObject createExecutionPlaneV3(String id, JsonObject input);
 
     @Schema(name = "PolicyDefinitionInput", example = PolicyDefinitionInputSchema.POLICY_DEFINITION_INPUT_EXAMPLE)
     record PolicyDefinitionInputSchema(
@@ -194,6 +205,58 @@ public interface PolicyDefinitionApiV31Alpha {
                         "error2"
                     ]
                 }
+                """;
+    }
+
+    @Schema(name = "PolicyEvaluationPlanRequestSchema", example = PolicyEvaluationPlanRequestSchema.POLICY_EVALUATION_PLAN_REQUEST_INPUT_EXAMPLE)
+    record PolicyEvaluationPlanRequestSchema(
+            String policyScope) {
+
+        public static final String POLICY_EVALUATION_PLAN_REQUEST_INPUT_EXAMPLE = """
+                {
+                    "@context": { "@vocab": "https://w3id.org/edc/v0.0.1/ns/" },
+                    "@type": "PolicyEvaluationPlanRequest",
+                    "policyScope": "catalog"
+                }
+                """;
+    }
+
+    @Schema(name = "PolicyEvaluationPlanSchema", example = PolicyEvaluationPlanSchema.POLICY_EVALUATION_PLANE_OUTPUT_EXAMPLE)
+    record PolicyEvaluationPlanSchema() {
+
+        public static final String POLICY_EVALUATION_PLANE_OUTPUT_EXAMPLE = """
+                {
+                     "@type": "PolicyEvaluationPlan",
+                     "preValidators": "DcpScopeExtractorFunction",
+                     "permissionSteps": {
+                         "@type": "PermissionStep",
+                         "isFiltered": false,
+                         "filteringReasons": [],
+                         "ruleFunctions": [],
+                         "constraintSteps": {
+                             "@type": "AtomicConstraintStep",
+                             "isFiltered": true,
+                             "filteringReasons": [
+                                 "leftOperand 'MembershipCredential' is not bound to scope 'request.catalog'",
+                                 "leftOperand 'MembershipCredential' is not bound to any function within scope 'request.catalog'"
+                             ],
+                             "functionParams": [
+                                 "'MembershipCredential'",
+                                 "EQ",
+                                 "'active'"
+                             ]
+                         },
+                         "dutySteps": []
+                     },
+                     "prohibitionSteps": [],
+                     "obligationSteps": [],
+                     "postValidators": "DefaultScopeMappingFunction",
+                     "@context": {
+                         "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
+                         "edc": "https://w3id.org/edc/v0.0.1/ns/",
+                         "odrl": "http://www.w3.org/ns/odrl/2/"
+                     }
+                 }
                 """;
     }
 

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/validation/PolicyEvaluationPlanRequestValidator.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/validation/PolicyEvaluationPlanRequestValidator.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.api.management.policy.validation;
+
+import jakarta.json.JsonObject;
+import org.eclipse.edc.validator.jsonobject.JsonObjectValidator;
+import org.eclipse.edc.validator.jsonobject.validators.MandatoryValue;
+import org.eclipse.edc.validator.spi.Validator;
+
+import static org.eclipse.edc.connector.controlplane.api.management.policy.model.PolicyEvaluationPlanRequest.EDC_POLICY_EVALUATION_PLAN_REQUEST_POLICY_SCOPE;
+
+public class PolicyEvaluationPlanRequestValidator {
+
+    public static Validator<JsonObject> instance() {
+        return JsonObjectValidator.newValidator()
+                .verify(EDC_POLICY_EVALUATION_PLAN_REQUEST_POLICY_SCOPE, MandatoryValue::new)
+                .build();
+    }
+}

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/policy/PolicyDefinitionApiTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/policy/PolicyDefinitionApiTest.java
@@ -29,12 +29,16 @@ import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.connector.controlplane.api.management.policy.model.PolicyEvaluationPlanRequest.EDC_POLICY_EVALUATION_PLAN_REQUEST_POLICY_SCOPE;
+import static org.eclipse.edc.connector.controlplane.api.management.policy.model.PolicyEvaluationPlanRequest.EDC_POLICY_EVALUATION_PLAN_REQUEST_TYPE;
 import static org.eclipse.edc.connector.controlplane.api.management.policy.model.PolicyValidationResult.EDC_POLICY_VALIDATION_RESULT_ERRORS;
 import static org.eclipse.edc.connector.controlplane.api.management.policy.model.PolicyValidationResult.EDC_POLICY_VALIDATION_RESULT_IS_VALID;
 import static org.eclipse.edc.connector.controlplane.api.management.policy.model.PolicyValidationResult.EDC_POLICY_VALIDATION_RESULT_TYPE;
 import static org.eclipse.edc.connector.controlplane.api.management.policy.v2.PolicyDefinitionApiV2.PolicyDefinitionInputSchema.POLICY_DEFINITION_INPUT_EXAMPLE;
 import static org.eclipse.edc.connector.controlplane.api.management.policy.v2.PolicyDefinitionApiV2.PolicyDefinitionOutputSchema.POLICY_DEFINITION_OUTPUT_EXAMPLE;
+import static org.eclipse.edc.connector.controlplane.api.management.policy.v31alpha.PolicyDefinitionApiV31Alpha.PolicyEvaluationPlanRequestSchema.POLICY_EVALUATION_PLAN_REQUEST_INPUT_EXAMPLE;
+import static org.eclipse.edc.connector.controlplane.api.management.policy.v31alpha.PolicyDefinitionApiV31Alpha.PolicyEvaluationPlanSchema.POLICY_EVALUATION_PLANE_OUTPUT_EXAMPLE;
 import static org.eclipse.edc.connector.controlplane.api.management.policy.v31alpha.PolicyDefinitionApiV31Alpha.PolicyValidationResultSchema.POLICY_VALIDATION_RESULT_OUTPUT_EXAMPLE;
 import static org.eclipse.edc.connector.controlplane.policy.spi.PolicyDefinition.EDC_POLICY_DEFINITION_POLICY;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
@@ -43,6 +47,12 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.EDC_CREATED_AT;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.junit.extensions.TestServiceExtensionContext.testServiceExtensionContext;
+import static org.eclipse.edc.policy.engine.spi.plan.PolicyEvaluationPlan.EDC_POLICY_EVALUATION_PLAN_OBLIGATION_STEPS;
+import static org.eclipse.edc.policy.engine.spi.plan.PolicyEvaluationPlan.EDC_POLICY_EVALUATION_PLAN_PERMISSION_STEPS;
+import static org.eclipse.edc.policy.engine.spi.plan.PolicyEvaluationPlan.EDC_POLICY_EVALUATION_PLAN_POST_VALIDATORS;
+import static org.eclipse.edc.policy.engine.spi.plan.PolicyEvaluationPlan.EDC_POLICY_EVALUATION_PLAN_PRE_VALIDATORS;
+import static org.eclipse.edc.policy.engine.spi.plan.PolicyEvaluationPlan.EDC_POLICY_EVALUATION_PLAN_PROHIBITION_STEPS;
+import static org.eclipse.edc.policy.engine.spi.plan.PolicyEvaluationPlan.EDC_POLICY_EVALUATION_PLAN_TYPE;
 import static org.mockito.Mockito.mock;
 
 class PolicyDefinitionApiTest {
@@ -98,6 +108,32 @@ class PolicyDefinitionApiTest {
             assertThat(content.getJsonArray(TYPE).getString(0)).isEqualTo(EDC_POLICY_VALIDATION_RESULT_TYPE);
             assertThat(content.getJsonArray(EDC_POLICY_VALIDATION_RESULT_IS_VALID).getJsonObject(0).getBoolean(VALUE)).isEqualTo(false);
             assertThat(content.getJsonArray(EDC_POLICY_VALIDATION_RESULT_ERRORS).size()).isEqualTo(2);
+        });
+    }
+    
+    @Test
+    void policyEvaluationPlanRequestExample() throws JsonProcessingException {
+        var jsonObject = objectMapper.readValue(POLICY_EVALUATION_PLAN_REQUEST_INPUT_EXAMPLE, JsonObject.class);
+        var expanded = jsonLd.expand(jsonObject);
+
+        assertThat(expanded).isSucceeded().satisfies(content -> {
+            assertThat(content.getJsonArray(TYPE).getString(0)).isEqualTo(EDC_POLICY_EVALUATION_PLAN_REQUEST_TYPE);
+            assertThat(content.getJsonArray(EDC_POLICY_EVALUATION_PLAN_REQUEST_POLICY_SCOPE).getJsonObject(0).getString(VALUE)).isEqualTo("catalog");
+        });
+    }
+
+    @Test
+    void policyEvaluationPlanOutputExample() throws JsonProcessingException {
+        var jsonObject = objectMapper.readValue(POLICY_EVALUATION_PLANE_OUTPUT_EXAMPLE, JsonObject.class);
+        var expanded = jsonLd.expand(jsonObject);
+
+        assertThat(expanded).isSucceeded().satisfies(content -> {
+            assertThat(content.getJsonArray(TYPE).getString(0)).isEqualTo(EDC_POLICY_EVALUATION_PLAN_TYPE);
+            assertThat(content.getJsonArray(EDC_POLICY_EVALUATION_PLAN_PRE_VALIDATORS)).hasSize(1);
+            assertThat(content.getJsonArray(EDC_POLICY_EVALUATION_PLAN_PERMISSION_STEPS)).hasSize(1);
+            assertThat(content.getJsonArray(EDC_POLICY_EVALUATION_PLAN_PROHIBITION_STEPS)).hasSize(0);
+            assertThat(content.getJsonArray(EDC_POLICY_EVALUATION_PLAN_OBLIGATION_STEPS)).hasSize(0);
+            assertThat(content.getJsonArray(EDC_POLICY_EVALUATION_PLAN_POST_VALIDATORS)).hasSize(1);
         });
     }
 }

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/policy/transform/JsonObjectFromPolicyEvaluationPlanTransformerTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/policy/transform/JsonObjectFromPolicyEvaluationPlanTransformerTest.java
@@ -1,0 +1,228 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.api.management.policy.transform;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.policy.engine.spi.AtomicConstraintFunction;
+import org.eclipse.edc.policy.engine.spi.RuleFunction;
+import org.eclipse.edc.policy.engine.spi.plan.PolicyEvaluationPlan;
+import org.eclipse.edc.policy.engine.spi.plan.step.AndConstraintStep;
+import org.eclipse.edc.policy.engine.spi.plan.step.AtomicConstraintStep;
+import org.eclipse.edc.policy.engine.spi.plan.step.ConstraintStep;
+import org.eclipse.edc.policy.engine.spi.plan.step.DutyStep;
+import org.eclipse.edc.policy.engine.spi.plan.step.OrConstraintStep;
+import org.eclipse.edc.policy.engine.spi.plan.step.PermissionStep;
+import org.eclipse.edc.policy.engine.spi.plan.step.ProhibitionStep;
+import org.eclipse.edc.policy.engine.spi.plan.step.RuleFunctionStep;
+import org.eclipse.edc.policy.engine.spi.plan.step.ValidatorStep;
+import org.eclipse.edc.policy.engine.spi.plan.step.XoneConstraintStep;
+import org.eclipse.edc.policy.model.AtomicConstraint;
+import org.eclipse.edc.policy.model.LiteralExpression;
+import org.eclipse.edc.policy.model.Permission;
+import org.eclipse.edc.policy.model.Rule;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.policy.engine.spi.plan.PolicyEvaluationPlan.EDC_POLICY_EVALUATION_PLAN_OBLIGATION_STEPS;
+import static org.eclipse.edc.policy.engine.spi.plan.PolicyEvaluationPlan.EDC_POLICY_EVALUATION_PLAN_PERMISSION_STEPS;
+import static org.eclipse.edc.policy.engine.spi.plan.PolicyEvaluationPlan.EDC_POLICY_EVALUATION_PLAN_POST_VALIDATORS;
+import static org.eclipse.edc.policy.engine.spi.plan.PolicyEvaluationPlan.EDC_POLICY_EVALUATION_PLAN_PRE_VALIDATORS;
+import static org.eclipse.edc.policy.engine.spi.plan.PolicyEvaluationPlan.EDC_POLICY_EVALUATION_PLAN_PROHIBITION_STEPS;
+import static org.eclipse.edc.policy.engine.spi.plan.step.AndConstraintStep.EDC_AND_CONSTRAINT_STEP_TYPE;
+import static org.eclipse.edc.policy.engine.spi.plan.step.AtomicConstraintStep.EDC_ATOMIC_CONSTRAINT_STEP_FILTERING_REASONS;
+import static org.eclipse.edc.policy.engine.spi.plan.step.AtomicConstraintStep.EDC_ATOMIC_CONSTRAINT_STEP_FUNCTION_NAME;
+import static org.eclipse.edc.policy.engine.spi.plan.step.AtomicConstraintStep.EDC_ATOMIC_CONSTRAINT_STEP_FUNCTION_PARAMS;
+import static org.eclipse.edc.policy.engine.spi.plan.step.AtomicConstraintStep.EDC_ATOMIC_CONSTRAINT_STEP_IS_FILTERED;
+import static org.eclipse.edc.policy.engine.spi.plan.step.AtomicConstraintStep.EDC_ATOMIC_CONSTRAINT_STEP_TYPE;
+import static org.eclipse.edc.policy.engine.spi.plan.step.MultiplicityConstraintStep.EDC_MULTIPLICITY_CONSTRAINT_STEPS;
+import static org.eclipse.edc.policy.engine.spi.plan.step.OrConstraintStep.EDC_OR_CONSTRAINT_STEP_TYPE;
+import static org.eclipse.edc.policy.engine.spi.plan.step.PermissionStep.EDC_PERMISSION_STEP_DUTY_STEPS;
+import static org.eclipse.edc.policy.engine.spi.plan.step.PermissionStep.EDC_PERMISSION_STEP_TYPE;
+import static org.eclipse.edc.policy.engine.spi.plan.step.RuleStep.EDC_RULE_CONSTRAINT_STEPS;
+import static org.eclipse.edc.policy.engine.spi.plan.step.RuleStep.EDC_RULE_FUNCTIONS;
+import static org.eclipse.edc.policy.engine.spi.plan.step.RuleStep.EDC_RULE_STEP_FILTERING_REASONS;
+import static org.eclipse.edc.policy.engine.spi.plan.step.RuleStep.EDC_RULE_STEP_IS_FILTERED;
+import static org.eclipse.edc.policy.engine.spi.plan.step.XoneConstraintStep.EDC_XONE_CONSTRAINT_STEP_TYPE;
+import static org.eclipse.edc.policy.model.Operator.EQ;
+import static org.junit.jupiter.params.provider.Arguments.of;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class JsonObjectFromPolicyEvaluationPlanTransformerTest {
+    
+    private final JsonObjectFromPolicyEvaluationPlanTransformer transformer = new JsonObjectFromPolicyEvaluationPlanTransformer(Json.createBuilderFactory(emptyMap()));
+    private final TransformerContext context = mock(TransformerContext.class);
+
+    private static AtomicConstraint atomicConstraint(String key, String value) {
+        var left = new LiteralExpression(key);
+        var right = new LiteralExpression(value);
+        return AtomicConstraint.Builder.newInstance()
+                .leftExpression(left)
+                .operator(EQ)
+                .rightExpression(right)
+                .build();
+    }
+
+    private static AtomicConstraintStep atomicConstraintStep(AtomicConstraint atomicConstraint) {
+        AtomicConstraintFunction<Rule> function = mock();
+        when(function.name()).thenReturn("AtomicConstraintFunction");
+        return new AtomicConstraintStep(atomicConstraint, List.of("filtered constraint"), mock(), function);
+    }
+
+    @Test
+    void types() {
+        assertThat(transformer.getInputType()).isEqualTo(PolicyEvaluationPlan.class);
+        assertThat(transformer.getOutputType()).isEqualTo(JsonObject.class);
+    }
+
+    @Test
+    void transform_withPermissionStep() {
+        var plan = PolicyEvaluationPlan.Builder.newInstance().permission(permissionStep()).build();
+
+        var result = transformer.transform(plan, context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getJsonArray(EDC_POLICY_EVALUATION_PLAN_PERMISSION_STEPS)).hasSize(1);
+        var permission = result.getJsonArray(EDC_POLICY_EVALUATION_PLAN_PERMISSION_STEPS).get(0).asJsonObject();
+
+        assertThat(permission.getString(TYPE)).isEqualTo(EDC_PERMISSION_STEP_TYPE);
+        assertThat(permission.getBoolean(EDC_RULE_STEP_IS_FILTERED)).isEqualTo(true);
+        assertThat(permission.getJsonArray(EDC_RULE_STEP_FILTERING_REASONS)).contains(Json.createValue("filter reason"));
+        assertThat(permission.getJsonArray(EDC_PERMISSION_STEP_DUTY_STEPS)).hasSize(1);
+        assertThat(permission.getJsonArray(EDC_RULE_FUNCTIONS)).hasSize(1).contains(Json.createValue("PermissionFunction"));
+        assertThat(permission.getJsonArray(EDC_RULE_CONSTRAINT_STEPS)).hasSize(1);
+
+        var constraint = permission.getJsonArray(EDC_RULE_CONSTRAINT_STEPS).get(0).asJsonObject();
+
+        assertThat(constraint.getString(TYPE)).isEqualTo(EDC_ATOMIC_CONSTRAINT_STEP_TYPE);
+        assertThat(constraint.getBoolean(EDC_ATOMIC_CONSTRAINT_STEP_IS_FILTERED)).isTrue();
+        assertThat(constraint.getJsonArray(EDC_ATOMIC_CONSTRAINT_STEP_FILTERING_REASONS)).hasSize(1)
+                .contains(Json.createValue("filtered constraint"));
+        assertThat(constraint.getString(EDC_ATOMIC_CONSTRAINT_STEP_FUNCTION_NAME)).isEqualTo("AtomicConstraintFunction");
+        assertThat(constraint.getJsonArray(EDC_ATOMIC_CONSTRAINT_STEP_FUNCTION_PARAMS))
+                .hasSize(3)
+                .containsExactly(Json.createValue("'foo'"), Json.createValue("EQ"), Json.createValue("'bar'"));
+
+    }
+
+    @Test
+    void transform_withValidators() {
+
+        var validator = new ValidatorStep(mock());
+        var plan = PolicyEvaluationPlan.Builder.newInstance()
+                .preValidator(validator)
+                .postValidator(validator)
+                .build();
+
+        var result = transformer.transform(plan, context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getJsonArray(EDC_POLICY_EVALUATION_PLAN_PRE_VALIDATORS)).hasSize(1);
+        assertThat(result.getJsonArray(EDC_POLICY_EVALUATION_PLAN_POST_VALIDATORS)).hasSize(1);
+
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(MultiplicityStepProvider.class)
+    void transformWithMultiplicitySteps(PolicyEvaluationPlan plan, String ruleStepProperty, String multiplicityType) {
+
+        var result = transformer.transform(plan, context);
+
+        assertThat(result).isNotNull();
+
+        assertThat(result.getJsonArray(ruleStepProperty)).hasSize(1);
+        var rule = result.getJsonArray(ruleStepProperty).get(0).asJsonObject();
+
+        assertThat(rule.getJsonArray(EDC_RULE_CONSTRAINT_STEPS)).hasSize(1);
+        var constraint = rule.getJsonArray(EDC_RULE_CONSTRAINT_STEPS).get(0).asJsonObject();
+
+        assertThat(constraint.getString(TYPE)).isEqualTo(multiplicityType);
+        assertThat(constraint.getJsonArray(EDC_MULTIPLICITY_CONSTRAINT_STEPS)).hasSize(2);
+
+    }
+
+    private PolicyEvaluationPlan createPlan() {
+        return PolicyEvaluationPlan.Builder.newInstance()
+                .preValidator(new ValidatorStep(mock()))
+                .duty(dutyStep())
+                .permission(permissionStep())
+                .prohibition(prohibitionStep())
+                .postValidator(new ValidatorStep(mock()))
+                .build();
+    }
+
+    private DutyStep dutyStep() {
+        return DutyStep.Builder.newInstance().rule(mock()).filtered(false).build();
+    }
+
+    private PermissionStep permissionStep() {
+        return permissionStep(atomicConstraintStep(atomicConstraint("foo", "bar")));
+    }
+
+    private PermissionStep permissionStep(ConstraintStep constraintStep) {
+        RuleFunction<Permission> function = mock();
+        when(function.name()).thenReturn("PermissionFunction");
+        return PermissionStep.Builder.newInstance()
+                .rule(mock())
+                .filtered(true)
+                .filteringReason("filter reason")
+                .ruleFunction(new RuleFunctionStep<>(function, mock()))
+                .constraint(constraintStep)
+                .dutyStep(DutyStep.Builder.newInstance().rule(mock()).filtered(false).build()).build();
+    }
+
+    private ProhibitionStep prohibitionStep() {
+        return ProhibitionStep.Builder.newInstance()
+                .rule(mock())
+                .build();
+    }
+
+    private static class MultiplicityStepProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+
+            var firstConstraint = atomicConstraintStep(atomicConstraint("foo", "bar"));
+            var secondConstraint = atomicConstraintStep(atomicConstraint("baz", "bar"));
+
+            List<ConstraintStep> constraints = List.of(firstConstraint, secondConstraint);
+
+            var orConstraintStep = new OrConstraintStep(constraints, mock());
+            var andConstraintStep = new AndConstraintStep(constraints, mock());
+            var xoneConstraintStep = new XoneConstraintStep(constraints, mock());
+
+            var permission = PermissionStep.Builder.newInstance().constraint(orConstraintStep).rule(mock()).build();
+            var duty = DutyStep.Builder.newInstance().constraint(xoneConstraintStep).rule(mock()).build();
+            var prohibition = ProhibitionStep.Builder.newInstance().constraint(andConstraintStep).rule(mock()).build();
+
+            return Stream.of(
+                    of(PolicyEvaluationPlan.Builder.newInstance().permission(permission).build(), EDC_POLICY_EVALUATION_PLAN_PERMISSION_STEPS, EDC_OR_CONSTRAINT_STEP_TYPE),
+                    of(PolicyEvaluationPlan.Builder.newInstance().duty(duty).build(), EDC_POLICY_EVALUATION_PLAN_OBLIGATION_STEPS, EDC_XONE_CONSTRAINT_STEP_TYPE),
+                    of(PolicyEvaluationPlan.Builder.newInstance().prohibition(prohibition).build(), EDC_POLICY_EVALUATION_PLAN_PROHIBITION_STEPS, EDC_AND_CONSTRAINT_STEP_TYPE)
+            );
+        }
+    }
+}

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/policy/transform/JsonObjectFromPolicyValidationResultTransformerTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/policy/transform/JsonObjectFromPolicyValidationResultTransformerTest.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.api.management.policy.transform;
+
+import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.controlplane.api.management.policy.model.PolicyValidationResult;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.connector.controlplane.api.management.policy.model.PolicyValidationResult.EDC_POLICY_VALIDATION_RESULT_ERRORS;
+import static org.eclipse.edc.connector.controlplane.api.management.policy.model.PolicyValidationResult.EDC_POLICY_VALIDATION_RESULT_IS_VALID;
+import static org.eclipse.edc.connector.controlplane.api.management.policy.model.PolicyValidationResult.EDC_POLICY_VALIDATION_RESULT_TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.mockito.Mockito.mock;
+
+class JsonObjectFromPolicyValidationResultTransformerTest {
+
+    private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
+
+    private final JsonObjectFromPolicyValidationResultTransformer transformer = new JsonObjectFromPolicyValidationResultTransformer(jsonFactory);
+    private final TransformerContext context = mock(TransformerContext.class);
+
+    @Test
+    void types() {
+        assertThat(transformer.getOutputType()).isEqualTo(JsonObject.class);
+        assertThat(transformer.getInputType()).isEqualTo(PolicyValidationResult.class);
+    }
+
+    @Test
+    void transform() {
+        var validationResult = new PolicyValidationResult(false, List.of("error1", "error2"));
+
+        var result = transformer.transform(validationResult, context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getString(TYPE)).isEqualTo(EDC_POLICY_VALIDATION_RESULT_TYPE);
+        assertThat(result.getBoolean(EDC_POLICY_VALIDATION_RESULT_IS_VALID)).isFalse();
+        assertThat(result.getJsonArray(EDC_POLICY_VALIDATION_RESULT_ERRORS)).hasSize(2)
+                .contains(Json.createValue("error1"), Json.createValue("error2"));
+    }
+    
+}

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/policy/transform/JsonObjectToPolicyEvaluationPlanRequestTransformerTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/policy/transform/JsonObjectToPolicyEvaluationPlanRequestTransformerTest.java
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.api.management.policy.transform;
+
+import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.controlplane.api.management.policy.model.PolicyEvaluationPlanRequest;
+import org.eclipse.edc.jsonld.TitaniumJsonLd;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.Test;
+
+import static jakarta.json.Json.createObjectBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.connector.controlplane.api.management.policy.model.PolicyEvaluationPlanRequest.EDC_POLICY_EVALUATION_PLAN_REQUEST_POLICY_SCOPE;
+import static org.eclipse.edc.connector.controlplane.api.management.policy.model.PolicyEvaluationPlanRequest.EDC_POLICY_EVALUATION_PLAN_REQUEST_TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.mockito.Mockito.mock;
+
+public class JsonObjectToPolicyEvaluationPlanRequestTransformerTest {
+
+    private final JsonObjectToPolicyEvaluationPlanRequestTransformer transformer = new JsonObjectToPolicyEvaluationPlanRequestTransformer();
+    private final TransformerContext context = mock(TransformerContext.class);
+    private final TitaniumJsonLd jsonLd = new TitaniumJsonLd(mock(Monitor.class));
+
+    @Test
+    void types() {
+        assertThat(transformer.getInputType()).isEqualTo(JsonObject.class);
+        assertThat(transformer.getOutputType()).isEqualTo(PolicyEvaluationPlanRequest.class);
+    }
+
+    @Test
+    void transform() {
+        var json = createObjectBuilder()
+                .add(TYPE, EDC_POLICY_EVALUATION_PLAN_REQUEST_TYPE)
+                .add(EDC_POLICY_EVALUATION_PLAN_REQUEST_POLICY_SCOPE, "scope")
+                .build();
+
+        var result = transformer.transform(expand(json), context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.policyScope()).isEqualTo("scope");
+    }
+
+    private JsonObject expand(JsonObject jsonObject) {
+        return jsonLd.expand(jsonObject).orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+    }
+}

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/policy/validation/PolicyEvaluationPlanRequestValidatorTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/policy/validation/PolicyEvaluationPlanRequestValidatorTest.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.api.management.policy.validation;
+
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
+import org.assertj.core.api.Assertions;
+import org.eclipse.edc.validator.spi.ValidationFailure;
+import org.eclipse.edc.validator.spi.Validator;
+import org.eclipse.edc.validator.spi.Violation;
+import org.junit.jupiter.api.Test;
+
+import static jakarta.json.Json.createArrayBuilder;
+import static jakarta.json.Json.createObjectBuilder;
+import static org.assertj.core.api.InstanceOfAssertFactories.list;
+import static org.eclipse.edc.connector.controlplane.api.management.policy.model.PolicyEvaluationPlanRequest.EDC_POLICY_EVALUATION_PLAN_REQUEST_POLICY_SCOPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+
+public class PolicyEvaluationPlanRequestValidatorTest {
+    
+    private final Validator<JsonObject> validator = PolicyEvaluationPlanRequestValidator.instance();
+
+    @Test
+    void shouldSucceed_whenObjectIsValid() {
+        var request = createObjectBuilder()
+                .add(EDC_POLICY_EVALUATION_PLAN_REQUEST_POLICY_SCOPE, value("scope"))
+                .build();
+
+        var result = validator.validate(request);
+
+        assertThat(result).isSucceeded();
+    }
+
+    @Test
+    void shouldFail_whenIdIsBlank() {
+        var request = createObjectBuilder()
+                .build();
+
+        var result = validator.validate(request);
+
+        assertThat(result).isFailed().extracting(ValidationFailure::getViolations).asInstanceOf(list(Violation.class))
+                .isNotEmpty()
+                .anySatisfy(violation -> Assertions.assertThat(violation.message()).contains("blank"));
+    }
+
+    private JsonArrayBuilder value(String value) {
+        return createArrayBuilder().add(createObjectBuilder().add(VALUE, value));
+    }
+}

--- a/spi/common/policy-engine-spi/src/main/java/org/eclipse/edc/policy/engine/spi/AtomicConstraintFunction.java
+++ b/spi/common/policy-engine-spi/src/main/java/org/eclipse/edc/policy/engine/spi/AtomicConstraintFunction.java
@@ -34,8 +34,7 @@ public interface AtomicConstraintFunction<R extends Rule> {
      * @param context    the policy context
      */
     boolean evaluate(Operator operator, Object rightValue, R rule, PolicyContext context);
-
-
+    
     /**
      * Performs a validation of an atomic constraint
      *
@@ -46,5 +45,12 @@ public interface AtomicConstraintFunction<R extends Rule> {
      */
     default Result<Void> validate(Operator operator, Object rightValue, R rule) {
         return Result.success();
+    }
+
+    /**
+     * Returns the name of the function
+     */
+    default String name() {
+        return getClass().getSimpleName();
     }
 }

--- a/spi/common/policy-engine-spi/src/main/java/org/eclipse/edc/policy/engine/spi/DynamicAtomicConstraintFunction.java
+++ b/spi/common/policy-engine-spi/src/main/java/org/eclipse/edc/policy/engine/spi/DynamicAtomicConstraintFunction.java
@@ -43,7 +43,6 @@ public interface DynamicAtomicConstraintFunction<R extends Rule> {
      */
     boolean canHandle(Object leftValue);
 
-
     /**
      * Performs a validation of an atomic constraint
      *
@@ -55,6 +54,13 @@ public interface DynamicAtomicConstraintFunction<R extends Rule> {
      */
     default Result<Void> validate(Object leftValue, Operator operator, Object rightValue, R rule) {
         return Result.success();
+    }
+
+    /**
+     * Returns the name of the function
+     */
+    default String name() {
+        return getClass().getSimpleName();
     }
 
 }

--- a/spi/common/policy-engine-spi/src/main/java/org/eclipse/edc/policy/engine/spi/RuleFunction.java
+++ b/spi/common/policy-engine-spi/src/main/java/org/eclipse/edc/policy/engine/spi/RuleFunction.java
@@ -25,4 +25,11 @@ public interface RuleFunction<R extends Rule> {
      * Performs the rule evaluation.
      */
     boolean evaluate(R rule, PolicyContext context);
+    
+    /**
+     * Returns the name of the function
+     */
+    default String name() {
+        return getClass().getSimpleName();
+    }
 }

--- a/spi/common/policy-engine-spi/src/main/java/org/eclipse/edc/policy/engine/spi/plan/PolicyEvaluationPlan.java
+++ b/spi/common/policy-engine-spi/src/main/java/org/eclipse/edc/policy/engine/spi/plan/PolicyEvaluationPlan.java
@@ -23,17 +23,27 @@ import org.eclipse.edc.policy.model.Policy;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+
 /**
  * The {@link PolicyEvaluationPlan} contains information about the evaluation process of a {@link Policy}
  * withing a scope without executing it.
  */
 public class PolicyEvaluationPlan {
 
+    public static final String EDC_POLICY_EVALUATION_PLAN_TYPE = EDC_NAMESPACE + "PolicyEvaluationPlan";
+    public static final String EDC_POLICY_EVALUATION_PLAN_PRE_VALIDATORS = EDC_NAMESPACE + "preValidators";
+    public static final String EDC_POLICY_EVALUATION_PLAN_POST_VALIDATORS = EDC_NAMESPACE + "postValidators";
+    public static final String EDC_POLICY_EVALUATION_PLAN_PERMISSION_STEPS = EDC_NAMESPACE + "permissionSteps";
+    public static final String EDC_POLICY_EVALUATION_PLAN_PROHIBITION_STEPS = EDC_NAMESPACE + "prohibitionSteps";
+    public static final String EDC_POLICY_EVALUATION_PLAN_OBLIGATION_STEPS = EDC_NAMESPACE + "obligationSteps";
+
+
     private final List<ValidatorStep> preValidators = new ArrayList<>();
     private final List<ValidatorStep> postValidators = new ArrayList<>();
     private final List<PermissionStep> permissionSteps = new ArrayList<>();
     private final List<ProhibitionStep> prohibitionSteps = new ArrayList<>();
-    private final List<DutyStep> dutySteps = new ArrayList<>();
+    private final List<DutyStep> obligationSteps = new ArrayList<>();
 
     public List<ValidatorStep> getPostValidators() {
         return postValidators;
@@ -47,8 +57,8 @@ public class PolicyEvaluationPlan {
         return permissionSteps;
     }
 
-    public List<DutyStep> getDutySteps() {
-        return dutySteps;
+    public List<DutyStep> getObligationSteps() {
+        return obligationSteps;
     }
 
     public List<ProhibitionStep> getProhibitionSteps() {
@@ -83,8 +93,8 @@ public class PolicyEvaluationPlan {
             return this;
         }
 
-        public Builder obligation(DutyStep dutyStep) {
-            plan.dutySteps.add(dutyStep);
+        public Builder duty(DutyStep dutyStep) {
+            plan.obligationSteps.add(dutyStep);
             return this;
         }
 

--- a/spi/common/policy-engine-spi/src/main/java/org/eclipse/edc/policy/engine/spi/plan/step/AndConstraintStep.java
+++ b/spi/common/policy-engine-spi/src/main/java/org/eclipse/edc/policy/engine/spi/plan/step/AndConstraintStep.java
@@ -18,11 +18,15 @@ import org.eclipse.edc.policy.model.AndConstraint;
 
 import java.util.List;
 
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+
 /**
  * An evaluation step for {@link AndConstraint}
  */
 public final class AndConstraintStep extends MultiplicityConstraintStep<AndConstraint> implements ConstraintStep {
 
+    public static final String EDC_AND_CONSTRAINT_STEP_TYPE = EDC_NAMESPACE + "AndConstraintStep";
+    
     public AndConstraintStep(List<ConstraintStep> steps, AndConstraint constraint) {
         super(steps, constraint);
     }

--- a/spi/common/policy-engine-spi/src/main/java/org/eclipse/edc/policy/engine/spi/plan/step/AtomicConstraintStep.java
+++ b/spi/common/policy-engine-spi/src/main/java/org/eclipse/edc/policy/engine/spi/plan/step/AtomicConstraintStep.java
@@ -18,13 +18,42 @@ import org.eclipse.edc.policy.engine.spi.AtomicConstraintFunction;
 import org.eclipse.edc.policy.model.AtomicConstraint;
 import org.eclipse.edc.policy.model.Rule;
 
+import java.util.List;
+import java.util.Optional;
+
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+
 /**
  * An evaluation step for {@link AtomicConstraint}.
  * <p>
  * The {@link AtomicConstraintStep} should be considered filtered when the left expression is not bound to a
  * scope or an evaluation function {@link AtomicConstraintFunction}
  */
-public record AtomicConstraintStep(AtomicConstraint constraint, boolean isFiltered, Rule rule,
+public record AtomicConstraintStep(AtomicConstraint constraint,
+                                   List<String> filteringReasons,
+                                   Rule rule,
                                    AtomicConstraintFunction<? extends Rule> function) implements ConstraintStep {
 
+    public static final String EDC_ATOMIC_CONSTRAINT_STEP_TYPE = EDC_NAMESPACE + "AtomicConstraintStep";
+    public static final String EDC_ATOMIC_CONSTRAINT_STEP_IS_FILTERED = EDC_NAMESPACE + "isFiltered";
+    public static final String EDC_ATOMIC_CONSTRAINT_STEP_FILTERING_REASONS = EDC_NAMESPACE + "filteringReasons";
+    public static final String EDC_ATOMIC_CONSTRAINT_STEP_FUNCTION_NAME = EDC_NAMESPACE + "functionName";
+    public static final String EDC_ATOMIC_CONSTRAINT_STEP_FUNCTION_PARAMS = EDC_NAMESPACE + "functionParams";
+
+    public boolean isFiltered() {
+        return !filteringReasons.isEmpty();
+    }
+
+    public String functionName() {
+        return Optional.ofNullable(function)
+                .map(AtomicConstraintFunction::name)
+                .orElse(null);
+    }
+
+    public List<String> functionParams() {
+        return List.of(
+                constraint.getLeftExpression().toString(),
+                constraint.getOperator().toString(),
+                constraint.getRightExpression().toString());
+    }
 }

--- a/spi/common/policy-engine-spi/src/main/java/org/eclipse/edc/policy/engine/spi/plan/step/DutyStep.java
+++ b/spi/common/policy-engine-spi/src/main/java/org/eclipse/edc/policy/engine/spi/plan/step/DutyStep.java
@@ -16,11 +16,15 @@ package org.eclipse.edc.policy.engine.spi.plan.step;
 
 import org.eclipse.edc.policy.model.Duty;
 
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+
 /**
  * An evaluation step for {@link Duty} rule;
  */
 public class DutyStep extends RuleStep<Duty> {
 
+    public static final String EDC_DUTY_STEP_TYPE = EDC_NAMESPACE + "DutyStep";
+    
     public static class Builder extends RuleStep.Builder<Duty, DutyStep, Builder> {
 
         private Builder() {

--- a/spi/common/policy-engine-spi/src/main/java/org/eclipse/edc/policy/engine/spi/plan/step/MultiplicityConstraintStep.java
+++ b/spi/common/policy-engine-spi/src/main/java/org/eclipse/edc/policy/engine/spi/plan/step/MultiplicityConstraintStep.java
@@ -18,22 +18,26 @@ import org.eclipse.edc.policy.model.MultiplicityConstraint;
 
 import java.util.List;
 
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+
 /**
  * Base evaluation step for {@link MultiplicityConstraint}. It carries the {@link MultiplicityConstraint}
  * and the collection of child {@link ConstraintStep}.
  */
 public abstract class MultiplicityConstraintStep<T extends MultiplicityConstraint> {
+    
+    public static final String EDC_MULTIPLICITY_CONSTRAINT_STEPS = EDC_NAMESPACE + "constraintSteps";
 
-    private final List<ConstraintStep> steps;
+    private final List<ConstraintStep> constraintSteps;
     private final T constraint;
 
-    public MultiplicityConstraintStep(List<ConstraintStep> steps, T constraint) {
+    public MultiplicityConstraintStep(List<ConstraintStep> constraintSteps, T constraint) {
         this.constraint = constraint;
-        this.steps = steps;
+        this.constraintSteps = constraintSteps;
     }
 
-    public List<ConstraintStep> getSteps() {
-        return steps;
+    public List<ConstraintStep> getConstraintSteps() {
+        return constraintSteps;
     }
 
     public T getConstraint() {

--- a/spi/common/policy-engine-spi/src/main/java/org/eclipse/edc/policy/engine/spi/plan/step/OrConstraintStep.java
+++ b/spi/common/policy-engine-spi/src/main/java/org/eclipse/edc/policy/engine/spi/plan/step/OrConstraintStep.java
@@ -18,12 +18,17 @@ import org.eclipse.edc.policy.model.OrConstraint;
 
 import java.util.List;
 
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+
 /**
  * An evaluation step for {@link OrConstraint}
  */
 public final class OrConstraintStep extends MultiplicityConstraintStep<OrConstraint> implements ConstraintStep {
 
+    public static final String EDC_OR_CONSTRAINT_STEP_TYPE = EDC_NAMESPACE + "OrConstraintStep";
+
     public OrConstraintStep(List<ConstraintStep> steps, OrConstraint constraint) {
         super(steps, constraint);
     }
+
 }

--- a/spi/common/policy-engine-spi/src/main/java/org/eclipse/edc/policy/engine/spi/plan/step/PermissionStep.java
+++ b/spi/common/policy-engine-spi/src/main/java/org/eclipse/edc/policy/engine/spi/plan/step/PermissionStep.java
@@ -19,11 +19,16 @@ import org.eclipse.edc.policy.model.Permission;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+
 /**
  * An evaluation step for {@link Permission} rule;
  */
 public class PermissionStep extends RuleStep<Permission> {
-    
+
+    public static final String EDC_PERMISSION_STEP_TYPE = EDC_NAMESPACE + "PermissionStep";
+    public static final String EDC_PERMISSION_STEP_DUTY_STEPS = EDC_NAMESPACE + "dutySteps";
+
     private final List<DutyStep> dutySteps = new ArrayList<>();
 
     public List<DutyStep> getDutySteps() {

--- a/spi/common/policy-engine-spi/src/main/java/org/eclipse/edc/policy/engine/spi/plan/step/ProhibitionStep.java
+++ b/spi/common/policy-engine-spi/src/main/java/org/eclipse/edc/policy/engine/spi/plan/step/ProhibitionStep.java
@@ -17,11 +17,15 @@ package org.eclipse.edc.policy.engine.spi.plan.step;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.eclipse.edc.policy.model.Prohibition;
 
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+
 /**
  * An evaluation step for {@link Prohibition} rule;
  */
 public class ProhibitionStep extends RuleStep<Prohibition> {
 
+    public static final String EDC_PROHIBITION_STEP_TYPE = EDC_NAMESPACE + "ProhibitionStep";
+    
     public static class Builder extends RuleStep.Builder<Prohibition, ProhibitionStep, Builder> {
 
         private Builder() {

--- a/spi/common/policy-engine-spi/src/main/java/org/eclipse/edc/policy/engine/spi/plan/step/RuleFunctionStep.java
+++ b/spi/common/policy-engine-spi/src/main/java/org/eclipse/edc/policy/engine/spi/plan/step/RuleFunctionStep.java
@@ -22,4 +22,10 @@ import org.eclipse.edc.policy.model.Rule;
  */
 public record RuleFunctionStep<R extends Rule>(RuleFunction<R> function, R rule) {
 
+    /**
+     * Returns the {@link RuleFunction#name()}
+     */
+    public String functionName() {
+        return function.name();
+    }
 }

--- a/spi/common/policy-engine-spi/src/main/java/org/eclipse/edc/policy/engine/spi/plan/step/RuleStep.java
+++ b/spi/common/policy-engine-spi/src/main/java/org/eclipse/edc/policy/engine/spi/plan/step/RuleStep.java
@@ -20,6 +20,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+
 /**
  * Base step class for {@link Rule}s evaluation. A rule can have multiple {@link ConstraintStep}
  * and {@link RuleFunctionStep} associated during the evaluation process.
@@ -27,10 +29,16 @@ import java.util.Objects;
  */
 public abstract class RuleStep<R extends Rule> {
 
+    public static final String EDC_RULE_STEP_IS_FILTERED = EDC_NAMESPACE + "isFiltered";
+    public static final String EDC_RULE_STEP_FILTERING_REASONS = EDC_NAMESPACE + "filteringReasons";
+    public static final String EDC_RULE_CONSTRAINT_STEPS = EDC_NAMESPACE + "constraintSteps";
+    public static final String EDC_RULE_FUNCTIONS = EDC_NAMESPACE + "ruleFunctions";
+
     protected R rule;
     protected boolean isFiltered = false;
 
     protected List<ConstraintStep> constraintSteps = new ArrayList<>();
+    protected List<String> filteringReasons = new ArrayList<>();
 
     protected List<RuleFunctionStep<R>> ruleFunctions = new ArrayList<>();
 
@@ -40,6 +48,10 @@ public abstract class RuleStep<R extends Rule> {
 
     public List<RuleFunctionStep<R>> getRuleFunctions() {
         return ruleFunctions;
+    }
+
+    public List<String> getFilteringReasons() {
+        return filteringReasons;
     }
 
     public boolean isFiltered() {
@@ -68,6 +80,11 @@ public abstract class RuleStep<R extends Rule> {
 
         public B filtered(boolean isFiltered) {
             ruleStep.isFiltered = isFiltered;
+            return (B) this;
+        }
+
+        public B filteringReason(String reason) {
+            ruleStep.filteringReasons.add(reason);
             return (B) this;
         }
 

--- a/spi/common/policy-engine-spi/src/main/java/org/eclipse/edc/policy/engine/spi/plan/step/ValidatorStep.java
+++ b/spi/common/policy-engine-spi/src/main/java/org/eclipse/edc/policy/engine/spi/plan/step/ValidatorStep.java
@@ -24,4 +24,10 @@ import java.util.function.BiFunction;
  */
 public record ValidatorStep(BiFunction<Policy, PolicyContext, Boolean> validator) {
 
+    /**
+     * Returns the name of the validator
+     */
+    public String name() {
+        return validator.getClass().getSimpleName();
+    }
 }

--- a/spi/common/policy-engine-spi/src/main/java/org/eclipse/edc/policy/engine/spi/plan/step/XoneConstraintStep.java
+++ b/spi/common/policy-engine-spi/src/main/java/org/eclipse/edc/policy/engine/spi/plan/step/XoneConstraintStep.java
@@ -18,10 +18,14 @@ import org.eclipse.edc.policy.model.XoneConstraint;
 
 import java.util.List;
 
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+
 /**
  * An evaluation step for {@link XoneConstraint}
  */
 public final class XoneConstraintStep extends MultiplicityConstraintStep<XoneConstraint> implements ConstraintStep {
+
+    public static final String EDC_XONE_CONSTRAINT_STEP_TYPE = EDC_NAMESPACE + "XoneConstraintStep";
 
     public XoneConstraintStep(List<ConstraintStep> steps, XoneConstraint constraint) {
         super(steps, constraint);

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/controlplane/services/spi/policydefinition/PolicyDefinitionService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/controlplane/services/spi/policydefinition/PolicyDefinitionService.java
@@ -15,10 +15,10 @@
 package org.eclipse.edc.connector.controlplane.services.spi.policydefinition;
 
 import org.eclipse.edc.connector.controlplane.policy.spi.PolicyDefinition;
+import org.eclipse.edc.policy.engine.spi.plan.PolicyEvaluationPlan;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import org.eclipse.edc.spi.query.QuerySpec;
-import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.jetbrains.annotations.NotNull;
 
@@ -80,6 +80,13 @@ public interface PolicyDefinitionService {
      * @param policy the policy
      * @return successful if valid, a failure otherwise
      */
-    Result<Void> validate(Policy policy);
-
+    ServiceResult<Void> validate(Policy policy);
+    
+    /**
+     * Validates a {@link Policy}
+     *
+     * @param policy the policy
+     * @return successful if valid, a failure otherwise
+     */
+    ServiceResult<PolicyEvaluationPlan> createEvaluationPlan(String scope, Policy policy);
 }


### PR DESCRIPTION
## What this PR changes/adds

introduces an alpha REST API for policy evaluation plan. 

## Why it does that

Improve policies management and debuggability

## Further notes

For example given this policy in MVD:

<details>
  <summary>policy example</summary>

 ```json
 {
        "@id": "require-membership",
        "@type": "PolicyDefinition",
        "createdAt": 1725466366896,
        "policy": {
            "@id": "51d3c610-b141-4269-a4c0-df2a77122cfe",
            "@type": "odrl:Set",
            "odrl:permission": {
                "odrl:action": {
                    "@id": "use"
                },
                "odrl:constraint": {
                    "odrl:leftOperand": {
                        "@id": "MembershipCredential"
                    },
                    "odrl:operator": {
                        "@id": "odrl:eq"
                    },
                    "odrl:rightOperand": "active"
                }
            },
            "odrl:prohibition": [],
            "odrl:obligation": []
        },
        "@context": {
            "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
            "edc": "https://w3id.org/edc/v0.0.1/ns/",
            "odrl": "http://www.w3.org/ns/odrl/2/"
        }
    },
```
</details>

An evaluation plan output within the `catalog` scope will look like this:

<details>
  <summary>evaluation plan  in catalog scope</summary>

```json
{
    "@type": "PolicyEvaluationPlan",
    "preValidators": [],
    "permissionSteps": {
        "@type": "PermissionStep",
        "isFiltered": false,
        "filteringReasons": [],
        "ruleFunctionSteps": "ExamplePermissionFunction",
        "constraintSteps": {
            "@type": "AtomicConstraintStep",
            "isFiltered": false,
            "filteringReasons": [],
            "functionName": "MembershipCredentialEvaluationFunction",
            "functionParams": [
                "'MembershipCredential'",
                "EQ",
                "'active'"
            ]
        },
        "dutySteps": []
    },
    "prohibitionSteps": [],
    "obligationSteps": [],
    "postValidators": [],
    "@context": {
        "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
        "edc": "https://w3id.org/edc/v0.0.1/ns/",
        "odrl": "http://www.w3.org/ns/odrl/2/"
    }
}
```
</details>

while in the `request.catalog` scope will look like this:

<details>
  <summary>evaluation plan  in catalog scope</summary>

```json
{
    "@type": "PolicyEvaluationPlan",
    "preValidators": "DcpScopeExtractorFunction",
    "permissionSteps": {
        "@type": "PermissionStep",
        "isFiltered": false,
        "filteringReasons": [],
        "ruleFunctionSteps": [],
        "constraintSteps": {
            "@type": "AtomicConstraintStep",
            "isFiltered": true,
            "filteringReasons": [
                "leftOperand 'MembershipCredential' is not bound to scope 'request.catalog'",
                "leftOperand 'MembershipCredential' is not bound to any function within scope 'request.catalog'"
            ],
            "functionParams": [
                "'MembershipCredential'",
                "EQ",
                "'active'"
            ]
        },
        "dutySteps": []
    },
    "prohibitionSteps": [],
    "obligationSteps": [],
    "postValidators": "DefaultScopeMappingFunction",
    "@context": {
        "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
        "edc": "https://w3id.org/edc/v0.0.1/ns/",
        "odrl": "http://www.w3.org/ns/odrl/2/"
    }
}
```
</details>

## Linked Issue(s)

Closes #4447 
