### PR TITLE
fix: catch exceptions in CompletableFutureRetryProcess

### DIFF
--- a/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/CompletableFutureRetryProcess.java
+++ b/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/CompletableFutureRetryProcess.java
@@ -47,7 +47,8 @@ public class CompletableFutureRetryProcess<E extends StatefulEntity<E>, C, SELF 
     @Override
     boolean process(E entity, String description) {
         monitor.debug(format("%s: ID %s. %s", entity.getClass().getSimpleName(), entity.getId(), description));
-        process.get()
+
+        runProcess()
                 .whenComplete((result, throwable) -> {
                     var reloadedEntity = Optional.ofNullable(entityRetrieve)
                             .map(it -> it.apply(entity.getId()))
@@ -81,6 +82,14 @@ public class CompletableFutureRetryProcess<E extends StatefulEntity<E>, C, SELF 
                 });
 
         return true;
+    }
+
+    private CompletableFuture<C> runProcess() {
+        try {
+            return process.get();
+        } catch (Throwable e) {
+            return CompletableFuture.failedFuture(e);
+        }
     }
 
     public SELF onSuccess(BiConsumer<E, C> onSuccessHandler) {

--- a/core/common/lib/state-machine-lib/src/test/java/org/eclipse/edc/statemachine/retry/CompletableFutureRetryProcessTest.java
+++ b/core/common/lib/state-machine-lib/src/test/java/org/eclipse/edc/statemachine/retry/CompletableFutureRetryProcessTest.java
@@ -107,4 +107,17 @@ class CompletableFutureRetryProcessTest {
 
         verify(onFailure).accept(eq(entity), isA(EdcException.class));
     }
+
+    @Test
+    void shouldFail_whenExceptionIsThrown() {
+        when(process.get()).thenThrow(new EdcException("generic error"));
+        var entity = TestEntity.Builder.newInstance().id(UUID.randomUUID().toString()).clock(clock).build();
+        var retryProcess = new CompletableFutureRetryProcess<>(entity, process, mock(Monitor.class), clock, configuration);
+
+        var result = retryProcess.onSuccess(onSuccess).onFailure(onFailure).execute("any");
+
+        assertThat(result).isTrue();
+        verify(process).get();
+        verify(onFailure).accept(eq(entity), isA(EdcException.class));
+    }
 }

--- a/core/common/lib/state-machine-lib/src/test/java/org/eclipse/edc/statemachine/retry/StatusResultRetryProcessTest.java
+++ b/core/common/lib/state-machine-lib/src/test/java/org/eclipse/edc/statemachine/retry/StatusResultRetryProcessTest.java
@@ -98,18 +98,17 @@ class StatusResultRetryProcessTest {
         verify(onFailure).accept(entity, statusResult.getFailure());
     }
 
-
     @Test
     void shouldCallFatalError_whenExceptionIsThrown() {
         when(process.get()).thenThrow(new EdcException("code throws an exception"));
         var entity = TestEntity.Builder.newInstance().id(UUID.randomUUID().toString()).clock(clock).build();
         var retryProcess = new StatusResultRetryProcess<>(entity, process, mock(Monitor.class), clock, configuration);
 
-        var result = retryProcess.onSuccess(onSuccess).onFatalError(onFatalError).execute("any");
+        var result = retryProcess.onSuccess(onSuccess).onFailure(onFailure).execute("any");
 
         assertThat(result).isTrue();
         verify(process).get();
-        verify(onFatalError).accept(same(entity), any());
+        verify(onFailure).accept(same(entity), any());
         verifyNoInteractions(onSuccess);
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Catches exceptions that could happen in the `CompletableFutureRetryProcess`

## Why it does that

avoid state machine entry to stale

## Further notes

- I'm not considering this PR a bugfix because the bug-ish behavior is in the component that throws an unexpected exception (according to the issue it would be `AzureStorageDataSinkFactory`). having the overarching component to handle it safely it is a new feature to the state machine retry process component that will prevent such potential bugs downstream.
- improved behavior on `StatusResultRetryProcess`, that was treating the throwable as a "fatal error", but in fact it is better to consider it a generic failure because the exception could be temporary

## Linked Issue(s)

Closes #4464 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
