### PR TITLE
refactor: add DspNamespace usage

### DIFF
--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiController.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiController.java
@@ -32,11 +32,11 @@ import org.eclipse.edc.connector.controlplane.catalog.spi.CatalogError;
 import org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequestMessage;
 import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
 import org.eclipse.edc.connector.controlplane.services.spi.catalog.CatalogProtocolService;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.protocol.dsp.http.spi.message.ContinuationTokenManager;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
 import org.eclipse.edc.protocol.dsp.http.spi.message.GetDspRequest;
 import org.eclipse.edc.protocol.dsp.http.spi.message.PostDspRequest;
-import org.eclipse.edc.protocol.dsp.spi.type.DspNamespace;
 
 import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -59,13 +59,13 @@ public class DspCatalogApiController {
     private final DspRequestHandler dspRequestHandler;
     private final ContinuationTokenManager continuationTokenManager;
     private final String protocol;
-    private final DspNamespace namespace;
+    private final JsonLdNamespace namespace;
 
     public DspCatalogApiController(CatalogProtocolService service, DspRequestHandler dspRequestHandler, ContinuationTokenManager continuationTokenManager) {
         this(service, dspRequestHandler, continuationTokenManager, DATASPACE_PROTOCOL_HTTP, DSP_NAMESPACE_V_08);
     }
 
-    public DspCatalogApiController(CatalogProtocolService service, DspRequestHandler dspRequestHandler, ContinuationTokenManager continuationTokenManager, String protocol, DspNamespace namespace) {
+    public DspCatalogApiController(CatalogProtocolService service, DspRequestHandler dspRequestHandler, ContinuationTokenManager continuationTokenManager, String protocol, JsonLdNamespace namespace) {
         this.service = service;
         this.dspRequestHandler = dspRequestHandler;
         this.continuationTokenManager = continuationTokenManager;

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/test/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiControllerTest.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-http-api/src/test/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiControllerTest.java
@@ -24,13 +24,13 @@ import org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequestMessage;
 import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
 import org.eclipse.edc.connector.controlplane.services.spi.catalog.CatalogProtocolService;
 import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.junit.annotations.ApiTest;
 import org.eclipse.edc.protocol.dsp.http.spi.message.ContinuationTokenManager;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
 import org.eclipse.edc.protocol.dsp.http.spi.message.GetDspRequest;
 import org.eclipse.edc.protocol.dsp.http.spi.message.PostDspRequest;
 import org.eclipse.edc.protocol.dsp.http.spi.message.ResponseDecorator;
-import org.eclipse.edc.protocol.dsp.spi.type.DspNamespace;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
@@ -90,7 +90,7 @@ class DspCatalogApiControllerTest {
 
         protected abstract String basePath();
 
-        protected abstract DspNamespace namespace();
+        protected abstract JsonLdNamespace namespace();
 
         private RequestSpecification baseRequest() {
             return given()
@@ -183,7 +183,7 @@ class DspCatalogApiControllerTest {
         }
 
         @Override
-        protected DspNamespace namespace() {
+        protected JsonLdNamespace namespace() {
             return DSP_NAMESPACE_V_08;
         }
 
@@ -203,7 +203,7 @@ class DspCatalogApiControllerTest {
         }
 
         @Override
-        protected DspNamespace namespace() {
+        protected JsonLdNamespace namespace() {
             return DSP_NAMESPACE_V_2024_1;
         }
 

--- a/data-protocols/dsp/dsp-catalog/lib/dsp-catalog-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/catalog/transform/from/JsonObjectFromCatalogErrorTransformer.java
+++ b/data-protocols/dsp/dsp-catalog/lib/dsp-catalog-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/catalog/transform/from/JsonObjectFromCatalogErrorTransformer.java
@@ -17,14 +17,15 @@ package org.eclipse.edc.protocol.dsp.catalog.transform.from;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.catalog.spi.CatalogError;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspCatalogPropertyAndTypeNames.DSPACE_TYPE_CATALOG_ERROR_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CODE_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_REASON_TERM;
 
@@ -36,11 +37,11 @@ public class JsonObjectFromCatalogErrorTransformer extends AbstractNamespaceAwar
     private final JsonBuilderFactory jsonFactory;
 
     public JsonObjectFromCatalogErrorTransformer(JsonBuilderFactory jsonFactory) {
-        this(jsonFactory, DSPACE_SCHEMA);
+        this(jsonFactory, DSP_NAMESPACE_V_08);
     }
 
-    public JsonObjectFromCatalogErrorTransformer(JsonBuilderFactory jsonFactory, String schema) {
-        super(CatalogError.class, JsonObject.class, schema);
+    public JsonObjectFromCatalogErrorTransformer(JsonBuilderFactory jsonFactory, JsonLdNamespace namespace) {
+        super(CatalogError.class, JsonObject.class, namespace);
         this.jsonFactory = jsonFactory;
     }
 

--- a/data-protocols/dsp/dsp-catalog/lib/dsp-catalog-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/catalog/transform/from/JsonObjectFromCatalogRequestMessageTransformer.java
+++ b/data-protocols/dsp/dsp-catalog/lib/dsp-catalog-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/catalog/transform/from/JsonObjectFromCatalogRequestMessageTransformer.java
@@ -17,15 +17,16 @@ package org.eclipse.edc.protocol.dsp.catalog.transform.from;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequestMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspCatalogPropertyAndTypeNames.DSPACE_PROPERTY_FILTER_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspCatalogPropertyAndTypeNames.DSPACE_TYPE_CATALOG_REQUEST_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 
 /**
  * Transforms a {@link CatalogRequestMessage} to a {@link JsonObject} in JSON-LD expanded form.
@@ -35,11 +36,11 @@ public class JsonObjectFromCatalogRequestMessageTransformer extends AbstractName
     private final JsonBuilderFactory jsonFactory;
 
     public JsonObjectFromCatalogRequestMessageTransformer(JsonBuilderFactory jsonFactory) {
-        this(jsonFactory, DSPACE_SCHEMA);
+        this(jsonFactory, DSP_NAMESPACE_V_08);
     }
 
-    public JsonObjectFromCatalogRequestMessageTransformer(JsonBuilderFactory jsonFactory, String schema) {
-        super(CatalogRequestMessage.class, JsonObject.class, schema);
+    public JsonObjectFromCatalogRequestMessageTransformer(JsonBuilderFactory jsonFactory, JsonLdNamespace namespace) {
+        super(CatalogRequestMessage.class, JsonObject.class, namespace);
         this.jsonFactory = jsonFactory;
     }
 

--- a/data-protocols/dsp/dsp-catalog/lib/dsp-catalog-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/catalog/transform/from/JsonObjectFromCatalogTransformer.java
+++ b/data-protocols/dsp/dsp-catalog/lib/dsp-catalog-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/catalog/transform/from/JsonObjectFromCatalogTransformer.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
 import org.eclipse.edc.spi.agent.ParticipantIdMapper;
 import org.eclipse.edc.transform.spi.TransformerContext;
@@ -28,12 +29,12 @@ import static jakarta.json.stream.JsonCollectors.toJsonArray;
 import static java.util.Optional.ofNullable;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_CATALOG_TYPE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DATASET_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DATA_SERVICE_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DISTRIBUTION_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DSPACE_PROPERTY_PARTICIPANT_ID_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 
 /**
  * Converts from a {@link Catalog} to a DCAT catalog as a {@link JsonObject} in JSON-LD expanded form.
@@ -44,10 +45,10 @@ public class JsonObjectFromCatalogTransformer extends AbstractNamespaceAwareJson
     private final ParticipantIdMapper participantIdMapper;
 
     public JsonObjectFromCatalogTransformer(JsonBuilderFactory jsonFactory, ObjectMapper mapper, ParticipantIdMapper participantIdMapper) {
-        this(jsonFactory, mapper, participantIdMapper, DSPACE_SCHEMA);
+        this(jsonFactory, mapper, participantIdMapper, DSP_NAMESPACE_V_08);
     }
 
-    public JsonObjectFromCatalogTransformer(JsonBuilderFactory jsonFactory, ObjectMapper mapper, ParticipantIdMapper participantIdMapper, String namespace) {
+    public JsonObjectFromCatalogTransformer(JsonBuilderFactory jsonFactory, ObjectMapper mapper, ParticipantIdMapper participantIdMapper, JsonLdNamespace namespace) {
         super(Catalog.class, JsonObject.class, namespace);
         this.jsonFactory = jsonFactory;
         this.mapper = mapper;

--- a/data-protocols/dsp/dsp-catalog/lib/dsp-catalog-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/catalog/transform/to/JsonObjectToCatalogRequestMessageTransformer.java
+++ b/data-protocols/dsp/dsp-catalog/lib/dsp-catalog-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/catalog/transform/to/JsonObjectToCatalogRequestMessageTransformer.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.protocol.dsp.catalog.transform.to;
 
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequestMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.transform.spi.TransformerContext;
@@ -24,8 +25,8 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
 
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspCatalogPropertyAndTypeNames.DSPACE_PROPERTY_FILTER_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 
 /**
  * Transforms a {@link JsonObject} in JSON-LD expanded form to a {@link CatalogRequestMessage}.
@@ -33,10 +34,10 @@ import static org.eclipse.edc.protocol.dsp.spi.type.DspCatalogPropertyAndTypeNam
 public class JsonObjectToCatalogRequestMessageTransformer extends AbstractNamespaceAwareJsonLdTransformer<JsonObject, CatalogRequestMessage> {
 
     public JsonObjectToCatalogRequestMessageTransformer() {
-        this(DSPACE_SCHEMA);
+        this(DSP_NAMESPACE_V_08);
     }
 
-    public JsonObjectToCatalogRequestMessageTransformer(String namespace) {
+    public JsonObjectToCatalogRequestMessageTransformer(JsonLdNamespace namespace) {
         super(JsonObject.class, CatalogRequestMessage.class, namespace);
     }
 

--- a/data-protocols/dsp/dsp-catalog/lib/dsp-catalog-validation-lib/src/main/java/org/eclipse/edc/protocol/dsp/catalog/validation/CatalogRequestMessageValidator.java
+++ b/data-protocols/dsp/dsp-catalog/lib/dsp-catalog-validation-lib/src/main/java/org/eclipse/edc/protocol/dsp/catalog/validation/CatalogRequestMessageValidator.java
@@ -15,28 +15,29 @@
 package org.eclipse.edc.protocol.dsp.catalog.validation;
 
 import jakarta.json.JsonObject;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.spi.query.CriterionOperatorRegistry;
 import org.eclipse.edc.validator.jsonobject.JsonObjectValidator;
 import org.eclipse.edc.validator.jsonobject.validators.TypeIs;
 import org.eclipse.edc.validator.jsonobject.validators.model.QuerySpecValidator;
 import org.eclipse.edc.validator.spi.Validator;
 
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspCatalogPropertyAndTypeNames.DSPACE_PROPERTY_FILTER_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspCatalogPropertyAndTypeNames.DSPACE_TYPE_CATALOG_REQUEST_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 
 /**
  * Validator for {@link CatalogRequestMessageValidator} Json-LD representation
  */
 public class CatalogRequestMessageValidator {
     public static Validator<JsonObject> instance(CriterionOperatorRegistry criterionOperatorRegistry) {
-        return instance(criterionOperatorRegistry, DSPACE_SCHEMA);
+        return instance(criterionOperatorRegistry, DSP_NAMESPACE_V_08);
     }
 
-    public static Validator<JsonObject> instance(CriterionOperatorRegistry criterionOperatorRegistry, String schema) {
+    public static Validator<JsonObject> instance(CriterionOperatorRegistry criterionOperatorRegistry, JsonLdNamespace namespace) {
         return JsonObjectValidator.newValidator()
-                .verify(path -> new TypeIs(path, schema + DSPACE_TYPE_CATALOG_REQUEST_MESSAGE_TERM))
-                .verifyObject(schema + DSPACE_PROPERTY_FILTER_TERM, path -> QuerySpecValidator.instance(path, criterionOperatorRegistry))
+                .verify(path -> new TypeIs(path, namespace.toIri(DSPACE_TYPE_CATALOG_REQUEST_MESSAGE_TERM)))
+                .verifyObject(namespace.toIri(DSPACE_PROPERTY_FILTER_TERM), path -> QuerySpecValidator.instance(path, criterionOperatorRegistry))
                 .build();
     }
 }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/DspNegotiationApiController.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-api/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/DspNegotiationApiController.java
@@ -33,10 +33,10 @@ import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.Con
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractOfferMessage;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequestMessage;
 import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationProtocolService;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
 import org.eclipse.edc.protocol.dsp.http.spi.message.GetDspRequest;
 import org.eclipse.edc.protocol.dsp.http.spi.message.PostDspRequest;
-import org.eclipse.edc.protocol.dsp.spi.type.DspNamespace;
 
 import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static org.eclipse.edc.protocol.dsp.http.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP;
@@ -68,7 +68,7 @@ public class DspNegotiationApiController {
 
     private final DspRequestHandler dspRequestHandler;
     private final String protocol;
-    private final DspNamespace namespace;
+    private final JsonLdNamespace namespace;
     private final ContractNegotiationProtocolService protocolService;
 
     public DspNegotiationApiController(ContractNegotiationProtocolService protocolService,
@@ -80,7 +80,7 @@ public class DspNegotiationApiController {
     public DspNegotiationApiController(ContractNegotiationProtocolService protocolService,
                                        DspRequestHandler dspRequestHandler,
                                        String protocol,
-                                       DspNamespace namespace) {
+                                       JsonLdNamespace namespace) {
         this.protocolService = protocolService;
         this.dspRequestHandler = dspRequestHandler;
         this.protocol = protocol;

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-api/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/DspNegotiationApiControllerTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-http-api/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/DspNegotiationApiControllerTest.java
@@ -25,11 +25,11 @@ import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.Con
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractOfferMessage;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequestMessage;
 import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationProtocolService;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.junit.annotations.ApiTest;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
 import org.eclipse.edc.protocol.dsp.http.spi.message.GetDspRequest;
 import org.eclipse.edc.protocol.dsp.http.spi.message.PostDspRequest;
-import org.eclipse.edc.protocol.dsp.spi.type.DspNamespace;
 import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -178,7 +178,7 @@ class DspNegotiationApiControllerTest {
 
         protected abstract String basePath();
 
-        protected abstract DspNamespace namespace();
+        protected abstract JsonLdNamespace namespace();
 
         private RequestSpecification baseRequest() {
             var authHeader = "auth";
@@ -232,7 +232,7 @@ class DspNegotiationApiControllerTest {
         }
 
         @Override
-        protected DspNamespace namespace() {
+        protected JsonLdNamespace namespace() {
             return DSP_NAMESPACE_V_08;
         }
 
@@ -252,7 +252,7 @@ class DspNegotiationApiControllerTest {
         }
 
         @Override
-        protected DspNamespace namespace() {
+        protected JsonLdNamespace namespace() {
             return DSP_NAMESPACE_V_2024_1;
         }
 

--- a/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractAgreementMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractAgreementMessageTransformer.java
@@ -18,6 +18,7 @@ import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreementMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
@@ -26,9 +27,9 @@ import org.jetbrains.annotations.Nullable;
 import static java.time.Instant.ofEpochSecond;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ASSIGNEE_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ASSIGNER_ATTRIBUTE;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_AGREEMENT_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_TIMESTAMP_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE_TERM;
@@ -44,10 +45,10 @@ public class JsonObjectFromContractAgreementMessageTransformer extends AbstractN
     private final JsonBuilderFactory jsonFactory;
 
     public JsonObjectFromContractAgreementMessageTransformer(JsonBuilderFactory jsonFactory) {
-        this(jsonFactory, DSPACE_SCHEMA);
+        this(jsonFactory, DSP_NAMESPACE_V_08);
     }
 
-    public JsonObjectFromContractAgreementMessageTransformer(JsonBuilderFactory jsonFactory, String namespace) {
+    public JsonObjectFromContractAgreementMessageTransformer(JsonBuilderFactory jsonFactory, JsonLdNamespace namespace) {
         super(ContractAgreementMessage.class, JsonObject.class, namespace);
         this.jsonFactory = jsonFactory;
     }

--- a/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractAgreementVerificationMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractAgreementVerificationMessageTransformer.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.protocol.dsp.negotiation.transform.from;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreementVerificationMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
@@ -24,7 +25,7 @@ import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_AGREEMENT_VERIFICATION_MESSAGE_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID_TERM;
@@ -37,10 +38,10 @@ public class JsonObjectFromContractAgreementVerificationMessageTransformer exten
     private final JsonBuilderFactory jsonFactory;
 
     public JsonObjectFromContractAgreementVerificationMessageTransformer(JsonBuilderFactory jsonFactory) {
-        this(jsonFactory, DSPACE_SCHEMA);
+        this(jsonFactory, DSP_NAMESPACE_V_08);
     }
 
-    public JsonObjectFromContractAgreementVerificationMessageTransformer(JsonBuilderFactory jsonFactory, String namespace) {
+    public JsonObjectFromContractAgreementVerificationMessageTransformer(JsonBuilderFactory jsonFactory, JsonLdNamespace namespace) {
         super(ContractAgreementVerificationMessage.class, JsonObject.class, namespace);
         this.jsonFactory = jsonFactory;
     }

--- a/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractNegotiationErrorTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractNegotiationErrorTransformer.java
@@ -17,13 +17,14 @@ package org.eclipse.edc.protocol.dsp.negotiation.transform.from;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationError;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_ERROR_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CODE_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_REASON_TERM;
@@ -36,10 +37,10 @@ public class JsonObjectFromContractNegotiationErrorTransformer extends AbstractN
     private final JsonBuilderFactory jsonFactory;
 
     public JsonObjectFromContractNegotiationErrorTransformer(JsonBuilderFactory jsonFactory) {
-        this(jsonFactory, DSPACE_SCHEMA);
+        this(jsonFactory, DSP_NAMESPACE_V_08);
     }
 
-    public JsonObjectFromContractNegotiationErrorTransformer(JsonBuilderFactory jsonFactory, String namespace) {
+    public JsonObjectFromContractNegotiationErrorTransformer(JsonBuilderFactory jsonFactory, JsonLdNamespace namespace) {
         super(ContractNegotiationError.class, JsonObject.class, namespace);
         this.jsonFactory = jsonFactory;
     }

--- a/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractNegotiationEventMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractNegotiationEventMessageTransformer.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.protocol.dsp.negotiation.transform.from;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractNegotiationEventMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
@@ -24,7 +25,7 @@ import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_EVENT_TYPE_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_VALUE_NEGOTIATION_EVENT_TYPE_ACCEPTED_TERM;
@@ -41,10 +42,10 @@ public class JsonObjectFromContractNegotiationEventMessageTransformer extends Ab
     private final JsonBuilderFactory jsonFactory;
 
     public JsonObjectFromContractNegotiationEventMessageTransformer(JsonBuilderFactory jsonFactory) {
-        this(jsonFactory, DSPACE_SCHEMA);
+        this(jsonFactory, DSP_NAMESPACE_V_08);
     }
 
-    public JsonObjectFromContractNegotiationEventMessageTransformer(JsonBuilderFactory jsonFactory, String namespace) {
+    public JsonObjectFromContractNegotiationEventMessageTransformer(JsonBuilderFactory jsonFactory, JsonLdNamespace namespace) {
         super(ContractNegotiationEventMessage.class, JsonObject.class, namespace);
         this.jsonFactory = jsonFactory;
     }

--- a/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractNegotiationTerminationMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractNegotiationTerminationMessageTransformer.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.protocol.dsp.negotiation.transform.from;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationTerminationMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
@@ -24,7 +25,7 @@ import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_TERMINATION_MESSAGE_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CODE_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID_TERM;
@@ -39,10 +40,10 @@ public class JsonObjectFromContractNegotiationTerminationMessageTransformer exte
     private final JsonBuilderFactory jsonFactory;
 
     public JsonObjectFromContractNegotiationTerminationMessageTransformer(JsonBuilderFactory jsonFactory) {
-        this(jsonFactory, DSPACE_SCHEMA);
+        this(jsonFactory, DSP_NAMESPACE_V_08);
     }
 
-    public JsonObjectFromContractNegotiationTerminationMessageTransformer(JsonBuilderFactory jsonFactory, String namespace) {
+    public JsonObjectFromContractNegotiationTerminationMessageTransformer(JsonBuilderFactory jsonFactory, JsonLdNamespace namespace) {
         super(ContractNegotiationTerminationMessage.class, JsonObject.class, namespace);
         this.jsonFactory = jsonFactory;
     }

--- a/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractNegotiationTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractNegotiationTransformer.java
@@ -18,6 +18,7 @@ import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
@@ -25,7 +26,7 @@ import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_IRI;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_VALUE_NEGOTIATION_STATE_ACCEPTED_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_VALUE_NEGOTIATION_STATE_AGREED_TERM;
@@ -47,10 +48,10 @@ public class JsonObjectFromContractNegotiationTransformer extends AbstractNamesp
     private final JsonBuilderFactory jsonFactory;
 
     public JsonObjectFromContractNegotiationTransformer(JsonBuilderFactory jsonFactory) {
-        this(jsonFactory, DSPACE_SCHEMA);
+        this(jsonFactory, DSP_NAMESPACE_V_08);
     }
 
-    public JsonObjectFromContractNegotiationTransformer(JsonBuilderFactory jsonFactory, String namespace) {
+    public JsonObjectFromContractNegotiationTransformer(JsonBuilderFactory jsonFactory, JsonLdNamespace namespace) {
         super(ContractNegotiation.class, JsonObject.class, namespace);
         this.jsonFactory = jsonFactory;
     }

--- a/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractOfferMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractOfferMessageTransformer.java
@@ -18,6 +18,7 @@ import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractOfferMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
@@ -25,7 +26,7 @@ import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_OFFER_MESSAGE_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS_TERM;
@@ -40,10 +41,10 @@ public class JsonObjectFromContractOfferMessageTransformer extends AbstractNames
     private final JsonBuilderFactory jsonFactory;
 
     public JsonObjectFromContractOfferMessageTransformer(JsonBuilderFactory jsonFactory) {
-        this(jsonFactory, DSPACE_SCHEMA);
+        this(jsonFactory, DSP_NAMESPACE_V_08);
     }
 
-    public JsonObjectFromContractOfferMessageTransformer(JsonBuilderFactory jsonFactory, String namespace) {
+    public JsonObjectFromContractOfferMessageTransformer(JsonBuilderFactory jsonFactory, JsonLdNamespace namespace) {
         super(ContractOfferMessage.class, JsonObject.class, namespace);
         this.jsonFactory = jsonFactory;
     }

--- a/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractRequestMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/from/JsonObjectFromContractRequestMessageTransformer.java
@@ -18,6 +18,7 @@ import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequestMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
@@ -25,7 +26,7 @@ import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS_TERM;
@@ -41,10 +42,10 @@ public class JsonObjectFromContractRequestMessageTransformer extends AbstractNam
     private final JsonBuilderFactory jsonFactory;
 
     public JsonObjectFromContractRequestMessageTransformer(JsonBuilderFactory jsonFactory) {
-        this(jsonFactory, DSPACE_SCHEMA);
+        this(jsonFactory, DSP_NAMESPACE_V_08);
     }
 
-    public JsonObjectFromContractRequestMessageTransformer(JsonBuilderFactory jsonFactory, String namespace) {
+    public JsonObjectFromContractRequestMessageTransformer(JsonBuilderFactory jsonFactory, JsonLdNamespace namespace) {
         super(ContractRequestMessage.class, JsonObject.class, namespace);
         this.jsonFactory = jsonFactory;
     }

--- a/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractAgreementMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractAgreementMessageTransformer.java
@@ -18,6 +18,7 @@ import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreementMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.transform.spi.TransformerContext;
@@ -29,7 +30,7 @@ import java.time.format.DateTimeParseException;
 import java.util.Set;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_AGREEMENT_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_ID_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_ID_TERM;
@@ -45,10 +46,10 @@ public class JsonObjectToContractAgreementMessageTransformer extends AbstractNam
     private final Set<String> excludedPolicyKeywords;
 
     public JsonObjectToContractAgreementMessageTransformer() {
-        this(DSPACE_SCHEMA);
+        this(DSP_NAMESPACE_V_08);
     }
 
-    public JsonObjectToContractAgreementMessageTransformer(String namespace) {
+    public JsonObjectToContractAgreementMessageTransformer(JsonLdNamespace namespace) {
         super(JsonObject.class, ContractAgreementMessage.class, namespace);
         excludedPolicyKeywords = Set.of(forNamespace(DSPACE_PROPERTY_TIMESTAMP_TERM),
                 forNamespace(forNamespace(DSPACE_PROPERTY_CONSUMER_ID_TERM)),

--- a/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractAgreementVerificationMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractAgreementVerificationMessageTransformer.java
@@ -16,12 +16,13 @@ package org.eclipse.edc.protocol.dsp.negotiation.transform.to;
 
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreementVerificationMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_AGREEMENT_VERIFICATION_MESSAGE_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID_TERM;
@@ -32,10 +33,10 @@ import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPA
 public class JsonObjectToContractAgreementVerificationMessageTransformer extends AbstractNamespaceAwareJsonLdTransformer<JsonObject, ContractAgreementVerificationMessage> {
 
     public JsonObjectToContractAgreementVerificationMessageTransformer() {
-        this(DSPACE_SCHEMA);
+        this(DSP_NAMESPACE_V_08);
     }
 
-    public JsonObjectToContractAgreementVerificationMessageTransformer(String namespace) {
+    public JsonObjectToContractAgreementVerificationMessageTransformer(JsonLdNamespace namespace) {
         super(JsonObject.class, ContractAgreementVerificationMessage.class, namespace);
     }
 

--- a/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractNegotiationAckTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractNegotiationAckTransformer.java
@@ -16,12 +16,13 @@ package org.eclipse.edc.protocol.dsp.negotiation.transform.to;
 
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.protocol.ContractNegotiationAck;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_STATE_TERM;
@@ -32,10 +33,10 @@ import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPA
 public class JsonObjectToContractNegotiationAckTransformer extends AbstractNamespaceAwareJsonLdTransformer<JsonObject, ContractNegotiationAck> {
 
     public JsonObjectToContractNegotiationAckTransformer() {
-        this(DSPACE_SCHEMA);
+        this(DSP_NAMESPACE_V_08);
     }
 
-    public JsonObjectToContractNegotiationAckTransformer(String namespace) {
+    public JsonObjectToContractNegotiationAckTransformer(JsonLdNamespace namespace) {
         super(JsonObject.class, ContractNegotiationAck.class, namespace);
     }
 

--- a/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractNegotiationEventMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractNegotiationEventMessageTransformer.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.protocol.dsp.negotiation.transform.to;
 
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractNegotiationEventMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
@@ -23,7 +24,7 @@ import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractNegotiationEventMessage.Type.ACCEPTED;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractNegotiationEventMessage.Type.FINALIZED;
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_EVENT_TYPE_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_VALUE_NEGOTIATION_EVENT_TYPE_ACCEPTED_TERM;
@@ -37,10 +38,10 @@ import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPA
 public class JsonObjectToContractNegotiationEventMessageTransformer extends AbstractNamespaceAwareJsonLdTransformer<JsonObject, ContractNegotiationEventMessage> {
 
     public JsonObjectToContractNegotiationEventMessageTransformer() {
-        this(DSPACE_SCHEMA);
+        this(DSP_NAMESPACE_V_08);
     }
 
-    public JsonObjectToContractNegotiationEventMessageTransformer(String namespace) {
+    public JsonObjectToContractNegotiationEventMessageTransformer(JsonLdNamespace namespace) {
         super(JsonObject.class, ContractNegotiationEventMessage.class, namespace);
     }
 

--- a/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractNegotiationTerminationMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractNegotiationTerminationMessageTransformer.java
@@ -17,13 +17,14 @@ package org.eclipse.edc.protocol.dsp.negotiation.transform.to;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationTerminationMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import static jakarta.json.JsonValue.ValueType.ARRAY;
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_TERMINATION_MESSAGE_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CODE_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID_TERM;
@@ -36,10 +37,10 @@ import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPA
 public class JsonObjectToContractNegotiationTerminationMessageTransformer extends AbstractNamespaceAwareJsonLdTransformer<JsonObject, ContractNegotiationTerminationMessage> {
 
     public JsonObjectToContractNegotiationTerminationMessageTransformer() {
-        this(DSPACE_SCHEMA);
+        this(DSP_NAMESPACE_V_08);
     }
 
-    public JsonObjectToContractNegotiationTerminationMessageTransformer(String namespace) {
+    public JsonObjectToContractNegotiationTerminationMessageTransformer(JsonLdNamespace namespace) {
         super(JsonObject.class, ContractNegotiationTerminationMessage.class, namespace);
     }
 

--- a/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractOfferMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractOfferMessageTransformer.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.protocol.dsp.negotiation.transform.to;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractOfferMessage;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractOffer;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.policy.model.PolicyType;
@@ -26,7 +27,7 @@ import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_OFFER_MESSAGE_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS_TERM;
@@ -39,10 +40,10 @@ import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPA
 public class JsonObjectToContractOfferMessageTransformer extends AbstractNamespaceAwareJsonLdTransformer<JsonObject, ContractOfferMessage> {
 
     public JsonObjectToContractOfferMessageTransformer() {
-        this(DSPACE_SCHEMA);
+        this(DSP_NAMESPACE_V_08);
     }
 
-    public JsonObjectToContractOfferMessageTransformer(String namespace) {
+    public JsonObjectToContractOfferMessageTransformer(JsonLdNamespace namespace) {
         super(JsonObject.class, ContractOfferMessage.class, namespace);
     }
 

--- a/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractRequestMessageTransformer.java
+++ b/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractRequestMessageTransformer.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.protocol.dsp.negotiation.transform.to;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequestMessage;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractOffer;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.transform.spi.TransformerContext;
@@ -24,7 +25,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS_TERM;
@@ -37,10 +38,10 @@ import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPA
 public class JsonObjectToContractRequestMessageTransformer extends AbstractNamespaceAwareJsonLdTransformer<JsonObject, ContractRequestMessage> {
 
     public JsonObjectToContractRequestMessageTransformer() {
-        this(DSPACE_SCHEMA);
+        this(DSP_NAMESPACE_V_08);
     }
 
-    public JsonObjectToContractRequestMessageTransformer(String namespace) {
+    public JsonObjectToContractRequestMessageTransformer(JsonLdNamespace namespace) {
         super(JsonObject.class, ContractRequestMessage.class, namespace);
     }
 

--- a/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-validation-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/validation/ContractAgreementMessageValidator.java
+++ b/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-validation-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/validation/ContractAgreementMessageValidator.java
@@ -16,11 +16,12 @@ package org.eclipse.edc.protocol.dsp.negotiation.validation;
 
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreementMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.validator.jsonobject.JsonObjectValidator;
 import org.eclipse.edc.validator.jsonobject.validators.TypeIs;
 import org.eclipse.edc.validator.spi.Validator;
 
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE_TERM;
 
 /**
@@ -29,12 +30,12 @@ import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTyp
 public class ContractAgreementMessageValidator {
 
     public static Validator<JsonObject> instance() {
-        return instance(DSPACE_SCHEMA);
+        return instance(DSP_NAMESPACE_V_08);
     }
 
-    public static Validator<JsonObject> instance(String schema) {
+    public static Validator<JsonObject> instance(JsonLdNamespace namespace) {
         return JsonObjectValidator.newValidator()
-                .verify(path -> new TypeIs(path, schema + DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE_TERM))
+                .verify(path -> new TypeIs(path, namespace.toIri(DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE_TERM)))
                 .build();
     }
 }

--- a/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-validation-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/validation/ContractAgreementVerificationMessageValidator.java
+++ b/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-validation-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/validation/ContractAgreementVerificationMessageValidator.java
@@ -16,11 +16,12 @@ package org.eclipse.edc.protocol.dsp.negotiation.validation;
 
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreementVerificationMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.validator.jsonobject.JsonObjectValidator;
 import org.eclipse.edc.validator.jsonobject.validators.TypeIs;
 import org.eclipse.edc.validator.spi.Validator;
 
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_AGREEMENT_VERIFICATION_MESSAGE_TERM;
 
 /**
@@ -28,12 +29,12 @@ import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTyp
  */
 public class ContractAgreementVerificationMessageValidator {
     public static Validator<JsonObject> instance() {
-        return instance(DSPACE_SCHEMA);
+        return instance(DSP_NAMESPACE_V_08);
     }
 
-    public static Validator<JsonObject> instance(String schema) {
+    public static Validator<JsonObject> instance(JsonLdNamespace namespace) {
         return JsonObjectValidator.newValidator()
-                .verify(path -> new TypeIs(path, schema + DSPACE_TYPE_CONTRACT_AGREEMENT_VERIFICATION_MESSAGE_TERM))
+                .verify(path -> new TypeIs(path, namespace.toIri(DSPACE_TYPE_CONTRACT_AGREEMENT_VERIFICATION_MESSAGE_TERM)))
                 .build();
     }
 }

--- a/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-validation-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/validation/ContractNegotiationEventMessageValidator.java
+++ b/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-validation-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/validation/ContractNegotiationEventMessageValidator.java
@@ -16,11 +16,12 @@ package org.eclipse.edc.protocol.dsp.negotiation.validation;
 
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractNegotiationEventMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.validator.jsonobject.JsonObjectValidator;
 import org.eclipse.edc.validator.jsonobject.validators.TypeIs;
 import org.eclipse.edc.validator.spi.Validator;
 
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE_TERM;
 
 /**
@@ -28,12 +29,12 @@ import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTyp
  */
 public class ContractNegotiationEventMessageValidator {
     public static Validator<JsonObject> instance() {
-        return instance(DSPACE_SCHEMA);
+        return instance(DSP_NAMESPACE_V_08);
     }
 
-    public static Validator<JsonObject> instance(String schema) {
+    public static Validator<JsonObject> instance(JsonLdNamespace namespace) {
         return JsonObjectValidator.newValidator()
-                .verify(path -> new TypeIs(path, schema + DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE_TERM))
+                .verify(path -> new TypeIs(path, namespace.toIri(DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE_TERM)))
                 .build();
     }
 }

--- a/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-validation-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/validation/ContractNegotiationTerminationMessageValidator.java
+++ b/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-validation-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/validation/ContractNegotiationTerminationMessageValidator.java
@@ -16,11 +16,12 @@ package org.eclipse.edc.protocol.dsp.negotiation.validation;
 
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationTerminationMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.validator.jsonobject.JsonObjectValidator;
 import org.eclipse.edc.validator.jsonobject.validators.TypeIs;
 import org.eclipse.edc.validator.spi.Validator;
 
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_TERMINATION_MESSAGE_TERM;
 
 /**
@@ -28,12 +29,12 @@ import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTyp
  */
 public class ContractNegotiationTerminationMessageValidator {
     public static Validator<JsonObject> instance() {
-        return instance(DSPACE_SCHEMA);
+        return instance(DSP_NAMESPACE_V_08);
     }
 
-    public static Validator<JsonObject> instance(String schema) {
+    public static Validator<JsonObject> instance(JsonLdNamespace namespace) {
         return JsonObjectValidator.newValidator()
-                .verify(path -> new TypeIs(path, schema + DSPACE_TYPE_CONTRACT_NEGOTIATION_TERMINATION_MESSAGE_TERM))
+                .verify(path -> new TypeIs(path, namespace.toIri(DSPACE_TYPE_CONTRACT_NEGOTIATION_TERMINATION_MESSAGE_TERM)))
                 .build();
     }
 }

--- a/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-validation-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/validation/ContractOfferMessageValidator.java
+++ b/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-validation-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/validation/ContractOfferMessageValidator.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.protocol.dsp.negotiation.validation;
 
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractOfferMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.validator.jsonobject.JsonObjectValidator;
 import org.eclipse.edc.validator.jsonobject.validators.MandatoryIdNotBlank;
 import org.eclipse.edc.validator.jsonobject.validators.MandatoryObject;
@@ -23,8 +24,8 @@ import org.eclipse.edc.validator.jsonobject.validators.MandatoryValue;
 import org.eclipse.edc.validator.jsonobject.validators.TypeIs;
 import org.eclipse.edc.validator.spi.Validator;
 
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIBUTE;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_OFFER_MESSAGE_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS_TERM;
@@ -34,18 +35,18 @@ import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPA
  */
 public class ContractOfferMessageValidator {
     public static Validator<JsonObject> instance() {
-        return instance(DSPACE_SCHEMA);
+        return instance(DSP_NAMESPACE_V_08);
     }
 
-    public static Validator<JsonObject> instance(String schema) {
+    public static Validator<JsonObject> instance(JsonLdNamespace namespace) {
         return JsonObjectValidator.newValidator()
-                .verify(path -> new TypeIs(path, schema + DSPACE_TYPE_CONTRACT_OFFER_MESSAGE_TERM))
-                .verifyObject(schema + DSPACE_PROPERTY_OFFER_TERM, v -> v
+                .verify(path -> new TypeIs(path, namespace.toIri(DSPACE_TYPE_CONTRACT_OFFER_MESSAGE_TERM)))
+                .verifyObject(namespace.toIri(DSPACE_PROPERTY_OFFER_TERM), v -> v
                         .verifyId(MandatoryIdNotBlank::new)
                         .verify(ODRL_TARGET_ATTRIBUTE, MandatoryObject::new)
                         .verifyObject(ODRL_TARGET_ATTRIBUTE, b -> b.verifyId(MandatoryIdNotBlank::new))
                 )
-                .verify(schema + DSPACE_PROPERTY_CALLBACK_ADDRESS_TERM, MandatoryValue::new)
+                .verify(namespace.toIri(DSPACE_PROPERTY_CALLBACK_ADDRESS_TERM), MandatoryValue::new)
                 .build();
     }
 }

--- a/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-validation-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/validation/ContractRequestMessageValidator.java
+++ b/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-validation-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/validation/ContractRequestMessageValidator.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.protocol.dsp.negotiation.validation;
 
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequestMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.validator.jsonobject.JsonObjectValidator;
 import org.eclipse.edc.validator.jsonobject.validators.MandatoryIdNotBlank;
 import org.eclipse.edc.validator.jsonobject.validators.MandatoryObject;
@@ -23,8 +24,8 @@ import org.eclipse.edc.validator.jsonobject.validators.MandatoryValue;
 import org.eclipse.edc.validator.jsonobject.validators.TypeIs;
 import org.eclipse.edc.validator.spi.Validator;
 
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIBUTE;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS_TERM;
@@ -34,18 +35,18 @@ import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPA
  */
 public class ContractRequestMessageValidator {
     public static Validator<JsonObject> instance() {
-        return instance(DSPACE_SCHEMA);
+        return instance(DSP_NAMESPACE_V_08);
     }
 
-    public static Validator<JsonObject> instance(String schema) {
+    public static Validator<JsonObject> instance(JsonLdNamespace namespace) {
         return JsonObjectValidator.newValidator()
-                .verify(path -> new TypeIs(path, schema + DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE_TERM))
-                .verifyObject(schema + DSPACE_PROPERTY_OFFER_TERM, v -> v
+                .verify(path -> new TypeIs(path, namespace.toIri(DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE_TERM)))
+                .verifyObject(namespace.toIri(DSPACE_PROPERTY_OFFER_TERM), v -> v
                         .verifyId(MandatoryIdNotBlank::new)
                         .verify(ODRL_TARGET_ATTRIBUTE, MandatoryObject::new)
                         .verifyObject(ODRL_TARGET_ATTRIBUTE, b -> b.verifyId(MandatoryIdNotBlank::new))
                 )
-                .verify(schema + DSPACE_PROPERTY_CALLBACK_ADDRESS_TERM, MandatoryValue::new)
+                .verify(namespace.toIri(DSPACE_PROPERTY_CALLBACK_ADDRESS_TERM), MandatoryValue::new)
                 .build();
     }
 }

--- a/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/spi/type/DspConstants.java
+++ b/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/spi/type/DspConstants.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.edc.protocol.dsp.spi.type;
 
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
+
 import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
 import static org.eclipse.edc.protocol.dsp.spi.version.DspVersions.V_08_VERSION;
 import static org.eclipse.edc.protocol.dsp.spi.version.DspVersions.V_2024_1_VERSION;
@@ -29,6 +31,6 @@ public interface DspConstants {
     String DSP_TRANSFORMER_CONTEXT_V_08 = DSP_TRANSFORMER_CONTEXT + DSP_CONTEXT_SEPARATOR + V_08_VERSION;
     String DSP_TRANSFORMER_CONTEXT_V_2024_1 = DSP_TRANSFORMER_CONTEXT + DSP_CONTEXT_SEPARATOR + V_2024_1_VERSION;
 
-    DspNamespace DSP_NAMESPACE_V_08 = new DspNamespace(DSPACE_SCHEMA);
-    DspNamespace DSP_NAMESPACE_V_2024_1 = new DspNamespace(DSPACE_SCHEMA);
+    JsonLdNamespace DSP_NAMESPACE_V_08 = new JsonLdNamespace(DSPACE_SCHEMA);
+    JsonLdNamespace DSP_NAMESPACE_V_2024_1 = new JsonLdNamespace(DSPACE_SCHEMA);
 }

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-http-api/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/controller/DspTransferProcessApiController.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-http-api/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/controller/DspTransferProcessApiController.java
@@ -32,10 +32,10 @@ import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.Transf
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferStartMessage;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferSuspensionMessage;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferTerminationMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
 import org.eclipse.edc.protocol.dsp.http.spi.message.GetDspRequest;
 import org.eclipse.edc.protocol.dsp.http.spi.message.PostDspRequest;
-import org.eclipse.edc.protocol.dsp.spi.type.DspNamespace;
 
 import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static org.eclipse.edc.protocol.dsp.http.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP;
@@ -64,13 +64,13 @@ public class DspTransferProcessApiController {
     private final TransferProcessProtocolService protocolService;
     private final DspRequestHandler dspRequestHandler;
     private final String protocol;
-    private final DspNamespace namespace;
+    private final JsonLdNamespace namespace;
 
     public DspTransferProcessApiController(TransferProcessProtocolService protocolService, DspRequestHandler dspRequestHandler) {
         this(protocolService, dspRequestHandler, DATASPACE_PROTOCOL_HTTP, DSP_NAMESPACE_V_08);
     }
 
-    public DspTransferProcessApiController(TransferProcessProtocolService protocolService, DspRequestHandler dspRequestHandler, String protocol, DspNamespace namespace) {
+    public DspTransferProcessApiController(TransferProcessProtocolService protocolService, DspRequestHandler dspRequestHandler, String protocol, JsonLdNamespace namespace) {
         this.protocolService = protocolService;
         this.dspRequestHandler = dspRequestHandler;
         this.protocol = protocol;

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-http-api/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/controller/DspTransferProcessApiControllerTest.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-http-api/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/controller/DspTransferProcessApiControllerTest.java
@@ -26,11 +26,11 @@ import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.Transf
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferStartMessage;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferSuspensionMessage;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferTerminationMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.junit.annotations.ApiTest;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
 import org.eclipse.edc.protocol.dsp.http.spi.message.GetDspRequest;
 import org.eclipse.edc.protocol.dsp.http.spi.message.PostDspRequest;
-import org.eclipse.edc.protocol.dsp.spi.type.DspNamespace;
 import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -152,7 +152,7 @@ class DspTransferProcessApiControllerTest {
 
         protected abstract String basePath();
 
-        protected abstract DspNamespace namespace();
+        protected abstract JsonLdNamespace namespace();
 
         private RequestSpecification baseRequest() {
             return given()
@@ -198,7 +198,7 @@ class DspTransferProcessApiControllerTest {
         }
 
         @Override
-        protected DspNamespace namespace() {
+        protected JsonLdNamespace namespace() {
             return DSP_NAMESPACE_V_08;
         }
 
@@ -218,7 +218,7 @@ class DspTransferProcessApiControllerTest {
         }
 
         @Override
-        protected DspNamespace namespace() {
+        protected JsonLdNamespace namespace() {
             return DSP_NAMESPACE_V_2024_1;
         }
 

--- a/data-protocols/dsp/dsp-transfer-process/lib/dsp-transfer-process-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/type/from/JsonObjectFromTransferCompletionMessageTransformer.java
+++ b/data-protocols/dsp/dsp-transfer-process/lib/dsp-transfer-process-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/type/from/JsonObjectFromTransferCompletionMessageTransformer.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.protocol.dsp.transferprocess.transform.type.from;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferCompletionMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
@@ -24,7 +25,7 @@ import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE_TERM;
@@ -35,10 +36,10 @@ public class JsonObjectFromTransferCompletionMessageTransformer extends Abstract
     private final JsonBuilderFactory jsonBuilderFactory;
 
     public JsonObjectFromTransferCompletionMessageTransformer(JsonBuilderFactory jsonBuilderFactory) {
-        this(jsonBuilderFactory, DSPACE_SCHEMA);
+        this(jsonBuilderFactory, DSP_NAMESPACE_V_08);
     }
 
-    public JsonObjectFromTransferCompletionMessageTransformer(JsonBuilderFactory jsonBuilderFactory, String namespace) {
+    public JsonObjectFromTransferCompletionMessageTransformer(JsonBuilderFactory jsonBuilderFactory, JsonLdNamespace namespace) {
         super(TransferCompletionMessage.class, JsonObject.class, namespace);
         this.jsonBuilderFactory = jsonBuilderFactory;
     }

--- a/data-protocols/dsp/dsp-transfer-process/lib/dsp-transfer-process-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/type/from/JsonObjectFromTransferErrorTransformer.java
+++ b/data-protocols/dsp/dsp-transfer-process/lib/dsp-transfer-process-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/type/from/JsonObjectFromTransferErrorTransformer.java
@@ -17,13 +17,14 @@ package org.eclipse.edc.protocol.dsp.transferprocess.transform.type.from;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferError;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CODE_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_REASON_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_ERROR_TERM;
@@ -36,10 +37,10 @@ public class JsonObjectFromTransferErrorTransformer extends AbstractNamespaceAwa
     private final JsonBuilderFactory jsonFactory;
 
     public JsonObjectFromTransferErrorTransformer(JsonBuilderFactory jsonFactory) {
-        this(jsonFactory, DSPACE_SCHEMA);
+        this(jsonFactory, DSP_NAMESPACE_V_08);
     }
 
-    public JsonObjectFromTransferErrorTransformer(JsonBuilderFactory jsonFactory, String namespace) {
+    public JsonObjectFromTransferErrorTransformer(JsonBuilderFactory jsonFactory, JsonLdNamespace namespace) {
         super(TransferError.class, JsonObject.class, namespace);
         this.jsonFactory = jsonFactory;
     }

--- a/data-protocols/dsp/dsp-transfer-process/lib/dsp-transfer-process-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/type/from/JsonObjectFromTransferProcessTransformer.java
+++ b/data-protocols/dsp/dsp-transfer-process/lib/dsp-transfer-process-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/type/from/JsonObjectFromTransferProcessTransformer.java
@@ -18,6 +18,7 @@ import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
@@ -25,7 +26,7 @@ import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_STATE_TERM;
@@ -36,10 +37,10 @@ public class JsonObjectFromTransferProcessTransformer extends AbstractNamespaceA
     private final JsonBuilderFactory jsonBuilderFactory;
 
     public JsonObjectFromTransferProcessTransformer(JsonBuilderFactory jsonBuilderFactory) {
-        this(jsonBuilderFactory, DSPACE_SCHEMA);
+        this(jsonBuilderFactory, DSP_NAMESPACE_V_08);
     }
 
-    public JsonObjectFromTransferProcessTransformer(JsonBuilderFactory jsonBuilderFactory, String namespace) {
+    public JsonObjectFromTransferProcessTransformer(JsonBuilderFactory jsonBuilderFactory, JsonLdNamespace namespace) {
         super(TransferProcess.class, JsonObject.class, namespace);
         this.jsonBuilderFactory = jsonBuilderFactory;
     }

--- a/data-protocols/dsp/dsp-transfer-process/lib/dsp-transfer-process-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/type/from/JsonObjectFromTransferRequestMessageTransformer.java
+++ b/data-protocols/dsp/dsp-transfer-process/lib/dsp-transfer-process-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/type/from/JsonObjectFromTransferRequestMessageTransformer.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.protocol.dsp.transferprocess.transform.type.from;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferRequestMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
@@ -26,8 +27,8 @@ import java.util.Optional;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCT_FORMAT_ATTRIBUTE;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_PROPERTY_CONTRACT_AGREEMENT_ID_TERM;
@@ -40,10 +41,10 @@ public class JsonObjectFromTransferRequestMessageTransformer extends AbstractNam
     private final JsonBuilderFactory jsonBuilderFactory;
 
     public JsonObjectFromTransferRequestMessageTransformer(JsonBuilderFactory jsonBuilderFactory) {
-        this(jsonBuilderFactory, DSPACE_SCHEMA);
+        this(jsonBuilderFactory, DSP_NAMESPACE_V_08);
     }
 
-    public JsonObjectFromTransferRequestMessageTransformer(JsonBuilderFactory jsonBuilderFactory, String namespace) {
+    public JsonObjectFromTransferRequestMessageTransformer(JsonBuilderFactory jsonBuilderFactory, JsonLdNamespace namespace) {
         super(TransferRequestMessage.class, JsonObject.class, namespace);
         this.jsonBuilderFactory = jsonBuilderFactory;
     }

--- a/data-protocols/dsp/dsp-transfer-process/lib/dsp-transfer-process-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/type/from/JsonObjectFromTransferStartMessageTransformer.java
+++ b/data-protocols/dsp/dsp-transfer-process/lib/dsp-transfer-process-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/type/from/JsonObjectFromTransferStartMessageTransformer.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.protocol.dsp.transferprocess.transform.type.from;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferStartMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
@@ -24,7 +25,7 @@ import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_PROPERTY_DATA_ADDRESS_TERM;
@@ -35,10 +36,10 @@ public class JsonObjectFromTransferStartMessageTransformer extends AbstractNames
     private final JsonBuilderFactory jsonBuilderFactory;
 
     public JsonObjectFromTransferStartMessageTransformer(JsonBuilderFactory jsonBuilderFactory) {
-        this(jsonBuilderFactory, DSPACE_SCHEMA);
+        this(jsonBuilderFactory, DSP_NAMESPACE_V_08);
     }
 
-    public JsonObjectFromTransferStartMessageTransformer(JsonBuilderFactory jsonBuilderFactory, String namespace) {
+    public JsonObjectFromTransferStartMessageTransformer(JsonBuilderFactory jsonBuilderFactory, JsonLdNamespace namespace) {
         super(TransferStartMessage.class, JsonObject.class, namespace);
         this.jsonBuilderFactory = jsonBuilderFactory;
     }

--- a/data-protocols/dsp/dsp-transfer-process/lib/dsp-transfer-process-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/type/from/JsonObjectFromTransferSuspensionMessageTransformer.java
+++ b/data-protocols/dsp/dsp-transfer-process/lib/dsp-transfer-process-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/type/from/JsonObjectFromTransferSuspensionMessageTransformer.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.protocol.dsp.transferprocess.transform.type.from;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferSuspensionMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
@@ -24,7 +25,7 @@ import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CODE_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID_TERM;
@@ -36,10 +37,10 @@ public class JsonObjectFromTransferSuspensionMessageTransformer extends Abstract
     private final JsonBuilderFactory jsonBuilderFactory;
 
     public JsonObjectFromTransferSuspensionMessageTransformer(JsonBuilderFactory jsonBuilderFactory) {
-        this(jsonBuilderFactory, DSPACE_SCHEMA);
+        this(jsonBuilderFactory, DSP_NAMESPACE_V_08);
     }
 
-    public JsonObjectFromTransferSuspensionMessageTransformer(JsonBuilderFactory jsonBuilderFactory, String namespace) {
+    public JsonObjectFromTransferSuspensionMessageTransformer(JsonBuilderFactory jsonBuilderFactory, JsonLdNamespace namespace) {
         super(TransferSuspensionMessage.class, JsonObject.class, namespace);
         this.jsonBuilderFactory = jsonBuilderFactory;
     }

--- a/data-protocols/dsp/dsp-transfer-process/lib/dsp-transfer-process-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/type/from/JsonObjectFromTransferTerminationMessageTransformer.java
+++ b/data-protocols/dsp/dsp-transfer-process/lib/dsp-transfer-process-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/type/from/JsonObjectFromTransferTerminationMessageTransformer.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.protocol.dsp.transferprocess.transform.type.from;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferTerminationMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
@@ -24,7 +25,7 @@ import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CODE_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID_TERM;
@@ -36,10 +37,10 @@ public class JsonObjectFromTransferTerminationMessageTransformer extends Abstrac
     private final JsonBuilderFactory jsonBuilderFactory;
 
     public JsonObjectFromTransferTerminationMessageTransformer(JsonBuilderFactory jsonBuilderFactory) {
-        this(jsonBuilderFactory, DSPACE_SCHEMA);
+        this(jsonBuilderFactory, DSP_NAMESPACE_V_08);
     }
 
-    public JsonObjectFromTransferTerminationMessageTransformer(JsonBuilderFactory jsonBuilderFactory, String namespace) {
+    public JsonObjectFromTransferTerminationMessageTransformer(JsonBuilderFactory jsonBuilderFactory, JsonLdNamespace namespace) {
         super(TransferTerminationMessage.class, JsonObject.class, namespace);
         this.jsonBuilderFactory = jsonBuilderFactory;
     }

--- a/data-protocols/dsp/dsp-transfer-process/lib/dsp-transfer-process-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/type/to/JsonObjectToTransferCompletionMessageTransformer.java
+++ b/data-protocols/dsp/dsp-transfer-process/lib/dsp-transfer-process-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/type/to/JsonObjectToTransferCompletionMessageTransformer.java
@@ -16,12 +16,13 @@ package org.eclipse.edc.protocol.dsp.transferprocess.transform.type.to;
 
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferCompletionMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE_TERM;
@@ -29,10 +30,10 @@ import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAn
 public class JsonObjectToTransferCompletionMessageTransformer extends AbstractNamespaceAwareJsonLdTransformer<JsonObject, TransferCompletionMessage> {
 
     public JsonObjectToTransferCompletionMessageTransformer() {
-        this(DSPACE_SCHEMA);
+        this(DSP_NAMESPACE_V_08);
     }
 
-    public JsonObjectToTransferCompletionMessageTransformer(String namespace) {
+    public JsonObjectToTransferCompletionMessageTransformer(JsonLdNamespace namespace) {
         super(JsonObject.class, TransferCompletionMessage.class, namespace);
     }
 

--- a/data-protocols/dsp/dsp-transfer-process/lib/dsp-transfer-process-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/type/to/JsonObjectToTransferProcessAckTransformer.java
+++ b/data-protocols/dsp/dsp-transfer-process/lib/dsp-transfer-process-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/type/to/JsonObjectToTransferProcessAckTransformer.java
@@ -16,12 +16,13 @@ package org.eclipse.edc.protocol.dsp.transferprocess.transform.type.to;
 
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferProcessAck;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_STATE_TERM;
@@ -32,10 +33,10 @@ import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPA
 public class JsonObjectToTransferProcessAckTransformer extends AbstractNamespaceAwareJsonLdTransformer<JsonObject, TransferProcessAck> {
 
     public JsonObjectToTransferProcessAckTransformer() {
-        this(DSPACE_SCHEMA);
+        this(DSP_NAMESPACE_V_08);
     }
 
-    public JsonObjectToTransferProcessAckTransformer(String namespace) {
+    public JsonObjectToTransferProcessAckTransformer(JsonLdNamespace namespace) {
         super(JsonObject.class, TransferProcessAck.class, namespace);
     }
 

--- a/data-protocols/dsp/dsp-transfer-process/lib/dsp-transfer-process-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/type/to/JsonObjectToTransferRequestMessageTransformer.java
+++ b/data-protocols/dsp/dsp-transfer-process/lib/dsp-transfer-process-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/type/to/JsonObjectToTransferRequestMessageTransformer.java
@@ -16,14 +16,15 @@ package org.eclipse.edc.protocol.dsp.transferprocess.transform.type.to;
 
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferRequestMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCT_FORMAT_ATTRIBUTE;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_PROPERTY_CONTRACT_AGREEMENT_ID_TERM;
@@ -33,10 +34,10 @@ import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAn
 public class JsonObjectToTransferRequestMessageTransformer extends AbstractNamespaceAwareJsonLdTransformer<JsonObject, TransferRequestMessage> {
 
     public JsonObjectToTransferRequestMessageTransformer() {
-        this(DSPACE_SCHEMA);
+        this(DSP_NAMESPACE_V_08);
     }
 
-    public JsonObjectToTransferRequestMessageTransformer(String namespace) {
+    public JsonObjectToTransferRequestMessageTransformer(JsonLdNamespace namespace) {
         super(JsonObject.class, TransferRequestMessage.class, namespace);
     }
 

--- a/data-protocols/dsp/dsp-transfer-process/lib/dsp-transfer-process-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/type/to/JsonObjectToTransferStartMessageTransformer.java
+++ b/data-protocols/dsp/dsp-transfer-process/lib/dsp-transfer-process-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/type/to/JsonObjectToTransferStartMessageTransformer.java
@@ -16,13 +16,14 @@ package org.eclipse.edc.protocol.dsp.transferprocess.transform.type.to;
 
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferStartMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_PROPERTY_DATA_ADDRESS_TERM;
@@ -31,10 +32,10 @@ import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAn
 public class JsonObjectToTransferStartMessageTransformer extends AbstractNamespaceAwareJsonLdTransformer<JsonObject, TransferStartMessage> {
 
     public JsonObjectToTransferStartMessageTransformer() {
-        this(DSPACE_SCHEMA);
+        this(DSP_NAMESPACE_V_08);
     }
 
-    public JsonObjectToTransferStartMessageTransformer(String namespace) {
+    public JsonObjectToTransferStartMessageTransformer(JsonLdNamespace namespace) {
         super(JsonObject.class, TransferStartMessage.class, namespace);
     }
 

--- a/data-protocols/dsp/dsp-transfer-process/lib/dsp-transfer-process-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/type/to/JsonObjectToTransferSuspensionMessageTransformer.java
+++ b/data-protocols/dsp/dsp-transfer-process/lib/dsp-transfer-process-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/type/to/JsonObjectToTransferSuspensionMessageTransformer.java
@@ -20,6 +20,7 @@ import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonValue;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferSuspensionMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.transform.spi.TransformerContext;
@@ -29,7 +30,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Map;
 
 import static jakarta.json.JsonValue.ValueType.ARRAY;
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CODE_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID_TERM;
@@ -42,10 +43,10 @@ public class JsonObjectToTransferSuspensionMessageTransformer extends AbstractNa
     private final ObjectMapper objectMapper;
 
     public JsonObjectToTransferSuspensionMessageTransformer(ObjectMapper objectMapper) {
-        this(objectMapper, DSPACE_SCHEMA);
+        this(objectMapper, DSP_NAMESPACE_V_08);
     }
 
-    public JsonObjectToTransferSuspensionMessageTransformer(ObjectMapper objectMapper, String namespace) {
+    public JsonObjectToTransferSuspensionMessageTransformer(ObjectMapper objectMapper, JsonLdNamespace namespace) {
         super(JsonObject.class, TransferSuspensionMessage.class, namespace);
         this.objectMapper = objectMapper;
     }

--- a/data-protocols/dsp/dsp-transfer-process/lib/dsp-transfer-process-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/type/to/JsonObjectToTransferTerminationMessageTransformer.java
+++ b/data-protocols/dsp/dsp-transfer-process/lib/dsp-transfer-process-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/type/to/JsonObjectToTransferTerminationMessageTransformer.java
@@ -17,13 +17,14 @@ package org.eclipse.edc.protocol.dsp.transferprocess.transform.type.to;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferTerminationMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import static jakarta.json.JsonValue.ValueType.ARRAY;
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CODE_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID_TERM;
@@ -33,10 +34,10 @@ import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAn
 public class JsonObjectToTransferTerminationMessageTransformer extends AbstractNamespaceAwareJsonLdTransformer<JsonObject, TransferTerminationMessage> {
 
     public JsonObjectToTransferTerminationMessageTransformer() {
-        this(DSPACE_SCHEMA);
+        this(DSP_NAMESPACE_V_08);
     }
 
-    public JsonObjectToTransferTerminationMessageTransformer(String namespace) {
+    public JsonObjectToTransferTerminationMessageTransformer(JsonLdNamespace namespace) {
         super(JsonObject.class, TransferTerminationMessage.class, namespace);
     }
 

--- a/data-protocols/dsp/dsp-transfer-process/lib/dsp-transfer-process-validation-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/validation/TransferCompletionMessageValidator.java
+++ b/data-protocols/dsp/dsp-transfer-process/lib/dsp-transfer-process-validation-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/validation/TransferCompletionMessageValidator.java
@@ -16,11 +16,12 @@ package org.eclipse.edc.protocol.dsp.transferprocess.validation;
 
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferCompletionMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.validator.jsonobject.JsonObjectValidator;
 import org.eclipse.edc.validator.jsonobject.validators.TypeIs;
 import org.eclipse.edc.validator.spi.Validator;
 
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE_TERM;
 
 /**
@@ -29,12 +30,12 @@ import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAn
 public class TransferCompletionMessageValidator {
 
     public static Validator<JsonObject> instance() {
-        return instance(DSPACE_SCHEMA);
+        return instance(DSP_NAMESPACE_V_08);
     }
 
-    public static Validator<JsonObject> instance(String schema) {
+    public static Validator<JsonObject> instance(JsonLdNamespace namespace) {
         return JsonObjectValidator.newValidator()
-                .verify(path -> new TypeIs(path, schema + DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE_TERM))
+                .verify(path -> new TypeIs(path, namespace.toIri(DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE_TERM)))
                 .build();
     }
 }

--- a/data-protocols/dsp/dsp-transfer-process/lib/dsp-transfer-process-validation-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/validation/TransferRequestMessageValidator.java
+++ b/data-protocols/dsp/dsp-transfer-process/lib/dsp-transfer-process-validation-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/validation/TransferRequestMessageValidator.java
@@ -16,11 +16,12 @@ package org.eclipse.edc.protocol.dsp.transferprocess.validation;
 
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferRequestMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.validator.jsonobject.JsonObjectValidator;
 import org.eclipse.edc.validator.jsonobject.validators.TypeIs;
 import org.eclipse.edc.validator.spi.Validator;
 
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_REQUEST_MESSAGE_TERM;
 
 /**
@@ -29,12 +30,12 @@ import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAn
 public class TransferRequestMessageValidator {
 
     public static Validator<JsonObject> instance() {
-        return instance(DSPACE_SCHEMA);
+        return instance(DSP_NAMESPACE_V_08);
     }
 
-    public static Validator<JsonObject> instance(String schema) {
+    public static Validator<JsonObject> instance(JsonLdNamespace namespace) {
         return JsonObjectValidator.newValidator()
-                .verify(path -> new TypeIs(path, schema + DSPACE_TYPE_TRANSFER_REQUEST_MESSAGE_TERM))
+                .verify(path -> new TypeIs(path, namespace.toIri(DSPACE_TYPE_TRANSFER_REQUEST_MESSAGE_TERM)))
                 .build();
     }
 }

--- a/data-protocols/dsp/dsp-transfer-process/lib/dsp-transfer-process-validation-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/validation/TransferStartMessageValidator.java
+++ b/data-protocols/dsp/dsp-transfer-process/lib/dsp-transfer-process-validation-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/validation/TransferStartMessageValidator.java
@@ -16,11 +16,12 @@ package org.eclipse.edc.protocol.dsp.transferprocess.validation;
 
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferStartMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.validator.jsonobject.JsonObjectValidator;
 import org.eclipse.edc.validator.jsonobject.validators.TypeIs;
 import org.eclipse.edc.validator.spi.Validator;
 
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_START_MESSAGE_TERM;
 
 /**
@@ -29,12 +30,12 @@ import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAn
 public class TransferStartMessageValidator {
 
     public static Validator<JsonObject> instance() {
-        return instance(DSPACE_SCHEMA);
+        return instance(DSP_NAMESPACE_V_08);
     }
 
-    public static Validator<JsonObject> instance(String schema) {
+    public static Validator<JsonObject> instance(JsonLdNamespace namespace) {
         return JsonObjectValidator.newValidator()
-                .verify(path -> new TypeIs(path, schema + DSPACE_TYPE_TRANSFER_START_MESSAGE_TERM))
+                .verify(path -> new TypeIs(path, namespace.toIri(DSPACE_TYPE_TRANSFER_START_MESSAGE_TERM)))
                 .build();
     }
 }

--- a/data-protocols/dsp/dsp-transfer-process/lib/dsp-transfer-process-validation-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/validation/TransferTerminationMessageValidator.java
+++ b/data-protocols/dsp/dsp-transfer-process/lib/dsp-transfer-process-validation-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/validation/TransferTerminationMessageValidator.java
@@ -16,11 +16,12 @@ package org.eclipse.edc.protocol.dsp.transferprocess.validation;
 
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferTerminationMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.validator.jsonobject.JsonObjectValidator;
 import org.eclipse.edc.validator.jsonobject.validators.TypeIs;
 import org.eclipse.edc.validator.spi.Validator;
 
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_TERMINATION_MESSAGE_TERM;
 
 /**
@@ -29,12 +30,12 @@ import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAn
 public class TransferTerminationMessageValidator {
 
     public static Validator<JsonObject> instance() {
-        return instance(DSPACE_SCHEMA);
+        return instance(DSP_NAMESPACE_V_08);
     }
 
-    public static Validator<JsonObject> instance(String schema) {
+    public static Validator<JsonObject> instance(JsonLdNamespace namespace) {
         return JsonObjectValidator.newValidator()
-                .verify(path -> new TypeIs(path, schema + DSPACE_TYPE_TRANSFER_TERMINATION_MESSAGE_TERM))
+                .verify(path -> new TypeIs(path, namespace.toIri(DSPACE_TYPE_TRANSFER_TERMINATION_MESSAGE_TERM)))
                 .build();
     }
 }

--- a/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/JsonLdNamespace.java
+++ b/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/JsonLdNamespace.java
@@ -12,12 +12,12 @@
  *
  */
 
-package org.eclipse.edc.protocol.dsp.spi.type;
+package org.eclipse.edc.jsonld.spi;
 
 /**
- * Represents a namespace for DSP terms.
+ * Represents a namespace for terms.
  */
-public record DspNamespace(String namespace) {
+public record JsonLdNamespace(String namespace) {
 
     /**
      * Converts a given term to its IRI (Internationalized Resource Identifier) by appending it to the namespace.

--- a/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/transformer/AbstractNamespaceAwareJsonLdTransformer.java
+++ b/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/transformer/AbstractNamespaceAwareJsonLdTransformer.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.edc.jsonld.spi.transformer;
 
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
+
 /**
  * Abstract base class for JSON-LD transformers that are aware of a specific namespace.
  * This class extends {@link AbstractJsonLdTransformer} and provides additional functionality
@@ -24,15 +26,15 @@ package org.eclipse.edc.jsonld.spi.transformer;
  */
 public abstract class AbstractNamespaceAwareJsonLdTransformer<INPUT, OUTPUT> extends AbstractJsonLdTransformer<INPUT, OUTPUT> {
 
-    private final String namespace;
+    private final JsonLdNamespace namespace;
 
-    protected AbstractNamespaceAwareJsonLdTransformer(Class<INPUT> input, Class<OUTPUT> output, String namespace) {
+    protected AbstractNamespaceAwareJsonLdTransformer(Class<INPUT> input, Class<OUTPUT> output, JsonLdNamespace namespace) {
         super(input, output);
         this.namespace = namespace;
     }
 
     protected String forNamespace(String term) {
-        return namespace + term;
+        return namespace.toIri(term);
     }
 
 }


### PR DESCRIPTION
## What this PR changes/adds

add DspNamespace usage instead of hardcoded strings.

Additionally the `DspNamespace` has been renamed and moved in `json-ld-spi` so it can be used not only in DSP layer

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #4561 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
