### PR TITLE
refactor: set INFO as default log level, downgraded some log calls

### DIFF
--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/config/ConfigurationLoader.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/config/ConfigurationLoader.java
@@ -47,7 +47,7 @@ public class ConfigurationLoader {
         var config = serviceLocator.loadImplementors(ConfigurationExtension.class, false)
                 .stream().peek(extension -> {
                     extension.initialize(monitor);
-                    monitor.info("Initialized " + extension.name());
+                    monitor.debug("ConfigurationExtension Initialized: " + extension.name());
                 })
                 .map(ConfigurationExtension::getConfig)
                 .filter(Objects::nonNull)

--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/lifecycle/ExtensionLifecycleManager.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/lifecycle/ExtensionLifecycleManager.java
@@ -45,13 +45,14 @@ public class ExtensionLifecycleManager {
      */
     public static void bootServiceExtensions(List<InjectionContainer<ServiceExtension>> containers, ServiceExtensionContext context) {
         var injector = new InjectorImpl(new InjectionPointDefaultServiceSupplier());
+        var monitor = context.getMonitor();
 
         for (var container : containers) {
             var target = container.getInjectionTarget();
             injector.inject(container, context);
 
             target.initialize(context);
-            context.getMonitor().info("Initialized " + target.name());
+            monitor.debug("Initialized " + target.name());
 
             var serviceProviders = container.getServiceProviders();
             if (serviceProviders != null) {
@@ -64,15 +65,16 @@ public class ExtensionLifecycleManager {
         for (var container : containers) {
             var target = container.getInjectionTarget();
             target.prepare();
-            context.getMonitor().info("Prepared " + target.name());
+            monitor.debug("Prepared " + target.name());
         }
 
         for (var container : containers) {
             var target = container.getInjectionTarget();
             target.start();
-            context.getMonitor().info("Started " + target.name());
+            monitor.debug("Started " + target.name());
         }
 
+        monitor.info(containers.size() + " service extensions started");
     }
 
 }

--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/runtime/BaseRuntime.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/runtime/BaseRuntime.java
@@ -85,6 +85,8 @@ public class BaseRuntime {
      */
     public void boot(boolean addShutdownHook) {
         monitor = createMonitor();
+        monitor.info("Booting EDC runtime");
+
         var config = configurationLoader.loadConfiguration(monitor);
         context = createServiceExtensionContext(config);
 
@@ -119,7 +121,7 @@ public class BaseRuntime {
         while (iter.hasPrevious()) {
             var extension = iter.previous();
             extension.shutdown();
-            monitor.info("Shutdown " + extension.name());
+            monitor.debug("Shutdown " + extension.name());
             iter.remove();
         }
         monitor.info("Shutdown complete");
@@ -178,14 +180,15 @@ public class BaseRuntime {
     }
 
     /**
-     * Hook point to instantiate a {@link Monitor}. By default, the runtime instantiates a {@code Monitor} using the Service Loader mechanism, i.e. by calling the {@link ExtensionLoader#loadMonitor(String...)} method.
+     * Hook point to instantiate a {@link Monitor}. By default, the runtime instantiates a {@code Monitor} using the 
+     * Service Loader mechanism, i.e. by calling the {@link ExtensionLoader#loadMonitor(String...)} method.
      * <p>
      * Please consider using the extension mechanism (i.e. {@link MonitorExtension}) rather than supplying a custom monitor by overriding this method.
      * However, for development/testing scenarios it might be an easy solution to just override this method.
      */
     @NotNull
     protected Monitor createMonitor() {
-        return ExtensionLoader.loadMonitor(programArgs);
+        return extensionLoader.loadMonitor(programArgs);
     }
 
 }

--- a/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/EmbeddedRuntime.java
+++ b/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/EmbeddedRuntime.java
@@ -34,14 +34,11 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.eclipse.edc.boot.system.ExtensionLoader.loadMonitor;
 
 /**
  * Embedded runtime that runs inside another runtime
  */
 public class EmbeddedRuntime extends BaseRuntime {
-
-    private static final Monitor MONITOR = loadMonitor();
 
     private final String name;
     private final Map<String, String> properties;
@@ -68,8 +65,9 @@ public class EmbeddedRuntime extends BaseRuntime {
 
     @Override
     public void boot(boolean addShutdownHook) {
+        var monitor = super.createMonitor();
         try {
-            MONITOR.info("Starting runtime %s".formatted(name));
+            monitor.info("Starting runtime %s".formatted(name));
 
             // Temporarily inject system properties.
             var savedProperties = (Properties) System.getProperties().clone();
@@ -97,7 +95,7 @@ public class EmbeddedRuntime extends BaseRuntime {
                 throw new EdcException("Failed to start EDC runtime", runtimeException.get());
             }
 
-            MONITOR.info("Runtime %s started".formatted(name));
+            monitor.info("Runtime %s started".formatted(name));
             // Restore system properties.
             System.setProperties(savedProperties);
         } catch (Exception e) {

--- a/extensions/common/http/jersey-core/src/main/java/org/eclipse/edc/web/jersey/JerseyRestService.java
+++ b/extensions/common/http/jersey-core/src/main/java/org/eclipse/edc/web/jersey/JerseyRestService.java
@@ -116,7 +116,7 @@ public class JerseyRestService implements WebService {
         var servletContainer = new ServletContainer(resourceConfig);
         webServer.registerServlet(contextAlias, servletContainer);
 
-        monitor.info("Registered Web API context alias: " + contextAlias);
+        monitor.debug("Registered Web API context alias: " + contextAlias);
     }
 
     /**

--- a/extensions/common/http/jetty-core/src/main/java/org/eclipse/edc/web/jetty/JettyService.java
+++ b/extensions/common/http/jetty-core/src/main/java/org/eclipse/edc/web/jetty/JettyService.java
@@ -89,10 +89,10 @@ public class JettyService implements WebServer {
 
                 if (keyStore != null) {
                     connector = httpsServerConnector(mapping.getPort());
-                    monitor.info("HTTPS context '" + mapping.getName() + "' listening on port " + mapping.getPort());
+                    monitor.debug("HTTPS context '" + mapping.getName() + "' listening on port " + mapping.getPort());
                 } else {
                     connector = httpServerConnector();
-                    monitor.info("HTTP context '" + mapping.getName() + "' listening on port " + mapping.getPort());
+                    monitor.debug("HTTP context '" + mapping.getName() + "' listening on port " + mapping.getPort());
                 }
 
                 connector.setName(mapping.getName());

--- a/extensions/common/http/jetty-core/src/main/java/org/eclipse/edc/web/jetty/WebServiceConfigurerImpl.java
+++ b/extensions/common/http/jetty-core/src/main/java/org/eclipse/edc/web/jetty/WebServiceConfigurerImpl.java
@@ -51,7 +51,7 @@ public class WebServiceConfigurerImpl implements WebServiceConfigurer {
             }
         }
 
-        monitor.info(format("%s will be available under port=%s, path=%s", settings.getName(), port, path));
+        monitor.debug(format("%s will be available under port=%s, path=%s", settings.getName(), port, path));
 
         return WebServiceConfiguration.Builder.newInstance()
                 .path(path)

--- a/extensions/common/vault/vault-hashicorp/src/main/java/org/eclipse/edc/vault/hashicorp/health/HashicorpVaultHealthExtension.java
+++ b/extensions/common/vault/vault-hashicorp/src/main/java/org/eclipse/edc/vault/hashicorp/health/HashicorpVaultHealthExtension.java
@@ -54,7 +54,7 @@ public class HashicorpVaultHealthExtension implements ServiceExtension {
             healthCheckService.addStartupStatusProvider(healthCheck);
             monitor.debug("Vault health check initialization complete");
         } else {
-            monitor.info("Vault health check disabled");
+            monitor.debug("Vault health check disabled");
         }
     }
 }

--- a/extensions/control-plane/provision/provision-http/src/main/java/org/eclipse/edc/connector/controlplane/provision/http/HttpProvisionerExtension.java
+++ b/extensions/control-plane/provision/provision-http/src/main/java/org/eclipse/edc/connector/controlplane/provision/http/HttpProvisionerExtension.java
@@ -97,7 +97,7 @@ public class HttpProvisionerExtension implements ServiceExtension {
             if (configuration.getProvisionerType() == ProvisionerConfiguration.ProvisionerType.PROVIDER) {
                 var generator = new HttpProviderResourceDefinitionGenerator(configuration.getDataAddressType());
                 manifestGenerator.registerGenerator(generator);
-                monitor.info(format("Registering provider provisioner: %s [%s]", configuration.getName(), configuration.getEndpoint().toString()));
+                monitor.debug(format("Registering provider provisioner: %s [%s]", configuration.getName(), configuration.getEndpoint().toString()));
             } else {
                 monitor.warning(format("Client-side provisioning not yet supported by the %s. Skipping configuration for %s", name(), configuration.getName()));
             }

--- a/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSource.java
+++ b/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSource.java
@@ -82,7 +82,7 @@ public class HttpDataSource implements DataSource {
                     try {
                         response.close();
                     } catch (Exception e) {
-                        monitor.info("Error closing failed response", e);
+                        monitor.severe("Error closing failed response", e);
                     }
                 }
             }

--- a/extensions/data-plane/data-plane-iam/src/main/java/org/eclipse/edc/connector/dataplane/iam/service/DefaultDataPlaneAccessTokenServiceImpl.java
+++ b/extensions/data-plane/data-plane-iam/src/main/java/org/eclipse/edc/connector/dataplane/iam/service/DefaultDataPlaneAccessTokenServiceImpl.java
@@ -99,7 +99,7 @@ public class DefaultDataPlaneAccessTokenServiceImpl implements DataPlaneAccessTo
 
         // if there is no "jti" header on the token params, we'll assign a random one, and add it back to the decorators
         if (id == null) {
-            monitor.info("No '%s' claim found on TokenParameters. Will generate a random one.".formatted(TOKEN_ID));
+            monitor.debug("No '%s' claim found on TokenParameters. Will generate a random one.".formatted(TOKEN_ID));
             id = UUID.randomUUID().toString();
             var tokenIdDecorator = new TokenIdDecorator(id);
             allDecorators.add(tokenIdDecorator);

--- a/extensions/data-plane/data-plane-self-registration/src/main/java/org/eclipse/edc/connector/dataplane/registration/DataplaneSelfRegistrationExtension.java
+++ b/extensions/data-plane/data-plane-self-registration/src/main/java/org/eclipse/edc/connector/dataplane/registration/DataplaneSelfRegistrationExtension.java
@@ -99,7 +99,7 @@ public class DataplaneSelfRegistrationExtension implements ServiceExtension {
         monitor.debug("Initiate data plane registration.");
         dataPlaneSelectorService.addInstance(instance)
                 .onSuccess(it -> {
-                    monitor.info("data plane registered to control plane");
+                    monitor.debug("data plane registered to control plane");
                     isRegistered.set(true);
                 })
                 .onFailure(f -> registrationError.set(f.getFailureDetail()))
@@ -110,7 +110,7 @@ public class DataplaneSelfRegistrationExtension implements ServiceExtension {
     public void shutdown() {
         if (context.getConfig().getBoolean(SELF_UNREGISTRATION, DEFAULT_SELF_UNREGISTRATION)) {
             dataPlaneSelectorService.unregister(context.getComponentId())
-                    .onSuccess(it -> context.getMonitor().info("data plane successfully unregistered"))
+                    .onSuccess(it -> context.getMonitor().debug("data plane successfully unregistered"))
                     .onFailure(failure -> context.getMonitor().severe("error during data plane de-registration. %s: %s"
                             .formatted(failure.getReason(), failure.getFailureDetail())));
         }

--- a/spi/common/boot-spi/src/main/java/org/eclipse/edc/spi/monitor/ConsoleMonitor.java
+++ b/spi/common/boot-spi/src/main/java/org/eclipse/edc/spi/monitor/ConsoleMonitor.java
@@ -119,7 +119,7 @@ public class ConsoleMonitor implements Monitor {
         }
 
         public static Level getDefaultLevel() {
-            return Level.DEBUG;
+            return Level.INFO;
         }
 
     }


### PR DESCRIPTION
## What this PR changes/adds

Sets `INFO` as default log level when the default `ConsoleMonitor` instance is created.
Switch some `INFO` logs to `DEBUG` (especially in the startup phase).

## Why it does that

log cleanup

## Further notes

- refactored the way monitor extensions are loaded, before was through a static method that duplicated the logic already existing in `ServiceLocator`

## Linked Issue(s)

Closes #4625 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
