### PR TITLE
chore: management API JSON-LD context improvements

### DIFF
--- a/extensions/common/json-ld/src/main/resources/document/management-context-v1.jsonld
+++ b/extensions/common/json-ld/src/main/resources/document/management-context-v1.jsonld
@@ -3,7 +3,15 @@
     "@version": 1.1,
     "edc": "https://w3id.org/edc/v0.0.1/ns/",
     "Asset": "edc:Asset",
-    "PolicyDefinition": "edc:PolicyDefinition",
+    "PolicyDefinition": {
+      "@id": "edc:PolicyDefinition",
+      "@context": {
+        "@import": "http://www.w3.org/ns/odrl.jsonld",
+        "@propagate": true,
+        "uid": null,
+        "type": null
+      }
+    },
     "DataAddress": {
       "@id": "edc:DataAddress",
       "@context": {
@@ -13,7 +21,15 @@
     },
     "ContractDefinition": "edc:ContractDefinition",
     "Criterion": "edc:Criterion",
-    "ContractRequest": "edc:ContractRequest",
+    "ContractRequest": {
+      "@id": "edc:ContractRequest",
+      "@context": {
+        "@import": "http://www.w3.org/ns/odrl.jsonld",
+        "@propagate": true,
+        "uid": null,
+        "type": null
+      }
+    },
     "QuerySpec": "edc:QuerySpec",
     "ContractNegotiation": {
       "@id": "edc:ContractNegotiation",
@@ -91,14 +107,7 @@
     },
     "providerId": "edc:providerId",
     "policy": {
-      "@id": "edc:policy",
-      "@context": [
-        "http://www.w3.org/ns/odrl.jsonld",
-        {
-          "uid": null,
-          "type": null
-        }
-      ]
+      "@id": "edc:policy"
     },
     "counterPartyId": "edc:counterPartyId",
     "state": "edc:state",

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TestFunctions.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TestFunctions.java
@@ -319,7 +319,7 @@ public class TestFunctions {
 
     public static JsonObjectBuilder policy(JsonObject permission) {
         return createObjectBuilder()
-                .add(TYPE, "http://www.w3.org/ns/odrl/2/Set")
+                .add(TYPE, "Set")
                 .add("obligation", createArrayBuilder().build())
                 .add("permission", permission)
                 .add("target", "assetId")


### PR DESCRIPTION
## What this PR changes/adds

Applies a [type-scoped-context](https://www.w3.org/TR/json-ld11/#dfn-type-scoped-context) for importing with `@import`
the ODRL context when needed. 

## Why it does that

Fixes the `@type` of Policy which wasn't compacted correctly when scoping the context in the `property`

etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
