### PR TITLE
refactor(policy): narrow ScopeExtractor policy context type bounds

### DIFF
--- a/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/scope/DcpScopeExtractorRegistry.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/scope/DcpScopeExtractorRegistry.java
@@ -16,7 +16,7 @@ package org.eclipse.edc.iam.identitytrust.core.scope;
 
 import org.eclipse.edc.iam.identitytrust.spi.scope.ScopeExtractor;
 import org.eclipse.edc.iam.identitytrust.spi.scope.ScopeExtractorRegistry;
-import org.eclipse.edc.policy.engine.spi.PolicyContext;
+import org.eclipse.edc.policy.context.request.spi.RequestPolicyContext;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.result.Result;
 
@@ -34,7 +34,7 @@ public class DcpScopeExtractorRegistry implements ScopeExtractorRegistry {
     }
 
     @Override
-    public Result<Set<String>> extractScopes(Policy policy, PolicyContext policyContext) {
+    public Result<Set<String>> extractScopes(Policy policy, RequestPolicyContext policyContext) {
         var visitor = new DcpScopeExtractorVisitor(extractors, policyContext);
         var policies = policy.accept(visitor);
         if (policyContext.hasProblems()) {

--- a/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/scope/DcpScopeExtractorVisitor.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/scope/DcpScopeExtractorVisitor.java
@@ -15,7 +15,7 @@
 package org.eclipse.edc.iam.identitytrust.core.scope;
 
 import org.eclipse.edc.iam.identitytrust.spi.scope.ScopeExtractor;
-import org.eclipse.edc.policy.engine.spi.PolicyContext;
+import org.eclipse.edc.policy.context.request.spi.RequestPolicyContext;
 import org.eclipse.edc.policy.model.AndConstraint;
 import org.eclipse.edc.policy.model.AtomicConstraint;
 import org.eclipse.edc.policy.model.Constraint;
@@ -42,9 +42,9 @@ import java.util.stream.Collectors;
 public class DcpScopeExtractorVisitor implements Policy.Visitor<Set<String>>, Rule.Visitor<Set<String>>, Constraint.Visitor<Set<String>>, Expression.Visitor<Object> {
 
     private final List<ScopeExtractor> mappers;
-    private final PolicyContext policyContext;
+    private final RequestPolicyContext policyContext;
 
-    public DcpScopeExtractorVisitor(List<ScopeExtractor> mappers, PolicyContext policyContext) {
+    public DcpScopeExtractorVisitor(List<ScopeExtractor> mappers, RequestPolicyContext policyContext) {
         this.mappers = mappers;
         this.policyContext = policyContext;
     }

--- a/extensions/common/iam/identity-trust/identity-trust-core/src/test/java/org/eclipse/edc/iam/identitytrust/core/scope/DcpScopeExtractorRegistryTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/test/java/org/eclipse/edc/iam/identitytrust/core/scope/DcpScopeExtractorRegistryTest.java
@@ -15,7 +15,7 @@
 package org.eclipse.edc.iam.identitytrust.core.scope;
 
 import org.eclipse.edc.iam.identitytrust.spi.scope.ScopeExtractor;
-import org.eclipse.edc.policy.engine.spi.PolicyContext;
+import org.eclipse.edc.policy.context.request.spi.RequestPolicyContext;
 import org.eclipse.edc.policy.model.Constraint;
 import org.eclipse.edc.policy.model.Operator;
 import org.eclipse.edc.policy.model.Policy;
@@ -50,14 +50,12 @@ import static org.mockito.Mockito.when;
 
 public class DcpScopeExtractorRegistryTest {
 
+    private final RequestPolicyContext ctx = mock();
+    private final ScopeExtractor extractor = mock();
     private final DcpScopeExtractorRegistry registry = new DcpScopeExtractorRegistry();
-    private ScopeExtractor extractor;
-    private PolicyContext ctx;
 
     @BeforeEach
     void setup() {
-        extractor = mock(ScopeExtractor.class);
-        ctx = mock(PolicyContext.class);
         registry.registerScopeExtractor(extractor);
     }
 

--- a/spi/common/identity-trust-spi/build.gradle.kts
+++ b/spi/common/identity-trust-spi/build.gradle.kts
@@ -21,6 +21,7 @@ plugins {
 dependencies {
     api(project(":spi:common:core-spi"))
     api(project(":spi:common:participant-spi"))
+    api(project(":spi:common:policy:request-policy-context-spi"))
     api(project(":spi:common:policy-engine-spi"))
     api(project(":spi:common:verifiable-credentials-spi"))
     api(libs.iron.vc) {

--- a/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/iam/identitytrust/spi/scope/ScopeExtractor.java
+++ b/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/iam/identitytrust/spi/scope/ScopeExtractor.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.edc.iam.identitytrust.spi.scope;
 
-import org.eclipse.edc.policy.engine.spi.PolicyContext;
+import org.eclipse.edc.policy.context.request.spi.RequestPolicyContext;
 import org.eclipse.edc.policy.engine.spi.PolicyEngine;
 import org.eclipse.edc.policy.model.AtomicConstraint;
 import org.eclipse.edc.policy.model.Operator;
@@ -36,5 +36,5 @@ public interface ScopeExtractor {
      * @param rightValue the right-side expression for the constraint.
      * @param context    the policy context
      */
-    Set<String> extractScopes(Object leftValue, Operator operator, Object rightValue, PolicyContext context);
+    Set<String> extractScopes(Object leftValue, Operator operator, Object rightValue, RequestPolicyContext context);
 }

--- a/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/iam/identitytrust/spi/scope/ScopeExtractorRegistry.java
+++ b/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/iam/identitytrust/spi/scope/ScopeExtractorRegistry.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.edc.iam.identitytrust.spi.scope;
 
-import org.eclipse.edc.policy.engine.spi.PolicyContext;
+import org.eclipse.edc.policy.context.request.spi.RequestPolicyContext;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import org.eclipse.edc.spi.result.Result;
@@ -41,5 +41,5 @@ public interface ScopeExtractorRegistry {
      * @param policyContext The policy context
      * @return The set of scopes to use if succeeded, otherwise failure
      */
-    Result<Set<String>> extractScopes(Policy policy, PolicyContext policyContext);
+    Result<Set<String>> extractScopes(Policy policy, RequestPolicyContext policyContext);
 }


### PR DESCRIPTION
## What this PR changes/adds

Binds `ScopeExtractor` to `RequestPolicyContext` because it's the actual upper type that's passed to it. 

## Why it does that

simplify implementation from adopters point of view

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #4569 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
