### PR TITLE
fix: add  capability to encode `kid` header in request to Oauth2 server 

### DIFF
--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceExtension.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceExtension.java
@@ -53,7 +53,7 @@ import static java.lang.String.format;
 /**
  * Provides OAuth2 client credentials flow support.
  */
-@Provides({ IdentityService.class })
+@Provides({IdentityService.class})
 @Extension(value = Oauth2ServiceExtension.NAME)
 public class Oauth2ServiceExtension implements ServiceExtension {
 
@@ -125,7 +125,12 @@ public class Oauth2ServiceExtension implements ServiceExtension {
 
         var certificate = Optional.ofNullable(certificateResolver.resolveCertificate(configuration.getPublicCertificateAlias()))
                 .orElseThrow(() -> new EdcException("Public certificate not found: " + configuration.getPublicCertificateAlias()));
-        jwtDecoratorRegistry.register(OAUTH2_TOKEN_CONTEXT, new Oauth2AssertionDecorator(configuration.getProviderAudience(), configuration.getClientId(), clock, configuration.getTokenExpiration()));
+        jwtDecoratorRegistry.register(OAUTH2_TOKEN_CONTEXT, Oauth2AssertionDecorator.Builder.newInstance()
+                .audience(configuration.getProviderAudience())
+                .clientId(configuration.getClientId())
+                .clock(clock)
+                .validity(configuration.getTokenExpiration())
+                .build());
         jwtDecoratorRegistry.register(OAUTH2_TOKEN_CONTEXT, new X509CertificateDecorator(certificate));
 
         providerKeyResolver = identityProviderKeyResolver(context);

--- a/extensions/data-plane/data-plane-http-oauth2-core/src/main/java/org/eclipse/edc/connector/dataplane/http/oauth2/Oauth2CredentialsRequestFactory.java
+++ b/extensions/data-plane/data-plane-http-oauth2-core/src/main/java/org/eclipse/edc/connector/dataplane/http/oauth2/Oauth2CredentialsRequestFactory.java
@@ -33,6 +33,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.eclipse.edc.iam.oauth2.spi.Oauth2DataAddressSchema.CLIENT_ID;
 import static org.eclipse.edc.iam.oauth2.spi.Oauth2DataAddressSchema.CLIENT_SECRET_KEY;
+import static org.eclipse.edc.iam.oauth2.spi.Oauth2DataAddressSchema.KEY_ID;
 import static org.eclipse.edc.iam.oauth2.spi.Oauth2DataAddressSchema.PRIVATE_KEY_NAME;
 import static org.eclipse.edc.iam.oauth2.spi.Oauth2DataAddressSchema.SCOPE;
 import static org.eclipse.edc.iam.oauth2.spi.Oauth2DataAddressSchema.TOKEN_URL;
@@ -104,7 +105,13 @@ public class Oauth2CredentialsRequestFactory {
         var validity = Optional.ofNullable(dataAddress.getStringProperty(VALIDITY))
                 .map(this::parseLong)
                 .orElse(DEFAULT_TOKEN_VALIDITY);
-        var decorator = new Oauth2AssertionDecorator(dataAddress.getStringProperty(TOKEN_URL), dataAddress.getStringProperty(CLIENT_ID), clock, validity);
+        var decorator = Oauth2AssertionDecorator.Builder.newInstance()
+                .audience(dataAddress.getStringProperty(TOKEN_URL))
+                .clientId(dataAddress.getStringProperty(CLIENT_ID))
+                .clock(clock)
+                .validity(validity)
+                .kid(dataAddress.getStringProperty(KEY_ID))
+                .build();
         var service = new JwtGenerationService(jwsSignerProvider);
 
         return service.generate(pkSecret, decorator);

--- a/spi/common/oauth2-spi/src/main/java/org/eclipse/edc/iam/oauth2/spi/Oauth2AssertionDecorator.java
+++ b/spi/common/oauth2-spi/src/main/java/org/eclipse/edc/iam/oauth2/spi/Oauth2AssertionDecorator.java
@@ -14,12 +14,15 @@
 
 package org.eclipse.edc.iam.oauth2.spi;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import org.eclipse.edc.spi.iam.TokenParameters;
+import org.eclipse.edc.token.spi.KeyIdDecorator;
 import org.eclipse.edc.token.spi.TokenDecorator;
 
 import java.time.Clock;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.AUDIENCE;
@@ -32,25 +35,72 @@ import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.SUBJECT;
 
 public class Oauth2AssertionDecorator implements TokenDecorator {
 
-    private final String audience;
-    private final String clientId;
-    private final Clock clock;
-    private final long validity;
+    private String audience;
+    private String clientId;
+    private Clock clock;
+    private long validity;
+    private String kid;
 
-    public Oauth2AssertionDecorator(String audience, String clientId, Clock clock, long validity) {
-        this.audience = audience;
-        this.clientId = clientId;
-        this.clock = clock;
-        this.validity = validity;
+    private Oauth2AssertionDecorator() {
     }
 
     @Override
     public TokenParameters.Builder decorate(TokenParameters.Builder tokenParameters) {
+        new KeyIdDecorator(kid).decorate(tokenParameters);
         return tokenParameters.claims(AUDIENCE, List.of(audience))
                 .claims(ISSUER, clientId)
                 .claims(SUBJECT, clientId)
                 .claims(JWT_ID, UUID.randomUUID().toString())
                 .claims(ISSUED_AT, Date.from(clock.instant()))
                 .claims(EXPIRATION_TIME, Date.from(clock.instant().plusSeconds(validity)));
+    }
+
+    public static class Builder {
+
+        private final Oauth2AssertionDecorator decorator;
+
+        private Builder() {
+            decorator = new Oauth2AssertionDecorator();
+        }
+
+        @JsonCreator
+        public static Oauth2AssertionDecorator.Builder newInstance() {
+            return new Oauth2AssertionDecorator.Builder();
+        }
+
+        public Builder audience(String audience) {
+            decorator.audience = audience;
+            return this;
+        }
+
+        public Builder clientId(String clientId) {
+            decorator.clientId = clientId;
+            return this;
+        }
+
+        public Builder clock(Clock clock) {
+            decorator.clock = clock;
+            return this;
+        }
+
+        public Builder validity(long validity) {
+            decorator.validity = validity;
+            return this;
+        }
+
+        public Builder kid(String kid) {
+            decorator.kid = kid;
+            return this;
+        }
+
+        public Oauth2AssertionDecorator build() {
+            Objects.requireNonNull(decorator.audience, "Audience must be set");
+            Objects.requireNonNull(decorator.clientId, "Client ID must be set");
+            if (decorator.validity <= 0) {
+                throw new IllegalArgumentException("Validity must be greater than 0");
+            }
+            decorator.clock = Objects.requireNonNullElse(decorator.clock, Clock.systemUTC());
+            return decorator;
+        }
     }
 }

--- a/spi/common/oauth2-spi/src/main/java/org/eclipse/edc/iam/oauth2/spi/Oauth2DataAddressSchema.java
+++ b/spi/common/oauth2-spi/src/main/java/org/eclipse/edc/iam/oauth2/spi/Oauth2DataAddressSchema.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.iam.oauth2.spi;
 public interface Oauth2DataAddressSchema {
     String CLIENT_ID = "oauth2:clientId";
     String CLIENT_SECRET_KEY = "oauth2:clientSecretKey";
+    String KEY_ID = "oauth2:kid";
     String TOKEN_URL = "oauth2:tokenUrl";
     String VALIDITY = "oauth2:validity";
     String PRIVATE_KEY_NAME = "oauth2:privateKeyName";


### PR DESCRIPTION
## What this PR changes/adds

As of today, Oauth2AssertionDecorator does not provide the capability to encode the optional kid header in the access token request to Oauth2 server.

## Why it does that

We should be able to specify a kid: https://www.rfc-editor.org/rfc/rfc7515#page-11

## Linked Issue(s)

Closes #4626 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
