### PR TITLE
docs: DR about state machine startup operation

### DIFF
--- a/docs/developer/decision-records/2024-11-11-state-machine-startup-processors/README.md
+++ b/docs/developer/decision-records/2024-11-11-state-machine-startup-processors/README.md
@@ -1,0 +1,32 @@
+# State machine startup processors
+
+## Decision
+
+We will add the possibility to register one-time, at-startup processors to the `StateMachine` component.
+
+## Rationale
+
+A state machine could need some bootstrap work to getting ready at startup, as restarting stopped jobs.
+
+## Approach
+
+On the state machine builder there will be a new method that will permit to register a startup processor:
+```java
+Builder startupProcessor(Processor startupProcessor) {
+    loop.startupProcessors.add(startupProcessor);
+    return this;
+}
+```
+
+The startup logic will be executed before the first iteration loop:
+```java
+for (var startupProcessor : startupProcessors) {
+    try {
+        startupProcessor.process();
+    } catch (Throwable e) {
+        monitor.severe(format("StateMachineManager [%s] startup error caught", name), e);
+    }
+}
+```
+
+At the end of the startup phase, the state machine will engage the main loop.

--- a/docs/developer/decision-records/README.md
+++ b/docs/developer/decision-records/README.md
@@ -66,4 +66,5 @@
 - [2024-10-06 Typed Policy Scopes through Contexts](./2024-10-05-typed-policy-context)
 - [2024-10-10 DAPS module deprecation](./2024-10-10-daps-deprecation)
 - [2024-10-24 bidirectional-data-transfers](./2024-10-24-bidirectional-data-transfers)
+- [2024-11-11 State machine startup processors](./2024-11-11-state-machine-startup-processors)
 


### PR DESCRIPTION
## What this PR changes/adds

Decision about "startup processors" in the state machine component (as requested in https://github.com/eclipse-edc/Connector/pull/4612#issuecomment-2464999629)

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
