### PR TITLE
fix: only return dataset with valid offers

### DIFF
--- a/core/control-plane/control-plane-catalog/src/main/java/org/eclipse/edc/connector/controlplane/catalog/DatasetResolverImpl.java
+++ b/core/control-plane/control-plane-catalog/src/main/java/org/eclipse/edc/connector/controlplane/catalog/DatasetResolverImpl.java
@@ -62,6 +62,10 @@ public class DatasetResolverImpl implements DatasetResolver {
     @NotNull
     public Stream<Dataset> query(ParticipantAgent agent, QuerySpec querySpec) {
         var contractDefinitions = contractDefinitionResolver.definitionsFor(agent).toList();
+        if (contractDefinitions.isEmpty()) {
+            return Stream.empty();
+        }
+        
         var assetsQuery = QuerySpec.Builder.newInstance().offset(0).limit(MAX_VALUE).filter(querySpec.getFilterExpression()).build();
         return assetIndex.queryAssets(assetsQuery)
                 .map(asset -> toDataset(contractDefinitions, asset))
@@ -73,9 +77,14 @@ public class DatasetResolverImpl implements DatasetResolver {
     @Override
     public Dataset getById(ParticipantAgent agent, String id) {
         var contractDefinitions = contractDefinitionResolver.definitionsFor(agent).toList();
+        if (contractDefinitions.isEmpty()) {
+            return null;
+        }
+        
         return Optional.of(id)
                 .map(assetIndex::findById)
                 .map(asset -> toDataset(contractDefinitions, asset))
+                .filter(Dataset::hasOffers)
                 .orElse(null);
     }
 

--- a/core/control-plane/control-plane-catalog/src/test/java/org/eclipse/edc/connector/controlplane/catalog/DatasetResolverImplTest.java
+++ b/core/control-plane/control-plane-catalog/src/test/java/org/eclipse/edc/connector/controlplane/catalog/DatasetResolverImplTest.java
@@ -56,6 +56,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -97,6 +98,16 @@ class DatasetResolverImplTest {
             });
             assertThat(dataset.getProperties()).contains(entry("key", "value"));
         });
+    }
+    
+    @Test
+    void query_shouldNotQueryAssets_whenNoValidContractDefinition() {
+        when(contractDefinitionResolver.definitionsFor(any())).thenReturn(Stream.empty());
+        
+        var datasets = datasetResolver.query(createParticipantAgent(), QuerySpec.none());
+        
+        assertThat(datasets).isNotNull().isEmpty();
+        verify(assetIndex, never()).queryAssets(any());
     }
 
     @Test
@@ -301,11 +312,11 @@ class DatasetResolverImplTest {
         var participantAgent = createParticipantAgent();
         
         when(contractDefinitionResolver.definitionsFor(any())).thenReturn(Stream.empty());
-        when(assetIndex.findById(any())).thenReturn(createAsset("datasetId").build());
         
         var dataset = datasetResolver.getById(participantAgent, "datasetId");
         
         assertThat(dataset).isNull();
+        verify(assetIndex, never()).findById(any());
     }
     
     @Test

--- a/core/control-plane/control-plane-catalog/src/test/java/org/eclipse/edc/connector/controlplane/catalog/DatasetResolverImplTest.java
+++ b/core/control-plane/control-plane-catalog/src/test/java/org/eclipse/edc/connector/controlplane/catalog/DatasetResolverImplTest.java
@@ -295,6 +295,39 @@ class DatasetResolverImplTest {
 
         assertThat(dataset).isNull();
     }
+    
+    @Test
+    void getById_shouldReturnNull_whenNoValidContractDefinition() {
+        var participantAgent = createParticipantAgent();
+        
+        when(contractDefinitionResolver.definitionsFor(any())).thenReturn(Stream.empty());
+        when(assetIndex.findById(any())).thenReturn(createAsset("datasetId").build());
+        
+        var dataset = datasetResolver.getById(participantAgent, "datasetId");
+        
+        assertThat(dataset).isNull();
+    }
+    
+    @Test
+    void getById_shouldReturnNull_whenNoValidContractDefinitionForAsset() {
+        var assetId = "assetId";
+        var participantAgent = createParticipantAgent();
+        
+        when(contractDefinitionResolver.definitionsFor(any())).thenReturn(Stream.of(
+                contractDefinitionBuilder("definition")
+                        .assetsSelectorCriterion(Criterion.Builder.newInstance()
+                                .operandRight(EDC_NAMESPACE + "id")
+                                .operator("=")
+                                .operandLeft("a-different-asset")
+                                .build())
+                        .build()
+        ));
+        when(assetIndex.findById(any())).thenReturn(createAsset(assetId).build());
+        
+        var dataset = datasetResolver.getById(participantAgent, assetId);
+        
+        assertThat(dataset).isNull();
+    }
 
     private ContractDefinition.Builder contractDefinitionBuilder(String id) {
         return ContractDefinition.Builder.newInstance()


### PR DESCRIPTION
## What this PR changes/adds

Adds a check to the `DatasetResolverImpl` to only return a dataset if it has an offer attached.

## Why it does that

To avoid exposing sensitive information (asset metadata) if the requesting participant is not authorized to see it.

## Further notes

Also adds a check for `query` and `getById` to immediately return if no valid contract definitions exist for the requesting participant, as then no offers would be returned anyway, so it doesn't make sense to query and evaluate the assets in that case.
