### PR TITLE
fix: make consumer use the consumer process id to handle a provider offer

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -82,7 +82,7 @@ maven/mavencentral/com.jcraft/jzlib/1.1.3, BSD-2-Clause, approved, CQ6218
 maven/mavencentral/com.lmax/disruptor/3.4.4, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.networknt/json-schema-validator/1.0.76, Apache-2.0, approved, CQ22638
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.28, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.41.2, , restricted, clearlydefined
+maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.41.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.puppycrawl.tools/checkstyle/10.18.2, LGPL-2.1-or-later AND (Apache-2.0 AND LGPL-2.1-or-later) AND Apache-2.0, approved, #16060
 maven/mavencentral/com.samskivert/jmustache/1.15, BSD-2-Clause AND BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/com.squareup.okhttp3/okhttp-dnsoverhttps/4.12.0, Apache-2.0, approved, #11159

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
@@ -115,7 +115,7 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
                 .compose(agent -> {
                     ServiceResult<ContractNegotiation> result = message.getConsumerPid() == null
                             ? createNegotiation(message, agent.getIdentity(), CONSUMER, message.getCallbackAddress())
-                            : getAndLeaseNegotiation(message.getProviderPid())
+                            : getAndLeaseNegotiation(message.getConsumerPid())
                             .compose(negotiation -> validateRequest(agent, negotiation).map(it -> negotiation));
 
                     return result.onSuccess(negotiation -> {

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
@@ -688,7 +688,7 @@ class ContractNegotiationProtocolServiceImplTest {
             var updatedNegotiation = result.getContent();
             assertThat(updatedNegotiation.getContractOffers()).hasSize(2);
             assertThat(updatedNegotiation.getLastContractOffer()).isEqualTo(contractOffer);
-            verify(store).findByIdAndLease("providerPid");
+            verify(store).findByIdAndLease("consumerPid");
             verify(listener).offered(any());
             verify(transactionContext, atLeastOnce()).execute(any(TransactionContext.ResultTransactionBlock.class));
         }


### PR DESCRIPTION
## What this PR changes/adds

The incorrect process id is used. See #4527.

## Linked Issue(s)

Closes #4527
