### PR TITLE
Extract PolicyValidator to PolicyPreValidator and PolicyPostValidator.

### DIFF
--- a/core/common/lib/policy-engine-lib/src/main/java/org/eclipse/edc/policy/engine/validation/PolicyChainValidator.java
+++ b/core/common/lib/policy-engine-lib/src/main/java/org/eclipse/edc/policy/engine/validation/PolicyChainValidator.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.policy.engine.validation;
+
+import org.eclipse.edc.policy.engine.spi.PolicyContext;
+import org.eclipse.edc.policy.engine.spi.plan.step.ValidatorStep;
+import org.eclipse.edc.policy.evaluator.PolicyEvaluationResult;
+import org.eclipse.edc.policy.model.Policy;
+
+import java.util.function.BiFunction;
+
+/**
+ * Policy Validator for Pre and Post {@link PolicyEvaluationResult}
+ */
+public interface PolicyChainValidator extends BiFunction<Policy, PolicyContext, Boolean> {
+
+    /**
+     * Return the Validator
+     *
+     * @return Validator {@link ValidatorStep}
+     */
+    ValidatorStep getValidator();
+}

--- a/core/common/lib/policy-engine-lib/src/main/java/org/eclipse/edc/policy/engine/validation/PolicyPostValidator.java
+++ b/core/common/lib/policy-engine-lib/src/main/java/org/eclipse/edc/policy/engine/validation/PolicyPostValidator.java
@@ -1,0 +1,23 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.policy.engine.validation;
+
+import org.eclipse.edc.policy.evaluator.PolicyEvaluationResult;
+
+/**
+ * Policy Validator for Post {@link PolicyEvaluationResult}
+ */
+public interface PolicyPostValidator extends PolicyChainValidator {
+}

--- a/core/common/lib/policy-engine-lib/src/main/java/org/eclipse/edc/policy/engine/validation/PolicyPostValidatorImpl.java
+++ b/core/common/lib/policy-engine-lib/src/main/java/org/eclipse/edc/policy/engine/validation/PolicyPostValidatorImpl.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.policy.engine.validation;
+
+import org.eclipse.edc.policy.engine.spi.PolicyContext;
+import org.eclipse.edc.policy.engine.spi.plan.step.ValidatorStep;
+import org.eclipse.edc.policy.model.Policy;
+
+import java.util.function.BiFunction;
+
+public class PolicyPostValidatorImpl implements PolicyPostValidator {
+
+    private final ValidatorStep validator;
+
+    public PolicyPostValidatorImpl(BiFunction<Policy, PolicyContext, Boolean> validator) {
+        this.validator = new ValidatorStep(validator);
+    }
+
+    @Override
+    public Boolean apply(Policy policy, PolicyContext context) {
+        return this.validator.validator().apply(policy, context);
+    }
+
+    @Override
+    public ValidatorStep getValidator() {
+        return this.validator;
+    }
+}

--- a/core/common/lib/policy-engine-lib/src/main/java/org/eclipse/edc/policy/engine/validation/PolicyPreValidator.java
+++ b/core/common/lib/policy-engine-lib/src/main/java/org/eclipse/edc/policy/engine/validation/PolicyPreValidator.java
@@ -1,0 +1,23 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.policy.engine.validation;
+
+import org.eclipse.edc.policy.evaluator.PolicyEvaluationResult;
+
+/**
+ * Policy Validator for Pre {@link PolicyEvaluationResult}
+ */
+public interface PolicyPreValidator extends PolicyChainValidator {
+}

--- a/core/common/lib/policy-engine-lib/src/main/java/org/eclipse/edc/policy/engine/validation/PolicyPreValidatorImpl.java
+++ b/core/common/lib/policy-engine-lib/src/main/java/org/eclipse/edc/policy/engine/validation/PolicyPreValidatorImpl.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.policy.engine.validation;
+
+import org.eclipse.edc.policy.engine.spi.PolicyContext;
+import org.eclipse.edc.policy.engine.spi.plan.step.ValidatorStep;
+import org.eclipse.edc.policy.model.Policy;
+
+import java.util.function.BiFunction;
+
+public class PolicyPreValidatorImpl implements PolicyPreValidator {
+
+    private final ValidatorStep validator;
+
+    public PolicyPreValidatorImpl(BiFunction<Policy, PolicyContext, Boolean> validator) {
+        this.validator = new ValidatorStep(validator);
+    }
+
+    @Override
+    public Boolean apply(Policy policy, PolicyContext context) {
+        return this.validator.validator().apply(policy, context);
+    }
+
+    public ValidatorStep getValidator() {
+        return validator;
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

Extract PolicyValidator to PolicyPreValidator and PolicyPostValidator to own interfaces using a Chain one as parent (to standardize usage)

## Why it does that

To ease readability

## Further notes

PolicyChainValidator was added to ease usage (avoids repeated code) and keep failValidator() with generic validator.

## Linked Issue(s)

Closes https://github.com/eclipse-edc/Connector/issues/4446
