### PR TITLE
fix: package declaration of JtiValidationStore

### DIFF
--- a/extensions/common/store/sql/jti-validation-store-sql/src/main/java/org/eclipse/edc/jtivalidation/store/sql/SqlJtiValidationStore.java
+++ b/extensions/common/store/sql/jti-validation-store-sql/src/main/java/org/eclipse/edc/jtivalidation/store/sql/SqlJtiValidationStore.java
@@ -12,10 +12,10 @@
  *
  */
 
-package org.eclipse.edc.edr.store.index;
+package org.eclipse.edc.jtivalidation.store.sql;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.eclipse.edc.edr.store.index.sql.schema.JtiValidationStoreStatements;
+import org.eclipse.edc.jtivalidation.store.sql.schema.JtiValidationStoreStatements;
 import org.eclipse.edc.jwt.validation.jti.JtiValidationEntry;
 import org.eclipse.edc.jwt.validation.jti.JtiValidationStore;
 import org.eclipse.edc.spi.monitor.Monitor;

--- a/extensions/common/store/sql/jti-validation-store-sql/src/main/java/org/eclipse/edc/jtivalidation/store/sql/SqlJtiValidationStoreExtension.java
+++ b/extensions/common/store/sql/jti-validation-store-sql/src/main/java/org/eclipse/edc/jtivalidation/store/sql/SqlJtiValidationStoreExtension.java
@@ -12,11 +12,11 @@
  *
  */
 
-package org.eclipse.edc.edr.store.index;
+package org.eclipse.edc.jtivalidation.store.sql;
 
 
-import org.eclipse.edc.edr.store.index.sql.schema.JtiValidationStoreStatements;
-import org.eclipse.edc.edr.store.index.sql.schema.postgres.PostgresDialectStatements;
+import org.eclipse.edc.jtivalidation.store.sql.schema.JtiValidationStoreStatements;
+import org.eclipse.edc.jtivalidation.store.sql.schema.postgres.PostgresDialectStatements;
 import org.eclipse.edc.jwt.validation.jti.JtiValidationStore;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;

--- a/extensions/common/store/sql/jti-validation-store-sql/src/main/java/org/eclipse/edc/jtivalidation/store/sql/schema/BaseSqlDialectStatements.java
+++ b/extensions/common/store/sql/jti-validation-store-sql/src/main/java/org/eclipse/edc/jtivalidation/store/sql/schema/BaseSqlDialectStatements.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.edr.store.index.sql.schema;
+package org.eclipse.edc.jtivalidation.store.sql.schema;
 
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.sql.translation.SqlOperatorTranslator;

--- a/extensions/common/store/sql/jti-validation-store-sql/src/main/java/org/eclipse/edc/jtivalidation/store/sql/schema/JtiValidationStoreStatements.java
+++ b/extensions/common/store/sql/jti-validation-store-sql/src/main/java/org/eclipse/edc/jtivalidation/store/sql/schema/JtiValidationStoreStatements.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.edr.store.index.sql.schema;
+package org.eclipse.edc.jtivalidation.store.sql.schema;
 
 import org.eclipse.edc.sql.statement.SqlStatements;
 

--- a/extensions/common/store/sql/jti-validation-store-sql/src/main/java/org/eclipse/edc/jtivalidation/store/sql/schema/postgres/PostgresDialectStatements.java
+++ b/extensions/common/store/sql/jti-validation-store-sql/src/main/java/org/eclipse/edc/jtivalidation/store/sql/schema/postgres/PostgresDialectStatements.java
@@ -12,9 +12,9 @@
  *
  */
 
-package org.eclipse.edc.edr.store.index.sql.schema.postgres;
+package org.eclipse.edc.jtivalidation.store.sql.schema.postgres;
 
-import org.eclipse.edc.edr.store.index.sql.schema.BaseSqlDialectStatements;
+import org.eclipse.edc.jtivalidation.store.sql.schema.BaseSqlDialectStatements;
 import org.eclipse.edc.sql.dialect.PostgresDialect;
 import org.eclipse.edc.sql.translation.PostgresqlOperatorTranslator;
 

--- a/extensions/common/store/sql/jti-validation-store-sql/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/common/store/sql/jti-validation-store-sql/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -12,4 +12,4 @@
 #
 #
 
-org.eclipse.edc.edr.store.index.SqlJtiValidationStoreExtension
+org.eclipse.edc.jtivalidation.store.sql.SqlJtiValidationStoreExtension

--- a/extensions/common/store/sql/jti-validation-store-sql/src/test/java/org/eclipse/edc/jtivalidation/store/sql/SqlJtiValidationStoreExtensionTest.java
+++ b/extensions/common/store/sql/jti-validation-store-sql/src/test/java/org/eclipse/edc/jtivalidation/store/sql/SqlJtiValidationStoreExtensionTest.java
@@ -12,10 +12,8 @@
  *
  */
 
-package org.eclipse.edc.edr.store.index.sql;
+package org.eclipse.edc.jtivalidation.store.sql;
 
-import org.eclipse.edc.edr.store.index.SqlJtiValidationStore;
-import org.eclipse.edc.edr.store.index.SqlJtiValidationStoreExtension;
 import org.eclipse.edc.json.JacksonTypeManager;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.jwt.validation.jti.JtiValidationStore;
@@ -27,7 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.edr.store.index.SqlJtiValidationStoreExtension.DATASOURCE_NAME;
+import static org.eclipse.edc.jtivalidation.store.sql.SqlJtiValidationStoreExtension.DATASOURCE_NAME;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;

--- a/extensions/common/store/sql/jti-validation-store-sql/src/test/java/org/eclipse/edc/jtivalidation/store/sql/SqlJtiValidationStoreTest.java
+++ b/extensions/common/store/sql/jti-validation-store-sql/src/test/java/org/eclipse/edc/jtivalidation/store/sql/SqlJtiValidationStoreTest.java
@@ -12,12 +12,11 @@
  *
  */
 
-package org.eclipse.edc.edr.store.index.sql;
+package org.eclipse.edc.jtivalidation.store.sql;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.eclipse.edc.edr.store.index.SqlJtiValidationStore;
-import org.eclipse.edc.edr.store.index.sql.schema.BaseSqlDialectStatements;
-import org.eclipse.edc.edr.store.index.sql.schema.postgres.PostgresDialectStatements;
+import org.eclipse.edc.jtivalidation.store.sql.schema.BaseSqlDialectStatements;
+import org.eclipse.edc.jtivalidation.store.sql.schema.postgres.PostgresDialectStatements;
 import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.junit.testfixtures.TestUtils;
 import org.eclipse.edc.jwt.validation.jti.JtiValidationStore;


### PR DESCRIPTION
## What this PR changes/adds

This fixes the package declaration of the JTI validation store

## Why it does that


it had a wrong package declaration, which causes confusion, and more importantly, causes runtime errors

## Further notes

specifically, the class
`org.eclipse.edc.edr.store.index.sql.schema.postgres.PostgresDialectStatements` existed twice on the classpath, but one was now updated to be `org.eclipse.edc.jtivalidation.store.index.sql.schema.postgres.PostgresDialectStatements`

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
