### PR TITLE
feat: restart interrupted data flows

### DIFF
--- a/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/EmbeddedRuntime.java
+++ b/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/EmbeddedRuntime.java
@@ -31,6 +31,7 @@ import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -49,6 +50,7 @@ public class EmbeddedRuntime extends BaseRuntime {
     private final ExecutorService executorService = Executors.newSingleThreadExecutor();
     private final MultiSourceServiceLocator serviceLocator;
     private final URL[] classPathEntries;
+    private Future<?> runtimeThread;
 
     public EmbeddedRuntime(String name, Map<String, String> properties, String... additionalModules) {
         this(new MultiSourceServiceLocator(), name, properties, ClasspathReader.classpathFor(additionalModules));
@@ -78,7 +80,7 @@ public class EmbeddedRuntime extends BaseRuntime {
             var runtimeException = new AtomicReference<Exception>();
             var latch = new CountDownLatch(1);
 
-            executorService.execute(() -> {
+            runtimeThread = executorService.submit(() -> {
                 try {
                     var classLoader = URLClassLoader.newInstance(classPathEntries);
 
@@ -110,6 +112,9 @@ public class EmbeddedRuntime extends BaseRuntime {
     public void shutdown() {
         serviceLocator.clearSystemExtensions();
         super.shutdown();
+        if (runtimeThread != null && !runtimeThread.isDone()) {
+            runtimeThread.cancel(true);
+        }
     }
 
     @Override

--- a/core/common/lib/query-lib/src/main/java/org/eclipse/edc/query/CriterionOperatorRegistryImpl.java
+++ b/core/common/lib/query-lib/src/main/java/org/eclipse/edc/query/CriterionOperatorRegistryImpl.java
@@ -45,6 +45,7 @@ public class CriterionOperatorRegistryImpl implements CriterionOperatorRegistry 
         registry.registerOperatorPredicate(ILIKE, new IlikeOperatorPredicate());
         registry.registerOperatorPredicate(CONTAINS, new ContainsOperatorPredicate());
         registry.registerOperatorPredicate(NOT_EQUAL, new NotEqualOperatorPredicate());
+        registry.registerOperatorPredicate(LESS_THAN, new LessThanOperatorPredicate());
         return registry;
     }
 

--- a/core/common/lib/query-lib/src/main/java/org/eclipse/edc/query/LessThanOperatorPredicate.java
+++ b/core/common/lib/query-lib/src/main/java/org/eclipse/edc/query/LessThanOperatorPredicate.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2024 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.query;
+
+import org.eclipse.edc.spi.query.OperatorPredicate;
+
+import java.util.Comparator;
+
+public class LessThanOperatorPredicate implements OperatorPredicate {
+    @Override
+    public boolean test(Object value, Object comparedTo) {
+        if (value instanceof Number number1 && comparedTo instanceof Number number2) {
+            return Double.compare(number1.doubleValue(), number2.doubleValue()) < 0;
+        }
+
+        if (value instanceof String string1 && comparedTo instanceof String string2) {
+            return Comparator.<String>naturalOrder().compare(string1, string2) < 0;
+        }
+
+        return false;
+    }
+}

--- a/core/common/lib/query-lib/src/test/java/org/eclipse/edc/query/LessThanOperatorPredicateTest.java
+++ b/core/common/lib/query-lib/src/test/java/org/eclipse/edc/query/LessThanOperatorPredicateTest.java
@@ -32,8 +32,14 @@ class LessThanOperatorPredicateTest {
 
     @ParameterizedTest
     @ArgumentsSource(ValidValues.class)
-    void shouldReturnTrue_whenOperandAreNumbers(Object value, Object comparedTo) {
+    void shouldReturnTrue_whenValueLessThanComparedOne(Object value, Object comparedTo) {
         assertThat(predicate.test(value, comparedTo)).isTrue();
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(InvalidValues.class)
+    void shouldReturnFalse_whenValueNotLessThanComparedOne(Object value, Object comparedTo) {
+        assertThat(predicate.test(value, comparedTo)).isFalse();
     }
 
     private static class ValidValues implements ArgumentsProvider {
@@ -49,4 +55,19 @@ class LessThanOperatorPredicateTest {
             );
         }
     }
+
+    private static class InvalidValues implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                    arguments(1, 1),
+                    arguments(1, 1L),
+                    arguments(1, 1.0f),
+                    arguments(1, 1.0d),
+                    arguments("a", "a")
+            );
+        }
+    }
+
 }

--- a/core/common/lib/query-lib/src/test/java/org/eclipse/edc/query/LessThanOperatorPredicateTest.java
+++ b/core/common/lib/query-lib/src/test/java/org/eclipse/edc/query/LessThanOperatorPredicateTest.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2024 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.query;
+
+import org.eclipse.edc.spi.query.OperatorPredicate;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class LessThanOperatorPredicateTest {
+
+    private final OperatorPredicate predicate = new LessThanOperatorPredicate();
+
+    @ParameterizedTest
+    @ArgumentsSource(ValidValues.class)
+    void shouldReturnTrue_whenOperandAreNumbers(Object value, Object comparedTo) {
+        assertThat(predicate.test(value, comparedTo)).isTrue();
+    }
+
+    private static class ValidValues implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                    arguments(1, 2),
+                    arguments(1, 2L),
+                    arguments(1, 1.01f),
+                    arguments(1, 1.01d),
+                    arguments("a", "b")
+            );
+        }
+    }
+}

--- a/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/AbstractStateEntityManager.java
+++ b/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/AbstractStateEntityManager.java
@@ -55,7 +55,6 @@ public abstract class AbstractStateEntityManager<E extends StatefulEntity<E>, S 
 
     @Override
     public void start() {
-        entityRetryProcessFactory = new EntityRetryProcessFactory(monitor, clock, entityRetryProcessConfiguration);
         var stateMachineManagerBuilder = StateMachineManager.Builder
                 .newInstance(getClass().getSimpleName(), monitor, executorInstrumentation, waitStrategy);
         stateMachineManager = configureStateMachineManager(stateMachineManagerBuilder).build();

--- a/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/StateMachineManager.java
+++ b/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/StateMachineManager.java
@@ -39,6 +39,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 public class StateMachineManager {
 
     private final List<Processor> processors = new ArrayList<>();
+    private final List<Processor> startupProcessors = new ArrayList<>();
     private final ScheduledExecutorService executor;
     private final AtomicBoolean active = new AtomicBoolean();
     private final WaitStrategy waitStrategy;
@@ -65,6 +66,7 @@ public class StateMachineManager {
      */
     public Future<?> start() {
         active.set(true);
+        performStartupLogic();
         return scheduleNextIterationIn(0L);
     }
 
@@ -101,6 +103,19 @@ public class StateMachineManager {
                 performLogic();
             }
         };
+    }
+
+    private void performStartupLogic() {
+        for (var startupProcessor : startupProcessors) {
+            try {
+                long count;
+                do {
+                    count = startupProcessor.process();
+                } while (count > 0);
+            } catch (Throwable e) {
+                monitor.severe(format("StateMachineManager [%s] startup error caught", name), e);
+            }
+        }
     }
 
     private void performLogic() {
@@ -147,6 +162,17 @@ public class StateMachineManager {
 
         public Builder shutdownTimeout(int seconds) {
             loop.shutdownTimeout = seconds;
+            return this;
+        }
+
+        /**
+         * Register a processor that will run once at startup before the regular processors.
+         *
+         * @param startupProcessor the processor.
+         * @return the builder.
+         */
+        public Builder startupProcessor(Processor startupProcessor) {
+            loop.startupProcessors.add(startupProcessor);
             return this;
         }
 

--- a/core/common/lib/state-machine-lib/src/test/java/org/eclipse/edc/statemachine/StateMachineManagerTest.java
+++ b/core/common/lib/state-machine-lib/src/test/java/org/eclipse/edc/statemachine/StateMachineManagerTest.java
@@ -24,12 +24,10 @@ import org.junit.jupiter.api.Test;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -37,8 +35,8 @@ import static org.mockito.Mockito.when;
 
 class StateMachineManagerTest {
 
-    private final WaitStrategy waitStrategy = mock();
-    private final Monitor monitor = mock();
+    private final WaitStrategy waitStrategy = mock(WaitStrategy.class);
+    private final Monitor monitor = mock(Monitor.class);
     private final ExecutorInstrumentation instrumentation = ExecutorInstrumentation.noop();
 
     @BeforeEach
@@ -47,9 +45,12 @@ class StateMachineManagerTest {
     }
 
     @Test
-    void shouldExecuteProcessorsAsyncAndCanBeStopped() {
+    void shouldExecuteProcessorsAsyncAndCanBeStopped() throws InterruptedException {
         var processor = mock(Processor.class);
-        when(processor.process()).thenAnswer(i -> process(1));
+        when(processor.process()).thenAnswer(i -> {
+            Thread.sleep(100L);
+            return 1L;
+        });
         var stateMachine = StateMachineManager.Builder.newInstance("test", monitor, instrumentation, waitStrategy)
                 .processor(processor)
                 .shutdownTimeout(1)
@@ -66,10 +67,12 @@ class StateMachineManagerTest {
     }
 
     @Test
-    void shouldNotWaitForSomeTimeIfTheresAtLeastOneProcessedEntity() {
+    void shouldNotWaitForSomeTimeIfTheresAtLeastOneProcessedEntity() throws InterruptedException {
         var processor = mock(Processor.class);
         when(processor.process()).thenReturn(1L);
-        doAnswer(i -> 1L).when(waitStrategy).success();
+        doAnswer(i -> {
+            return 1L;
+        }).when(waitStrategy).success();
         var stateMachine = StateMachineManager.Builder.newInstance("test", monitor, instrumentation, waitStrategy)
                 .processor(processor)
                 .build();
@@ -83,11 +86,13 @@ class StateMachineManagerTest {
     }
 
     @Test
-    void shouldWaitForSomeTimeIfNoEntityIsProcessed() {
+    void shouldWaitForSomeTimeIfNoEntityIsProcessed() throws InterruptedException {
         var processor = mock(Processor.class);
         when(processor.process()).thenReturn(0L);
         var waitStrategy = mock(WaitStrategy.class);
-        doAnswer(i -> 0L).when(waitStrategy).waitForMillis();
+        doAnswer(i -> {
+            return 0L;
+        }).when(waitStrategy).waitForMillis();
         var stateMachine = StateMachineManager.Builder.newInstance("test", monitor, instrumentation, waitStrategy)
                 .processor(processor)
                 .build();
@@ -113,10 +118,12 @@ class StateMachineManagerTest {
     }
 
     @Test
-    void shouldWaitRetryTimeWhenAnExceptionIsThrownByAnProcessor() {
+    void shouldWaitRetryTimeWhenAnExceptionIsThrownByAnProcessor() throws InterruptedException {
         var processor = mock(Processor.class);
         when(processor.process()).thenThrow(new EdcException("exception")).thenReturn(0L);
-        when(waitStrategy.retryInMillis()).thenAnswer(i -> 1L);
+        when(waitStrategy.retryInMillis()).thenAnswer(i -> {
+            return 1L;
+        });
         var stateMachine = StateMachineManager.Builder.newInstance("test", monitor, instrumentation, waitStrategy)
                 .processor(processor)
                 .build();
@@ -127,37 +134,5 @@ class StateMachineManagerTest {
             assertThat(stateMachine.isActive()).isTrue();
             verify(waitStrategy).retryInMillis();
         });
-    }
-
-    @Test
-    void shouldExecuteStartupProcessorUntilItHasEntitiesToProcess() {
-        var processor = mock(Processor.class);
-        when(processor.process()).thenAnswer(i -> process(1));
-        var startupProcessor = mock(Processor.class);
-        when(startupProcessor.process()).thenAnswer(i -> process(1)).thenAnswer(i -> process(1)).thenAnswer(i -> process(0));
-        var stateMachine = StateMachineManager.Builder.newInstance("test", monitor, instrumentation, waitStrategy)
-                .startupProcessor(startupProcessor)
-                .processor(processor)
-                .shutdownTimeout(1)
-                .build();
-
-        stateMachine.start();
-
-        await().untilAsserted(() -> {
-            verify(processor, atLeast(2)).process();
-            verify(startupProcessor, times(3)).process();
-
-            assertThat(stateMachine.stop()).succeedsWithin(2, SECONDS);
-            verifyNoMoreInteractions(processor);
-        });
-    }
-
-    private long process(long count) {
-        try {
-            Thread.sleep(10L);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
-        return count;
     }
 }

--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/DataPlaneFrameworkExtension.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/DataPlaneFrameworkExtension.java
@@ -151,6 +151,7 @@ public class DataPlaneFrameworkExtension implements ServiceExtension {
         if (dataPlaneManager != null) {
             dataPlaneManager.stop();
         }
+        pipelineService.closeAll();
     }
 
     @Provider

--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/DataPlaneFrameworkExtension.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/DataPlaneFrameworkExtension.java
@@ -143,6 +143,7 @@ public class DataPlaneFrameworkExtension implements ServiceExtension {
 
     @Override
     public void start() {
+        dataPlaneManager.restartFlows();
         dataPlaneManager.start();
     }
 

--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/pipeline/PipelineServiceImpl.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/pipeline/PipelineServiceImpl.java
@@ -121,6 +121,11 @@ public class PipelineServiceImpl implements PipelineService {
     }
 
     @Override
+    public void closeAll() {
+        sources.forEach((processId, source) -> terminate(processId));
+    }
+
+    @Override
     public void registerFactory(DataSourceFactory factory) {
         sourceFactories.add(factory);
     }

--- a/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/DataPlaneFrameworkExtensionTest.java
+++ b/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/DataPlaneFrameworkExtensionTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.connector.dataplane.framework;
 
 import org.eclipse.edc.connector.dataplane.framework.registry.TransferServiceRegistryImpl;
+import org.eclipse.edc.connector.dataplane.spi.pipeline.PipelineService;
 import org.eclipse.edc.connector.dataplane.spi.registry.TransferServiceRegistry;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.system.ExecutorInstrumentation;
@@ -24,12 +25,17 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(DependencyInjectionExtension.class)
 class DataPlaneFrameworkExtensionTest {
 
+    private final PipelineService pipelineService = mock();
+
     @BeforeEach
     public void setUp(ServiceExtensionContext context) {
+        context.registerService(PipelineService.class, pipelineService);
         context.registerService(ExecutorInstrumentation.class, ExecutorInstrumentation.noop());
     }
 
@@ -40,4 +46,10 @@ class DataPlaneFrameworkExtensionTest {
         assertThat(context.getService(TransferServiceRegistry.class)).isInstanceOf(TransferServiceRegistryImpl.class);
     }
 
+    @Test
+    void shouldClosePipelineService_whenShutdown(DataPlaneFrameworkExtension extension) {
+        extension.shutdown();
+
+        verify(pipelineService).closeAll();
+    }
 }

--- a/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImplTest.java
+++ b/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImplTest.java
@@ -65,6 +65,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -586,6 +587,9 @@ class DataPlaneManagerImplTest {
             await().untilAsserted(() -> {
                 verify(transferService, times(2)).transfer(isA(DataFlowStartMessage.class));
                 verify(store, times(2)).save(argThat(it -> it.getState() == STARTED.code()));
+                var captor = ArgumentCaptor.forClass(Criterion[].class);
+                verify(store, atLeast(1)).nextNotLeased(anyInt(), captor.capture());
+                assertThat(captor.getValue()).contains(new Criterion("transferType.flowType", "=", "PUSH"));
             });
         }
     }

--- a/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/pipeline/PipelineServiceImplTest.java
+++ b/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/pipeline/PipelineServiceImplTest.java
@@ -195,6 +195,25 @@ class PipelineServiceImplTest {
 
     }
 
+    @Nested
+    class CloseAll {
+
+        @Test
+        void shouldCloseAllTheOngoingDataFlows() throws Exception {
+            when(sourceFactory.supportedType()).thenReturn("source");
+            when(sourceFactory.createSource(any())).thenReturn(source);
+            when(sinkFactory.supportedType()).thenReturn("destination");
+            when(sinkFactory.createSink(any())).thenReturn(sink);
+            when(sink.transfer(any())).thenReturn(new CompletableFuture<>());
+
+            service.transfer(dataFlow("source", "destination").toRequest());
+
+            service.closeAll();
+
+            verify(source).close();
+        }
+    }
+
     private DataFlow dataFlow(String sourceType, String destinationType) {
         return DataFlow.Builder.newInstance()
                 .id("1")

--- a/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/PostgresqlOperatorTranslator.java
+++ b/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/translation/PostgresqlOperatorTranslator.java
@@ -20,6 +20,7 @@ import static org.eclipse.edc.spi.query.CriterionOperatorRegistry.CONTAINS;
 import static org.eclipse.edc.spi.query.CriterionOperatorRegistry.EQUAL;
 import static org.eclipse.edc.spi.query.CriterionOperatorRegistry.ILIKE;
 import static org.eclipse.edc.spi.query.CriterionOperatorRegistry.IN;
+import static org.eclipse.edc.spi.query.CriterionOperatorRegistry.LESS_THAN;
 import static org.eclipse.edc.spi.query.CriterionOperatorRegistry.LIKE;
 import static org.eclipse.edc.spi.query.CriterionOperatorRegistry.NOT_EQUAL;
 
@@ -37,6 +38,7 @@ public class PostgresqlOperatorTranslator implements SqlOperatorTranslator {
             case ILIKE -> new SqlOperator("ilike", String.class);
             case IN -> new SqlOperator("in", Collection.class);
             case CONTAINS -> new SqlOperator("??", Object.class);
+            case LESS_THAN -> new SqlOperator("<", Object.class);
             default -> null;
         };
     }

--- a/extensions/common/sql/sql-core/src/test/java/org/eclipse/edc/sql/translation/PostgresqlOperatorTranslatorTest.java
+++ b/extensions/common/sql/sql-core/src/test/java/org/eclipse/edc/sql/translation/PostgresqlOperatorTranslatorTest.java
@@ -73,6 +73,14 @@ class PostgresqlOperatorTranslatorTest {
     }
 
     @Test
+    void shouldTranslate_lessThan() {
+        var operator = translator.translate("<");
+
+        assertThat(operator.representation()).isEqualTo("<");
+        assertThat(operator.rightOperandClass()).isEqualTo(Object.class);
+    }
+
+    @Test
     void shouldReturnNull_whenOperatorNotSupported() {
         var operator = translator.translate("not-supported");
 

--- a/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/schema/BaseSqlDataPlaneStatements.java
+++ b/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/schema/BaseSqlDataPlaneStatements.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.edc.connector.dataplane.store.sql.schema;
 
-import org.eclipse.edc.connector.dataplane.store.sql.schema.postgres.DataPlaneMapping;
+import org.eclipse.edc.connector.dataplane.store.sql.schema.postgres.DataFlowMapping;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.sql.translation.SqlOperatorTranslator;
 import org.eclipse.edc.sql.translation.SqlQueryStatement;
@@ -74,7 +74,7 @@ public class BaseSqlDataPlaneStatements implements DataPlaneStatements {
 
     @Override
     public SqlQueryStatement createQuery(QuerySpec querySpec) {
-        return new SqlQueryStatement(getSelectTemplate(), querySpec, new DataPlaneMapping(this), operatorTranslator);
+        return new SqlQueryStatement(getSelectTemplate(), querySpec, new DataFlowMapping(this), operatorTranslator);
     }
 
     @Override

--- a/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/schema/postgres/DataFlowMapping.java
+++ b/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/schema/postgres/DataFlowMapping.java
@@ -17,14 +17,23 @@ package org.eclipse.edc.connector.dataplane.store.sql.schema.postgres;
 import org.eclipse.edc.connector.dataplane.spi.DataFlow;
 import org.eclipse.edc.connector.dataplane.store.sql.schema.DataPlaneStatements;
 import org.eclipse.edc.sql.lease.StatefulEntityMapping;
+import org.eclipse.edc.sql.translation.TranslationMapping;
 
 /**
  * Maps fields of a {@link DataFlow} onto the
  * corresponding SQL schema (= column names) enabling access through Postgres JSON operators where applicable
  */
-public class DataPlaneMapping extends StatefulEntityMapping {
+public class DataFlowMapping extends StatefulEntityMapping {
 
-    public DataPlaneMapping(DataPlaneStatements statements) {
+    public DataFlowMapping(DataPlaneStatements statements) {
         super(statements);
+        add("transferType", new TransferTypeMapping(statements));
+    }
+
+    private static class TransferTypeMapping extends TranslationMapping {
+
+        TransferTypeMapping(DataPlaneStatements statements) {
+            add("flowType", statements.getFlowTypeColumn());
+        }
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/CriterionOperatorRegistry.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/CriterionOperatorRegistry.java
@@ -27,6 +27,7 @@ public interface CriterionOperatorRegistry {
     String LIKE = "like";
     String ILIKE = "ilike";
     String CONTAINS = "contains";
+    String LESS_THAN = "<";
 
     /**
      * Register an operator with the related operator predicate.

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/manager/DataPlaneManager.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/manager/DataPlaneManager.java
@@ -73,4 +73,11 @@ public interface DataPlaneManager extends StateEntityManager {
      * @return success if data flow is terminated, failed otherwise.
      */
     StatusResult<Void> terminate(String dataFlowId, @Nullable String reason);
+
+    /**
+     * Restart flows
+     *
+     * @return success if succeeded, failure otherwise.
+     */
+    StatusResult<Void> restartFlows();
 }

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/pipeline/TransferService.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/pipeline/TransferService.java
@@ -60,4 +60,11 @@ public interface TransferService {
      */
     StreamResult<Void> terminate(DataFlow dataFlow);
 
+
+    /**
+     * Close all the ongoing DataFlows
+     */
+    void closeAll();
+
+
 }


### PR DESCRIPTION
## What this PR changes/adds

Restarts long running transfers after a data-plane restart

## Why it does that

dataplane should be able to recover the transfers after a reboot

## Further notes

- this only provides the feature in a single data-plane instance environment, clustered environment will be supported in subsequent PRs
- added @Postgresql version of E2E tests for streaming. also because this scenario, that provides for the reboot is only testable with a persistent store and not in memory.
- added a `closeAll` method on `TransferService` that will shut down all the transfers during the shut down phase.
- implemented the `<` operator, I was actually surprised that it didn't already existed. this was necessary, I will provide an issue/PR to implement also the greater than.

the `restartFlows` method will in the future called in a different way as we're reasoning about the startup phases

## Linked Issue(s)

Part of #4440 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
