### PR TITLE
fix:Fatal error while resume PULL transfer process

### DIFF
--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferProcess.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferProcess.java
@@ -288,7 +288,7 @@ public class TransferProcess extends StatefulEntity<TransferProcess> {
     }
 
     public boolean canBeStartedConsumer() {
-        return currentStateIsOneOf(STARTED, REQUESTED, STARTING, RESUMED);
+        return currentStateIsOneOf(STARTED, REQUESTED, STARTING, RESUMED, SUSPENDED);
     }
 
     public void transitionStarted(String dataPlaneId) {


### PR DESCRIPTION
## What this PR changes/adds

Allow to change consumer state from "SUSPENDED" to "STARTED".

## Why it does that

Currently system throw an exception on consumer side while trying to change state from "SUSPENDED" to "STARTED".

## Further notes

N/A

## Linked Issue(s)

https://github.com/eclipse-edc/Connector/issues/4591

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
