### PR TITLE
refactor: save one iteration of the extension list in DependencyGraph

### DIFF
--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/ProviderMethodScanner.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/ProviderMethodScanner.java
@@ -36,25 +36,7 @@ public class ProviderMethodScanner {
      * Returns all methods annotated with {@link Provider}.
      */
     public Stream<ProviderMethod> allProviders() {
-        return getProviderMethods(target);
-    }
-
-    /**
-     * Returns all methods annotated with {@link Provider}, where {@link Provider#isDefault()} is {@code false}
-     */
-    public Stream<ProviderMethod> nonDefaultProviders() {
-        return getProviderMethods(target).filter(pm -> !pm.isDefault());
-    }
-
-    /**
-     * Returns all methods annotated with {@link Provider}, where {@link Provider#isDefault()} is {@code true}
-     */
-    public Stream<ProviderMethod> defaultProviders() {
-        return getProviderMethods(target).filter(ProviderMethod::isDefault);
-    }
-
-    private Stream<ProviderMethod> getProviderMethods(Object extension) {
-        return Arrays.stream(extension.getClass().getDeclaredMethods())
+        return Arrays.stream(target.getClass().getDeclaredMethods())
                 .filter(m -> m.getAnnotation(Provider.class) != null)
                 .map(ProviderMethod::new)
                 .peek(method -> {
@@ -66,4 +48,5 @@ public class ProviderMethodScanner {
                     }
                 });
     }
+
 }

--- a/core/common/boot/src/test/java/org/eclipse/edc/boot/system/injection/ProviderMethodScannerTest.java
+++ b/core/common/boot/src/test/java/org/eclipse/edc/boot/system/injection/ProviderMethodScannerTest.java
@@ -33,21 +33,9 @@ class ProviderMethodScannerTest {
     }
 
     @Test
-    void allProviders() {
-        assertThat(scanner.allProviders()).hasSize(3);
-    }
-
-    @Test
-    void providerMethods() {
-        assertThat(scanner
-                .nonDefaultProviders())
-                .hasSize(2);
-    }
-
-    @Test
-    void defaultProviderMethods() throws NoSuchMethodException {
-        assertThat(scanner
-                .defaultProviders())
+    void allProviders() throws NoSuchMethodException {
+        assertThat(scanner.allProviders()).hasSize(3)
+                .filteredOn(ProviderMethod::isDefault)
                 .hasSize(1)
                 .extracting(ProviderMethod::getMethod)
                 .containsOnly(TestExtension.class.getMethod("providerDefault"));
@@ -56,16 +44,14 @@ class ProviderMethodScannerTest {
     @Test
     void verifyInvalidReturnType() {
         var scanner = new ProviderMethodScanner(new InvalidTestExtension());
-        assertThatThrownBy(() -> scanner.nonDefaultProviders().toList()).isInstanceOf(EdcInjectionException.class);
-        assertThatThrownBy(() -> scanner.defaultProviders().toList()).isInstanceOf(EdcInjectionException.class);
+        assertThatThrownBy(() -> scanner.allProviders().toList()).isInstanceOf(EdcInjectionException.class);
     }
 
     @Test
     void verifyInvalidVisibility() {
         var scanner = new ProviderMethodScanner(new InvalidTestExtension2());
 
-        assertThatThrownBy(() -> scanner.nonDefaultProviders().toList()).isInstanceOf(EdcInjectionException.class);
-        assertThatThrownBy(() -> scanner.defaultProviders().toList()).isInstanceOf(EdcInjectionException.class);
+        assertThatThrownBy(() -> scanner.allProviders().toList()).isInstanceOf(EdcInjectionException.class);
     }
 
     private static class TestExtension implements ServiceExtension {


### PR DESCRIPTION
## What this PR changes/adds

Last PR of the "startup" optimization work (see also #4593 #4590 #4587)

This one ensures that the injection containers are instantiated in the first extensions loop so there's no need to create them in the additional loop that was executed right before method's return.
This saves some other millyseconds and memory, as the `serviceProviders` map is not necessary anymore.

## Why it does that

startup optimization

## Further notes

- removed 2 unused methods in the `ProviderMethodScanner` component

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
