### PR TITLE
refactor: avoid logging on WebApplicationException

### DIFF
--- a/extensions/common/http/jersey-core/src/main/java/org/eclipse/edc/web/jersey/mapper/UnexpectedExceptionMapper.java
+++ b/extensions/common/http/jersey-core/src/main/java/org/eclipse/edc/web/jersey/mapper/UnexpectedExceptionMapper.java
@@ -44,11 +44,11 @@ public class UnexpectedExceptionMapper implements ExceptionMapper<Throwable> {
 
     @Override
     public Response toResponse(Throwable exception) {
-        monitor.severe("JerseyExtension: Unexpected exception caught", exception);
-        if (exception instanceof WebApplicationException) {
-            return ((WebApplicationException) exception).getResponse();
+        if (exception instanceof WebApplicationException webApplicationException) {
+            return webApplicationException.getResponse();
         }
 
+        monitor.severe("JerseyExtension: Unexpected exception caught", exception);
         var status = exceptionMap.getOrDefault(exception.getClass(), INTERNAL_SERVER_ERROR);
 
         return Response.status(status).build();


### PR DESCRIPTION
## What this PR changes/adds

Log only real unexpected exceptions

## Why it does that

improve logging

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #4554 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
