### PR TITLE
refactor: supports multi protocols dsp-http

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -30,7 +30,7 @@ maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.18.0, Apache-2.
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.14.0, Apache-2.0, approved, #5933
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.16.2, Apache-2.0, approved, #11855
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.18.0, Apache-2.0, approved, #16370
-maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jakarta-jsonp/2.18.0, , restricted, clearlydefined
+maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jakarta-jsonp/2.18.0, Apache-2.0, restricted, clearlydefined
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.14.0, Apache-2.0, approved, #4699
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.16.2, Apache-2.0, approved, #11853
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.18.0, , restricted, clearlydefined

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiController.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiController.java
@@ -41,6 +41,7 @@ import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.eclipse.edc.protocol.dsp.catalog.http.api.CatalogApiPaths.BASE_PATH;
 import static org.eclipse.edc.protocol.dsp.catalog.http.api.CatalogApiPaths.CATALOG_REQUEST;
 import static org.eclipse.edc.protocol.dsp.catalog.http.api.CatalogApiPaths.DATASET_REQUEST;
+import static org.eclipse.edc.protocol.dsp.http.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspCatalogPropertyAndTypeNames.DSPACE_TYPE_CATALOG_ERROR;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspCatalogPropertyAndTypeNames.DSPACE_TYPE_CATALOG_REQUEST_MESSAGE;
 
@@ -55,11 +56,17 @@ public class DspCatalogApiController {
     private final CatalogProtocolService service;
     private final DspRequestHandler dspRequestHandler;
     private final ContinuationTokenManager continuationTokenManager;
+    private final String protocol;
 
     public DspCatalogApiController(CatalogProtocolService service, DspRequestHandler dspRequestHandler, ContinuationTokenManager continuationTokenManager) {
+        this(service, dspRequestHandler, continuationTokenManager, DATASPACE_PROTOCOL_HTTP);
+    }
+
+    public DspCatalogApiController(CatalogProtocolService service, DspRequestHandler dspRequestHandler, ContinuationTokenManager continuationTokenManager, String protocol) {
         this.service = service;
         this.dspRequestHandler = dspRequestHandler;
         this.continuationTokenManager = continuationTokenManager;
+        this.protocol = protocol;
     }
 
     @POST
@@ -80,6 +87,7 @@ public class DspCatalogApiController {
                 .message(messageJson)
                 .serviceCall(service::getCatalog)
                 .errorType(DSPACE_TYPE_CATALOG_ERROR)
+                .protocol(protocol)
                 .build();
 
         var responseDecorator = continuationTokenManager.createResponseDecorator(uriInfo.getAbsolutePath().toString());
@@ -94,6 +102,7 @@ public class DspCatalogApiController {
                 .id(id)
                 .serviceCall(service::getDataset)
                 .errorType(DSPACE_TYPE_CATALOG_ERROR)
+                .protocol(protocol)
                 .build();
 
         return dspRequestHandler.getResource(request);

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiController20241.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiController20241.java
@@ -20,21 +20,22 @@ import jakarta.ws.rs.Produces;
 import org.eclipse.edc.connector.controlplane.services.spi.catalog.CatalogProtocolService;
 import org.eclipse.edc.protocol.dsp.http.spi.message.ContinuationTokenManager;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
-import org.eclipse.edc.protocol.dsp.spi.version.DspVersions;
 
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.eclipse.edc.protocol.dsp.catalog.http.api.CatalogApiPaths.BASE_PATH;
+import static org.eclipse.edc.protocol.dsp.http.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP_V_2024_1;
+import static org.eclipse.edc.protocol.dsp.spi.version.DspVersions.V_2024_1_PATH;
 
 /**
  * Versioned Catalog endpoint, same as {@link DspCatalogApiController} but exposed on the /2024/1 path
  */
 @Consumes({ APPLICATION_JSON })
 @Produces({ APPLICATION_JSON })
-@Path(DspVersions.V_2024_1_PATH + BASE_PATH)
+@Path(V_2024_1_PATH + BASE_PATH)
 public class DspCatalogApiController20241 extends DspCatalogApiController {
 
     public DspCatalogApiController20241(CatalogProtocolService service, DspRequestHandler dspRequestHandler,
                                         ContinuationTokenManager responseDecorator) {
-        super(service, dspRequestHandler, responseDecorator);
+        super(service, dspRequestHandler, responseDecorator, DATASPACE_PROTOCOL_HTTP_V_2024_1);
     }
 }

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/test/java/org/eclipse/edc/protocol/dsp/catalog/http/api/DspCatalogApiExtensionTest.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/test/java/org/eclipse/edc/protocol/dsp/catalog/http/api/DspCatalogApiExtensionTest.java
@@ -14,9 +14,10 @@
 
 package org.eclipse.edc.protocol.dsp.catalog.http.api;
 
-import org.eclipse.edc.connector.controlplane.services.spi.protocol.ProtocolVersion;
 import org.eclipse.edc.connector.controlplane.services.spi.protocol.ProtocolVersionRegistry;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.protocol.dsp.spi.transform.DspProtocolTypeTransformerRegistry;
+import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,22 +25,28 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.eclipse.edc.protocol.dsp.spi.type.DspCatalogPropertyAndTypeNames.DSPACE_TYPE_CATALOG_REQUEST_MESSAGE;
+import static org.eclipse.edc.protocol.dsp.spi.version.DspVersions.V_08;
+import static org.eclipse.edc.protocol.dsp.spi.version.DspVersions.V_2024_1;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(DependencyInjectionExtension.class)
 class DspCatalogApiExtensionTest {
 
     private final JsonObjectValidatorRegistry validatorRegistry = mock();
     private final ProtocolVersionRegistry versionRegistry = mock();
+    private final DspProtocolTypeTransformerRegistry dspTransformerRegistry = mock();
 
     @BeforeEach
     void setUp(ServiceExtensionContext context) {
         context.registerService(JsonObjectValidatorRegistry.class, validatorRegistry);
         context.registerService(ProtocolVersionRegistry.class, versionRegistry);
+        context.registerService(DspProtocolTypeTransformerRegistry.class, dspTransformerRegistry);
+
+        when(dspTransformerRegistry.forProtocol(any())).thenReturn(Result.success(mock()));
     }
 
     @Test
@@ -53,6 +60,7 @@ class DspCatalogApiExtensionTest {
     void shouldRegisterDspVersion(DspCatalogApiExtension extension, ServiceExtensionContext context) {
         extension.initialize(context);
 
-        verify(versionRegistry).register(isA(ProtocolVersion.class));
+        verify(versionRegistry).register(V_08);
+        verify(versionRegistry).register(V_2024_1);
     }
 }

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/dispatcher/DspCatalogHttpDispatcherExtension.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/dispatcher/DspCatalogHttpDispatcherExtension.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.connector.controlplane.catalog.spi.DatasetRequestMessage;
 import org.eclipse.edc.protocol.dsp.catalog.http.dispatcher.delegate.ByteArrayBodyExtractor;
 import org.eclipse.edc.protocol.dsp.http.dispatcher.GetDspHttpRequestFactory;
 import org.eclipse.edc.protocol.dsp.http.dispatcher.PostDspHttpRequestFactory;
+import org.eclipse.edc.protocol.dsp.http.spi.DspProtocolParser;
 import org.eclipse.edc.protocol.dsp.http.spi.dispatcher.DspHttpRemoteMessageDispatcher;
 import org.eclipse.edc.protocol.dsp.http.spi.serialization.JsonLdRemoteMessageSerializer;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
@@ -43,6 +44,8 @@ public class DspCatalogHttpDispatcherExtension implements ServiceExtension {
     private DspHttpRemoteMessageDispatcher messageDispatcher;
     @Inject
     private JsonLdRemoteMessageSerializer remoteMessageSerializer;
+    @Inject
+    private DspProtocolParser dspProtocolParser;
 
     @Override
     public String name() {
@@ -55,12 +58,12 @@ public class DspCatalogHttpDispatcherExtension implements ServiceExtension {
 
         messageDispatcher.registerMessage(
                 CatalogRequestMessage.class,
-                new PostDspHttpRequestFactory<>(remoteMessageSerializer, m -> BASE_PATH + CATALOG_REQUEST),
+                new PostDspHttpRequestFactory<>(remoteMessageSerializer, dspProtocolParser, m -> BASE_PATH + CATALOG_REQUEST),
                 byteArrayBodyExtractor
         );
         messageDispatcher.registerMessage(
                 DatasetRequestMessage.class,
-                new GetDspHttpRequestFactory<>(m -> BASE_PATH + DATASET_REQUEST + "/" + m.getDatasetId()),
+                new GetDspHttpRequestFactory<>(dspProtocolParser, m -> BASE_PATH + DATASET_REQUEST + "/" + m.getDatasetId()),
                 byteArrayBodyExtractor
         );
     }

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/dispatcher/delegate/ByteArrayBodyExtractor.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/dispatcher/delegate/ByteArrayBodyExtractor.java
@@ -25,7 +25,7 @@ import java.io.IOException;
  */
 public class ByteArrayBodyExtractor implements DspHttpResponseBodyExtractor<byte[]> {
     @Override
-    public byte[] extractBody(ResponseBody responseBody) {
+    public byte[] extractBody(ResponseBody responseBody, String protocol) {
         try {
             if (responseBody == null) {
                 return null;

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/src/test/java/org/eclipse/edc/protocol/dsp/catalog/http/dispatcher/delegate/ByteArrayBodyExtractorTest.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-dispatcher/src/test/java/org/eclipse/edc/protocol/dsp/catalog/http/dispatcher/delegate/ByteArrayBodyExtractorTest.java
@@ -35,14 +35,14 @@ class ByteArrayBodyExtractorTest {
         var bytes = "test".getBytes();
         when(responseBody.bytes()).thenReturn(bytes);
 
-        var result = extractor.extractBody(responseBody);
+        var result = extractor.extractBody(responseBody, "protocol");
 
         assertThat(result).isEqualTo(bytes);
     }
 
     @Test
     void shouldReturnNull_whenBodyIsNull() {
-        var result = extractor.extractBody(null);
+        var result = extractor.extractBody(null, "protocol");
 
         assertThat(result).isNull();
     }
@@ -52,7 +52,7 @@ class ByteArrayBodyExtractorTest {
         var responseBody = mock(ResponseBody.class);
         when(responseBody.bytes()).thenThrow(new IOException());
 
-        assertThatThrownBy(() -> extractor.extractBody(responseBody)).isInstanceOf(EdcException.class);
+        assertThatThrownBy(() -> extractor.extractBody(responseBody, "protocol")).isInstanceOf(EdcException.class);
     }
 
 }

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/main/java/org/eclipse/edc/protocol/dsp/catalog/transform/DspCatalogTransformExtension.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/main/java/org/eclipse/edc/protocol/dsp/catalog/transform/DspCatalogTransformExtension.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.protocol.dsp.catalog.transform;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.json.Json;
 import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromCatalogRequestMessageTransformer;
 import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromCatalogTransformer;
@@ -31,6 +32,8 @@ import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 
 import java.util.Map;
 
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_TRANSFORMER_CONTEXT_V_08;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_TRANSFORMER_CONTEXT_V_2024_1;
 import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
 
 /**
@@ -57,10 +60,16 @@ public class DspCatalogTransformExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var jsonFactory = Json.createBuilderFactory(Map.of());
         var mapper = typeManager.getMapper(JSON_LD);
 
-        var dspApiTransformerRegistry = registry.forContext("dsp-api");
+        registerTransformers(DSP_TRANSFORMER_CONTEXT_V_08, mapper);
+        registerTransformers(DSP_TRANSFORMER_CONTEXT_V_2024_1, mapper);
+    }
+
+    private void registerTransformers(String version, ObjectMapper mapper) {
+        var jsonFactory = Json.createBuilderFactory(Map.of());
+
+        var dspApiTransformerRegistry = registry.forContext(version);
         dspApiTransformerRegistry.register(new JsonObjectFromCatalogRequestMessageTransformer(jsonFactory));
         dspApiTransformerRegistry.register(new JsonObjectToCatalogRequestMessageTransformer());
 

--- a/data-protocols/dsp/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/http/dispatcher/DspHttpRemoteMessageDispatcherImpl.java
+++ b/data-protocols/dsp/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/http/dispatcher/DspHttpRemoteMessageDispatcherImpl.java
@@ -126,7 +126,7 @@ public class DspHttpRemoteMessageDispatcherImpl implements DspHttpRemoteMessageD
                             .build();
 
                     return httpClient.executeAsync(requestWithAuth, List.of(retryWhenStatusNot2xxOr4xx()))
-                            .thenApply(response -> handleResponse(response, responseType, handler.bodyExtractor));
+                            .thenApply(response -> handleResponse(response, message.getProtocol(), responseType, handler.bodyExtractor));
                 })
                 .orElse(failure -> failedFuture(new EdcException(format("Unable to obtain credentials: %s", failure.getFailureDetail()))));
     }
@@ -143,10 +143,10 @@ public class DspHttpRemoteMessageDispatcherImpl implements DspHttpRemoteMessageD
     }
 
     @NotNull
-    private <T> StatusResult<T> handleResponse(Response response, Class<T> responseType, DspHttpResponseBodyExtractor<T> bodyExtractor) {
+    private <T> StatusResult<T> handleResponse(Response response, String protocol, Class<T> responseType, DspHttpResponseBodyExtractor<T> bodyExtractor) {
         try (var responseBody = response.body()) {
             if (response.isSuccessful()) {
-                var responsePayload = bodyExtractor.extractBody(responseBody);
+                var responsePayload = bodyExtractor.extractBody(responseBody, protocol);
 
                 return StatusResult.success(responseType.cast(responsePayload));
             } else {

--- a/data-protocols/dsp/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/http/protocol/DspProtocolParserImpl.java
+++ b/data-protocols/dsp/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/http/protocol/DspProtocolParserImpl.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.http.protocol;
+
+import org.eclipse.edc.connector.controlplane.services.spi.protocol.ProtocolVersion;
+import org.eclipse.edc.connector.controlplane.services.spi.protocol.ProtocolVersionRegistry;
+import org.eclipse.edc.protocol.dsp.http.spi.DspProtocolParser;
+import org.eclipse.edc.spi.result.Result;
+
+import static org.eclipse.edc.protocol.dsp.http.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP;
+import static org.eclipse.edc.protocol.dsp.http.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP_SEPARATOR;
+import static org.eclipse.edc.protocol.dsp.spi.version.DspVersions.V_08;
+
+public class DspProtocolParserImpl implements DspProtocolParser {
+
+    private final ProtocolVersionRegistry versionRegistry;
+
+    public DspProtocolParserImpl(ProtocolVersionRegistry versionRegistry) {
+        this.versionRegistry = versionRegistry;
+    }
+
+    @Override
+    public Result<ProtocolVersion> parse(String protocol) {
+        var protocolWithVersion = protocol.split(DATASPACE_PROTOCOL_HTTP_SEPARATOR);
+        var protocolName = protocolWithVersion[0];
+
+        if (!protocolName.equals(DATASPACE_PROTOCOL_HTTP)) {
+            return Result.failure("Protocol %s not supported. Expected protocol: %s".formatted(protocolName, DATASPACE_PROTOCOL_HTTP));
+        }
+
+        if (protocolWithVersion.length == 1) {
+            return Result.success(V_08);
+        }
+        var protocolVersion = protocolWithVersion[1];
+
+        return versionRegistry.getAll().protocolVersions()
+                .stream().filter(protoVersion -> protoVersion.version().equals(protocolVersion))
+                .findFirst()
+                .map(Result::success)
+                .orElseGet(() -> Result.failure("Protocol %s with version %s not supported".formatted(protocolName, protocolVersion)));
+    }
+}

--- a/data-protocols/dsp/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/http/transform/DspProtocolTypeTransformerRegistryImpl.java
+++ b/data-protocols/dsp/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/http/transform/DspProtocolTypeTransformerRegistryImpl.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.http.transform;
+
+import org.eclipse.edc.protocol.dsp.http.spi.DspProtocolParser;
+import org.eclipse.edc.protocol.dsp.spi.transform.DspProtocolTypeTransformerRegistry;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_CONTEXT_SEPARATOR;
+
+public class DspProtocolTypeTransformerRegistryImpl implements DspProtocolTypeTransformerRegistry {
+    
+    private final TypeTransformerRegistry transformerRegistry;
+    private final String transformerContextPrefix;
+    private final DspProtocolParser protocolParser;
+
+    public DspProtocolTypeTransformerRegistryImpl(TypeTransformerRegistry transformerRegistry, String transformerContextPrefix, DspProtocolParser protocolParser) {
+        this.transformerRegistry = transformerRegistry;
+        this.transformerContextPrefix = transformerContextPrefix;
+        this.protocolParser = protocolParser;
+    }
+
+    @Override
+    public Result<TypeTransformerRegistry> forProtocol(String protocol) {
+        return protocolParser.parse(protocol)
+                .map(protocolVersion -> transformerRegistry.forContext(transformerContextPrefix + DSP_CONTEXT_SEPARATOR + protocolVersion.version()));
+    }
+
+}

--- a/data-protocols/dsp/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/http/dispatcher/DspHttpRemoteMessageDispatcherImplTest.java
+++ b/data-protocols/dsp/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/http/dispatcher/DspHttpRemoteMessageDispatcherImplTest.java
@@ -362,7 +362,7 @@ class DspHttpRemoteMessageDispatcherImplTest {
         @Test
         void shouldShouldReturnSuccess_whenResponseIsSuccessful() {
             respondWith(dummyResponse(200), bodyExtractor);
-            when(bodyExtractor.extractBody(any())).thenReturn("response");
+            when(bodyExtractor.extractBody(any(), any())).thenReturn("response");
 
             var future = dispatcher.dispatch(String.class, new TestMessage());
 
@@ -384,7 +384,7 @@ class DspHttpRemoteMessageDispatcherImplTest {
                     assertThat(failure.getMessages()).containsOnly("expectedValue");
                 });
             });
-            verify(bodyExtractor, never()).extractBody(any());
+            verify(bodyExtractor, never()).extractBody(any(), any());
         }
 
         @Test
@@ -399,7 +399,7 @@ class DspHttpRemoteMessageDispatcherImplTest {
                     assertThat(failure.getMessages()).allMatch(it -> it.contains("is null"));
                 });
             });
-            verify(bodyExtractor, never()).extractBody(any());
+            verify(bodyExtractor, never()).extractBody(any(), any());
         }
 
         @Test
@@ -413,7 +413,7 @@ class DspHttpRemoteMessageDispatcherImplTest {
                     assertThat(failure.status()).isEqualTo(ERROR_RETRY);
                 });
             });
-            verify(bodyExtractor, never()).extractBody(any());
+            verify(bodyExtractor, never()).extractBody(any(), any());
         }
 
         private void respondWith(okhttp3.Response response, DspHttpResponseBodyExtractor<Object> bodyExtractor) {

--- a/data-protocols/dsp/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/http/dispatcher/GetDspHttpRequestFactoryTest.java
+++ b/data-protocols/dsp/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/http/dispatcher/GetDspHttpRequestFactoryTest.java
@@ -15,7 +15,10 @@
 package org.eclipse.edc.protocol.dsp.http.dispatcher;
 
 import org.eclipse.edc.protocol.dsp.http.TestMessage;
+import org.eclipse.edc.protocol.dsp.http.spi.DspProtocolParser;
 import org.eclipse.edc.protocol.dsp.http.spi.dispatcher.RequestPathProvider;
+import org.eclipse.edc.protocol.dsp.spi.version.DspVersions;
+import org.eclipse.edc.spi.result.Result;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,11 +29,13 @@ import static org.mockito.Mockito.when;
 class GetDspHttpRequestFactoryTest {
 
     private final RequestPathProvider<TestMessage> pathProvider = mock();
-    private final GetDspHttpRequestFactory<TestMessage> factory = new GetDspHttpRequestFactory<>(pathProvider);
+    private final DspProtocolParser dspProtocolParser = mock();
+    private final GetDspHttpRequestFactory<TestMessage> factory = new GetDspHttpRequestFactory<>(dspProtocolParser, pathProvider);
 
     @Test
     void shouldCreateProperHttpRequest() {
         when(pathProvider.providePath(any())).thenReturn("/message/request/path");
+        when(dspProtocolParser.parse("protocol")).thenReturn(Result.success(DspVersions.V_08));
 
         var message = new TestMessage("protocol", "http://counter-party", "counterPartyId");
         var request = factory.createRequest(message);
@@ -38,4 +43,5 @@ class GetDspHttpRequestFactoryTest {
         assertThat(request.url().url().toString()).isEqualTo("http://counter-party/message/request/path");
         assertThat(request.method()).isEqualTo("GET");
     }
+    
 }

--- a/data-protocols/dsp/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/http/dispatcher/PostDspHttpRequestFactoryTest.java
+++ b/data-protocols/dsp/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/http/dispatcher/PostDspHttpRequestFactoryTest.java
@@ -17,8 +17,11 @@ package org.eclipse.edc.protocol.dsp.http.dispatcher;
 import okhttp3.MediaType;
 import okio.Buffer;
 import org.eclipse.edc.protocol.dsp.http.TestMessage;
+import org.eclipse.edc.protocol.dsp.http.spi.DspProtocolParser;
 import org.eclipse.edc.protocol.dsp.http.spi.dispatcher.RequestPathProvider;
 import org.eclipse.edc.protocol.dsp.http.spi.serialization.JsonLdRemoteMessageSerializer;
+import org.eclipse.edc.protocol.dsp.spi.version.DspVersions;
+import org.eclipse.edc.spi.result.Result;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,11 +33,13 @@ class PostDspHttpRequestFactoryTest {
 
     private final RequestPathProvider<TestMessage> pathProvider = mock();
     private final JsonLdRemoteMessageSerializer serializer = mock();
-    private final PostDspHttpRequestFactory<TestMessage> factory = new PostDspHttpRequestFactory<>(serializer, pathProvider);
+    private final DspProtocolParser dspProtocolParser = mock();
+    private final PostDspHttpRequestFactory<TestMessage> factory = new PostDspHttpRequestFactory<>(serializer, dspProtocolParser, pathProvider);
 
     @Test
     void shouldCreateProperHttpRequest() {
         when(serializer.serialize(any())).thenReturn("serializedMessage");
+        when(dspProtocolParser.parse("protocol")).thenReturn(Result.success(DspVersions.V_08));
         when(pathProvider.providePath(any())).thenReturn("/message/request/path");
 
         var message = new TestMessage("protocol", "http://counter-party", "counterPartyId");
@@ -52,4 +57,6 @@ class PostDspHttpRequestFactoryTest {
 
         });
     }
+
+
 }

--- a/data-protocols/dsp/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/http/protocol/DspProtocolParserImplTest.java
+++ b/data-protocols/dsp/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/http/protocol/DspProtocolParserImplTest.java
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.http.protocol;
+
+import org.eclipse.edc.connector.controlplane.services.spi.protocol.ProtocolVersionRegistry;
+import org.eclipse.edc.connector.controlplane.services.spi.protocol.ProtocolVersions;
+import org.eclipse.edc.protocol.dsp.spi.version.DspVersions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.protocol.dsp.http.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP;
+import static org.eclipse.edc.protocol.dsp.http.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP_V_2024_1;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DspProtocolParserImplTest {
+
+    private final ProtocolVersionRegistry protocolVersionRegistry = mock();
+    private final DspProtocolParserImpl parser = new DspProtocolParserImpl(protocolVersionRegistry);
+    private final ProtocolVersions protocolVersions = new ProtocolVersions(List.of(DspVersions.V_08, DspVersions.V_2024_1));
+
+    @BeforeEach
+    void beforeEach() {
+        when(protocolVersionRegistry.getAll()).thenReturn(protocolVersions);
+    }
+
+    @Test
+    void shouldParseProtocol() {
+        assertThat(parser.parse(DATASPACE_PROTOCOL_HTTP)).isSucceeded()
+                .isEqualTo(DspVersions.V_08);
+    }
+
+    @Test
+    void shouldParseProtocolWithVersion() {
+        assertThat(parser.parse(DATASPACE_PROTOCOL_HTTP_V_2024_1)).isSucceeded()
+                .isEqualTo(DspVersions.V_2024_1);
+    }
+
+    @Test
+    void shouldFailToParseProtocol_whenTypeNotSupported() {
+        assertThat(parser.parse("myprotocol:v10")).isFailed();
+    }
+
+    @Test
+    void shouldFailToParseProtocol_whenVersionNotSupported() {
+        assertThat(parser.parse(DATASPACE_PROTOCOL_HTTP + ":wrongVersion")).isFailed();
+    }
+}

--- a/data-protocols/dsp/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/http/transform/DspProtocolTypeTransformerRegistryImplTest.java
+++ b/data-protocols/dsp/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/http/transform/DspProtocolTypeTransformerRegistryImplTest.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.http.transform;
+
+import org.eclipse.edc.protocol.dsp.http.spi.DspProtocolParser;
+import org.eclipse.edc.protocol.dsp.spi.version.DspVersions;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.junit.jupiter.api.Test;
+
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.protocol.dsp.http.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_TRANSFORMER_CONTEXT;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_TRANSFORMER_CONTEXT_V_08;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DspProtocolTypeTransformerRegistryImplTest {
+
+    private final TypeTransformerRegistry transformerRegistry = mock();
+    private final DspProtocolParser protocolParser = mock();
+    private final DspProtocolTypeTransformerRegistryImpl dspTransformerRegistry = new DspProtocolTypeTransformerRegistryImpl(transformerRegistry, DSP_TRANSFORMER_CONTEXT, protocolParser);
+
+    @Test
+    void forProtocol() {
+        when(protocolParser.parse(DATASPACE_PROTOCOL_HTTP)).thenReturn(Result.success(DspVersions.V_08));
+        when(transformerRegistry.forContext(DSP_TRANSFORMER_CONTEXT_V_08)).thenReturn(transformerRegistry);
+        assertThat(dspTransformerRegistry.forProtocol(DATASPACE_PROTOCOL_HTTP)).isSucceeded()
+                .isEqualTo(transformerRegistry);
+    }
+
+}

--- a/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/http/spi/DspProtocolParser.java
+++ b/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/http/spi/DspProtocolParser.java
@@ -12,18 +12,19 @@
  *
  */
 
-package org.eclipse.edc.protocol.dsp.spi.version;
+package org.eclipse.edc.protocol.dsp.http.spi;
 
 import org.eclipse.edc.connector.controlplane.services.spi.protocol.ProtocolVersion;
+import org.eclipse.edc.spi.result.Result;
 
-public interface DspVersions {
+/**
+ * DSP protocol string parser
+ */
+public interface DspProtocolParser {
 
-    String V_2024_1_VERSION = "2024/1";
-    String V_2024_1_PATH = "/" + V_2024_1_VERSION;
-    ProtocolVersion V_2024_1 = new ProtocolVersion(V_2024_1_VERSION, V_2024_1_PATH);
-
-    String V_08_VERSION = "v0.8";
-    String V_08_PATH = "/";
-    ProtocolVersion V_08 = new ProtocolVersion(V_08_VERSION, V_08_PATH);
-
+    /**
+     * Parses the DSP protocol string with format {@literal dataspace-protocol-http:<version>}
+     * and extract the resulting {@link ProtocolVersion}
+     */
+    Result<ProtocolVersion> parse(String protocol);
 }

--- a/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/http/spi/dispatcher/DspHttpRequestFactory.java
+++ b/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/http/spi/dispatcher/DspHttpRequestFactory.java
@@ -25,6 +25,13 @@ import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
 @FunctionalInterface
 public interface DspHttpRequestFactory<M extends RemoteMessage> {
 
+    default String removeTrailingSlash(String path) {
+        if (path.endsWith("/")) {
+            return path.substring(0, path.length() - 1);
+        }
+        return path;
+    }
+
     /**
      * Create the request given the message and a {@link RequestPathProvider}
      *

--- a/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/http/spi/dispatcher/response/DspHttpResponseBodyExtractor.java
+++ b/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/http/spi/dispatcher/response/DspHttpResponseBodyExtractor.java
@@ -24,7 +24,7 @@ import okhttp3.ResponseBody;
 @FunctionalInterface
 public interface DspHttpResponseBodyExtractor<R> {
 
-    DspHttpResponseBodyExtractor<Object> NOOP = r -> null;
+    DspHttpResponseBodyExtractor<Object> NOOP = (r, p) -> null;
 
     /**
      * Extract the body from the Response
@@ -32,5 +32,5 @@ public interface DspHttpResponseBodyExtractor<R> {
      * @param responseBody the Response.
      * @return the body.
      */
-    R extractBody(ResponseBody responseBody);
+    R extractBody(ResponseBody responseBody, String protocol);
 }

--- a/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/http/spi/message/DspRequest.java
+++ b/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/http/spi/message/DspRequest.java
@@ -27,6 +27,7 @@ public class DspRequest<I, R> {
     protected final Class<I> inputClass;
     protected String token;
     protected String errorType;
+    protected String protocol;
     protected BiFunction<I, TokenRepresentation, ServiceResult<R>> serviceCall;
 
     public DspRequest(Class<I> inputClass, Class<R> resultClass) {
@@ -36,6 +37,10 @@ public class DspRequest<I, R> {
 
     public String getToken() {
         return token;
+    }
+
+    public String getProtocol() {
+        return protocol;
     }
 
     public Class<I> getInputClass() {
@@ -67,6 +72,11 @@ public class DspRequest<I, R> {
             return self();
         }
 
+        public B protocol(String protocol) {
+            message.protocol = protocol;
+            return self();
+        }
+
         public B serviceCall(BiFunction<I, TokenRepresentation, ServiceResult<R>> serviceCall) {
             message.serviceCall = serviceCall;
             return self();
@@ -80,6 +90,7 @@ public class DspRequest<I, R> {
         public M build() {
             requireNonNull(message.serviceCall);
             requireNonNull(message.errorType);
+            requireNonNull(message.protocol);
             return message;
         }
 

--- a/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/http/spi/types/HttpMessageProtocol.java
+++ b/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/http/spi/types/HttpMessageProtocol.java
@@ -14,11 +14,16 @@
 
 package org.eclipse.edc.protocol.dsp.http.spi.types;
 
+import org.eclipse.edc.protocol.dsp.spi.version.DspVersions;
+
 /**
  * Provides the name to be used as reference to the dataspace protocol in remote messages.
  */
 public class HttpMessageProtocol {
 
+    // When not explicit the default will be v0.8 for backward compatibility
     public static final String DATASPACE_PROTOCOL_HTTP = "dataspace-protocol-http";
+    public static final String DATASPACE_PROTOCOL_HTTP_SEPARATOR = ":";
+    public static final String DATASPACE_PROTOCOL_HTTP_V_2024_1 = DATASPACE_PROTOCOL_HTTP + DATASPACE_PROTOCOL_HTTP_SEPARATOR + DspVersions.V_2024_1_VERSION;
 
 }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/DspNegotiationApiExtension.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/DspNegotiationApiExtension.java
@@ -39,6 +39,7 @@ import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTyp
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_TERMINATION_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_OFFER_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE;
+import static org.eclipse.edc.protocol.dsp.spi.version.DspVersions.V_08;
 import static org.eclipse.edc.protocol.dsp.spi.version.DspVersions.V_2024_1;
 
 /**
@@ -78,5 +79,6 @@ public class DspNegotiationApiExtension implements ServiceExtension {
         webService.registerResource(ApiContext.PROTOCOL, new DspNegotiationApiController20241(protocolService, dspRequestHandler));
 
         versionRegistry.register(V_2024_1);
+        versionRegistry.register(V_08);
     }
 }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/DspNegotiationApiController.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/DspNegotiationApiController.java
@@ -37,6 +37,7 @@ import org.eclipse.edc.protocol.dsp.http.spi.message.GetDspRequest;
 import org.eclipse.edc.protocol.dsp.http.spi.message.PostDspRequest;
 
 import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static org.eclipse.edc.protocol.dsp.http.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP;
 import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.AGREEMENT;
 import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.BASE_PATH;
 import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.CONTRACT_OFFER;
@@ -64,12 +65,21 @@ import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTyp
 public class DspNegotiationApiController {
 
     private final DspRequestHandler dspRequestHandler;
+    private final String protocol;
     private final ContractNegotiationProtocolService protocolService;
 
     public DspNegotiationApiController(ContractNegotiationProtocolService protocolService,
                                        DspRequestHandler dspRequestHandler) {
+
+        this(protocolService, dspRequestHandler, DATASPACE_PROTOCOL_HTTP);
+    }
+
+    public DspNegotiationApiController(ContractNegotiationProtocolService protocolService,
+                                       DspRequestHandler dspRequestHandler,
+                                       String protocol) {
         this.protocolService = protocolService;
         this.dspRequestHandler = dspRequestHandler;
+        this.protocol = protocol;
     }
 
     /**
@@ -85,6 +95,7 @@ public class DspNegotiationApiController {
         var request = GetDspRequest.Builder.newInstance(ContractNegotiation.class)
                 .id(id).token(token).serviceCall(protocolService::findById)
                 .errorType(DSPACE_TYPE_CONTRACT_NEGOTIATION_ERROR)
+                .protocol(protocol)
                 .build();
 
         return dspRequestHandler.getResource(request);
@@ -106,6 +117,7 @@ public class DspNegotiationApiController {
                 .token(token)
                 .serviceCall(protocolService::notifyRequested)
                 .errorType(DSPACE_TYPE_CONTRACT_NEGOTIATION_ERROR)
+                .protocol(protocol)
                 .build();
 
         return dspRequestHandler.createResource(request);
@@ -127,6 +139,7 @@ public class DspNegotiationApiController {
                 .token(token)
                 .serviceCall(protocolService::notifyOffered)
                 .errorType(DSPACE_TYPE_CONTRACT_NEGOTIATION_ERROR)
+                .protocol(protocol)
                 .build();
 
         return dspRequestHandler.createResource(request);
@@ -152,6 +165,7 @@ public class DspNegotiationApiController {
                 .token(token)
                 .serviceCall(protocolService::notifyRequested)
                 .errorType(DSPACE_TYPE_CONTRACT_NEGOTIATION_ERROR)
+                .protocol(protocol)
                 .build();
 
         return dspRequestHandler.updateResource(request);
@@ -180,6 +194,7 @@ public class DspNegotiationApiController {
                     case ACCEPTED -> protocolService.notifyAccepted(message, claimToken);
                 })
                 .errorType(DSPACE_TYPE_CONTRACT_NEGOTIATION_ERROR)
+                .protocol(protocol)
                 .build();
 
         return dspRequestHandler.updateResource(request);
@@ -205,6 +220,7 @@ public class DspNegotiationApiController {
                 .token(token)
                 .serviceCall(protocolService::notifyVerified)
                 .errorType(DSPACE_TYPE_CONTRACT_NEGOTIATION_ERROR)
+                .protocol(protocol)
                 .build();
 
         return dspRequestHandler.updateResource(request);
@@ -230,6 +246,7 @@ public class DspNegotiationApiController {
                 .token(token)
                 .serviceCall(protocolService::notifyTerminated)
                 .errorType(DSPACE_TYPE_CONTRACT_NEGOTIATION_ERROR)
+                .protocol(protocol)
                 .build();
 
         return dspRequestHandler.updateResource(request);
@@ -255,6 +272,7 @@ public class DspNegotiationApiController {
                 .token(token)
                 .serviceCall(protocolService::notifyOffered)
                 .errorType(DSPACE_TYPE_CONTRACT_NEGOTIATION_ERROR)
+                .protocol(protocol)
                 .build();
 
         return dspRequestHandler.updateResource(request);
@@ -280,6 +298,7 @@ public class DspNegotiationApiController {
                 .token(token)
                 .serviceCall(protocolService::notifyAgreed)
                 .errorType(DSPACE_TYPE_CONTRACT_NEGOTIATION_ERROR)
+                .protocol(protocol)
                 .build();
 
         return dspRequestHandler.updateResource(request);

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/DspNegotiationApiController20241.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/DspNegotiationApiController20241.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.C
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
 import org.eclipse.edc.protocol.dsp.spi.version.DspVersions;
 
+import static org.eclipse.edc.protocol.dsp.http.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP_V_2024_1;
 import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.BASE_PATH;
 
 /**
@@ -33,6 +34,6 @@ import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPa
 public class DspNegotiationApiController20241 extends DspNegotiationApiController {
 
     public DspNegotiationApiController20241(ContractNegotiationProtocolService protocolService, DspRequestHandler dspRequestHandler) {
-        super(protocolService, dspRequestHandler);
+        super(protocolService, dspRequestHandler, DATASPACE_PROTOCOL_HTTP_V_2024_1);
     }
 }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/DspNegotiationTransformExtension.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-transform/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/DspNegotiationTransformExtension.java
@@ -37,6 +37,9 @@ import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 
 import java.util.Map;
 
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_TRANSFORMER_CONTEXT_V_08;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_TRANSFORMER_CONTEXT_V_2024_1;
+
 /**
  * Provides the transformers for negotiation message types via the {@link TypeTransformerRegistry}.
  */
@@ -55,9 +58,14 @@ public class DspNegotiationTransformExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
+        registerTransformers(DSP_TRANSFORMER_CONTEXT_V_08);
+        registerTransformers(DSP_TRANSFORMER_CONTEXT_V_2024_1);
+    }
+
+    private void registerTransformers(String version) {
         var builderFactory = Json.createBuilderFactory(Map.of());
 
-        var dspApiTransformerRegistry = registry.forContext("dsp-api");
+        var dspApiTransformerRegistry = registry.forContext(version);
         dspApiTransformerRegistry.register(new JsonObjectFromContractAgreementMessageTransformer(builderFactory));
         dspApiTransformerRegistry.register(new JsonObjectFromContractAgreementVerificationMessageTransformer(builderFactory));
         dspApiTransformerRegistry.register(new JsonObjectFromContractNegotiationEventMessageTransformer(builderFactory));

--- a/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/spi/transform/DspProtocolTypeTransformerRegistry.java
+++ b/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/spi/transform/DspProtocolTypeTransformerRegistry.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.spi.transform;
+
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+
+/**
+ * Returns the right {@link TypeTransformerRegistry} for the provided dsp protocol {@literal  dataspace-http-protocol:<version>}
+ */
+public interface DspProtocolTypeTransformerRegistry {
+
+    Result<TypeTransformerRegistry> forProtocol(String protocol);
+}

--- a/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/spi/type/DspConstants.java
+++ b/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/spi/type/DspConstants.java
@@ -14,9 +14,17 @@
 
 package org.eclipse.edc.protocol.dsp.spi.type;
 
+import static org.eclipse.edc.protocol.dsp.spi.version.DspVersions.V_08_VERSION;
+import static org.eclipse.edc.protocol.dsp.spi.version.DspVersions.V_2024_1_VERSION;
+
 /**
  * Dataspace protocol constants.
  */
 public interface DspConstants {
+
+    String DSP_CONTEXT_SEPARATOR = ":";
     String DSP_SCOPE = "DSP";
+    String DSP_TRANSFORMER_CONTEXT = "dsp-api";
+    String DSP_TRANSFORMER_CONTEXT_V_08 = DSP_TRANSFORMER_CONTEXT + DSP_CONTEXT_SEPARATOR + V_08_VERSION;
+    String DSP_TRANSFORMER_CONTEXT_V_2024_1 = DSP_TRANSFORMER_CONTEXT + DSP_CONTEXT_SEPARATOR + V_2024_1_VERSION;
 }

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-http-api/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/DspTransferProcessApiExtension.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-http-api/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/DspTransferProcessApiExtension.java
@@ -35,6 +35,7 @@ import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAn
 import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_REQUEST_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_START_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_TERMINATION_MESSAGE;
+import static org.eclipse.edc.protocol.dsp.spi.version.DspVersions.V_08;
 import static org.eclipse.edc.protocol.dsp.spi.version.DspVersions.V_2024_1;
 
 /**
@@ -66,5 +67,6 @@ public class DspTransferProcessApiExtension implements ServiceExtension {
         webService.registerResource(ApiContext.PROTOCOL, new DspTransferProcessApiController20241(transferProcessProtocolService, dspRequestHandler));
 
         versionRegistry.register(V_2024_1);
+        versionRegistry.register(V_08);
     }
 }

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-http-api/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/controller/DspTransferProcessApiController.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-http-api/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/controller/DspTransferProcessApiController.java
@@ -36,6 +36,7 @@ import org.eclipse.edc.protocol.dsp.http.spi.message.GetDspRequest;
 import org.eclipse.edc.protocol.dsp.http.spi.message.PostDspRequest;
 
 import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static org.eclipse.edc.protocol.dsp.http.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_ERROR;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_REQUEST_MESSAGE;
@@ -60,10 +61,16 @@ public class DspTransferProcessApiController {
 
     private final TransferProcessProtocolService protocolService;
     private final DspRequestHandler dspRequestHandler;
+    private final String protocol;
 
     public DspTransferProcessApiController(TransferProcessProtocolService protocolService, DspRequestHandler dspRequestHandler) {
+        this(protocolService, dspRequestHandler, DATASPACE_PROTOCOL_HTTP);
+    }
+
+    public DspTransferProcessApiController(TransferProcessProtocolService protocolService, DspRequestHandler dspRequestHandler, String protocol) {
         this.protocolService = protocolService;
         this.dspRequestHandler = dspRequestHandler;
+        this.protocol = protocol;
     }
 
     /**
@@ -78,6 +85,7 @@ public class DspTransferProcessApiController {
         var request = GetDspRequest.Builder.newInstance(TransferProcess.class)
                 .id(id).token(token).errorType(DSPACE_TYPE_TRANSFER_ERROR)
                 .serviceCall(protocolService::findById)
+                .protocol(protocol)
                 .build();
 
         return dspRequestHandler.getResource(request);
@@ -99,6 +107,7 @@ public class DspTransferProcessApiController {
                 .expectedMessageType(DSPACE_TYPE_TRANSFER_REQUEST_MESSAGE)
                 .serviceCall(protocolService::notifyRequested)
                 .errorType(DSPACE_TYPE_TRANSFER_ERROR)
+                .protocol(protocol)
                 .build();
 
         return dspRequestHandler.createResource(request);
@@ -122,6 +131,7 @@ public class DspTransferProcessApiController {
                 .token(token)
                 .serviceCall(protocolService::notifyStarted)
                 .errorType(DSPACE_TYPE_TRANSFER_ERROR)
+                .protocol(protocol)
                 .build();
 
         return dspRequestHandler.updateResource(request);
@@ -145,6 +155,7 @@ public class DspTransferProcessApiController {
                 .token(token)
                 .serviceCall(protocolService::notifyCompleted)
                 .errorType(DSPACE_TYPE_TRANSFER_ERROR)
+                .protocol(protocol)
                 .build();
 
         return dspRequestHandler.updateResource(request);
@@ -168,6 +179,7 @@ public class DspTransferProcessApiController {
                 .token(token)
                 .serviceCall(protocolService::notifyTerminated)
                 .errorType(DSPACE_TYPE_TRANSFER_ERROR)
+                .protocol(protocol)
                 .build();
 
         return dspRequestHandler.updateResource(request);
@@ -191,6 +203,7 @@ public class DspTransferProcessApiController {
                 .token(token)
                 .serviceCall(protocolService::notifySuspended)
                 .errorType(DSPACE_TYPE_TRANSFER_ERROR)
+                .protocol(protocol)
                 .build();
 
         return dspRequestHandler.updateResource(request);

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-http-api/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/controller/DspTransferProcessApiController20241.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-http-api/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/controller/DspTransferProcessApiController20241.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.Trans
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
 import org.eclipse.edc.protocol.dsp.spi.version.DspVersions;
 
+import static org.eclipse.edc.protocol.dsp.http.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP_V_2024_1;
 import static org.eclipse.edc.protocol.dsp.transferprocess.http.api.TransferProcessApiPaths.BASE_PATH;
 
 
@@ -34,6 +35,6 @@ import static org.eclipse.edc.protocol.dsp.transferprocess.http.api.TransferProc
 public class DspTransferProcessApiController20241 extends DspTransferProcessApiController {
 
     public DspTransferProcessApiController20241(TransferProcessProtocolService protocolService, DspRequestHandler dspRequestHandler) {
-        super(protocolService, dspRequestHandler);
+        super(protocolService, dspRequestHandler, DATASPACE_PROTOCOL_HTTP_V_2024_1);
     }
 }

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/DspTransferProcessTransformExtension.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-transform/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/DspTransferProcessTransformExtension.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.protocol.dsp.transferprocess.transform;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.json.Json;
 import org.eclipse.edc.protocol.dsp.transferprocess.transform.type.from.JsonObjectFromTransferCompletionMessageTransformer;
 import org.eclipse.edc.protocol.dsp.transferprocess.transform.type.from.JsonObjectFromTransferProcessTransformer;
@@ -37,6 +38,8 @@ import org.eclipse.edc.transform.transformer.edc.from.JsonObjectFromDataAddressT
 
 import java.util.Map;
 
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_TRANSFORMER_CONTEXT_V_08;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_TRANSFORMER_CONTEXT_V_2024_1;
 import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
 
 /**
@@ -60,10 +63,16 @@ public class DspTransferProcessTransformExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var builderFactory = Json.createBuilderFactory(Map.of());
         var objectMapper = typeManager.getMapper(JSON_LD);
 
-        var dspRegistry = registry.forContext("dsp-api");
+        registerTransformers(DSP_TRANSFORMER_CONTEXT_V_08, objectMapper);
+        registerTransformers(DSP_TRANSFORMER_CONTEXT_V_2024_1, objectMapper);
+    }
+
+    private void registerTransformers(String version, ObjectMapper objectMapper) {
+        var builderFactory = Json.createBuilderFactory(Map.of());
+
+        var dspRegistry = registry.forContext(version);
 
         dspRegistry.register(new JsonObjectFromTransferProcessTransformer(builderFactory));
         dspRegistry.register(new JsonObjectFromTransferStartMessageTransformer(builderFactory));
@@ -80,4 +89,5 @@ public class DspTransferProcessTransformExtension implements ServiceExtension {
         dspRegistry.register(new JsonObjectToTransferProcessAckTransformer());
         dspRegistry.register(new JsonObjectToTransferSuspensionMessageTransformer(objectMapper));
     }
+
 }

--- a/data-protocols/dsp/dsp-version/dsp-version-http-api/src/main/java/org/eclipse/edc/protocol/dsp/version/http/api/DspVersionApiController.java
+++ b/data-protocols/dsp/dsp-version/dsp-version-http-api/src/main/java/org/eclipse/edc/protocol/dsp/version/http/api/DspVersionApiController.java
@@ -26,6 +26,7 @@ import org.eclipse.edc.protocol.dsp.http.spi.message.GetDspRequest;
 
 import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.eclipse.edc.protocol.dsp.http.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspVersionPropertyAndTypeNames.DSPACE_TYPE_VERSIONS_ERROR;
 
 @Produces(APPLICATION_JSON)
@@ -46,6 +47,7 @@ public class DspVersionApiController {
                 .token(token)
                 .errorType(DSPACE_TYPE_VERSIONS_ERROR)
                 .serviceCall((id, tokenRepresentation) -> service.getAll(tokenRepresentation))
+                .protocol(DATASPACE_PROTOCOL_HTTP)
                 .build();
 
         return requestHandler.getResource(request);

--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/Participant.java
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/Participant.java
@@ -83,6 +83,10 @@ public class Participant {
         return protocol;
     }
 
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
     public Endpoint getProtocolEndpoint() {
         return protocolEndpoint;
     }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/message/ProcessRemoteMessage.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/message/ProcessRemoteMessage.java
@@ -27,13 +27,12 @@ import static java.util.UUID.randomUUID;
  * <p>
  * The {@link #processId} represent the ID of the process on the recipient part.
  */
-public abstract class ProcessRemoteMessage implements RemoteMessage {
+public abstract class ProcessRemoteMessage extends ProtocolRemoteMessage {
 
     protected String id;
     protected String processId;
     protected String consumerPid;
     protected String providerPid;
-    protected String protocol = "unknown";
     protected String counterPartyAddress;
     protected String counterPartyId;
 
@@ -52,17 +51,7 @@ public abstract class ProcessRemoteMessage implements RemoteMessage {
     public @NotNull String getId() {
         return id;
     }
-
-    @Override
-    public String getProtocol() {
-        return protocol;
-    }
-
-    public void setProtocol(String protocol) {
-        Objects.requireNonNull(protocol);
-        this.protocol = protocol;
-    }
-
+    
     /**
      * Returns the process id for this instance, that could be consumerPid or providerPid.
      *

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/message/ProtocolRemoteMessage.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/message/ProtocolRemoteMessage.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.spi.types.domain.message;
+
+import java.util.Objects;
+
+public abstract class ProtocolRemoteMessage implements RemoteMessage {
+
+    protected String protocol = "unknown";
+    
+    @Override
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        Objects.requireNonNull(protocol);
+        this.protocol = protocol;
+    }
+}

--- a/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/CatalogRequestMessage.java
+++ b/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/CatalogRequestMessage.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.query.QuerySpec;
-import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
+import org.eclipse.edc.spi.types.domain.message.ProtocolRemoteMessage;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -30,7 +30,7 @@ import java.util.Objects;
  * A request for a participant's {@link Catalog}.
  */
 @JsonDeserialize(builder = CatalogRequestMessage.Builder.class)
-public class CatalogRequestMessage implements RemoteMessage {
+public class CatalogRequestMessage extends ProtocolRemoteMessage {
 
     private final Policy policy;
     private List<String> additionalScopes = new ArrayList<>();

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferPullEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferPullEndToEndTest.java
@@ -353,6 +353,38 @@ class TransferPullEndToEndTest {
 
     @Nested
     @EndToEndTest
+    class InMemoryV2024Rev1 extends Tests {
+
+
+        @RegisterExtension
+        static final RuntimeExtension CONSUMER_CONTROL_PLANE = new RuntimePerClassExtension(
+                Runtimes.IN_MEMORY_CONTROL_PLANE.create("consumer-control-plane", CONSUMER.controlPlaneConfiguration()));
+        @RegisterExtension
+        static final RuntimeExtension PROVIDER_CONTROL_PLANE = new RuntimePerClassExtension(
+                Runtimes.IN_MEMORY_CONTROL_PLANE.create("provider-control-plane", PROVIDER.controlPlaneConfiguration()));
+        @RegisterExtension
+        static final RuntimeExtension PROVIDER_DATA_PLANE = new RuntimePerClassExtension(
+                Runtimes.IN_MEMORY_DATA_PLANE.create("provider-data-plane", PROVIDER.dataPlaneConfiguration()));
+
+        // TODO: replace with something better. Temporary hack
+        @BeforeAll
+        static void beforeAll() {
+            CONSUMER.setProtocol("dataspace-protocol-http:2024/1");
+        }
+
+        @AfterAll
+        static void afterAll() {
+            CONSUMER.setProtocol("dataspace-protocol-http");
+        }
+
+        @Override
+        protected Vault getDataplaneVault() {
+            return PROVIDER_DATA_PLANE.getService(Vault.class);
+        }
+    }
+
+    @Nested
+    @EndToEndTest
     class EmbeddedDataPlane extends Tests {
 
         @RegisterExtension


### PR DESCRIPTION
## What this PR changes/adds

Supports multi protocols in DspRequest and DspHttpRemoteMessageDispatcherImpl

- Introduced a new `ProtocolVersion` for `v0.8` default one, bind in the default controllers without a version in the path. 
- Introduced `DspProtocolTypeTransformerRegistry` spi for fetching the right `TypeTransformerRegistry` given a protocol. 
- Introduced `DspProtocolParser` for parsing the protocol format `dataspace-protocol-http:<version>` into a `ProtocolVersion`
- Introduced a `ProtocolRemoteMessage` for holding the protocol and changing it in ingress on `DspRequestHandlerImpl`
- `PostDspHttpRequestFactory` and `GetDspHttpRequestFactory` uses the `DspProtocolParser` for extracting the right protocol version from a `RemoteMessage#protocol`

## Why it does that

supporting multiple dsp protocols

## Further notes

Currently both `v0.8` and `2024/1` have the same transformers registered. In subsequent PRs the `2024/1` should be fixed to point to the right namespace.

The `JsonLd` context refactor has no been applied in this PR. Currently they still use the same `JsonLD` configuration under the `DSP` scope. 

## Linked Issue(s)

Closes #4507 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
