### PR TITLE
feat: improve handling of default values for ValueInjectionPoints

### DIFF
--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/DependencyGraph.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/DependencyGraph.java
@@ -121,7 +121,7 @@ public class DependencyGraph {
 
                         var defaultServiceProvider = defaultServiceProviders.get(injectionPoint.getType());
                         if (defaultServiceProvider != null) {
-                            injectionPoint.setDefaultServiceProvider(defaultServiceProvider);
+                            injectionPoint.setDefaultValueProvider(defaultServiceProvider);
                         }
                     })
                     .forEach(injectionPoint -> container.getInjectionPoints().add(injectionPoint));

--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/ConfigurationInjectionPoint.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/ConfigurationInjectionPoint.java
@@ -14,12 +14,13 @@
 
 package org.eclipse.edc.boot.system.injection;
 
-import org.eclipse.edc.boot.system.injection.lifecycle.ServiceProvider;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.result.AbstractResult;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.system.ValueProvider;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -88,7 +89,7 @@ public class ConfigurationInjectionPoint<T> implements InjectionPoint<T> {
      * Not used here, will always return null
      */
     @Override
-    public ServiceProvider getDefaultServiceProvider() {
+    public @Nullable ValueProvider getDefaultValueProvider() {
         return null;
     }
 
@@ -96,7 +97,7 @@ public class ConfigurationInjectionPoint<T> implements InjectionPoint<T> {
      * Not used here
      */
     @Override
-    public void setDefaultServiceProvider(ServiceProvider defaultServiceProvider) {
+    public void setDefaultValueProvider(ValueProvider defaultValueProvider) {
 
     }
 
@@ -182,7 +183,7 @@ public class ConfigurationInjectionPoint<T> implements InjectionPoint<T> {
     private @NotNull List<FieldValue> resolveSettingsFields(ServiceExtensionContext context, Field[] fields) {
         return injectionPointsFrom(fields)
                 .map(ip -> {
-                    var val = ip.resolve(context, null /*the default supplier arg is not used anyway*/);
+                    var val = ip.resolve(context, new InjectionPointDefaultServiceSupplier());
                     var fieldName = ip.getTargetField().getName();
                     return new FieldValue(fieldName, val);
                 })

--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/InjectionPoint.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/InjectionPoint.java
@@ -14,9 +14,9 @@
 
 package org.eclipse.edc.boot.system.injection;
 
-import org.eclipse.edc.boot.system.injection.lifecycle.ServiceProvider;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.system.ValueProvider;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -57,22 +57,23 @@ public interface InjectionPoint<T> {
      *
      * @return the default service provider if any, null otherwise
      */
-    @Nullable ServiceProvider getDefaultServiceProvider();
+    @Nullable ValueProvider getDefaultValueProvider();
 
     /**
      * Sets the default service provider.
      *
-     * @param defaultServiceProvider the default service provider
+     * @param defaultValueProvider the default service provider
      */
-    void setDefaultServiceProvider(ServiceProvider defaultServiceProvider);
+    void setDefaultValueProvider(ValueProvider defaultValueProvider);
 
     /**
      * Resolves the value for an injected field from either the context or a default service supplier. For some injection points,
      * this may also return a (statically declared) default value.
      *
      * @param context                The {@link ServiceExtensionContext} from which the value is resolved.
-     * @param defaultServiceSupplier Some service dynamically resolve a default value in case the actual value isn't found on the context.
-     * @return The resolved value, or null if the injected field is not required..
+     * @param defaultServiceSupplier Provider for default values that can be resolved statically (e.g. through an annotation attribute) or
+     *                               dynamically (e.g. by instantiating an object or resolving from context).
+     * @return The resolved value, or null if the injected field is not required.
      * @throws EdcInjectionException in case the value could not be resolved
      */
     Object resolve(ServiceExtensionContext context, DefaultServiceSupplier defaultServiceSupplier);

--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/InjectionPointDefaultServiceSupplier.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/InjectionPointDefaultServiceSupplier.java
@@ -17,6 +17,8 @@ package org.eclipse.edc.boot.system.injection;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.jetbrains.annotations.Nullable;
 
+import static java.util.Optional.ofNullable;
+
 /**
  * Supplies the default {@link org.eclipse.edc.boot.system.injection.lifecycle.ServiceProvider} that has been stored in
  * the {@link InjectionPoint}
@@ -25,11 +27,11 @@ public class InjectionPointDefaultServiceSupplier implements DefaultServiceSuppl
 
     @Override
     public @Nullable Object provideFor(InjectionPoint<?> injectionPoint, ServiceExtensionContext context) {
-        var defaultService = injectionPoint.getDefaultServiceProvider();
+        var defaultService = injectionPoint.getDefaultValueProvider();
         if (injectionPoint.isRequired() && defaultService == null) {
             throw new EdcInjectionException("No default provider for required service " + injectionPoint.getType());
         }
-        return defaultService == null ? null : defaultService.register(context);
+        return ofNullable(defaultService).map(vp -> vp.apply(context)).orElse(null);
     }
 
 }

--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/InjectionPointDefaultServiceSupplier.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/InjectionPointDefaultServiceSupplier.java
@@ -31,7 +31,7 @@ public class InjectionPointDefaultServiceSupplier implements DefaultServiceSuppl
         if (injectionPoint.isRequired() && defaultService == null) {
             throw new EdcInjectionException("No default provider for required service " + injectionPoint.getType());
         }
-        return ofNullable(defaultService).map(vp -> vp.apply(context)).orElse(null);
+        return ofNullable(defaultService).map(vp -> vp.get(context)).orElse(null);
     }
 
 }

--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/ServiceInjectionPoint.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/ServiceInjectionPoint.java
@@ -14,10 +14,11 @@
 
 package org.eclipse.edc.boot.system.injection;
 
-import org.eclipse.edc.boot.system.injection.lifecycle.ServiceProvider;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.system.ValueProvider;
+import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Field;
 import java.util.List;
@@ -36,7 +37,7 @@ public class ServiceInjectionPoint<T> implements InjectionPoint<T> {
     private final T instance;
     private final Field injectedField;
     private final boolean isRequired;
-    private ServiceProvider defaultServiceProvider;
+    private ValueProvider defaultServiceProvider;
 
     public ServiceInjectionPoint(T instance, Field injectedField) {
         this(instance, injectedField, true);
@@ -75,13 +76,13 @@ public class ServiceInjectionPoint<T> implements InjectionPoint<T> {
     }
 
     @Override
-    public ServiceProvider getDefaultServiceProvider() {
+    public @Nullable ValueProvider getDefaultValueProvider() {
         return defaultServiceProvider;
     }
 
     @Override
-    public void setDefaultServiceProvider(ServiceProvider defaultServiceProvider) {
-        this.defaultServiceProvider = defaultServiceProvider;
+    public void setDefaultValueProvider(ValueProvider defaultValueProvider) {
+        this.defaultServiceProvider = defaultValueProvider;
 
     }
 

--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/lifecycle/ExtensionLifecycleManager.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/lifecycle/ExtensionLifecycleManager.java
@@ -55,7 +55,7 @@ public class ExtensionLifecycleManager {
 
             var serviceProviders = container.getServiceProviders();
             if (serviceProviders != null) {
-                serviceProviders.forEach(serviceProvider -> serviceProvider.apply(context));
+                serviceProviders.forEach(serviceProvider -> serviceProvider.get(context));
             }
         }
 

--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/lifecycle/ExtensionLifecycleManager.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/lifecycle/ExtensionLifecycleManager.java
@@ -55,7 +55,7 @@ public class ExtensionLifecycleManager {
 
             var serviceProviders = container.getServiceProviders();
             if (serviceProviders != null) {
-                serviceProviders.forEach(serviceProvider -> serviceProvider.register(context));
+                serviceProviders.forEach(serviceProvider -> serviceProvider.apply(context));
             }
         }
 

--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/lifecycle/ServiceProvider.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/lifecycle/ServiceProvider.java
@@ -35,7 +35,7 @@ public record ServiceProvider(ProviderMethod method, ServiceExtension extension)
      * @return the instantiated service.
      */
     @Override
-    public Object apply(ServiceExtensionContext context) {
+    public Object get(ServiceExtensionContext context) {
         var type = method.getReturnType();
         var service = method.invoke(extension, context);
         context.registerService(type, service);

--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/lifecycle/ServiceProvider.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/lifecycle/ServiceProvider.java
@@ -18,14 +18,15 @@ import org.eclipse.edc.boot.system.injection.ProviderMethod;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.system.ValueProvider;
 
 /**
  * Represent a service provider, that's a method annotated with the {@link Provider}
  *
- * @param method the provider method.
+ * @param method    the provider method.
  * @param extension the extension in which the method is contained.
  */
-public record ServiceProvider(ProviderMethod method, ServiceExtension extension) {
+public record ServiceProvider(ProviderMethod method, ServiceExtension extension) implements ValueProvider {
 
     /**
      * Call the method and register the service.
@@ -33,11 +34,11 @@ public record ServiceProvider(ProviderMethod method, ServiceExtension extension)
      * @param context the service context.
      * @return the instantiated service.
      */
-    public Object register(ServiceExtensionContext context) {
+    @Override
+    public Object apply(ServiceExtensionContext context) {
         var type = method.getReturnType();
         var service = method.invoke(extension, context);
         context.registerService(type, service);
         return service;
     }
-
 }

--- a/core/common/boot/src/test/java/org/eclipse/edc/boot/system/injection/ConfigurationInjectionPointTest.java
+++ b/core/common/boot/src/test/java/org/eclipse/edc/boot/system/injection/ConfigurationInjectionPointTest.java
@@ -57,12 +57,12 @@ class ConfigurationInjectionPointTest {
     }
 
     @Test
-    void getDefaultServiceProvider() {
-        assertThat(injectionPoint.getDefaultServiceProvider()).isNull();
+    void getDefaultValueProvider() {
+        assertThat(injectionPoint.getDefaultValueProvider()).isNull();
     }
 
     @Test
-    void setDefaultServiceProvider() {
+    void setDefaultValueProvider() {
         //noop
     }
 

--- a/core/common/boot/src/test/java/org/eclipse/edc/boot/system/injection/InjectionPointDefaultServiceSupplierTest.java
+++ b/core/common/boot/src/test/java/org/eclipse/edc/boot/system/injection/InjectionPointDefaultServiceSupplierTest.java
@@ -32,8 +32,8 @@ class InjectionPointDefaultServiceSupplierTest {
     void shouldRegisterDefaultService() {
         var injectionPoint = new ServiceInjectionPoint<>("any", mock());
         ServiceProvider serviceProvider = mock();
-        when(serviceProvider.register(any())).thenReturn("service");
-        injectionPoint.setDefaultServiceProvider(serviceProvider);
+        when(serviceProvider.apply(any())).thenReturn("service");
+        injectionPoint.setDefaultValueProvider(serviceProvider);
         ServiceExtensionContext context = mock();
 
         var service = supplier.provideFor(injectionPoint, context);

--- a/core/common/boot/src/test/java/org/eclipse/edc/boot/system/injection/InjectionPointDefaultServiceSupplierTest.java
+++ b/core/common/boot/src/test/java/org/eclipse/edc/boot/system/injection/InjectionPointDefaultServiceSupplierTest.java
@@ -32,7 +32,7 @@ class InjectionPointDefaultServiceSupplierTest {
     void shouldRegisterDefaultService() {
         var injectionPoint = new ServiceInjectionPoint<>("any", mock());
         ServiceProvider serviceProvider = mock();
-        when(serviceProvider.apply(any())).thenReturn("service");
+        when(serviceProvider.get(any())).thenReturn("service");
         injectionPoint.setDefaultValueProvider(serviceProvider);
         ServiceExtensionContext context = mock();
 

--- a/core/common/boot/src/test/java/org/eclipse/edc/boot/system/injection/ValueInjectionPointTest.java
+++ b/core/common/boot/src/test/java/org/eclipse/edc/boot/system/injection/ValueInjectionPointTest.java
@@ -52,7 +52,7 @@ class ValueInjectionPointTest {
 
         @Test
         void getDefaultServiceProvider() {
-            assertThat(getInjectionPoint().getDefaultServiceProvider()).isNull();
+            assertThat(getInjectionPoint().getDefaultValueProvider()).isNull();
         }
 
         @Test
@@ -78,7 +78,7 @@ class ValueInjectionPointTest {
             when(contextMock.getConfig()).thenReturn(config);
             when(contextMock.getMonitor()).thenReturn(mock());
             var ip = createInjectionPoint(getInjectionPoint(), "requiredValWithDefault", ExtensionWithConfigValue.class);
-            assertThat(ip.resolve(contextMock, mock())).isEqualTo(ExtensionWithConfigValue.DEFAULT_VALUE);
+            assertThat(ip.resolve(contextMock, new InjectionPointDefaultServiceSupplier())).isEqualTo(ExtensionWithConfigValue.DEFAULT_VALUE);
         }
 
         @Test

--- a/core/common/boot/src/test/java/org/eclipse/edc/boot/system/injection/lifecycle/ServiceProviderTest.java
+++ b/core/common/boot/src/test/java/org/eclipse/edc/boot/system/injection/lifecycle/ServiceProviderTest.java
@@ -37,7 +37,7 @@ class ServiceProviderTest {
         ServiceExtensionContext context = mock();
         var serviceProvider = new ServiceProvider(providerMethod, extension);
 
-        var registered = serviceProvider.apply(context);
+        var registered = serviceProvider.get(context);
 
         assertThat(registered).isEqualTo(service);
         verify(context).registerService(TestService.class, service);

--- a/core/common/boot/src/test/java/org/eclipse/edc/boot/system/injection/lifecycle/ServiceProviderTest.java
+++ b/core/common/boot/src/test/java/org/eclipse/edc/boot/system/injection/lifecycle/ServiceProviderTest.java
@@ -37,7 +37,7 @@ class ServiceProviderTest {
         ServiceExtensionContext context = mock();
         var serviceProvider = new ServiceProvider(providerMethod, extension);
 
-        var registered = serviceProvider.register(context);
+        var registered = serviceProvider.apply(context);
 
         assertThat(registered).isEqualTo(service);
         verify(context).registerService(TestService.class, service);
@@ -52,5 +52,6 @@ class ServiceProviderTest {
 
     }
 
-    private interface TestService {}
+    private interface TestService {
+    }
 }

--- a/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/CoreServicesExtension.java
+++ b/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/CoreServicesExtension.java
@@ -58,12 +58,17 @@ import static org.eclipse.edc.participant.spi.ParticipantAgentService.DEFAULT_ID
 public class CoreServicesExtension implements ServiceExtension {
 
     public static final String NAME = "Core Services";
+
     @Setting(description = "The name of the claim key used to determine the participant identity", defaultValue = DEFAULT_IDENTITY_CLAIM_KEY)
     public static final String EDC_AGENT_IDENTITY_KEY = "edc.agent.identity.key";
+
     private static final String DEFAULT_EDC_HOSTNAME = "localhost";
+
     public static final String EDC_HOSTNAME = "edc.hostname";
+
     @Setting(description = "Connector hostname, which e.g. is used in referer urls", defaultValue = DEFAULT_EDC_HOSTNAME, key = EDC_HOSTNAME, warnOnMissingConfig = true)
     public static String hostname;
+
     @Inject
     private EventExecutorServiceContainer eventExecutorServiceContainer;
 

--- a/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/DependencyInjectionExtension.java
+++ b/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/DependencyInjectionExtension.java
@@ -52,7 +52,7 @@ public class DependencyInjectionExtension extends BaseRuntime implements BeforeE
         context = spy(super.createServiceExtensionContext(ConfigFactory.empty()));
         context.initialize();
         factory = new ReflectiveObjectFactory(
-                new InjectorImpl((ip, c) -> ofNullable(ip.getDefaultValueProvider()).map(vp -> vp.apply(c)).orElseGet(() -> mock(ip.getType()))),
+                new InjectorImpl((ip, c) -> ofNullable(ip.getDefaultValueProvider()).map(vp -> vp.get(c)).orElseGet(() -> mock(ip.getType()))),
                 new InjectionPointScanner(),
                 context
         );

--- a/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/DependencyInjectionExtension.java
+++ b/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/DependencyInjectionExtension.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 
+import static java.util.Optional.ofNullable;
 import static org.eclipse.edc.util.types.Cast.cast;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -51,7 +52,7 @@ public class DependencyInjectionExtension extends BaseRuntime implements BeforeE
         context = spy(super.createServiceExtensionContext(ConfigFactory.empty()));
         context.initialize();
         factory = new ReflectiveObjectFactory(
-                new InjectorImpl((ip, c) -> mock(ip.getType())),
+                new InjectorImpl((ip, c) -> ofNullable(ip.getDefaultValueProvider()).map(vp -> vp.apply(c)).orElseGet(() -> mock(ip.getType()))),
                 new InjectionPointScanner(),
                 context
         );

--- a/spi/common/boot-spi/src/main/java/org/eclipse/edc/spi/system/ValueProvider.java
+++ b/spi/common/boot-spi/src/main/java/org/eclipse/edc/spi/system/ValueProvider.java
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.spi.system;
+
+@FunctionalInterface
+public interface ValueProvider {
+    Object apply(ServiceExtensionContext context);
+}

--- a/spi/common/boot-spi/src/main/java/org/eclipse/edc/spi/system/ValueProvider.java
+++ b/spi/common/boot-spi/src/main/java/org/eclipse/edc/spi/system/ValueProvider.java
@@ -14,7 +14,18 @@
 
 package org.eclipse.edc.spi.system;
 
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Functional interface to provide default values for injection points.
+ */
 @FunctionalInterface
 public interface ValueProvider {
-    Object apply(ServiceExtensionContext context);
+    /**
+     * Attempts to resolve the default value for a particular {@code InjectionPoint} from the context.
+     *
+     * @param context The DI container from which to resolve the default value
+     * @return the default value, or null if no default value was found
+     */
+    @Nullable Object get(ServiceExtensionContext context);
 }


### PR DESCRIPTION
## What this PR changes/adds

this PR improves the handling of default values for `ValueInjectionPoints`. 

Specifically, the `ValueInjectionPoint` now has a default `ValueProvider`, which reads the default value from the annotation attribute.

## Why it does that

re-use existing infrastructure

## Further notes

the `ServiceProvider` class now implements the `ValueProvider` interface and is a specific variant for `ServiceInjectionPoints`

## Linked Issue(s)

Contributes to #4610


_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
