### PR TITLE
feat: use new Configuration Injection mechanism everywhere

### DIFF
--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/BootServicesExtension.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/BootServicesExtension.java
@@ -37,13 +37,13 @@ public class BootServicesExtension implements ServiceExtension {
 
     public static final String NAME = "Boot Services";
 
-    @Setting(value = "Configures the participant id this runtime is operating on behalf of")
+    @Setting(description = "Configures the participant id this runtime is operating on behalf of")
     public static final String PARTICIPANT_ID = "edc.participant.id";
 
-    @Setting(value = "Configures the runtime id. This should be fully or partly randomized, and need not be stable across restarts. It is recommended to leave this value blank.", defaultValue = "<random UUID>")
+    @Setting(description = "Configures the runtime id. This should be fully or partly randomized, and need not be stable across restarts. It is recommended to leave this value blank.", defaultValue = "<random UUID>")
     public static final String RUNTIME_ID = "edc.runtime.id";
 
-    @Setting(value = "Configures this component's ID. This should be a unique, stable and deterministic identifier.", defaultValue = "<random UUID>")
+    @Setting(description = "Configures this component's ID. This should be a unique, stable and deterministic identifier.", defaultValue = "<random UUID>")
     public static final String COMPONENT_ID = "edc.component.id";
 
     private HealthCheckServiceImpl healthCheckService;

--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/ConfigurationInjectionPoint.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/ConfigurationInjectionPoint.java
@@ -126,7 +126,7 @@ public class ConfigurationInjectionPoint<T> implements InjectionPoint<T> {
 
         } else { // all other classes MUST have a default constructor.
             try {
-                var pojoClass = Class.forName(configurationObject.getType().getName());
+                var pojoClass = configurationObject.getType();
                 var defaultCtor = pojoClass.getDeclaredConstructor();
                 defaultCtor.setAccessible(true);
                 var instance = defaultCtor.newInstance();
@@ -145,8 +145,7 @@ public class ConfigurationInjectionPoint<T> implements InjectionPoint<T> {
                 return instance;
             } catch (NoSuchMethodException e) {
                 throw new EdcInjectionException("Configuration objects must declare a default constructor, but '%s' does not.".formatted(configurationObject.getType()));
-            } catch (ClassNotFoundException | InstantiationException | IllegalAccessException |
-                     InvocationTargetException e) {
+            } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
                 throw new EdcInjectionException(e);
             }
         }

--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/InjectionPointDefaultServiceSupplier.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/InjectionPointDefaultServiceSupplier.java
@@ -29,7 +29,7 @@ public class InjectionPointDefaultServiceSupplier implements DefaultServiceSuppl
     public @Nullable Object provideFor(InjectionPoint<?> injectionPoint, ServiceExtensionContext context) {
         var defaultService = injectionPoint.getDefaultValueProvider();
         if (injectionPoint.isRequired() && defaultService == null) {
-            throw new EdcInjectionException("No default provider for required service " + injectionPoint.getType());
+            throw new EdcInjectionException("No default provider for required injection point " + injectionPoint);
         }
         return ofNullable(defaultService).map(vp -> vp.get(context)).orElse(null);
     }

--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/ValueInjectionPoint.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/ValueInjectionPoint.java
@@ -192,19 +192,19 @@ public class ValueInjectionPoint<T> implements InjectionPoint<T> {
 
     private Object parseEntry(String string, Class<?> valueType) {
         try {
-            if (valueType == Long.class) {
+            if (valueType == Long.class || valueType == long.class) {
                 return Long.parseLong(string);
             }
-            if (valueType == Integer.class) {
+            if (valueType == Integer.class || valueType == int.class) {
                 return Integer.parseInt(string);
             }
-            if (valueType == Double.class) {
+            if (valueType == Double.class || valueType == double.class) {
                 return Double.parseDouble(string);
             }
         } catch (NumberFormatException e) {
             throw new EdcInjectionException("Config field '%s' is of type '%s', but the value resolved from key '%s' is \"%s\" which cannot be interpreted as %s.".formatted(targetField.getName(), valueType, annotationValue.key(), string, valueType));
         }
-        if (valueType == Boolean.class) {
+        if (valueType == Boolean.class || valueType == boolean.class) {
             return Boolean.parseBoolean(string);
         }
 

--- a/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/CoreDefaultServicesExtension.java
+++ b/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/CoreDefaultServicesExtension.java
@@ -27,10 +27,10 @@ import org.eclipse.edc.connector.core.event.EventExecutorServiceContainer;
 import org.eclipse.edc.http.client.EdcHttpClientImpl;
 import org.eclipse.edc.http.spi.EdcHttpClient;
 import org.eclipse.edc.participant.spi.ParticipantIdMapper;
+import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
-import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
@@ -49,52 +49,16 @@ public class CoreDefaultServicesExtension implements ServiceExtension {
 
     public static final String NAME = "Core Default Services";
 
-    private static final int DEFAULT_RETRY_POLICY_MAX_RETRIES = 5;
-    private static final int DEFAULT_RETRY_POLICY_BACKOFF_MIN_MILLIS = 500;
-    private static final int DEFAULT_RETRY_POLICY_BACKOFF_MAX_MILLIS = 10000;
-    private static final boolean DEFAULT_RETRY_POLICY_LOG_ON_RETRY = false;
-    private static final boolean DEFAULT_RETRY_POLICY_LOG_ON_RETRY_SCHEDULED = false;
-    private static final boolean DEFAULT_RETRY_POLICY_LOG_ON_RETRIES_EXCEEDED = false;
-    private static final boolean DEFAULT_RETRY_POLICY_LOG_ON_FAILED_ATTEMPT = false;
-    private static final boolean DEFAULT_RETRY_POLICY_LOG_ON_ABORT = false;
-    private static final int DEFAULT_OK_HTTP_CLIENT_TIMEOUT_CONNECT = 30;
-    private static final int DEFAULT_OK_HTTP_CLIENT_TIMEOUT_READ = 30;
-    private static final boolean DEFAULT_OK_HTTP_CLIENT_HTTPS_ENFORCE = false;
-    private static final int DEFAULT_OK_HTTP_CLIENT_SEND_BUFFER_SIZE = 0;
-    private static final int DEFAULT_OK_HTTP_CLIENT_RECEIVE_BUFFER_SIZE = 0;
-
-    @Setting(value = "RetryPolicy: Maximum retries before a failure is propagated", defaultValue = DEFAULT_RETRY_POLICY_MAX_RETRIES + "", type = "int")
-    private static final String RETRY_POLICY_MAX_RETRIES = "edc.core.retry.retries.max";
-    @Setting(value = "RetryPolicy: Minimum number of milliseconds for exponential backoff", defaultValue = DEFAULT_RETRY_POLICY_BACKOFF_MIN_MILLIS + "", type = "int")
-    private static final String RETRY_POLICY_BACKOFF_MIN_MILLIS = "edc.core.retry.backoff.min";
-    @Setting(value = "RetryPolicy: Maximum number of milliseconds for exponential backoff", defaultValue = DEFAULT_RETRY_POLICY_BACKOFF_MAX_MILLIS + "", type = "int")
-    private static final String RETRY_POLICY_BACKOFF_MAX_MILLIS = "edc.core.retry.backoff.max";
-    @Setting(value = "RetryPolicy: Log onRetry events", defaultValue = DEFAULT_RETRY_POLICY_LOG_ON_RETRY + "", type = "boolean")
-    private static final String RETRY_POLICY_LOG_ON_RETRY = "edc.core.retry.log.on.retry";
-    @Setting(value = "RetryPolicy: Log onRetryScheduled events", defaultValue = DEFAULT_RETRY_POLICY_LOG_ON_RETRY_SCHEDULED + "", type = "boolean")
-    private static final String RETRY_POLICY_LOG_ON_RETRY_SCHEDULED = "edc.core.retry.log.on.retry.scheduled";
-    @Setting(value = "RetryPolicy: Log onRetriesExceeded events", defaultValue = DEFAULT_RETRY_POLICY_LOG_ON_RETRIES_EXCEEDED + "", type = "boolean")
-    private static final String RETRY_POLICY_LOG_ON_RETRIES_EXCEEDED = "edc.core.retry.log.on.retries.exceeded";
-    @Setting(value = "RetryPolicy: Log onFailedAttempt events", defaultValue = DEFAULT_RETRY_POLICY_LOG_ON_FAILED_ATTEMPT + "", type = "boolean")
-    private static final String RETRY_POLICY_LOG_ON_FAILED_ATTEMPT = "edc.core.retry.log.on.failed.attempt";
-    @Setting(value = "RetryPolicy: Log onAbort events", defaultValue = DEFAULT_RETRY_POLICY_LOG_ON_ABORT + "", type = "boolean")
-    private static final String RETRY_POLICY_LOG_ON_ABORT = "edc.core.retry.log.on.abort";
-    @Setting(value = "OkHttpClient: If true, enable HTTPS call enforcement", defaultValue = DEFAULT_OK_HTTP_CLIENT_HTTPS_ENFORCE + "", type = "boolean")
-    private static final String OK_HTTP_CLIENT_HTTPS_ENFORCE = "edc.http.client.https.enforce";
-    @Setting(value = "OkHttpClient: connect timeout, in seconds", defaultValue = DEFAULT_OK_HTTP_CLIENT_TIMEOUT_CONNECT + "", type = "int")
-    private static final String OK_HTTP_CLIENT_TIMEOUT_CONNECT = "edc.http.client.timeout.connect";
-    @Setting(value = "OkHttpClient: read timeout, in seconds", defaultValue = DEFAULT_OK_HTTP_CLIENT_TIMEOUT_READ + "", type = "int")
-    private static final String OK_HTTP_CLIENT_TIMEOUT_READ = "edc.http.client.timeout.read";
-    @Setting(value = "OkHttpClient: send buffer size, in bytes", defaultValue = DEFAULT_OK_HTTP_CLIENT_SEND_BUFFER_SIZE + "", type = "int", min = 1)
-    private static final String OK_HTTP_CLIENT_SEND_BUFFER_SIZE = "edc.http.client.send.buffer.size";
-    @Setting(value = "OkHttpClient: receive buffer size, in bytes", defaultValue = DEFAULT_OK_HTTP_CLIENT_RECEIVE_BUFFER_SIZE + "", type = "int", min = 1)
-    private static final String OK_HTTP_CLIENT_RECEIVE_BUFFER_SIZE = "edc.http.client.receive.buffer.size";
 
     /**
      * An optional OkHttp {@link EventListener} that can be used to instrument OkHttp client for collecting metrics.
      */
     @Inject(required = false)
     private EventListener okHttpEventListener;
+    @Configuration
+    private OkHttpClientConfiguration configuration;
+    @Configuration
+    private RetryPolicyConfiguration retryPolicyConfiguration;
 
     @Override
     public String name() {
@@ -134,31 +98,13 @@ public class CoreDefaultServicesExtension implements ServiceExtension {
 
     @Provider
     public OkHttpClient okHttpClient(ServiceExtensionContext context) {
-        var configuration = OkHttpClientConfiguration.Builder.newInstance()
-                .enforceHttps(context.getSetting(OK_HTTP_CLIENT_HTTPS_ENFORCE, DEFAULT_OK_HTTP_CLIENT_HTTPS_ENFORCE))
-                .connectTimeout(context.getSetting(OK_HTTP_CLIENT_TIMEOUT_CONNECT, DEFAULT_OK_HTTP_CLIENT_TIMEOUT_CONNECT))
-                .readTimeout(context.getSetting(OK_HTTP_CLIENT_TIMEOUT_READ, DEFAULT_OK_HTTP_CLIENT_TIMEOUT_READ))
-                .sendBufferSize(context.getSetting(OK_HTTP_CLIENT_SEND_BUFFER_SIZE, DEFAULT_OK_HTTP_CLIENT_SEND_BUFFER_SIZE))
-                .receiveBufferSize(context.getSetting(OK_HTTP_CLIENT_RECEIVE_BUFFER_SIZE, DEFAULT_OK_HTTP_CLIENT_RECEIVE_BUFFER_SIZE))
-                .build();
-
         return OkHttpClientFactory.create(configuration, okHttpEventListener, context.getMonitor());
     }
 
     @Provider
     public <T> RetryPolicy<T> retryPolicy(ServiceExtensionContext context) {
-        var configuration = RetryPolicyConfiguration.Builder.newInstance()
-                .maxRetries(context.getSetting(RETRY_POLICY_MAX_RETRIES, DEFAULT_RETRY_POLICY_MAX_RETRIES))
-                .minBackoff(context.getSetting(RETRY_POLICY_BACKOFF_MIN_MILLIS, DEFAULT_RETRY_POLICY_BACKOFF_MIN_MILLIS))
-                .maxBackoff(context.getSetting(RETRY_POLICY_BACKOFF_MAX_MILLIS, DEFAULT_RETRY_POLICY_BACKOFF_MAX_MILLIS))
-                .logOnRetry(context.getSetting(RETRY_POLICY_LOG_ON_RETRY, DEFAULT_RETRY_POLICY_LOG_ON_RETRY))
-                .logOnRetryScheduled(context.getSetting(RETRY_POLICY_LOG_ON_RETRY_SCHEDULED, DEFAULT_RETRY_POLICY_LOG_ON_RETRY_SCHEDULED))
-                .logOnRetriesExceeded(context.getSetting(RETRY_POLICY_LOG_ON_RETRIES_EXCEEDED, DEFAULT_RETRY_POLICY_LOG_ON_RETRIES_EXCEEDED))
-                .logOnFailedAttempt(context.getSetting(RETRY_POLICY_LOG_ON_FAILED_ATTEMPT, DEFAULT_RETRY_POLICY_LOG_ON_FAILED_ATTEMPT))
-                .logOnAbort(context.getSetting(RETRY_POLICY_LOG_ON_ABORT, DEFAULT_RETRY_POLICY_LOG_ON_ABORT))
-                .build();
 
-        return RetryPolicyFactory.create(configuration, context.getMonitor());
+        return RetryPolicyFactory.create(retryPolicyConfiguration, context.getMonitor());
     }
 
     @Provider(isDefault = true)

--- a/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/base/OkHttpClientConfiguration.java
+++ b/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/base/OkHttpClientConfiguration.java
@@ -14,15 +14,30 @@
 
 package org.eclipse.edc.connector.core.base;
 
-public class OkHttpClientConfiguration {
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.runtime.metamodel.annotation.Settings;
 
+@Settings
+public class OkHttpClientConfiguration {
+    public static final boolean DEFAULT_OK_HTTP_CLIENT_HTTPS_ENFORCE = false;
+    public static final int DEFAULT_OK_HTTP_CLIENT_TIMEOUT_CONNECT = 30;
+    public static final int DEFAULT_OK_HTTP_CLIENT_TIMEOUT_READ = 30;
+    public static final int DEFAULT_OK_HTTP_CLIENT_SEND_BUFFER_SIZE = 0;
+    public static final int DEFAULT_OK_HTTP_CLIENT_RECEIVE_BUFFER_SIZE = 0;
+
+    @Setting(description = "OkHttpClient: If true, enable HTTPS call enforcement", defaultValue = DEFAULT_OK_HTTP_CLIENT_HTTPS_ENFORCE + "", key = "edc.http.client.https.enforce")
     private boolean enforceHttps;
+
+    @Setting(description = "OkHttpClient: connect timeout, in seconds", defaultValue = DEFAULT_OK_HTTP_CLIENT_TIMEOUT_CONNECT + "", key = "edc.http.client.timeout.connect")
     private int connectTimeout;
+    @Setting(description = "OkHttpClient: read timeout, in seconds", defaultValue = DEFAULT_OK_HTTP_CLIENT_TIMEOUT_READ + "", key = "edc.http.client.timeout.read")
     private int readTimeout;
+    @Setting(description = "OkHttpClient: send buffer size, in bytes", defaultValue = DEFAULT_OK_HTTP_CLIENT_SEND_BUFFER_SIZE + "", key = "edc.http.client.send.buffer.size", min = 1)
     private int sendBufferSize;
+    @Setting(description = "OkHttpClient: receive buffer size, in bytes", defaultValue = DEFAULT_OK_HTTP_CLIENT_RECEIVE_BUFFER_SIZE + "", key = "edc.http.client.receive.buffer.size", min = 1)
     private int receiveBufferSize;
 
-    private OkHttpClientConfiguration() {
+    public OkHttpClientConfiguration() {
     }
 
     public boolean isEnforceHttps() {
@@ -45,15 +60,20 @@ public class OkHttpClientConfiguration {
         return receiveBufferSize;
     }
 
+    public Builder toBuilder() {
+        return new Builder(this);
+    }
+
     public static class Builder {
 
-        private final OkHttpClientConfiguration instance = new OkHttpClientConfiguration();
+        private final OkHttpClientConfiguration instance;
 
-        public static Builder newInstance() {
-            return new Builder();
+        private Builder(OkHttpClientConfiguration okHttpClientConfiguration) {
+            this.instance = okHttpClientConfiguration;
         }
 
-        private Builder() {
+        public static Builder newInstance() {
+            return new Builder(new OkHttpClientConfiguration());
         }
 
         public Builder enforceHttps(boolean enforceHttps) {
@@ -85,4 +105,5 @@ public class OkHttpClientConfiguration {
             return instance;
         }
     }
+
 }

--- a/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/base/RetryPolicyConfiguration.java
+++ b/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/base/RetryPolicyConfiguration.java
@@ -14,18 +14,38 @@
 
 package org.eclipse.edc.connector.core.base;
 
-public class RetryPolicyConfiguration {
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.runtime.metamodel.annotation.Settings;
 
+@Settings
+public class RetryPolicyConfiguration {
+    public static final int DEFAULT_RETRY_POLICY_MAX_RETRIES = 5;
+    public static final int DEFAULT_RETRY_POLICY_BACKOFF_MIN_MILLIS = 500;
+    public static final int DEFAULT_RETRY_POLICY_BACKOFF_MAX_MILLIS = 10000;
+    public static final boolean DEFAULT_RETRY_POLICY_LOG_ON_RETRY = false;
+    public static final boolean DEFAULT_RETRY_POLICY_LOG_ON_RETRY_SCHEDULED = false;
+    public static final boolean DEFAULT_RETRY_POLICY_LOG_ON_RETRIES_EXCEEDED = false;
+    public static final boolean DEFAULT_RETRY_POLICY_LOG_ON_FAILED_ATTEMPT = false;
+    public static final boolean DEFAULT_RETRY_POLICY_LOG_ON_ABORT = false;
+
+    @Setting(description = "RetryPolicy: Maximum retries before a failure is propagated", defaultValue = DEFAULT_RETRY_POLICY_MAX_RETRIES + "", key = "edc.core.retry.retries.max")
     private int maxRetries;
+    @Setting(description = "RetryPolicy: Minimum number of milliseconds for exponential backoff", defaultValue = DEFAULT_RETRY_POLICY_BACKOFF_MIN_MILLIS + "", key = "edc.core.retry.backoff.min")
     private int minBackoff = 1;
+    @Setting(description = "RetryPolicy: Maximum number of milliseconds for exponential backoff", defaultValue = DEFAULT_RETRY_POLICY_BACKOFF_MAX_MILLIS + "", key = "edc.core.retry.backoff.max")
     private int maxBackoff = Integer.MAX_VALUE;
+    @Setting(description = "RetryPolicy: Log onRetry events", defaultValue = DEFAULT_RETRY_POLICY_LOG_ON_RETRY + "", key = "edc.core.retry.log.on.retry")
     private boolean logOnRetry;
+    @Setting(description = "RetryPolicy: Log onRetryScheduled events", defaultValue = DEFAULT_RETRY_POLICY_LOG_ON_RETRY_SCHEDULED + "", key = "edc.core.retry.log.on.retry.scheduled")
     private boolean logOnRetryScheduled;
+    @Setting(description = "RetryPolicy: Log onRetriesExceeded events", defaultValue = DEFAULT_RETRY_POLICY_LOG_ON_RETRIES_EXCEEDED + "", key = "edc.core.retry.log.on.retries.exceeded")
     private boolean logOnRetriesExceeded;
+    @Setting(description = "RetryPolicy: Log onFailedAttempt events", defaultValue = DEFAULT_RETRY_POLICY_LOG_ON_FAILED_ATTEMPT + "", key = "edc.core.retry.log.on.failed.attempt")
     private boolean logOnFailedAttempt;
+    @Setting(description = "RetryPolicy: Log onAbort events", defaultValue = DEFAULT_RETRY_POLICY_LOG_ON_ABORT + "", key = "edc.core.retry.log.on.abort")
     private boolean logOnAbort;
 
-    private RetryPolicyConfiguration() {
+    public RetryPolicyConfiguration() {
     }
 
     public int getMaxRetries() {
@@ -60,15 +80,20 @@ public class RetryPolicyConfiguration {
         return logOnAbort;
     }
 
+    public Builder toBuilder() {
+        return new Builder(this);
+    }
+
     public static class Builder {
 
-        private final RetryPolicyConfiguration instance = new RetryPolicyConfiguration();
+        private final RetryPolicyConfiguration instance;
 
-        public static Builder newInstance() {
-            return new Builder();
+        private Builder(RetryPolicyConfiguration instance) {
+            this.instance = instance;
         }
 
-        private Builder() {
+        public static Builder newInstance() {
+            return new Builder(new RetryPolicyConfiguration());
         }
 
         public Builder maxRetries(int maxRetries) {

--- a/core/common/connector-core/src/test/java/org/eclipse/edc/connector/core/base/OkHttpClientFactoryTest.java
+++ b/core/common/connector-core/src/test/java/org/eclipse/edc/connector/core/base/OkHttpClientFactoryTest.java
@@ -37,6 +37,7 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class OkHttpClientFactoryTest {
 
@@ -47,7 +48,7 @@ class OkHttpClientFactoryTest {
 
     @Test
     void shouldPrintLogIfHttpsNotEnforced() {
-        var configuration = OkHttpClientConfiguration.Builder.newInstance().build();
+        var configuration = mock(OkHttpClientConfiguration.class);
 
         var okHttpClient = OkHttpClientFactory.create(configuration, eventListener, monitor)
                 .newBuilder().addInterceptor(dummySuccessfulResponse())
@@ -60,7 +61,8 @@ class OkHttpClientFactoryTest {
 
     @Test
     void shouldEnforceHttpsCalls() {
-        var configuration = OkHttpClientConfiguration.Builder.newInstance().enforceHttps(true).build();
+        var configuration = mock(OkHttpClientConfiguration.class);
+        when(configuration.isEnforceHttps()).thenReturn(true);
 
         var okHttpClient = OkHttpClientFactory.create(configuration, eventListener, monitor)
                 .newBuilder().addInterceptor(dummySuccessfulResponse())
@@ -73,10 +75,9 @@ class OkHttpClientFactoryTest {
 
     @Test
     void shouldCreateCustomSocketFactory_whenSendSocketBufferIsSet() {
-        var configuration = OkHttpClientConfiguration.Builder.newInstance()
-                .sendBufferSize(4096)
-                .receiveBufferSize(4096)
-                .build();
+        var configuration = mock(OkHttpClientConfiguration.class);
+        when(configuration.getSendBufferSize()).thenReturn(4096);
+        when(configuration.getReceiveBufferSize()).thenReturn(4096);
 
         var okHttpClient = OkHttpClientFactory.create(configuration, eventListener, monitor)
                 .newBuilder()

--- a/core/common/edr-store-core/src/main/java/org/eclipse/edc/edr/store/EndpointDataReferenceStoreDefaultServicesExtension.java
+++ b/core/common/edr-store-core/src/main/java/org/eclipse/edc/edr/store/EndpointDataReferenceStoreDefaultServicesExtension.java
@@ -25,15 +25,13 @@ import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.query.CriterionOperatorRegistry;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.system.ServiceExtension;
-import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 
-@Extension(EndpointDataReferenceStoreExtension.NAME)
+@Extension(EndpointDataReferenceStoreDefaultServicesExtension.NAME)
 public class EndpointDataReferenceStoreDefaultServicesExtension implements ServiceExtension {
 
-    public static final String DEFAULT_EDR_VAULT_PATH = "";
-    @Setting(value = "Directory/Path where to store EDRs in the vault for vaults that supports hierarchical structuring.", defaultValue = DEFAULT_EDR_VAULT_PATH)
-    public static final String EDC_EDR_VAULT_PATH = "edc.edr.vault.path";
+    @Setting(description = "Directory/Path where to store EDRs in the vault for vaults that supports hierarchical structuring.", key = "edc.edr.vault.path", required = false)
+    private String vaultPath = "";
     protected static final String NAME = "Endpoint Data Reference Core Default Services Extension";
 
     @Inject
@@ -47,9 +45,13 @@ public class EndpointDataReferenceStoreDefaultServicesExtension implements Servi
 
 
     @Provider(isDefault = true)
-    public EndpointDataReferenceCache endpointDataReferenceCache(ServiceExtensionContext context) {
-        var vaultDirectory = context.getConfig().getString(EDC_EDR_VAULT_PATH, DEFAULT_EDR_VAULT_PATH);
-        return new VaultEndpointDataReferenceCache(vault, vaultDirectory, typeManager.getMapper());
+    public EndpointDataReferenceCache endpointDataReferenceCache() {
+        return new VaultEndpointDataReferenceCache(vault, vaultPath, typeManager.getMapper());
+    }
+
+    @Override
+    public String name() {
+        return NAME;
     }
 
     @Provider(isDefault = true)

--- a/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/DependencyInjectionExtension.java
+++ b/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/DependencyInjectionExtension.java
@@ -58,7 +58,9 @@ public class DependencyInjectionExtension extends BaseRuntime implements BeforeE
                         .orElseGet(() -> {
                             if (ip instanceof ServiceInjectionPoint<?>) {
                                 return mock(ip.getType());
-                            } else return ip.resolve(context, (t, ctx) -> null);
+                            } else {
+                                return ip.resolve(context, (t, ctx) -> null);
+                            }
                         })),
                 new InjectionPointScanner(),
                 context

--- a/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/DependencyInjectionExtension.java
+++ b/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/DependencyInjectionExtension.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.junit.extensions;
 import org.eclipse.edc.boot.system.injection.InjectionPointScanner;
 import org.eclipse.edc.boot.system.injection.InjectorImpl;
 import org.eclipse.edc.boot.system.injection.ObjectFactory;
+import org.eclipse.edc.boot.system.injection.ServiceInjectionPoint;
 import org.eclipse.edc.boot.system.runtime.BaseRuntime;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
@@ -52,7 +53,13 @@ public class DependencyInjectionExtension extends BaseRuntime implements BeforeE
         context = spy(super.createServiceExtensionContext(ConfigFactory.empty()));
         context.initialize();
         factory = new ReflectiveObjectFactory(
-                new InjectorImpl((ip, c) -> ofNullable(ip.getDefaultValueProvider()).map(vp -> vp.get(c)).orElseGet(() -> mock(ip.getType()))),
+                new InjectorImpl((ip, c) -> ofNullable(ip.getDefaultValueProvider())
+                        .map(vp -> vp.get(c))
+                        .orElseGet(() -> {
+                            if (ip instanceof ServiceInjectionPoint<?>) {
+                                return mock(ip.getType());
+                            } else return ip.resolve(context, (t, ctx) -> null);
+                        })),
                 new InjectionPointScanner(),
                 context
         );

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
@@ -100,7 +100,7 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
 
     public static final String NAME = "Control Plane Services";
 
-    @Setting(key = "edc.policy.validation.enabled", description = "If true enables the policy validation when creating and updating policy definitions", defaultValue = "false")
+    @Setting(description = "If true enables the policy validation when creating and updating policy definitions", defaultValue = "false", key = "edc.policy.validation.enabled")
     private Boolean validatePolicy;
 
     @Inject

--- a/core/data-plane-selector/data-plane-selector-core/src/main/java/org/eclipse/edc/connector/dataplane/selector/DataPlaneSelectorExtension.java
+++ b/core/data-plane-selector/data-plane-selector-core/src/main/java/org/eclipse/edc/connector/dataplane/selector/DataPlaneSelectorExtension.java
@@ -43,14 +43,14 @@ public class DataPlaneSelectorExtension implements ServiceExtension {
 
     private static final int DEFAULT_CHECK_PERIOD = 60;
 
-    @Setting(value = "the iteration wait time in milliseconds in the data plane selector state machine.", defaultValue = DEFAULT_ITERATION_WAIT + "", type = "long")
-    private static final String DATA_PLANE_SELECTOR_STATE_MACHINE_ITERATION_WAIT_MILLIS = "edc.data.plane.selector.state-machine.iteration-wait-millis";
+    @Setting(description = "the iteration wait time in milliseconds in the data plane selector state machine.", defaultValue = DEFAULT_ITERATION_WAIT + "", key = "edc.data.plane.selector.state-machine.iteration-wait-millis")
+    private Long stateMachineIterationWait;
 
-    @Setting(value = "the batch size in the data plane selector state machine.", defaultValue = DEFAULT_BATCH_SIZE + "", type = "int")
-    private static final String DATA_PLANE_SELECTOR_STATE_MACHINE_BATCH_SIZE = "edc.data.plane.selector.state-machine.batch-size";
+    @Setting(description = "the batch size in the data plane selector state machine.", defaultValue = DEFAULT_BATCH_SIZE + "", key = "edc.data.plane.selector.state-machine.batch-size")
+    private int stateMachineBatchSize;
 
-    @Setting(value = "the check period for data plane availability, in seconds", defaultValue = DEFAULT_CHECK_PERIOD + "", type = "int")
-    private static final String DATA_PLANE_SELECTOR_CHECK_PERIOD = "edc.data.plane.selector.state-machine.check.period";
+    @Setting(description = "the check period for data plane availability, in seconds", defaultValue = DEFAULT_CHECK_PERIOD + "", key = "edc.data.plane.selector.state-machine.check.period")
+    private int selectorCheckPeriod;
 
     @Inject
     private DataPlaneInstanceStore instanceStore;
@@ -70,14 +70,11 @@ public class DataPlaneSelectorExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var config = context.getConfig();
-        var iterationWait = config.getLong(DATA_PLANE_SELECTOR_STATE_MACHINE_ITERATION_WAIT_MILLIS, DEFAULT_ITERATION_WAIT);
-        var checkPeriod = config.getInteger(DATA_PLANE_SELECTOR_CHECK_PERIOD, DEFAULT_CHECK_PERIOD);
 
         var configuration = new DataPlaneSelectorManagerConfiguration(
-                new ExponentialWaitStrategy(iterationWait),
-                config.getInteger(DATA_PLANE_SELECTOR_STATE_MACHINE_BATCH_SIZE, DEFAULT_BATCH_SIZE),
-                Duration.ofSeconds(checkPeriod)
+                new ExponentialWaitStrategy(stateMachineIterationWait),
+                stateMachineBatchSize,
+                Duration.ofSeconds(selectorCheckPeriod)
         );
 
         manager = DataPlaneSelectorManagerImpl.Builder.newInstance()

--- a/core/data-plane-selector/data-plane-selector-core/src/main/java/org/eclipse/edc/connector/dataplane/selector/DataPlaneSelectorExtension.java
+++ b/core/data-plane-selector/data-plane-selector-core/src/main/java/org/eclipse/edc/connector/dataplane/selector/DataPlaneSelectorExtension.java
@@ -44,7 +44,7 @@ public class DataPlaneSelectorExtension implements ServiceExtension {
     private static final int DEFAULT_CHECK_PERIOD = 60;
 
     @Setting(description = "the iteration wait time in milliseconds in the data plane selector state machine.", defaultValue = DEFAULT_ITERATION_WAIT + "", key = "edc.data.plane.selector.state-machine.iteration-wait-millis")
-    private Long stateMachineIterationWait;
+    private long stateMachineIterationWait;
 
     @Setting(description = "the batch size in the data plane selector state machine.", defaultValue = DEFAULT_BATCH_SIZE + "", key = "edc.data.plane.selector.state-machine.batch-size")
     private int stateMachineBatchSize;

--- a/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/PolicyMonitorExtension.java
+++ b/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/PolicyMonitorExtension.java
@@ -52,7 +52,8 @@ public class PolicyMonitorExtension implements ServiceExtension {
 
     public static final String NAME = "Policy Monitor";
 
-    @Setting(description = "the iteration wait time in milliseconds in the policy monitor state machine. Default value " + DEFAULT_ITERATION_WAIT, key = "edc.policy.monitor.state-machine.iteration-wait-millis", defaultValue = DEFAULT_ITERATION_WAIT + "")
+    @Setting(description = "the iteration wait time in milliseconds in the policy monitor state machine. Default value " + DEFAULT_ITERATION_WAIT,
+            key = "edc.policy.monitor.state-machine.iteration-wait-millis", defaultValue = DEFAULT_ITERATION_WAIT + "")
     private long iterationWaitMillis;
 
     @Setting(description = "the batch size in the policy monitor state machine. Default value " + DEFAULT_BATCH_SIZE, key = "edc.policy.monitor.state-machine.batch-size", defaultValue = DEFAULT_BATCH_SIZE + "")

--- a/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/PolicyMonitorExtension.java
+++ b/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/PolicyMonitorExtension.java
@@ -52,11 +52,11 @@ public class PolicyMonitorExtension implements ServiceExtension {
 
     public static final String NAME = "Policy Monitor";
 
-    @Setting(value = "the iteration wait time in milliseconds in the policy monitor state machine. Default value " + DEFAULT_ITERATION_WAIT, type = "long")
-    private static final String POLICY_MONITOR_ITERATION_WAIT_MILLIS = "edc.policy.monitor.state-machine.iteration-wait-millis";
+    @Setting(description = "the iteration wait time in milliseconds in the policy monitor state machine. Default value " + DEFAULT_ITERATION_WAIT, key = "edc.policy.monitor.state-machine.iteration-wait-millis", defaultValue = DEFAULT_ITERATION_WAIT + "")
+    private long iterationWaitMillis;
 
-    @Setting(value = "the batch size in the policy monitor state machine. Default value " + DEFAULT_BATCH_SIZE, type = "int")
-    private static final String POLICY_MONITOR_BATCH_SIZE = "edc.policy.monitor.state-machine.batch-size";
+    @Setting(description = "the batch size in the policy monitor state machine. Default value " + DEFAULT_BATCH_SIZE, key = "edc.policy.monitor.state-machine.batch-size", defaultValue = DEFAULT_BATCH_SIZE + "")
+    private int batchSize;
 
     @Inject
     private ExecutorInstrumentation executorInstrumentation;
@@ -89,7 +89,6 @@ public class PolicyMonitorExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var iterationWaitMillis = context.getSetting(POLICY_MONITOR_ITERATION_WAIT_MILLIS, DEFAULT_ITERATION_WAIT);
         var waitStrategy = new ExponentialWaitStrategy(iterationWaitMillis);
 
         policyEngine.registerScope(POLICY_MONITOR_SCOPE, PolicyMonitorContext.class);
@@ -99,7 +98,7 @@ public class PolicyMonitorExtension implements ServiceExtension {
 
         manager = PolicyMonitorManagerImpl.Builder.newInstance()
                 .clock(clock)
-                .batchSize(context.getSetting(POLICY_MONITOR_BATCH_SIZE, DEFAULT_BATCH_SIZE))
+                .batchSize(batchSize)
                 .waitStrategy(waitStrategy)
                 .executorInstrumentation(executorInstrumentation)
                 .monitor(context.getMonitor())

--- a/data-protocols/dsp/dsp-http-api-configuration/src/main/java/org/eclipse/edc/protocol/dsp/http/api/configuration/DspApiConfigurationExtension.java
+++ b/data-protocols/dsp/dsp-http-api-configuration/src/main/java/org/eclipse/edc/protocol/dsp/http/api/configuration/DspApiConfigurationExtension.java
@@ -54,6 +54,7 @@ import org.eclipse.edc.web.spi.configuration.WebServiceSettings;
 import java.util.Map;
 
 import static java.lang.String.format;
+import static java.util.Optional.ofNullable;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
 import static org.eclipse.edc.jsonld.spi.Namespaces.DCAT_PREFIX;
 import static org.eclipse.edc.jsonld.spi.Namespaces.DCAT_SCHEMA;
@@ -81,9 +82,9 @@ public class DspApiConfigurationExtension implements ServiceExtension {
 
     public static final String NAME = "Dataspace Protocol API Configuration Extension";
 
-    @Setting(value = "Configures endpoint for reaching the Protocol API.", defaultValue = "<hostname:protocol.port/protocol.path>")
-    public static final String DSP_CALLBACK_ADDRESS = "edc.dsp.callback.address";
-    
+    @Setting(description = "Configures endpoint for reaching the Protocol API in the form \"<hostname:protocol.port/protocol.path>\"", key = "edc.dsp.callback.address", required = false)
+    private String callbackAddress;
+
     @SettingContext("Protocol API context setting key")
     private static final String PROTOCOL_CONFIG_KEY = "web.http." + ApiContext.PROTOCOL;
 
@@ -121,7 +122,9 @@ public class DspApiConfigurationExtension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
         var contextConfig = context.getConfig(PROTOCOL_CONFIG_KEY);
         var apiConfiguration = configurator.configure(contextConfig, webServer, SETTINGS);
-        var dspWebhookAddress = context.getSetting(DSP_CALLBACK_ADDRESS, format("http://%s:%s%s", hostname.get(), apiConfiguration.getPort(), apiConfiguration.getPath()));
+        var dspWebhookAddress = ofNullable(callbackAddress).orElseGet(() -> format("http://%s:%s%s", hostname.get(), apiConfiguration.getPort(), apiConfiguration.getPath()));
+
+
         context.registerService(ProtocolWebhook.class, () -> dspWebhookAddress);
 
         var jsonLdMapper = typeManager.getMapper(JSON_LD);

--- a/data-protocols/dsp/dsp-http-api-configuration/src/test/java/org/eclipse/edc/protocol/dsp/http/api/configuration/DspApiConfigurationExtensionTest.java
+++ b/data-protocols/dsp/dsp-http-api-configuration/src/test/java/org/eclipse/edc/protocol/dsp/http/api/configuration/DspApiConfigurationExtensionTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.protocol.dsp.http.api.configuration;
 
+import org.eclipse.edc.boot.system.injection.ObjectFactory;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.protocol.ProtocolWebhook;
@@ -45,7 +46,6 @@ import static org.eclipse.edc.jsonld.spi.Namespaces.DCT_PREFIX;
 import static org.eclipse.edc.jsonld.spi.Namespaces.DCT_SCHEMA;
 import static org.eclipse.edc.policy.model.OdrlNamespace.ODRL_PREFIX;
 import static org.eclipse.edc.policy.model.OdrlNamespace.ODRL_SCHEMA;
-import static org.eclipse.edc.protocol.dsp.http.api.configuration.DspApiConfigurationExtension.DSP_CALLBACK_ADDRESS;
 import static org.eclipse.edc.protocol.dsp.http.api.configuration.DspApiConfigurationExtension.SETTINGS;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_SCOPE_V_08;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_SCOPE_V_2024_1;
@@ -99,13 +99,14 @@ class DspApiConfigurationExtensionTest {
     }
 
     @Test
-    void shouldUseConfiguredProtocolWebhook(DspApiConfigurationExtension extension, ServiceExtensionContext context) {
+    void shouldUseConfiguredProtocolWebhook(ServiceExtensionContext context, ObjectFactory factory) {
         var webhookAddress = "http://webhook";
         when(context.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of(
                 "web.http.protocol.port", String.valueOf(1234),
-                "web.http.protocol.path", "/path"))
+                "web.http.protocol.path", "/path",
+                "edc.dsp.callback.address", webhookAddress))
         );
-        when(context.getSetting(eq(DSP_CALLBACK_ADDRESS), any())).thenReturn(webhookAddress);
+        var extension = factory.constructInstance(DspApiConfigurationExtension.class);
 
         extension.initialize(context);
 

--- a/extensions/common/api/control-api-configuration/src/main/java/org/eclipse/edc/connector/api/control/configuration/ControlApiConfigurationExtension.java
+++ b/extensions/common/api/control-api-configuration/src/main/java/org/eclipse/edc/connector/api/control/configuration/ControlApiConfigurationExtension.java
@@ -45,6 +45,7 @@ import java.net.URI;
 import java.util.stream.Stream;
 
 import static java.lang.String.format;
+import static java.util.Optional.ofNullable;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
 import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_PREFIX;
 import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
@@ -64,8 +65,8 @@ public class ControlApiConfigurationExtension implements ServiceExtension {
 
     public static final String NAME = "Control API configuration";
 
-    @Setting(value = "Configures endpoint for reaching the Control API. If it's missing it defaults to the hostname configuration.")
-    public static final String CONTROL_API_ENDPOINT = "edc.control.endpoint";
+    @Setting(description = "Configures endpoint for reaching the Control API. If it's missing it defaults to the hostname configuration.", key = "edc.control.endpoint", required = false)
+    private String controlEndpoint;
     public static final String CONTROL_SCOPE = "CONTROL_API";
     private static final String WEB_SERVICE_NAME = "Control API";
     @SettingContext("Control API context setting key")
@@ -138,7 +139,8 @@ public class ControlApiConfigurationExtension implements ServiceExtension {
     }
 
     private ControlApiUrl controlApiUrl(ServiceExtensionContext context, WebServiceConfiguration config) {
-        var callbackAddress = context.getSetting(CONTROL_API_ENDPOINT, format("http://%s:%s%s", hostname.get(), config.getPort(), config.getPath()));
+        var callbackAddress = ofNullable(controlEndpoint).orElseGet(() -> format("http://%s:%s%s", hostname.get(), config.getPort(), config.getPath()));
+        
         try {
             var url = URI.create(callbackAddress);
             return () -> url;

--- a/extensions/common/api/management-api-configuration/src/test/java/org/eclipse/edc/connector/api/management/configuration/ManagementApiConfigurationExtensionTest.java
+++ b/extensions/common/api/management-api-configuration/src/test/java/org/eclipse/edc/connector/api/management/configuration/ManagementApiConfigurationExtensionTest.java
@@ -95,12 +95,13 @@ class ManagementApiConfigurationExtensionTest {
     }
 
     @Test
-    void initialize_WithContextEnabled() {
-        var context = contextWithConfig(ConfigFactory.fromMap(Map.of("edc.management.context.enabled", "true")));
+    void initialize_withContextEnabled(ObjectFactory factory, ServiceExtensionContext context) {
+        when(context.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of("edc.management.context.enabled", "true")));
+        
         var configuration = WebServiceConfiguration.Builder.newInstance().path("/path").port(1234).build();
         when(configurer.configure(any(), any(), any())).thenReturn(configuration);
 
-        extension.initialize(context);
+        factory.constructInstance(ManagementApiConfigurationExtension.class).initialize(context);
 
         verify(jsonLd, times(0)).registerNamespace(any(), any(), any());
         verify(jsonLd).registerContext(EDC_CONNECTOR_MANAGEMENT_CONTEXT, MANAGEMENT_SCOPE);

--- a/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-accounts-api/src/main/java/org/eclipse/edc/api/iam/identitytrust/sts/accounts/StsAccountsApiExtension.java
+++ b/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-accounts-api/src/main/java/org/eclipse/edc/api/iam/identitytrust/sts/accounts/StsAccountsApiExtension.java
@@ -36,8 +36,8 @@ public class StsAccountsApiExtension implements ServiceExtension {
     public static final String NAME = "Secure Token Service Accounts API Extension";
     public static final String STS_ACCOUNTS_API_CONTEXT = "sts-accounts-api";
 
-    @Setting(value = "API key (or Vault alias) for the STS Accounts API's default authentication mechanism (token-based).")
-    public static final String STS_ACCOUNTS_API_KEY = "edc.api.accounts.key";
+    @Setting(description = "API key (or Vault alias) for the STS Accounts API's default authentication mechanism (token-based).", key = "edc.api.accounts.key")
+    private String accountsApiKeyOrAlias;
 
     @Inject
     private StsAccountService clientService;
@@ -68,8 +68,7 @@ public class StsAccountsApiExtension implements ServiceExtension {
     }
 
     private String resolveApiKey(ServiceExtensionContext context) {
-        var keyOrAlias = context.getConfig().getString(STS_ACCOUNTS_API_KEY);
-        return ofNullable(vault.resolveSecret(keyOrAlias))
-                .orElse(keyOrAlias);
+        return ofNullable(vault.resolveSecret(accountsApiKeyOrAlias))
+                .orElse(accountsApiKeyOrAlias);
     }
 }

--- a/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-accounts-api/src/test/java/org/eclipse/edc/api/iam/identitytrust/sts/accounts/StsAccountsApiExtensionTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-accounts-api/src/test/java/org/eclipse/edc/api/iam/identitytrust/sts/accounts/StsAccountsApiExtensionTest.java
@@ -22,13 +22,15 @@ import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.configuration.Config;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.eclipse.edc.web.spi.WebService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.util.Map;
+
 import static org.eclipse.edc.api.iam.identitytrust.sts.accounts.StsAccountsApiExtension.STS_ACCOUNTS_API_CONTEXT;
-import static org.eclipse.edc.api.iam.identitytrust.sts.accounts.StsAccountsApiExtension.STS_ACCOUNTS_API_KEY;
 import static org.eclipse.edc.web.spi.configuration.ApiContext.STS_ACCOUNTS;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
@@ -40,6 +42,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(DependencyInjectionExtension.class)
 class StsAccountsApiExtensionTest {
 
+    private static final String STS_ACCOUNTS_API_KEY = "edc.api.accounts.key";
     private final ApiAuthenticationRegistry apiAuthenticationRegistry = mock();
     private final WebService webService = mock();
     private final Vault vault = mock();
@@ -49,6 +52,9 @@ class StsAccountsApiExtensionTest {
         context.registerService(ApiAuthenticationRegistry.class, apiAuthenticationRegistry);
         context.registerService(WebService.class, webService);
         context.registerService(Vault.class, vault);
+
+        var config = ConfigFactory.fromMap(Map.of(STS_ACCOUNTS_API_KEY, "test-api-key"));
+        when(context.getConfig()).thenReturn(config);
     }
 
     @Test
@@ -69,10 +75,7 @@ class StsAccountsApiExtensionTest {
 
     @Test
     void initialize_noAuthServicePresent_withApiKeyInConfig(StsAccountsApiExtension extension, ServiceExtensionContext context) {
-        var config = mock(Config.class);
-        when(config.getString(eq(STS_ACCOUNTS_API_KEY)))
-                .thenReturn("test-api-key");
-        when(context.getConfig()).thenReturn(config);
+
         when(apiAuthenticationRegistry.hasService(eq(STS_ACCOUNTS_API_CONTEXT))).thenReturn(false);
 
         extension.initialize(context);
@@ -85,10 +88,6 @@ class StsAccountsApiExtensionTest {
 
     @Test
     void initialize_otherAuthServicePresent_withApiKeyInConfig(StsAccountsApiExtension extension, ServiceExtensionContext context) {
-        var config = mock(Config.class);
-        when(config.getString(eq(STS_ACCOUNTS_API_KEY)))
-                .thenReturn("test-api-key");
-        when(context.getConfig()).thenReturn(config);
         when(apiAuthenticationRegistry.hasService(eq(STS_ACCOUNTS_API_CONTEXT))).thenReturn(true);
 
         extension.initialize(context);

--- a/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-core/src/main/java/org/eclipse/edc/iam/identitytrust/sts/defaults/StsDefaultServicesExtension.java
+++ b/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-core/src/main/java/org/eclipse/edc/iam/identitytrust/sts/defaults/StsDefaultServicesExtension.java
@@ -43,8 +43,8 @@ public class StsDefaultServicesExtension implements ServiceExtension {
 
     public static final String NAME = "Secure Token Service Default Services";
 
-    @Setting(value = "Self-issued ID Token expiration in minutes. By default is 5 minutes", defaultValue = "" + StsDefaultServicesExtension.DEFAULT_STS_TOKEN_EXPIRATION_MIN)
-    private static final String STS_TOKEN_EXPIRATION = "edc.iam.sts.token.expiration"; // in minutes
+    @Setting(description = "Self-issued ID Token expiration in minutes. By default is 5 minutes", defaultValue = "" + StsDefaultServicesExtension.DEFAULT_STS_TOKEN_EXPIRATION_MIN, key = "edc.iam.sts.token.expiration")
+    private int tokenExpirationMinutes;
 
     private static final int DEFAULT_STS_TOKEN_EXPIRATION_MIN = 5;
 
@@ -75,12 +75,11 @@ public class StsDefaultServicesExtension implements ServiceExtension {
 
     @Provider
     public StsClientTokenGeneratorService clientTokenService(ServiceExtensionContext context) {
-        var tokenExpiration = context.getSetting(STS_TOKEN_EXPIRATION, DEFAULT_STS_TOKEN_EXPIRATION_MIN);
         return new StsClientTokenGeneratorServiceImpl(
                 (client) -> new JwtGenerationService(jwsSignerProvider),
                 StsAccount::getPrivateKeyAlias,
                 clock,
-                TimeUnit.MINUTES.toSeconds(tokenExpiration),
+                TimeUnit.MINUTES.toSeconds(tokenExpirationMinutes),
                 jtiValidationStore);
     }
 

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceConfiguration.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceConfiguration.java
@@ -16,21 +16,40 @@
 package org.eclipse.edc.iam.oauth2;
 
 import org.eclipse.edc.iam.oauth2.identity.Oauth2ServiceImpl;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.runtime.metamodel.annotation.Settings;
 
 /**
  * Configuration values and dependencies for {@link Oauth2ServiceImpl}.
  */
+@Settings
 public class Oauth2ServiceConfiguration {
+    static final String ISSUED_AT_LEEWAY = "edc.oauth.validation.issued.at.leeway";
+    private static final int DEFAULT_TOKEN_EXPIRATION = 5;
 
+    @Setting(description = "URL to obtain OAuth2 JSON Web Key Sets", key = "edc.oauth.provider.jwks.url", defaultValue = "http://localhost/empty_jwks_url")
+    private String jwksUrl;
+    @Setting(description = "OAuth2 Token URL", key = "edc.oauth.token.url")
     private String tokenUrl;
+    @Setting(description = "OAuth2 client ID", key = "edc.oauth.client.id")
     private String clientId;
+    @Setting(description = "Vault alias for the private key", key = "edc.oauth.private.key.alias")
     private String privateKeyAlias;
+    @Setting(description = "Vault alias for the certificate", key = "edc.oauth.certificate.alias")
     private String publicCertificateAlias;
+    @Setting(description = "outgoing tokens 'aud' claim value, by default it's the connector id", key = "edc.oauth.provider.audience", required = false)
     private String providerAudience;
+    @Setting(description = "Leeway in seconds for validating the not before (nbf) claim in the token.", defaultValue = "10", key = "edc.oauth.validation.nbf.leeway")
     private int notBeforeValidationLeeway;
+    @Setting(description = "Leeway in seconds for validating the issuedAt claim in the token. By default it is 0 seconds.", defaultValue = "0", key = ISSUED_AT_LEEWAY)
     private int issuedAtLeeway;
+    @Setting(description = "incoming tokens 'aud' claim required value, by default it's the provider audience value", key = "edc.oauth.endpoint.audience", required = false)
     private String endpointAudience;
 
+    @Setting(description = "Refresh time for the JWKS, in minutes", key = "edc.oauth.provider.jwks.refresh", defaultValue = "5")
+    private int providerJwksRefresh; // in minutes
+
+    @Setting(description = "Token expiration in minutes. By default is 5 minutes", key = "edc.oauth.token.expiration", defaultValue = DEFAULT_TOKEN_EXPIRATION + "")
     private Long tokenExpiration;
 
     private Oauth2ServiceConfiguration() {
@@ -73,14 +92,27 @@ public class Oauth2ServiceConfiguration {
         return tokenExpiration;
     }
 
-    public static class Builder {
-        private final Oauth2ServiceConfiguration configuration = new Oauth2ServiceConfiguration();
+    public int getProviderJwksRefresh() {
+        return providerJwksRefresh;
+    }
 
-        private Builder() {
+    public String getJwksUrl() {
+        return jwksUrl;
+    }
+
+    public Builder toBuilder() {
+        return new Builder(this);
+    }
+
+    public static class Builder {
+        private final Oauth2ServiceConfiguration configuration;
+
+        private Builder(Oauth2ServiceConfiguration configuration) {
+            this.configuration = configuration;
         }
 
         public static Builder newInstance() {
-            return new Builder();
+            return new Builder(new Oauth2ServiceConfiguration());
         }
 
         public Builder tokenUrl(String url) {

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/identity/Oauth2ServiceImpl.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/identity/Oauth2ServiceImpl.java
@@ -17,7 +17,6 @@
 
 package org.eclipse.edc.iam.oauth2.identity;
 
-import org.eclipse.edc.iam.oauth2.Oauth2ServiceConfiguration;
 import org.eclipse.edc.iam.oauth2.spi.client.Oauth2Client;
 import org.eclipse.edc.iam.oauth2.spi.client.Oauth2CredentialsRequest;
 import org.eclipse.edc.iam.oauth2.spi.client.PrivateKeyOauth2CredentialsRequest;
@@ -47,7 +46,7 @@ public class Oauth2ServiceImpl implements IdentityService {
 
     private static final String GRANT_TYPE = "client_credentials";
 
-    private final Oauth2ServiceConfiguration configuration;
+    private final String tokenUrl;
     private final Supplier<String> privateKeySupplier;
     private final Oauth2Client client;
     private final TokenDecoratorRegistry jwtDecoratorRegistry;
@@ -59,16 +58,16 @@ public class Oauth2ServiceImpl implements IdentityService {
     /**
      * Creates a new instance of the OAuth2 Service
      *
-     * @param configuration          The configuration
+     * @param tokenUrl               Token URL
      * @param tokenGenerationService Service used to generate the signed tokens
      * @param client                 client for Oauth2 server
      * @param jwtDecoratorRegistry   Registry containing the decorator for build the JWT
      * @param tokenValidationService Service used for token validation
      */
-    public Oauth2ServiceImpl(Oauth2ServiceConfiguration configuration, TokenGenerationService tokenGenerationService, Supplier<String> privateKeyIdSupplier,
+    public Oauth2ServiceImpl(String tokenUrl, TokenGenerationService tokenGenerationService, Supplier<String> privateKeyIdSupplier,
                              Oauth2Client client, TokenDecoratorRegistry jwtDecoratorRegistry, TokenValidationRulesRegistry tokenValidationRuleRegistry, TokenValidationService tokenValidationService,
                              PublicKeyResolver publicKeyResolver) {
-        this.configuration = configuration;
+        this.tokenUrl = tokenUrl;
         this.privateKeySupplier = privateKeyIdSupplier;
         this.client = client;
         this.jwtDecoratorRegistry = jwtDecoratorRegistry;
@@ -100,7 +99,7 @@ public class Oauth2ServiceImpl implements IdentityService {
     @NotNull
     private Oauth2CredentialsRequest createRequest(TokenParameters parameters, String assertion) {
         return PrivateKeyOauth2CredentialsRequest.Builder.newInstance()
-                .url(configuration.getTokenUrl())
+                .url(tokenUrl)
                 .clientAssertion(assertion)
                 .scope(parameters.getStringClaim(JwtRegisteredClaimNames.SCOPE))
                 .grantType(GRANT_TYPE)

--- a/extensions/common/iam/oauth2/oauth2-core/src/test/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceExtensionTest.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/test/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceExtensionTest.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.edc.iam.oauth2;
 
+import org.eclipse.edc.boot.system.injection.ObjectFactory;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.keys.spi.CertificateResolver;
 import org.eclipse.edc.keys.spi.PrivateKeyResolver;
@@ -53,7 +54,7 @@ class Oauth2ServiceExtensionTest {
     }
 
     @Test
-    void verifyExtensionWithCertificateAlias(Oauth2ServiceExtension extension, ServiceExtensionContext context) {
+    void verifyExtensionWithCertificateAlias(ServiceExtensionContext context, ObjectFactory objectFactory) {
         var config = spy(ConfigFactory.fromMap(Map.of(
                 "edc.oauth.client.id", "id",
                 "edc.oauth.token.url", "url",
@@ -63,14 +64,14 @@ class Oauth2ServiceExtensionTest {
         mockRsaPrivateKey("p_alias");
 
         when(context.getConfig(any())).thenReturn(config);
-        extension.initialize(context);
+        objectFactory.constructInstance(Oauth2ServiceExtension.class).initialize(context);
 
         verify(config, times(1)).getString("edc.oauth.certificate.alias");
         verify(config, never()).getString("edc.oauth.public.key.alias");
     }
 
     @Test
-    void leewayWarningLoggedWhenLeewayUnconfigured(Oauth2ServiceExtension extension, ServiceExtensionContext context) {
+    void leewayWarningLoggedWhenLeewayUnconfigured(ServiceExtensionContext context, ObjectFactory objectFactory) {
         var config = spy(ConfigFactory.fromMap(Map.of(
                 "edc.oauth.client.id", "id",
                 "edc.oauth.token.url", "url",
@@ -81,15 +82,15 @@ class Oauth2ServiceExtensionTest {
 
         var monitor = mock(Monitor.class);
         when(context.getMonitor()).thenReturn(monitor);
-        when(context.getConfig(any())).thenReturn(config);
-        extension.initialize(context);
+        when(context.getConfig()).thenReturn(config);
+        objectFactory.constructInstance(Oauth2ServiceExtension.class).initialize(context);
 
         var message = "No value was configured for 'edc.oauth.validation.issued.at.leeway'.";
         verify(monitor, times(1)).info(contains(message));
     }
 
     @Test
-    void leewayNoWarningWhenLeewayConfigured(Oauth2ServiceExtension extension, ServiceExtensionContext context) {
+    void leewayNoWarningWhenLeewayConfigured(ServiceExtensionContext context, ObjectFactory objectFactory) {
         var config = spy(ConfigFactory.fromMap(Map.of(
                 "edc.oauth.client.id", "id",
                 "edc.oauth.token.url", "url",
@@ -102,7 +103,7 @@ class Oauth2ServiceExtensionTest {
         var monitor = mock(Monitor.class);
         when(context.getMonitor()).thenReturn(monitor);
         when(context.getConfig(any())).thenReturn(config);
-        extension.initialize(context);
+        objectFactory.constructInstance(Oauth2ServiceExtension.class).initialize(context);
 
         var message = "No value was configured for 'edc.oauth.validation.issued.at.leeway'.";
         verify(monitor, never()).info(contains(message));

--- a/extensions/common/iam/oauth2/oauth2-core/src/test/java/org/eclipse/edc/iam/oauth2/identity/Oauth2ServiceImplTest.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/test/java/org/eclipse/edc/iam/oauth2/identity/Oauth2ServiceImplTest.java
@@ -52,7 +52,6 @@ import org.mockito.ArgumentCaptor;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.Date;
-import java.util.Map;
 import java.util.UUID;
 
 import static com.nimbusds.jwt.JWTClaimNames.AUDIENCE;
@@ -114,7 +113,7 @@ class Oauth2ServiceImplTest {
         registry.addRule(OAUTH2_TOKEN_CONTEXT, new NotBeforeValidationRule(Clock.systemUTC(), configuration.getNotBeforeValidationLeeway()));
         registry.addRule(OAUTH2_TOKEN_CONTEXT, new ExpirationIssuedAtValidationRule(Clock.systemUTC(), configuration.getIssuedAtLeeway()));
 
-        authService = new Oauth2ServiceImpl(configuration, tokenGenerationService, () -> TEST_PRIVATE_KEY_ID, client, jwtDecoratorRegistry, registry,
+        authService = new Oauth2ServiceImpl(configuration.getTokenUrl(), tokenGenerationService, () -> TEST_PRIVATE_KEY_ID, client, jwtDecoratorRegistry, registry,
                 tokenValidationService, publicKeyResolverMock);
 
     }
@@ -212,15 +211,6 @@ class Oauth2ServiceImplTest {
 
         assertThat(result.succeeded()).isTrue();
         assertThat(result.getContent().getClaims()).hasSize(3).containsKeys(AUDIENCE, NOT_BEFORE, EXPIRATION_TIME);
-    }
-
-    private PrivateKeyOauth2CredentialsRequest createRequest(Map<String, String> additional) {
-        return PrivateKeyOauth2CredentialsRequest.Builder.newInstance()
-                .grantType("client_credentials")
-                .clientAssertion("assertion-token")
-                .scope("scope")
-                .params(additional)
-                .build();
     }
 
     private RSAKey testKey() throws JOSEException {

--- a/extensions/common/iam/oauth2/oauth2-daps/src/main/java/org/eclipse/edc/iam/oauth2/daps/DapsExtension.java
+++ b/extensions/common/iam/oauth2/oauth2-daps/src/main/java/org/eclipse/edc/iam/oauth2/daps/DapsExtension.java
@@ -34,10 +34,11 @@ public class DapsExtension implements ServiceExtension {
 
     public static final String NAME = "DAPS";
     public static final String DEFAULT_TOKEN_SCOPE = "idsc:IDS_CONNECTOR_ATTRIBUTES_ALL";
-    @Setting(value = "The value of the scope claim that is passed to DAPS to obtain a DAT", defaultValue = DEFAULT_TOKEN_SCOPE)
-    public static final String DAPS_TOKEN_SCOPE = "edc.iam.token.scope";
     public static final String OAUTH_2_DAPS_TOKEN_CONTEXT = "oauth2-daps";
 
+    @Setting(description = "The value of the scope claim that is passed to DAPS to obtain a DAT", defaultValue = DEFAULT_TOKEN_SCOPE, key = "edc.iam.token.scope")
+    private String scope;
+    
     @Inject
     private TokenDecoratorRegistry jwtDecoratorRegistry;
 
@@ -54,8 +55,6 @@ public class DapsExtension implements ServiceExtension {
 
     @Provider
     public TokenDecorator createDapsTokenDecorator(ServiceExtensionContext context) {
-        var scope = context.getConfig().getString(DAPS_TOKEN_SCOPE);
-
         return new DapsTokenDecorator(scope);
     }
 }

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/JsonLdExtension.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/JsonLdExtension.java
@@ -56,16 +56,19 @@ public class JsonLdExtension implements ServiceExtension {
     public static final String CONFIG_VALUE_URL = "url";
 
     private static final boolean DEFAULT_HTTP_HTTPS_RESOLUTION = false;
-    @Setting(value = "If set enable http json-ld document resolution", type = "boolean", defaultValue = DEFAULT_HTTP_HTTPS_RESOLUTION + "")
-    private static final String HTTP_ENABLE_SETTING = "edc.jsonld.http.enabled";
-    @Setting(value = "If set enable https json-ld document resolution", type = "boolean", defaultValue = DEFAULT_HTTP_HTTPS_RESOLUTION + "")
-    private static final String HTTPS_ENABLE_SETTING = "edc.jsonld.https.enabled";
+    @Setting(description = "If set enable http json-ld document resolution", defaultValue = DEFAULT_HTTP_HTTPS_RESOLUTION + "", key = "edc.jsonld.http.enabled")
+    private boolean httpResolutionEnabled;
+
+    @Setting(description = "If set enable https json-ld document resolution", type = "boolean", defaultValue = DEFAULT_HTTP_HTTPS_RESOLUTION + "", key = "edc.jsonld.https.enabled")
+    private boolean httpsResolutionEnabled;
+
     private static final boolean DEFAULT_AVOID_VOCAB_CONTEXT = false;
-    @Setting(value = "If true disable the @vocab context definition. This could be used to avoid api breaking changes", type = "boolean", defaultValue = DEFAULT_AVOID_VOCAB_CONTEXT + "")
-    private static final String AVOID_VOCAB_CONTEXT = "edc.jsonld.vocab.disable";
+    @Setting(description = "If true disable the @vocab context definition. This could be used to avoid api breaking changes", defaultValue = DEFAULT_AVOID_VOCAB_CONTEXT + "", key = "edc.jsonld.vocab.disable")
+    private boolean avoidVocab;
+
     private static final boolean DEFAULT_CHECK_PREFIXES = true;
-    @Setting(value = "If true a validation on expended object will be made against configured prefixes", type = "boolean", defaultValue = DEFAULT_CHECK_PREFIXES + "")
-    private static final String CHECK_PREFIXES = "edc.jsonld.prefixes.check";
+    @Setting(description = "If true a validation on expended object will be made against configured prefixes", type = "boolean", defaultValue = DEFAULT_CHECK_PREFIXES + "", key = "edc.jsonld.prefixes.check")
+    private boolean checkPrefixes;
 
     @Inject
     private TypeManager typeManager;
@@ -82,12 +85,11 @@ public class JsonLdExtension implements ServiceExtension {
 
     @Provider
     public JsonLd createJsonLdService(ServiceExtensionContext context) {
-        var config = context.getConfig();
         var configuration = JsonLdConfiguration.Builder.newInstance()
-                .httpEnabled(config.getBoolean(HTTP_ENABLE_SETTING, DEFAULT_HTTP_HTTPS_RESOLUTION))
-                .httpsEnabled(config.getBoolean(HTTPS_ENABLE_SETTING, DEFAULT_HTTP_HTTPS_RESOLUTION))
-                .avoidVocab(config.getBoolean(AVOID_VOCAB_CONTEXT, DEFAULT_AVOID_VOCAB_CONTEXT))
-                .checkPrefixes(config.getBoolean(CHECK_PREFIXES, DEFAULT_CHECK_PREFIXES))
+                .httpEnabled(httpResolutionEnabled)
+                .httpsEnabled(httpsResolutionEnabled)
+                .avoidVocab(avoidVocab)
+                .checkPrefixes(checkPrefixes)
                 .build();
         var monitor = context.getMonitor();
         var service = new TitaniumJsonLd(monitor, configuration);

--- a/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/JsonLdExtensionTest.java
+++ b/extensions/common/json-ld/src/test/java/org/eclipse/edc/jsonld/JsonLdExtensionTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.File;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,7 +40,7 @@ class JsonLdExtensionTest {
     }
 
     @Test
-    void verifyCachedDocsFromConfig_oneValidEntry(ServiceExtensionContext context, JsonLdExtension extension) throws URISyntaxException {
+    void verifyCachedDocsFromConfig_oneValidEntry(ServiceExtensionContext context, JsonLdExtension extension) {
         var config = ConfigFactory.fromMap(Map.of(
                 "edc.jsonld.document.foo.url", "http://foo.org/doc.json",
                 "edc.jsonld.document.foo.path", "/tmp/foo/doc.json")
@@ -56,7 +55,7 @@ class JsonLdExtensionTest {
     }
 
     @Test
-    void verifyCachedDocsFromConfig_oneValidEntry_withSuperfluous(ServiceExtensionContext context, JsonLdExtension extension) throws URISyntaxException {
+    void verifyCachedDocsFromConfig_oneValidEntry_withSuperfluous(ServiceExtensionContext context, JsonLdExtension extension) {
         var config = ConfigFactory.fromMap(Map.of(
                 "edc.jsonld.document.foo.url", "http://foo.org/doc.json",
                 "edc.jsonld.document.foo.invalid", "should be ignored",
@@ -72,7 +71,7 @@ class JsonLdExtensionTest {
     }
 
     @Test
-    void verifyCachedDocsFromConfig_multipleValidEntries(ServiceExtensionContext context, JsonLdExtension extension) throws URISyntaxException {
+    void verifyCachedDocsFromConfig_multipleValidEntries(ServiceExtensionContext context, JsonLdExtension extension) {
         var config = ConfigFactory.fromMap(Map.of(
                 "edc.jsonld.document.foo.url", "http://foo.org/doc.json",
                 "edc.jsonld.document.foo.path", "/tmp/foo/doc.json",
@@ -90,7 +89,7 @@ class JsonLdExtensionTest {
     }
 
     @Test
-    void verifyCachedDocsFromConfig_multipleEntries_oneIncomplete(ServiceExtensionContext context, JsonLdExtension extension) throws URISyntaxException {
+    void verifyCachedDocsFromConfig_multipleEntries_oneIncomplete(ServiceExtensionContext context, JsonLdExtension extension) {
         var config = ConfigFactory.fromMap(Map.of(
                 "edc.jsonld.document.foo.url", "http://foo.org/doc.json",
                 "edc.jsonld.document.foo.path", "/tmp/foo/doc.json",
@@ -108,7 +107,7 @@ class JsonLdExtensionTest {
     }
 
     @Test
-    void verifyCachedDocsFromConfig_multipleEntries_oneInvalid(ServiceExtensionContext context, JsonLdExtension extension) throws URISyntaxException {
+    void verifyCachedDocsFromConfig_multipleEntries_oneInvalid(ServiceExtensionContext context, JsonLdExtension extension) {
         var config = ConfigFactory.fromMap(Map.of(
                 "edc.jsonld.document.foo.url", "http://foo.org/doc.json",
                 "edc.jsonld.document.foo.path", "/tmp/foo/doc.json",

--- a/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/SqlCoreExtension.java
+++ b/extensions/common/sql/sql-core/src/main/java/org/eclipse/edc/sql/SqlCoreExtension.java
@@ -24,16 +24,14 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.transaction.spi.NoopTransactionContext;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 
-import static java.lang.Integer.parseInt;
-
 @Extension(value = SqlCoreExtension.NAME)
 public class SqlCoreExtension implements ServiceExtension {
 
     public static final String NAME = "SQL Core";
 
     public static final String DEFAULT_EDC_SQL_FETCH_SIZE = "5000";
-    @Setting(value = "Fetch size value used in SQL queries", defaultValue = DEFAULT_EDC_SQL_FETCH_SIZE)
-    public static final String EDC_SQL_FETCH_SIZE = "edc.sql.fetch.size";
+    @Setting(description = "Fetch size value used in SQL queries", defaultValue = DEFAULT_EDC_SQL_FETCH_SIZE, key = "edc.sql.fetch.size")
+    private int fetchSize;
 
     @Inject
     private TransactionContext transactionContext;
@@ -52,7 +50,6 @@ public class SqlCoreExtension implements ServiceExtension {
 
     @Provider
     public QueryExecutor sqlQueryExecutor(ServiceExtensionContext context) {
-        var fetchSize = context.getSetting(EDC_SQL_FETCH_SIZE, parseInt(DEFAULT_EDC_SQL_FETCH_SIZE));
         var configuration = new SqlQueryExecutorConfiguration(fetchSize);
         return new SqlQueryExecutor(configuration);
     }

--- a/extensions/common/sql/sql-pool/sql-pool-apache-commons/src/main/java/org/eclipse/edc/sql/pool/commons/CommonsConnectionPoolServiceExtension.java
+++ b/extensions/common/sql/sql-pool/sql-pool-apache-commons/src/main/java/org/eclipse/edc/sql/pool/commons/CommonsConnectionPoolServiceExtension.java
@@ -46,28 +46,28 @@ public class CommonsConnectionPoolServiceExtension implements ServiceExtension {
     public static final String EDC_DATASOURCE_PREFIX = "edc.datasource";
     private static final String EDC_DATASOURCE_CONFIG_CONTEXT = EDC_DATASOURCE_PREFIX + ".<name>";
 
-    @Setting(value = "JDBC url", required = true, context = EDC_DATASOURCE_CONFIG_CONTEXT)
+    @Setting(description = "JDBC url", required = true, context = EDC_DATASOURCE_CONFIG_CONTEXT)
     public static final String URL = "url";
-    @Setting(value = "Username to be used for the JDBC connection. Can be omitted if not required, or if the user is encoded in the JDBC url.", context = EDC_DATASOURCE_CONFIG_CONTEXT)
+    @Setting(description = "Username to be used for the JDBC connection. Can be omitted if not required, or if the user is encoded in the JDBC url.", context = EDC_DATASOURCE_CONFIG_CONTEXT)
     public static final String USER = "user";
-    @Setting(value = "Username to be used for the JDBC connection. Can be omitted if not required, or if the password is encoded in the JDBC url.", context = EDC_DATASOURCE_CONFIG_CONTEXT)
+    @Setting(description = "Username to be used for the JDBC connection. Can be omitted if not required, or if the password is encoded in the JDBC url.", context = EDC_DATASOURCE_CONFIG_CONTEXT)
     public static final String PASSWORD = "password";
 
-    @Setting(value = "Pool max idle connections", type = "int", context = EDC_DATASOURCE_CONFIG_CONTEXT)
+    @Setting(description = "Pool max idle connections", type = "int", context = EDC_DATASOURCE_CONFIG_CONTEXT)
     public static final String POOL_CONNECTIONS_MAX_IDLE = "pool.connections.max-idle";
-    @Setting(value = "Pool max total connections", type = "int", context = EDC_DATASOURCE_CONFIG_CONTEXT)
+    @Setting(description = "Pool max total connections", type = "int", context = EDC_DATASOURCE_CONFIG_CONTEXT)
     public static final String POOL_CONNECTIONS_MAX_TOTAL = "pool.connections.max-total";
-    @Setting(value = "Pool min idle connections", type = "int", context = EDC_DATASOURCE_CONFIG_CONTEXT)
+    @Setting(description = "Pool min idle connections", type = "int", context = EDC_DATASOURCE_CONFIG_CONTEXT)
     public static final String POOL_CONNECTIONS_MIN_IDLE = "pool.connections.min-idle";
-    @Setting(value = "Pool test on borrow", type = "boolean", context = EDC_DATASOURCE_CONFIG_CONTEXT)
+    @Setting(description = "Pool test on borrow", type = "boolean", context = EDC_DATASOURCE_CONFIG_CONTEXT)
     public static final String POOL_CONNECTION_TEST_ON_BORROW = "pool.connection.test.on-borrow";
-    @Setting(value = "Pool test on create", type = "boolean", context = EDC_DATASOURCE_CONFIG_CONTEXT)
+    @Setting(description = "Pool test on create", type = "boolean", context = EDC_DATASOURCE_CONFIG_CONTEXT)
     public static final String POOL_CONNECTION_TEST_ON_CREATE = "pool.connection.test.on-create";
-    @Setting(value = "Pool test on return", type = "boolean", context = EDC_DATASOURCE_CONFIG_CONTEXT)
+    @Setting(description = "Pool test on return", type = "boolean", context = EDC_DATASOURCE_CONFIG_CONTEXT)
     public static final String POOL_CONNECTION_TEST_ON_RETURN = "pool.connection.test.on-return";
-    @Setting(value = "Pool test while idle", type = "boolean", context = EDC_DATASOURCE_CONFIG_CONTEXT)
+    @Setting(description = "Pool test while idle", type = "boolean", context = EDC_DATASOURCE_CONFIG_CONTEXT)
     public static final String POOL_CONNECTION_TEST_WHILE_IDLE = "pool.connection.test.while-idle";
-    @Setting(value = "Pool test query", context = EDC_DATASOURCE_CONFIG_CONTEXT)
+    @Setting(description = "Pool test query", context = EDC_DATASOURCE_CONFIG_CONTEXT)
     public static final String POOL_CONNECTION_TEST_QUERY = "pool.connection.test.query";
 
     @Inject

--- a/extensions/common/store/sql/edr-index-sql/src/main/java/org/eclipse/edc/edr/store/index/SqlEndpointDataReferenceEntryIndexExtension.java
+++ b/extensions/common/store/sql/edr-index-sql/src/main/java/org/eclipse/edc/edr/store/index/SqlEndpointDataReferenceEntryIndexExtension.java
@@ -27,7 +27,6 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.sql.QueryExecutor;
 import org.eclipse.edc.sql.bootstrapper.SqlSchemaBootstrapper;
-import org.eclipse.edc.sql.configuration.DataSourceName;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 
@@ -35,11 +34,8 @@ import org.eclipse.edc.transaction.spi.TransactionContext;
 @Extension(value = "SQL edr entry store")
 public class SqlEndpointDataReferenceEntryIndexExtension implements ServiceExtension {
 
-    @Deprecated(since = "0.8.1")
-    public static final String DATASOURCE_SETTING_NAME = "edc.datasource.edr.name";
-
-    @Setting(value = "The datasource to be used", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE)
-    public static final String DATASOURCE_NAME = "edc.sql.store.edr.datasource";
+    @Setting(description = "The datasource to be used", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE, key = "edc.sql.store.edr.datasource")
+    private String dataSourceName;
 
     @Inject
     private DataSourceRegistry dataSourceRegistry;
@@ -61,8 +57,6 @@ public class SqlEndpointDataReferenceEntryIndexExtension implements ServiceExten
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var dataSourceName = DataSourceName.getDataSourceName(DATASOURCE_NAME, DATASOURCE_SETTING_NAME, context.getConfig(), context.getMonitor());
-
         var sqlStore = new SqlEndpointDataReferenceEntryIndex(dataSourceRegistry, dataSourceName, transactionContext, typeManager.getMapper(),
                 getStatementImpl(), queryExecutor);
 

--- a/extensions/common/store/sql/edr-index-sql/src/test/java/org/eclipse/edc/edr/store/index/sql/SqlEndpointDataReferenceEntryIndexExtensionTest.java
+++ b/extensions/common/store/sql/edr-index-sql/src/test/java/org/eclipse/edc/edr/store/index/sql/SqlEndpointDataReferenceEntryIndexExtensionTest.java
@@ -27,11 +27,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.edr.store.index.SqlEndpointDataReferenceEntryIndexExtension.DATASOURCE_NAME;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(DependencyInjectionExtension.class)
@@ -53,6 +50,5 @@ public class SqlEndpointDataReferenceEntryIndexExtensionTest {
         var service = context.getService(EndpointDataReferenceEntryIndex.class);
         assertThat(service).isInstanceOf(SqlEndpointDataReferenceEntryIndex.class);
 
-        verify(config).getString(eq(DATASOURCE_NAME), any());
     }
 }

--- a/extensions/common/store/sql/jti-validation-store-sql/src/main/java/org/eclipse/edc/jtivalidation/store/sql/SqlJtiValidationStoreExtension.java
+++ b/extensions/common/store/sql/jti-validation-store-sql/src/main/java/org/eclipse/edc/jtivalidation/store/sql/SqlJtiValidationStoreExtension.java
@@ -34,10 +34,8 @@ import org.eclipse.edc.transaction.spi.TransactionContext;
 @Extension(value = "SQL JTI Validation store")
 public class SqlJtiValidationStoreExtension implements ServiceExtension {
 
-
-    @Setting(value = "The datasource to be used", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE)
-    public static final String DATASOURCE_NAME = "edc.sql.store.jti.datasource";
-
+    @Setting(description = "The datasource to be used", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE, key = "edc.sql.store.jti.datasource")
+    private String dataSourceName;
 
     @Inject
     private DataSourceRegistry dataSourceRegistry;
@@ -60,8 +58,6 @@ public class SqlJtiValidationStoreExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var dataSourceName = context.getConfig().getString(DATASOURCE_NAME, DataSourceRegistry.DEFAULT_DATASOURCE);
-
         var sqlStore = new SqlJtiValidationStore(dataSourceRegistry, dataSourceName, transactionContext, typeManager.getMapper(),
                 getStatementImpl(), queryExecutor, context.getMonitor());
 

--- a/extensions/common/store/sql/jti-validation-store-sql/src/test/java/org/eclipse/edc/jtivalidation/store/sql/SqlJtiValidationStoreExtensionTest.java
+++ b/extensions/common/store/sql/jti-validation-store-sql/src/test/java/org/eclipse/edc/jtivalidation/store/sql/SqlJtiValidationStoreExtensionTest.java
@@ -25,11 +25,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.jtivalidation.store.sql.SqlJtiValidationStoreExtension.DATASOURCE_NAME;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(DependencyInjectionExtension.class)
@@ -51,6 +48,5 @@ public class SqlJtiValidationStoreExtensionTest {
         var service = context.getService(JtiValidationStore.class);
         assertThat(service).isInstanceOf(SqlJtiValidationStore.class);
 
-        verify(config).getString(eq(DATASOURCE_NAME), any());
     }
 }

--- a/extensions/common/store/sql/sts-client-store-sql/src/main/java/org/eclipse/edc/iam/identitytrust/sts/store/SqlStsClientStoreExtension.java
+++ b/extensions/common/store/sql/sts-client-store-sql/src/main/java/org/eclipse/edc/iam/identitytrust/sts/store/SqlStsClientStoreExtension.java
@@ -36,8 +36,8 @@ import static org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry.DEFA
 @Extension(value = "SQL sts accounts store")
 public class SqlStsClientStoreExtension implements ServiceExtension {
 
-    @Setting(value = "The datasource to be used", defaultValue = DEFAULT_DATASOURCE)
-    public static final String DATASOURCE_NAME = "edc.sql.store.stsclient.datasource";
+    @Setting(description = "The datasource to be used", defaultValue = DEFAULT_DATASOURCE, key = "edc.sql.store.stsclient.datasource")
+    private String dataSourceName;
 
     @Inject
     private DataSourceRegistry dataSourceRegistry;
@@ -59,7 +59,6 @@ public class SqlStsClientStoreExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var dataSourceName = context.getSetting(DATASOURCE_NAME, DEFAULT_DATASOURCE);
 
         var sqlStore = new SqlStsAccountStore(dataSourceRegistry, dataSourceName, transactionContext, typeManager.getMapper(),
                 getStatementImpl(), queryExecutor);

--- a/extensions/common/store/sql/sts-client-store-sql/src/test/java/org/eclipse/edc/iam/identitytrust/sts/store/SqlStsAccountStoreExtensionTest.java
+++ b/extensions/common/store/sql/sts-client-store-sql/src/test/java/org/eclipse/edc/iam/identitytrust/sts/store/SqlStsAccountStoreExtensionTest.java
@@ -25,11 +25,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.iam.identitytrust.sts.store.SqlStsClientStoreExtension.DATASOURCE_NAME;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(DependencyInjectionExtension.class)
@@ -51,6 +48,5 @@ public class SqlStsAccountStoreExtensionTest {
         var service = context.getService(StsAccountStore.class);
         assertThat(service).isInstanceOf(SqlStsAccountStore.class);
 
-        verify(config).getString(eq(DATASOURCE_NAME), any());
     }
 }

--- a/extensions/common/vault/vault-hashicorp/src/main/java/org/eclipse/edc/vault/hashicorp/client/HashicorpVaultClient.java
+++ b/extensions/common/vault/vault-hashicorp/src/main/java/org/eclipse/edc/vault/hashicorp/client/HashicorpVaultClient.java
@@ -40,6 +40,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * This is a client implementation for interacting with Hashicorp Vault.
@@ -119,7 +120,7 @@ public class HashicorpVaultClient {
      * @return boolean indicating if the token is renewable
      */
     public Result<Boolean> isTokenRenewable() {
-        var uri = settings.url()
+        var uri = baseUrl(settings)
                 .newBuilder()
                 .addPathSegments(TOKEN_LOOK_UP_SELF_PATH)
                 .build();
@@ -156,7 +157,7 @@ public class HashicorpVaultClient {
      * @return long representing the remaining ttl of the token in seconds
      */
     public Result<Long> renewToken() {
-        var uri = settings.url()
+        var uri = baseUrl(settings)
                 .newBuilder()
                 .addPathSegments(TOKEN_RENEW_SELF_PATH)
                 .build();
@@ -261,7 +262,7 @@ public class HashicorpVaultClient {
         // status
         // code instead of the standby status codes
 
-        return settings.url()
+        return baseUrl(settings)
                 .newBuilder()
                 .addPathSegments(PathUtil.trimLeadingOrEndingSlash(vaultHealthPath))
                 .addQueryParameter("standbyok", isVaultHealthStandbyOk ? "true" : "false")
@@ -278,7 +279,7 @@ public class HashicorpVaultClient {
         var vaultApiPath = settings.secretPath();
         var folderPath = settings.getFolderPath();
 
-        var builder = settings.url()
+        var builder = baseUrl(settings)
                 .newBuilder()
                 .addPathSegments(PathUtil.trimLeadingOrEndingSlash(vaultApiPath))
                 .addPathSegment(entryType);
@@ -308,6 +309,12 @@ public class HashicorpVaultClient {
                 .headers(headers)
                 .post(createRequestBody(requestBody))
                 .build();
+    }
+
+    @NotNull
+    private HttpUrl baseUrl(HashicorpVaultSettings settings) {
+        var url = settings.url();
+        return Objects.requireNonNull(HttpUrl.parse(url));
     }
 
     @NotNull

--- a/extensions/common/vault/vault-hashicorp/src/main/java/org/eclipse/edc/vault/hashicorp/client/HashicorpVaultSettings.java
+++ b/extensions/common/vault/vault-hashicorp/src/main/java/org/eclipse/edc/vault/hashicorp/client/HashicorpVaultSettings.java
@@ -14,31 +14,51 @@
 
 package org.eclipse.edc.vault.hashicorp.client;
 
-import okhttp3.HttpUrl;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.runtime.metamodel.annotation.Settings;
 
 import static java.util.Objects.requireNonNull;
 
 /**
  * Settings for the {@link HashicorpVaultClient}.
  */
+@Settings
 public class HashicorpVaultSettings {
+    public static final String VAULT_API_HEALTH_PATH_DEFAULT = "/v1/sys/health";
+    public static final String VAULT_API_SECRET_PATH_DEFAULT = "/v1/secret";
+    public static final boolean VAULT_HEALTH_CHECK_STANDBY_OK_DEFAULT = false;
+    public static final long VAULT_TOKEN_RENEW_BUFFER_DEFAULT = 30;
+    public static final long VAULT_TOKEN_TTL_DEFAULT = 300;
+    public static final boolean VAULT_HEALTH_CHECK_ENABLED_DEFAULT = true;
+    public static final boolean VAULT_TOKEN_SCHEDULED_RENEW_ENABLED_DEFAULT = true;
 
-    private HttpUrl url;
+    @Setting(description = "The URL of the Hashicorp Vault", key = "edc.vault.hashicorp.url")
+    private String url;
+    @Setting(description = "Whether or not the vault health check is enabled", defaultValue = VAULT_HEALTH_CHECK_ENABLED_DEFAULT + "", key = "edc.vault.hashicorp.health.check.enabled")
     private boolean healthCheckEnabled;
+    @Setting(description = "The URL path of the vault's /health endpoint", defaultValue = VAULT_API_HEALTH_PATH_DEFAULT, key = "edc.vault.hashicorp.api.health.check.path")
     private String healthCheckPath;
+    @Setting(description = "Specifies if being a standby should still return the active status code instead of the standby status code", defaultValue = VAULT_HEALTH_CHECK_STANDBY_OK_DEFAULT + "", key = "edc.vault.hashicorp.health.check.standby.ok")
     private boolean healthStandbyOk;
+    @Setting(description = "The token used to access the Hashicorp Vault", key = "edc.vault.hashicorp.token")
     private String token;
+    @Setting(description = "Whether the automatic token renewal process will be triggered or not. Should be disabled only for development and testing purposes",
+            defaultValue = VAULT_TOKEN_SCHEDULED_RENEW_ENABLED_DEFAULT + "", key = "edc.vault.hashicorp.token.scheduled-renew-enabled")
     private boolean scheduledTokenRenewEnabled;
+    @Setting(description = "The time-to-live (ttl) value of the Hashicorp Vault token in seconds", defaultValue = VAULT_TOKEN_TTL_DEFAULT + "", key = "edc.vault.hashicorp.token.ttl")
     private long ttl;
+    @Setting(description = "The renew buffer of the Hashicorp Vault token in seconds", defaultValue = VAULT_TOKEN_RENEW_BUFFER_DEFAULT + "", key = "edc.vault.hashicorp.token.renew-buffer")
     private long renewBuffer;
+    @Setting(description = "The URL path of the vault's /secret endpoint", defaultValue = VAULT_API_SECRET_PATH_DEFAULT, key = "edc.vault.hashicorp.api.secret.path")
     private String secretPath;
+    @Setting(description = "The path of the folder that the secret is stored in, relative to VAULT_FOLDER_PATH", required = false, key = "edc.vault.hashicorp.folder")
 
     private String folderPath;
 
     private HashicorpVaultSettings() {
     }
 
-    public HttpUrl url() {
+    public String url() {
         return url;
     }
 
@@ -91,7 +111,7 @@ public class HashicorpVaultSettings {
 
         public Builder url(String url) {
             requireNonNull(url, "Vault url must not be null");
-            values.url = HttpUrl.parse(url);
+            values.url = url;
             return this;
         }
 

--- a/extensions/common/vault/vault-hashicorp/src/main/java/org/eclipse/edc/vault/hashicorp/health/HashicorpVaultHealthExtension.java
+++ b/extensions/common/vault/vault-hashicorp/src/main/java/org/eclipse/edc/vault/hashicorp/health/HashicorpVaultHealthExtension.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.edc.vault.hashicorp.health;
 
+import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Requires;
@@ -22,9 +23,8 @@ import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.health.HealthCheckService;
 import org.eclipse.edc.vault.hashicorp.client.HashicorpVaultClient;
+import org.eclipse.edc.vault.hashicorp.client.HashicorpVaultSettings;
 
-import static org.eclipse.edc.vault.hashicorp.HashicorpVaultExtension.VAULT_HEALTH_CHECK_ENABLED;
-import static org.eclipse.edc.vault.hashicorp.HashicorpVaultExtension.VAULT_HEALTH_CHECK_ENABLED_DEFAULT;
 
 @Requires(HealthCheckService.class)
 @Extension(value = HashicorpVaultHealthExtension.NAME)
@@ -38,6 +38,9 @@ public class HashicorpVaultHealthExtension implements ServiceExtension {
     @Inject
     private HashicorpVaultClient client;
 
+    @Configuration
+    private HashicorpVaultSettings settings;
+
     @Override
     public String name() {
         return NAME;
@@ -46,8 +49,7 @@ public class HashicorpVaultHealthExtension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
         var monitor = context.getMonitor().withPrefix(NAME);
-        var healthCheckEnabled = context.getSetting(VAULT_HEALTH_CHECK_ENABLED, VAULT_HEALTH_CHECK_ENABLED_DEFAULT);
-        if (healthCheckEnabled) {
+        if (settings.healthCheckEnabled()) {
             var healthCheck = new HashicorpVaultHealthCheck(client, monitor);
             healthCheckService.addLivenessProvider(healthCheck);
             healthCheckService.addReadinessProvider(healthCheck);

--- a/extensions/common/vault/vault-hashicorp/src/test/java/org/eclipse/edc/vault/hashicorp/HashicorpVaultIntegrationTest.java
+++ b/extensions/common/vault/vault-hashicorp/src/test/java/org/eclipse/edc/vault/hashicorp/HashicorpVaultIntegrationTest.java
@@ -39,7 +39,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ComponentTest
 @Testcontainers
-//@ExtendWith(RuntimePerClassExtension.class)
 class HashicorpVaultIntegrationTest {
     static final String DOCKER_IMAGE_NAME = "vault:1.9.6";
     static final String VAULT_ENTRY_KEY = "testing";
@@ -54,10 +53,6 @@ class HashicorpVaultIntegrationTest {
     private static final String VAULT_URL = "edc.vault.hashicorp.url";
     private static final String VAULT_TOKEN = "edc.vault.hashicorp.token";
 
-//    @BeforeEach
-//    void beforeEach(RuntimeExtension extension) {
-//        extension.setConfiguration(getConfig());
-//    }
 
     @RegisterExtension
     protected static RuntimeExtension runtime = new RuntimePerClassExtension(new EmbeddedRuntime("vault-runtime", getConfig(), "extensions:common:vault:vault-hashicorp"));

--- a/extensions/common/vault/vault-hashicorp/src/test/java/org/eclipse/edc/vault/hashicorp/HashicorpVaultIntegrationTest.java
+++ b/extensions/common/vault/vault-hashicorp/src/test/java/org/eclipse/edc/vault/hashicorp/HashicorpVaultIntegrationTest.java
@@ -16,14 +16,16 @@
 package org.eclipse.edc.vault.hashicorp;
 
 import org.eclipse.edc.junit.annotations.ComponentTest;
-import org.eclipse.edc.junit.extensions.EdcExtension;
+import org.eclipse.edc.junit.extensions.EmbeddedRuntime;
+import org.eclipse.edc.junit.extensions.RuntimeExtension;
+import org.eclipse.edc.junit.extensions.RuntimePerClassExtension;
 import org.eclipse.edc.spi.security.Vault;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.vault.VaultContainer;
@@ -34,12 +36,10 @@ import java.util.UUID;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.vault.hashicorp.HashicorpVaultExtension.VAULT_TOKEN;
-import static org.eclipse.edc.vault.hashicorp.HashicorpVaultExtension.VAULT_URL;
 
 @ComponentTest
 @Testcontainers
-@ExtendWith(EdcExtension.class)
+//@ExtendWith(RuntimePerClassExtension.class)
 class HashicorpVaultIntegrationTest {
     static final String DOCKER_IMAGE_NAME = "vault:1.9.6";
     static final String VAULT_ENTRY_KEY = "testing";
@@ -48,14 +48,20 @@ class HashicorpVaultIntegrationTest {
     static final String TOKEN = UUID.randomUUID().toString();
 
     @Container
-    public static final VaultContainer<?> VAULTCONTAINER = new VaultContainer<>(DOCKER_IMAGE_NAME)
+    private static final VaultContainer<?> VAULTCONTAINER = new VaultContainer<>(DOCKER_IMAGE_NAME)
             .withVaultToken(TOKEN)
             .withSecretInVault("secret/" + VAULT_ENTRY_KEY, format("%s=%s", VAULT_DATA_ENTRY_NAME, VAULT_ENTRY_VALUE));
+    private static final String VAULT_URL = "edc.vault.hashicorp.url";
+    private static final String VAULT_TOKEN = "edc.vault.hashicorp.token";
 
-    @BeforeEach
-    void beforeEach(EdcExtension extension) {
-        extension.setConfiguration(getConfig());
-    }
+//    @BeforeEach
+//    void beforeEach(RuntimeExtension extension) {
+//        extension.setConfiguration(getConfig());
+//    }
+
+    @RegisterExtension
+    protected static RuntimeExtension runtime = new RuntimePerClassExtension(new EmbeddedRuntime("vault-runtime", getConfig(), "extensions:common:vault:vault-hashicorp"));
+
 
     @Test
     @DisplayName("Resolve a secret that exists")
@@ -136,10 +142,15 @@ class HashicorpVaultIntegrationTest {
         assertThat(vault.resolveSecret(key)).isNull();
     }
 
-    private Map<String, String> getConfig() {
+    private static Map<String, String> getConfig() {
+        // container might not be started, lazily start and wait for it to come up
+        if (!VAULTCONTAINER.isRunning()) {
+            VAULTCONTAINER.start();
+            VAULTCONTAINER.waitingFor(Wait.forHealthcheck());
+        }
         return new HashMap<>() {
             {
-                put(VAULT_URL, format("http://%s:%s", VAULTCONTAINER.getHost(), VAULTCONTAINER.getFirstMappedPort()));
+                put(VAULT_URL, "http://%s:%d".formatted(VAULTCONTAINER.getHost(), VAULTCONTAINER.getFirstMappedPort()));
                 put(VAULT_TOKEN, TOKEN);
             }
         };

--- a/extensions/common/vault/vault-hashicorp/src/test/java/org/eclipse/edc/vault/hashicorp/client/HashicorpVaultSettingsTest.java
+++ b/extensions/common/vault/vault-hashicorp/src/test/java/org/eclipse/edc/vault/hashicorp/client/HashicorpVaultSettingsTest.java
@@ -14,14 +14,13 @@
 
 package org.eclipse.edc.vault.hashicorp.client;
 
-import okhttp3.HttpUrl;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.vault.hashicorp.HashicorpVaultExtension.VAULT_TOKEN_RENEW_BUFFER_DEFAULT;
-import static org.eclipse.edc.vault.hashicorp.HashicorpVaultExtension.VAULT_TOKEN_TTL_DEFAULT;
+import static org.eclipse.edc.vault.hashicorp.client.HashicorpVaultSettings.VAULT_TOKEN_RENEW_BUFFER_DEFAULT;
+import static org.eclipse.edc.vault.hashicorp.client.HashicorpVaultSettings.VAULT_TOKEN_TTL_DEFAULT;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -29,7 +28,6 @@ class HashicorpVaultSettingsTest {
 
     private static final String TOKEN = "token";
     private static final String URL = "https://test.com/vault";
-    private static final HttpUrl HTTP_URL = HttpUrl.parse(URL);
     private static final String HEALTH_CHECK_PATH = "/healthcheck/path";
     private static final String SECRET_PATH = "/secret/path";
 
@@ -40,7 +38,7 @@ class HashicorpVaultSettingsTest {
                 TOKEN,
                 HEALTH_CHECK_PATH, VAULT_TOKEN_TTL_DEFAULT,
                 VAULT_TOKEN_RENEW_BUFFER_DEFAULT));
-        assertThat(settings.url()).isEqualTo(HTTP_URL);
+        assertThat(settings.url()).isEqualTo(URL);
         assertThat(settings.healthCheckEnabled()).isEqualTo(true);
         assertThat(settings.healthCheckPath()).isEqualTo(HEALTH_CHECK_PATH);
         assertThat(settings.healthStandbyOk()).isEqualTo(true);
@@ -59,17 +57,6 @@ class HashicorpVaultSettingsTest {
                 HEALTH_CHECK_PATH, VAULT_TOKEN_TTL_DEFAULT,
                 VAULT_TOKEN_RENEW_BUFFER_DEFAULT));
         assertThat(throwable.getMessage()).isEqualTo("Vault url must not be null");
-    }
-
-    @Test
-    void createSettings_withVaultUrlInvalid_shouldThrowException() {
-        var throwable = assertThrows(Exception.class, () -> createSettings(
-                "this is not valid",
-                TOKEN,
-                HEALTH_CHECK_PATH,
-                VAULT_TOKEN_TTL_DEFAULT,
-                VAULT_TOKEN_RENEW_BUFFER_DEFAULT));
-        assertThat(throwable.getMessage()).isEqualTo("Vault url must be valid");
     }
 
     @Test

--- a/extensions/control-plane/edr/edr-store-receiver/src/main/java/org/eclipse/edc/connector/controlplane/edr/store/receiver/EndpointDataReferenceStoreReceiverExtension.java
+++ b/extensions/control-plane/edr/edr-store-receiver/src/main/java/org/eclipse/edc/connector/controlplane/edr/store/receiver/EndpointDataReferenceStoreReceiverExtension.java
@@ -34,8 +34,9 @@ public class EndpointDataReferenceStoreReceiverExtension implements ServiceExten
 
     public static final String NAME = "Endpoint Data Reference Store Receiver Extension";
     private static final String DEFAULT_SYNC_LISTENER = "false";
-    @Setting(value = "If true the EDR receiver will be registered as synchronous listener", defaultValue = DEFAULT_SYNC_LISTENER)
-    private static final String EDC_EDR_RECEIVER_SYNC = "edc.edr.receiver.sync";
+    @Setting(description = "If true the EDR receiver will be registered as synchronous listener", defaultValue = DEFAULT_SYNC_LISTENER, key = "edc.edr.receiver.sync")
+    private boolean isSyncMode;
+
     @Inject
     private EventRouter router;
 
@@ -61,7 +62,6 @@ public class EndpointDataReferenceStoreReceiverExtension implements ServiceExten
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var isSyncMode = context.getSetting(EDC_EDR_RECEIVER_SYNC, Boolean.parseBoolean(EDC_EDR_RECEIVER_SYNC));
         var receiver = new EndpointDataReferenceStoreReceiver(dataReferenceStore, policyArchive, agreementService, transactionContext, monitor.withPrefix("EDR Receiver"));
         if (isSyncMode) {
             router.registerSync(TransferProcessEvent.class, receiver);

--- a/extensions/control-plane/edr/edr-store-receiver/src/test/java/org/eclipse/edc/connector/controlplane/edr/store/receiver/EndpointDataReferenceStoreReceiverExtensionTest.java
+++ b/extensions/control-plane/edr/edr-store-receiver/src/test/java/org/eclipse/edc/connector/controlplane/edr/store/receiver/EndpointDataReferenceStoreReceiverExtensionTest.java
@@ -14,13 +14,17 @@
 
 package org.eclipse.edc.connector.controlplane.edr.store.receiver;
 
+import org.eclipse.edc.boot.system.injection.ObjectFactory;
 import org.eclipse.edc.connector.controlplane.transfer.spi.event.TransferProcessEvent;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -48,9 +52,11 @@ public class EndpointDataReferenceStoreReceiverExtensionTest {
     }
 
     @Test
-    void initialize_withSyncConfig(ServiceExtensionContext context, EndpointDataReferenceStoreReceiverExtension extension) {
-        when(context.getSetting("edc.edr.receiver.sync", false)).thenReturn(true);
-        extension.initialize(context);
+    void initialize_withSyncConfig(ServiceExtensionContext context, ObjectFactory objectFactory) {
+
+        when(context.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of("edc.edr.receiver.sync", "true")));
+
+        objectFactory.constructInstance(EndpointDataReferenceStoreReceiverExtension.class).initialize(context);
         verify(eventRouter).registerSync(eq(TransferProcessEvent.class), isA(EndpointDataReferenceStoreReceiver.class));
         verify(eventRouter, never()).register(any(), any());
     }

--- a/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/assetindex/SqlAssetIndexServiceExtension.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/assetindex/SqlAssetIndexServiceExtension.java
@@ -28,7 +28,6 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.sql.QueryExecutor;
 import org.eclipse.edc.sql.bootstrapper.SqlSchemaBootstrapper;
-import org.eclipse.edc.sql.configuration.DataSourceName;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 
@@ -39,8 +38,8 @@ public class SqlAssetIndexServiceExtension implements ServiceExtension {
     @Deprecated(since = "0.8.1")
     public static final String DATASOURCE_SETTING_NAME = "edc.datasource.asset.name";
 
-    @Setting(value = "The datasource to be used", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE)
-    public static final String DATASOURCE_NAME = "edc.sql.store.asset.datasource";
+    @Setting(description = "The datasource to be used", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE, key = "edc.sql.store.asset.datasource")
+    private String dataSourceName;
 
     @Inject
     private DataSourceRegistry dataSourceRegistry;
@@ -62,8 +61,6 @@ public class SqlAssetIndexServiceExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var dataSourceName = DataSourceName.getDataSourceName(DATASOURCE_NAME, DATASOURCE_SETTING_NAME, context.getConfig(), context.getMonitor());
-
         var sqlAssetLoader = new SqlAssetIndex(dataSourceRegistry, dataSourceName, transactionContext, typeManager.getMapper(), getDialect(), queryExecutor);
 
         context.registerService(AssetIndex.class, sqlAssetLoader);

--- a/extensions/control-plane/store/sql/asset-index-sql/src/test/java/org/eclipse/edc/connector/controlplane/store/sql/assetindex/SqlAssetIndexServiceExtensionTest.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/test/java/org/eclipse/edc/connector/controlplane/store/sql/assetindex/SqlAssetIndexServiceExtensionTest.java
@@ -26,11 +26,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.connector.controlplane.store.sql.assetindex.SqlAssetIndexServiceExtension.DATASOURCE_NAME;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(DependencyInjectionExtension.class)
@@ -55,6 +52,5 @@ public class SqlAssetIndexServiceExtensionTest {
         var dataAddressResolver = context.getService(DataAddressResolver.class);
         assertThat(dataAddressResolver).isInstanceOf(SqlAssetIndex.class);
 
-        verify(config).getString(eq(DATASOURCE_NAME), any());
     }
 }

--- a/extensions/control-plane/store/sql/contract-definition-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractdefinition/SqlContractDefinitionStoreExtension.java
+++ b/extensions/control-plane/store/sql/contract-definition-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractdefinition/SqlContractDefinitionStoreExtension.java
@@ -28,7 +28,6 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.sql.QueryExecutor;
 import org.eclipse.edc.sql.bootstrapper.SqlSchemaBootstrapper;
-import org.eclipse.edc.sql.configuration.DataSourceName;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 
@@ -36,11 +35,9 @@ import org.eclipse.edc.transaction.spi.TransactionContext;
 @Extension(value = "SQL contract definition store")
 public class SqlContractDefinitionStoreExtension implements ServiceExtension {
 
-    @Deprecated(since = "0.8.1")
-    public static final String DATASOURCE_SETTING_NAME = "edc.datasource.contractdefinition.name";
 
-    @Setting(value = "The datasource to be used", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE)
-    public static final String DATASOURCE_NAME = "edc.sql.store.contractdefinition.datasource";
+    @Setting(description = "The datasource to be used", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE, key = "edc.sql.store.contractdefinition.datasource")
+    private String dataSourceName;
 
     @Inject
     private DataSourceRegistry dataSourceRegistry;
@@ -62,8 +59,6 @@ public class SqlContractDefinitionStoreExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var dataSourceName = DataSourceName.getDataSourceName(DATASOURCE_NAME, DATASOURCE_SETTING_NAME, context.getConfig(), context.getMonitor());
-
         var sqlContractDefinitionStore = new SqlContractDefinitionStore(dataSourceRegistry, dataSourceName, transactionContext,
                 getStatementImpl(), typeManager.getMapper(), queryExecutor);
 

--- a/extensions/control-plane/store/sql/contract-definition-store-sql/src/test/java/org/eclipse/edc/connector/controlplane/store/sql/contractdefinition/SqlContractDefinitionStoreExtensionTest.java
+++ b/extensions/control-plane/store/sql/contract-definition-store-sql/src/test/java/org/eclipse/edc/connector/controlplane/store/sql/contractdefinition/SqlContractDefinitionStoreExtensionTest.java
@@ -25,11 +25,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.connector.controlplane.store.sql.contractdefinition.SqlContractDefinitionStoreExtension.DATASOURCE_NAME;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(DependencyInjectionExtension.class)
@@ -51,6 +48,5 @@ public class SqlContractDefinitionStoreExtensionTest {
         var service = context.getService(ContractDefinitionStore.class);
         assertThat(service).isInstanceOf(ContractDefinitionStore.class);
 
-        verify(config).getString(eq(DATASOURCE_NAME), any());
     }
 }

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/SqlContractNegotiationStoreExtension.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/SqlContractNegotiationStoreExtension.java
@@ -27,7 +27,6 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.sql.QueryExecutor;
 import org.eclipse.edc.sql.bootstrapper.SqlSchemaBootstrapper;
-import org.eclipse.edc.sql.configuration.DataSourceName;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 
@@ -37,11 +36,8 @@ import java.time.Clock;
 @Extension(value = "SQL contract negotiation store")
 public class SqlContractNegotiationStoreExtension implements ServiceExtension {
 
-    @Deprecated(since = "0.8.1")
-    public static final String DATASOURCE_SETTING_NAME = "edc.datasource.contractnegotiation.name";
-
-    @Setting(value = "The datasource to be used", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE)
-    public static final String DATASOURCE_NAME = "edc.sql.store.contractnegotiation.datasource";
+    @Setting(description = "The datasource to be used", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE, key = "edc.sql.store.contractnegotiation.datasource")
+    private String dataSourceName;
 
     @Inject
     private DataSourceRegistry dataSourceRegistry;
@@ -66,8 +62,6 @@ public class SqlContractNegotiationStoreExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var dataSourceName = DataSourceName.getDataSourceName(DATASOURCE_NAME, DATASOURCE_SETTING_NAME, context.getConfig(), context.getMonitor());
-
         var sqlStore = new SqlContractNegotiationStore(dataSourceRegistry, dataSourceName, trxContext,
                 typeManager.getMapper(), getStatementImpl(), context.getRuntimeId(), clock, queryExecutor);
         context.registerService(ContractNegotiationStore.class, sqlStore);
@@ -80,9 +74,5 @@ public class SqlContractNegotiationStoreExtension implements ServiceExtension {
      */
     private ContractNegotiationStatements getStatementImpl() {
         return statements != null ? statements : new PostgresDialectStatements();
-    }
-
-    private String getDataSourceName(ServiceExtensionContext context) {
-        return context.getConfig().getString(DATASOURCE_SETTING_NAME, DataSourceRegistry.DEFAULT_DATASOURCE);
     }
 }

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/test/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/SqlContractNegotiationStoreExtensionTest.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/test/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/SqlContractNegotiationStoreExtensionTest.java
@@ -33,12 +33,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.eclipse.edc.connector.controlplane.store.sql.contractnegotiation.SqlContractNegotiationStoreExtension.DATASOURCE_NAME;
-import static org.eclipse.edc.connector.controlplane.store.sql.contractnegotiation.SqlContractNegotiationStoreExtension.DATASOURCE_SETTING_NAME;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(DependencyInjectionExtension.class)
@@ -50,7 +45,6 @@ class SqlContractNegotiationStoreExtensionTest {
     void initialize(ServiceExtensionContext context, ObjectFactory factory) {
         var config = mock(Config.class);
         when(context.getConfig()).thenReturn(config);
-        when(config.getString(DATASOURCE_SETTING_NAME, DataSourceRegistry.DEFAULT_DATASOURCE)).thenReturn("test");
 
         context.registerService(DataSourceRegistry.class, mock(DataSourceRegistry.class));
         context.registerService(TransactionContext.class, mock(TransactionContext.class));
@@ -64,7 +58,6 @@ class SqlContractNegotiationStoreExtensionTest {
         var service = context.getService(ContractNegotiationStore.class);
         assertThat(service).isInstanceOf(SqlContractNegotiationStore.class);
         assertThat(service).extracting("statements").isInstanceOf(BaseSqlDialectStatements.class);
-        verify(config).getString(eq(DATASOURCE_NAME), any());
 
     }
 

--- a/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/policydefinition/SqlPolicyStoreExtension.java
+++ b/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/policydefinition/SqlPolicyStoreExtension.java
@@ -27,7 +27,6 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.sql.QueryExecutor;
 import org.eclipse.edc.sql.bootstrapper.SqlSchemaBootstrapper;
-import org.eclipse.edc.sql.configuration.DataSourceName;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 
@@ -35,11 +34,8 @@ import org.eclipse.edc.transaction.spi.TransactionContext;
 @Extension("SQL policy store")
 public class SqlPolicyStoreExtension implements ServiceExtension {
 
-    @Deprecated(since = "0.8.1")
-    public static final String DATASOURCE_SETTING_NAME = "edc.datasource.policy.name";
-
-    @Setting(value = "The datasource to be used", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE)
-    public static final String DATASOURCE_NAME = "edc.sql.store.policy.datasource";
+    @Setting(description = "The datasource to be used", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE, key = "edc.sql.store.policy.datasource")
+    private String dataSourceName;
 
     @Inject
     private DataSourceRegistry dataSourceRegistry;
@@ -60,7 +56,6 @@ public class SqlPolicyStoreExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var dataSourceName = DataSourceName.getDataSourceName(DATASOURCE_NAME, DATASOURCE_SETTING_NAME, context.getConfig(), context.getMonitor());
 
         var sqlPolicyStore = new SqlPolicyDefinitionStore(dataSourceRegistry, dataSourceName, transactionContext,
                 typeManager.getMapper(), getStatementImpl(), queryExecutor);
@@ -77,7 +72,4 @@ public class SqlPolicyStoreExtension implements ServiceExtension {
         return statements != null ? statements : new PostgresDialectStatements();
     }
 
-    private String getDataSourceName(ServiceExtensionContext context) {
-        return context.getConfig().getString(DATASOURCE_SETTING_NAME, DataSourceRegistry.DEFAULT_DATASOURCE);
-    }
 }

--- a/extensions/control-plane/store/sql/policy-definition-store-sql/src/test/java/org/eclipse/edc/connector/controlplane/store/sql/policydefinition/SqlPolicyDefinitionStoreExtensionTest.java
+++ b/extensions/control-plane/store/sql/policy-definition-store-sql/src/test/java/org/eclipse/edc/connector/controlplane/store/sql/policydefinition/SqlPolicyDefinitionStoreExtensionTest.java
@@ -26,11 +26,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.connector.controlplane.store.sql.policydefinition.SqlPolicyStoreExtension.DATASOURCE_NAME;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(DependencyInjectionExtension.class)
@@ -53,6 +50,5 @@ public class SqlPolicyDefinitionStoreExtensionTest {
         var service = context.getService(PolicyDefinitionStore.class);
         assertThat(service).isInstanceOf(SqlPolicyDefinitionStore.class);
 
-        verify(config).getString(eq(DATASOURCE_NAME), any());
     }
 }

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/transferprocess/SqlTransferProcessStoreExtension.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/transferprocess/SqlTransferProcessStoreExtension.java
@@ -27,7 +27,6 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.sql.QueryExecutor;
 import org.eclipse.edc.sql.bootstrapper.SqlSchemaBootstrapper;
-import org.eclipse.edc.sql.configuration.DataSourceName;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 
@@ -37,11 +36,8 @@ import java.time.Clock;
 @Extension(value = "SQL transfer process store")
 public class SqlTransferProcessStoreExtension implements ServiceExtension {
 
-    @Deprecated(since = "0.8.1")
-    public static final String DATASOURCE_SETTING_NAME = "edc.datasource.transferprocess.name";
-
-    @Setting(value = "The datasource to be used", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE)
-    public static final String DATASOURCE_NAME = "edc.sql.store.transferprocess.datasource";
+    @Setting(description = "The datasource to be used", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE, key = "edc.sql.store.transferprocess.datasource")
+    private String dataSourceName;
 
     @Inject
     private DataSourceRegistry dataSourceRegistry;
@@ -64,7 +60,6 @@ public class SqlTransferProcessStoreExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var dataSourceName = DataSourceName.getDataSourceName(DATASOURCE_NAME, DATASOURCE_SETTING_NAME, context.getConfig(), context.getMonitor());
 
         var store = new SqlTransferProcessStore(dataSourceRegistry, dataSourceName, trxContext,
                 typeManager.getMapper(), getStatementImpl(), context.getRuntimeId(), clock, queryExecutor);

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/test/java/org/eclipse/edc/connector/controlplane/store/sql/transferprocess/SqlTransferProcessStoreExtensionTest.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/test/java/org/eclipse/edc/connector/controlplane/store/sql/transferprocess/SqlTransferProcessStoreExtensionTest.java
@@ -26,11 +26,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.connector.controlplane.store.sql.transferprocess.SqlTransferProcessStoreExtension.DATASOURCE_NAME;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(DependencyInjectionExtension.class)
@@ -52,6 +49,5 @@ public class SqlTransferProcessStoreExtensionTest {
         var service = context.getService(TransferProcessStore.class);
         assertThat(service).isInstanceOf(SqlTransferProcessStore.class);
 
-        verify(config).getString(eq(DATASOURCE_NAME), any());
     }
 }

--- a/extensions/control-plane/transfer/transfer-data-plane-signaling/src/main/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/TransferDataPlaneSignalingExtension.java
+++ b/extensions/control-plane/transfer/transfer-data-plane-signaling/src/main/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/TransferDataPlaneSignalingExtension.java
@@ -39,8 +39,8 @@ public class TransferDataPlaneSignalingExtension implements ServiceExtension {
 
     private static final String DEFAULT_DATAPLANE_SELECTOR_STRATEGY = "random";
 
-    @Setting(value = "Defines strategy for Data Plane instance selection in case Data Plane is not embedded in current runtime", defaultValue = DEFAULT_DATAPLANE_SELECTOR_STRATEGY)
-    private static final String DPF_SELECTOR_STRATEGY = "edc.dataplane.client.selector.strategy";
+    @Setting(description = "Defines strategy for Data Plane instance selection in case Data Plane is not embedded in current runtime", defaultValue = DEFAULT_DATAPLANE_SELECTOR_STRATEGY, key = "edc.dataplane.client.selector.strategy")
+    private String selectionStrategy;
 
     @Inject
     private DataFlowManager dataFlowManager;
@@ -62,7 +62,6 @@ public class TransferDataPlaneSignalingExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var selectionStrategy = context.getSetting(DPF_SELECTOR_STRATEGY, DEFAULT_DATAPLANE_SELECTOR_STRATEGY);
         var controller = new DataPlaneSignalingFlowController(callbackUrl, selectorService, getPropertiesProvider(),
                 clientFactory, selectionStrategy, transferTypeParser);
         dataFlowManager.register(controller);

--- a/extensions/control-plane/transfer/transfer-pull-http-dynamic-receiver/src/main/java/org/eclipse/edc/connector/controlplane/receiver/http/dynamic/HttpDynamicEndpointDataReferenceReceiverExtension.java
+++ b/extensions/control-plane/transfer/transfer-pull-http-dynamic-receiver/src/main/java/org/eclipse/edc/connector/controlplane/receiver/http/dynamic/HttpDynamicEndpointDataReferenceReceiverExtension.java
@@ -31,13 +31,14 @@ public class HttpDynamicEndpointDataReferenceReceiverExtension implements Servic
 
     public static final String NAME = "Http Dynamic Endpoint Data Reference Receiver";
 
-    @Setting(value = "Fallback endpoint when url is missing the the transfer process")
-    private static final String HTTP_RECEIVER_ENDPOINT = "edc.receiver.http.dynamic.endpoint";
+    @Setting(description = "Fallback endpoint when url is missing the the transfer process", key = "edc.receiver.http.dynamic.endpoint", required = false)
+    private String fallbackEndpoint;
 
-    @Setting(value = "Header name that will be sent with the EDR")
-    private static final String HTTP_RECEIVER_AUTH_KEY = "edc.receiver.http.dynamic.auth-key";
-    @Setting(value = "Header value that will be sent with the EDR")
-    private static final String HTTP_RECEIVER_AUTH_CODE = "edc.receiver.http.dynamic.auth-code";
+    @Setting(description = "Header name that will be sent with the EDR", key = "edc.receiver.http.dynamic.auth-key", required = false)
+    private String authKey;
+
+    @Setting(description = "Header value that will be sent with the EDR", key = "edc.receiver.http.dynamic.auth-code", required = false)
+    private String authCode;
 
     @Inject
     private EndpointDataReferenceReceiverRegistry receiverRegistry;
@@ -65,10 +66,6 @@ public class HttpDynamicEndpointDataReferenceReceiverExtension implements Servic
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var fallbackEndpoint = context.getSetting(HTTP_RECEIVER_ENDPOINT, null);
-        var authKey = context.getSetting(HTTP_RECEIVER_AUTH_KEY, null);
-        var authCode = context.getSetting(HTTP_RECEIVER_AUTH_CODE, null);
-
         var receiver = HttpDynamicEndpointDataReferenceReceiver.Builder.newInstance()
                 .httpClient(httpClient)
                 .typeManager(typeManager)

--- a/extensions/data-plane-selector/data-plane-selector-client/src/main/java/org/eclipse/edc/connector/dataplane/selector/DataPlaneSelectorClientExtension.java
+++ b/extensions/data-plane-selector/data-plane-selector-client/src/main/java/org/eclipse/edc/connector/dataplane/selector/DataPlaneSelectorClientExtension.java
@@ -40,11 +40,11 @@ public class DataPlaneSelectorClientExtension implements ServiceExtension {
 
     public static final String NAME = "DataPlane Selector client";
 
-    @Setting(value = "DataPlane selector api URL", required = true)
-    static final String DPF_SELECTOR_URL_SETTING = "edc.dpf.selector.url";
+    @Setting(description = "DataPlane selector api URL", key = "edc.dpf.selector.url")
+    private String selectorApiUrl;
 
-    @Setting(value = "Defines strategy for Data Plane instance selection in case Data Plane is not embedded in current runtime", defaultValue = DataPlaneSelectorService.DEFAULT_STRATEGY)
-    private static final String DPF_SELECTOR_STRATEGY = "edc.dataplane.client.selector.strategy";
+    @Setting(description = "Defines strategy for Data Plane instance selection in case Data Plane is not embedded in current runtime", defaultValue = DataPlaneSelectorService.DEFAULT_STRATEGY, key = "edc.dataplane.client.selector.strategy")
+    private String selectionStrategy;
 
     @Inject
     private ControlApiHttpClient httpClient;
@@ -76,10 +76,7 @@ public class DataPlaneSelectorClientExtension implements ServiceExtension {
 
     @Provider
     public DataPlaneSelectorService dataPlaneSelectorService(ServiceExtensionContext context) {
-        var config = context.getConfig();
-        var url = config.getString(DPF_SELECTOR_URL_SETTING);
-        var selectionStrategy = config.getString(DPF_SELECTOR_STRATEGY, DataPlaneSelectorService.DEFAULT_STRATEGY);
-        return new RemoteDataPlaneSelectorService(httpClient, url, typeManager.getMapper(JSON_LD), typeTransformerRegistry,
+        return new RemoteDataPlaneSelectorService(httpClient, selectorApiUrl, typeManager.getMapper(JSON_LD), typeTransformerRegistry,
                 selectionStrategy, jsonLd);
     }
 }

--- a/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/selector/store/sql/SqlDataPlaneInstanceStoreExtension.java
+++ b/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/selector/store/sql/SqlDataPlaneInstanceStoreExtension.java
@@ -27,7 +27,6 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.sql.QueryExecutor;
 import org.eclipse.edc.sql.bootstrapper.SqlSchemaBootstrapper;
-import org.eclipse.edc.sql.configuration.DataSourceName;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 
@@ -41,12 +40,9 @@ import java.time.Clock;
 public class SqlDataPlaneInstanceStoreExtension implements ServiceExtension {
     public static final String NAME = "Sql Data Plane Instance Store";
 
-    @Deprecated(since = "0.8.1")
-    @Setting(value = "Name of the datasource to use for accessing data plane instances")
-    public static final String DATASOURCE_SETTING_NAME = "edc.datasource.dataplaneinstance.name";
 
-    @Setting(value = "The datasource to be used", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE)
-    public static final String DATASOURCE_NAME = "edc.sql.store.dataplaneinstance.datasource";
+    @Setting(description = "The datasource to be used", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE, key = "edc.sql.store.dataplaneinstance.datasource")
+    private String dataSourceName;
 
     @Inject
     private DataSourceRegistry dataSourceRegistry;
@@ -76,8 +72,6 @@ public class SqlDataPlaneInstanceStoreExtension implements ServiceExtension {
 
     @Provider
     public DataPlaneInstanceStore dataPlaneInstanceStore(ServiceExtensionContext context) {
-        var dataSourceName = DataSourceName.getDataSourceName(DATASOURCE_NAME, DATASOURCE_SETTING_NAME, context.getConfig(), context.getMonitor());
-
         sqlSchemaBootstrapper.addStatementFromResource(dataSourceName, "dataplane-instance-schema.sql");
         return new SqlDataPlaneInstanceStore(dataSourceRegistry, dataSourceName, transactionContext,
                 getStatementImpl(), typeManager.getMapper(), queryExecutor, clock, context.getRuntimeId());

--- a/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/src/test/java/org/eclipse/edc/connector/dataplane/selector/store/sql/SqlDataPlaneInstanceStoreExtensionTest.java
+++ b/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/src/test/java/org/eclipse/edc/connector/dataplane/selector/store/sql/SqlDataPlaneInstanceStoreExtensionTest.java
@@ -24,11 +24,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.connector.dataplane.selector.store.sql.SqlDataPlaneInstanceStoreExtension.DATASOURCE_NAME;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(DependencyInjectionExtension.class)
@@ -48,6 +45,5 @@ public class SqlDataPlaneInstanceStoreExtensionTest {
         var store = extension.dataPlaneInstanceStore(context);
         assertThat(store).isInstanceOf(SqlDataPlaneInstanceStore.class);
 
-        verify(config).getString(eq(DATASOURCE_NAME), any());
     }
 }

--- a/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/DataPlaneHttpExtension.java
+++ b/extensions/data-plane/data-plane-http/src/main/java/org/eclipse/edc/connector/dataplane/http/DataPlaneHttpExtension.java
@@ -41,8 +41,8 @@ public class DataPlaneHttpExtension implements ServiceExtension {
     public static final String NAME = "Data Plane HTTP";
     private static final int DEFAULT_PARTITION_SIZE = 5;
 
-    @Setting(value = "Number of partitions for parallel message push in the HttpDataSink", type = "int", defaultValue = DEFAULT_PARTITION_SIZE + "")
-    private static final String EDC_DATAPLANE_HTTP_SINK_PARTITION_SIZE = "edc.dataplane.http.sink.partition.size";
+    @Setting(description = "Number of partitions for parallel message push in the HttpDataSink", defaultValue = DEFAULT_PARTITION_SIZE + "", key = "edc.dataplane.http.sink.partition.size")
+    private int partitionSize;
 
     @Inject
     private EdcHttpClient httpClient;
@@ -67,7 +67,6 @@ public class DataPlaneHttpExtension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
         var monitor = context.getMonitor();
-        var sinkPartitionSize = context.getSetting(EDC_DATAPLANE_HTTP_SINK_PARTITION_SIZE, DEFAULT_PARTITION_SIZE);
 
         var paramsProvider = new HttpRequestParamsProviderImpl(vault, typeManager);
         context.registerService(HttpRequestParamsProvider.class, paramsProvider);
@@ -77,7 +76,7 @@ public class DataPlaneHttpExtension implements ServiceExtension {
         var sourceFactory = new HttpDataSourceFactory(httpClient, paramsProvider, monitor, httpRequestFactory);
         pipelineService.registerFactory(sourceFactory);
 
-        var sinkFactory = new HttpDataSinkFactory(httpClient, executorContainer.getExecutorService(), sinkPartitionSize, monitor, paramsProvider, httpRequestFactory);
+        var sinkFactory = new HttpDataSinkFactory(httpClient, executorContainer.getExecutorService(), partitionSize, monitor, paramsProvider, httpRequestFactory);
         pipelineService.registerFactory(sinkFactory);
     }
 

--- a/extensions/data-plane/data-plane-iam/src/main/java/org/eclipse/edc/connector/dataplane/iam/DataPlaneIamDefaultServicesExtension.java
+++ b/extensions/data-plane/data-plane-iam/src/main/java/org/eclipse/edc/connector/dataplane/iam/DataPlaneIamDefaultServicesExtension.java
@@ -35,10 +35,11 @@ public class DataPlaneIamDefaultServicesExtension implements ServiceExtension {
 
     public static final String NAME = "Data Plane Default IAM Services";
 
-    @Setting(value = "Alias of private key used for signing tokens, retrieved from private key resolver")
-    public static final String TOKEN_SIGNER_PRIVATE_KEY_ALIAS = "edc.transfer.proxy.token.signer.privatekey.alias";
-    @Setting(value = "Alias of public key used for verifying the tokens, retrieved from the vault")
-    public static final String TOKEN_VERIFIER_PUBLIC_KEY_ALIAS = "edc.transfer.proxy.token.verifier.publickey.alias";
+    @Setting(description = "Alias of private key used for signing tokens, retrieved from private key resolver", key = "edc.transfer.proxy.token.signer.privatekey.alias")
+    private String tokenSignerPrivateKeyAlias;
+
+    @Setting(description = "Alias of public key used for verifying the tokens, retrieved from the vault", key = "edc.transfer.proxy.token.verifier.publickey.alias")
+    private String tokenVerifierPublicKeyAlias;
 
     @Inject
     private AccessTokenDataStore accessTokenDataStore;
@@ -62,8 +63,6 @@ public class DataPlaneIamDefaultServicesExtension implements ServiceExtension {
 
     @Provider(isDefault = true)
     public DataPlaneAccessTokenService defaultAccessTokenService(ServiceExtensionContext context) {
-        var tokenVerifierPublicKeyAlias = context.getConfig().getString(TOKEN_VERIFIER_PUBLIC_KEY_ALIAS);
-        var tokenSignerPrivateKeyAlias = context.getConfig().getString(TOKEN_SIGNER_PRIVATE_KEY_ALIAS);
         var monitor = context.getMonitor().withPrefix("DataPlane IAM");
         return new DefaultDataPlaneAccessTokenServiceImpl(new JwtGenerationService(jwsSignerProvider),
                 accessTokenDataStore, monitor,

--- a/extensions/data-plane/data-plane-kafka/src/main/java/org/eclipse/edc/connector/dataplane/kafka/DataPlaneKafkaExtension.java
+++ b/extensions/data-plane/data-plane-kafka/src/main/java/org/eclipse/edc/connector/dataplane/kafka/DataPlaneKafkaExtension.java
@@ -34,8 +34,8 @@ public class DataPlaneKafkaExtension implements ServiceExtension {
 
     private static final int DEFAULT_PARTITION_SIZE = 5;
 
-    @Setting(value = "The partitionSize used by the kafka data sink", type = "int", defaultValue = DEFAULT_PARTITION_SIZE + "", min = 1)
-    private static final String EDC_DATAPLANE_KAFKA_SINK_PARTITION_SIZE = "edc.dataplane.kafka.sink.partition.size";
+    @Setting(description = "The partitionSize used by the kafka data sink", defaultValue = DEFAULT_PARTITION_SIZE + "", min = 1, key = "edc.dataplane.kafka.sink.partition.size")
+    private int partitionSize;
 
     @Inject
     private DataTransferExecutorServiceContainer executorContainer;
@@ -56,9 +56,8 @@ public class DataPlaneKafkaExtension implements ServiceExtension {
         var monitor = context.getMonitor();
         var propertiesFactory = new KafkaPropertiesFactory();
 
-        var sinkPartitionSize = context.getSetting(EDC_DATAPLANE_KAFKA_SINK_PARTITION_SIZE, DEFAULT_PARTITION_SIZE);
 
         pipelineService.registerFactory(new KafkaDataSourceFactory(monitor, propertiesFactory, clock));
-        pipelineService.registerFactory(new KafkaDataSinkFactory(executorContainer.getExecutorService(), monitor, propertiesFactory, sinkPartitionSize));
+        pipelineService.registerFactory(new KafkaDataSinkFactory(executorContainer.getExecutorService(), monitor, propertiesFactory, partitionSize));
     }
 }

--- a/extensions/data-plane/data-plane-public-api-v2/src/main/java/org/eclipse/edc/connector/dataplane/api/DataPlanePublicApiV2Extension.java
+++ b/extensions/data-plane/data-plane-public-api-v2/src/main/java/org/eclipse/edc/connector/dataplane/api/DataPlanePublicApiV2Extension.java
@@ -51,7 +51,7 @@ public class DataPlanePublicApiV2Extension implements ServiceExtension {
 
     @Setting(description = "Base url of the public API endpoint without the trailing slash. This should correspond to the values configured " +
                            "in '" + DEFAULT_PUBLIC_PORT + "' and '" + PUBLIC_CONTEXT_PATH + "'.",
-            defaultValue = "http://<HOST>:" + DEFAULT_PUBLIC_PORT + PUBLIC_CONTEXT_PATH,
+            required = false,
             key = "edc.dataplane.api.public.baseurl", warnOnMissingConfig = true)
     private String publicBaseUrl;
 
@@ -105,6 +105,11 @@ public class DataPlanePublicApiV2Extension implements ServiceExtension {
                 "Data plane proxy transfers"
         );
 
+
+        if (publicBaseUrl == null) {
+            publicBaseUrl = "http://%s:%d%s".formatted(hostname.get(), configuration.getPort(), configuration.getPath());
+            context.getMonitor().warning("The public API endpoint was not explicitly configured, the default '%s' will be used.".formatted(publicBaseUrl));
+        }
         var endpoint = Endpoint.url(publicBaseUrl);
         generatorService.addGeneratorFunction("HttpData", dataAddress -> endpoint);
 

--- a/extensions/data-plane/data-plane-self-registration/src/main/java/org/eclipse/edc/connector/dataplane/registration/DataplaneSelfRegistrationExtension.java
+++ b/extensions/data-plane/data-plane-self-registration/src/main/java/org/eclipse/edc/connector/dataplane/registration/DataplaneSelfRegistrationExtension.java
@@ -48,8 +48,9 @@ public class DataplaneSelfRegistrationExtension implements ServiceExtension {
 
     public static final boolean DEFAULT_SELF_UNREGISTRATION = false;
     public static final String NAME = "Dataplane Self Registration";
-    @Setting(value = "Enable data-plane un-registration at shutdown (not suggested for clustered environments)", type = "boolean", defaultValue = DEFAULT_SELF_UNREGISTRATION + "")
-    static final String SELF_UNREGISTRATION = "edc.data.plane.self.unregistration";
+    @Setting(description = "Enable data-plane un-registration at shutdown (not suggested for clustered environments)", defaultValue = DEFAULT_SELF_UNREGISTRATION + "", key = "edc.data.plane.self.unregistration")
+    private boolean selfUnregistration;
+
     private final AtomicBoolean isRegistered = new AtomicBoolean(false);
     private final AtomicReference<String> registrationError = new AtomicReference<>("Data plane self registration not complete");
     @Inject
@@ -108,7 +109,7 @@ public class DataplaneSelfRegistrationExtension implements ServiceExtension {
 
     @Override
     public void shutdown() {
-        if (context.getConfig().getBoolean(SELF_UNREGISTRATION, DEFAULT_SELF_UNREGISTRATION)) {
+        if (selfUnregistration) {
             dataPlaneSelectorService.unregister(context.getComponentId())
                     .onSuccess(it -> context.getMonitor().debug("data plane successfully unregistered"))
                     .onFailure(failure -> context.getMonitor().severe("error during data plane de-registration. %s: %s"

--- a/extensions/data-plane/data-plane-self-registration/src/test/java/org/eclipse/edc/connector/dataplane/registration/DataplaneSelfRegistrationExtensionTest.java
+++ b/extensions/data-plane/data-plane-self-registration/src/test/java/org/eclipse/edc/connector/dataplane/registration/DataplaneSelfRegistrationExtensionTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.connector.dataplane.registration;
 
+import org.eclipse.edc.boot.system.injection.ObjectFactory;
 import org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService;
 import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
 import org.eclipse.edc.connector.dataplane.spi.iam.PublicEndpointGeneratorService;
@@ -39,7 +40,6 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.eclipse.edc.connector.dataplane.registration.DataplaneSelfRegistrationExtension.SELF_UNREGISTRATION;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -117,13 +117,15 @@ class DataplaneSelfRegistrationExtensionTest {
     }
 
     @Test
-    void shouldUnregisterInstanceAtShutdown_whenConfigured(DataplaneSelfRegistrationExtension extension, ServiceExtensionContext context) {
+    void shouldUnregisterInstanceAtShutdown_whenConfigured(ServiceExtensionContext context, ObjectFactory objectFactory) {
         when(context.getComponentId()).thenReturn("componentId");
-        when(context.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of(SELF_UNREGISTRATION, "true")));
+        when(context.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of("edc.data.plane.self.unregistration", "true")));
         when(dataPlaneSelectorService.unregister(any())).thenReturn(ServiceResult.success());
-        extension.initialize(context);
 
-        extension.shutdown();
+        var ext = objectFactory.constructInstance(DataplaneSelfRegistrationExtension.class);
+        ext.initialize(context);
+
+        ext.shutdown();
 
         verify(dataPlaneSelectorService).unregister("componentId");
     }

--- a/extensions/data-plane/store/sql/accesstokendata-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/SqlAccessTokenDataStoreExtension.java
+++ b/extensions/data-plane/store/sql/accesstokendata-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/SqlAccessTokenDataStoreExtension.java
@@ -27,7 +27,6 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.sql.QueryExecutor;
 import org.eclipse.edc.sql.bootstrapper.SqlSchemaBootstrapper;
-import org.eclipse.edc.sql.configuration.DataSourceName;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 
@@ -41,12 +40,8 @@ public class SqlAccessTokenDataStoreExtension implements ServiceExtension {
 
     public static final String NAME = "Sql AccessTokenData Store";
 
-    @Deprecated(since = "0.8.1")
-    @Setting(value = "Name of the datasource to use for accessing data plane store")
-    private static final String DATASOURCE_SETTING_NAME = "edc.datasource.accesstokendata.name";
-
-    @Setting(value = "The datasource to be used", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE)
-    public static final String DATASOURCE_NAME = "edc.sql.store.accesstokendata.datasource";
+    @Setting(description = "The datasource to be used", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE, key = "edc.sql.store.accesstokendata.datasource")
+    private String dataSourceName;
 
     @Inject
     private DataSourceRegistry dataSourceRegistry;
@@ -75,8 +70,6 @@ public class SqlAccessTokenDataStoreExtension implements ServiceExtension {
 
     @Provider
     public AccessTokenDataStore dataPlaneStore(ServiceExtensionContext context) {
-        var dataSourceName = DataSourceName.getDataSourceName(DATASOURCE_NAME, DATASOURCE_SETTING_NAME, context.getConfig(), context.getMonitor());
-
         sqlSchemaBootstrapper.addStatementFromResource(dataSourceName, "accesstoken-data-schema.sql");
         return new SqlAccessTokenDataStore(dataSourceRegistry, dataSourceName, transactionContext,
                 getStatementImpl(), typeManager.getMapper(), queryExecutor);

--- a/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/SqlDataPlaneStoreExtension.java
+++ b/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/SqlDataPlaneStoreExtension.java
@@ -26,7 +26,6 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.sql.QueryExecutor;
 import org.eclipse.edc.sql.bootstrapper.SqlSchemaBootstrapper;
-import org.eclipse.edc.sql.configuration.DataSourceName;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 
@@ -40,12 +39,8 @@ public class SqlDataPlaneStoreExtension implements ServiceExtension {
 
     public static final String NAME = "Sql Data Plane Store";
 
-    @Deprecated(since = "0.8.1")
-    @Setting(value = "Name of the datasource to use for accessing data plane store")
-    private static final String DATASOURCE_SETTING_NAME = "edc.datasource.dataplane.name";
-
-    @Setting(value = "The datasource to be used", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE)
-    public static final String DATASOURCE_NAME = "edc.sql.store.dataplane.datasource";
+    @Setting(description = "The datasource to be used", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE, key = "edc.sql.store.dataplane.datasource")
+    private String dataSourceName;
 
     @Inject
     private DataSourceRegistry dataSourceRegistry;
@@ -74,8 +69,6 @@ public class SqlDataPlaneStoreExtension implements ServiceExtension {
 
     @Provider
     public DataPlaneStore dataPlaneStore(ServiceExtensionContext context) {
-        var dataSourceName = DataSourceName.getDataSourceName(DATASOURCE_NAME, DATASOURCE_SETTING_NAME, context.getConfig(), context.getMonitor());
-
         sqlSchemaBootstrapper.addStatementFromResource(dataSourceName, "dataplane-schema.sql");
         return new SqlDataPlaneStore(dataSourceRegistry, dataSourceName, transactionContext,
                 getStatementImpl(), typeManager.getMapper(), clock, queryExecutor, context.getRuntimeId());

--- a/extensions/policy-monitor/store/sql/policy-monitor-store-sql/src/main/java/org/eclipse/edc/connector/policy/monitor/store/sql/SqlPolicyMonitorStoreExtension.java
+++ b/extensions/policy-monitor/store/sql/policy-monitor-store-sql/src/main/java/org/eclipse/edc/connector/policy/monitor/store/sql/SqlPolicyMonitorStoreExtension.java
@@ -25,22 +25,15 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.sql.QueryExecutor;
 import org.eclipse.edc.sql.bootstrapper.SqlSchemaBootstrapper;
-import org.eclipse.edc.sql.configuration.DataSourceName;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 
 import java.time.Clock;
 
-import static org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry.DEFAULT_DATASOURCE;
-
 public class SqlPolicyMonitorStoreExtension implements ServiceExtension {
 
-    @Deprecated(since = "0.8.1")
-    @Setting(value = "Name of the datasource to use for accessing policy monitor store", defaultValue = DEFAULT_DATASOURCE)
-    private static final String DATASOURCE_SETTING_NAME = "edc.datasource.policy-monitor.name";
-
-    @Setting(value = "The datasource to be used", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE)
-    public static final String DATASOURCE_NAME = "edc.sql.store.policy-monitor.datasource";
+    @Setting(description = "The datasource to be used", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE, key = "edc.sql.store.policy-monitor.datasource")
+    private String dataSourceName;
 
     @Inject
     private DataSourceRegistry dataSourceRegistry;
@@ -65,7 +58,6 @@ public class SqlPolicyMonitorStoreExtension implements ServiceExtension {
 
     @Provider
     public PolicyMonitorStore policyMonitorStore(ServiceExtensionContext context) {
-        var dataSourceName = DataSourceName.getDataSourceName(DATASOURCE_NAME, DATASOURCE_SETTING_NAME, context.getConfig(), context.getMonitor());
 
         sqlSchemaBootstrapper.addStatementFromResource(dataSourceName, "policy-monitor-schema.sql");
 

--- a/system-tests/bom-tests/src/test/java/org/eclipse/edc/test/bom/BomSmokeTests.java
+++ b/system-tests/bom-tests/src/test/java/org/eclipse/edc/test/bom/BomSmokeTests.java
@@ -78,6 +78,9 @@ public class BomSmokeTests {
                                 put("web.http.control.path", "/api/control");
                                 put("web.http.management.port", "8081");
                                 put("web.http.management.path", "/api/management");
+                                put("edc.iam.sts.privatekey.alias", "privatekey");
+                                put("edc.iam.sts.publickey.id", "publickey");
+                                put("edc.iam.issuer.id", "did:web:someone");
                             }
                         },
                         ":dist:bom:controlplane-dcp-bom"


### PR DESCRIPTION
## What this PR changes/adds

This PR upgrades the entire code base to use the new Configuration Injection feature that was developed recently.

Note that this does **not** include:
- runtime id and component id, as they are not read by an extension but by the `ServiceExtensionContext`
- any property with a `context` attribute, as that is not yet implemented

## Why it does that

reduce code verbosity

## Further notes

- in tests, the `ObjectFactory` has to be used to construct the extension, because at the time the extension is injected into the test method, it is already fully constructed (i.e. all config values are already assigned) and that means, that mocking config values _in_ the test method is not possible, because it's too late. Directly injecting the extension into test methods only works when the config is set directly in the `@BeforeEach` method.
- sorry for the big change set

## Linked Issue(s)

Closes #4610

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
