### PR TITLE
chore: remove deprecated Dataplane properties

### DIFF
--- a/core/common/lib/transform-lib/src/main/java/org/eclipse/edc/transform/transformer/edc/from/JsonObjectFromDataPlaneInstanceTransformer.java
+++ b/core/common/lib/transform-lib/src/main/java/org/eclipse/edc/transform/transformer/edc/from/JsonObjectFromDataPlaneInstanceTransformer.java
@@ -26,14 +26,12 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
 
-import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_DEST_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_SOURCE_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_TRANSFER_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.DATAPLANE_INSTANCE_STATE;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.DATAPLANE_INSTANCE_STATE_TIMESTAMP;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.LAST_ACTIVE;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.PROPERTIES;
-import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.TURN_COUNT;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.URL;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
@@ -54,8 +52,7 @@ public class JsonObjectFromDataPlaneInstanceTransformer extends AbstractJsonLdTr
                 .add(ID, dataPlaneInstance.getId())
                 .add(TYPE, DataPlaneInstance.DATAPLANE_INSTANCE_TYPE)
                 .add(URL, dataPlaneInstance.getUrl().toString())
-                .add(LAST_ACTIVE, dataPlaneInstance.getLastActive())
-                .add(TURN_COUNT, dataPlaneInstance.getTurnCount());
+                .add(LAST_ACTIVE, dataPlaneInstance.getLastActive());
 
         //properties
         if (dataPlaneInstance.getProperties() != null && !dataPlaneInstance.getProperties().isEmpty()) {
@@ -66,9 +63,6 @@ public class JsonObjectFromDataPlaneInstanceTransformer extends AbstractJsonLdTr
 
         var srcBldr = jsonFactory.createArrayBuilder(dataPlaneInstance.getAllowedSourceTypes());
         builder.add(ALLOWED_SOURCE_TYPES, srcBldr);
-
-        var dstBldr = jsonFactory.createArrayBuilder(dataPlaneInstance.getAllowedDestTypes());
-        builder.add(ALLOWED_DEST_TYPES, dstBldr);
 
         var transferTypesBldr = jsonFactory.createArrayBuilder(dataPlaneInstance.getAllowedTransferTypes());
         builder.add(ALLOWED_TRANSFER_TYPES, transferTypesBldr);

--- a/core/common/lib/transform-lib/src/main/java/org/eclipse/edc/transform/transformer/edc/to/JsonObjectToDataPlaneInstanceTransformer.java
+++ b/core/common/lib/transform-lib/src/main/java/org/eclipse/edc/transform/transformer/edc/to/JsonObjectToDataPlaneInstanceTransformer.java
@@ -30,14 +30,12 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_DEST_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_SOURCE_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_TRANSFER_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.Builder;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.DATAPLANE_INSTANCE_STATE_TIMESTAMP;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.LAST_ACTIVE;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.PROPERTIES;
-import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.TURN_COUNT;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.URL;
 
 public class JsonObjectToDataPlaneInstanceTransformer extends AbstractJsonLdTransformer<JsonObject, DataPlaneInstance> {
@@ -64,11 +62,6 @@ public class JsonObjectToDataPlaneInstanceTransformer extends AbstractJsonLdTran
                 }
             }
             case LAST_ACTIVE -> transformLong(context, jsonValue, builder::lastActive);
-            case TURN_COUNT -> builder.turnCount(transformInt(jsonValue, context));
-            case ALLOWED_DEST_TYPES -> {
-                var set = jsonValue.asJsonArray().stream().map(jv -> transformString(jv, context)).collect(Collectors.toSet());
-                builder.allowedDestTypes(set);
-            }
             case ALLOWED_SOURCE_TYPES -> {
                 var set = jsonValue.asJsonArray().stream().map(jv -> transformString(jv, context)).collect(Collectors.toSet());
                 builder.allowedSourceTypes(set);

--- a/core/common/lib/transform-lib/src/test/java/org/eclipse/edc/transform/transformer/edc/from/JsonObjectFromDataPlaneInstanceTransformerTest.java
+++ b/core/common/lib/transform-lib/src/test/java/org/eclipse/edc/transform/transformer/edc/from/JsonObjectFromDataPlaneInstanceTransformerTest.java
@@ -24,14 +24,12 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_DEST_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_SOURCE_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_TRANSFER_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.DATAPLANE_INSTANCE_STATE;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.DATAPLANE_INSTANCE_STATE_TIMESTAMP;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.LAST_ACTIVE;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.PROPERTIES;
-import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.TURN_COUNT;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.URL;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstanceStates.AVAILABLE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
@@ -54,10 +52,8 @@ class JsonObjectFromDataPlaneInstanceTransformerTest {
                 .id("test-id")
                 .url("http://foo.bar")
                 .allowedSourceType("test-source-type")
-                .allowedDestType("test-dest-type")
                 .allowedTransferType("test-transfer-type")
                 .lastActive(15)
-                .turnCount(42)
                 .property("foo", "bar")
                 .build();
 
@@ -67,10 +63,8 @@ class JsonObjectFromDataPlaneInstanceTransformerTest {
         assertThat(jsonObject.getString(ID)).isEqualTo("test-id");
         assertThat(jsonObject.getString(URL)).isEqualTo("http://foo.bar");
         assertThat(jsonObject.getJsonArray(ALLOWED_SOURCE_TYPES)).hasSize(1).allMatch(v -> ((JsonString) v).getString().equals("test-source-type"));
-        assertThat(jsonObject.getJsonArray(ALLOWED_DEST_TYPES)).hasSize(1).allMatch(v -> ((JsonString) v).getString().equals("test-dest-type"));
         assertThat(jsonObject.getJsonArray(ALLOWED_TRANSFER_TYPES)).hasSize(1).allMatch(v -> ((JsonString) v).getString().equals("test-transfer-type"));
         assertThat(jsonObject.getJsonNumber(LAST_ACTIVE).intValue()).isEqualTo(15);
-        assertThat(jsonObject.getJsonNumber(TURN_COUNT).intValue()).isEqualTo(42);
         assertThat(jsonObject.getJsonObject(PROPERTIES).getJsonString("foo").getString()).isEqualTo("bar");
 
     }
@@ -81,10 +75,8 @@ class JsonObjectFromDataPlaneInstanceTransformerTest {
                 .id("test-id")
                 .url("http://foo.bar")
                 .allowedSourceType("test-source-type")
-                .allowedDestType("test-dest-type")
                 .allowedTransferType("test-transfer-type")
                 .lastActive(15)
-                .turnCount(42)
                 .state(AVAILABLE.code())
                 .property("foo", "bar")
                 .build();
@@ -95,10 +87,8 @@ class JsonObjectFromDataPlaneInstanceTransformerTest {
         assertThat(jsonObject.getString(ID)).isEqualTo("test-id");
         assertThat(jsonObject.getString(URL)).isEqualTo("http://foo.bar");
         assertThat(jsonObject.getJsonArray(ALLOWED_SOURCE_TYPES)).hasSize(1).allMatch(v -> ((JsonString) v).getString().equals("test-source-type"));
-        assertThat(jsonObject.getJsonArray(ALLOWED_DEST_TYPES)).hasSize(1).allMatch(v -> ((JsonString) v).getString().equals("test-dest-type"));
         assertThat(jsonObject.getJsonArray(ALLOWED_TRANSFER_TYPES)).hasSize(1).allMatch(v -> ((JsonString) v).getString().equals("test-transfer-type"));
         assertThat(jsonObject.getJsonNumber(LAST_ACTIVE).intValue()).isEqualTo(15);
-        assertThat(jsonObject.getJsonNumber(TURN_COUNT).intValue()).isEqualTo(42);
         assertThat(jsonObject.getString(DATAPLANE_INSTANCE_STATE)).isEqualTo(AVAILABLE.name());
         assertThat(jsonObject.getJsonNumber(DATAPLANE_INSTANCE_STATE_TIMESTAMP).longValue()).isEqualTo(dpi.getStateTimestamp());
         assertThat(jsonObject.getJsonObject(PROPERTIES).getJsonString("foo").getString()).isEqualTo("bar");

--- a/core/common/lib/transform-lib/src/test/java/org/eclipse/edc/transform/transformer/edc/to/JsonObjectToDataPlaneInstanceTransformerTest.java
+++ b/core/common/lib/transform-lib/src/test/java/org/eclipse/edc/transform/transformer/edc/to/JsonObjectToDataPlaneInstanceTransformerTest.java
@@ -30,11 +30,9 @@ import static jakarta.json.Json.createArrayBuilder;
 import static jakarta.json.Json.createObjectBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_DEST_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_SOURCE_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_TRANSFER_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.LAST_ACTIVE;
-import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.TURN_COUNT;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.URL;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
@@ -67,16 +65,12 @@ class JsonObjectToDataPlaneInstanceTransformerTest {
                 .add(URL, "http://somewhere.com:1234/api/v1")
                 .add(ALLOWED_SOURCE_TYPES, createArrayBuilder(Set.of("source1", "source2")))
                 .add(LAST_ACTIVE, 234L)
-                .add(TURN_COUNT, 42)
-                .add(ALLOWED_DEST_TYPES, createArrayBuilder(Set.of("dest1", "dest2")))
                 .build();
 
         var dpi = transformer.transform(expand(json), context);
         assertThat(dpi).isNotNull();
         assertThat(dpi.getUrl().toString()).isEqualTo("http://somewhere.com:1234/api/v1");
-        assertThat(dpi.getTurnCount()).isEqualTo(42);
         assertThat(dpi.getLastActive()).isEqualTo(234L);
-        assertThat(dpi.getAllowedDestTypes()).hasSize(2).containsExactlyInAnyOrder("dest1", "dest2");
         assertThat(dpi.getAllowedSourceTypes()).hasSize(2).containsExactlyInAnyOrder("source1", "source2");
     }
 
@@ -103,17 +97,13 @@ class JsonObjectToDataPlaneInstanceTransformerTest {
                 .add(URL, "http://somewhere.com:1234/api/v1")
                 .add(ALLOWED_SOURCE_TYPES, createArrayBuilder(Set.of("source1", "source2")))
                 .add(LAST_ACTIVE, 234L)
-                .add(TURN_COUNT, 42)
-                .add(ALLOWED_DEST_TYPES, createArrayBuilder(Set.of("dest1", "dest2")))
                 .add(ALLOWED_TRANSFER_TYPES, createArrayBuilder(Set.of("transfer1", "transfer2")))
                 .build();
 
         var dpi = transformer.transform(expand(json), context);
         assertThat(dpi).isNotNull();
         assertThat(dpi.getUrl().toString()).isEqualTo("http://somewhere.com:1234/api/v1");
-        assertThat(dpi.getTurnCount()).isEqualTo(42);
         assertThat(dpi.getLastActive()).isEqualTo(234L);
-        assertThat(dpi.getAllowedDestTypes()).hasSize(2).containsExactlyInAnyOrder("dest1", "dest2");
         assertThat(dpi.getAllowedSourceTypes()).hasSize(2).containsExactlyInAnyOrder("source1", "source2");
         assertThat(dpi.getAllowedTransferTypes()).hasSize(2).containsExactlyInAnyOrder("transfer1", "transfer2");
     }
@@ -124,7 +114,6 @@ class JsonObjectToDataPlaneInstanceTransformerTest {
                 .add(ID, "test-id")
                 .add(URL, "very_invalid_not_an_url")
                 .add(ALLOWED_SOURCE_TYPES, createArrayBuilder(Set.of("source1", "source2")))
-                .add(ALLOWED_DEST_TYPES, createArrayBuilder(Set.of("dest1", "dest2")))
                 .build();
 
         // NPE is thrown by the builder method inside the transformer

--- a/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImplTest.java
+++ b/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImplTest.java
@@ -108,8 +108,6 @@ class DataPlaneManagerImplTest {
                 .flowType(FlowType.PUSH)
                 .build();
 
-        when(authorizationService.createEndpointDataReference(eq(request))).thenReturn(Result.success(DataAddress.Builder.newInstance().type("type").build()));
-
         manager.start(request);
 
         var captor = ArgumentCaptor.forClass(DataFlow.class);
@@ -122,7 +120,7 @@ class DataPlaneManagerImplTest {
         assertThat(dataFlow.getProperties()).isEqualTo(request.getProperties());
         assertThat(dataFlow.getState()).isEqualTo(RECEIVED.code());
 
-        verify(authorizationService).createEndpointDataReference(eq(request));
+        verifyNoInteractions(authorizationService);
     }
 
     @Test

--- a/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImplTest.java
+++ b/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImplTest.java
@@ -108,6 +108,8 @@ class DataPlaneManagerImplTest {
                 .flowType(FlowType.PUSH)
                 .build();
 
+        when(authorizationService.createEndpointDataReference(eq(request))).thenReturn(Result.success(DataAddress.Builder.newInstance().type("type").build()));
+
         manager.start(request);
 
         var captor = ArgumentCaptor.forClass(DataFlow.class);
@@ -120,7 +122,7 @@ class DataPlaneManagerImplTest {
         assertThat(dataFlow.getProperties()).isEqualTo(request.getProperties());
         assertThat(dataFlow.getState()).isEqualTo(RECEIVED.code());
 
-        verifyNoInteractions(authorizationService);
+        verify(authorizationService).createEndpointDataReference(eq(request));
     }
 
     @Test
@@ -290,6 +292,88 @@ class DataPlaneManagerImplTest {
         verify(store).save(argThat(f -> f.getProperties().containsKey(TERMINATION_REASON)));
     }
 
+    @Test
+    void completed_shouldNotifyResultToControlPlane() {
+        var dataFlow = dataFlowBuilder().state(COMPLETED.code()).build();
+        when(store.nextNotLeased(anyInt(), stateIs(COMPLETED.code()))).thenReturn(List.of(dataFlow)).thenReturn(emptyList());
+        when(transferProcessApiClient.completed(any())).thenReturn(Result.success());
+
+        manager.start();
+
+        await().untilAsserted(() -> {
+            verify(transferProcessApiClient).completed(any());
+            verify(store).save(argThat(it -> it.getState() == NOTIFIED.code()));
+        });
+    }
+
+    @Test
+    void completed_shouldNotTransitionToNotified() {
+        var dataFlow = dataFlowBuilder().state(COMPLETED.code()).build();
+        when(store.nextNotLeased(anyInt(), stateIs(COMPLETED.code()))).thenReturn(List.of(dataFlow)).thenReturn(emptyList());
+        when(transferProcessApiClient.completed(any())).thenReturn(Result.failure(""));
+
+        manager.start();
+
+        await().untilAsserted(() -> {
+            verify(transferProcessApiClient).completed(any());
+            verify(store).save(argThat(it -> it.getState() == COMPLETED.code()));
+        });
+    }
+
+    @Test
+    void failed_shouldNotifyResultToControlPlane() {
+        var dataFlow = dataFlowBuilder().state(FAILED.code()).errorDetail("an error").build();
+        when(store.nextNotLeased(anyInt(), stateIs(FAILED.code()))).thenReturn(List.of(dataFlow)).thenReturn(emptyList());
+        when(store.findById(any())).thenReturn(dataFlow);
+
+        when(transferProcessApiClient.failed(any(), eq("an error"))).thenReturn(Result.success());
+
+        manager.start();
+
+        await().untilAsserted(() -> {
+            verify(transferProcessApiClient).failed(any(), eq("an error"));
+            verify(store).save(argThat(it -> it.getState() == NOTIFIED.code()));
+        });
+    }
+
+    @Test
+    void failed_shouldNotTransitionToNotified() {
+        var dataFlow = dataFlowBuilder().state(FAILED.code()).errorDetail("an error").build();
+        when(store.nextNotLeased(anyInt(), stateIs(FAILED.code()))).thenReturn(List.of(dataFlow)).thenReturn(emptyList());
+        when(store.findById(any())).thenReturn(dataFlow);
+
+        when(transferProcessApiClient.failed(any(), eq("an error"))).thenReturn(Result.failure("an error"));
+
+        manager.start();
+
+        await().untilAsserted(() -> {
+            verify(transferProcessApiClient).failed(any(), eq("an error"));
+            verify(store).save(argThat(it -> it.getState() == FAILED.code()));
+        });
+    }
+
+    private DataFlow.Builder dataFlowBuilder() {
+        return DataFlow.Builder.newInstance()
+                .source(DataAddress.Builder.newInstance().type("source").build())
+                .destination(DataAddress.Builder.newInstance().type("destination").build())
+                .callbackAddress(URI.create("http://any"))
+                .transferType(new TransferType("DestinationType", FlowType.PUSH))
+                .properties(Map.of("key", "value"));
+    }
+
+    private Criterion[] stateIs(int state) {
+        return aryEq(new Criterion[]{ hasState(state) });
+    }
+
+    private DataFlowStartMessage createRequest() {
+        return DataFlowStartMessage.Builder.newInstance()
+                .id("1")
+                .processId("1")
+                .sourceDataAddress(DataAddress.Builder.newInstance().type("type").build())
+                .destinationDataAddress(DataAddress.Builder.newInstance().type("type").build())
+                .build();
+    }
+
     @Nested
     class Received {
         @Test
@@ -410,88 +494,6 @@ class DataPlaneManagerImplTest {
                 verify(store, atLeastOnce()).save(argThat(it -> it.getState() == FAILED.code()));
             });
         }
-    }
-
-    @Test
-    void completed_shouldNotifyResultToControlPlane() {
-        var dataFlow = dataFlowBuilder().state(COMPLETED.code()).build();
-        when(store.nextNotLeased(anyInt(), stateIs(COMPLETED.code()))).thenReturn(List.of(dataFlow)).thenReturn(emptyList());
-        when(transferProcessApiClient.completed(any())).thenReturn(Result.success());
-
-        manager.start();
-
-        await().untilAsserted(() -> {
-            verify(transferProcessApiClient).completed(any());
-            verify(store).save(argThat(it -> it.getState() == NOTIFIED.code()));
-        });
-    }
-
-    @Test
-    void completed_shouldNotTransitionToNotified() {
-        var dataFlow = dataFlowBuilder().state(COMPLETED.code()).build();
-        when(store.nextNotLeased(anyInt(), stateIs(COMPLETED.code()))).thenReturn(List.of(dataFlow)).thenReturn(emptyList());
-        when(transferProcessApiClient.completed(any())).thenReturn(Result.failure(""));
-
-        manager.start();
-
-        await().untilAsserted(() -> {
-            verify(transferProcessApiClient).completed(any());
-            verify(store).save(argThat(it -> it.getState() == COMPLETED.code()));
-        });
-    }
-
-    @Test
-    void failed_shouldNotifyResultToControlPlane() {
-        var dataFlow = dataFlowBuilder().state(FAILED.code()).errorDetail("an error").build();
-        when(store.nextNotLeased(anyInt(), stateIs(FAILED.code()))).thenReturn(List.of(dataFlow)).thenReturn(emptyList());
-        when(store.findById(any())).thenReturn(dataFlow);
-
-        when(transferProcessApiClient.failed(any(), eq("an error"))).thenReturn(Result.success());
-
-        manager.start();
-
-        await().untilAsserted(() -> {
-            verify(transferProcessApiClient).failed(any(), eq("an error"));
-            verify(store).save(argThat(it -> it.getState() == NOTIFIED.code()));
-        });
-    }
-
-    @Test
-    void failed_shouldNotTransitionToNotified() {
-        var dataFlow = dataFlowBuilder().state(FAILED.code()).errorDetail("an error").build();
-        when(store.nextNotLeased(anyInt(), stateIs(FAILED.code()))).thenReturn(List.of(dataFlow)).thenReturn(emptyList());
-        when(store.findById(any())).thenReturn(dataFlow);
-
-        when(transferProcessApiClient.failed(any(), eq("an error"))).thenReturn(Result.failure("an error"));
-
-        manager.start();
-
-        await().untilAsserted(() -> {
-            verify(transferProcessApiClient).failed(any(), eq("an error"));
-            verify(store).save(argThat(it -> it.getState() == FAILED.code()));
-        });
-    }
-
-    private DataFlow.Builder dataFlowBuilder() {
-        return DataFlow.Builder.newInstance()
-                .source(DataAddress.Builder.newInstance().type("source").build())
-                .destination(DataAddress.Builder.newInstance().type("destination").build())
-                .callbackAddress(URI.create("http://any"))
-                .transferType(new TransferType("DestinationType", FlowType.PUSH))
-                .properties(Map.of("key", "value"));
-    }
-
-    private Criterion[] stateIs(int state) {
-        return aryEq(new Criterion[]{ hasState(state) });
-    }
-
-    private DataFlowStartMessage createRequest() {
-        return DataFlowStartMessage.Builder.newInstance()
-                .id("1")
-                .processId("1")
-                .sourceDataAddress(DataAddress.Builder.newInstance().type("type").build())
-                .destinationDataAddress(DataAddress.Builder.newInstance().type("type").build())
-                .build();
     }
 
     @Nested

--- a/extensions/common/api/control-api-configuration/src/main/resources/control-api-version.json
+++ b/extensions/common/api/control-api-configuration/src/main/resources/control-api-version.json
@@ -1,8 +1,8 @@
 [
   {
-    "version": "1.0.2",
+    "version": "1.0.3",
     "urlPath": "/v1",
-    "lastUpdated": "2024-09-04T14:30:00Z",
+    "lastUpdated": "2024-10-24T14:30:00Z",
     "maturity": "stable"
   }
 ]

--- a/extensions/common/iam/identity-trust/identity-trust-core/src/test/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtensionTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/test/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtensionTest.java
@@ -72,7 +72,7 @@ class IdentityAndTrustExtensionTest {
         extension.initialize(context);
         extension.start();
 
-        await().atLeast(Duration.ofSeconds(1)) // that's the initial delay
+        await().atLeast(Duration.ofMillis(500)) // that's the initial delay
                 .untilAsserted(() -> verify(storeMock, atLeastOnce()).deleteExpired());
     }
 

--- a/extensions/control-plane/transfer/transfer-data-plane-signaling/src/test/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/flow/DataPlaneSignalingFlowControllerTest.java
+++ b/extensions/control-plane/transfer/transfer-data-plane-signaling/src/test/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/flow/DataPlaneSignalingFlowControllerTest.java
@@ -66,6 +66,36 @@ public class DataPlaneSignalingFlowControllerTest {
             () -> URI.create("http://localhost"), selectorService, propertiesProvider, dataPlaneClientFactory,
             "random", transferTypeParser);
 
+    @NotNull
+    private DataPlaneInstance.Builder dataPlaneInstanceBuilder() {
+        return DataPlaneInstance.Builder.newInstance().url("http://any");
+    }
+
+    private DataPlaneInstance createDataPlaneInstance() {
+        return dataPlaneInstanceBuilder().build();
+    }
+
+    private DataAddress testDataAddress() {
+        return DataAddress.Builder.newInstance().type("test-type").build();
+    }
+
+    private TransferProcess transferProcess(String destinationType, String transferType) {
+        return TransferProcess.Builder.newInstance()
+                .transferType(transferType)
+                .dataDestination(DataAddress.Builder.newInstance().type(destinationType).build())
+                .build();
+    }
+
+    private TransferProcess.Builder transferProcessBuilder() {
+        return TransferProcess.Builder.newInstance()
+                .correlationId(UUID.randomUUID().toString())
+                .protocol("test-protocol")
+                .contractId(UUID.randomUUID().toString())
+                .assetId(UUID.randomUUID().toString())
+                .counterPartyAddress("test.connector.address")
+                .dataDestination(DataAddress.Builder.newInstance().type("test").build());
+    }
+
     @Nested
     class CanHandle {
         @Test
@@ -258,7 +288,8 @@ public class DataPlaneSignalingFlowControllerTest {
             assertThat(result).isFailed().detail().contains("Failed to select the data plane for terminating the transfer process");
         }
 
-        @Test // a null dataPlaneId means that the flow has not been started so it can be considered as already terminated
+        @Test
+            // a null dataPlaneId means that the flow has not been started so it can be considered as already terminated
         void shouldReturnSuccess_whenDataPlaneIdIsNull() {
             var transferProcess = transferProcessBuilder()
                     .id("transferProcessId")
@@ -332,9 +363,9 @@ public class DataPlaneSignalingFlowControllerTest {
         @Test
         void transferTypes_shouldReturnTypesForSpecifiedAsset() {
             when(selectorService.getAll()).thenReturn(ServiceResult.success(List.of(
-                    dataPlaneInstanceBuilder().allowedTransferType("Custom-PUSH").allowedSourceType("TargetSrc").allowedDestType("TargetDest").build(),
-                    dataPlaneInstanceBuilder().allowedTransferType("Custom-PULL").allowedSourceType("TargetSrc").allowedDestType("AnotherTargetDest").build(),
-                    dataPlaneInstanceBuilder().allowedSourceType("AnotherSrc").allowedDestType("ThisWontBeListed").build()
+                    dataPlaneInstanceBuilder().allowedTransferType("Custom-PUSH").allowedSourceType("TargetSrc").build(),
+                    dataPlaneInstanceBuilder().allowedTransferType("Custom-PULL").allowedSourceType("TargetSrc").build(),
+                    dataPlaneInstanceBuilder().allowedSourceType("AnotherSrc").build()
             )));
             var asset = Asset.Builder.newInstance().dataAddress(DataAddress.Builder.newInstance().type("TargetSrc").build()).build();
 
@@ -352,36 +383,6 @@ public class DataPlaneSignalingFlowControllerTest {
 
             assertThat(transferTypes).isEmpty();
         }
-    }
-
-    @NotNull
-    private DataPlaneInstance.Builder dataPlaneInstanceBuilder() {
-        return DataPlaneInstance.Builder.newInstance().url("http://any");
-    }
-
-    private DataPlaneInstance createDataPlaneInstance() {
-        return dataPlaneInstanceBuilder().build();
-    }
-
-    private DataAddress testDataAddress() {
-        return DataAddress.Builder.newInstance().type("test-type").build();
-    }
-
-    private TransferProcess transferProcess(String destinationType, String transferType) {
-        return TransferProcess.Builder.newInstance()
-                .transferType(transferType)
-                .dataDestination(DataAddress.Builder.newInstance().type(destinationType).build())
-                .build();
-    }
-
-    private TransferProcess.Builder transferProcessBuilder() {
-        return TransferProcess.Builder.newInstance()
-                .correlationId(UUID.randomUUID().toString())
-                .protocol("test-protocol")
-                .contractId(UUID.randomUUID().toString())
-                .assetId(UUID.randomUUID().toString())
-                .counterPartyAddress("test.connector.address")
-                .dataDestination(DataAddress.Builder.newInstance().type("test").build());
     }
 
 }

--- a/extensions/control-plane/transfer/transfer-data-plane-signaling/src/test/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/flow/DataPlaneSignalingFlowControllerTest.java
+++ b/extensions/control-plane/transfer/transfer-data-plane-signaling/src/test/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/flow/DataPlaneSignalingFlowControllerTest.java
@@ -66,36 +66,6 @@ public class DataPlaneSignalingFlowControllerTest {
             () -> URI.create("http://localhost"), selectorService, propertiesProvider, dataPlaneClientFactory,
             "random", transferTypeParser);
 
-    @NotNull
-    private DataPlaneInstance.Builder dataPlaneInstanceBuilder() {
-        return DataPlaneInstance.Builder.newInstance().url("http://any");
-    }
-
-    private DataPlaneInstance createDataPlaneInstance() {
-        return dataPlaneInstanceBuilder().build();
-    }
-
-    private DataAddress testDataAddress() {
-        return DataAddress.Builder.newInstance().type("test-type").build();
-    }
-
-    private TransferProcess transferProcess(String destinationType, String transferType) {
-        return TransferProcess.Builder.newInstance()
-                .transferType(transferType)
-                .dataDestination(DataAddress.Builder.newInstance().type(destinationType).build())
-                .build();
-    }
-
-    private TransferProcess.Builder transferProcessBuilder() {
-        return TransferProcess.Builder.newInstance()
-                .correlationId(UUID.randomUUID().toString())
-                .protocol("test-protocol")
-                .contractId(UUID.randomUUID().toString())
-                .assetId(UUID.randomUUID().toString())
-                .counterPartyAddress("test.connector.address")
-                .dataDestination(DataAddress.Builder.newInstance().type("test").build());
-    }
-
     @Nested
     class CanHandle {
         @Test
@@ -383,6 +353,36 @@ public class DataPlaneSignalingFlowControllerTest {
 
             assertThat(transferTypes).isEmpty();
         }
+    }
+
+    @NotNull
+    private DataPlaneInstance.Builder dataPlaneInstanceBuilder() {
+        return DataPlaneInstance.Builder.newInstance().url("http://any");
+    }
+
+    private DataPlaneInstance createDataPlaneInstance() {
+        return dataPlaneInstanceBuilder().build();
+    }
+
+    private DataAddress testDataAddress() {
+        return DataAddress.Builder.newInstance().type("test-type").build();
+    }
+
+    private TransferProcess transferProcess(String destinationType, String transferType) {
+        return TransferProcess.Builder.newInstance()
+                .transferType(transferType)
+                .dataDestination(DataAddress.Builder.newInstance().type(destinationType).build())
+                .build();
+    }
+
+    private TransferProcess.Builder transferProcessBuilder() {
+        return TransferProcess.Builder.newInstance()
+                .correlationId(UUID.randomUUID().toString())
+                .protocol("test-protocol")
+                .contractId(UUID.randomUUID().toString())
+                .assetId(UUID.randomUUID().toString())
+                .counterPartyAddress("test.connector.address")
+                .dataDestination(DataAddress.Builder.newInstance().type("test").build());
     }
 
 }

--- a/extensions/control-plane/transfer/transfer-data-plane-signaling/src/test/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/flow/DataPlaneSignalingFlowControllerTest.java
+++ b/extensions/control-plane/transfer/transfer-data-plane-signaling/src/test/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/flow/DataPlaneSignalingFlowControllerTest.java
@@ -288,8 +288,8 @@ public class DataPlaneSignalingFlowControllerTest {
             assertThat(result).isFailed().detail().contains("Failed to select the data plane for terminating the transfer process");
         }
 
+        // a null dataPlaneId means that the flow has not been started so it can be considered as already terminated
         @Test
-            // a null dataPlaneId means that the flow has not been started so it can be considered as already terminated
         void shouldReturnSuccess_whenDataPlaneIdIsNull() {
             var transferProcess = transferProcessBuilder()
                     .id("transferProcessId")

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/validation/DataPlaneInstanceValidator.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/api/validation/DataPlaneInstanceValidator.java
@@ -21,7 +21,6 @@ import org.eclipse.edc.validator.jsonobject.validators.MandatoryValue;
 import org.eclipse.edc.validator.jsonobject.validators.OptionalIdNotBlank;
 import org.eclipse.edc.validator.spi.Validator;
 
-import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_DEST_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_SOURCE_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.URL;
 
@@ -35,7 +34,6 @@ public class DataPlaneInstanceValidator {
                 .verifyId(OptionalIdNotBlank::new)
                 .verify(URL, MandatoryValue::new)
                 .verify(ALLOWED_SOURCE_TYPES, MandatoryArray.min(1))
-                .verify(ALLOWED_DEST_TYPES, MandatoryArray.min(1))
                 .build();
     }
 

--- a/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/TestFunctions.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/TestFunctions.java
@@ -21,7 +21,6 @@ import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstan
 
 import java.util.Set;
 
-import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_DEST_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_SOURCE_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.URL;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
@@ -39,7 +38,6 @@ public class TestFunctions {
         return createInstanceJsonBuilder(id)
                 .add(URL, "http://somewhere.com:1234/api/v1")
                 .add(ALLOWED_SOURCE_TYPES, Json.createArrayBuilder(Set.of("source1", "source2")))
-                .add(ALLOWED_DEST_TYPES, Json.createArrayBuilder(Set.of("dest1", "dest2")))
                 .build();
     }
 

--- a/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/api/DataPlaneApiSelectorTest.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/api/DataPlaneApiSelectorTest.java
@@ -64,7 +64,6 @@ public class DataPlaneApiSelectorTest {
                 .satisfies(transformed -> {
                     assertThat(transformed.getId()).isNotBlank();
                     assertThat(transformed.getUrl().toString()).isEqualTo("http://somewhere.com:1234/api/v1");
-                    assertThat(transformed.getAllowedDestTypes()).containsExactlyInAnyOrder("your-dest-type");
                     assertThat(transformed.getAllowedSourceTypes()).containsExactlyInAnyOrder("source-type1", "source-type2");
                     assertThat(transformed.getAllowedTransferTypes()).containsExactlyInAnyOrder("transfer-type");
                 });

--- a/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/api/v2/DataPlaneSelectorApiV2ControllerTest.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/api/v2/DataPlaneSelectorApiV2ControllerTest.java
@@ -146,12 +146,10 @@ public class DataPlaneSelectorApiV2ControllerTest {
     void select(DataPlaneInstanceStore store) {
         var dpi = createInstanceBuilder("test-id1")
                 .allowedSourceType("test-src1")
-                .allowedDestType("test-dst1")
                 .allowedTransferType("transfer-type-1")
                 .build();
         var dpi2 = createInstanceBuilder("test-id2")
                 .allowedSourceType("test-src2")
-                .allowedDestType("test-dst2")
                 .allowedTransferType("transfer-type-2")
                 .build();
         Stream.of(dpi, dpi2).peek(DataPlaneInstance::transitionToAvailable).forEach(store::save);
@@ -172,11 +170,9 @@ public class DataPlaneSelectorApiV2ControllerTest {
     void select_noneCanHandle_shouldReturnEmpty(DataPlaneInstanceStore store) {
         var dpi = createInstanceBuilder("test-id")
                 .allowedSourceType("test-src1")
-                .allowedDestType("test-dst1")
                 .build();
         var dpi2 = createInstanceBuilder("test-id")
                 .allowedSourceType("test-src2")
-                .allowedDestType("test-dst2")
                 .build();
         List.of(dpi, dpi2).forEach(store::save);
 
@@ -195,11 +191,9 @@ public class DataPlaneSelectorApiV2ControllerTest {
     void select_selectionStrategyNotFound(DataPlaneInstanceStore store) {
         var dpi = createInstanceBuilder("test-id")
                 .allowedSourceType("test-src1")
-                .allowedDestType("test-dst1")
                 .build();
         var dpi2 = createInstanceBuilder("test-id")
                 .allowedSourceType("test-src2")
-                .allowedDestType("test-dst2")
                 .build();
         List.of(dpi, dpi2).forEach(store::save);
 
@@ -217,12 +211,10 @@ public class DataPlaneSelectorApiV2ControllerTest {
     void select_withCustomStrategy(DataPlaneInstanceStore store, SelectionStrategyRegistry selectionStrategyRegistry) {
         var dpi = createInstanceBuilder("test-id1")
                 .allowedSourceType("test-src1")
-                .allowedDestType("test-dst1")
                 .allowedTransferType("transfer-type-1")
                 .build();
         var dpi2 = createInstanceBuilder("test-id2")
                 .allowedSourceType("test-src1")
-                .allowedDestType("test-dst1")
                 .allowedTransferType("transfer-type-2")
                 .build();
         Stream.of(dpi, dpi2).peek(DataPlaneInstance::transitionToAvailable).forEach(store::save);

--- a/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/validation/DataPlaneInstanceValidatorTest.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/validation/DataPlaneInstanceValidatorTest.java
@@ -18,13 +18,11 @@ import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.dataplane.selector.api.validation.DataPlaneInstanceValidator;
 import org.eclipse.edc.validator.spi.Validator;
-import org.eclipse.edc.validator.spi.Violation;
 import org.junit.jupiter.api.Test;
 
 import static jakarta.json.Json.createArrayBuilder;
 import static jakarta.json.Json.createObjectBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_DEST_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_SOURCE_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.URL;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
@@ -38,7 +36,6 @@ public class DataPlaneInstanceValidatorTest {
     void shouldSucceed_whenValidInput() {
         var input = createObjectBuilder()
                 .add(URL, value("http://myurl"))
-                .add(ALLOWED_DEST_TYPES, createArrayBuilder().add("test"))
                 .add(ALLOWED_SOURCE_TYPES, createArrayBuilder().add("test"))
                 .build();
 
@@ -52,7 +49,6 @@ public class DataPlaneInstanceValidatorTest {
         var input = createObjectBuilder()
                 .add(ID, " ")
                 .add(URL, value("http://myurl"))
-                .add(ALLOWED_DEST_TYPES, createArrayBuilder().add("test"))
                 .add(ALLOWED_SOURCE_TYPES, createArrayBuilder().add("test"))
                 .build();
 
@@ -65,7 +61,6 @@ public class DataPlaneInstanceValidatorTest {
     void shouldFail_whenUrlIsMissing() {
         var input = createObjectBuilder()
                 .add(ID, "my_id")
-                .add(ALLOWED_DEST_TYPES, createArrayBuilder().add("test"))
                 .add(ALLOWED_SOURCE_TYPES, createArrayBuilder().add("test"))
                 .build();
 
@@ -75,19 +70,16 @@ public class DataPlaneInstanceValidatorTest {
     }
 
     @Test
-    void shouldFail_whenAllowDestAndSourceAreEmpty() {
+    void shouldFail_whenAllowedSourceEmpty() {
         var input = createObjectBuilder()
                 .add(ID, "my_id")
                 .add(URL, value("http://myurl"))
-                .add(ALLOWED_DEST_TYPES, createArrayBuilder())
                 .add(ALLOWED_SOURCE_TYPES, createArrayBuilder())
                 .build();
 
         var result = validator.validate(input);
 
-        assertThat(result).isFailed().satisfies(failure -> assertThat(failure.getViolations()).hasSize(2)
-                .map(Violation::path)
-                .contains(ALLOWED_DEST_TYPES, ALLOWED_SOURCE_TYPES));
+        assertThat(result).isFailed().satisfies(failure -> assertThat(failure.getViolations()).hasSize(1));
     }
 
     private JsonArrayBuilder value(String value) {

--- a/extensions/data-plane-selector/data-plane-selector-control-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/control/api/DataPlaneInstanceValidator.java
+++ b/extensions/data-plane-selector/data-plane-selector-control-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/control/api/DataPlaneInstanceValidator.java
@@ -21,7 +21,6 @@ import org.eclipse.edc.validator.jsonobject.validators.MandatoryIdNotBlank;
 import org.eclipse.edc.validator.jsonobject.validators.MandatoryValue;
 import org.eclipse.edc.validator.spi.Validator;
 
-import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_DEST_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_SOURCE_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_TRANSFER_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.URL;
@@ -36,7 +35,6 @@ public class DataPlaneInstanceValidator {
                 .verifyId(MandatoryIdNotBlank::new)
                 .verify(URL, MandatoryValue::new)
                 .verify(ALLOWED_SOURCE_TYPES, MandatoryArray.min(1))
-                .verify(ALLOWED_DEST_TYPES, MandatoryArray.min(1))
                 .verify(ALLOWED_TRANSFER_TYPES, MandatoryArray.min(1))
                 .build();
     }

--- a/extensions/data-plane-selector/data-plane-selector-control-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/control/api/DataplaneSelectorControlApi.java
+++ b/extensions/data-plane-selector/data-plane-selector-control-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/control/api/DataplaneSelectorControlApi.java
@@ -140,7 +140,6 @@ public interface DataplaneSelectorControlApi {
                         "source-type1",
                         "source-type2"
                     ],
-                    "allowedDestTypes": ["your-dest-type"],
                     "allowedTransferTypes": ["transfer-type"]
                 }
                 """;

--- a/extensions/data-plane-selector/data-plane-selector-control-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/control/api/DataPlaneInstanceValidatorTest.java
+++ b/extensions/data-plane-selector/data-plane-selector-control-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/control/api/DataPlaneInstanceValidatorTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.Test;
 import static jakarta.json.Json.createArrayBuilder;
 import static jakarta.json.Json.createObjectBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_DEST_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_SOURCE_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_TRANSFER_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.URL;
@@ -43,7 +42,6 @@ class DataPlaneInstanceValidatorTest {
                 .add(ID, "id")
                 .add(URL, value("url"))
                 .add(ALLOWED_SOURCE_TYPES, createArrayBuilder().add(value("src")))
-                .add(ALLOWED_DEST_TYPES, createArrayBuilder().add(value("dest")))
                 .add(ALLOWED_TRANSFER_TYPES, createArrayBuilder().add(value("transfer")))
                 .build();
 
@@ -63,7 +61,6 @@ class DataPlaneInstanceValidatorTest {
                 .anySatisfy(v -> assertThat(v.path()).isEqualTo(ID))
                 .anySatisfy(v -> assertThat(v.path()).isEqualTo(URL))
                 .anySatisfy(v -> assertThat(v.path()).isEqualTo(ALLOWED_SOURCE_TYPES))
-                .anySatisfy(v -> assertThat(v.path()).isEqualTo(ALLOWED_DEST_TYPES))
                 .anySatisfy(v -> assertThat(v.path()).isEqualTo(ALLOWED_TRANSFER_TYPES));
     }
 
@@ -71,7 +68,6 @@ class DataPlaneInstanceValidatorTest {
     void shouldFail_whenAllowedTypesAreEmpty() {
         var json = createObjectBuilder()
                 .add(ALLOWED_SOURCE_TYPES, createArrayBuilder())
-                .add(ALLOWED_DEST_TYPES, createArrayBuilder())
                 .add(ALLOWED_TRANSFER_TYPES, createArrayBuilder())
                 .build();
 
@@ -80,7 +76,6 @@ class DataPlaneInstanceValidatorTest {
         assertThat(result).isFailed().extracting(ValidationFailure::getViolations, InstanceOfAssertFactories.list(Violation.class))
                 .isNotEmpty()
                 .anySatisfy(v -> assertThat(v.path()).isEqualTo(ALLOWED_SOURCE_TYPES))
-                .anySatisfy(v -> assertThat(v.path()).isEqualTo(ALLOWED_DEST_TYPES))
                 .anySatisfy(v -> assertThat(v.path()).isEqualTo(ALLOWED_TRANSFER_TYPES));
     }
 

--- a/extensions/data-plane-selector/data-plane-selector-control-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/control/api/DataplaneSelectorControlApiTest.java
+++ b/extensions/data-plane-selector/data-plane-selector-control-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/control/api/DataplaneSelectorControlApiTest.java
@@ -58,8 +58,6 @@ class DataplaneSelectorControlApiTest {
                         .satisfies(transformed -> {
                             assertThat(transformed.getId()).isNotBlank();
                             assertThat(transformed.getUrl()).isNotNull();
-                            assertThat(transformed.getAllowedDestTypes()).isNotEmpty();
-                            assertThat(transformed.getAllowedDestTypes()).isNotEmpty();
                             assertThat(transformed.getAllowedTransferTypes()).isNotEmpty();
                         }));
     }

--- a/extensions/data-plane/data-plane-self-registration/src/main/java/org/eclipse/edc/connector/dataplane/registration/DataplaneSelfRegistrationExtension.java
+++ b/extensions/data-plane/data-plane-self-registration/src/main/java/org/eclipse/edc/connector/dataplane/registration/DataplaneSelfRegistrationExtension.java
@@ -46,8 +46,8 @@ import static org.eclipse.edc.spi.types.domain.transfer.FlowType.PUSH;
 @Extension(NAME)
 public class DataplaneSelfRegistrationExtension implements ServiceExtension {
 
-    private static final boolean DEFAULT_SELF_UNREGISTRATION = false;
     public static final String NAME = "Dataplane Self Registration";
+    public static final boolean DEFAULT_SELF_UNREGISTRATION = false;
     @Setting(value = "Enable data-plane un-registration at shutdown (not suggested for clustered environments)", type = "boolean", defaultValue = DEFAULT_SELF_UNREGISTRATION + "")
     static final String SELF_UNREGISTRATION = "edc.data.plane.self.unregistration";
     private final AtomicBoolean isRegistered = new AtomicBoolean(false);
@@ -86,7 +86,6 @@ public class DataplaneSelfRegistrationExtension implements ServiceExtension {
                 .id(context.getComponentId())
                 .url(controlApiUrl.get().toString() + "/v1/dataflows")
                 .allowedSourceTypes(pipelineService.supportedSourceTypes())
-                .allowedDestTypes(pipelineService.supportedSinkTypes())
                 .allowedTransferType(transferTypes.collect(toSet()))
                 .build();
 

--- a/extensions/data-plane/data-plane-self-registration/src/test/java/org/eclipse/edc/connector/dataplane/registration/DataplaneSelfRegistrationExtensionTest.java
+++ b/extensions/data-plane/data-plane-self-registration/src/test/java/org/eclipse/edc/connector/dataplane/registration/DataplaneSelfRegistrationExtensionTest.java
@@ -86,7 +86,6 @@ class DataplaneSelfRegistrationExtensionTest {
         assertThat(dataPlaneInstance.getId()).isEqualTo("componentId");
         assertThat(dataPlaneInstance.getUrl()).isEqualTo(new URL("http://control/api/url/v1/dataflows"));
         assertThat(dataPlaneInstance.getAllowedSourceTypes()).containsExactlyInAnyOrder("sourceType", "anotherSourceType");
-        assertThat(dataPlaneInstance.getAllowedDestTypes()).containsExactlyInAnyOrder("sinkType", "anotherSinkType");
         assertThat(dataPlaneInstance.getAllowedTransferTypes())
                 .containsExactlyInAnyOrder("pullDestType-PULL", "anotherPullDestType-PULL", "sinkType-PUSH", "anotherSinkType-PUSH");
 

--- a/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/instance/DataPlaneInstance.java
+++ b/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/instance/DataPlaneInstance.java
@@ -44,15 +44,11 @@ import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 public class DataPlaneInstance extends StatefulEntity<DataPlaneInstance> {
 
     public static final String DATAPLANE_INSTANCE_TYPE = EDC_NAMESPACE + "DataPlaneInstance";
-    @Deprecated(since = "0.6.3")
-    public static final String TURN_COUNT = EDC_NAMESPACE + "turnCount";
     public static final String LAST_ACTIVE = EDC_NAMESPACE + "lastActive";
     public static final String URL = EDC_NAMESPACE + "url";
     public static final String PROPERTIES = EDC_NAMESPACE + "properties";
     public static final String ALLOWED_TRANSFER_TYPES = EDC_NAMESPACE + "allowedTransferTypes";
     public static final String ALLOWED_SOURCE_TYPES = EDC_NAMESPACE + "allowedSourceTypes";
-    @Deprecated(since = "0.7.0")
-    public static final String ALLOWED_DEST_TYPES = EDC_NAMESPACE + "allowedDestTypes";
 
     public static final String DATAPLANE_INSTANCE_STATE = EDC_NAMESPACE + "state";
     public static final String DATAPLANE_INSTANCE_STATE_TIMESTAMP = EDC_NAMESPACE + "stateTimestamp";
@@ -61,10 +57,6 @@ public class DataPlaneInstance extends StatefulEntity<DataPlaneInstance> {
     private Map<String, Object> properties = new HashMap<>();
     private Set<String> allowedTransferTypes = new HashSet<>();
     private Set<String> allowedSourceTypes = new HashSet<>();
-    @Deprecated(since = "0.7.0")
-    private Set<String> allowedDestTypes = new HashSet<>();
-    @Deprecated(since = "0.6.3")
-    private int turnCount = 0;
     private long lastActive = Instant.now().toEpochMilli();
     private URL url;
 
@@ -76,8 +68,6 @@ public class DataPlaneInstance extends StatefulEntity<DataPlaneInstance> {
         var builder = Builder.newInstance()
                 .url(url)
                 .lastActive(lastActive)
-                .turnCount(turnCount)
-                .allowedDestTypes(allowedDestTypes)
                 .allowedSourceTypes(allowedSourceTypes)
                 .allowedTransferType(allowedTransferTypes)
                 .properties(properties);
@@ -108,10 +98,6 @@ public class DataPlaneInstance extends StatefulEntity<DataPlaneInstance> {
         return url;
     }
 
-    @Deprecated(since = "0.6.3")
-    public int getTurnCount() {
-        return turnCount;
-    }
 
     public long getLastActive() {
         return lastActive;
@@ -123,11 +109,6 @@ public class DataPlaneInstance extends StatefulEntity<DataPlaneInstance> {
 
     public Set<String> getAllowedSourceTypes() {
         return Collections.unmodifiableSet(allowedSourceTypes);
-    }
-
-    @Deprecated(since = "0.7.0")
-    public Set<String> getAllowedDestTypes() {
-        return Collections.unmodifiableSet(allowedDestTypes);
     }
 
     public Set<String> getAllowedTransferTypes() {
@@ -162,12 +143,6 @@ public class DataPlaneInstance extends StatefulEntity<DataPlaneInstance> {
             return new Builder(new DataPlaneInstance());
         }
 
-        @Deprecated(since = "0.6.3")
-        public Builder turnCount(int turnCount) {
-            entity.turnCount = turnCount;
-            return this;
-        }
-
         public Builder lastActive(long lastActive) {
             entity.lastActive = lastActive;
             return this;
@@ -175,11 +150,6 @@ public class DataPlaneInstance extends StatefulEntity<DataPlaneInstance> {
 
         public Builder allowedSourceType(String type) {
             entity.allowedSourceTypes.add(type);
-            return this;
-        }
-
-        public Builder allowedDestType(String type) {
-            entity.allowedDestTypes.add(type);
             return this;
         }
 
@@ -204,11 +174,6 @@ public class DataPlaneInstance extends StatefulEntity<DataPlaneInstance> {
 
         public Builder property(String key, Object value) {
             entity.properties.put(key, value);
-            return this;
-        }
-
-        public Builder allowedDestTypes(Set<String> types) {
-            entity.allowedDestTypes = types;
             return this;
         }
 

--- a/spi/data-plane-selector/data-plane-selector-spi/src/test/java/org/eclipse/edc/connector/dataplane/selector/spi/instance/DataPlaneInstanceTest.java
+++ b/spi/data-plane-selector/data-plane-selector-spi/src/test/java/org/eclipse/edc/connector/dataplane/selector/spi/instance/DataPlaneInstanceTest.java
@@ -42,21 +42,17 @@ class DataPlaneInstanceTest {
     void verifySerialization() throws MalformedURLException, JsonProcessingException {
         var inst = DataPlaneInstance.Builder.newInstance()
                 .id("test-id")
-                .turnCount(7)
                 .lastActive(Instant.now().toEpochMilli())
                 .url(new URL("http://localhost:8234/some/path"))
                 .property("someprop", "someval")
                 .allowedSourceType("allowedSrc1")
                 .allowedSourceType("allowedSrc2")
-                .allowedDestType("allowedDest1")
-                .allowedDestType("allowedDest2")
                 .build();
 
         var json = mapper.writeValueAsString(inst);
 
         assertThat(json).isNotNull()
                 .contains("url\":\"http://localhost:8234/some/path\"")
-                .contains("\"turnCount\":7")
                 .contains("\"someprop\":\"someval\"");
 
         var deserialized = mapper.readValue(json, DataPlaneInstance.class).copy();

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/CatalogApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/CatalogApiEndToEndTest.java
@@ -186,7 +186,7 @@ public class CatalogApiEndToEndTest {
         void getDataset_shouldReturnDataset(ManagementEndToEndTestContext context, AssetIndex assetIndex,
                                             DataPlaneInstanceStore dataPlaneInstanceStore) {
             var dataPlaneInstance = DataPlaneInstance.Builder.newInstance().url("http://localhost/any")
-                    .allowedDestType("any").allowedSourceType("test-type").allowedTransferType("any").build();
+                    .allowedSourceType("test-type").allowedTransferType("any").build();
             dataPlaneInstanceStore.save(dataPlaneInstance);
 
             assetIndex.create(createAsset("asset-id", "test-type").build());


### PR DESCRIPTION
## What this PR changes/adds

Removes the deprecated `turnCount` and `allowedDestTypes` from the DataPlaneInstance

## Why it does that

deprecated since 0.6 and 0.7 respectively

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
