### PR TITLE
fix: catch exceptions in the StatusResultRetryProcess

### DIFF
--- a/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/StatusResultRetryProcess.java
+++ b/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/StatusResultRetryProcess.java
@@ -24,6 +24,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 import static java.lang.String.format;
+import static org.eclipse.edc.spi.response.ResponseStatus.FATAL_ERROR;
 
 /**
  * Provides retry capabilities to a synchronous process that returns a {@link StatusResult} object
@@ -45,7 +46,13 @@ public class StatusResultRetryProcess<E extends StatefulEntity<E>, C> extends Re
     @Override
     boolean process(E entity, String description) {
         monitor.debug(format("%s: ID %s. %s", entity.getClass().getSimpleName(), entity.getId(), description));
-        var result = process.get();
+
+        StatusResult<C> result;
+        try {
+            result = process.get();
+        } catch (Exception e) {
+            result = StatusResult.failure(FATAL_ERROR, "Unexpected exception thrown %s: %s".formatted(e, e.getMessage()));
+        }
 
         handleResult(entity, description, result);
 


### PR DESCRIPTION
## What this PR changes/adds

Make `StatusResultRetryProcess` to catch eventual exceptions and consider it as a failure instead of having the caller to do so.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #4457 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
