### PR TITLE
docs: deprecate DAPS module

### DIFF
--- a/docs/developer/decision-records/2024-10-10-daps-deprecation/README.md
+++ b/docs/developer/decision-records/2024-10-10-daps-deprecation/README.md
@@ -2,7 +2,7 @@
 
 ## Decision
 
-We will stop publishing DAPS related modules.
+We will stop publishing DAPS related module.
 
 ## Rationale
 
@@ -11,8 +11,4 @@ used, makes DAPS obsolete, and maintaining it is an unneeded effort by the EDC c
 
 ## Approach
 
-In EDC version 0.10.0 we deprecated:
-- module `oauth2-daps`
-- class `Oauth2ServiceImpl`
-
-they will be removed without further warnings in the subsequent versions.
+The `oauth2-daps` has been deprecated in EDC version 0.10.0 and it  be removed without further warnings in the subsequent versions.

--- a/docs/developer/decision-records/2024-10-10-daps-deprecation/README.md
+++ b/docs/developer/decision-records/2024-10-10-daps-deprecation/README.md
@@ -1,0 +1,18 @@
+# DAPS module deprecation
+
+## Decision
+
+We will stop publishing DAPS related modules.
+
+## Rationale
+
+Shifting toward decentralized identity model though the adoption of Decentralized Claims Protocol as the protocol to be
+used, makes DAPS obsolete, and maintaining it is an unneeded effort by the EDC committer group.
+
+## Approach
+
+In EDC version 0.10.0 we deprecated:
+- module `oauth2-daps`
+- class `Oauth2ServiceImpl`
+
+they will be removed without further warnings in the subsequent versions.

--- a/docs/developer/decision-records/README.md
+++ b/docs/developer/decision-records/README.md
@@ -64,3 +64,5 @@
 - [2024-09-25 Multiple Protocol Versions](./2024-09-25-multiple-protocol-versions)
 - [2024-10-02 Clustered data-plane](./2024-10-02-clustered-data-plane/)
 - [2024-10-06 Typed Policy Scopes through Contexts](./2024-10-05-typed-policy-context)
+- [2024-10-10 DAPS module deprecation](./2024-10-10-daps-deprecation)
+

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/identity/Oauth2ServiceImpl.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/identity/Oauth2ServiceImpl.java
@@ -42,7 +42,10 @@ import static org.eclipse.edc.iam.oauth2.Oauth2ServiceExtension.OAUTH2_TOKEN_CON
 
 /**
  * Implements the OAuth2 client credentials flow and bearer token validation.
+ *
+ * @deprecated will be removed in the next versions.
  */
+@Deprecated(since = "0.10.0")
 public class Oauth2ServiceImpl implements IdentityService {
 
     private static final String GRANT_TYPE = "client_credentials";

--- a/extensions/common/iam/oauth2/oauth2-daps/src/main/java/org/eclipse/edc/iam/oauth2/daps/DapsExtension.java
+++ b/extensions/common/iam/oauth2/oauth2-daps/src/main/java/org/eclipse/edc/iam/oauth2/daps/DapsExtension.java
@@ -25,8 +25,11 @@ import org.eclipse.edc.token.spi.TokenDecoratorRegistry;
 
 /**
  * Provides specialization of Oauth2 extension to interact with DAPS instance
+ *
+ * @deprecated will be removed in the next versions.
  */
 @Extension(value = DapsExtension.NAME)
+@Deprecated(since = "0.10.0")
 public class DapsExtension implements ServiceExtension {
 
     public static final String NAME = "DAPS";
@@ -45,6 +48,7 @@ public class DapsExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
+        context.getMonitor().warning("The extension %s has been deprecated, please switch to a decentralized implementation".formatted(NAME));
         jwtDecoratorRegistry.register(OAUTH_2_DAPS_TOKEN_CONTEXT, new DapsJwtDecorator());
     }
 

--- a/extensions/common/iam/oauth2/oauth2-daps/src/main/java/org/eclipse/edc/iam/oauth2/daps/DapsJwtDecorator.java
+++ b/extensions/common/iam/oauth2/oauth2-daps/src/main/java/org/eclipse/edc/iam/oauth2/daps/DapsJwtDecorator.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.iam.oauth2.daps;
 import org.eclipse.edc.spi.iam.TokenParameters;
 import org.eclipse.edc.token.spi.TokenDecorator;
 
+@Deprecated(since = "0.10.0")
 public class DapsJwtDecorator implements TokenDecorator {
 
     @Override

--- a/extensions/common/iam/oauth2/oauth2-daps/src/main/java/org/eclipse/edc/iam/oauth2/daps/DapsTokenDecorator.java
+++ b/extensions/common/iam/oauth2/oauth2-daps/src/main/java/org/eclipse/edc/iam/oauth2/daps/DapsTokenDecorator.java
@@ -20,7 +20,10 @@ import org.eclipse.edc.token.spi.TokenDecorator;
 
 /**
  * Token decorator that sets the {@code scope} claim on the token that is used on DSP request egress
+ *
+ * @deprecated will be removed in the upcoming versions.
  */
+@Deprecated(since = "0.10.0")
 public class DapsTokenDecorator implements TokenDecorator {
     private final String scope;
 


### PR DESCRIPTION
## What this PR changes/adds

Deprecate `oauth2-daps` module and releated classes.

## Why it does that

cleanup

## Further notes

- given that the code effort was minimal, I included the DR in the same PR

## Linked Issue(s)

Closes #4534 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
