### PR TITLE
fix: build failing on Windows (#4484)

### DIFF
--- a/core/common/connector-core/src/test/java/org/eclipse/edc/connector/core/LocalPublicKeyDefaultExtensionTest.java
+++ b/core/common/connector-core/src/test/java/org/eclipse/edc/connector/core/LocalPublicKeyDefaultExtensionTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.nio.file.Paths;
 import java.security.PublicKey;
 import java.util.Map;
 
@@ -73,7 +74,7 @@ class LocalPublicKeyDefaultExtensionTest {
         var value = TestUtils.getResourceFileContentAsString("rsa_2048.pem");
         var keys = Map.of(
                 "key1.id", "key1",
-                "key1.path", path.getPath());
+                "key1.path", Paths.get(path).toString());
 
         when(keyParserRegistry.parsePublic(value)).thenReturn(Result.success(mock(PublicKey.class)));
         when(context.getConfig(EDC_PUBLIC_KEYS_PREFIX)).thenReturn(ConfigFactory.fromMap(keys));

--- a/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/ClasspathReader.java
+++ b/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/ClasspathReader.java
@@ -40,6 +40,9 @@ public class ClasspathReader {
      */
     public static URL[] classpathFor(String... modules) {
         try {
+            if (modules.length == 0) {
+                return new URL[0];
+            }
             // Run a Gradle custom task to determine the runtime classpath of the module to run
             var printClasspath = Arrays.stream(modules).map(it -> it + ":printClasspath");
             var commandStream = Stream.of(GRADLE_WRAPPER.getCanonicalPath(), "-q");

--- a/core/common/lib/keys-lib/src/main/java/org/eclipse/edc/keys/VaultCertificateResolver.java
+++ b/core/common/lib/keys-lib/src/main/java/org/eclipse/edc/keys/VaultCertificateResolver.java
@@ -47,7 +47,7 @@ public class VaultCertificateResolver implements CertificateResolver {
         }
 
         try {
-            var encoded = certificateRepresentation.replace(HEADER, "").replaceAll(System.lineSeparator(), "").replace(FOOTER, "");
+            var encoded = certificateRepresentation.replace(HEADER, "").replaceAll("\\R", "").replace(FOOTER, "");
             CertificateFactory fact = CertificateFactory.getInstance("X.509");
             return (X509Certificate) fact.generateCertificate(new ByteArrayInputStream(Base64.getDecoder().decode(encoded.getBytes())));
         } catch (GeneralSecurityException | IllegalArgumentException e) {

--- a/core/common/lib/keys-lib/src/test/java/org/eclipse/edc/keys/VaultCertificateResolverTest.java
+++ b/core/common/lib/keys-lib/src/test/java/org/eclipse/edc/keys/VaultCertificateResolverTest.java
@@ -58,7 +58,7 @@ class VaultCertificateResolverTest {
         var pemReceived = convertCertificateToPem(certificate);
 
         verify(vault, times(1)).resolveSecret(KEY);
-        assertThat(pemReceived).isEqualTo(pemExpected);
+        assertThat(pemReceived.split("\\R")).isEqualTo(pemExpected.split("\\R"));
     }
 
     @Test

--- a/extensions/common/iam/oauth2/oauth2-core/src/test/java/org/eclipse/edc/iam/oauth2/jwt/X509CertificateDecoratorTest.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/test/java/org/eclipse/edc/iam/oauth2/jwt/X509CertificateDecoratorTest.java
@@ -36,7 +36,7 @@ class X509CertificateDecoratorTest {
     private static X509Certificate createCertificate() throws CertificateException, IOException {
         var classloader = Thread.currentThread().getContextClassLoader();
         var pem = new String(Objects.requireNonNull(classloader.getResourceAsStream(TEST_CERT_FILE)).readAllBytes());
-        var encoded = pem.replace(HEADER, "").replaceAll(System.lineSeparator(), "").replace(FOOTER, "");
+        var encoded = pem.replace(HEADER, "").replaceAll("\\R", "").replace(FOOTER, "");
         CertificateFactory fact = CertificateFactory.getInstance("X.509");
         return (X509Certificate) fact.generateCertificate(new ByteArrayInputStream(Base64.getDecoder().decode(encoded.getBytes())));
     }


### PR DESCRIPTION
## What this PR changes/adds

Change path handling to correctly handle Windows path names.

Change line ending handling from using `System.lineSeparator` to using the regex \R to treat all unicode line ending character sequences as the line endings.

Change unit tests that compared certificates read from file, to ignore the line ending characters, so differences in line ending did not break the test.

## Why it does that

The code failed during the unit tests when build on Windows, this change corrects the issues and enables the code to build. Generally checking for specific line endings (ie. `System.lineSeperator`) could be avoided and instead using the `\R` to match all unicode line endings will make the code more robust towards being built on different systems.

## Linked Issue(s)

Closes #4484 
