### PR TITLE
fix: return StsClient from create()

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -195,7 +195,7 @@ maven/mavencentral/net.javacrumbs.json-unit/json-unit-core/2.36.0, Apache-2.0, a
 maven/mavencentral/net.minidev/accessors-smart/2.4.7, Apache-2.0, approved, #7515
 maven/mavencentral/net.minidev/json-smart/2.4.7, Apache-2.0, approved, #3288
 maven/mavencentral/net.sf.jopt-simple/jopt-simple/5.0.4, MIT, approved, CQ13174
-maven/mavencentral/net.sf.saxon/Saxon-HE/12.5, MPL-2.0-no-copyleft-exception AND (LicenseRef-scancode-proprietary-license AND MPL-2.0-no-copyleft-exception) AND (MPL-2.0-no-copyleft-exception AND X11) AND (MIT AND MPL-2.0-no-copyleft-exception) AND (MPL-1.0 AND MPL-2.0-no-copyleft-exception) AND (Apache-2.0 AND MPL-2.0-no-copyleft-exception) AND MPL-1.0, restricted, #16061
+maven/mavencentral/net.sf.saxon/Saxon-HE/12.5, W3C-19980720 AND MPL-2.0 AND MPL-1.0, approved, #16061
 maven/mavencentral/org.antlr/antlr4-runtime/4.13.2, BSD-3-Clause, approved, #10767
 maven/mavencentral/org.apache.commons/commons-compress/1.24.0, Apache-2.0 AND BSD-3-Clause AND bzip2-1.0.6 AND LicenseRef-Public-Domain, approved, #10368
 maven/mavencentral/org.apache.commons/commons-digester3/3.2, Apache-2.0, approved, clearlydefined

--- a/extensions/common/store/sql/sts-client-store-sql/src/main/java/org/eclipse/edc/iam/identitytrust/sts/store/SqlStsClientStore.java
+++ b/extensions/common/store/sql/sts-client-store-sql/src/main/java/org/eclipse/edc/iam/identitytrust/sts/store/SqlStsClientStore.java
@@ -65,7 +65,7 @@ public class SqlStsClientStore extends AbstractSqlStore implements StsClientStor
                         client.getCreatedAt()
                 );
 
-                return StoreResult.success();
+                return StoreResult.success(client);
             } catch (Exception e) {
                 throw new EdcPersistenceException(e);
             }

--- a/spi/common/identity-trust-sts-spi/src/testFixtures/java/org/eclipse/edc/iam/identitytrust/sts/spi/store/fixtures/StsClientStoreTestBase.java
+++ b/spi/common/identity-trust-sts-spi/src/testFixtures/java/org/eclipse/edc/iam/identitytrust/sts/spi/store/fixtures/StsClientStoreTestBase.java
@@ -82,7 +82,7 @@ public abstract class StsClientStoreTestBase {
         @DisplayName("Save a single client that not exists")
         void create() {
             var client = createClient(getRandomId());
-            assertThat(getStsClientStore().create(client)).isSucceeded();
+            assertThat(getStsClientStore().create(client)).isSucceeded().usingRecursiveComparison().isEqualTo(client);
 
             var clientFromDb = getStsClientStore().findByClientId(client.getId()).getContent();
             assertThat(client).usingRecursiveComparison().isEqualTo(clientFromDb);


### PR DESCRIPTION
## What this PR changes/adds

returns the `StsClient` from `StsClientStore#create()`

## Why it does that

it was null before, allow for fluent statements

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
