### PR TITLE
fix: typo dcat:endpointUrl 

### DIFF
--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/main/java/org/eclipse/edc/protocol/dsp/catalog/transform/from/JsonObjectFromDataServiceTransformer.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/main/java/org/eclipse/edc/protocol/dsp/catalog/transform/from/JsonObjectFromDataServiceTransformer.java
@@ -27,6 +27,7 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DATA_SERVICE_TYPE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_ENDPOINT_DESCRIPTION_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_ENDPOINT_URL_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_ENDPOINT_URL_OLD_ATTRIBUTE;
 
 /**
  * Converts from a {@link DataService} to a DCAT data service as a {@link JsonObject} in JSON-LD expanded form.
@@ -47,6 +48,7 @@ public class JsonObjectFromDataServiceTransformer extends AbstractJsonLdTransfor
                 .add(TYPE, DCAT_DATA_SERVICE_TYPE);
 
         addIfNotNull(dataService.getEndpointDescription(), DCAT_ENDPOINT_DESCRIPTION_ATTRIBUTE, objectBuilder);
+        addIfNotNull(dataService.getEndpointUrl(), DCAT_ENDPOINT_URL_OLD_ATTRIBUTE, objectBuilder);
         addIfNotNull(dataService.getEndpointUrl(), DCAT_ENDPOINT_URL_ATTRIBUTE, objectBuilder);
 
         return objectBuilder.build();

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/test/java/org/eclipse/edc/protocol/dsp/catalog/transform/from/JsonObjectFromDataServiceTransformerTest.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-transform/src/test/java/org/eclipse/edc/protocol/dsp/catalog/transform/from/JsonObjectFromDataServiceTransformerTest.java
@@ -29,6 +29,7 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DATA_SERVICE_TYPE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_ENDPOINT_DESCRIPTION_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_ENDPOINT_URL_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_ENDPOINT_URL_OLD_ATTRIBUTE;
 import static org.mockito.Mockito.mock;
 
 class JsonObjectFromDataServiceTransformerTest {
@@ -57,6 +58,7 @@ class JsonObjectFromDataServiceTransformerTest {
         assertThat(result.getJsonString(ID).getString()).isEqualTo(dataService.getId());
         assertThat(result.getJsonString(TYPE).getString()).isEqualTo(DCAT_DATA_SERVICE_TYPE);
         assertThat(result.getJsonString(DCAT_ENDPOINT_DESCRIPTION_ATTRIBUTE).getString()).isEqualTo("description");
+        assertThat(result.getJsonString(DCAT_ENDPOINT_URL_OLD_ATTRIBUTE).getString()).isEqualTo("url");
         assertThat(result.getJsonString(DCAT_ENDPOINT_URL_ATTRIBUTE).getString()).isEqualTo("url");
     }
 

--- a/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/PropertyAndTypeNames.java
+++ b/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/PropertyAndTypeNames.java
@@ -33,7 +33,9 @@ public interface PropertyAndTypeNames {
     String DCAT_DATASET_ATTRIBUTE = DCAT_SCHEMA + "dataset";
     String DCAT_DISTRIBUTION_ATTRIBUTE = DCAT_SCHEMA + "distribution";
     String DCAT_ACCESS_SERVICE_ATTRIBUTE = DCAT_SCHEMA + "accessService";
-    String DCAT_ENDPOINT_URL_ATTRIBUTE = DCAT_SCHEMA + "endpointUrl";
+    @Deprecated(since = "0.10.0")
+    String DCAT_ENDPOINT_URL_OLD_ATTRIBUTE = DCAT_SCHEMA + "endpointUrl";
+    String DCAT_ENDPOINT_URL_ATTRIBUTE = DCAT_SCHEMA + "endpointURL";
     String DCAT_ENDPOINT_DESCRIPTION_ATTRIBUTE = DCAT_SCHEMA + "endpointDescription";
 
     //EDC


### PR DESCRIPTION
## What this PR changes/adds

adds `dcat:endpointURL` and deprecate `dcat:endpointUrl` in DataService transformer

## Linked Issue(s)

Closes #4523 
