### PR TITLE
refactor: optimize dependency graph performances

### DIFF
--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/DependencyGraph.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/DependencyGraph.java
@@ -32,7 +32,6 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -44,6 +43,10 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Optional.ofNullable;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
 
 
 /**
@@ -77,44 +80,43 @@ public class DependencyGraph {
 
         // check if all injected fields are satisfied, collect missing ones and throw exception otherwise
         var unsatisfiedInjectionPoints = new ArrayList<InjectionPoint<ServiceExtension>>();
-        var injectionPoints = extensions.stream()
-                .flatMap(ext -> getInjectedFields(ext).stream()
-                        .peek(injectionPoint -> {
-                            if (!canResolve(dependencyMap, injectionPoint.getType())) {
-                                if (injectionPoint.isRequired()) {
-                                    unsatisfiedInjectionPoints.add(injectionPoint);
-                                }
-                            } else {
-                                // get() would return null, if the feature is already in the context's service list
-                                ofNullable(dependencyMap.get(injectionPoint.getType()))
-                                        .ifPresent(l -> l.stream()
-                                                .filter(d -> !Objects.equals(d, ext)) // remove dependencies onto oneself
-                                                .forEach(provider -> sort.addDependency(ext, provider)));
-                            }
-                        })
-                )
-                .collect(Collectors.toList());
+        var unsatisfiedRequirements = new ArrayList<String>();
 
-        //throw an exception if still unsatisfied links
+        var injectionPoints = extensions.stream()
+                .collect(toMap(identity(), ext -> {
+
+                    //check that all the @Required features are there
+                    getRequiredFeatures(ext.getClass()).forEach(feature -> {
+                        var dependencies = dependencyMap.get(feature);
+                        if (dependencies == null) {
+                            unsatisfiedRequirements.add(feature.getName());
+                        } else {
+                            dependencies.forEach(dependency -> sort.addDependency(ext, dependency));
+                        }
+                    });
+
+                    return injectionPointScanner.getInjectionPoints(ext)
+                            .peek(injectionPoint -> {
+                                if (!canResolve(dependencyMap, injectionPoint.getType())) {
+                                    if (injectionPoint.isRequired()) {
+                                        unsatisfiedInjectionPoints.add(injectionPoint);
+                                    }
+                                } else {
+                                    // get() would return null, if the feature is already in the context's service list
+                                    ofNullable(dependencyMap.get(injectionPoint.getType()))
+                                            .ifPresent(l -> l.stream()
+                                                    .filter(d -> !Objects.equals(d, ext)) // remove dependencies onto oneself
+                                                    .forEach(provider -> sort.addDependency(ext, provider)));
+                                }
+                            })
+                            .collect(toSet());
+                }));
+
         if (!unsatisfiedInjectionPoints.isEmpty()) {
             var string = "The following injected fields were not provided:\n";
             string += unsatisfiedInjectionPoints.stream().map(InjectionPoint::toString).collect(Collectors.joining("\n"));
             throw new EdcInjectionException(string);
         }
-
-        //check that all the @Required features are there
-        var unsatisfiedRequirements = new ArrayList<String>();
-        extensions.forEach(ext -> {
-            var features = getRequiredFeatures(ext.getClass());
-            features.forEach(feature -> {
-                var dependencies = dependencyMap.get(feature);
-                if (dependencies == null) {
-                    unsatisfiedRequirements.add(feature.getName());
-                } else {
-                    dependencies.forEach(dependency -> sort.addDependency(ext, dependency));
-                }
-            });
-        });
 
         if (!unsatisfiedRequirements.isEmpty()) {
             var string = String.format("The following @Require'd features were not provided: [%s]", String.join(", ", unsatisfiedRequirements));
@@ -123,11 +125,10 @@ public class DependencyGraph {
 
         sort.sort(extensions);
 
-        // todo: should the list of InjectionContainers be generated directly by the flatmap?
         // convert the sorted list of extensions into an equally sorted list of InjectionContainers
         return extensions.stream()
-                .map(se -> new InjectionContainer<>(se, injectionPoints.stream().filter(ip -> ip.getInstance() == se).collect(Collectors.toSet())))
-                .collect(Collectors.toList());
+                .map(key -> new InjectionContainer<>(key, injectionPoints.get(key)))
+                .toList();
     }
 
     private boolean canResolve(Map<Class<?>, List<ServiceExtension>> dependencyMap, Class<?> featureName) {
@@ -142,18 +143,17 @@ public class DependencyGraph {
 
     private Map<Class<?>, List<ServiceExtension>> createDependencyMap(List<ServiceExtension> extensions) {
         Map<Class<?>, List<ServiceExtension>> dependencyMap = new HashMap<>();
-        extensions.forEach(ext -> getDefaultProvidedFeatures(ext).forEach(feature -> dependencyMap.computeIfAbsent(feature, k -> new ArrayList<>()).add(ext)));
         extensions.forEach(ext -> getProvidedFeatures(ext).forEach(feature -> dependencyMap.computeIfAbsent(feature, k -> new ArrayList<>()).add(ext)));
         return dependencyMap;
     }
 
-    private Set<Class<?>> getRequiredFeatures(Class<?> clazz) {
+    private Stream<Class<?>> getRequiredFeatures(Class<?> clazz) {
         var requiresAnnotation = clazz.getAnnotation(Requires.class);
         if (requiresAnnotation != null) {
             var features = requiresAnnotation.value();
-            return Stream.of(features).collect(Collectors.toSet());
+            return Stream.of(features);
         }
-        return Collections.emptySet();
+        return Stream.empty();
     }
 
     /**
@@ -165,18 +165,12 @@ public class DependencyGraph {
         // check all @Provides
         var providesAnnotation = ext.getClass().getAnnotation(Provides.class);
         if (providesAnnotation != null) {
-            var featureStrings = Arrays.stream(providesAnnotation.value()).collect(Collectors.toSet());
-            allProvides.addAll(featureStrings);
+            allProvides.addAll(Arrays.asList(providesAnnotation.value()));
         }
-        // check all @Provider methods
-        allProvides.addAll(new ProviderMethodScanner(ext).nonDefaultProviders().stream().map(ProviderMethod::getReturnType).collect(Collectors.toSet()));
-        return allProvides;
-    }
 
-    private Set<Class<?>> getDefaultProvidedFeatures(ServiceExtension ext) {
-        return new ProviderMethodScanner(ext).defaultProviders().stream()
-                .map(ProviderMethod::getReturnType)
-                .collect(Collectors.toSet());
+        // check all @Provider methods
+        new ProviderMethodScanner(ext).allProviders().map(ProviderMethod::getReturnType).forEach(allProvides::add);
+        return allProvides;
     }
 
     /**
@@ -184,23 +178,10 @@ public class DependencyGraph {
      * explicit @Requires annotations are not necessary
      */
     private List<ServiceExtension> sortByType(List<ServiceExtension> loadedExtensions) {
-        var baseDependencies = loadedExtensions.stream().filter(e -> e.getClass().getAnnotation(BaseExtension.class) != null).collect(Collectors.toList());
-        if (baseDependencies.isEmpty()) {
-            throw new EdcException("No base dependencies were found on the classpath. Please add the \"core:common:connector-core\" module to your classpath!");
-        }
-
-        return loadedExtensions.stream().sorted(new ServiceExtensionComparator()).collect(Collectors.toList());
+        return loadedExtensions.stream().sorted(new SortByType()).collect(toList());
     }
 
-    /**
-     * Obtains all features a specific extension provides as strings
-     */
-    private Set<InjectionPoint<ServiceExtension>> getInjectedFields(ServiceExtension ext) {
-        // initialize with legacy list
-        return injectionPointScanner.getInjectionPoints(ext);
-    }
-
-    private static class ServiceExtensionComparator implements Comparator<ServiceExtension> {
+    private static class SortByType implements Comparator<ServiceExtension> {
         @Override
         public int compare(ServiceExtension o1, ServiceExtension o2) {
             return orderFor(o1.getClass()).compareTo(orderFor(o2.getClass()));

--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/InjectionPointScanner.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/InjectionPointScanner.java
@@ -18,14 +18,15 @@ import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 
 import java.util.Arrays;
 import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Scans a particular (partly constructed) object for fields that are annotated with {@link Inject} and returns them
  * in a {@link Set}
  */
 public class InjectionPointScanner {
-    public <T> Set<InjectionPoint<T>> getInjectionPoints(T instance) {
+
+    public <T> Stream<InjectionPoint<T>> getInjectionPoints(T instance) {
 
         var targetClass = instance.getClass();
 
@@ -34,7 +35,6 @@ public class InjectionPointScanner {
                 .map(f -> {
                     var isRequired = f.getAnnotation(Inject.class).required();
                     return new FieldInjectionPoint<>(instance, f, isRequired);
-                })
-                .collect(Collectors.toSet());
+                });
     }
 }

--- a/core/common/boot/src/test/java/org/eclipse/edc/boot/system/injection/ProviderMethodScannerTest.java
+++ b/core/common/boot/src/test/java/org/eclipse/edc/boot/system/injection/ProviderMethodScannerTest.java
@@ -33,11 +33,15 @@ class ProviderMethodScannerTest {
     }
 
     @Test
+    void allProviders() {
+        assertThat(scanner.allProviders()).hasSize(3);
+    }
+
+    @Test
     void providerMethods() {
         assertThat(scanner
                 .nonDefaultProviders())
                 .hasSize(2);
-
     }
 
     @Test
@@ -52,16 +56,16 @@ class ProviderMethodScannerTest {
     @Test
     void verifyInvalidReturnType() {
         var scanner = new ProviderMethodScanner(new InvalidTestExtension());
-        assertThatThrownBy(scanner::nonDefaultProviders).isInstanceOf(EdcInjectionException.class);
-        assertThatThrownBy(scanner::defaultProviders).isInstanceOf(EdcInjectionException.class);
+        assertThatThrownBy(() -> scanner.nonDefaultProviders().toList()).isInstanceOf(EdcInjectionException.class);
+        assertThatThrownBy(() -> scanner.defaultProviders().toList()).isInstanceOf(EdcInjectionException.class);
     }
 
     @Test
     void verifyInvalidVisibility() {
         var scanner = new ProviderMethodScanner(new InvalidTestExtension2());
 
-        assertThatThrownBy(scanner::nonDefaultProviders).isInstanceOf(EdcInjectionException.class);
-        assertThatThrownBy(scanner::defaultProviders).isInstanceOf(EdcInjectionException.class);
+        assertThatThrownBy(() -> scanner.nonDefaultProviders().toList()).isInstanceOf(EdcInjectionException.class);
+        assertThatThrownBy(() -> scanner.defaultProviders().toList()).isInstanceOf(EdcInjectionException.class);
     }
 
     private static class TestExtension implements ServiceExtension {

--- a/core/common/boot/src/test/java/org/eclipse/edc/boot/system/injection/lifecycle/RegistrationPhaseTest.java
+++ b/core/common/boot/src/test/java/org/eclipse/edc/boot/system/injection/lifecycle/RegistrationPhaseTest.java
@@ -19,7 +19,7 @@ import org.eclipse.edc.boot.system.injection.ProviderMethodScanner;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.junit.jupiter.api.Test;
 
-import java.util.Set;
+import java.util.stream.Stream;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -32,9 +32,10 @@ import static org.mockito.Mockito.when;
 
 class RegistrationPhaseTest extends PhaseTest {
 
+    private final ProviderMethodScanner scannerMock = mock();
+
     @Test
     void registerProviders_noProviderMethod() {
-        ProviderMethodScanner scannerMock = mock(ProviderMethodScanner.class);
         var rp = new RegistrationPhase(new Phase(injector, container, context, monitor) {
         }, scannerMock);
         when(container.getInjectionTarget()).thenReturn(mock(ServiceExtension.class));
@@ -53,7 +54,7 @@ class RegistrationPhaseTest extends PhaseTest {
         when(providerMethod.invoke(any(), any())).thenReturn(new TestService());
         when(providerMethod.getReturnType()).thenAnswer(a -> TestService.class);
         when(context.hasService(TestService.class)).thenReturn(false);
-        when(scannerMock.nonDefaultProviders()).thenReturn(Set.of(providerMethod));
+        when(scannerMock.nonDefaultProviders()).thenReturn(Stream.of(providerMethod));
 
         var rp = new RegistrationPhase(new Phase(injector, container, context, monitor) {
         }, scannerMock);
@@ -69,7 +70,7 @@ class RegistrationPhaseTest extends PhaseTest {
     @Test
     void registerProviders_withProvider_isDefault_notRegistered() {
         var scannerMock = mock(ProviderMethodScanner.class);
-        when(scannerMock.nonDefaultProviders()).thenReturn(Set.of());
+        when(scannerMock.nonDefaultProviders()).thenReturn(Stream.empty());
 
         var rp = new RegistrationPhase(new Phase(injector, container, context, monitor) {
         }, scannerMock);

--- a/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/DependencyInjectionExtension.java
+++ b/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/DependencyInjectionExtension.java
@@ -17,7 +17,6 @@ package org.eclipse.edc.junit.extensions;
 import org.eclipse.edc.boot.system.injection.InjectionPointScanner;
 import org.eclipse.edc.boot.system.injection.InjectorImpl;
 import org.eclipse.edc.boot.system.injection.ObjectFactory;
-import org.eclipse.edc.boot.system.injection.ReflectiveObjectFactory;
 import org.eclipse.edc.boot.system.runtime.BaseRuntime;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;

--- a/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/ReflectiveObjectFactory.java
+++ b/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/ReflectiveObjectFactory.java
@@ -12,8 +12,12 @@
  *
  */
 
-package org.eclipse.edc.boot.system.injection;
+package org.eclipse.edc.junit.extensions;
 
+import org.eclipse.edc.boot.system.injection.InjectionContainer;
+import org.eclipse.edc.boot.system.injection.InjectionPointScanner;
+import org.eclipse.edc.boot.system.injection.Injector;
+import org.eclipse.edc.boot.system.injection.ObjectFactory;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.jetbrains.annotations.NotNull;
@@ -23,6 +27,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 
 import static java.lang.String.format;
+import static java.util.stream.Collectors.toSet;
 
 /**
  * This is a {@link ObjectFactory} that uses reflection and dependency injection to construct object instances.
@@ -48,8 +53,7 @@ public class ReflectiveObjectFactory implements ObjectFactory {
     }
 
     private <T> @NotNull InjectionContainer<T> createInjectionContainer(T instance) {
-        var injectFields = injectionPointScanner.getInjectionPoints(instance);
-        return new InjectionContainer<>(instance, injectFields);
+        return new InjectionContainer<>(instance, injectionPointScanner.getInjectionPoints(instance).collect(toSet()));
     }
 
     @NotNull

--- a/core/common/junit/src/test/java/org/eclipse/edc/junit/extensions/ReflectiveObjectFactoryTest.java
+++ b/core/common/junit/src/test/java/org/eclipse/edc/junit/extensions/ReflectiveObjectFactoryTest.java
@@ -12,11 +12,10 @@
  *
  */
 
-package org.eclipse.edc.boot.system;
+package org.eclipse.edc.junit.extensions;
 
 import org.eclipse.edc.boot.system.injection.InjectionPointScanner;
 import org.eclipse.edc.boot.system.injection.InjectorImpl;
-import org.eclipse.edc.boot.system.injection.ReflectiveObjectFactory;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;


### PR DESCRIPTION
## What this PR changes/adds

Does some little tweaks to `DependencyGraph` to improve performance, both time and memory wise.

The code used to measure the improvements has been put on `ExtensionLoader` in the `loadServiceExtensions` method:
```java
Runtime runtime = Runtime.getRuntime();
var memoryUsed = runtime.totalMemory() - runtime.freeMemory();
System.out.println("USED MEMORY BEFORE: " + memoryUsed);
var l = System.currentTimeMillis();
System.out.println("CREATE DEPENDENCY GRAPH STARTED AT " + l);
var injectionContainers = new DependencyGraph(context).of(serviceExtensions);
System.out.println("DEPENDENCY GRAPH CREATED IN " + (System.currentTimeMillis() - l));
System.out.println("USED MEMORY BY DEP GRAPH: " + ((runtime.totalMemory() - runtime.freeMemory()) - memoryUsed));
```

With the changes put in place (details in the "further notes" section) I observed, measuring 10 times and extracting the mean value:
- execution time lowered by ≈ 20% (from 62,4ms to 48,1ms)
- memory used lowered by ≈ 5% (from 7.92Mb to 7.46Mb)

these improvements don't look really game changing, but they will be definitely helpful in multiple-connectors environment, plus it's always good to apply good code practices (see below)

## Why it does that

startup performances

## Further notes
The improvements evolve around:
- less loops on `extensions`: removed 2 unnecessary iterations
- avoid collection of streams if not really needed
- build injectionPoints sets to be put in injection containers directly when they are evaluated first, this is avoiding instantiation of N (number of extensions) streams and filter of the whole set of injection points. 
- moved `ReflectiveObjectFactory` into `junit` module as it's only used in test context.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
