### PR TITLE
fix: add missing @Priority to the AuthenticationRequestFilter

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ edc = "0.11.0-SNAPSHOT"
 failsafe = "3.3.2"
 h2 = "2.3.232"
 httpMockServer = "5.15.0"
+jakarta-annotation = "3.0.0"
 jakarta-json = "2.1.3"
 jakarta-transaction = "2.0.1"
 jackson = "2.18.0"
@@ -55,6 +56,7 @@ jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
 jackson-datatype-jakarta-jsonp = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jakarta-jsonp", version.ref = "jackson" }
 jackson-datatype-jsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310", version.ref = "jackson" }
+jakarta-annotation = { module = "jakarta.annotation:jakarta.annotation-api", version.ref = "jakarta-annotation" }
 jakarta-json-api = { module = "jakarta.json:jakarta.json-api", version.ref = "jakarta-json" }
 jakarta-rsApi = { module = "jakarta.ws.rs:jakarta.ws.rs-api", version.ref = "rsApi" }
 jakarta-transaction-api = { module = "jakarta.transaction:jakarta.transaction-api", version.ref = "jakarta-transaction" }

--- a/spi/common/auth-spi/build.gradle.kts
+++ b/spi/common/auth-spi/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     api(project(":spi:common:web-spi"))
 
     implementation(libs.jakarta.rsApi)
+    implementation(libs.jakarta.annotation)
 }
 
 

--- a/spi/common/auth-spi/src/main/java/org/eclipse/edc/api/auth/spi/AuthenticationRequestFilter.java
+++ b/spi/common/auth-spi/src/main/java/org/eclipse/edc/api/auth/spi/AuthenticationRequestFilter.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.edc.api.auth.spi;
 
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import org.eclipse.edc.api.auth.spi.registry.ApiAuthenticationRegistry;
@@ -29,6 +31,7 @@ import static java.util.stream.Collectors.toMap;
  * to be able to handle CORS requests properly, OPTIONS requests are not validated as their headers usually don't
  * contain credentials.
  */
+@Priority(Priorities.AUTHENTICATION)
 public class AuthenticationRequestFilter implements ContainerRequestFilter {
 
     private final ApiAuthenticationRegistry authenticationRegistry;


### PR DESCRIPTION
## What this PR changes/adds

This PR add the jarkarta @Priority annotation to the AuthenticationFilter.

## Why it does that

Allow other extension to register filters in the correct order of precedence.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #4580

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
