### PR TITLE
fix: not required properties in DcpDefaultServicesExtension

### DIFF
--- a/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/DcpDefaultServicesExtension.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/DcpDefaultServicesExtension.java
@@ -87,7 +87,7 @@ public class DcpDefaultServicesExtension implements ServiceExtension {
 
         if (context.getSetting(OAUTH_TOKENURL_PROPERTY, null) != null) {
             context.getMonitor().warning("The property '%s' was configured, but no remote SecureTokenService was found on the classpath. ".formatted(OAUTH_TOKENURL_PROPERTY) +
-                    "This could be an indicator of a configuration problem.");
+                    "This could be an indication of a configuration problem.");
         }
 
         return new EmbeddedSecureTokenService(new JwtGenerationService(externalSigner), () -> privateKeyAlias, () -> publicKeyId, clock, TimeUnit.MINUTES.toSeconds(stsTokenExpirationMin), jtiValidationStore);

--- a/extensions/common/iam/identity-trust/identity-trust-core/src/test/java/org/eclipse/edc/iam/identitytrust/core/DcpDefaultServicesExtensionTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/test/java/org/eclipse/edc/iam/identitytrust/core/DcpDefaultServicesExtensionTest.java
@@ -23,6 +23,7 @@ import org.eclipse.edc.iam.identitytrust.core.scope.DcpScopeExtractorRegistry;
 import org.eclipse.edc.iam.identitytrust.sts.embedded.EmbeddedSecureTokenService;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.keys.spi.PrivateKeyResolver;
+import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
@@ -37,6 +38,9 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.eclipse.edc.iam.identitytrust.core.DcpDefaultServicesExtension.STS_PRIVATE_KEY_ALIAS;
+import static org.eclipse.edc.iam.identitytrust.core.DcpDefaultServicesExtension.STS_PUBLIC_KEY_ID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -90,6 +94,17 @@ class DcpDefaultServicesExtensionTest {
 
         verify(mockedMonitor).info(anyString());
         verify(mockedMonitor).warning(anyString());
+    }
+
+    @Test
+    void verify_defaultServiceWithMissingConfig(ServiceExtensionContext context) {
+        var ext = new DcpDefaultServicesExtension();
+        
+        assertThatThrownBy(() -> ext.createDefaultTokenService(context))
+                .isInstanceOf(EdcException.class)
+                .hasMessageContaining(STS_PUBLIC_KEY_ID)
+                .hasMessageContaining(STS_PRIVATE_KEY_ALIAS);
+
     }
 
     @Test


### PR DESCRIPTION
## What this PR changes/adds

The following properties config in `DcpDefaultServicesExtension` are marked required:

- `edc.iam.sts.publickey.id`
- `edc.iam.sts.privatekey.alias`

They are only required when the embedded STS is used. 

## Why it does that

It fixes the case where the `SecureTokenService` is not default (provided by another extension)

but the above properties are still required

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
