### PR TITLE
docs: update broken sample runtime link

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ capabilities a connector has) is defined by the `build.gradle.kts` file inside t
 where a Java class containing a `main` method should go. We will call that class a "runtime" and in order for the
 connector to become operational the `runtime` needs to perform several important tasks (="bootstrapping"). For an
 example take a look at
-[this runtime](https://github.com/eclipse-edc/Samples/blob/main/other/custom-runtime/src/main/java/org/eclipse/edc/sample/runtime/CustomRuntime.java)
+[this runtime](https://github.com/eclipse-edc/Samples/tree/main/basic/basic-01-basic-connector).
 
 ### `data-protocols`
 


### PR DESCRIPTION
## What this PR changes/adds

Fixes the broken link to the sample runtime.
Changes the link from referring from the custom to the basic sample runtime example.

## Why it does that

The current [link](https://github.com/eclipse-edc/Samples/blob/main/other/custom-runtime/src/main/java/org/eclipse/edc/sample/runtime/CustomRuntime.java) refers to a directory, which no longer exists.

The updated link refers to the basic instead of the custom sample runtime, as this provides an easier entrypoint into connector runtimes.
A link to the custom sample runtime is included in the README.md of the basic sample runtime.

## Further notes

-

## Linked Issue(s)

-
