### PR TITLE
feat: allow bi-directional data transfers

### DIFF
--- a/core/common/lib/transform-lib/src/main/java/org/eclipse/edc/transform/transformer/dspace/to/JsonObjectToDataAddressDspaceTransformer.java
+++ b/core/common/lib/transform-lib/src/main/java/org/eclipse/edc/transform/transformer/dspace/to/JsonObjectToDataAddressDspaceTransformer.java
@@ -78,6 +78,6 @@ public class JsonObjectToDataAddressDspaceTransformer extends AbstractNamespaceA
     }
 
     //container to hold endpoint property objects
-    private record DspaceEndpointProperty(String name, String value) {
+    private record DspaceEndpointProperty(String name, Object value) {
     }
 }

--- a/core/common/lib/transform-lib/src/main/java/org/eclipse/edc/transform/transformer/dspace/to/JsonObjectToDataAddressDspaceTransformer.java
+++ b/core/common/lib/transform-lib/src/main/java/org/eclipse/edc/transform/transformer/dspace/to/JsonObjectToDataAddressDspaceTransformer.java
@@ -78,6 +78,6 @@ public class JsonObjectToDataAddressDspaceTransformer extends AbstractNamespaceA
     }
 
     //container to hold endpoint property objects
-    private record DspaceEndpointProperty(String name, Object value) {
+    private record DspaceEndpointProperty(String name, String value) {
     }
 }

--- a/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/flow/TransferTypeParserImpl.java
+++ b/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/flow/TransferTypeParserImpl.java
@@ -25,7 +25,7 @@ public class TransferTypeParserImpl implements TransferTypeParser {
 
     /**
      * Parses a compose transfer type string into a {@link TransferType}:
-     * {@code DESTTYPE-{PUSH|PULL}(/RESPONSETYPE)}, for example {@code HttpData-PULL/Websocket}
+     * {@code DESTTYPE-{PUSH|PULL}(-RESPONSETYPE)}, for example {@code HttpData-PULL/Websocket}
      *
      * @param transferType the transfer type string representation.
      * @return a {@link TransferType}
@@ -33,7 +33,7 @@ public class TransferTypeParserImpl implements TransferTypeParser {
     @Override
     public Result<TransferType> parse(String transferType) {
         Optional<Result<TransferType>> parsed = Optional.ofNullable(transferType)
-                .map(type -> type.split("[-/]"))
+                .map(type -> type.split("-"))
                 .filter(tokens -> tokens.length >= 2)
                 .map(tokens -> parseFlowType(tokens[1]).map(flowType -> new TransferType(tokens[0], flowType, tokens.length > 2 ? tokens[2] : null)));
 

--- a/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/flow/TransferTypeParserImpl.java
+++ b/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/flow/TransferTypeParserImpl.java
@@ -23,12 +23,19 @@ import java.util.Optional;
 
 public class TransferTypeParserImpl implements TransferTypeParser {
 
+    /**
+     * Parses a compose transfer type string into a {@link TransferType}:
+     * {@code DESTTYPE-{PUSH|PULL}(/RESPONSETYPE)}, for example {@code HttpData-PULL/Websocket}
+     *
+     * @param transferType the transfer type string representation.
+     * @return a {@link TransferType}
+     */
     @Override
     public Result<TransferType> parse(String transferType) {
         Optional<Result<TransferType>> parsed = Optional.ofNullable(transferType)
-                .map(type -> type.split("-"))
-                .filter(tokens -> tokens.length == 2)
-                .map(tokens -> parseFlowType(tokens[1]).map(flowType -> new TransferType(tokens[0], flowType)));
+                .map(type -> type.split("[-/]"))
+                .filter(tokens -> tokens.length >= 2)
+                .map(tokens -> parseFlowType(tokens[1]).map(flowType -> new TransferType(tokens[0], flowType, tokens.length > 2 ? tokens[2] : null)));
 
         return parsed.orElse(Result.failure("Failed to extract flow type from transferType %s".formatted(transferType)));
     }

--- a/core/control-plane/control-plane-transfer/src/test/java/org/eclipse/edc/connector/controlplane/transfer/flow/TransferTypeParserImplTest.java
+++ b/core/control-plane/control-plane-transfer/src/test/java/org/eclipse/edc/connector/controlplane/transfer/flow/TransferTypeParserImplTest.java
@@ -60,4 +60,10 @@ class TransferTypeParserImplTest {
         assertThat(result).isFailed();
     }
 
+    @Test
+    void shouldParseReturnChannel() {
+        var result = parser.parse("DestinationType-PUSH/BackChannelType");
+        assertThat(result).isSucceeded().satisfies(type -> assertThat(type.responseChannelType()).isEqualTo("BackChannelType"));
+    }
+
 }

--- a/core/control-plane/control-plane-transfer/src/test/java/org/eclipse/edc/connector/controlplane/transfer/flow/TransferTypeParserImplTest.java
+++ b/core/control-plane/control-plane-transfer/src/test/java/org/eclipse/edc/connector/controlplane/transfer/flow/TransferTypeParserImplTest.java
@@ -62,7 +62,7 @@ class TransferTypeParserImplTest {
 
     @Test
     void shouldParseReturnChannel() {
-        var result = parser.parse("DestinationType-PUSH/BackChannelType");
+        var result = parser.parse("DestinationType-PUSH-BackChannelType");
         assertThat(result).isSucceeded().satisfies(type -> assertThat(type.responseChannelType()).isEqualTo("BackChannelType"));
     }
 

--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/PublicEndpointGeneratorServiceImpl.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/PublicEndpointGeneratorServiceImpl.java
@@ -63,4 +63,9 @@ class PublicEndpointGeneratorServiceImpl implements PublicEndpointGeneratorServi
     public Set<String> supportedDestinationTypes() {
         return generatorFunctions.keySet();
     }
+
+    @Override
+    public Set<String> supportedResponseTypes() {
+        return responseChannelFunctions.keySet();
+    }
 }

--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/PublicEndpointGeneratorServiceImpl.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/PublicEndpointGeneratorServiceImpl.java
@@ -23,9 +23,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static java.util.Optional.ofNullable;
 
 class PublicEndpointGeneratorServiceImpl implements PublicEndpointGeneratorService {
     private final Map<String, Function<DataAddress, Endpoint>> generatorFunctions = new ConcurrentHashMap<>();
+    private final Map<String, Supplier<Endpoint>> responseChannelFunctions = new ConcurrentHashMap<>();
 
     @Override
     public Result<Endpoint> generateFor(String destinationType, DataAddress sourceDataAddress) {
@@ -39,8 +43,20 @@ class PublicEndpointGeneratorServiceImpl implements PublicEndpointGeneratorServi
     }
 
     @Override
+    public Result<Endpoint> generateResponseFor(String responseChannelType) {
+        var function = responseChannelFunctions.get(responseChannelType);
+        return ofNullable(function).map(Supplier::get).map(Result::success)
+                .orElseGet(() -> Result.failure("No Response Channel Endpoint generator function registered for response channel type '%s'".formatted(responseChannelType)));
+    }
+
+    @Override
     public void addGeneratorFunction(String destinationType, Function<DataAddress, Endpoint> generatorFunction) {
         generatorFunctions.put(destinationType, generatorFunction);
+    }
+
+    @Override
+    public void addGeneratorFunction(String responseChannelType, Supplier<Endpoint> generatorFunction) {
+        responseChannelFunctions.put(responseChannelType, generatorFunction);
     }
 
     @Override

--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImpl.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImpl.java
@@ -46,6 +46,7 @@ import static org.eclipse.edc.connector.dataplane.spi.DataFlowStates.RECEIVED;
 import static org.eclipse.edc.connector.dataplane.spi.DataFlowStates.STARTED;
 import static org.eclipse.edc.spi.persistence.StateEntityStore.hasState;
 import static org.eclipse.edc.spi.response.ResponseStatus.FATAL_ERROR;
+import static org.eclipse.edc.spi.result.Result.success;
 
 /**
  * Default data manager implementation.
@@ -65,7 +66,7 @@ public class DataPlaneManagerImpl extends AbstractStateEntityManager<DataFlow, D
         // TODO for now no validation for pull scenario, since the transfer service registry
         //  is not applicable here. Probably validation only on the source part required.
         if (FlowType.PULL.equals(dataRequest.getFlowType())) {
-            return Result.success(true);
+            return success(true);
         } else {
             var transferService = transferServiceRegistry.resolveTransferService(dataRequest);
             return transferService != null ?
@@ -177,10 +178,17 @@ public class DataPlaneManagerImpl extends AbstractStateEntityManager<DataFlow, D
     private Result<DataFlowResponseMessage> handlePush(DataFlowStartMessage startMessage, DataFlow.Builder dataFlowBuilder) {
         dataFlowBuilder.state(RECEIVED.code());
 
-        var result = authorizationService.createEndpointDataReference(startMessage);
+        var responseChannelType = startMessage.getTransferType().responseChannelType();
+        if (responseChannelType != null) {
+            monitor.debug("PUSH dataflow with responseChannel '%s' received. Will generate data address".formatted(responseChannelType));
+            var result = authorizationService.createEndpointDataReference(startMessage);
 
-        return result.map(da -> DataFlowResponseMessage.Builder.newInstance()
-                .dataAddress(da)
+            return result.map(da -> DataFlowResponseMessage.Builder.newInstance()
+                    .dataAddress(da)
+                    .build());
+        }
+        return success(DataFlowResponseMessage.Builder.newInstance()
+                .dataAddress(null)
                 .build());
     }
 

--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImpl.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImpl.java
@@ -88,7 +88,7 @@ public class DataPlaneManagerImpl extends AbstractStateEntityManager<DataFlow, D
 
         var response = switch (startMessage.getFlowType()) {
             case PULL -> handlePull(startMessage, dataFlowBuilder);
-            case PUSH -> handlePush(dataFlowBuilder);
+            case PUSH -> handlePush(startMessage, dataFlowBuilder);
         };
 
         return response.onSuccess(m -> update(dataFlowBuilder.build()));
@@ -174,11 +174,13 @@ public class DataPlaneManagerImpl extends AbstractStateEntityManager<DataFlow, D
                         .build());
     }
 
-    private Result<DataFlowResponseMessage> handlePush(DataFlow.Builder dataFlowBuilder) {
+    private Result<DataFlowResponseMessage> handlePush(DataFlowStartMessage startMessage, DataFlow.Builder dataFlowBuilder) {
         dataFlowBuilder.state(RECEIVED.code());
 
-        return Result.success(DataFlowResponseMessage.Builder.newInstance()
-                .dataAddress(null)
+        var result = authorizationService.createEndpointDataReference(startMessage);
+
+        return result.map(da -> DataFlowResponseMessage.Builder.newInstance()
+                .dataAddress(da)
                 .build());
     }
 

--- a/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/PublicEndpointGeneratorServiceImplTest.java
+++ b/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/PublicEndpointGeneratorServiceImplTest.java
@@ -28,6 +28,15 @@ class PublicEndpointGeneratorServiceImplTest {
 
     private final PublicEndpointGeneratorService generatorService = new PublicEndpointGeneratorServiceImpl();
 
+    @Test
+    void supportedTypes() {
+        generatorService.addGeneratorFunction("type", dataAddress -> new Endpoint("any", "any"));
+
+        var result = generatorService.supportedDestinationTypes();
+
+        assertThat(result).containsOnly("type");
+    }
+
     @Nested
     class GenerateFor {
 
@@ -54,12 +63,25 @@ class PublicEndpointGeneratorServiceImplTest {
 
     }
 
-    @Test
-    void supportedTypes() {
-        generatorService.addGeneratorFunction("type", dataAddress -> new Endpoint("any", "any"));
+    @Nested
+    class GenerateResponseFor {
 
-        var result = generatorService.supportedDestinationTypes();
+        @Test
+        void shouldGenerateEndpointBasedOnDestinationType() {
+            var endpoint = new Endpoint("fizz", "bar-type");
 
-        assertThat(result).containsOnly("type");
+            generatorService.addGeneratorFunction("destinationType", () -> endpoint);
+
+            var result = generatorService.generateResponseFor("destinationType");
+
+            assertThat(result).isSucceeded().isEqualTo(endpoint);
+        }
+
+        @Test
+        void shouldFail_whenFunctionIsNotRegistered() {
+            var result = generatorService.generateResponseFor("any");
+            assertThat(result).isFailed();
+        }
+
     }
 }

--- a/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImplTest.java
+++ b/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImplTest.java
@@ -353,28 +353,6 @@ class DataPlaneManagerImplTest {
         });
     }
 
-    private DataFlow.Builder dataFlowBuilder() {
-        return DataFlow.Builder.newInstance()
-                .source(DataAddress.Builder.newInstance().type("source").build())
-                .destination(DataAddress.Builder.newInstance().type("destination").build())
-                .callbackAddress(URI.create("http://any"))
-                .transferType(new TransferType("DestinationType", FlowType.PUSH))
-                .properties(Map.of("key", "value"));
-    }
-
-    private Criterion[] stateIs(int state) {
-        return aryEq(new Criterion[]{ hasState(state) });
-    }
-
-    private DataFlowStartMessage createRequest() {
-        return DataFlowStartMessage.Builder.newInstance()
-                .id("1")
-                .processId("1")
-                .sourceDataAddress(DataAddress.Builder.newInstance().type("type").build())
-                .destinationDataAddress(DataAddress.Builder.newInstance().type("type").build())
-                .build();
-    }
-
     @Nested
     class Received {
         @Test
@@ -588,6 +566,28 @@ class DataPlaneManagerImplTest {
             assertThat(result).isSucceeded();
             verify(store).save(argThat(f -> f.getState() == SUSPENDED.code()));
         }
+    }
+
+    private DataFlow.Builder dataFlowBuilder() {
+        return DataFlow.Builder.newInstance()
+                .source(DataAddress.Builder.newInstance().type("source").build())
+                .destination(DataAddress.Builder.newInstance().type("destination").build())
+                .callbackAddress(URI.create("http://any"))
+                .transferType(new TransferType("DestinationType", FlowType.PUSH))
+                .properties(Map.of("key", "value"));
+    }
+
+    private Criterion[] stateIs(int state) {
+        return aryEq(new Criterion[]{ hasState(state) });
+    }
+
+    private DataFlowStartMessage createRequest() {
+        return DataFlowStartMessage.Builder.newInstance()
+                .id("1")
+                .processId("1")
+                .sourceDataAddress(DataAddress.Builder.newInstance().type("type").build())
+                .destinationDataAddress(DataAddress.Builder.newInstance().type("type").build())
+                .build();
     }
 
 }

--- a/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImplTest.java
+++ b/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImplTest.java
@@ -70,7 +70,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 
@@ -99,7 +98,6 @@ class DataPlaneManagerImplTest {
 
     @Test
     void initiateDataFlow() {
-        when(authorizationService.createEndpointDataReference(any())).thenReturn(Result.success(DataAddress.Builder.newInstance().type("type").build()));
         var request = DataFlowStartMessage.Builder.newInstance()
                 .id("1")
                 .processId("1")
@@ -122,8 +120,7 @@ class DataPlaneManagerImplTest {
         assertThat(dataFlow.getProperties()).isEqualTo(request.getProperties());
         assertThat(dataFlow.getState()).isEqualTo(RECEIVED.code());
 
-        verify(authorizationService).createEndpointDataReference(request);
-        verifyNoMoreInteractions(authorizationService);
+        verifyNoInteractions(authorizationService);
     }
 
     @Test

--- a/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImplTest.java
+++ b/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImplTest.java
@@ -70,6 +70,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 
@@ -98,6 +99,7 @@ class DataPlaneManagerImplTest {
 
     @Test
     void initiateDataFlow() {
+        when(authorizationService.createEndpointDataReference(any())).thenReturn(Result.success(DataAddress.Builder.newInstance().type("type").build()));
         var request = DataFlowStartMessage.Builder.newInstance()
                 .id("1")
                 .processId("1")
@@ -120,7 +122,8 @@ class DataPlaneManagerImplTest {
         assertThat(dataFlow.getProperties()).isEqualTo(request.getProperties());
         assertThat(dataFlow.getState()).isEqualTo(RECEIVED.code());
 
-        verifyNoInteractions(authorizationService);
+        verify(authorizationService).createEndpointDataReference(request);
+        verifyNoMoreInteractions(authorizationService);
     }
 
     @Test
@@ -290,6 +293,88 @@ class DataPlaneManagerImplTest {
         verify(store).save(argThat(f -> f.getProperties().containsKey(TERMINATION_REASON)));
     }
 
+    @Test
+    void completed_shouldNotifyResultToControlPlane() {
+        var dataFlow = dataFlowBuilder().state(COMPLETED.code()).build();
+        when(store.nextNotLeased(anyInt(), stateIs(COMPLETED.code()))).thenReturn(List.of(dataFlow)).thenReturn(emptyList());
+        when(transferProcessApiClient.completed(any())).thenReturn(Result.success());
+
+        manager.start();
+
+        await().untilAsserted(() -> {
+            verify(transferProcessApiClient).completed(any());
+            verify(store).save(argThat(it -> it.getState() == NOTIFIED.code()));
+        });
+    }
+
+    @Test
+    void completed_shouldNotTransitionToNotified() {
+        var dataFlow = dataFlowBuilder().state(COMPLETED.code()).build();
+        when(store.nextNotLeased(anyInt(), stateIs(COMPLETED.code()))).thenReturn(List.of(dataFlow)).thenReturn(emptyList());
+        when(transferProcessApiClient.completed(any())).thenReturn(Result.failure(""));
+
+        manager.start();
+
+        await().untilAsserted(() -> {
+            verify(transferProcessApiClient).completed(any());
+            verify(store).save(argThat(it -> it.getState() == COMPLETED.code()));
+        });
+    }
+
+    @Test
+    void failed_shouldNotifyResultToControlPlane() {
+        var dataFlow = dataFlowBuilder().state(FAILED.code()).errorDetail("an error").build();
+        when(store.nextNotLeased(anyInt(), stateIs(FAILED.code()))).thenReturn(List.of(dataFlow)).thenReturn(emptyList());
+        when(store.findById(any())).thenReturn(dataFlow);
+
+        when(transferProcessApiClient.failed(any(), eq("an error"))).thenReturn(Result.success());
+
+        manager.start();
+
+        await().untilAsserted(() -> {
+            verify(transferProcessApiClient).failed(any(), eq("an error"));
+            verify(store).save(argThat(it -> it.getState() == NOTIFIED.code()));
+        });
+    }
+
+    @Test
+    void failed_shouldNotTransitionToNotified() {
+        var dataFlow = dataFlowBuilder().state(FAILED.code()).errorDetail("an error").build();
+        when(store.nextNotLeased(anyInt(), stateIs(FAILED.code()))).thenReturn(List.of(dataFlow)).thenReturn(emptyList());
+        when(store.findById(any())).thenReturn(dataFlow);
+
+        when(transferProcessApiClient.failed(any(), eq("an error"))).thenReturn(Result.failure("an error"));
+
+        manager.start();
+
+        await().untilAsserted(() -> {
+            verify(transferProcessApiClient).failed(any(), eq("an error"));
+            verify(store).save(argThat(it -> it.getState() == FAILED.code()));
+        });
+    }
+
+    private DataFlow.Builder dataFlowBuilder() {
+        return DataFlow.Builder.newInstance()
+                .source(DataAddress.Builder.newInstance().type("source").build())
+                .destination(DataAddress.Builder.newInstance().type("destination").build())
+                .callbackAddress(URI.create("http://any"))
+                .transferType(new TransferType("DestinationType", FlowType.PUSH))
+                .properties(Map.of("key", "value"));
+    }
+
+    private Criterion[] stateIs(int state) {
+        return aryEq(new Criterion[]{ hasState(state) });
+    }
+
+    private DataFlowStartMessage createRequest() {
+        return DataFlowStartMessage.Builder.newInstance()
+                .id("1")
+                .processId("1")
+                .sourceDataAddress(DataAddress.Builder.newInstance().type("type").build())
+                .destinationDataAddress(DataAddress.Builder.newInstance().type("type").build())
+                .build();
+    }
+
     @Nested
     class Received {
         @Test
@@ -410,88 +495,6 @@ class DataPlaneManagerImplTest {
                 verify(store, atLeastOnce()).save(argThat(it -> it.getState() == FAILED.code()));
             });
         }
-    }
-
-    @Test
-    void completed_shouldNotifyResultToControlPlane() {
-        var dataFlow = dataFlowBuilder().state(COMPLETED.code()).build();
-        when(store.nextNotLeased(anyInt(), stateIs(COMPLETED.code()))).thenReturn(List.of(dataFlow)).thenReturn(emptyList());
-        when(transferProcessApiClient.completed(any())).thenReturn(Result.success());
-
-        manager.start();
-
-        await().untilAsserted(() -> {
-            verify(transferProcessApiClient).completed(any());
-            verify(store).save(argThat(it -> it.getState() == NOTIFIED.code()));
-        });
-    }
-
-    @Test
-    void completed_shouldNotTransitionToNotified() {
-        var dataFlow = dataFlowBuilder().state(COMPLETED.code()).build();
-        when(store.nextNotLeased(anyInt(), stateIs(COMPLETED.code()))).thenReturn(List.of(dataFlow)).thenReturn(emptyList());
-        when(transferProcessApiClient.completed(any())).thenReturn(Result.failure(""));
-
-        manager.start();
-
-        await().untilAsserted(() -> {
-            verify(transferProcessApiClient).completed(any());
-            verify(store).save(argThat(it -> it.getState() == COMPLETED.code()));
-        });
-    }
-
-    @Test
-    void failed_shouldNotifyResultToControlPlane() {
-        var dataFlow = dataFlowBuilder().state(FAILED.code()).errorDetail("an error").build();
-        when(store.nextNotLeased(anyInt(), stateIs(FAILED.code()))).thenReturn(List.of(dataFlow)).thenReturn(emptyList());
-        when(store.findById(any())).thenReturn(dataFlow);
-
-        when(transferProcessApiClient.failed(any(), eq("an error"))).thenReturn(Result.success());
-
-        manager.start();
-
-        await().untilAsserted(() -> {
-            verify(transferProcessApiClient).failed(any(), eq("an error"));
-            verify(store).save(argThat(it -> it.getState() == NOTIFIED.code()));
-        });
-    }
-
-    @Test
-    void failed_shouldNotTransitionToNotified() {
-        var dataFlow = dataFlowBuilder().state(FAILED.code()).errorDetail("an error").build();
-        when(store.nextNotLeased(anyInt(), stateIs(FAILED.code()))).thenReturn(List.of(dataFlow)).thenReturn(emptyList());
-        when(store.findById(any())).thenReturn(dataFlow);
-
-        when(transferProcessApiClient.failed(any(), eq("an error"))).thenReturn(Result.failure("an error"));
-
-        manager.start();
-
-        await().untilAsserted(() -> {
-            verify(transferProcessApiClient).failed(any(), eq("an error"));
-            verify(store).save(argThat(it -> it.getState() == FAILED.code()));
-        });
-    }
-
-    private DataFlow.Builder dataFlowBuilder() {
-        return DataFlow.Builder.newInstance()
-                .source(DataAddress.Builder.newInstance().type("source").build())
-                .destination(DataAddress.Builder.newInstance().type("destination").build())
-                .callbackAddress(URI.create("http://any"))
-                .transferType(new TransferType("DestinationType", FlowType.PUSH))
-                .properties(Map.of("key", "value"));
-    }
-
-    private Criterion[] stateIs(int state) {
-        return aryEq(new Criterion[]{ hasState(state) });
-    }
-
-    private DataFlowStartMessage createRequest() {
-        return DataFlowStartMessage.Builder.newInstance()
-                .id("1")
-                .processId("1")
-                .sourceDataAddress(DataAddress.Builder.newInstance().type("type").build())
-                .destinationDataAddress(DataAddress.Builder.newInstance().type("type").build())
-                .build();
     }
 
     @Nested

--- a/docs/developer/decision-records/2024-10-24-bidirectional-data-transfers/README.md
+++ b/docs/developer/decision-records/2024-10-24-bidirectional-data-transfers/README.md
@@ -61,10 +61,10 @@ The required changes to the Data Plane Framework to support bidirectional data t
 
 The `DataAddress` in the `DataFlowResponseMessage` will contain properties symmetric to front channel HTTP endpoints:
 
-- `https://w3id.org/edc/v0.0.1/ns/responseChannel/endpoint`: the URL
-- `https://w3id.org/edc/v0.0.1/ns/responseChannel/endpoint`: the type of endpoint
-- `https://w3id.org/edc/v0.0.1/ns/responseChannel/authorization`: the authorization token [optional]
-- `https://w3id.org/edc/v0.0.1/ns/responseChannel/authType`: the type of auth token, e.g. `"bearer"` [optional]
+- `https://w3id.org/edc/v0.0.1/ns/responseChannel-endpoint`: the URL
+- `https://w3id.org/edc/v0.0.1/ns/responseChannel-endpoint`: the type of endpoint
+- `https://w3id.org/edc/v0.0.1/ns/responseChannel-authorization`: the authorization token [optional]
+- `https://w3id.org/edc/v0.0.1/ns/responseChannel-authType`: the type of auth token, e.g. `"bearer"` [optional]
 
 These properties will be flattened into the original `DataAddress`, since `dspace:endpointProperty` fields are defined
 as strings.
@@ -75,7 +75,7 @@ The `DataPlaneManagerImpl` and its collaborators will need to be refactored to g
 channel `DataAddresses`:
 
 - `DataPlaneManagerImpl` must be modified to return an EDR in the case of a provider PUSH. This EDR will only contain
-  `https://w3id.org/edc/v0.0.1/ns/responseChannel/*` entries. The manager will delegate to
+  `https://w3id.org/edc/v0.0.1/ns/responseChannel-*` entries. The manager will delegate to
   `DataPlaneAuthorizationService`
   to generate the response.
 - `DataPlaneAuthorizationServiceImpl` must be enhanced to support `responseChannel` generation. This should be keyed off

--- a/docs/developer/decision-records/2024-10-24-bidirectional-data-transfers/README.md
+++ b/docs/developer/decision-records/2024-10-24-bidirectional-data-transfers/README.md
@@ -86,15 +86,15 @@ channel `DataAddresses`:
 
 ### On the Control Plane
 
-The `TransferType` object will be extended to contain another optional lproperty `responseChannelType`, which is encoded
+The `TransferType` object will be extended to contain another optional property `responseChannelType`, which is encoded
 as follows:
 
 ```
-DESTTYPE-FLOW/RESPONSETYPE, e.g. HttpData-PULL/gRpc
+DESTTYPE-FLOW-RESPONSETYPE, e.g. HttpData-PULL-gRpc
 ```
 
 In the catalog, every `DataSet` will be represented by `Distributions` both with and without the `responseChannelType`,
-e.g. `HttpData-PULL/gRpc` and `HttpData-PULL`. This keeps consistency with the current data plane selection mechanism.
+e.g. `HttpData-PULL-gRpc` and `HttpData-PULL`. This keeps consistency with the current data plane selection mechanism.
 
 ### Technical Considerations
 

--- a/docs/developer/decision-records/2024-10-24-bidirectional-data-transfers/README.md
+++ b/docs/developer/decision-records/2024-10-24-bidirectional-data-transfers/README.md
@@ -1,0 +1,108 @@
+## Decision
+
+Provider data planes may expose a response channel endpoint to allow consumers to send feedback and control information
+about ongoing data transfers.
+Exposing a response channel is optional, and its carrier technology is independent of the "data channel".
+
+## Rationale
+
+In scenarios where the consumer needs to provide feedback information like error data or flow control etc. a feedback
+channel comes in handy.
+
+Bidirectional data transfers involve transmissions that can be sent by either the provider or consumer during the
+transfer's lifetime. The provider sends data over a forward channel, while the client uses a response channel to send
+data related to the forward transmission. For example, a provider sends parts data over the forward channel, while the
+consumer sends data related to errors in the forward transmission via the response channel.
+
+Bidirectional data transfers should be modeled using a single Dataspace Protocol *offer* and *contract agreement*. In
+other words, a single offer represents the ability to send both forward and response messages, while an active contract
+agreement can be used to initiate the transfer.
+
+## Approach
+
+Bidirectional flows can be implemented using a variety of wire protocols, for example, HTTP or a messaging layer.
+However, all scenarios correspond to one of two endpoint topologies:
+
+- The consumer offers the forward channel endpoint, and the provider offers the response channel endpoint.
+- The provider offers both the forward and response channel endpoints.
+
+The Dataspace Protocol (DSP) defines two categories of data transfer: *push* and *pull*. The endpoint topologies
+correlate to these categories as follows:
+
+| Provider Push                                                                               | Consumer Pull                                              |
+|---------------------------------------------------------------------------------------------|------------------------------------------------------------|
+| Consumer offers the forward channel endpoint; provider offers the response channel endpoint | Provider offers the forward and response channel endpoints |
+
+**In each case, the provider always offers the response channel.**
+
+### On the Data Plane
+
+The Data Plane establishes data transfer communication channels and endpoints using a *wire protocol*. There are many
+ways to do this, two of which are described below.
+
+**HTTP Endpoints**
+
+The forward and response channels are separate endpoints. The endpoints may be static, where all messages in a
+particular direction are sent to the same endpoint, which then uses a correlation mechanism to process them, for
+example, `https://test.com/forwardChannel` and `https//test.com/responseChannel`. Or, the endpoints may be dynamic,
+where a path part contains a correlation ID, for example, `https://test.com/transferId/forwardChannel`
+and `https://test.com/transferId/responseChannel`.
+
+**Queues and Pub/Sub**
+
+In this scenario, the forward channel is a *queue* or a pub/sub *topic* while the response channel is a *queue*. This is
+a typical architecture used when designing systems with Message-Oriented-Middleware.
+
+### Required Changes to the Data Plane Framework
+
+The required changes to the Data Plane Framework to support bidirectional data transfers are minimal.
+
+#### Response Endpoint in the `DataAddress`
+
+The `DataAddress` in the `DataFlowResponseMessage` will contain properties symmetric to front channel HTTP endpoints:
+
+- `https://w3id.org/edc/v0.0.1/ns/responseChannel/endpoint`: the URL
+- `https://w3id.org/edc/v0.0.1/ns/responseChannel/endpoint`: the type of endpoint
+- `https://w3id.org/edc/v0.0.1/ns/responseChannel/authorization`: the authorization token [optional]
+- `https://w3id.org/edc/v0.0.1/ns/responseChannel/authType`: the type of auth token, e.g. `"bearer"` [optional]
+
+These properties will be flattened into the original `DataAddress`, since `dspace:endpointProperty` fields are defined
+as strings.
+
+#### The DataPlaneManager
+
+The `DataPlaneManagerImpl` and its collaborators will need to be refactored to generate response
+channel `DataAddresses`:
+
+- `DataPlaneManagerImpl` must be modified to return an EDR in the case of a provider PUSH. This EDR will only contain
+  `https://w3id.org/edc/v0.0.1/ns/responseChannel/*` entries. The manager will delegate to
+  `DataPlaneAuthorizationService`
+  to generate the response.
+- `DataPlaneAuthorizationServiceImpl` must be enhanced to support `responseChannel` generation. This should be keyed off
+  of the transfer type. As part of this process, a `DataPlaneAuthorizationServiceImpl.createEndpointDataReference` must
+  generate a `responseChannel` endpoint by delegating to a new
+  method `PublicEndpointGeneratorService.generateCallbackFor(sourceDataAddress).` Access Tokens can be generated
+  from `DataPlaneAccessTokenService`.
+
+### On the Control Plane
+
+The `TransferType` object will be extended to contain another optional lproperty `responseChannelType`, which is encoded
+as follows:
+
+```
+DESTTYPE-FLOW/RESPONSETYPE, e.g. HttpData-PULL/gRpc
+```
+
+In the catalog, every `DataSet` will be represented by `Distributions` both with and without the `responseChannelType`,
+e.g. `HttpData-PULL/gRpc` and `HttpData-PULL`. This keeps consistency with the current data plane selection mechanism.
+
+### Technical Considerations
+
+The above changes can work with both DSP pull and push scenarios. However, it is important to note a potential race
+condition that could be introduced in PUSH transfers. Namely, provider-pushed data could potentially arrive before the
+DSP start message containing the response channel `DataAddress` is received by the client. This is due to the nature of
+asynchronous communications. In this case, the client would either need to skip sending a response or store the response
+messages to send when it receives the response channel `DataAddress`.
+
+The response channel lifetime is tied to the forward channel. For example, when the forward channel is closed, the
+response channel will also be closed.

--- a/docs/developer/decision-records/README.md
+++ b/docs/developer/decision-records/README.md
@@ -65,4 +65,5 @@
 - [2024-10-02 Clustered data-plane](./2024-10-02-clustered-data-plane/)
 - [2024-10-06 Typed Policy Scopes through Contexts](./2024-10-05-typed-policy-context)
 - [2024-10-10 DAPS module deprecation](./2024-10-10-daps-deprecation)
+- [2024-10-24 bidirectional-data-transfers](./2024-10-24-bidirectional-data-transfers)
 

--- a/extensions/data-plane/data-plane-iam/src/main/java/org/eclipse/edc/connector/dataplane/iam/service/DataPlaneAuthorizationServiceImpl.java
+++ b/extensions/data-plane/data-plane-iam/src/main/java/org/eclipse/edc/connector/dataplane/iam/service/DataPlaneAuthorizationServiceImpl.java
@@ -121,12 +121,12 @@ public class DataPlaneAuthorizationServiceImpl implements DataPlaneAuthorization
     private Result<DataAddress.Builder> addResponseChannel(DataAddress.Builder builder, TokenRepresentation tokenRepresentation, Endpoint returnChannelEndpoint) {
         var map = new HashMap<String, String>() {
             {
-                put(EDC_NAMESPACE + "responseChannel/endpoint", returnChannelEndpoint.endpoint());
-                put(EDC_NAMESPACE + "responseChannel/endpointType", returnChannelEndpoint.endpointType());
-                put(EDC_NAMESPACE + "responseChannel/authorization", tokenRepresentation.getToken());
+                put(EDC_NAMESPACE + "responseChannel-endpoint", returnChannelEndpoint.endpoint());
+                put(EDC_NAMESPACE + "responseChannel-endpointType", returnChannelEndpoint.endpointType());
+                put(EDC_NAMESPACE + "responseChannel-authorization", tokenRepresentation.getToken());
             }
         };
-        tokenRepresentation.getAdditional().forEach((k, v) -> map.put(k.replace(EDC_NAMESPACE, EDC_NAMESPACE + "responseChannel/"), v.toString()));
+        tokenRepresentation.getAdditional().forEach((k, v) -> map.put(k.replace(EDC_NAMESPACE, EDC_NAMESPACE + "responseChannel-"), v.toString()));
 
         map.forEach(builder::property);
 

--- a/extensions/data-plane/data-plane-integration-tests/src/test/java/org/eclipse/edc/connector/dataplane/http/DataPlaneHttpIntegrationTests.java
+++ b/extensions/data-plane/data-plane-integration-tests/src/test/java/org/eclipse/edc/connector/dataplane/http/DataPlaneHttpIntegrationTests.java
@@ -31,6 +31,7 @@ import org.eclipse.edc.junit.extensions.EmbeddedRuntime;
 import org.eclipse.edc.junit.extensions.RuntimeExtension;
 import org.eclipse.edc.junit.extensions.RuntimePerClassExtension;
 import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -97,10 +98,7 @@ public class DataPlaneHttpIntegrationTests {
     private static final String AUTH_HEADER_KEY = AUTHORIZATION.toString();
     private static final String SOURCE_AUTH_VALUE = "source-auth-key";
     private static final String SINK_AUTH_VALUE = "sink-auth-key";
-    private static ClientAndServer httpSourceMockServer;
-    private static ClientAndServer httpSinkMockServer;
-    private final Duration timeout = Duration.ofSeconds(30);
-
+    private static final DataPlaneAuthorizationService DATA_PLANE_AUTHORIZATION_SERVICE = mock();
     private static final EmbeddedRuntime RUNTIME = new EmbeddedRuntime(
             "data-plane-server",
             Map.of(
@@ -119,12 +117,16 @@ public class DataPlaneHttpIntegrationTests {
             ":extensions:data-plane:data-plane-http",
             ":extensions:data-plane:data-plane-public-api-v2",
             ":extensions:data-plane:data-plane-signaling:data-plane-signaling-api"
-    ).registerServiceMock(DataPlaneAuthorizationService.class, mock());
+    ).registerServiceMock(DataPlaneAuthorizationService.class, DATA_PLANE_AUTHORIZATION_SERVICE);
+    private static ClientAndServer httpSourceMockServer;
+    private static ClientAndServer httpSinkMockServer;
+    private final Duration timeout = Duration.ofSeconds(30);
 
     @BeforeAll
     public static void setUp() {
         httpSourceMockServer = startClientAndServer(HTTP_SOURCE_API_PORT);
         httpSinkMockServer = startClientAndServer(HTTP_SINK_API_PORT);
+        when(DATA_PLANE_AUTHORIZATION_SERVICE.createEndpointDataReference(any())).thenReturn(Result.success(DataAddress.Builder.newInstance().type("type").build()));
     }
 
     @AfterAll
@@ -137,6 +139,60 @@ public class DataPlaneHttpIntegrationTests {
     public void resetMockServer() {
         httpSourceMockServer.reset();
         httpSinkMockServer.reset();
+    }
+
+    /**
+     * Mock HTTP GET request for source.
+     *
+     * @return see {@link HttpRequest}
+     */
+    private HttpRequest getRequest(String path) {
+        return getRequest(emptyMap(), path);
+    }
+
+    /**
+     * Mock HTTP GET request with query params for source.
+     *
+     * @return see {@link HttpRequest}
+     */
+    private HttpRequest getRequest(Map<String, String> queryParams, String path) {
+        var request = request();
+
+        var paramsList = queryParams.entrySet()
+                .stream()
+                .map(entry -> param(entry.getKey(), entry.getValue()))
+                .toList();
+
+        request.withQueryStringParameters(new Parameters(paramsList).withKeyMatchStyle(MATCHING_KEY));
+
+        return request
+                .withMethod(HttpMethod.GET.name())
+                .withHeader(AUTH_HEADER_KEY, SOURCE_AUTH_VALUE)
+                .withPath("/" + path);
+    }
+
+    private HttpRequest postRequest(String responseBody, MediaType contentType) {
+        return request()
+                .withMethod(HttpMethod.POST.name())
+                .withHeader(AUTH_HEADER_KEY, SINK_AUTH_VALUE)
+                .withContentType(contentType)
+                .withBody(binary(responseBody.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    /**
+     * Mock http OK response from sink.
+     *
+     * @return see {@link HttpResponse}
+     */
+    private HttpResponse successfulResponse() {
+        return response()
+                .withStatusCode(HttpStatusCode.OK_200.code());
+    }
+
+    private HttpResponse successfulResponse(String responseBody, MediaType contentType) {
+        return successfulResponse()
+                .withHeader(HttpHeaderNames.CONTENT_TYPE.toString(), contentType.toString())
+                .withBody(responseBody);
     }
 
     @Nested
@@ -379,59 +435,5 @@ public class DataPlaneHttpIntegrationTests {
                     .add("dspace:value", value);
         }
 
-    }
-
-    /**
-     * Mock HTTP GET request for source.
-     *
-     * @return see {@link HttpRequest}
-     */
-    private HttpRequest getRequest(String path) {
-        return getRequest(emptyMap(), path);
-    }
-
-    /**
-     * Mock HTTP GET request with query params for source.
-     *
-     * @return see {@link HttpRequest}
-     */
-    private HttpRequest getRequest(Map<String, String> queryParams, String path) {
-        var request = request();
-
-        var paramsList = queryParams.entrySet()
-                .stream()
-                .map(entry -> param(entry.getKey(), entry.getValue()))
-                .toList();
-
-        request.withQueryStringParameters(new Parameters(paramsList).withKeyMatchStyle(MATCHING_KEY));
-
-        return request
-                .withMethod(HttpMethod.GET.name())
-                .withHeader(AUTH_HEADER_KEY, SOURCE_AUTH_VALUE)
-                .withPath("/" + path);
-    }
-
-    private HttpRequest postRequest(String responseBody, MediaType contentType) {
-        return request()
-                .withMethod(HttpMethod.POST.name())
-                .withHeader(AUTH_HEADER_KEY, SINK_AUTH_VALUE)
-                .withContentType(contentType)
-                .withBody(binary(responseBody.getBytes(StandardCharsets.UTF_8)));
-    }
-
-    /**
-     * Mock http OK response from sink.
-     *
-     * @return see {@link HttpResponse}
-     */
-    private HttpResponse successfulResponse() {
-        return response()
-                .withStatusCode(HttpStatusCode.OK_200.code());
-    }
-
-    private HttpResponse successfulResponse(String responseBody, MediaType contentType) {
-        return successfulResponse()
-                .withHeader(HttpHeaderNames.CONTENT_TYPE.toString(), contentType.toString())
-                .withBody(responseBody);
     }
 }

--- a/extensions/data-plane/data-plane-integration-tests/src/test/java/org/eclipse/edc/connector/dataplane/http/DataPlaneHttpIntegrationTests.java
+++ b/extensions/data-plane/data-plane-integration-tests/src/test/java/org/eclipse/edc/connector/dataplane/http/DataPlaneHttpIntegrationTests.java
@@ -141,60 +141,6 @@ public class DataPlaneHttpIntegrationTests {
         httpSinkMockServer.reset();
     }
 
-    /**
-     * Mock HTTP GET request for source.
-     *
-     * @return see {@link HttpRequest}
-     */
-    private HttpRequest getRequest(String path) {
-        return getRequest(emptyMap(), path);
-    }
-
-    /**
-     * Mock HTTP GET request with query params for source.
-     *
-     * @return see {@link HttpRequest}
-     */
-    private HttpRequest getRequest(Map<String, String> queryParams, String path) {
-        var request = request();
-
-        var paramsList = queryParams.entrySet()
-                .stream()
-                .map(entry -> param(entry.getKey(), entry.getValue()))
-                .toList();
-
-        request.withQueryStringParameters(new Parameters(paramsList).withKeyMatchStyle(MATCHING_KEY));
-
-        return request
-                .withMethod(HttpMethod.GET.name())
-                .withHeader(AUTH_HEADER_KEY, SOURCE_AUTH_VALUE)
-                .withPath("/" + path);
-    }
-
-    private HttpRequest postRequest(String responseBody, MediaType contentType) {
-        return request()
-                .withMethod(HttpMethod.POST.name())
-                .withHeader(AUTH_HEADER_KEY, SINK_AUTH_VALUE)
-                .withContentType(contentType)
-                .withBody(binary(responseBody.getBytes(StandardCharsets.UTF_8)));
-    }
-
-    /**
-     * Mock http OK response from sink.
-     *
-     * @return see {@link HttpResponse}
-     */
-    private HttpResponse successfulResponse() {
-        return response()
-                .withStatusCode(HttpStatusCode.OK_200.code());
-    }
-
-    private HttpResponse successfulResponse(String responseBody, MediaType contentType) {
-        return successfulResponse()
-                .withHeader(HttpHeaderNames.CONTENT_TYPE.toString(), contentType.toString())
-                .withBody(responseBody);
-    }
-
     @Nested
     class Pull {
 
@@ -436,4 +382,60 @@ public class DataPlaneHttpIntegrationTests {
         }
 
     }
+
+    /**
+     * Mock HTTP GET request for source.
+     *
+     * @return see {@link HttpRequest}
+     */
+    private HttpRequest getRequest(String path) {
+        return getRequest(emptyMap(), path);
+    }
+
+    /**
+     * Mock HTTP GET request with query params for source.
+     *
+     * @return see {@link HttpRequest}
+     */
+    private HttpRequest getRequest(Map<String, String> queryParams, String path) {
+        var request = request();
+
+        var paramsList = queryParams.entrySet()
+                .stream()
+                .map(entry -> param(entry.getKey(), entry.getValue()))
+                .toList();
+
+        request.withQueryStringParameters(new Parameters(paramsList).withKeyMatchStyle(MATCHING_KEY));
+
+        return request
+                .withMethod(HttpMethod.GET.name())
+                .withHeader(AUTH_HEADER_KEY, SOURCE_AUTH_VALUE)
+                .withPath("/" + path);
+    }
+
+    private HttpRequest postRequest(String responseBody, MediaType contentType) {
+        return request()
+                .withMethod(HttpMethod.POST.name())
+                .withHeader(AUTH_HEADER_KEY, SINK_AUTH_VALUE)
+                .withContentType(contentType)
+                .withBody(binary(responseBody.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    /**
+     * Mock http OK response from sink.
+     *
+     * @return see {@link HttpResponse}
+     */
+    private HttpResponse successfulResponse() {
+        return response()
+                .withStatusCode(HttpStatusCode.OK_200.code());
+    }
+
+    private HttpResponse successfulResponse(String responseBody, MediaType contentType) {
+        return successfulResponse()
+                .withHeader(HttpHeaderNames.CONTENT_TYPE.toString(), contentType.toString())
+                .withBody(responseBody);
+    }
+
+
 }

--- a/extensions/data-plane/data-plane-public-api-v2/src/main/java/org/eclipse/edc/connector/dataplane/api/DataPlanePublicApiV2Extension.java
+++ b/extensions/data-plane/data-plane-public-api-v2/src/main/java/org/eclipse/edc/connector/dataplane/api/DataPlanePublicApiV2Extension.java
@@ -50,7 +50,7 @@ public class DataPlanePublicApiV2Extension implements ServiceExtension {
     private static final String PUBLIC_CONFIG_KEY = "web.http." + ApiContext.PUBLIC;
 
     @Setting(value = "Base url of the public API endpoint without the trailing slash. This should correspond to the values configured " +
-            "in '" + DEFAULT_PUBLIC_PORT + "' and '" + PUBLIC_CONTEXT_PATH + "'.", defaultValue = "http://<HOST>:" + DEFAULT_PUBLIC_PORT + PUBLIC_CONTEXT_PATH)
+                     "in '" + DEFAULT_PUBLIC_PORT + "' and '" + PUBLIC_CONTEXT_PATH + "'.", defaultValue = "http://<HOST>:" + DEFAULT_PUBLIC_PORT + PUBLIC_CONTEXT_PATH)
     private static final String PUBLIC_ENDPOINT = "edc.dataplane.api.public.baseurl";
 
     private static final int DEFAULT_THREAD_POOL = 10;
@@ -107,6 +107,8 @@ public class DataPlanePublicApiV2Extension implements ServiceExtension {
         }
         var endpoint = Endpoint.url(publicEndpoint);
         generatorService.addGeneratorFunction("HttpData", dataAddress -> endpoint);
+        var responseEndpoint = Endpoint.url(publicEndpoint + "/responseChannel");
+        generatorService.addGeneratorFunction("HttpData", () -> responseEndpoint);
 
         var publicApiController = new DataPlanePublicApiV2Controller(pipelineService, executorService, authorizationService);
         webService.registerResource(ApiContext.PUBLIC, publicApiController);

--- a/extensions/data-plane/data-plane-public-api-v2/src/main/java/org/eclipse/edc/connector/dataplane/api/DataPlanePublicApiV2Extension.java
+++ b/extensions/data-plane/data-plane-public-api-v2/src/main/java/org/eclipse/edc/connector/dataplane/api/DataPlanePublicApiV2Extension.java
@@ -109,7 +109,6 @@ public class DataPlanePublicApiV2Extension implements ServiceExtension {
         generatorService.addGeneratorFunction("HttpData", dataAddress -> endpoint);
         var responseEndpoint = Endpoint.url(publicEndpoint + "/responseChannel");
         generatorService.addGeneratorFunction("HttpData", () -> responseEndpoint);
-        generatorService.addGeneratorFunction("gRPC", () -> new Endpoint("yomama", "gRPC"));
 
         var publicApiController = new DataPlanePublicApiV2Controller(pipelineService, executorService, authorizationService);
         webService.registerResource(ApiContext.PUBLIC, publicApiController);

--- a/extensions/data-plane/data-plane-public-api-v2/src/main/java/org/eclipse/edc/connector/dataplane/api/DataPlanePublicApiV2Extension.java
+++ b/extensions/data-plane/data-plane-public-api-v2/src/main/java/org/eclipse/edc/connector/dataplane/api/DataPlanePublicApiV2Extension.java
@@ -53,6 +53,9 @@ public class DataPlanePublicApiV2Extension implements ServiceExtension {
                      "in '" + DEFAULT_PUBLIC_PORT + "' and '" + PUBLIC_CONTEXT_PATH + "'.", defaultValue = "http://<HOST>:" + DEFAULT_PUBLIC_PORT + PUBLIC_CONTEXT_PATH)
     private static final String PUBLIC_ENDPOINT = "edc.dataplane.api.public.baseurl";
 
+    @Setting(value = "Optional base url of the response channel endpoint without the trailing slash. A common practice is to use <PUBLIC_ENDPOINT>/responseChannel")
+    private static final String PUBLIC_RESPONSE_ENDPOINT = "edc.dataplane.api.public.response.baseurl";
+
     private static final int DEFAULT_THREAD_POOL = 10;
     private static final WebServiceSettings PUBLIC_SETTINGS = WebServiceSettings.Builder.newInstance()
             .apiConfigKey(PUBLIC_CONFIG_KEY)
@@ -107,8 +110,11 @@ public class DataPlanePublicApiV2Extension implements ServiceExtension {
         }
         var endpoint = Endpoint.url(publicEndpoint);
         generatorService.addGeneratorFunction("HttpData", dataAddress -> endpoint);
-        var responseEndpoint = Endpoint.url(publicEndpoint + "/responseChannel");
-        generatorService.addGeneratorFunction("HttpData", () -> responseEndpoint);
+
+        var responseEndpoint = context.getSetting(PUBLIC_RESPONSE_ENDPOINT, null);
+        if (responseEndpoint != null) {
+            generatorService.addGeneratorFunction("HttpData", () -> Endpoint.url(responseEndpoint));
+        }
 
         var publicApiController = new DataPlanePublicApiV2Controller(pipelineService, executorService, authorizationService);
         webService.registerResource(ApiContext.PUBLIC, publicApiController);

--- a/extensions/data-plane/data-plane-public-api-v2/src/main/java/org/eclipse/edc/connector/dataplane/api/DataPlanePublicApiV2Extension.java
+++ b/extensions/data-plane/data-plane-public-api-v2/src/main/java/org/eclipse/edc/connector/dataplane/api/DataPlanePublicApiV2Extension.java
@@ -109,6 +109,7 @@ public class DataPlanePublicApiV2Extension implements ServiceExtension {
         generatorService.addGeneratorFunction("HttpData", dataAddress -> endpoint);
         var responseEndpoint = Endpoint.url(publicEndpoint + "/responseChannel");
         generatorService.addGeneratorFunction("HttpData", () -> responseEndpoint);
+        generatorService.addGeneratorFunction("gRPC", () -> new Endpoint("yomama", "gRPC"));
 
         var publicApiController = new DataPlanePublicApiV2Controller(pipelineService, executorService, authorizationService);
         webService.registerResource(ApiContext.PUBLIC, publicApiController);

--- a/extensions/data-plane/data-plane-self-registration/src/main/java/org/eclipse/edc/connector/dataplane/registration/DataplaneSelfRegistrationExtension.java
+++ b/extensions/data-plane/data-plane-self-registration/src/main/java/org/eclipse/edc/connector/dataplane/registration/DataplaneSelfRegistrationExtension.java
@@ -117,10 +117,8 @@ public class DataplaneSelfRegistrationExtension implements ServiceExtension {
     }
 
     private @NotNull Stream<String> toTransferTypes(FlowType pull, Set<String> types, Set<String> responseTypes) {
-        if (responseTypes.isEmpty()) {
-            return types.stream().map(it -> "%s-%s".formatted(it, pull));
-        }
-        return responseTypes.stream().flatMap(responseType -> types.stream().map(it -> "%s-%s/%s".formatted(it, pull, responseType)));
+        Stream<String> transferTypes = types.stream().map(it -> "%s-%s".formatted(it, pull));
+        return Stream.concat(transferTypes, responseTypes.stream().flatMap(responseType -> types.stream().map(it -> "%s-%s/%s".formatted(it, pull, responseType))));
     }
 
     private class DataPlaneHealthCheck implements LivenessProvider, ReadinessProvider, StartupStatusProvider {

--- a/extensions/data-plane/data-plane-self-registration/src/main/java/org/eclipse/edc/connector/dataplane/registration/DataplaneSelfRegistrationExtension.java
+++ b/extensions/data-plane/data-plane-self-registration/src/main/java/org/eclipse/edc/connector/dataplane/registration/DataplaneSelfRegistrationExtension.java
@@ -46,7 +46,7 @@ import static org.eclipse.edc.spi.types.domain.transfer.FlowType.PUSH;
 @Extension(NAME)
 public class DataplaneSelfRegistrationExtension implements ServiceExtension {
 
-    private static final boolean DEFAULT_SELF_UNREGISTRATION = false;
+    public static final boolean DEFAULT_SELF_UNREGISTRATION = false;
     public static final String NAME = "Dataplane Self Registration";
     @Setting(value = "Enable data-plane un-registration at shutdown (not suggested for clustered environments)", type = "boolean", defaultValue = DEFAULT_SELF_UNREGISTRATION + "")
     static final String SELF_UNREGISTRATION = "edc.data.plane.self.unregistration";
@@ -78,8 +78,8 @@ public class DataplaneSelfRegistrationExtension implements ServiceExtension {
     @Override
     public void start() {
         var transferTypes = Stream.concat(
-                toTransferTypes(PULL, publicEndpointGeneratorService.supportedDestinationTypes()),
-                toTransferTypes(PUSH, pipelineService.supportedSinkTypes())
+                toTransferTypes(PULL, publicEndpointGeneratorService.supportedDestinationTypes(), publicEndpointGeneratorService.supportedResponseTypes()),
+                toTransferTypes(PUSH, pipelineService.supportedSinkTypes(), publicEndpointGeneratorService.supportedResponseTypes())
         );
 
         var instance = DataPlaneInstance.Builder.newInstance()
@@ -116,8 +116,11 @@ public class DataplaneSelfRegistrationExtension implements ServiceExtension {
         }
     }
 
-    private @NotNull Stream<String> toTransferTypes(FlowType pull, Set<String> types) {
-        return types.stream().map(it -> "%s-%s".formatted(it, pull));
+    private @NotNull Stream<String> toTransferTypes(FlowType pull, Set<String> types, Set<String> responseTypes) {
+        if (responseTypes.isEmpty()) {
+            return types.stream().map(it -> "%s-%s".formatted(it, pull));
+        }
+        return responseTypes.stream().flatMap(responseType -> types.stream().map(it -> "%s-%s/%s".formatted(it, pull, responseType)));
     }
 
     private class DataPlaneHealthCheck implements LivenessProvider, ReadinessProvider, StartupStatusProvider {

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/main/java/org/eclipse/edc/connector/api/signaling/transform/from/JsonObjectFromDataFlowStartMessageTransformer.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/main/java/org/eclipse/edc/connector/api/signaling/transform/from/JsonObjectFromDataFlowStartMessageTransformer.java
@@ -33,6 +33,7 @@ import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_PARTICIPANT_ID;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_PROPERTIES;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_SOURCE_DATA_ADDRESS;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_TRANSFER_RESPONSE_CHANNEL;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_TRANSFER_TYPE_DESTINATION;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_TYPE;
 
@@ -67,6 +68,10 @@ public class JsonObjectFromDataFlowStartMessageTransformer extends AbstractJsonL
 
         if (message.getDestinationDataAddress() != null) {
             builder.add(EDC_DATA_FLOW_START_MESSAGE_DESTINATION_DATA_ADDRESS, context.transform(message.getDestinationDataAddress(), JsonObject.class));
+        }
+
+        if (message.getTransferType().responseChannelType() != null) {
+            builder.add(EDC_DATA_FLOW_START_MESSAGE_TRANSFER_RESPONSE_CHANNEL, message.getTransferType().responseChannelType());
         }
 
         return builder.build();

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/main/java/org/eclipse/edc/connector/api/signaling/transform/to/JsonObjectToDataFlowStartMessageTransformer.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/main/java/org/eclipse/edc/connector/api/signaling/transform/to/JsonObjectToDataFlowStartMessageTransformer.java
@@ -38,6 +38,7 @@ import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_PARTICIPANT_ID;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_PROPERTIES;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_SOURCE_DATA_ADDRESS;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_TRANSFER_RESPONSE_CHANNEL;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_TRANSFER_TYPE_DESTINATION;
 
 /**
@@ -58,8 +59,9 @@ public class JsonObjectToDataFlowStartMessageTransformer extends AbstractJsonLdT
         if (transferTypeDestination != null && flowType != null) {
             builder.transferType(new TransferType(
                     transformString(transferTypeDestination, context),
-                    FlowType.valueOf(transformString(flowType, context))
-            ));
+                    FlowType.valueOf(transformString(flowType, context)),
+                    transformString(object.get(EDC_DATA_FLOW_START_MESSAGE_TRANSFER_RESPONSE_CHANNEL), context))
+            );
         } else {
             context.problem().missingProperty().property("%s - %s".formatted(EDC_DATA_FLOW_START_MESSAGE_TRANSFER_TYPE_DESTINATION, EDC_DATA_FLOW_START_MESSAGE_FLOW_TYPE))
                     .report();

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/test/java/org/eclipse/edc/connector/api/signaling/transform/from/JsonObjectFromDataFlowStartMessageTransformerTest.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/test/java/org/eclipse/edc/connector/api/signaling/transform/from/JsonObjectFromDataFlowStartMessageTransformerTest.java
@@ -37,6 +37,7 @@ import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_FLOW_TYPE;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_PARTICIPANT_ID;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_SOURCE_DATA_ADDRESS;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_TRANSFER_RESPONSE_CHANNEL;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_TRANSFER_TYPE_DESTINATION;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_TYPE;
 import static org.mockito.ArgumentMatchers.any;
@@ -62,7 +63,7 @@ class JsonObjectFromDataFlowStartMessageTransformerTest {
                 .assetId("assetId")
                 .agreementId("agreementId")
                 .participantId("participantId")
-                .transferType(new TransferType("HttpData", FlowType.PUSH))
+                .transferType(new TransferType("HttpData", FlowType.PUSH, "Websocket"))
                 .callbackAddress(URI.create("http://localhost"))
                 .sourceDataAddress(DataAddress.Builder.newInstance().type("sourceType").build())
                 .destinationDataAddress(DataAddress.Builder.newInstance().type("destType").build())
@@ -79,6 +80,7 @@ class JsonObjectFromDataFlowStartMessageTransformerTest {
         assertThat(jsonObject.getJsonString(EDC_DATA_FLOW_START_MESSAGE_DESTINATION_CALLBACK_ADDRESS).getString()).isEqualTo(message.getCallbackAddress().toString());
         assertThat(jsonObject.getJsonString(EDC_DATA_FLOW_START_MESSAGE_TRANSFER_TYPE_DESTINATION).getString()).isEqualTo("HttpData");
         assertThat(jsonObject.getJsonString(EDC_DATA_FLOW_START_MESSAGE_FLOW_TYPE).getString()).isEqualTo(message.getFlowType().toString());
+        assertThat(jsonObject.getJsonString(EDC_DATA_FLOW_START_MESSAGE_TRANSFER_RESPONSE_CHANNEL).getString()).isEqualTo("Websocket");
         assertThat(jsonObject.get(EDC_DATA_FLOW_START_MESSAGE_DESTINATION_DATA_ADDRESS)).isNotNull();
         assertThat(jsonObject.get(EDC_DATA_FLOW_START_MESSAGE_SOURCE_DATA_ADDRESS)).isNotNull();
     }

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/test/java/org/eclipse/edc/connector/api/signaling/transform/to/JsonObjectToDataFlowStartMessageTransformerTest.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/test/java/org/eclipse/edc/connector/api/signaling/transform/to/JsonObjectToDataFlowStartMessageTransformerTest.java
@@ -66,6 +66,7 @@ class JsonObjectToDataFlowStartMessageTransformerTest {
                 .add("participantId", "participantId")
                 .add("transferTypeDestination", "transferTypeDestination")
                 .add("flowType", "PULL")
+                .add("responseChannel", "Websocket")
                 .add("sourceDataAddress", jsonFactory.createObjectBuilder().add("type", "address-type"))
                 .add("destinationDataAddress", jsonFactory.createObjectBuilder().add("type", "address-type"))
                 .add("properties", jsonFactory.createObjectBuilder().add("foo", "bar"))
@@ -80,7 +81,7 @@ class JsonObjectToDataFlowStartMessageTransformerTest {
         assertThat(message.getAssetId()).isEqualTo("datasetId");
         assertThat(message.getAgreementId()).isEqualTo("agreementId");
         assertThat(message.getParticipantId()).isEqualTo("participantId");
-        assertThat(message.getTransferType()).isEqualTo(new TransferType("transferTypeDestination", FlowType.PULL));
+        assertThat(message.getTransferType()).isEqualTo(new TransferType("transferTypeDestination", FlowType.PULL, "Websocket"));
         assertThat(message.getDestinationDataAddress()).extracting(DataAddress::getType).isEqualTo("address-type");
         assertThat(message.getSourceDataAddress()).extracting(DataAddress::getType).isEqualTo("address-type");
         assertThat(message.getProperties()).containsEntry(EDC_NAMESPACE + "foo", "bar");

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/transfer/DataFlowStartMessage.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/transfer/DataFlowStartMessage.java
@@ -42,6 +42,7 @@ public class DataFlowStartMessage implements Polymorphic, TraceCarrier {
     public static final String EDC_DATA_FLOW_START_MESSAGE_TYPE = EDC_NAMESPACE + EDC_DATA_FLOW_START_MESSAGE_SIMPLE_TYPE;
     public static final String EDC_DATA_FLOW_START_MESSAGE_FLOW_TYPE = EDC_NAMESPACE + "flowType";
     public static final String EDC_DATA_FLOW_START_MESSAGE_TRANSFER_TYPE_DESTINATION = EDC_NAMESPACE + "transferTypeDestination";
+    public static final String EDC_DATA_FLOW_START_MESSAGE_TRANSFER_RESPONSE_CHANNEL = EDC_NAMESPACE + "responseChannel";
     public static final String EDC_DATA_FLOW_START_MESSAGE_DATASET_ID = EDC_NAMESPACE + "datasetId";
     public static final String EDC_DATA_FLOW_START_MESSAGE_PARTICIPANT_ID = EDC_NAMESPACE + "participantId";
     public static final String EDC_DATA_FLOW_START_MESSAGE_AGREEMENT_ID = EDC_NAMESPACE + "agreementId";

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/transfer/TransferType.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/transfer/TransferType.java
@@ -14,10 +14,17 @@
 
 package org.eclipse.edc.spi.types.domain.transfer;
 
+import org.jetbrains.annotations.Nullable;
+
 /**
  * Represent the transfer type.
  *
- * @param destinationType the destination data address type.
- * @param flowType the flow type.
+ * @param destinationType     the destination data address type designation.
+ * @param responseChannelType an optional type designation for the response channel
+ * @param flowType            the flow type.
  */
-public record TransferType(String destinationType, FlowType flowType) { }
+public record TransferType(String destinationType, FlowType flowType, @Nullable String responseChannelType) {
+    public TransferType(String destinationType, FlowType flowType) {
+        this(destinationType, flowType, null);
+    }
+}

--- a/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/instance/DataPlaneInstance.java
+++ b/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/instance/DataPlaneInstance.java
@@ -101,7 +101,8 @@ public class DataPlaneInstance extends StatefulEntity<DataPlaneInstance> {
     public boolean canHandle(DataAddress sourceAddress, @Nullable String transferType) {
         Objects.requireNonNull(sourceAddress, "source cannot be null!");
         Objects.requireNonNull(transferType, "transferType cannot be null!");
-        return allowedSourceTypes.contains(sourceAddress.getType()) && allowedTransferTypes.contains(transferType);
+        // startsWith: the allowed transferType could be HttpData-PULL/someResponseChannel, and we only need to match the HttpData-PULL
+        return allowedSourceTypes.contains(sourceAddress.getType()) && allowedTransferTypes.stream().anyMatch(s -> s.startsWith(transferType));
     }
 
     public URL getUrl() {

--- a/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/instance/DataPlaneInstance.java
+++ b/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/instance/DataPlaneInstance.java
@@ -102,7 +102,7 @@ public class DataPlaneInstance extends StatefulEntity<DataPlaneInstance> {
         Objects.requireNonNull(sourceAddress, "source cannot be null!");
         Objects.requireNonNull(transferType, "transferType cannot be null!");
         // startsWith: the allowed transferType could be HttpData-PULL/someResponseChannel, and we only need to match the HttpData-PULL
-        return allowedSourceTypes.contains(sourceAddress.getType()) && allowedTransferTypes.stream().anyMatch(s -> s.startsWith(transferType));
+        return allowedSourceTypes.contains(sourceAddress.getType()) && allowedTransferTypes.contains(transferType);
     }
 
     public URL getUrl() {

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/iam/PublicEndpointGeneratorService.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/iam/PublicEndpointGeneratorService.java
@@ -68,4 +68,6 @@ public interface PublicEndpointGeneratorService {
      * @return the supported types;
      */
     Set<String> supportedDestinationTypes();
+
+    Set<String> supportedResponseTypes();
 }

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/iam/PublicEndpointGeneratorService.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/iam/PublicEndpointGeneratorService.java
@@ -20,6 +20,7 @@ import org.eclipse.edc.spi.types.domain.DataAddress;
 
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Determines the public endpoint at which the data for a particular data transfer is exposed.
@@ -30,11 +31,19 @@ public interface PublicEndpointGeneratorService {
     /**
      * Generates an endpoint for a destination type and a particular {@link DataAddress}
      *
-     * @param destinationType the destination type
+     * @param destinationType   the destination type
      * @param sourceDataAddress the source data address.
      * @return The public {@link Endpoint} where the data is made available, or a failure if the endpoint could not be generated.
      */
     Result<Endpoint> generateFor(String destinationType, DataAddress sourceDataAddress);
+
+    /**
+     * Generates an endpoint for a response channel
+     *
+     * @param responseChannelType the response channel type
+     * @return The public {@link Endpoint} where the data is made available, or a failure if the endpoint could not be generated.
+     */
+    Result<Endpoint> generateResponseFor(String responseChannelType);
 
     /**
      * Adds a function that can generate a {@link Endpoint} for particular source data address. Typically, the source data address
@@ -44,6 +53,14 @@ public interface PublicEndpointGeneratorService {
      * @param generatorFunction the generator function
      */
     void addGeneratorFunction(String destinationType, Function<DataAddress, Endpoint> generatorFunction);
+
+    /**
+     * Adds a function that can generate a response channel {@link Endpoint}.
+     *
+     * @param responseChannelType The type of the source {@link DataAddress}
+     * @param generatorFunction   the generator function
+     */
+    void addGeneratorFunction(String responseChannelType, Supplier<Endpoint> generatorFunction);
 
     /**
      * Return the supported destination types.

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/iam/PublicEndpointGeneratorService.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/iam/PublicEndpointGeneratorService.java
@@ -65,9 +65,14 @@ public interface PublicEndpointGeneratorService {
     /**
      * Return the supported destination types.
      *
-     * @return the supported types;
+     * @return the supported types
      */
     Set<String> supportedDestinationTypes();
 
+    /**
+     * Return the types of return channels supported by this generator
+     *
+     * @return the supported types
+     */
     Set<String> supportedResponseTypes();
 }

--- a/system-tests/e2e-dataplane-tests/tests/src/test/java/org/eclipse/edc/test/e2e/DataPlaneSignalingApiEndToEndTest.java
+++ b/system-tests/e2e-dataplane-tests/tests/src/test/java/org/eclipse/edc/test/e2e/DataPlaneSignalingApiEndToEndTest.java
@@ -209,10 +209,10 @@ public class DataPlaneSignalingApiEndToEndTest extends AbstractDataPlaneTest {
         assertThat(dataAddress.getStringProperty("endpoint")).isEqualTo(DATAPLANE_PUBLIC_ENDPOINT_URL);
         assertThat(dataAddress.getStringProperty("authorization")).isNotNull();
         assertThat(dataAddress.getStringProperty("authType")).isEqualTo("bearer");
-        assertThat(dataAddress.getStringProperty("responseChannel/endpoint")).isEqualTo(DATAPLANE_PUBLIC_ENDPOINT_URL + "/responseChannel");
-        assertThat(dataAddress.getStringProperty("responseChannel/endpointType")).isEqualTo("https://w3id.org/idsa/v4.1/HTTP");
-        assertThat(dataAddress.getStringProperty("responseChannel/authType")).isEqualTo("bearer");
-        assertThat(dataAddress.getStringProperty("responseChannel/authorization")).isNotNull();
+        assertThat(dataAddress.getStringProperty("responseChannel-endpoint")).isEqualTo(DATAPLANE_PUBLIC_ENDPOINT_URL + "/responseChannel");
+        assertThat(dataAddress.getStringProperty("responseChannel-endpointType")).isEqualTo("https://w3id.org/idsa/v4.1/HTTP");
+        assertThat(dataAddress.getStringProperty("responseChannel-authType")).isEqualTo("bearer");
+        assertThat(dataAddress.getStringProperty("responseChannel-authorization")).isNotNull();
 
         // verify that the data flow was created
         var store = runtime.getService(DataPlaneStore.class).findById(processId);
@@ -261,10 +261,10 @@ public class DataPlaneSignalingApiEndToEndTest extends AbstractDataPlaneTest {
         assertThat(dataAddress.getStringProperty("endpoint")).isEqualTo(DATAPLANE_PUBLIC_ENDPOINT_URL);
         assertThat(dataAddress.getStringProperty("authorization")).isNotNull();
         assertThat(dataAddress.getStringProperty("authType")).isEqualTo("bearer");
-        assertThat(dataAddress.getStringProperty("responseChannel/endpoint")).isEqualTo(DATAPLANE_PUBLIC_ENDPOINT_URL + "/responseChannel");
-        assertThat(dataAddress.getStringProperty("responseChannel/endpointType")).isEqualTo("https://w3id.org/idsa/v4.1/HTTP");
-        assertThat(dataAddress.getStringProperty("responseChannel/authType")).isEqualTo("bearer");
-        assertThat(dataAddress.getStringProperty("responseChannel/authorization")).isNotNull();
+        assertThat(dataAddress.getStringProperty("responseChannel-endpoint")).isEqualTo(DATAPLANE_PUBLIC_ENDPOINT_URL + "/responseChannel");
+        assertThat(dataAddress.getStringProperty("responseChannel-endpointType")).isEqualTo("https://w3id.org/idsa/v4.1/HTTP");
+        assertThat(dataAddress.getStringProperty("responseChannel-authType")).isEqualTo("bearer");
+        assertThat(dataAddress.getStringProperty("responseChannel-authorization")).isNotNull();
 
         // verify that the data flow was created
         var store = runtime.getService(DataPlaneStore.class).findById(processId);

--- a/system-tests/e2e-dataplane-tests/tests/src/test/java/org/eclipse/edc/test/e2e/participant/DataPlaneParticipant.java
+++ b/system-tests/e2e-dataplane-tests/tests/src/test/java/org/eclipse/edc/test/e2e/participant/DataPlaneParticipant.java
@@ -31,6 +31,7 @@ public class DataPlaneParticipant extends Participant {
     private final URI dataPlaneDefault = URI.create("http://localhost:" + getFreePort());
     private final URI dataPlaneControl = URI.create("http://localhost:" + getFreePort() + "/control");
     private final URI dataPlanePublic = URI.create("http://localhost:" + getFreePort() + "/public");
+    private final URI dataplanePublicResponse = dataPlanePublic.resolve("/public/responseChannel");
 
     private DataPlaneParticipant() {
         super();
@@ -59,6 +60,7 @@ public class DataPlaneParticipant extends Participant {
                 put("edc.dataplane.http.sink.partition.size", "1");
                 put("edc.transfer.proxy.token.signer.privatekey.alias", "1");
                 put("edc.transfer.proxy.token.verifier.publickey.alias", "public-key");
+                put("edc.dataplane.api.public.response.baseurl", dataplanePublicResponse.toString());
             }
         };
     }


### PR DESCRIPTION
## What this PR changes/adds

this PR introduces the capability on provider dataplanes to create "response channel EDRs": data planes that support this can expose a "response channel" through which consumers can tunnel back control information

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
