### PR TITLE
fix:Termination of pull transfer process from consumer side not succe…

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProtocolServiceImpl.java
@@ -232,6 +232,12 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
 
     @NotNull
     private ServiceResult<TransferProcess> terminatedAction(TransferTerminationMessage message, TransferProcess transferProcess) {
+        if (transferProcess.getType() == PROVIDER) {
+            var termination = dataFlowManager.terminate(transferProcess);
+            if (termination.failed()) {
+                return ServiceResult.conflict("Cannot terminate transfer process %s: %s".formatted(transferProcess.getId(), termination.getFailureDetail()));
+            }
+        }
         if (transferProcess.canBeTerminated()) {
             observable.invokeForEach(l -> l.preTerminated(transferProcess));
             transferProcess.transitionTerminated();


### PR DESCRIPTION
…ss in real but stated as "TERMINATED"

## What this PR changes/adds

Run termination process from data flow manager for provider when termination initiated by consumer

## Why it does that

During termination PULL transfer process from consumer, system does not call method terminate() from DataFlowManager on provider side.
As a result process not terminated in real but transfer process had state "TERMINATED", and then it is not possible to initiate terminating process again not from consumer neither form provider side.

## Further notes

N/A

## Linked Issue(s)

https://github.com/eclipse-edc/Connector/issues/4592

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
