### PR TITLE
feat: adds flag to enable validation on create/update policy definitions

### DIFF
--- a/core/common/lib/policy-engine-lib/src/main/java/org/eclipse/edc/policy/engine/validation/PolicyValidator.java
+++ b/core/common/lib/policy-engine-lib/src/main/java/org/eclipse/edc/policy/engine/validation/PolicyValidator.java
@@ -136,7 +136,7 @@ public class PolicyValidator implements Policy.Visitor<Result<Void>>, Rule.Visit
     private Result<Void> validateConstraint(String leftOperand, Operator operator, Object rightOperand, Rule rule) {
         var functions = getValidations(leftOperand, rule.getClass());
         if (functions.isEmpty()) {
-            return Result.failure("left operand '%s' is not bound to any functions: Rule { %s }".formatted(leftOperand, rule));
+            return Result.failure("leftOperand '%s' is not bound to any functions: Rule { %s }".formatted(leftOperand, rule));
         } else {
             return functions.stream()
                     .map(f -> f.validate(leftOperand, operator, rightOperand, rule))
@@ -187,12 +187,12 @@ public class PolicyValidator implements Policy.Visitor<Result<Void>>, Rule.Visit
         return functions;
     }
 
-    private interface PolicyValidation {
-        Result<Void> validate(String leftOperand, Operator operator, Object rightOperand, Rule rule);
-    }
-
     private Rule currentRule() {
         return ruleContext.peek();
+    }
+
+    private interface PolicyValidation {
+        Result<Void> validate(String leftOperand, Operator operator, Object rightOperand, Rule rule);
     }
 
     public static class Builder {

--- a/core/common/lib/policy-engine-lib/src/test/java/org/eclipse/edc/policy/engine/PolicyEngineImplValidationTest.java
+++ b/core/common/lib/policy-engine-lib/src/test/java/org/eclipse/edc/policy/engine/PolicyEngineImplValidationTest.java
@@ -87,7 +87,7 @@ class PolicyEngineImplValidationTest {
         // The foo key is not bound nor to function nor in the RuleBindingRegistry
         assertThat(result).isFailed().messages().hasSize(2)
                 .anyMatch(s -> s.startsWith("leftOperand 'foo' is not bound to any scopes"))
-                .anyMatch(s -> s.startsWith("left operand 'foo' is not bound to any functions"));
+                .anyMatch(s -> s.startsWith("leftOperand 'foo' is not bound to any functions"));
 
     }
 
@@ -143,7 +143,7 @@ class PolicyEngineImplValidationTest {
 
         assertThat(result).isFailed()
                 .messages()
-                .anyMatch(s -> s.startsWith("left operand '%s' is not bound to any functions".formatted(leftOperand)));
+                .anyMatch(s -> s.startsWith("leftOperand '%s' is not bound to any functions".formatted(leftOperand)));
 
     }
 
@@ -181,7 +181,7 @@ class PolicyEngineImplValidationTest {
 
         // The input key is not bound any functions , the dynamic one cannot handle the input key
         assertThat(result).isFailed().messages().hasSize(1)
-                .anyMatch(s -> s.startsWith("left operand '%s' is not bound to any functions".formatted(key)));
+                .anyMatch(s -> s.startsWith("leftOperand '%s' is not bound to any functions".formatted(key)));
 
     }
 

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
@@ -75,6 +75,7 @@ import org.eclipse.edc.policy.engine.spi.PolicyEngine;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.command.CommandHandlerRegistry;
 import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.iam.IdentityService;
@@ -98,6 +99,9 @@ import static org.eclipse.edc.policy.context.request.spi.RequestVersionPolicyCon
 public class ControlPlaneServicesExtension implements ServiceExtension {
 
     public static final String NAME = "Control Plane Services";
+
+    @Setting(key = "edc.policy.validation.enabled", description = "If true enable the policy validation when creating and updating policy definitions", defaultValue = "false")
+    private Boolean validatePolicy;
 
     @Inject
     private Clock clock;
@@ -253,7 +257,7 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
         var policyDefinitionObservable = new PolicyDefinitionObservableImpl();
         policyDefinitionObservable.registerListener(new PolicyDefinitionEventListener(clock, eventRouter));
         return new PolicyDefinitionServiceImpl(transactionContext, policyDefinitionStore, contractDefinitionStore,
-                policyDefinitionObservable, policyEngine, QueryValidators.policyDefinition());
+                policyDefinitionObservable, policyEngine, QueryValidators.policyDefinition(), validatePolicy);
     }
 
     @Provider

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
@@ -100,7 +100,7 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
 
     public static final String NAME = "Control Plane Services";
 
-    @Setting(key = "edc.policy.validation.enabled", description = "If true enable the policy validation when creating and updating policy definitions", defaultValue = "false")
+    @Setting(key = "edc.policy.validation.enabled", description = "If true enables the policy validation when creating and updating policy definitions", defaultValue = "false")
     private Boolean validatePolicy;
 
     @Inject

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ManagementEndToEndExtension.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ManagementEndToEndExtension.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import static org.eclipse.edc.sql.testfixtures.PostgresqlEndToEndInstance.createDatabase;
 import static org.eclipse.edc.util.io.Ports.getFreePort;
@@ -56,10 +57,18 @@ public abstract class ManagementEndToEndExtension extends RuntimePerClassExtensi
     static class InMemory extends ManagementEndToEndExtension {
 
         protected InMemory() {
-            super(context());
+            super(context(Map.of()));
         }
 
-        private static ManagementEndToEndTestContext context() {
+        protected InMemory(Map<String, String> config) {
+            super(context(config));
+        }
+
+        public static InMemory withConfig(Map<String, String> config) {
+            return new InMemory(config);
+        }
+
+        private static ManagementEndToEndTestContext context(Map<String, String> config) {
             var managementPort = getFreePort();
             var protocolPort = getFreePort();
 
@@ -75,6 +84,7 @@ public abstract class ManagementEndToEndExtension extends RuntimePerClassExtensi
                             put("edc.dsp.callback.address", "http://localhost:" + protocolPort + "/protocol");
                             put("web.http.management.path", "/management");
                             put("web.http.management.port", String.valueOf(managementPort));
+                            putAll(config);
                         }
                     },
                     ":system-tests:management-api:management-api-test-runtime"


### PR DESCRIPTION
## What this PR changes/adds

adds a configuration `edc.policy.validation.enabled` for enabling the call to `PolicyEngine#validate` while creating/updating the `PolicyDefinition` 

## Why it does that

improves policy management

## Further notes

Renamed also the failure message from `left operand` to `leftOperand` for consistency 

## Linked Issue(s)

Closes #4619

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
