### PR TITLE
fix(ci): deactivate dataplane BOM smoke test for now

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -3,9 +3,9 @@ name: Run Tests
 on:
   workflow_dispatch:
   push:
-    branches: [ main, release/*, bugfix/* ]
+    branches: [main, release/*, bugfix/*]
   pull_request:
-    branches: [ main, release/*, bugfix/* ]
+    branches: [main, release/*, bugfix/*]
     paths-ignore:
       - "**.md"
       - "docs/**"
@@ -17,7 +17,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-
   CodeQL:
     uses: eclipse-edc/.github/.github/workflows/codeql-analysis.yml@main
     secrets: inherit
@@ -98,11 +97,9 @@ jobs:
 
       # we can't test the "controlplane-oauth2-com" because it only starts successfully if the public key is already in the vault
       matrix:
-        bom-directory: [ "dist/bom/dataplane-base-bom",
-                         "dist/bom/controlplane-dcp-bom",
-                         "dist/bom/sts-feature-bom" ]
+        bom-directory:
+          ["dist/bom/controlplane-dcp-bom", "dist/bom/sts-feature-bom"]
     uses: eclipse-edc/.github/.github/workflows/verify-bom.yml@main
     with:
       module-dir: ${{ matrix.bom-directory }}
       properties-file: example.properties
-


### PR DESCRIPTION

## What this PR changes/adds

deactivates the dataplane BOM smoke test for now until it has been replaced with a more robust test

## Why it does that

it was flaky


_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
