### PR TITLE
fix: only return dataset with valid offers (#4490)

### DIFF
--- a/core/control-plane/control-plane-catalog/src/main/java/org/eclipse/edc/connector/controlplane/catalog/DatasetResolverImpl.java
+++ b/core/control-plane/control-plane-catalog/src/main/java/org/eclipse/edc/connector/controlplane/catalog/DatasetResolverImpl.java
@@ -62,6 +62,10 @@ public class DatasetResolverImpl implements DatasetResolver {
     @NotNull
     public Stream<Dataset> query(ParticipantAgent agent, QuerySpec querySpec) {
         var contractDefinitions = contractDefinitionResolver.definitionsFor(agent).toList();
+        if (contractDefinitions.isEmpty()) {
+            return Stream.empty();
+        }
+        
         var assetsQuery = QuerySpec.Builder.newInstance().offset(0).limit(MAX_VALUE).filter(querySpec.getFilterExpression()).build();
         return assetIndex.queryAssets(assetsQuery)
                 .map(asset -> toDataset(contractDefinitions, asset))
@@ -73,9 +77,14 @@ public class DatasetResolverImpl implements DatasetResolver {
     @Override
     public Dataset getById(ParticipantAgent agent, String id) {
         var contractDefinitions = contractDefinitionResolver.definitionsFor(agent).toList();
+        if (contractDefinitions.isEmpty()) {
+            return null;
+        }
+        
         return Optional.of(id)
                 .map(assetIndex::findById)
                 .map(asset -> toDataset(contractDefinitions, asset))
+                .filter(Dataset::hasOffers)
                 .orElse(null);
     }
 


### PR DESCRIPTION
## What this PR changes/adds

Backports https://github.com/eclipse-edc/Connector/pull/4490 for 0.9.1

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
