### PR TITLE
feat: enable defining supported VC types for trusted issuers

### DIFF
--- a/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/defaults/DefaultTrustedIssuerRegistry.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/defaults/DefaultTrustedIssuerRegistry.java
@@ -17,28 +17,26 @@ package org.eclipse.edc.iam.identitytrust.core.defaults;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.Issuer;
 import org.eclipse.edc.iam.verifiablecredentials.spi.validation.TrustedIssuerRegistry;
 
-import java.util.Collection;
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Simple, memory-based implementation of a {@link TrustedIssuerRegistry}
+ * Simple, memory-based implementation of a {@link TrustedIssuerRegistry}.
  */
 public class DefaultTrustedIssuerRegistry implements TrustedIssuerRegistry {
-    private final Map<String, Issuer> store = new HashMap<>();
+
+    private final Map<String, Set<String>> store = new ConcurrentHashMap<>();
 
     @Override
-    public void addIssuer(Issuer issuer) {
-        store.put(issuer.id(), issuer);
+    public void register(Issuer issuer, String credentialType) {
+        store.computeIfAbsent(issuer.id(), k -> new HashSet<>()).add(credentialType);
     }
 
     @Override
-    public Issuer getById(String id) {
-        return store.get(id);
+    public Set<String> getSupportedTypes(Issuer issuer) {
+        return store.getOrDefault(issuer.id(), Set.of());
     }
 
-    @Override
-    public Collection<Issuer> getTrustedIssuers() {
-        return store.values();
-    }
 }

--- a/extensions/common/iam/identity-trust/identity-trust-core/src/test/java/org/eclipse/edc/iam/identitytrust/core/defaults/DefaultTrustedIssuerRegistryTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/test/java/org/eclipse/edc/iam/identitytrust/core/defaults/DefaultTrustedIssuerRegistryTest.java
@@ -26,40 +26,20 @@ class DefaultTrustedIssuerRegistryTest {
     private final DefaultTrustedIssuerRegistry registry = new DefaultTrustedIssuerRegistry();
 
     @Test
-    void addIssuer() {
+    void trustedIssuer() {
         var issuer = new Issuer("test-id", Map.of());
-        registry.addIssuer(issuer);
-        assertThat(registry.getTrustedIssuers()).containsExactly(issuer);
+
+        registry.register(issuer, "test-type1");
+        registry.register(issuer, "test-type2");
+
+        assertThat(registry.getSupportedTypes(issuer)).containsExactly("test-type1", "test-type2");
     }
 
     @Test
-    void addIssuer_exists_shouldReplace() {
+    void invalidIssuer() {
         var issuer = new Issuer("test-id", Map.of());
-        var issuer2 = new Issuer("test-id", Map.of("new-key", "new-val"));
-        registry.addIssuer(issuer);
-        registry.addIssuer(issuer2);
-        assertThat(registry.getTrustedIssuers()).containsExactly(issuer2);
+
+        assertThat(registry.getSupportedTypes(issuer)).isEmpty();
     }
 
-    @Test
-    void getById() {
-        var issuer = new Issuer("test-id", Map.of());
-        registry.addIssuer(issuer);
-        assertThat(registry.getById("test-id")).isEqualTo(issuer);
-    }
-
-    @Test
-    void getById_notFound() {
-        assertThat(registry.getById("nonexistent-id")).isNull();
-    }
-
-    @Test
-    void getTrustedIssuers() {
-        var issuer = new Issuer("test-id", Map.of());
-        var issuer2 = new Issuer("test-id2", Map.of("new-key", "new-val"));
-        registry.addIssuer(issuer);
-        registry.addIssuer(issuer2);
-
-        assertThat(registry.getTrustedIssuers()).containsExactlyInAnyOrder(issuer2, issuer);
-    }
 }

--- a/extensions/common/iam/identity-trust/identity-trust-issuers-configuration/src/main/java/org/eclipse/edc/iam/identitytrust/issuer/configuration/TrustedIssuerConfigurationExtension.java
+++ b/extensions/common/iam/identity-trust/identity-trust-issuers-configuration/src/main/java/org/eclipse/edc/iam/identitytrust/issuer/configuration/TrustedIssuerConfigurationExtension.java
@@ -26,6 +26,7 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.configuration.Config;
 import org.eclipse.edc.spi.types.TypeManager;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.eclipse.edc.iam.identitytrust.issuer.configuration.TrustedIssuerConfigurationExtension.NAME;
@@ -39,10 +40,12 @@ public class TrustedIssuerConfigurationExtension implements ServiceExtension {
     public static final String CONFIG_PREFIX = "edc.iam.trusted-issuer";
     public static final String CONFIG_ALIAS = CONFIG_PREFIX + ".<issuerAlias>.";
 
-    @Setting(context = CONFIG_ALIAS, value = "Additional properties of the issuer.")
-    public static final String PROPERTIES_SUFFIX = "properties";
     @Setting(context = CONFIG_ALIAS, value = "ID of the issuer.", required = true)
     public static final String ID_SUFFIX = "id";
+    @Setting(context = CONFIG_ALIAS, value = "Additional properties of the issuer.")
+    public static final String PROPERTIES_SUFFIX = "properties";
+    @Setting(context = CONFIG_ALIAS, value = "List of supported credential types for this issuer.")
+    public static final String SUPPORTEDTYPES_SUFFIX = "supportedtypes";
 
     protected static final String NAME = "Trusted Issuers Configuration Extensions";
 
@@ -56,19 +59,23 @@ public class TrustedIssuerConfigurationExtension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
         var config = context.getConfig(CONFIG_PREFIX);
-        var issuers = config.partition().map(this::configureIssuer).toList();
-        if (issuers.isEmpty()) {
+        var configs = config.partition().toList();
+        if (configs.isEmpty()) {
             monitor.warning("The list of trusted issuers is empty");
         }
-        issuers.forEach(issuer -> trustedIssuerRegistry.addIssuer(issuer));
+
+        configs.forEach(this::addIssuer);
     }
 
-    private Issuer configureIssuer(Config config) {
-
+    private void addIssuer(Config config) {
         var id = config.getString(ID_SUFFIX);
+        var supportedTypesConfig = config.getString(SUPPORTEDTYPES_SUFFIX, "[\"%s\"]".formatted(TrustedIssuerRegistry.WILDCARD));
+        var supportedTypes = typeManager.readValue(supportedTypesConfig, new TypeReference<List<String>>() {
+        });
         var propertiesConfig = config.getString(PROPERTIES_SUFFIX, "{}");
         var properties = typeManager.readValue(propertiesConfig, new TypeReference<Map<String, Object>>() {
         });
-        return new Issuer(id, properties);
+
+        supportedTypes.forEach(type -> trustedIssuerRegistry.register(new Issuer(id, properties), type));
     }
 }

--- a/extensions/common/iam/verifiable-credentials/src/main/java/org/eclipse/edc/iam/verifiablecredentials/VerifiableCredentialValidationServiceImpl.java
+++ b/extensions/common/iam/verifiable-credentials/src/main/java/org/eclipse/edc/iam/verifiablecredentials/VerifiableCredentialValidationServiceImpl.java
@@ -19,7 +19,6 @@ import org.eclipse.edc.iam.verifiablecredentials.rules.HasValidSubjectIds;
 import org.eclipse.edc.iam.verifiablecredentials.rules.IsInValidityPeriod;
 import org.eclipse.edc.iam.verifiablecredentials.rules.IsNotRevoked;
 import org.eclipse.edc.iam.verifiablecredentials.spi.VerifiableCredentialValidationService;
-import org.eclipse.edc.iam.verifiablecredentials.spi.model.Issuer;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.RevocationServiceRegistry;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredential;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiablePresentationContainer;
@@ -68,7 +67,7 @@ public class VerifiableCredentialValidationServiceImpl implements VerifiableCred
                 new IsInValidityPeriod(clock),
                 new HasValidSubjectIds(presentationHolder),
                 new IsNotRevoked(revocationServiceRegistry),
-                new HasValidIssuer(getTrustedIssuerIds())));
+                new HasValidIssuer(trustedIssuerRegistry)));
 
         filters.addAll(additionalRules);
         var results = credentials
@@ -78,7 +77,4 @@ public class VerifiableCredentialValidationServiceImpl implements VerifiableCred
         return results.orElseGet(() -> failure("Could not determine the status of the VC validation"));
     }
 
-    private List<String> getTrustedIssuerIds() {
-        return trustedIssuerRegistry.getTrustedIssuers().stream().map(Issuer::id).toList();
-    }
 }

--- a/extensions/common/iam/verifiable-credentials/src/test/java/org/eclipse/edc/iam/verifiablecredentials/VerifiableCredentialValidationServiceImplTest.java
+++ b/extensions/common/iam/verifiable-credentials/src/test/java/org/eclipse/edc/iam/verifiablecredentials/VerifiableCredentialValidationServiceImplTest.java
@@ -53,6 +53,7 @@ class VerifiableCredentialValidationServiceImplTest {
 
     @BeforeEach
     void setUp() {
+        when(trustedIssuerRegistryMock.getSupportedTypes(TRUSTED_ISSUER)).thenReturn(Set.of(TrustedIssuerRegistry.WILDCARD));
         when(revocationServiceRegistry.checkValidity(any())).thenReturn(Result.success());
     }
 
@@ -103,7 +104,6 @@ class VerifiableCredentialValidationServiceImplTest {
 
     @Test
     void credentialHasInvalidIssuer_issuerIsUrl() {
-        var consumerDid = "did:web:test-consumer";
         var presentation = createPresentationBuilder()
                 .type("VerifiablePresentation")
                 .credentials(List.of(createCredentialBuilder()
@@ -116,7 +116,7 @@ class VerifiableCredentialValidationServiceImplTest {
         var result = service.validate(List.of(vpContainer));
         assertThat(result).isFailed().messages()
                 .hasSizeGreaterThanOrEqualTo(1)
-                .contains("Issuer 'invalid-issuer' is not in the list of trusted issuers");
+                .contains("Credential types '[test-type]' are not supported for issuer 'invalid-issuer'");
     }
 
     @Test
@@ -133,7 +133,6 @@ class VerifiableCredentialValidationServiceImplTest {
                 .build();
         var vpContainer = new VerifiablePresentationContainer("test-vp", CredentialFormat.JSON_LD, presentation);
         when(verifierMock.verifyPresentation(any())).thenReturn(success());
-        when(trustedIssuerRegistryMock.getTrustedIssuers()).thenReturn(Set.of(TRUSTED_ISSUER));
         var result = service.validate(List.of(vpContainer));
         assertThat(result).isSucceeded();
     }
@@ -158,7 +157,6 @@ class VerifiableCredentialValidationServiceImplTest {
                 .build();
         var vpContainer = new VerifiablePresentationContainer("test-vp", CredentialFormat.JSON_LD, presentation);
         when(verifierMock.verifyPresentation(any())).thenReturn(success());
-        when(trustedIssuerRegistryMock.getTrustedIssuers()).thenReturn(Set.of(TRUSTED_ISSUER));
         var result = service.validate(List.of(vpContainer));
         assertThat(result).isSucceeded();
     }
@@ -202,8 +200,6 @@ class VerifiableCredentialValidationServiceImplTest {
         var vpContainer2 = new VerifiablePresentationContainer("test-vp", CredentialFormat.JSON_LD, presentation2);
 
         when(verifierMock.verifyPresentation(any())).thenReturn(success());
-        when(trustedIssuerRegistryMock.getTrustedIssuers()).thenReturn(Set.of(TRUSTED_ISSUER));
-
 
         var result = service.validate(List.of(vpContainer1, vpContainer2));
         assertThat(result).isSucceeded();
@@ -224,7 +220,6 @@ class VerifiableCredentialValidationServiceImplTest {
                 .build();
         var vpContainer = new VerifiablePresentationContainer("test-vp", CredentialFormat.JSON_LD, presentation);
         when(verifierMock.verifyPresentation(any())).thenReturn(success());
-        when(trustedIssuerRegistryMock.getTrustedIssuers()).thenReturn(Set.of(TRUSTED_ISSUER));
         when(revocationServiceRegistry.checkValidity(any())).thenReturn(Result.failure("invalid"));
 
         var result = service.validate(List.of(vpContainer));

--- a/spi/common/verifiable-credentials-spi/src/main/java/org/eclipse/edc/iam/verifiablecredentials/spi/validation/TrustedIssuerRegistry.java
+++ b/spi/common/verifiable-credentials-spi/src/main/java/org/eclipse/edc/iam/verifiablecredentials/spi/validation/TrustedIssuerRegistry.java
@@ -16,17 +16,30 @@ package org.eclipse.edc.iam.verifiablecredentials.spi.validation;
 
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.Issuer;
 
-import java.util.Collection;
+import java.util.Set;
 
 /**
- * A list of trusted VC issuers
+ * Trusted issuer registry.
  */
 public interface TrustedIssuerRegistry {
 
-    void addIssuer(Issuer issuer);
+    String WILDCARD = "*";
 
-    Issuer getById(String id);
+    /**
+     * Register a supported type for a trusted issuer.
+     *
+     * @param issuer         the issuer
+     * @param credentialType supported credential type for this issuer
+     */
+    void register(Issuer issuer, String credentialType);
 
-    Collection<Issuer> getTrustedIssuers();
+    /**
+     * Get the supported types for a given issuer.
+     *
+     * @param issuer the issuer
+     * @return set of supported credential types for this issuer.
+     */
+    Set<String> getSupportedTypes(Issuer issuer);
+
 }
 


### PR DESCRIPTION
## What this PR changes/adds

As of today the TrustedIssuerRegistry defines the list of trusted issuers ids. When validating the counter-party VCs, it is just checked that the issuer of each of these VC is contained in that list, which is quite limiting.

A typical use-case is that we want to be able to define the types of VCs that are supported for each trusted issuer.

## Why it does that

VC validation module.

## Linked Issue(s)

Closes #4453 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
