### PR TITLE
refactor: multi-namespace in dsp controllers

### DIFF
--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiController.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiController.java
@@ -36,6 +36,7 @@ import org.eclipse.edc.protocol.dsp.http.spi.message.ContinuationTokenManager;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
 import org.eclipse.edc.protocol.dsp.http.spi.message.GetDspRequest;
 import org.eclipse.edc.protocol.dsp.http.spi.message.PostDspRequest;
+import org.eclipse.edc.protocol.dsp.spi.type.DspNamespace;
 
 import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -43,7 +44,7 @@ import static org.eclipse.edc.protocol.dsp.catalog.http.api.CatalogApiPaths.BASE
 import static org.eclipse.edc.protocol.dsp.catalog.http.api.CatalogApiPaths.CATALOG_REQUEST;
 import static org.eclipse.edc.protocol.dsp.catalog.http.api.CatalogApiPaths.DATASET_REQUEST;
 import static org.eclipse.edc.protocol.dsp.http.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP;
-import static org.eclipse.edc.protocol.dsp.spi.type.DspCatalogPropertyAndTypeNames.DSPACE_TYPE_CATALOG_REQUEST_MESSAGE_IRI;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspCatalogPropertyAndTypeNames.DSPACE_TYPE_CATALOG_REQUEST_MESSAGE_TERM;
 
 /**
  * Provides the HTTP endpoint for receiving catalog requests.
@@ -57,16 +58,18 @@ public class DspCatalogApiController {
     private final DspRequestHandler dspRequestHandler;
     private final ContinuationTokenManager continuationTokenManager;
     private final String protocol;
+    private final DspNamespace namespace;
 
     public DspCatalogApiController(CatalogProtocolService service, DspRequestHandler dspRequestHandler, ContinuationTokenManager continuationTokenManager) {
-        this(service, dspRequestHandler, continuationTokenManager, DATASPACE_PROTOCOL_HTTP);
+        this(service, dspRequestHandler, continuationTokenManager, DATASPACE_PROTOCOL_HTTP, DspNamespace.V_08);
     }
 
-    public DspCatalogApiController(CatalogProtocolService service, DspRequestHandler dspRequestHandler, ContinuationTokenManager continuationTokenManager, String protocol) {
+    public DspCatalogApiController(CatalogProtocolService service, DspRequestHandler dspRequestHandler, ContinuationTokenManager continuationTokenManager, String protocol, DspNamespace namespace) {
         this.service = service;
         this.dspRequestHandler = dspRequestHandler;
         this.continuationTokenManager = continuationTokenManager;
         this.protocol = protocol;
+        this.namespace = namespace;
     }
 
     @POST
@@ -83,7 +86,7 @@ public class DspCatalogApiController {
 
         var request = PostDspRequest.Builder.newInstance(CatalogRequestMessage.class, Catalog.class, CatalogError.class)
                 .token(token)
-                .expectedMessageType(DSPACE_TYPE_CATALOG_REQUEST_MESSAGE_IRI)
+                .expectedMessageType(namespace.toIri(DSPACE_TYPE_CATALOG_REQUEST_MESSAGE_TERM))
                 .message(messageJson)
                 .serviceCall(service::getCatalog)
                 .errorProvider(CatalogError.Builder::newInstance)

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiController.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiController.java
@@ -45,6 +45,7 @@ import static org.eclipse.edc.protocol.dsp.catalog.http.api.CatalogApiPaths.CATA
 import static org.eclipse.edc.protocol.dsp.catalog.http.api.CatalogApiPaths.DATASET_REQUEST;
 import static org.eclipse.edc.protocol.dsp.http.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspCatalogPropertyAndTypeNames.DSPACE_TYPE_CATALOG_REQUEST_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 
 /**
  * Provides the HTTP endpoint for receiving catalog requests.
@@ -61,7 +62,7 @@ public class DspCatalogApiController {
     private final DspNamespace namespace;
 
     public DspCatalogApiController(CatalogProtocolService service, DspRequestHandler dspRequestHandler, ContinuationTokenManager continuationTokenManager) {
-        this(service, dspRequestHandler, continuationTokenManager, DATASPACE_PROTOCOL_HTTP, DspNamespace.V_08);
+        this(service, dspRequestHandler, continuationTokenManager, DATASPACE_PROTOCOL_HTTP, DSP_NAMESPACE_V_08);
     }
 
     public DspCatalogApiController(CatalogProtocolService service, DspRequestHandler dspRequestHandler, ContinuationTokenManager continuationTokenManager, String protocol, DspNamespace namespace) {

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiController20241.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiController20241.java
@@ -20,6 +20,7 @@ import jakarta.ws.rs.Produces;
 import org.eclipse.edc.connector.controlplane.services.spi.catalog.CatalogProtocolService;
 import org.eclipse.edc.protocol.dsp.http.spi.message.ContinuationTokenManager;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
+import org.eclipse.edc.protocol.dsp.spi.type.DspNamespace;
 
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.eclipse.edc.protocol.dsp.catalog.http.api.CatalogApiPaths.BASE_PATH;
@@ -36,6 +37,6 @@ public class DspCatalogApiController20241 extends DspCatalogApiController {
 
     public DspCatalogApiController20241(CatalogProtocolService service, DspRequestHandler dspRequestHandler,
                                         ContinuationTokenManager responseDecorator) {
-        super(service, dspRequestHandler, responseDecorator, DATASPACE_PROTOCOL_HTTP_V_2024_1);
+        super(service, dspRequestHandler, responseDecorator, DATASPACE_PROTOCOL_HTTP_V_2024_1, DspNamespace.V_2024_1);
     }
 }

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiController20241.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiController20241.java
@@ -20,11 +20,11 @@ import jakarta.ws.rs.Produces;
 import org.eclipse.edc.connector.controlplane.services.spi.catalog.CatalogProtocolService;
 import org.eclipse.edc.protocol.dsp.http.spi.message.ContinuationTokenManager;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
-import org.eclipse.edc.protocol.dsp.spi.type.DspNamespace;
 
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.eclipse.edc.protocol.dsp.catalog.http.api.CatalogApiPaths.BASE_PATH;
 import static org.eclipse.edc.protocol.dsp.http.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP_V_2024_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_2024_1;
 import static org.eclipse.edc.protocol.dsp.spi.version.DspVersions.V_2024_1_PATH;
 
 /**
@@ -37,6 +37,6 @@ public class DspCatalogApiController20241 extends DspCatalogApiController {
 
     public DspCatalogApiController20241(CatalogProtocolService service, DspRequestHandler dspRequestHandler,
                                         ContinuationTokenManager responseDecorator) {
-        super(service, dspRequestHandler, responseDecorator, DATASPACE_PROTOCOL_HTTP_V_2024_1, DspNamespace.V_2024_1);
+        super(service, dspRequestHandler, responseDecorator, DATASPACE_PROTOCOL_HTTP_V_2024_1, DSP_NAMESPACE_V_2024_1);
     }
 }

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/test/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiControllerTest.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/test/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiControllerTest.java
@@ -49,6 +49,8 @@ import static org.eclipse.edc.protocol.dsp.catalog.http.api.CatalogApiPaths.BASE
 import static org.eclipse.edc.protocol.dsp.catalog.http.api.CatalogApiPaths.CATALOG_REQUEST;
 import static org.eclipse.edc.protocol.dsp.catalog.http.api.CatalogApiPaths.DATASET_REQUEST;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspCatalogPropertyAndTypeNames.DSPACE_TYPE_CATALOG_REQUEST_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_2024_1;
 import static org.eclipse.edc.protocol.dsp.spi.version.DspVersions.V_2024_1_PATH;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -182,7 +184,7 @@ class DspCatalogApiControllerTest {
 
         @Override
         protected DspNamespace namespace() {
-            return DspNamespace.V_08;
+            return DSP_NAMESPACE_V_08;
         }
 
         @Override
@@ -202,7 +204,7 @@ class DspCatalogApiControllerTest {
 
         @Override
         protected DspNamespace namespace() {
-            return DspNamespace.V_2024_1;
+            return DSP_NAMESPACE_V_2024_1;
         }
 
         @Override

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/test/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiControllerTest.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/test/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiControllerTest.java
@@ -30,6 +30,7 @@ import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
 import org.eclipse.edc.protocol.dsp.http.spi.message.GetDspRequest;
 import org.eclipse.edc.protocol.dsp.http.spi.message.PostDspRequest;
 import org.eclipse.edc.protocol.dsp.http.spi.message.ResponseDecorator;
+import org.eclipse.edc.protocol.dsp.spi.type.DspNamespace;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
@@ -47,7 +48,8 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.protocol.dsp.catalog.http.api.CatalogApiPaths.BASE_PATH;
 import static org.eclipse.edc.protocol.dsp.catalog.http.api.CatalogApiPaths.CATALOG_REQUEST;
 import static org.eclipse.edc.protocol.dsp.catalog.http.api.CatalogApiPaths.DATASET_REQUEST;
-import static org.eclipse.edc.protocol.dsp.spi.type.DspCatalogPropertyAndTypeNames.DSPACE_TYPE_CATALOG_REQUEST_MESSAGE_IRI;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspCatalogPropertyAndTypeNames.DSPACE_TYPE_CATALOG_REQUEST_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.version.DspVersions.V_2024_1_PATH;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
@@ -56,115 +58,156 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-@ApiTest
-class DspCatalogApiControllerTest extends RestControllerTestBase {
+class DspCatalogApiControllerTest {
 
-    private final TypeTransformerRegistry transformerRegistry = mock();
-    private final CatalogProtocolService service = mock();
-    private final DspRequestHandler dspRequestHandler = mock();
-    private final ContinuationTokenManager continuationTokenManager = mock();
+    abstract static class Tests extends RestControllerTestBase {
 
-    @Test
-    void getDataset_shouldGetResource() {
-        when(dspRequestHandler.getResource(any())).thenReturn(Response.ok().type(APPLICATION_JSON).build());
-
-        baseRequest()
-                .get(DATASET_REQUEST + "/datasetId")
-                .then()
-                .statusCode(200)
-                .contentType(JSON);
-
-        var captor = ArgumentCaptor.forClass(GetDspRequest.class);
-        verify(dspRequestHandler).getResource(captor.capture());
-        var request = captor.getValue();
-        assertThat(request.getToken()).isEqualTo("auth");
-        assertThat(request.getResultClass()).isEqualTo(Dataset.class);
-        assertThat(request.getId()).isEqualTo("datasetId");
-    }
-
-    @Override
-    protected Object controller() {
-        return new DspCatalogApiController(service, dspRequestHandler, continuationTokenManager);
-    }
-
-    private RequestSpecification baseRequest() {
-        return given()
-                .baseUri("http://localhost:" + port)
-                .basePath(BASE_PATH)
-                .header(HttpHeaders.AUTHORIZATION, "auth")
-                .when();
-    }
-
-    @Nested
-    class RequestCatalog {
+        protected final TypeTransformerRegistry transformerRegistry = mock();
+        protected final CatalogProtocolService service = mock();
+        protected final DspRequestHandler dspRequestHandler = mock();
+        protected final ContinuationTokenManager continuationTokenManager = mock();
 
         @Test
-        void shouldCreateResource() {
-            var requestBody = createObjectBuilder().add(TYPE, DSPACE_TYPE_CATALOG_REQUEST_MESSAGE_IRI).build();
-            var catalog = createObjectBuilder().add(JsonLdKeywords.TYPE, "catalog").build();
-            when(transformerRegistry.transform(any(Catalog.class), eq(JsonObject.class))).thenReturn(Result.success(catalog));
-            when(dspRequestHandler.createResource(any(), any())).thenReturn(Response.ok().type(APPLICATION_JSON_TYPE).build());
-            when(continuationTokenManager.createResponseDecorator(any())).thenReturn(mock());
+        void getDataset_shouldGetResource() {
+            when(dspRequestHandler.getResource(any())).thenReturn(Response.ok().type(APPLICATION_JSON).build());
 
             baseRequest()
-                    .contentType(JSON)
-                    .body(requestBody)
-                    .post(CATALOG_REQUEST)
+                    .get(DATASET_REQUEST + "/datasetId")
                     .then()
                     .statusCode(200)
                     .contentType(JSON);
 
-            var captor = ArgumentCaptor.forClass(PostDspRequest.class);
-            verify(dspRequestHandler).createResource(captor.capture(), isA(ResponseDecorator.class));
+            var captor = ArgumentCaptor.forClass(GetDspRequest.class);
+            verify(dspRequestHandler).getResource(captor.capture());
             var request = captor.getValue();
-            assertThat(request.getInputClass()).isEqualTo(CatalogRequestMessage.class);
-            assertThat(request.getResultClass()).isEqualTo(Catalog.class);
-            assertThat(request.getExpectedMessageType()).isEqualTo(DSPACE_TYPE_CATALOG_REQUEST_MESSAGE_IRI);
-            assertThat(request.getProcessId()).isNull();
             assertThat(request.getToken()).isEqualTo("auth");
-            assertThat(request.getMessage()).isEqualTo(requestBody);
-            verify(continuationTokenManager).createResponseDecorator("http://localhost:%d/catalog/request".formatted(port));
+            assertThat(request.getResultClass()).isEqualTo(Dataset.class);
+            assertThat(request.getId()).isEqualTo("datasetId");
         }
 
-        @Test
-        void shouldApplyContinuationToken_whenPassed() {
-            var requestBody = createObjectBuilder().add(TYPE, DSPACE_TYPE_CATALOG_REQUEST_MESSAGE_IRI).build();
-            var catalog = createObjectBuilder().add(JsonLdKeywords.TYPE, "catalog").build();
-            when(transformerRegistry.transform(any(Catalog.class), eq(JsonObject.class))).thenReturn(Result.success(catalog));
-            when(dspRequestHandler.createResource(any(), any())).thenReturn(Response.ok().type(APPLICATION_JSON_TYPE).build());
-            when(continuationTokenManager.createResponseDecorator(any())).thenReturn(mock());
-            var enrichedRequestBody = createObjectBuilder(requestBody).add("query", Json.createObjectBuilder()).build();
-            when(continuationTokenManager.applyQueryFromToken(any(), any())).thenReturn(Result.success(enrichedRequestBody));
 
-            baseRequest()
-                    .contentType(JSON)
-                    .body(requestBody)
-                    .post(CATALOG_REQUEST + "?continuationToken=pagination-token")
-                    .then()
-                    .statusCode(200)
-                    .contentType(JSON);
+        protected abstract String basePath();
 
-            var captor = ArgumentCaptor.forClass(PostDspRequest.class);
-            verify(dspRequestHandler).createResource(captor.capture(), isA(ResponseDecorator.class));
-            var request = captor.getValue();
-            assertThat(request.getMessage()).isSameAs(enrichedRequestBody);
-            verify(continuationTokenManager).applyQueryFromToken(requestBody, "pagination-token");
+        protected abstract DspNamespace namespace();
+
+        private RequestSpecification baseRequest() {
+            return given()
+                    .baseUri("http://localhost:" + port)
+                    .basePath(basePath())
+                    .header(HttpHeaders.AUTHORIZATION, "auth")
+                    .when();
         }
 
-        @Test
-        void shouldReturnBadRequest_whenContinuationTokenIsNotValid() {
-            var requestBody = createObjectBuilder().add(TYPE, DSPACE_TYPE_CATALOG_REQUEST_MESSAGE_IRI).build();
-            when(continuationTokenManager.applyQueryFromToken(any(), any())).thenReturn(Result.failure("error"));
+        @Nested
+        class RequestCatalog {
 
-            baseRequest()
-                    .contentType(JSON)
-                    .body(requestBody)
-                    .post(CATALOG_REQUEST + "?continuationToken=pagination-token")
-                    .then()
-                    .statusCode(400);
+            @Test
+            void shouldCreateResource() {
+                var requestBody = createObjectBuilder().add(TYPE, namespace().toIri(DSPACE_TYPE_CATALOG_REQUEST_MESSAGE_TERM)).build();
+                var catalog = createObjectBuilder().add(JsonLdKeywords.TYPE, "catalog").build();
+                when(transformerRegistry.transform(any(Catalog.class), eq(JsonObject.class))).thenReturn(Result.success(catalog));
+                when(dspRequestHandler.createResource(any(), any())).thenReturn(Response.ok().type(APPLICATION_JSON_TYPE).build());
+                when(continuationTokenManager.createResponseDecorator(any())).thenReturn(mock());
 
-            verifyNoInteractions(dspRequestHandler, transformerRegistry);
+                baseRequest()
+                        .contentType(JSON)
+                        .body(requestBody)
+                        .post(CATALOG_REQUEST)
+                        .then()
+                        .statusCode(200)
+                        .contentType(JSON);
+
+                var captor = ArgumentCaptor.forClass(PostDspRequest.class);
+                verify(dspRequestHandler).createResource(captor.capture(), isA(ResponseDecorator.class));
+                var request = captor.getValue();
+                assertThat(request.getInputClass()).isEqualTo(CatalogRequestMessage.class);
+                assertThat(request.getResultClass()).isEqualTo(Catalog.class);
+                assertThat(request.getExpectedMessageType()).isEqualTo(namespace().toIri(DSPACE_TYPE_CATALOG_REQUEST_MESSAGE_TERM));
+                assertThat(request.getProcessId()).isNull();
+                assertThat(request.getToken()).isEqualTo("auth");
+                assertThat(request.getMessage()).isEqualTo(requestBody);
+                verify(continuationTokenManager).createResponseDecorator("http://localhost:%d%s".formatted(port, basePath() + CATALOG_REQUEST));
+            }
+
+            @Test
+            void shouldApplyContinuationToken_whenPassed() {
+                var requestBody = createObjectBuilder().add(TYPE, namespace().toIri(DSPACE_TYPE_CATALOG_REQUEST_MESSAGE_TERM)).build();
+                var catalog = createObjectBuilder().add(JsonLdKeywords.TYPE, "catalog").build();
+                when(transformerRegistry.transform(any(Catalog.class), eq(JsonObject.class))).thenReturn(Result.success(catalog));
+                when(dspRequestHandler.createResource(any(), any())).thenReturn(Response.ok().type(APPLICATION_JSON_TYPE).build());
+                when(continuationTokenManager.createResponseDecorator(any())).thenReturn(mock());
+                var enrichedRequestBody = createObjectBuilder(requestBody).add("query", Json.createObjectBuilder()).build();
+                when(continuationTokenManager.applyQueryFromToken(any(), any())).thenReturn(Result.success(enrichedRequestBody));
+
+                baseRequest()
+                        .contentType(JSON)
+                        .body(requestBody)
+                        .post(CATALOG_REQUEST + "?continuationToken=pagination-token")
+                        .then()
+                        .statusCode(200)
+                        .contentType(JSON);
+
+                var captor = ArgumentCaptor.forClass(PostDspRequest.class);
+                verify(dspRequestHandler).createResource(captor.capture(), isA(ResponseDecorator.class));
+                var request = captor.getValue();
+                assertThat(request.getMessage()).isSameAs(enrichedRequestBody);
+                verify(continuationTokenManager).applyQueryFromToken(requestBody, "pagination-token");
+            }
+
+            @Test
+            void shouldReturnBadRequest_whenContinuationTokenIsNotValid() {
+                var requestBody = createObjectBuilder().add(TYPE, namespace().toIri(DSPACE_TYPE_CATALOG_REQUEST_MESSAGE_TERM)).build();
+                when(continuationTokenManager.applyQueryFromToken(any(), any())).thenReturn(Result.failure("error"));
+
+                baseRequest()
+                        .contentType(JSON)
+                        .body(requestBody)
+                        .post(CATALOG_REQUEST + "?continuationToken=pagination-token")
+                        .then()
+                        .statusCode(400);
+
+                verifyNoInteractions(dspRequestHandler, transformerRegistry);
+            }
         }
     }
 
+    @ApiTest
+    @Nested
+    class DspCatalogApiControllerV08Test extends Tests {
+
+        @Override
+        protected String basePath() {
+            return BASE_PATH;
+        }
+
+        @Override
+        protected DspNamespace namespace() {
+            return DspNamespace.V_08;
+        }
+
+        @Override
+        protected Object controller() {
+            return new DspCatalogApiController(service, dspRequestHandler, continuationTokenManager);
+        }
+    }
+
+    @ApiTest
+    @Nested
+    class DspCatalogApiControllerV20241Test extends Tests {
+
+        @Override
+        protected String basePath() {
+            return V_2024_1_PATH + BASE_PATH;
+        }
+
+        @Override
+        protected DspNamespace namespace() {
+            return DspNamespace.V_2024_1;
+        }
+
+        @Override
+        protected Object controller() {
+            return new DspCatalogApiController20241(service, dspRequestHandler, continuationTokenManager);
+        }
+    }
 }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/DspNegotiationApiController.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/DspNegotiationApiController.java
@@ -49,6 +49,7 @@ import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPa
 import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.INITIAL_CONTRACT_REQUEST;
 import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.TERMINATION;
 import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.VERIFICATION;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_AGREEMENT_VERIFICATION_MESSAGE_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE_TERM;
@@ -73,7 +74,7 @@ public class DspNegotiationApiController {
     public DspNegotiationApiController(ContractNegotiationProtocolService protocolService,
                                        DspRequestHandler dspRequestHandler) {
 
-        this(protocolService, dspRequestHandler, DATASPACE_PROTOCOL_HTTP, DspNamespace.V_08);
+        this(protocolService, dspRequestHandler, DATASPACE_PROTOCOL_HTTP, DSP_NAMESPACE_V_08);
     }
 
     public DspNegotiationApiController(ContractNegotiationProtocolService protocolService,

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/DspNegotiationApiController.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/DspNegotiationApiController.java
@@ -36,6 +36,7 @@ import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.C
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
 import org.eclipse.edc.protocol.dsp.http.spi.message.GetDspRequest;
 import org.eclipse.edc.protocol.dsp.http.spi.message.PostDspRequest;
+import org.eclipse.edc.protocol.dsp.spi.type.DspNamespace;
 
 import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static org.eclipse.edc.protocol.dsp.http.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP;
@@ -48,12 +49,12 @@ import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPa
 import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.INITIAL_CONTRACT_REQUEST;
 import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.TERMINATION;
 import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.VERIFICATION;
-import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE_IRI;
-import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_AGREEMENT_VERIFICATION_MESSAGE_IRI;
-import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE_IRI;
-import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_TERMINATION_MESSAGE_IRI;
-import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_OFFER_MESSAGE_IRI;
-import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE_IRI;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_AGREEMENT_VERIFICATION_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_TERMINATION_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_OFFER_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE_TERM;
 
 /**
  * Provides consumer and provider endpoints for the contract negotiation according to the http binding
@@ -66,20 +67,23 @@ public class DspNegotiationApiController {
 
     private final DspRequestHandler dspRequestHandler;
     private final String protocol;
+    private final DspNamespace namespace;
     private final ContractNegotiationProtocolService protocolService;
 
     public DspNegotiationApiController(ContractNegotiationProtocolService protocolService,
                                        DspRequestHandler dspRequestHandler) {
 
-        this(protocolService, dspRequestHandler, DATASPACE_PROTOCOL_HTTP);
+        this(protocolService, dspRequestHandler, DATASPACE_PROTOCOL_HTTP, DspNamespace.V_08);
     }
 
     public DspNegotiationApiController(ContractNegotiationProtocolService protocolService,
                                        DspRequestHandler dspRequestHandler,
-                                       String protocol) {
+                                       String protocol,
+                                       DspNamespace namespace) {
         this.protocolService = protocolService;
         this.dspRequestHandler = dspRequestHandler;
         this.protocol = protocol;
+        this.namespace = namespace;
     }
 
     /**
@@ -112,7 +116,7 @@ public class DspNegotiationApiController {
     @Path(INITIAL_CONTRACT_REQUEST)
     public Response initialContractRequest(JsonObject jsonObject, @HeaderParam(AUTHORIZATION) String token) {
         var request = PostDspRequest.Builder.newInstance(ContractRequestMessage.class, ContractNegotiation.class, ContractNegotiationError.class)
-                .expectedMessageType(DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE_IRI)
+                .expectedMessageType(namespace.toIri(DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE_TERM))
                 .message(jsonObject)
                 .token(token)
                 .serviceCall(protocolService::notifyRequested)
@@ -134,7 +138,7 @@ public class DspNegotiationApiController {
     @Path(INITIAL_CONTRACT_OFFER)
     public Response initialContractOffer(JsonObject jsonObject, @HeaderParam(AUTHORIZATION) String token) {
         var request = PostDspRequest.Builder.newInstance(ContractOfferMessage.class, ContractNegotiation.class, ContractNegotiationError.class)
-                .expectedMessageType(DSPACE_TYPE_CONTRACT_OFFER_MESSAGE_IRI)
+                .expectedMessageType(namespace.toIri(DSPACE_TYPE_CONTRACT_OFFER_MESSAGE_TERM))
                 .message(jsonObject)
                 .token(token)
                 .serviceCall(protocolService::notifyOffered)
@@ -159,7 +163,7 @@ public class DspNegotiationApiController {
                                     JsonObject jsonObject,
                                     @HeaderParam(AUTHORIZATION) String token) {
         var request = PostDspRequest.Builder.newInstance(ContractRequestMessage.class, ContractNegotiation.class, ContractNegotiationError.class)
-                .expectedMessageType(DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE_IRI)
+                .expectedMessageType(namespace.toIri(DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE_TERM))
                 .processId(id)
                 .message(jsonObject)
                 .token(token)
@@ -185,7 +189,7 @@ public class DspNegotiationApiController {
                                 JsonObject jsonObject,
                                 @HeaderParam(AUTHORIZATION) String token) {
         var request = PostDspRequest.Builder.newInstance(ContractNegotiationEventMessage.class, ContractNegotiation.class, ContractNegotiationError.class)
-                .expectedMessageType(DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE_IRI)
+                .expectedMessageType(namespace.toIri(DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE_TERM))
                 .processId(id)
                 .message(jsonObject)
                 .token(token)
@@ -214,7 +218,7 @@ public class DspNegotiationApiController {
                                     JsonObject jsonObject,
                                     @HeaderParam(AUTHORIZATION) String token) {
         var request = PostDspRequest.Builder.newInstance(ContractAgreementVerificationMessage.class, ContractNegotiation.class, ContractNegotiationError.class)
-                .expectedMessageType(DSPACE_TYPE_CONTRACT_AGREEMENT_VERIFICATION_MESSAGE_IRI)
+                .expectedMessageType(namespace.toIri(DSPACE_TYPE_CONTRACT_AGREEMENT_VERIFICATION_MESSAGE_TERM))
                 .processId(id)
                 .message(jsonObject)
                 .token(token)
@@ -240,7 +244,7 @@ public class DspNegotiationApiController {
                                          JsonObject jsonObject,
                                          @HeaderParam(AUTHORIZATION) String token) {
         var request = PostDspRequest.Builder.newInstance(ContractNegotiationTerminationMessage.class, ContractNegotiation.class, ContractNegotiationError.class)
-                .expectedMessageType(DSPACE_TYPE_CONTRACT_NEGOTIATION_TERMINATION_MESSAGE_IRI)
+                .expectedMessageType(namespace.toIri(DSPACE_TYPE_CONTRACT_NEGOTIATION_TERMINATION_MESSAGE_TERM))
                 .processId(id)
                 .message(jsonObject)
                 .token(token)
@@ -266,7 +270,7 @@ public class DspNegotiationApiController {
                                   JsonObject body,
                                   @HeaderParam(AUTHORIZATION) String token) {
         var request = PostDspRequest.Builder.newInstance(ContractOfferMessage.class, ContractNegotiation.class, ContractNegotiationError.class)
-                .expectedMessageType(DSPACE_TYPE_CONTRACT_OFFER_MESSAGE_IRI)
+                .expectedMessageType(namespace.toIri(DSPACE_TYPE_CONTRACT_OFFER_MESSAGE_TERM))
                 .processId(id)
                 .message(body)
                 .token(token)
@@ -292,7 +296,7 @@ public class DspNegotiationApiController {
                                     JsonObject jsonObject,
                                     @HeaderParam(AUTHORIZATION) String token) {
         var request = PostDspRequest.Builder.newInstance(ContractAgreementMessage.class, ContractNegotiation.class, ContractNegotiationError.class)
-                .expectedMessageType(DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE_IRI)
+                .expectedMessageType(namespace.toIri(DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE_TERM))
                 .processId(id)
                 .message(jsonObject)
                 .token(token)

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/DspNegotiationApiController20241.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/DspNegotiationApiController20241.java
@@ -20,11 +20,11 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationProtocolService;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
-import org.eclipse.edc.protocol.dsp.spi.type.DspNamespace;
 import org.eclipse.edc.protocol.dsp.spi.version.DspVersions;
 
 import static org.eclipse.edc.protocol.dsp.http.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP_V_2024_1;
 import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.BASE_PATH;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_2024_1;
 
 /**
  * Versioned Negotiation endpoint, same as {@link DspNegotiationApiController} but exposed on the /2024/1 path
@@ -35,6 +35,6 @@ import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPa
 public class DspNegotiationApiController20241 extends DspNegotiationApiController {
 
     public DspNegotiationApiController20241(ContractNegotiationProtocolService protocolService, DspRequestHandler dspRequestHandler) {
-        super(protocolService, dspRequestHandler, DATASPACE_PROTOCOL_HTTP_V_2024_1, DspNamespace.V_2024_1);
+        super(protocolService, dspRequestHandler, DATASPACE_PROTOCOL_HTTP_V_2024_1, DSP_NAMESPACE_V_2024_1);
     }
 }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/DspNegotiationApiController20241.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/DspNegotiationApiController20241.java
@@ -20,6 +20,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationProtocolService;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
+import org.eclipse.edc.protocol.dsp.spi.type.DspNamespace;
 import org.eclipse.edc.protocol.dsp.spi.version.DspVersions;
 
 import static org.eclipse.edc.protocol.dsp.http.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP_V_2024_1;
@@ -34,6 +35,6 @@ import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPa
 public class DspNegotiationApiController20241 extends DspNegotiationApiController {
 
     public DspNegotiationApiController20241(ContractNegotiationProtocolService protocolService, DspRequestHandler dspRequestHandler) {
-        super(protocolService, dspRequestHandler, DATASPACE_PROTOCOL_HTTP_V_2024_1);
+        super(protocolService, dspRequestHandler, DATASPACE_PROTOCOL_HTTP_V_2024_1, DspNamespace.V_2024_1);
     }
 }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-api/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/DspNegotiationApiControllerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-api/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/DspNegotiationApiControllerTest.java
@@ -56,6 +56,8 @@ import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPa
 import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.INITIAL_CONTRACT_REQUEST;
 import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.TERMINATION;
 import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.VERIFICATION;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_2024_1;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_AGREEMENT_VERIFICATION_MESSAGE_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE_TERM;
@@ -231,7 +233,7 @@ class DspNegotiationApiControllerTest {
 
         @Override
         protected DspNamespace namespace() {
-            return DspNamespace.V_08;
+            return DSP_NAMESPACE_V_08;
         }
 
         @Override
@@ -251,7 +253,7 @@ class DspNegotiationApiControllerTest {
 
         @Override
         protected DspNamespace namespace() {
-            return DspNamespace.V_2024_1;
+            return DSP_NAMESPACE_V_2024_1;
         }
 
         @Override

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-api/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/DspNegotiationApiControllerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-api/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/DspNegotiationApiControllerTest.java
@@ -29,7 +29,9 @@ import org.eclipse.edc.junit.annotations.ApiTest;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
 import org.eclipse.edc.protocol.dsp.http.spi.message.GetDspRequest;
 import org.eclipse.edc.protocol.dsp.http.spi.message.PostDspRequest;
+import org.eclipse.edc.protocol.dsp.spi.type.DspNamespace;
 import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -54,167 +56,207 @@ import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPa
 import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.INITIAL_CONTRACT_REQUEST;
 import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.TERMINATION;
 import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.VERIFICATION;
-import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE_IRI;
-import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_AGREEMENT_VERIFICATION_MESSAGE_IRI;
-import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE_IRI;
-import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_TERMINATION_MESSAGE_IRI;
-import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_OFFER_MESSAGE_IRI;
-import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE_IRI;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_AGREEMENT_VERIFICATION_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_TERMINATION_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_OFFER_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.version.DspVersions.V_2024_1_PATH;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ApiTest
-class DspNegotiationApiControllerTest extends RestControllerTestBase {
+class DspNegotiationApiControllerTest {
 
-    private final ContractNegotiationProtocolService protocolService = mock();
-    private final DspRequestHandler dspRequestHandler = mock();
+    abstract static class Tests extends RestControllerTestBase {
 
-    @Test
-    void getNegotiation_shouldGetResource() {
-        when(dspRequestHandler.getResource(any())).thenReturn(Response.ok().type(APPLICATION_JSON_TYPE).build());
+        protected final ContractNegotiationProtocolService protocolService = mock();
+        protected final DspRequestHandler dspRequestHandler = mock();
 
-        var result = baseRequest()
-                .get(BASE_PATH + "negotiationId")
-                .then()
-                .contentType(APPLICATION_JSON)
-                .statusCode(200);
+        @Test
+        void getNegotiation_shouldGetResource() {
+            when(dspRequestHandler.getResource(any())).thenReturn(Response.ok().type(APPLICATION_JSON_TYPE).build());
 
-        assertThat(result).isNotNull();
-        var captor = ArgumentCaptor.forClass(GetDspRequest.class);
-        verify(dspRequestHandler).getResource(captor.capture());
-        var dspMessage = captor.getValue();
-        assertThat(dspMessage.getToken()).isEqualTo("auth");
-        assertThat(dspMessage.getId()).isEqualTo("negotiationId");
-        assertThat(dspMessage.getResultClass()).isEqualTo(ContractNegotiation.class);
-    }
+            var result = baseRequest()
+                    .get(basePath() + "negotiationId")
+                    .then()
+                    .contentType(APPLICATION_JSON)
+                    .statusCode(200);
 
-    @Test
-    void initialContractRequest_shouldCreateResource() {
-        var requestBody = createObjectBuilder().add("@type", DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE_IRI).build();
-        when(dspRequestHandler.createResource(any())).thenReturn(Response.ok().type(APPLICATION_JSON_TYPE).build());
+            assertThat(result).isNotNull();
+            var captor = ArgumentCaptor.forClass(GetDspRequest.class);
+            verify(dspRequestHandler).getResource(captor.capture());
+            var dspMessage = captor.getValue();
+            assertThat(dspMessage.getToken()).isEqualTo("auth");
+            assertThat(dspMessage.getId()).isEqualTo("negotiationId");
+            assertThat(dspMessage.getResultClass()).isEqualTo(ContractNegotiation.class);
+        }
 
-        var result = baseRequest()
-                .contentType(APPLICATION_JSON)
-                .body(requestBody)
-                .post(BASE_PATH + INITIAL_CONTRACT_REQUEST)
-                .then()
-                .statusCode(200)
-                .contentType(APPLICATION_JSON);
+        @Test
+        void initialContractRequest_shouldCreateResource() {
+            var requestBody = createObjectBuilder().add("@type", namespace().toIri(DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE_TERM)).build();
+            when(dspRequestHandler.createResource(any())).thenReturn(Response.ok().type(APPLICATION_JSON_TYPE).build());
 
-        assertThat(result).isNotNull();
-        var captor = ArgumentCaptor.forClass(PostDspRequest.class);
-        verify(dspRequestHandler).createResource(captor.capture());
-        var request = captor.getValue();
-        assertThat(request.getToken()).isEqualTo("auth");
-        assertThat(request.getProcessId()).isEqualTo(null);
-        assertThat(request.getMessage()).isNotNull();
-        assertThat(request.getInputClass()).isEqualTo(ContractRequestMessage.class);
-        assertThat(request.getResultClass()).isEqualTo(ContractNegotiation.class);
-        assertThat(request.getExpectedMessageType()).isEqualTo(DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE_IRI);
-    }
+            var result = baseRequest()
+                    .contentType(APPLICATION_JSON)
+                    .body(requestBody)
+                    .post(basePath() + INITIAL_CONTRACT_REQUEST)
+                    .then()
+                    .statusCode(200)
+                    .contentType(APPLICATION_JSON);
 
-    @Test
-    void initialContractOffer_shouldCreateResource() {
-        var requestBody = createObjectBuilder().add("@type", DSPACE_TYPE_CONTRACT_OFFER_MESSAGE_IRI).build();
-        when(dspRequestHandler.createResource(any())).thenReturn(Response.ok().type(APPLICATION_JSON_TYPE).build());
+            assertThat(result).isNotNull();
+            var captor = ArgumentCaptor.forClass(PostDspRequest.class);
+            verify(dspRequestHandler).createResource(captor.capture());
+            var request = captor.getValue();
+            assertThat(request.getToken()).isEqualTo("auth");
+            assertThat(request.getProcessId()).isEqualTo(null);
+            assertThat(request.getMessage()).isNotNull();
+            assertThat(request.getInputClass()).isEqualTo(ContractRequestMessage.class);
+            assertThat(request.getResultClass()).isEqualTo(ContractNegotiation.class);
+            assertThat(request.getExpectedMessageType()).isEqualTo(namespace().toIri(DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE_TERM));
+        }
 
-        var result = baseRequest()
-                .contentType(APPLICATION_JSON)
-                .body(requestBody)
-                .post(BASE_PATH + INITIAL_CONTRACT_OFFER)
-                .then()
-                .statusCode(200)
-                .contentType(APPLICATION_JSON);
+        @Test
+        void initialContractOffer_shouldCreateResource() {
+            var requestBody = createObjectBuilder().add("@type", namespace().toIri(DSPACE_TYPE_CONTRACT_OFFER_MESSAGE_TERM)).build();
+            when(dspRequestHandler.createResource(any())).thenReturn(Response.ok().type(APPLICATION_JSON_TYPE).build());
 
-        assertThat(result).isNotNull();
-        var captor = ArgumentCaptor.forClass(PostDspRequest.class);
-        verify(dspRequestHandler).createResource(captor.capture());
-        var request = captor.getValue();
-        assertThat(request.getToken()).isEqualTo("auth");
-        assertThat(request.getProcessId()).isEqualTo(null);
-        assertThat(request.getMessage()).isNotNull();
-        assertThat(request.getInputClass()).isEqualTo(ContractOfferMessage.class);
-        assertThat(request.getResultClass()).isEqualTo(ContractNegotiation.class);
-        assertThat(request.getExpectedMessageType()).isEqualTo(DSPACE_TYPE_CONTRACT_OFFER_MESSAGE_IRI);
-    }
+            var result = baseRequest()
+                    .contentType(APPLICATION_JSON)
+                    .body(requestBody)
+                    .post(basePath() + INITIAL_CONTRACT_OFFER)
+                    .then()
+                    .statusCode(200)
+                    .contentType(APPLICATION_JSON);
 
-    /**
-     * Verifies that an endpoint returns 401 if the identity service cannot verify the identity token.
-     *
-     * @param path the request path to the endpoint
-     */
-    @ParameterizedTest
-    @ArgumentsSource(ControllerMethodArguments.class)
-    void callEndpoint_shouldUpdateResource(String path, Class<?> messageClass, String messageType) {
-        when(dspRequestHandler.updateResource(any())).thenReturn(Response.ok().type(APPLICATION_JSON_TYPE).build());
-        var requestBody = createObjectBuilder().add("http://schema/key", "value").build();
+            assertThat(result).isNotNull();
+            var captor = ArgumentCaptor.forClass(PostDspRequest.class);
+            verify(dspRequestHandler).createResource(captor.capture());
+            var request = captor.getValue();
+            assertThat(request.getToken()).isEqualTo("auth");
+            assertThat(request.getProcessId()).isEqualTo(null);
+            assertThat(request.getMessage()).isNotNull();
+            assertThat(request.getInputClass()).isEqualTo(ContractOfferMessage.class);
+            assertThat(request.getResultClass()).isEqualTo(ContractNegotiation.class);
+            assertThat(request.getExpectedMessageType()).isEqualTo(namespace().toIri(DSPACE_TYPE_CONTRACT_OFFER_MESSAGE_TERM));
+        }
 
-        baseRequest()
-                .contentType(APPLICATION_JSON)
-                .body(requestBody)
-                .post(path)
-                .then()
-                .contentType(APPLICATION_JSON)
-                .statusCode(200);
+        /**
+         * Verifies that an endpoint returns 401 if the identity service cannot verify the identity token.
+         *
+         * @param path the request path to the endpoint
+         */
+        @ParameterizedTest
+        @ArgumentsSource(ControllerMethodArguments.class)
+        void callEndpoint_shouldUpdateResource(String path, Class<?> messageClass, String messageType) {
+            when(dspRequestHandler.updateResource(any())).thenReturn(Response.ok().type(APPLICATION_JSON_TYPE).build());
+            var requestBody = createObjectBuilder().add("http://schema/key", "value").build();
 
-        var captor = ArgumentCaptor.forClass(PostDspRequest.class);
-        verify(dspRequestHandler).updateResource(captor.capture());
-        var request = captor.getValue();
-        assertThat(request.getExpectedMessageType()).isEqualTo(messageType);
-        assertThat(request.getToken()).isEqualTo("auth");
-        assertThat(request.getProcessId()).isEqualTo("testId");
-        assertThat(request.getMessage()).isNotNull();
-        assertThat(request.getInputClass()).isEqualTo(messageClass);
-        assertThat(request.getResultClass()).isEqualTo(ContractNegotiation.class);
-        assertThat(request.getExpectedMessageType()).isEqualTo(messageType);
-    }
+            baseRequest()
+                    .contentType(APPLICATION_JSON)
+                    .body(requestBody)
+                    .post(basePath() + path)
+                    .then()
+                    .contentType(APPLICATION_JSON)
+                    .statusCode(200);
 
-    @Override
-    protected Object controller() {
-        return new DspNegotiationApiController(protocolService, dspRequestHandler);
-    }
+            var captor = ArgumentCaptor.forClass(PostDspRequest.class);
+            verify(dspRequestHandler).updateResource(captor.capture());
+            var request = captor.getValue();
+            assertThat(request.getExpectedMessageType()).isEqualTo(namespace().toIri(messageType));
+            assertThat(request.getToken()).isEqualTo("auth");
+            assertThat(request.getProcessId()).isEqualTo("testId");
+            assertThat(request.getMessage()).isNotNull();
+            assertThat(request.getInputClass()).isEqualTo(messageClass);
+            assertThat(request.getResultClass()).isEqualTo(ContractNegotiation.class);
+        }
 
-    private RequestSpecification baseRequest() {
-        var authHeader = "auth";
-        return given()
-                .baseUri("http://localhost:" + port)
-                .basePath("/")
-                .header(HttpHeaders.AUTHORIZATION, authHeader)
-                .when();
-    }
+        protected abstract String basePath();
 
-    private static class ControllerMethodArguments implements ArgumentsProvider {
-        @Override
-        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-            return Stream.of(
-                    Arguments.of(
-                            BASE_PATH + "testId" + CONTRACT_REQUEST,
-                            ContractRequestMessage.class,
-                            DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE_IRI),
-                    Arguments.of(
-                            BASE_PATH + "testId" + EVENT,
-                            ContractNegotiationEventMessage.class,
-                            DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE_IRI),
-                    Arguments.of(
-                            BASE_PATH + "testId" + AGREEMENT + VERIFICATION,
-                            ContractAgreementVerificationMessage.class,
-                            DSPACE_TYPE_CONTRACT_AGREEMENT_VERIFICATION_MESSAGE_IRI),
-                    Arguments.of(
-                            BASE_PATH + "testId" + TERMINATION,
-                            ContractNegotiationTerminationMessage.class,
-                            DSPACE_TYPE_CONTRACT_NEGOTIATION_TERMINATION_MESSAGE_IRI),
-                    Arguments.of(
-                            BASE_PATH + "testId" + AGREEMENT,
-                            ContractAgreementMessage.class,
-                            DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE_IRI),
-                    Arguments.of(
-                            BASE_PATH + "testId" + CONTRACT_OFFER,
-                            ContractOfferMessage.class,
-                            DSPACE_TYPE_CONTRACT_OFFER_MESSAGE_IRI)
-            );
+        protected abstract DspNamespace namespace();
+
+        private RequestSpecification baseRequest() {
+            var authHeader = "auth";
+            return given()
+                    .baseUri("http://localhost:" + port)
+                    .basePath("/")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader)
+                    .when();
+        }
+
+        private static class ControllerMethodArguments implements ArgumentsProvider {
+            @Override
+            public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+                return Stream.of(
+                        Arguments.of(
+                                "testId" + CONTRACT_REQUEST,
+                                ContractRequestMessage.class,
+                                DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE_TERM),
+                        Arguments.of(
+                                "testId" + EVENT,
+                                ContractNegotiationEventMessage.class,
+                                DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE_TERM),
+                        Arguments.of(
+                                "testId" + AGREEMENT + VERIFICATION,
+                                ContractAgreementVerificationMessage.class,
+                                DSPACE_TYPE_CONTRACT_AGREEMENT_VERIFICATION_MESSAGE_TERM),
+                        Arguments.of(
+                                "testId" + TERMINATION,
+                                ContractNegotiationTerminationMessage.class,
+                                DSPACE_TYPE_CONTRACT_NEGOTIATION_TERMINATION_MESSAGE_TERM),
+                        Arguments.of(
+                                "testId" + AGREEMENT,
+                                ContractAgreementMessage.class,
+                                DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE_TERM),
+                        Arguments.of(
+                                "testId" + CONTRACT_OFFER,
+                                ContractOfferMessage.class,
+                                DSPACE_TYPE_CONTRACT_OFFER_MESSAGE_TERM)
+                );
+            }
         }
     }
 
+    @ApiTest
+    @Nested
+    class DspNegotiationApiControllerV08Test extends Tests {
+
+        @Override
+        protected String basePath() {
+            return BASE_PATH;
+        }
+
+        @Override
+        protected DspNamespace namespace() {
+            return DspNamespace.V_08;
+        }
+
+        @Override
+        protected Object controller() {
+            return new DspNegotiationApiController(protocolService, dspRequestHandler);
+        }
+    }
+
+    @ApiTest
+    @Nested
+    class DspNegotiationApiControllerV20241Test extends Tests {
+
+        @Override
+        protected String basePath() {
+            return V_2024_1_PATH + BASE_PATH;
+        }
+
+        @Override
+        protected DspNamespace namespace() {
+            return DspNamespace.V_2024_1;
+        }
+
+        @Override
+        protected Object controller() {
+            return new DspNegotiationApiController20241(protocolService, dspRequestHandler);
+        }
+    }
 }

--- a/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/spi/type/DspConstants.java
+++ b/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/spi/type/DspConstants.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.protocol.dsp.spi.type;
 
+import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
 import static org.eclipse.edc.protocol.dsp.spi.version.DspVersions.V_08_VERSION;
 import static org.eclipse.edc.protocol.dsp.spi.version.DspVersions.V_2024_1_VERSION;
 
@@ -27,4 +28,7 @@ public interface DspConstants {
     String DSP_TRANSFORMER_CONTEXT = "dsp-api";
     String DSP_TRANSFORMER_CONTEXT_V_08 = DSP_TRANSFORMER_CONTEXT + DSP_CONTEXT_SEPARATOR + V_08_VERSION;
     String DSP_TRANSFORMER_CONTEXT_V_2024_1 = DSP_TRANSFORMER_CONTEXT + DSP_CONTEXT_SEPARATOR + V_2024_1_VERSION;
+
+    DspNamespace DSP_NAMESPACE_V_08 = new DspNamespace(DSPACE_SCHEMA);
+    DspNamespace DSP_NAMESPACE_V_2024_1 = new DspNamespace(DSPACE_SCHEMA);
 }

--- a/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/spi/type/DspNamespace.java
+++ b/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/spi/type/DspNamespace.java
@@ -14,30 +14,10 @@
 
 package org.eclipse.edc.protocol.dsp.spi.type;
 
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
-
 /**
- * Enum representing different versions of the DSP (Data Space Protocol) namespace.
- * Each version is associated with a specific namespace URI.
+ * Represents a namespace for DSP terms.
  */
-public enum DspNamespace {
-    V_08(DSPACE_SCHEMA),
-    V_2024_1(DSPACE_SCHEMA);
-
-    private final String namespace;
-
-    DspNamespace(String namespace) {
-        this.namespace = namespace;
-    }
-
-    /**
-     * Returns the namespace URI associated with the version.
-     *
-     * @return the namespace URI as a string.
-     */
-    public String namespace() {
-        return namespace;
-    }
+public record DspNamespace(String namespace) {
 
     /**
      * Converts a given term to its IRI (Internationalized Resource Identifier) by appending it to the namespace.

--- a/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/spi/type/DspNamespace.java
+++ b/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/spi/type/DspNamespace.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.spi.type;
+
+import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+
+/**
+ * Enum representing different versions of the DSP (Data Space Protocol) namespace.
+ * Each version is associated with a specific namespace URI.
+ */
+public enum DspNamespace {
+    V_08(DSPACE_SCHEMA),
+    V_2024_1(DSPACE_SCHEMA);
+
+    private final String namespace;
+
+    DspNamespace(String namespace) {
+        this.namespace = namespace;
+    }
+
+    /**
+     * Returns the namespace URI associated with the version.
+     *
+     * @return the namespace URI as a string.
+     */
+    public String namespace() {
+        return namespace;
+    }
+
+    /**
+     * Converts a given term to its IRI (Internationalized Resource Identifier) by appending it to the namespace.
+     *
+     * @param term the term to be converted to an IRI.
+     * @return the IRI as a string.
+     */
+    public String toIri(String term) {
+        return namespace + term;
+    }
+}

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-http-api/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/controller/DspTransferProcessApiController.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-http-api/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/controller/DspTransferProcessApiController.java
@@ -39,6 +39,7 @@ import org.eclipse.edc.protocol.dsp.spi.type.DspNamespace;
 
 import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static org.eclipse.edc.protocol.dsp.http.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_REQUEST_MESSAGE_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_START_MESSAGE_TERM;
@@ -66,7 +67,7 @@ public class DspTransferProcessApiController {
     private final DspNamespace namespace;
 
     public DspTransferProcessApiController(TransferProcessProtocolService protocolService, DspRequestHandler dspRequestHandler) {
-        this(protocolService, dspRequestHandler, DATASPACE_PROTOCOL_HTTP, DspNamespace.V_08);
+        this(protocolService, dspRequestHandler, DATASPACE_PROTOCOL_HTTP, DSP_NAMESPACE_V_08);
     }
 
     public DspTransferProcessApiController(TransferProcessProtocolService protocolService, DspRequestHandler dspRequestHandler, String protocol, DspNamespace namespace) {

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-http-api/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/controller/DspTransferProcessApiController.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-http-api/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/controller/DspTransferProcessApiController.java
@@ -35,14 +35,15 @@ import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.Transf
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
 import org.eclipse.edc.protocol.dsp.http.spi.message.GetDspRequest;
 import org.eclipse.edc.protocol.dsp.http.spi.message.PostDspRequest;
+import org.eclipse.edc.protocol.dsp.spi.type.DspNamespace;
 
 import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static org.eclipse.edc.protocol.dsp.http.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP;
-import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE_IRI;
-import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_REQUEST_MESSAGE_IRI;
-import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_START_MESSAGE_IRI;
-import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_SUSPENSION_MESSAGE_IRI;
-import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_TERMINATION_MESSAGE_IRI;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_REQUEST_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_START_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_SUSPENSION_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_TERMINATION_MESSAGE_TERM;
 import static org.eclipse.edc.protocol.dsp.transferprocess.http.api.TransferProcessApiPaths.BASE_PATH;
 import static org.eclipse.edc.protocol.dsp.transferprocess.http.api.TransferProcessApiPaths.TRANSFER_COMPLETION;
 import static org.eclipse.edc.protocol.dsp.transferprocess.http.api.TransferProcessApiPaths.TRANSFER_INITIAL_REQUEST;
@@ -62,15 +63,17 @@ public class DspTransferProcessApiController {
     private final TransferProcessProtocolService protocolService;
     private final DspRequestHandler dspRequestHandler;
     private final String protocol;
+    private final DspNamespace namespace;
 
     public DspTransferProcessApiController(TransferProcessProtocolService protocolService, DspRequestHandler dspRequestHandler) {
-        this(protocolService, dspRequestHandler, DATASPACE_PROTOCOL_HTTP);
+        this(protocolService, dspRequestHandler, DATASPACE_PROTOCOL_HTTP, DspNamespace.V_08);
     }
 
-    public DspTransferProcessApiController(TransferProcessProtocolService protocolService, DspRequestHandler dspRequestHandler, String protocol) {
+    public DspTransferProcessApiController(TransferProcessProtocolService protocolService, DspRequestHandler dspRequestHandler, String protocol, DspNamespace namespace) {
         this.protocolService = protocolService;
         this.dspRequestHandler = dspRequestHandler;
         this.protocol = protocol;
+        this.namespace = namespace;
     }
 
     /**
@@ -106,7 +109,7 @@ public class DspTransferProcessApiController {
         var request = PostDspRequest.Builder.newInstance(TransferRequestMessage.class, TransferProcess.class, TransferError.class)
                 .message(jsonObject)
                 .token(token)
-                .expectedMessageType(DSPACE_TYPE_TRANSFER_REQUEST_MESSAGE_IRI)
+                .expectedMessageType(namespace.toIri(DSPACE_TYPE_TRANSFER_REQUEST_MESSAGE_TERM))
                 .serviceCall(protocolService::notifyRequested)
                 .errorProvider(TransferError.Builder::newInstance)
                 .protocol(protocol)
@@ -128,7 +131,7 @@ public class DspTransferProcessApiController {
     public Response transferProcessStart(@PathParam("id") String id, JsonObject jsonObject, @HeaderParam(AUTHORIZATION) String token) {
         var request = PostDspRequest.Builder.newInstance(TransferStartMessage.class, TransferProcess.class, TransferError.class)
                 .processId(id)
-                .expectedMessageType(DSPACE_TYPE_TRANSFER_START_MESSAGE_IRI)
+                .expectedMessageType(namespace.toIri(DSPACE_TYPE_TRANSFER_START_MESSAGE_TERM))
                 .message(jsonObject)
                 .token(token)
                 .serviceCall(protocolService::notifyStarted)
@@ -152,7 +155,7 @@ public class DspTransferProcessApiController {
     public Response transferProcessCompletion(@PathParam("id") String id, JsonObject jsonObject, @HeaderParam(AUTHORIZATION) String token) {
         var request = PostDspRequest.Builder.newInstance(TransferCompletionMessage.class, TransferProcess.class, TransferError.class)
                 .processId(id)
-                .expectedMessageType(DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE_IRI)
+                .expectedMessageType(namespace.toIri(DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE_TERM))
                 .message(jsonObject)
                 .token(token)
                 .serviceCall(protocolService::notifyCompleted)
@@ -176,7 +179,7 @@ public class DspTransferProcessApiController {
     public Response transferProcessTermination(@PathParam("id") String id, JsonObject jsonObject, @HeaderParam(AUTHORIZATION) String token) {
         var request = PostDspRequest.Builder.newInstance(TransferTerminationMessage.class, TransferProcess.class, TransferError.class)
                 .processId(id)
-                .expectedMessageType(DSPACE_TYPE_TRANSFER_TERMINATION_MESSAGE_IRI)
+                .expectedMessageType(namespace.toIri(DSPACE_TYPE_TRANSFER_TERMINATION_MESSAGE_TERM))
                 .message(jsonObject)
                 .token(token)
                 .serviceCall(protocolService::notifyTerminated)
@@ -200,7 +203,7 @@ public class DspTransferProcessApiController {
     public Response transferProcessSuspension(@PathParam("id") String id, JsonObject jsonObject, @HeaderParam(AUTHORIZATION) String token) {
         var request = PostDspRequest.Builder.newInstance(TransferSuspensionMessage.class, TransferProcess.class, TransferError.class)
                 .processId(id)
-                .expectedMessageType(DSPACE_TYPE_TRANSFER_SUSPENSION_MESSAGE_IRI)
+                .expectedMessageType(namespace.toIri(DSPACE_TYPE_TRANSFER_SUSPENSION_MESSAGE_TERM))
                 .message(jsonObject)
                 .token(token)
                 .serviceCall(protocolService::notifySuspended)

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-http-api/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/controller/DspTransferProcessApiController20241.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-http-api/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/controller/DspTransferProcessApiController20241.java
@@ -20,10 +20,10 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessProtocolService;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
-import org.eclipse.edc.protocol.dsp.spi.type.DspNamespace;
 import org.eclipse.edc.protocol.dsp.spi.version.DspVersions;
 
 import static org.eclipse.edc.protocol.dsp.http.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP_V_2024_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_2024_1;
 import static org.eclipse.edc.protocol.dsp.transferprocess.http.api.TransferProcessApiPaths.BASE_PATH;
 
 
@@ -36,6 +36,6 @@ import static org.eclipse.edc.protocol.dsp.transferprocess.http.api.TransferProc
 public class DspTransferProcessApiController20241 extends DspTransferProcessApiController {
 
     public DspTransferProcessApiController20241(TransferProcessProtocolService protocolService, DspRequestHandler dspRequestHandler) {
-        super(protocolService, dspRequestHandler, DATASPACE_PROTOCOL_HTTP_V_2024_1, DspNamespace.V_2024_1);
+        super(protocolService, dspRequestHandler, DATASPACE_PROTOCOL_HTTP_V_2024_1, DSP_NAMESPACE_V_2024_1);
     }
 }

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-http-api/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/controller/DspTransferProcessApiController20241.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-http-api/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/controller/DspTransferProcessApiController20241.java
@@ -20,6 +20,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessProtocolService;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
+import org.eclipse.edc.protocol.dsp.spi.type.DspNamespace;
 import org.eclipse.edc.protocol.dsp.spi.version.DspVersions;
 
 import static org.eclipse.edc.protocol.dsp.http.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP_V_2024_1;
@@ -35,6 +36,6 @@ import static org.eclipse.edc.protocol.dsp.transferprocess.http.api.TransferProc
 public class DspTransferProcessApiController20241 extends DspTransferProcessApiController {
 
     public DspTransferProcessApiController20241(TransferProcessProtocolService protocolService, DspRequestHandler dspRequestHandler) {
-        super(protocolService, dspRequestHandler, DATASPACE_PROTOCOL_HTTP_V_2024_1);
+        super(protocolService, dspRequestHandler, DATASPACE_PROTOCOL_HTTP_V_2024_1, DspNamespace.V_2024_1);
     }
 }

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-http-api/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/controller/DspTransferProcessApiControllerTest.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-http-api/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/controller/DspTransferProcessApiControllerTest.java
@@ -30,7 +30,9 @@ import org.eclipse.edc.junit.annotations.ApiTest;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
 import org.eclipse.edc.protocol.dsp.http.spi.message.GetDspRequest;
 import org.eclipse.edc.protocol.dsp.http.spi.message.PostDspRequest;
+import org.eclipse.edc.protocol.dsp.spi.type.DspNamespace;
 import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -46,11 +48,12 @@ import static jakarta.json.Json.createObjectBuilder;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE_IRI;
-import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_REQUEST_MESSAGE_IRI;
-import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_START_MESSAGE_IRI;
-import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_SUSPENSION_MESSAGE_IRI;
-import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_TERMINATION_MESSAGE_IRI;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_REQUEST_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_START_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_SUSPENSION_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_TERMINATION_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.version.DspVersions.V_2024_1_PATH;
 import static org.eclipse.edc.protocol.dsp.transferprocess.http.api.TransferProcessApiPaths.BASE_PATH;
 import static org.eclipse.edc.protocol.dsp.transferprocess.http.api.TransferProcessApiPaths.TRANSFER_COMPLETION;
 import static org.eclipse.edc.protocol.dsp.transferprocess.http.api.TransferProcessApiPaths.TRANSFER_INITIAL_REQUEST;
@@ -63,121 +66,163 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ApiTest
-class DspTransferProcessApiControllerTest extends RestControllerTestBase {
+class DspTransferProcessApiControllerTest {
 
-    private static final String PROCESS_ID = "testId";
-    private final TransferProcessProtocolService protocolService = mock();
-    private final DspRequestHandler dspRequestHandler = mock();
+    abstract static class Tests extends RestControllerTestBase {
 
-    @Test
-    void getTransferProcess_shouldGetResource() {
-        var id = "transferProcessId";
+        private static final String PROCESS_ID = "testId";
+        protected final TransferProcessProtocolService protocolService = mock();
+        protected final DspRequestHandler dspRequestHandler = mock();
 
-        when(dspRequestHandler.getResource(any())).thenReturn(Response.ok().type(APPLICATION_JSON_TYPE).build());
+        @Test
+        void getTransferProcess_shouldGetResource() {
+            var id = "transferProcessId";
 
-        baseRequest()
-                .get(BASE_PATH + id)
-                .then()
-                .contentType(MediaType.APPLICATION_JSON)
-                .statusCode(200);
+            when(dspRequestHandler.getResource(any())).thenReturn(Response.ok().type(APPLICATION_JSON_TYPE).build());
 
-        var captor = ArgumentCaptor.forClass(GetDspRequest.class);
-        verify(dspRequestHandler).getResource(captor.capture());
-        var dspRequest = captor.getValue();
-        assertThat(dspRequest.getId()).isEqualTo("transferProcessId");
-        assertThat(dspRequest.getResultClass()).isEqualTo(TransferProcess.class);
-        assertThat(dspRequest.getToken()).isEqualTo("auth");
+            baseRequest()
+                    .get(basePath() + id)
+                    .then()
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .statusCode(200);
+
+            var captor = ArgumentCaptor.forClass(GetDspRequest.class);
+            verify(dspRequestHandler).getResource(captor.capture());
+            var dspRequest = captor.getValue();
+            assertThat(dspRequest.getId()).isEqualTo("transferProcessId");
+            assertThat(dspRequest.getResultClass()).isEqualTo(TransferProcess.class);
+            assertThat(dspRequest.getToken()).isEqualTo("auth");
+        }
+
+        @Test
+        void initiateTransferProcess_shouldCreateResource() {
+            when(dspRequestHandler.createResource(any())).thenReturn(Response.ok().type(APPLICATION_JSON_TYPE).build());
+
+            var result = baseRequest()
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(Json.createObjectBuilder().add(TYPE, namespace().toIri(DSPACE_TYPE_TRANSFER_REQUEST_MESSAGE_TERM)).build())
+                    .post(basePath() + TRANSFER_INITIAL_REQUEST)
+                    .then()
+                    .statusCode(200)
+                    .contentType(MediaType.APPLICATION_JSON);
+
+            assertThat(result).isNotNull();
+            var captor = ArgumentCaptor.forClass(PostDspRequest.class);
+            verify(dspRequestHandler).createResource(captor.capture());
+            var request = captor.getValue();
+            assertThat(request.getToken()).isEqualTo("auth");
+            assertThat(request.getProcessId()).isEqualTo(null);
+            assertThat(request.getInputClass()).isEqualTo(TransferRequestMessage.class);
+            assertThat(request.getResultClass()).isEqualTo(TransferProcess.class);
+            assertThat(request.getMessage()).isNotNull();
+            assertThat(request.getExpectedMessageType()).isEqualTo(namespace().toIri(DSPACE_TYPE_TRANSFER_REQUEST_MESSAGE_TERM));
+        }
+
+        /**
+         * Verifies that an endpoint returns 401 if the identity service cannot verify the identity token.
+         *
+         * @param path the request path to the endpoint
+         */
+        @ParameterizedTest
+        @ArgumentsSource(ControllerMethodArguments.class)
+        void callEndpoint_shouldUpdateResource(String path, Class<?> messageClass, String messageType) {
+            when(dspRequestHandler.updateResource(any())).thenReturn(Response.ok().type(APPLICATION_JSON_TYPE).build());
+            var requestBody = createObjectBuilder().add("http://schema/key", "value").build();
+
+            baseRequest()
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(requestBody)
+                    .post(basePath() + path)
+                    .then()
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .statusCode(200);
+
+            var captor = ArgumentCaptor.forClass(PostDspRequest.class);
+            verify(dspRequestHandler).updateResource(captor.capture());
+            var request = captor.getValue();
+            assertThat(request.getToken()).isEqualTo("auth");
+            assertThat(request.getProcessId()).isEqualTo(PROCESS_ID);
+            assertThat(request.getMessage()).isNotNull();
+            assertThat(request.getInputClass()).isEqualTo(messageClass);
+            assertThat(request.getResultClass()).isEqualTo(TransferProcess.class);
+            assertThat(request.getExpectedMessageType()).isEqualTo(namespace().toIri(messageType));
+        }
+
+        protected abstract String basePath();
+
+        protected abstract DspNamespace namespace();
+
+        private RequestSpecification baseRequest() {
+            return given()
+                    .baseUri("http://localhost:" + port)
+                    .basePath("/")
+                    .header(HttpHeaders.AUTHORIZATION, "auth")
+                    .when();
+        }
+
+        private static class ControllerMethodArguments implements ArgumentsProvider {
+            @Override
+            public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+                return Stream.of(
+                        Arguments.of(
+                                PROCESS_ID + TRANSFER_START,
+                                TransferStartMessage.class,
+                                DSPACE_TYPE_TRANSFER_START_MESSAGE_TERM),
+                        Arguments.of(
+                                PROCESS_ID + TRANSFER_COMPLETION,
+                                TransferCompletionMessage.class,
+                                DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE_TERM),
+                        Arguments.of(
+                                PROCESS_ID + TRANSFER_SUSPENSION,
+                                TransferSuspensionMessage.class,
+                                DSPACE_TYPE_TRANSFER_SUSPENSION_MESSAGE_TERM),
+                        Arguments.of(
+                                PROCESS_ID + TRANSFER_TERMINATION,
+                                TransferTerminationMessage.class,
+                                DSPACE_TYPE_TRANSFER_TERMINATION_MESSAGE_TERM)
+                );
+            }
+        }
+
     }
 
-    @Test
-    void initiateTransferProcess_shouldCreateResource() {
-        when(dspRequestHandler.createResource(any())).thenReturn(Response.ok().type(APPLICATION_JSON_TYPE).build());
+    @ApiTest
+    @Nested
+    class DspTransferProcessApiControllerV08Test extends Tests {
 
-        var result = baseRequest()
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(Json.createObjectBuilder().add(TYPE, DSPACE_TYPE_TRANSFER_REQUEST_MESSAGE_IRI).build())
-                .post(BASE_PATH + TRANSFER_INITIAL_REQUEST)
-                .then()
-                .statusCode(200)
-                .contentType(MediaType.APPLICATION_JSON);
-
-        assertThat(result).isNotNull();
-        var captor = ArgumentCaptor.forClass(PostDspRequest.class);
-        verify(dspRequestHandler).createResource(captor.capture());
-        var request = captor.getValue();
-        assertThat(request.getToken()).isEqualTo("auth");
-        assertThat(request.getProcessId()).isEqualTo(null);
-        assertThat(request.getInputClass()).isEqualTo(TransferRequestMessage.class);
-        assertThat(request.getResultClass()).isEqualTo(TransferProcess.class);
-        assertThat(request.getMessage()).isNotNull();
-        assertThat(request.getExpectedMessageType()).isEqualTo(DSPACE_TYPE_TRANSFER_REQUEST_MESSAGE_IRI);
-    }
-
-    /**
-     * Verifies that an endpoint returns 401 if the identity service cannot verify the identity token.
-     *
-     * @param path the request path to the endpoint
-     */
-    @ParameterizedTest
-    @ArgumentsSource(ControllerMethodArguments.class)
-    void callEndpoint_shouldUpdateResource(String path, Class<?> messageClass, String messageType) {
-        when(dspRequestHandler.updateResource(any())).thenReturn(Response.ok().type(APPLICATION_JSON_TYPE).build());
-        var requestBody = createObjectBuilder().add("http://schema/key", "value").build();
-
-        baseRequest()
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(requestBody)
-                .post(path)
-                .then()
-                .contentType(MediaType.APPLICATION_JSON)
-                .statusCode(200);
-
-        var captor = ArgumentCaptor.forClass(PostDspRequest.class);
-        verify(dspRequestHandler).updateResource(captor.capture());
-        var request = captor.getValue();
-        assertThat(request.getToken()).isEqualTo("auth");
-        assertThat(request.getProcessId()).isEqualTo(PROCESS_ID);
-        assertThat(request.getMessage()).isNotNull();
-        assertThat(request.getInputClass()).isEqualTo(messageClass);
-        assertThat(request.getResultClass()).isEqualTo(TransferProcess.class);
-        assertThat(request.getExpectedMessageType()).isEqualTo(messageType);
-    }
-
-    @Override
-    protected Object controller() {
-        return new DspTransferProcessApiController(protocolService, dspRequestHandler);
-    }
-
-    private RequestSpecification baseRequest() {
-        return given()
-                .baseUri("http://localhost:" + port)
-                .basePath("/")
-                .header(HttpHeaders.AUTHORIZATION, "auth")
-                .when();
-    }
-
-    private static class ControllerMethodArguments implements ArgumentsProvider {
         @Override
-        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-            return Stream.of(
-                    Arguments.of(
-                            BASE_PATH + PROCESS_ID + TRANSFER_START,
-                            TransferStartMessage.class,
-                            DSPACE_TYPE_TRANSFER_START_MESSAGE_IRI),
-                    Arguments.of(
-                            BASE_PATH + PROCESS_ID + TRANSFER_COMPLETION,
-                            TransferCompletionMessage.class,
-                            DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE_IRI),
-                    Arguments.of(
-                            BASE_PATH + PROCESS_ID + TRANSFER_SUSPENSION,
-                            TransferSuspensionMessage.class,
-                            DSPACE_TYPE_TRANSFER_SUSPENSION_MESSAGE_IRI),
-                    Arguments.of(
-                            BASE_PATH + PROCESS_ID + TRANSFER_TERMINATION,
-                            TransferTerminationMessage.class,
-                            DSPACE_TYPE_TRANSFER_TERMINATION_MESSAGE_IRI)
-            );
+        protected String basePath() {
+            return BASE_PATH;
+        }
+
+        @Override
+        protected DspNamespace namespace() {
+            return DspNamespace.V_08;
+        }
+
+        @Override
+        protected Object controller() {
+            return new DspTransferProcessApiController(protocolService, dspRequestHandler);
         }
     }
 
+    @ApiTest
+    @Nested
+    class DspTransferProcessControllerV20241Test extends Tests {
+
+        @Override
+        protected String basePath() {
+            return V_2024_1_PATH + BASE_PATH;
+        }
+
+        @Override
+        protected DspNamespace namespace() {
+            return DspNamespace.V_2024_1;
+        }
+
+        @Override
+        protected Object controller() {
+            return new DspTransferProcessApiController20241(protocolService, dspRequestHandler);
+        }
+    }
 }

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-http-api/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/controller/DspTransferProcessApiControllerTest.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-http-api/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/controller/DspTransferProcessApiControllerTest.java
@@ -48,6 +48,8 @@ import static jakarta.json.Json.createObjectBuilder;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_2024_1;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_REQUEST_MESSAGE_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_START_MESSAGE_TERM;
@@ -197,7 +199,7 @@ class DspTransferProcessApiControllerTest {
 
         @Override
         protected DspNamespace namespace() {
-            return DspNamespace.V_08;
+            return DSP_NAMESPACE_V_08;
         }
 
         @Override
@@ -217,7 +219,7 @@ class DspTransferProcessApiControllerTest {
 
         @Override
         protected DspNamespace namespace() {
-            return DspNamespace.V_2024_1;
+            return DSP_NAMESPACE_V_2024_1;
         }
 
         @Override


### PR DESCRIPTION
## What this PR changes/adds

Adds support for multi-namespace in dsp controllers by passing the namespace in the controller constructor.

In order to type the available dsp namespaces a class `DspNamespace` has been introduced.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #4510 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
