### PR TITLE
refactor(test): improve QueryValidator testing strategy

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
@@ -28,6 +28,7 @@ import org.eclipse.edc.connector.controlplane.contract.spi.validation.ContractVa
 import org.eclipse.edc.connector.controlplane.policy.spi.observe.PolicyDefinitionObservableImpl;
 import org.eclipse.edc.connector.controlplane.policy.spi.store.PolicyDefinitionStore;
 import org.eclipse.edc.connector.controlplane.services.asset.AssetEventListener;
+import org.eclipse.edc.connector.controlplane.services.asset.AssetQueryValidator;
 import org.eclipse.edc.connector.controlplane.services.asset.AssetServiceImpl;
 import org.eclipse.edc.connector.controlplane.services.catalog.CatalogProtocolServiceImpl;
 import org.eclipse.edc.connector.controlplane.services.catalog.CatalogServiceImpl;
@@ -40,6 +41,7 @@ import org.eclipse.edc.connector.controlplane.services.policydefinition.PolicyDe
 import org.eclipse.edc.connector.controlplane.services.policydefinition.PolicyDefinitionServiceImpl;
 import org.eclipse.edc.connector.controlplane.services.protocol.ProtocolTokenValidatorImpl;
 import org.eclipse.edc.connector.controlplane.services.protocol.VersionProtocolServiceImpl;
+import org.eclipse.edc.connector.controlplane.services.query.QueryValidators;
 import org.eclipse.edc.connector.controlplane.services.secret.SecretEventListener;
 import org.eclipse.edc.connector.controlplane.services.secret.SecretServiceImpl;
 import org.eclipse.edc.connector.controlplane.services.spi.asset.AssetService;
@@ -199,7 +201,8 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     public AssetService assetService() {
         var assetObservable = new AssetObservableImpl();
         assetObservable.registerListener(new AssetEventListener(clock, eventRouter));
-        return new AssetServiceImpl(assetIndex, contractNegotiationStore, transactionContext, assetObservable, dataAddressValidator);
+        return new AssetServiceImpl(assetIndex, contractNegotiationStore, transactionContext, assetObservable,
+                dataAddressValidator, new AssetQueryValidator());
     }
 
     @Provider
@@ -222,19 +225,20 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
 
     @Provider
     public ContractAgreementService contractAgreementService() {
-        return new ContractAgreementServiceImpl(contractNegotiationStore, transactionContext);
+        return new ContractAgreementServiceImpl(contractNegotiationStore, transactionContext, QueryValidators.contractAgreement());
     }
 
     @Provider
     public ContractDefinitionService contractDefinitionService() {
         var contractDefinitionObservable = new ContractDefinitionObservableImpl();
         contractDefinitionObservable.registerListener(new ContractDefinitionEventListener(clock, eventRouter));
-        return new ContractDefinitionServiceImpl(contractDefinitionStore, transactionContext, contractDefinitionObservable);
+        return new ContractDefinitionServiceImpl(contractDefinitionStore, transactionContext, contractDefinitionObservable, QueryValidators.contractDefinition());
     }
 
     @Provider
     public ContractNegotiationService contractNegotiationService() {
-        return new ContractNegotiationServiceImpl(contractNegotiationStore, consumerContractNegotiationManager, transactionContext, commandHandlerRegistry);
+        return new ContractNegotiationServiceImpl(contractNegotiationStore, consumerContractNegotiationManager,
+                transactionContext, commandHandlerRegistry, QueryValidators.contractNegotiation());
     }
 
     @Provider
@@ -248,13 +252,15 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     public PolicyDefinitionService policyDefinitionService() {
         var policyDefinitionObservable = new PolicyDefinitionObservableImpl();
         policyDefinitionObservable.registerListener(new PolicyDefinitionEventListener(clock, eventRouter));
-        return new PolicyDefinitionServiceImpl(transactionContext, policyDefinitionStore, contractDefinitionStore, policyDefinitionObservable, policyEngine);
+        return new PolicyDefinitionServiceImpl(transactionContext, policyDefinitionStore, contractDefinitionStore,
+                policyDefinitionObservable, policyEngine, QueryValidators.policyDefinition());
     }
 
     @Provider
     public TransferProcessService transferProcessService() {
         return new TransferProcessServiceImpl(transferProcessStore, transferProcessManager, transactionContext,
-                dataAddressValidator, commandHandlerRegistry, transferTypeParser, contractNegotiationStore);
+                dataAddressValidator, commandHandlerRegistry, transferTypeParser, contractNegotiationStore,
+                QueryValidators.transferProcess());
     }
 
     @Provider

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/asset/AssetQueryValidator.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/asset/AssetQueryValidator.java
@@ -22,10 +22,10 @@ import java.util.regex.Pattern;
 
 import static java.lang.String.format;
 
-class AssetQueryValidator extends QueryValidator {
+public class AssetQueryValidator extends QueryValidator {
     private static final Pattern VALID_QUERY_PATH_REGEX = Pattern.compile("^[A-Za-z_']+.*$");
 
-    AssetQueryValidator() {
+    public AssetQueryValidator() {
         super(Asset.class);
     }
 

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/asset/AssetServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/asset/AssetServiceImpl.java
@@ -43,13 +43,13 @@ public class AssetServiceImpl implements AssetService {
 
     public AssetServiceImpl(AssetIndex index, ContractNegotiationStore contractNegotiationStore,
                             TransactionContext transactionContext, AssetObservable observable,
-                            DataAddressValidatorRegistry dataAddressValidator) {
+                            DataAddressValidatorRegistry dataAddressValidator, QueryValidator queryValidator) {
         this.index = index;
         this.contractNegotiationStore = contractNegotiationStore;
         this.transactionContext = transactionContext;
         this.observable = observable;
         this.dataAddressValidator = dataAddressValidator;
-        queryValidator = new AssetQueryValidator();
+        this.queryValidator = queryValidator;
     }
 
     @Override

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/contractagreement/ContractAgreementServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/contractagreement/ContractAgreementServiceImpl.java
@@ -33,10 +33,10 @@ public class ContractAgreementServiceImpl implements ContractAgreementService {
     private final TransactionContext transactionContext;
     private final QueryValidator queryValidator;
 
-    public ContractAgreementServiceImpl(ContractNegotiationStore store, TransactionContext transactionContext) {
+    public ContractAgreementServiceImpl(ContractNegotiationStore store, TransactionContext transactionContext, QueryValidator queryValidator) {
         this.store = store;
         this.transactionContext = transactionContext;
-        queryValidator = new QueryValidator(ContractAgreement.class);
+        this.queryValidator = queryValidator;
     }
 
     @Override

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/contractdefinition/ContractDefinitionServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/contractdefinition/ContractDefinitionServiceImpl.java
@@ -33,11 +33,12 @@ public class ContractDefinitionServiceImpl implements ContractDefinitionService 
     private final ContractDefinitionObservable observable;
     private final QueryValidator queryValidator;
 
-    public ContractDefinitionServiceImpl(ContractDefinitionStore store, TransactionContext transactionContext, ContractDefinitionObservable observable) {
+    public ContractDefinitionServiceImpl(ContractDefinitionStore store, TransactionContext transactionContext,
+                                         ContractDefinitionObservable observable, QueryValidator queryValidator) {
         this.store = store;
         this.transactionContext = transactionContext;
         this.observable = observable;
-        queryValidator = new QueryValidator(ContractDefinition.class);
+        this.queryValidator = queryValidator;
     }
 
     @Override

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationServiceImpl.java
@@ -43,12 +43,13 @@ public class ContractNegotiationServiceImpl implements ContractNegotiationServic
     private final QueryValidator queryValidator;
 
     public ContractNegotiationServiceImpl(ContractNegotiationStore store, ConsumerContractNegotiationManager consumerManager,
-                                          TransactionContext transactionContext, CommandHandlerRegistry commandHandlerRegistry) {
+                                          TransactionContext transactionContext, CommandHandlerRegistry commandHandlerRegistry,
+                                          QueryValidator queryValidator) {
         this.store = store;
         this.consumerManager = consumerManager;
         this.transactionContext = transactionContext;
         this.commandHandlerRegistry = commandHandlerRegistry;
-        queryValidator = new QueryValidator(ContractNegotiation.class);
+        this.queryValidator = queryValidator;
     }
 
     @Override

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/policydefinition/PolicyDefinitionServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/policydefinition/PolicyDefinitionServiceImpl.java
@@ -53,13 +53,14 @@ public class PolicyDefinitionServiceImpl implements PolicyDefinitionService {
 
 
     public PolicyDefinitionServiceImpl(TransactionContext transactionContext, PolicyDefinitionStore policyStore,
-                                       ContractDefinitionStore contractDefinitionStore, PolicyDefinitionObservable observable, PolicyEngine policyEngine) {
+                                       ContractDefinitionStore contractDefinitionStore, PolicyDefinitionObservable observable,
+                                       PolicyEngine policyEngine, QueryValidator queryValidator) {
         this.transactionContext = transactionContext;
         this.policyStore = policyStore;
         this.contractDefinitionStore = contractDefinitionStore;
         this.observable = observable;
         this.policyEngine = policyEngine;
-        queryValidator = new QueryValidator(PolicyDefinition.class, getSubtypeMap());
+        this.queryValidator = queryValidator;
     }
 
     @Override

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/query/QueryValidator.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/query/QueryValidator.java
@@ -26,9 +26,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import static java.lang.String.format;
+import static java.util.Collections.emptyMap;
 
 /**
  * Validates that a particular query is valid, i.e. contains a left-hand operand, that conforms to the canonical
@@ -51,7 +51,7 @@ public class QueryValidator {
     }
 
     public QueryValidator(Class<?> canonicalType) {
-        this(canonicalType, null);
+        this(canonicalType, emptyMap());
     }
 
     /**
@@ -105,13 +105,12 @@ public class QueryValidator {
 
     private Field getFieldIncludingSubtypes(Class<?> type, String token) {
         var field = ReflectionUtil.getFieldRecursive(type, token);
-        if (field == null && subtypeMap != null) {
+        if (field == null) {
             var subTypes = subtypeMap.get(type);
             if (subTypes != null) {
-                var foundTypes = subTypes.stream().map(st -> getFieldIncludingSubtypes(st, token))
+                return subTypes.stream().map(st -> getFieldIncludingSubtypes(st, token))
                         .filter(Objects::nonNull)
-                        .collect(Collectors.toList());
-                return foundTypes.stream().findFirst().orElse(null);
+                        .findFirst().orElse(null);
             }
         }
         return field;

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/query/QueryValidators.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/query/QueryValidators.java
@@ -1,0 +1,102 @@
+/*
+ *  Copyright (c) 2024 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.services.query;
+
+import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractDefinition;
+import org.eclipse.edc.connector.controlplane.policy.spi.PolicyDefinition;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.ProvisionedContentResource;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.ProvisionedDataAddressResource;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.ProvisionedDataDestinationResource;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.ProvisionedResource;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
+import org.eclipse.edc.policy.model.AndConstraint;
+import org.eclipse.edc.policy.model.AtomicConstraint;
+import org.eclipse.edc.policy.model.Constraint;
+import org.eclipse.edc.policy.model.Expression;
+import org.eclipse.edc.policy.model.LiteralExpression;
+import org.eclipse.edc.policy.model.MultiplicityConstraint;
+import org.eclipse.edc.policy.model.OrConstraint;
+import org.eclipse.edc.policy.model.XoneConstraint;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Factory methods to instantiate {@link QueryValidators}
+ */
+public final class QueryValidators {
+
+    /**
+     * Validator for {@link ContractAgreement}
+     *
+     * @return the validator.
+     */
+    public static QueryValidator contractAgreement() {
+        return new QueryValidator(ContractAgreement.class);
+    }
+
+    /**
+     * Validator for {@link ContractDefinition}
+     *
+     * @return the validator.
+     */
+    public static QueryValidator contractDefinition() {
+        return new QueryValidator(ContractDefinition.class);
+    }
+
+    /**
+     * Validator for {@link ContractNegotiation}
+     *
+     * @return the validator.
+     */
+    public static QueryValidator contractNegotiation() {
+        return new QueryValidator(ContractNegotiation.class);
+    }
+
+    /**
+     * Validator for {@link PolicyDefinition}
+     *
+     * @return the validator.
+     */
+    public static QueryValidator policyDefinition() {
+        return new QueryValidator(PolicyDefinition.class, policySubtypeMap());
+    }
+
+    /**
+     * Validator for {@link TransferProcess}
+     *
+     * @return the validator.
+     */
+    public static QueryValidator transferProcess() {
+        return new QueryValidator(TransferProcess.class, transferProcessSubtypeMap());
+    }
+
+    private static Map<Class<?>, List<Class<?>>> policySubtypeMap() {
+        return Map.of(
+                Constraint.class, List.of(MultiplicityConstraint.class, AtomicConstraint.class),
+                MultiplicityConstraint.class, List.of(AndConstraint.class, OrConstraint.class, XoneConstraint.class),
+                Expression.class, List.of(LiteralExpression.class)
+        );
+    }
+
+    private static Map<Class<?>, List<Class<?>>> transferProcessSubtypeMap() {
+        return Map.of(
+                ProvisionedResource.class, List.of(ProvisionedDataAddressResource.class),
+                ProvisionedDataAddressResource.class, List.of(ProvisionedDataDestinationResource.class, ProvisionedContentResource.class)
+        );
+    }
+}

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessServiceImpl.java
@@ -23,10 +23,6 @@ import org.eclipse.edc.connector.controlplane.transfer.spi.flow.TransferTypePars
 import org.eclipse.edc.connector.controlplane.transfer.spi.store.TransferProcessStore;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.DeprovisionedResource;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.ProvisionResponse;
-import org.eclipse.edc.connector.controlplane.transfer.spi.types.ProvisionedContentResource;
-import org.eclipse.edc.connector.controlplane.transfer.spi.types.ProvisionedDataAddressResource;
-import org.eclipse.edc.connector.controlplane.transfer.spi.types.ProvisionedDataDestinationResource;
-import org.eclipse.edc.connector.controlplane.transfer.spi.types.ProvisionedResource;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest;
@@ -49,7 +45,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static java.lang.String.format;
@@ -67,7 +62,7 @@ public class TransferProcessServiceImpl implements TransferProcessService {
     public TransferProcessServiceImpl(TransferProcessStore transferProcessStore, TransferProcessManager manager,
                                       TransactionContext transactionContext, DataAddressValidatorRegistry dataAddressValidator,
                                       CommandHandlerRegistry commandHandlerRegistry, TransferTypeParser transferTypeParser,
-                                      ContractNegotiationStore contractNegotiationStore) {
+                                      ContractNegotiationStore contractNegotiationStore, QueryValidator queryValidator) {
         this.transferProcessStore = transferProcessStore;
         this.manager = manager;
         this.transactionContext = transactionContext;
@@ -75,7 +70,7 @@ public class TransferProcessServiceImpl implements TransferProcessService {
         this.commandHandlerRegistry = commandHandlerRegistry;
         this.transferTypeParser = transferTypeParser;
         this.contractNegotiationStore = contractNegotiationStore;
-        queryValidator = new QueryValidator(TransferProcess.class, getSubtypes());
+        this.queryValidator = queryValidator;
     }
 
     @Override
@@ -180,13 +175,6 @@ public class TransferProcessServiceImpl implements TransferProcessService {
 
     private ServiceResult<Void> execute(EntityCommand command) {
         return transactionContext.execute(() -> commandHandlerRegistry.execute(command).flatMap(ServiceResult::from));
-    }
-
-    private Map<Class<?>, List<Class<?>>> getSubtypes() {
-        return Map.of(
-                ProvisionedResource.class, List.of(ProvisionedDataAddressResource.class),
-                ProvisionedDataAddressResource.class, List.of(ProvisionedDataDestinationResource.class, ProvisionedContentResource.class)
-        );
     }
 
 }

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractdefinition/ContractDefinitionServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractdefinition/ContractDefinitionServiceImplTest.java
@@ -19,30 +19,26 @@ import org.eclipse.edc.connector.controlplane.contract.spi.definition.observe.Co
 import org.eclipse.edc.connector.controlplane.contract.spi.definition.observe.ContractDefinitionObservableImpl;
 import org.eclipse.edc.connector.controlplane.contract.spi.offer.store.ContractDefinitionStore;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractDefinition;
+import org.eclipse.edc.connector.controlplane.services.query.QueryValidator;
 import org.eclipse.edc.connector.controlplane.services.spi.contractdefinition.ContractDefinitionService;
-import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.StoreResult;
 import org.eclipse.edc.transaction.spi.NoopTransactionContext;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.ArgumentsProvider;
-import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import java.util.UUID;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.spi.query.Criterion.criterion;
+import static org.assertj.core.api.InstanceOfAssertFactories.list;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.spi.result.ServiceFailure.Reason.CONFLICT;
 import static org.eclipse.edc.spi.result.ServiceFailure.Reason.NOT_FOUND;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -60,8 +56,9 @@ class ContractDefinitionServiceImplTest {
     private final TransactionContext transactionContext = new NoopTransactionContext();
     private final ContractDefinitionObservable observable = new ContractDefinitionObservableImpl();
     private final ContractDefinitionListener listener = mock();
+    private final QueryValidator queryValidator = mock();
 
-    private final ContractDefinitionService service = new ContractDefinitionServiceImpl(store, transactionContext, observable);
+    private final ContractDefinitionService service = new ContractDefinitionServiceImpl(store, transactionContext, observable, queryValidator);
 
     @BeforeEach
     void setUp() {
@@ -91,35 +88,22 @@ class ContractDefinitionServiceImplTest {
     void search() {
         var definition = createContractDefinition();
         when(store.findAll(isA(QuerySpec.class))).thenReturn(Stream.of(definition));
+        when(queryValidator.validate(any())).thenReturn(Result.success());
 
         var result = service.search(QuerySpec.none());
 
-        assertThat(result.succeeded()).isTrue();
-        assertThat(result.getContent()).hasSize(1).first().matches(hasId(definition.getId()));
+        assertThat(result).isSucceeded().asInstanceOf(list(ContractDefinition.class))
+                .hasSize(1).first().matches(hasId(definition.getId()));
     }
 
-    @ParameterizedTest
-    @ArgumentsSource(InvalidFilters.class)
-    void search_invalidFilter(Criterion invalidFilter) {
-        var query = QuerySpec.Builder.newInstance()
-                .filter(invalidFilter)
-                .build();
+    @Test
+    void search_shouldFail_whenQueryIsNotValid() {
+        when(queryValidator.validate(any())).thenReturn(Result.failure("not valid"));
 
-        var result = service.search(query);
+        var result = service.search(QuerySpec.none());
 
-        assertThat(result.failed()).isTrue();
-    }
-
-    @ParameterizedTest
-    @ArgumentsSource(ValidFilters.class)
-    void search_validFilter(Criterion validFilter) {
-        var query = QuerySpec.Builder.newInstance()
-                .filter(validFilter)
-                .build();
-
-        service.search(query);
-
-        verify(store).findAll(query);
+        assertThat(result).isFailed();
+        verifyNoInteractions(store);
     }
 
     @Test
@@ -208,27 +192,6 @@ class ContractDefinitionServiceImplTest {
         assertThat(updated.failed()).isTrue();
         assertThat(updated.reason()).isEqualTo(NOT_FOUND);
         verify(listener, never()).updated(any());
-    }
-
-    private static class InvalidFilters implements ArgumentsProvider {
-        @Override
-        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-            return Stream.of(
-                    arguments(criterion("assetsSelector.leftHand", "=", "foo")), // invalid path
-                    arguments(criterion("accessPolicyId'LIKE/**/?/**/LIMIT/**/?/**/OFFSET/**/?;DROP/**/TABLE/**/test/**/--%20", "=", "%20ABC--")) //some SQL injection
-            );
-        }
-    }
-
-    private static class ValidFilters implements ArgumentsProvider {
-        @Override
-        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-            return Stream.of(
-                    arguments(criterion("assetsSelector.operandLeft", "=", "foo")),
-                    arguments(criterion("assetsSelector.operator", "=", "LIKE")),
-                    arguments(criterion("assetsSelector.operandRight", "=", "bar"))
-            );
-        }
     }
 
     @NotNull

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/query/QueryValidatorsTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/query/QueryValidatorsTest.java
@@ -1,0 +1,280 @@
+/*
+ *  Copyright (c) 2024 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.services.query;
+
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.util.stream.Stream;
+
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.spi.query.Criterion.criterion;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class QueryValidatorsTest {
+
+    @Nested
+    class PolicyDefinition {
+
+        private final QueryValidator validator = QueryValidators.policyDefinition();
+
+        @Test
+        void shouldSucceed_whenQueryIsEmpty() {
+            var result = validator.validate(QuerySpec.none());
+
+            assertThat(result).isSucceeded();
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(InvalidFilters.class)
+        void shouldFail_whenInvalidFilters(Criterion invalidFilter) {
+            var query = QuerySpec.Builder.newInstance()
+                    .filter(invalidFilter)
+                    .build();
+
+            var result = validator.validate(query);
+
+            assertThat(result).isFailed();
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(ValidFilters.class)
+        void shouldSucceed_whenValidFilters(Criterion validFilter) {
+            var query = QuerySpec.Builder.newInstance()
+                    .filter(validFilter)
+                    .build();
+
+            var result = validator.validate(query);
+
+            assertThat(result).isSucceeded();
+        }
+
+        private static class InvalidFilters implements ArgumentsProvider {
+            @Override
+            public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+                return Stream.of(
+                        arguments(criterion("policy.permissions.action.constraint.noexist", "=", "123455")), // wrong property
+                        arguments(criterion("permissions.action.constraint.leftExpression", "=", "123455")), // missing root
+                        arguments(criterion("policy.permissions.action.leftExpression", "=", "123455")) // skips path element
+                );
+            }
+        }
+
+        private static class ValidFilters implements ArgumentsProvider {
+            private static final String PRIVATE_PROPERTIES = "privateProperties";
+            private static final String EDC_NAMESPACE = "'https://w3id.org/edc/v0.0.1/ns/'";
+            private static final String KEY = "key";
+
+            private static final String VALUE = "123455";
+
+            @Override
+            public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+                return Stream.of(
+                        arguments(criterion(PRIVATE_PROPERTIES, "=", VALUE)), // path element with privateProperties
+                        arguments(criterion(PRIVATE_PROPERTIES + "." + KEY, "=", VALUE)), // path element with privateProperties and key
+                        arguments(criterion(PRIVATE_PROPERTIES + ".'" + KEY + "'", "=", VALUE)), // path element with privateProperties and 'key'
+                        arguments(criterion(PRIVATE_PROPERTIES + "." + EDC_NAMESPACE + KEY, "=", VALUE)) // path element with privateProperties and edc_namespace key
+                );
+            }
+        }
+    }
+
+    @Nested
+    class TransferProcess {
+
+        private final QueryValidator validator = QueryValidators.transferProcess();
+
+        @Test
+        void shouldSucceed_whenQueryIsEmpty() {
+            var result = validator.validate(QuerySpec.none());
+
+            assertThat(result).isSucceeded();
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(InvalidFilters.class)
+        void shouldFail_whenInvalidFilters(Criterion invalidFilter) {
+            var query = QuerySpec.Builder.newInstance()
+                    .filter(invalidFilter)
+                    .build();
+
+            var result = validator.validate(query);
+
+            assertThat(result).isFailed();
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(ValidFilters.class)
+        void shouldSucceed_whenValidFilters(Criterion validFilter) {
+            var query = QuerySpec.Builder.newInstance()
+                    .filter(validFilter)
+                    .build();
+
+            var result = validator.validate(query);
+
+            assertThat(result).isSucceeded();
+        }
+
+        private static class InvalidFilters implements ArgumentsProvider {
+            @Override
+            public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+                return Stream.of(
+                        arguments(criterion("provisionedResourceSet.resources.hastoken", "=", "true")), // wrong case
+                        arguments(criterion("resourceManifest.definitions.notexist", "=", "foobar")), // property not exist
+                        arguments(criterion("contentDataAddress.properties[*].someKey", "=", "someval")) // map types not supported
+                );
+            }
+        }
+
+        private static class ValidFilters implements ArgumentsProvider {
+            @Override
+            public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+                return Stream.of(
+                        arguments(criterion("deprovisionedResources.provisionedResourceId", "=", "someval")),
+                        arguments(criterion("type", "=", "CONSUMER")),
+                        arguments(criterion("provisionedResourceSet.resources.hasToken", "=", "true"))
+                );
+            }
+        }
+
+    }
+
+    @Nested
+    class ContractDefinition {
+
+        private final QueryValidator validator = QueryValidators.contractDefinition();
+
+        @Test
+        void shouldSucceed_whenQueryIsEmpty() {
+            var result = validator.validate(QuerySpec.none());
+
+            assertThat(result).isSucceeded();
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(InvalidFilters.class)
+        void shouldFail_whenInvalidFilters(Criterion invalidFilter) {
+            var query = QuerySpec.Builder.newInstance()
+                    .filter(invalidFilter)
+                    .build();
+
+            var result = validator.validate(query);
+
+            assertThat(result).isFailed();
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(ValidFilters.class)
+        void shouldSucceed_whenValidFilters(Criterion validFilter) {
+            var query = QuerySpec.Builder.newInstance()
+                    .filter(validFilter)
+                    .build();
+
+            var result = validator.validate(query);
+
+            assertThat(result).isSucceeded();
+        }
+
+        private static class InvalidFilters implements ArgumentsProvider {
+            @Override
+            public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+                return Stream.of(
+                        arguments(criterion("assetsSelector.leftHand", "=", "foo")), // invalid path
+                        arguments(criterion("accessPolicyId'LIKE/**/?/**/LIMIT/**/?/**/OFFSET/**/?;DROP/**/TABLE/**/test/**/--%20", "=", "%20ABC--")) //some SQL injection
+                );
+            }
+        }
+
+        private static class ValidFilters implements ArgumentsProvider {
+            @Override
+            public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+                return Stream.of(
+                        arguments(criterion("assetsSelector.operandLeft", "=", "foo")),
+                        arguments(criterion("assetsSelector.operator", "=", "LIKE")),
+                        arguments(criterion("assetsSelector.operandRight", "=", "bar"))
+                );
+            }
+        }
+
+    }
+
+    @Nested
+    class ContractNegotiation {
+
+        private final QueryValidator validator = QueryValidators.contractNegotiation();
+
+        @Test
+        void shouldSucceed_whenQueryIsEmpty() {
+            var result = validator.validate(QuerySpec.none());
+
+            assertThat(result).isSucceeded();
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(InvalidFilters.class)
+        void shouldFail_whenInvalidFilters(Criterion invalidFilter) {
+            var query = QuerySpec.Builder.newInstance()
+                    .filter(invalidFilter)
+                    .build();
+
+            var result = validator.validate(query);
+
+            assertThat(result).isFailed();
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(ValidFilters.class)
+        void shouldSucceed_whenValidFilters(Criterion validFilter) {
+            var query = QuerySpec.Builder.newInstance()
+                    .filter(validFilter)
+                    .build();
+
+            var result = validator.validate(query);
+
+            assertThat(result).isSucceeded();
+        }
+
+
+        private static class InvalidFilters implements ArgumentsProvider {
+            @Override
+            public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+                return Stream.of(
+                        arguments(criterion("contractAgreement.contractStartDate.begin", "=", "123455")), // invalid path
+                        arguments(criterion("contractOffers.policy.unexistent", "=", "123455")), // invalid path
+                        arguments(criterion("contractOffers.policy.assetid", "=", "123455")), // wrong case
+                        arguments(criterion("contractOffers.policy.=some-id", "=", "123455")) // incomplete path
+                );
+            }
+        }
+
+        private static class ValidFilters implements ArgumentsProvider {
+            @Override
+            public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+                return Stream.of(
+                        arguments(criterion("contractAgreement.assetId", "=", "test-asset")),
+                        arguments(criterion("contractAgreement.policy.assignee", "=", "123455"))
+                );
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
## What this PR changes/adds

Improve `QueryValidator`s testing strategy, by moving the instantiations to a factory and testing them separately from the services in which they are used

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #3731


_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
