### PR TITLE
fix: Fatal error while resume PULL transfer from provider

### DIFF
--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/Participant.java
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/Participant.java
@@ -23,6 +23,7 @@ import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractDefinition;
 import org.eclipse.edc.connector.controlplane.policy.spi.PolicyDefinition;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates;
 import org.eclipse.edc.jsonld.TitaniumJsonLd;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.jsonld.util.JacksonJsonLd;
@@ -496,6 +497,10 @@ public class Participant {
      */
     public String getContractNegotiationState(String id) {
         return getContractNegotiationField(id, "state");
+    }
+
+    public void awaitTransferToBeInState(String transferProcessId, TransferProcessStates state) {
+        await().atMost(timeout).until(() -> getTransferProcessState(transferProcessId), it -> Objects.equals(it, state.name()));
     }
 
     protected String getContractNegotiationField(String negotiationId, String fieldName) {

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferProcess.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferProcess.java
@@ -288,7 +288,7 @@ public class TransferProcess extends StatefulEntity<TransferProcess> {
     }
 
     public boolean canBeStartedConsumer() {
-        return currentStateIsOneOf(STARTED, REQUESTED, STARTING, RESUMED);
+        return currentStateIsOneOf(STARTED, REQUESTED, STARTING, RESUMED, SUSPENDED);
     }
 
     public void transitionStarted(String dataPlaneId) {

--- a/spi/control-plane/transfer-spi/src/test/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferProcessTest.java
+++ b/spi/control-plane/transfer-spi/src/test/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferProcessTest.java
@@ -101,6 +101,13 @@ class TransferProcessTest {
         // should not set the data plane id
         assertThat(process.getDataPlaneId()).isNull();
 
+        process.transitionSuspending("suspension");
+        process.transitionSuspended();
+
+        process.transitionStarted("dataPlaneId");
+        // should not set the data plane id
+        assertThat(process.getDataPlaneId()).isNull();
+
         process.transitionCompleting();
         process.transitionCompleted();
 

--- a/spi/control-plane/transfer-spi/src/test/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferProcessTest.java
+++ b/spi/control-plane/transfer-spi/src/test/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferProcessTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -32,6 +31,7 @@ import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess.Type.CONSUMER;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.STARTED;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.TERMINATING;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -87,9 +87,8 @@ class TransferProcessTest {
         assertThat(process).usingRecursiveComparison().isEqualTo(copy);
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = { "STARTED", "SUSPENDED"})
-    void verifyConsumerTransitions(String state) {
+    @Test
+    void verifyConsumerTransitions() {
         var process = TransferProcess.Builder.newInstance().id(UUID.randomUUID().toString()).type(CONSUMER).build();
 
         process.transitionProvisioning(ResourceManifest.Builder.newInstance().build());
@@ -100,24 +99,31 @@ class TransferProcessTest {
 
         assertThrows(IllegalStateException.class, process::transitionStarting, "STARTING is not a valid state for consumer");
         process.transitionStarted("dataPlaneId");
-        // should not set the data plane id
+
+        process.transitionSuspending("suspension");
+        process.transitionSuspended();
+
+        process.transitionStarted("dataPlaneId");
+
+        process.transitionCompleting();
+        process.transitionCompleted();
+
+        process.transitionDeprovisioning();
+        process.transitionDeprovisioned();
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = TransferProcessStates.class, mode = INCLUDE, names = { "STARTING", "SUSPENDED" })
+    void shouldNotSetDataPlaneIdOnStart_whenTransferIsConsumer(TransferProcessStates fromState) {
+        var process = TransferProcess.Builder.newInstance()
+                .id(UUID.randomUUID().toString()).type(CONSUMER)
+                .state(fromState.code())
+                .build();
+
+        process.transitionStarted("dataPlaneId");
+
+        assertThat(process.stateAsString()).isEqualTo(STARTED.name());
         assertThat(process.getDataPlaneId()).isNull();
-
-        switch (state) {
-            case "STARTED":
-                process.transitionCompleting();
-                process.transitionCompleted();
-
-                process.transitionDeprovisioning();
-                process.transitionDeprovisioned();
-                break;
-            case "SUSPENDED":
-                process.transitionSuspending("suspension");
-                process.transitionSuspended();
-                break;
-            default:
-                throw new IllegalArgumentException("Unsupported state: " + state);
-        }
     }
 
     @Test

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferEndToEndParticipant.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferEndToEndParticipant.java
@@ -17,17 +17,20 @@ package org.eclipse.edc.test.e2e;
 import io.restassured.common.mapper.TypeRef;
 import org.assertj.core.api.ThrowingConsumer;
 import org.eclipse.edc.connector.controlplane.test.system.utils.Participant;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.jetbrains.annotations.NotNull;
 
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static java.io.File.separator;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.eclipse.edc.boot.BootServicesExtension.PARTICIPANT_ID;
 import static org.eclipse.edc.sql.testfixtures.PostgresqlEndToEndInstance.defaultDatasourceConfiguration;
 import static org.eclipse.edc.util.io.Ports.getFreePort;
@@ -170,6 +173,10 @@ public class TransferEndToEndParticipant extends Participant {
                 .extract().body().asString();
 
         assertThat(data).satisfies(bodyAssertion);
+    }
+
+    protected void awaitTransferToBeInState(String transferProcessId, TransferProcessStates state) {
+        await().atMost(timeout).until(() -> getTransferProcessState(transferProcessId), it -> Objects.equals(it, state.name()));
     }
 
     @NotNull

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferEndToEndParticipant.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferEndToEndParticipant.java
@@ -17,20 +17,17 @@ package org.eclipse.edc.test.e2e;
 import io.restassured.common.mapper.TypeRef;
 import org.assertj.core.api.ThrowingConsumer;
 import org.eclipse.edc.connector.controlplane.test.system.utils.Participant;
-import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.jetbrains.annotations.NotNull;
 
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static java.io.File.separator;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 import static org.eclipse.edc.boot.BootServicesExtension.PARTICIPANT_ID;
 import static org.eclipse.edc.sql.testfixtures.PostgresqlEndToEndInstance.defaultDatasourceConfiguration;
 import static org.eclipse.edc.util.io.Ports.getFreePort;
@@ -173,10 +170,6 @@ public class TransferEndToEndParticipant extends Participant {
                 .extract().body().asString();
 
         assertThat(data).satisfies(bodyAssertion);
-    }
-
-    protected void awaitTransferToBeInState(String transferProcessId, TransferProcessStates state) {
-        await().atMost(timeout).until(() -> getTransferProcessState(transferProcessId), it -> Objects.equals(it, state.name()));
     }
 
     @NotNull

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferEndToEndTestBase.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferEndToEndTestBase.java
@@ -71,9 +71,9 @@ public abstract class TransferEndToEndTestBase {
         PROVIDER.createContractDefinition(assetId, UUID.randomUUID().toString(), noConstraintPolicyId, noConstraintPolicyId);
     }
 
-    protected void awaitTransferToBeInState(String transferProcessId, TransferProcessStates state) {
+    protected void awaitTransferToBeInState(TransferEndToEndParticipant participant, String transferProcessId, TransferProcessStates state) {
         await().atMost(timeout).until(
-                () -> CONSUMER.getTransferProcessState(transferProcessId),
+                () -> participant.getTransferProcessState(transferProcessId),
                 it -> Objects.equals(it, state.name())
         );
     }

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferEndToEndTestBase.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferEndToEndTestBase.java
@@ -15,17 +15,14 @@
 package org.eclipse.edc.test.e2e;
 
 import jakarta.json.JsonObject;
-import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates;
 import org.eclipse.edc.spi.security.Vault;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 
 import java.time.Duration;
 import java.util.Map;
-import java.util.Objects;
 import java.util.UUID;
 
-import static org.awaitility.Awaitility.await;
 import static org.eclipse.edc.connector.controlplane.test.system.utils.PolicyFixtures.noConstraintPolicy;
 import static org.eclipse.edc.junit.testfixtures.TestUtils.getResourceFileContentAsString;
 
@@ -70,12 +67,4 @@ public abstract class TransferEndToEndTestBase {
         PROVIDER.createAsset(assetId, Map.of("description", "description"), dataAddressProperties);
         PROVIDER.createContractDefinition(assetId, UUID.randomUUID().toString(), noConstraintPolicyId, noConstraintPolicyId);
     }
-
-    protected void awaitTransferToBeInState(TransferEndToEndParticipant participant, String transferProcessId, TransferProcessStates state) {
-        await().atMost(timeout).until(
-                () -> participant.getTransferProcessState(transferProcessId),
-                it -> Objects.equals(it, state.name())
-        );
-    }
-
 }

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferPullEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferPullEndToEndTest.java
@@ -127,7 +127,7 @@ class TransferPullEndToEndTest {
                     .withCallbacks(callbacks)
                     .execute();
 
-            awaitTransferToBeInState(CONSUMER, transferProcessId, STARTED);
+            CONSUMER.awaitTransferToBeInState(transferProcessId, STARTED);
 
             await().atMost(timeout).untilAsserted(() -> assertThat(events.get(transferProcessId)).isNotNull());
 
@@ -150,7 +150,7 @@ class TransferPullEndToEndTest {
                     .withTransferType("HttpData-PULL")
                     .execute();
 
-            awaitTransferToBeInState(CONSUMER, transferProcessId, STARTED);
+            CONSUMER.awaitTransferToBeInState(transferProcessId, STARTED);
 
             var edr = await().atMost(timeout).until(() -> CONSUMER.getEdr(transferProcessId), Objects::nonNull);
 
@@ -177,7 +177,7 @@ class TransferPullEndToEndTest {
                     .withTransferType("HttpData-PULL")
                     .execute();
 
-            awaitTransferToBeInState(CONSUMER, transferProcessId, STARTED);
+            CONSUMER.awaitTransferToBeInState(transferProcessId, STARTED);
 
             var edr = await().atMost(timeout).until(() -> CONSUMER.getEdr(transferProcessId), Objects::nonNull);
 
@@ -186,7 +186,7 @@ class TransferPullEndToEndTest {
 
             CONSUMER.suspendTransfer(transferProcessId, "supension");
 
-            awaitTransferToBeInState(CONSUMER, transferProcessId, SUSPENDED);
+            CONSUMER.awaitTransferToBeInState(transferProcessId, SUSPENDED);
 
             // checks that the EDR is gone once the transfer has been suspended
             await().atMost(timeout).untilAsserted(() -> assertThatThrownBy(() -> CONSUMER.getEdr(transferProcessId)));
@@ -196,7 +196,7 @@ class TransferPullEndToEndTest {
             CONSUMER.resumeTransfer(transferProcessId);
 
             // check that transfer is available again
-            awaitTransferToBeInState(CONSUMER, transferProcessId, STARTED);
+            CONSUMER.awaitTransferToBeInState(transferProcessId, STARTED);
             var secondEdr = await().atMost(timeout).until(() -> CONSUMER.getEdr(transferProcessId), Objects::nonNull);
             var secondMessage = UUID.randomUUID().toString();
             await().atMost(timeout).untilAsserted(() -> CONSUMER.pullData(secondEdr, Map.of("message", secondMessage), body -> assertThat(body).isEqualTo("data")));
@@ -214,7 +214,7 @@ class TransferPullEndToEndTest {
                     .withTransferType("HttpData-PULL")
                     .execute();
 
-            awaitTransferToBeInState(CONSUMER, consumerTransferProcessId, STARTED);
+            CONSUMER.awaitTransferToBeInState(consumerTransferProcessId, STARTED);
 
             var edr = await().atMost(timeout).until(() -> CONSUMER.getEdr(consumerTransferProcessId), Objects::nonNull);
 
@@ -227,7 +227,7 @@ class TransferPullEndToEndTest {
 
             PROVIDER.suspendTransfer(providerTransferProcessId, "supension");
 
-            awaitTransferToBeInState(PROVIDER, providerTransferProcessId, SUSPENDED);
+            PROVIDER.awaitTransferToBeInState(providerTransferProcessId, SUSPENDED);
 
             // checks that the EDR is gone once the transfer has been suspended
             await().atMost(timeout).untilAsserted(() -> assertThatThrownBy(() -> CONSUMER.getEdr(consumerTransferProcessId)));
@@ -237,7 +237,7 @@ class TransferPullEndToEndTest {
             PROVIDER.resumeTransfer(providerTransferProcessId);
 
             // check that transfer is available again
-            awaitTransferToBeInState(PROVIDER, providerTransferProcessId, STARTED);
+            PROVIDER.awaitTransferToBeInState(providerTransferProcessId, STARTED);
             var secondEdr = await().atMost(timeout).until(() -> CONSUMER.getEdr(consumerTransferProcessId), Objects::nonNull);
             var secondMessage = UUID.randomUUID().toString();
             await().atMost(timeout).untilAsserted(() -> CONSUMER.pullData(secondEdr, Map.of("message", secondMessage), body -> assertThat(body).isEqualTo("data")));
@@ -263,7 +263,7 @@ class TransferPullEndToEndTest {
                     .withTransferType("HttpData-PULL")
                     .execute();
 
-            awaitTransferToBeInState(CONSUMER, transferProcessId, STARTED);
+            CONSUMER.awaitTransferToBeInState(transferProcessId, STARTED);
 
             await().atMost(timeout).untilAsserted(() -> {
                 var edr = await().atMost(timeout).until(() -> CONSUMER.getEdr(transferProcessId), Objects::nonNull);
@@ -287,7 +287,7 @@ class TransferPullEndToEndTest {
                     .withTransferType("HttpData-PULL")
                     .execute();
 
-            awaitTransferToBeInState(CONSUMER, transferProcessId, TERMINATED);
+            CONSUMER.awaitTransferToBeInState(transferProcessId, TERMINATED);
         }
 
         @Test
@@ -302,7 +302,7 @@ class TransferPullEndToEndTest {
                     .withTransferType("HttpData-PULL")
                     .execute();
 
-            awaitTransferToBeInState(CONSUMER, transferProcessId, TERMINATED);
+            CONSUMER.awaitTransferToBeInState(transferProcessId, TERMINATED);
         }
 
         public JsonObject createCallback(String url, boolean transactional, Set<String> events) {

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferPullEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferPullEndToEndTest.java
@@ -127,7 +127,7 @@ class TransferPullEndToEndTest {
                     .withCallbacks(callbacks)
                     .execute();
 
-            awaitTransferToBeInState(transferProcessId, STARTED);
+            awaitTransferToBeInState(CONSUMER, transferProcessId, STARTED);
 
             await().atMost(timeout).untilAsserted(() -> assertThat(events.get(transferProcessId)).isNotNull());
 
@@ -150,7 +150,7 @@ class TransferPullEndToEndTest {
                     .withTransferType("HttpData-PULL")
                     .execute();
 
-            awaitTransferToBeInState(transferProcessId, STARTED);
+            awaitTransferToBeInState(CONSUMER, transferProcessId, STARTED);
 
             var edr = await().atMost(timeout).until(() -> CONSUMER.getEdr(transferProcessId), Objects::nonNull);
 
@@ -168,7 +168,7 @@ class TransferPullEndToEndTest {
         }
 
         @Test
-        void suspendAndResume_httpPull_dataTransfer_withEdrCache() {
+        void suspendAndResumeByConsumer_httpPull_dataTransfer_withEdrCache() {
             providerDataSource.when(HttpRequest.request()).respond(HttpResponse.response().withBody("data"));
             var assetId = UUID.randomUUID().toString();
             createResourcesOnProvider(assetId, httpSourceDataAddress());
@@ -177,7 +177,7 @@ class TransferPullEndToEndTest {
                     .withTransferType("HttpData-PULL")
                     .execute();
 
-            awaitTransferToBeInState(transferProcessId, STARTED);
+            awaitTransferToBeInState(CONSUMER, transferProcessId, STARTED);
 
             var edr = await().atMost(timeout).until(() -> CONSUMER.getEdr(transferProcessId), Objects::nonNull);
 
@@ -186,7 +186,7 @@ class TransferPullEndToEndTest {
 
             CONSUMER.suspendTransfer(transferProcessId, "supension");
 
-            awaitTransferToBeInState(transferProcessId, SUSPENDED);
+            awaitTransferToBeInState(CONSUMER, transferProcessId, SUSPENDED);
 
             // checks that the EDR is gone once the transfer has been suspended
             await().atMost(timeout).untilAsserted(() -> assertThatThrownBy(() -> CONSUMER.getEdr(transferProcessId)));
@@ -196,8 +196,49 @@ class TransferPullEndToEndTest {
             CONSUMER.resumeTransfer(transferProcessId);
 
             // check that transfer is available again
-            awaitTransferToBeInState(transferProcessId, STARTED);
+            awaitTransferToBeInState(CONSUMER, transferProcessId, STARTED);
             var secondEdr = await().atMost(timeout).until(() -> CONSUMER.getEdr(transferProcessId), Objects::nonNull);
+            var secondMessage = UUID.randomUUID().toString();
+            await().atMost(timeout).untilAsserted(() -> CONSUMER.pullData(secondEdr, Map.of("message", secondMessage), body -> assertThat(body).isEqualTo("data")));
+
+            providerDataSource.verify(HttpRequest.request("/source").withMethod("GET"));
+        }
+
+        @Test
+        void suspendAndResumeByProvider_httpPull_dataTransfer_withEdrCache() {
+            providerDataSource.when(HttpRequest.request()).respond(HttpResponse.response().withBody("data"));
+            var assetId = UUID.randomUUID().toString();
+            createResourcesOnProvider(assetId, httpSourceDataAddress());
+
+            var consumerTransferProcessId = CONSUMER.requestAssetFrom(assetId, PROVIDER)
+                    .withTransferType("HttpData-PULL")
+                    .execute();
+
+            awaitTransferToBeInState(CONSUMER, consumerTransferProcessId, STARTED);
+
+            var edr = await().atMost(timeout).until(() -> CONSUMER.getEdr(consumerTransferProcessId), Objects::nonNull);
+
+            var msg = UUID.randomUUID().toString();
+            await().atMost(timeout).untilAsserted(() -> CONSUMER.pullData(edr, Map.of("message", msg), body -> assertThat(body).isEqualTo("data")));
+
+            var providerTransferProcessId  = PROVIDER.getTransferProcesses().stream()
+                    .filter(filter -> filter.asJsonObject().getString("correlationId").equals(consumerTransferProcessId))
+                    .map(id -> id.asJsonObject().getString("@id")).findFirst().orElseThrow();
+
+            PROVIDER.suspendTransfer(providerTransferProcessId, "supension");
+
+            awaitTransferToBeInState(PROVIDER, providerTransferProcessId, SUSPENDED);
+
+            // checks that the EDR is gone once the transfer has been suspended
+            await().atMost(timeout).untilAsserted(() -> assertThatThrownBy(() -> CONSUMER.getEdr(consumerTransferProcessId)));
+            // checks that transfer fails
+            await().atMost(timeout).untilAsserted(() -> assertThatThrownBy(() -> CONSUMER.pullData(edr, Map.of("message", msg), body -> assertThat(body).isEqualTo("data"))));
+
+            PROVIDER.resumeTransfer(providerTransferProcessId);
+
+            // check that transfer is available again
+            awaitTransferToBeInState(PROVIDER, providerTransferProcessId, STARTED);
+            var secondEdr = await().atMost(timeout).until(() -> CONSUMER.getEdr(consumerTransferProcessId), Objects::nonNull);
             var secondMessage = UUID.randomUUID().toString();
             await().atMost(timeout).untilAsserted(() -> CONSUMER.pullData(secondEdr, Map.of("message", secondMessage), body -> assertThat(body).isEqualTo("data")));
 
@@ -222,7 +263,7 @@ class TransferPullEndToEndTest {
                     .withTransferType("HttpData-PULL")
                     .execute();
 
-            awaitTransferToBeInState(transferProcessId, STARTED);
+            awaitTransferToBeInState(CONSUMER, transferProcessId, STARTED);
 
             await().atMost(timeout).untilAsserted(() -> {
                 var edr = await().atMost(timeout).until(() -> CONSUMER.getEdr(transferProcessId), Objects::nonNull);
@@ -246,7 +287,7 @@ class TransferPullEndToEndTest {
                     .withTransferType("HttpData-PULL")
                     .execute();
 
-            awaitTransferToBeInState(transferProcessId, TERMINATED);
+            awaitTransferToBeInState(CONSUMER, transferProcessId, TERMINATED);
         }
 
         @Test
@@ -261,7 +302,7 @@ class TransferPullEndToEndTest {
                     .withTransferType("HttpData-PULL")
                     .execute();
 
-            awaitTransferToBeInState(transferProcessId, TERMINATED);
+            awaitTransferToBeInState(CONSUMER, transferProcessId, TERMINATED);
         }
 
         public JsonObject createCallback(String url, boolean transactional, Set<String> events) {

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferPushEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferPushEndToEndTest.java
@@ -82,7 +82,7 @@ class TransferPushEndToEndTest {
                     .withDestination(httpDataAddress("http://localhost:" + consumerDataDestination.getPort() + "/destination"))
                     .withTransferType("HttpData-PUSH").execute();
 
-            awaitTransferToBeInState(CONSUMER, transferProcessId, COMPLETED);
+            CONSUMER.awaitTransferToBeInState(transferProcessId, COMPLETED);
 
             providerDataSource.verify(HttpRequest.request("/source").withMethod("GET"));
             consumerDataDestination.verify(HttpRequest.request("/destination").withBody(BinaryBody.binary("data".getBytes())));
@@ -109,7 +109,7 @@ class TransferPushEndToEndTest {
                     .withDestination(httpDataAddress("http://localhost:" + consumerDataDestination.getPort() + "/destination"))
                     .withTransferType("HttpData-PUSH").execute();
 
-            awaitTransferToBeInState(CONSUMER, transferProcessId, COMPLETED);
+            CONSUMER.awaitTransferToBeInState(transferProcessId, COMPLETED);
 
             oauth2server.verify(HttpRequest.request("/token").withBody("grant_type=client_credentials&client_secret=supersecret&client_id=clientId"));
             providerDataSource.verify(HttpRequest.request("/source").withMethod("GET").withHeader("Authorization", "Bearer token"));

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferPushEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferPushEndToEndTest.java
@@ -82,7 +82,7 @@ class TransferPushEndToEndTest {
                     .withDestination(httpDataAddress("http://localhost:" + consumerDataDestination.getPort() + "/destination"))
                     .withTransferType("HttpData-PUSH").execute();
 
-            awaitTransferToBeInState(transferProcessId, COMPLETED);
+            awaitTransferToBeInState(CONSUMER, transferProcessId, COMPLETED);
 
             providerDataSource.verify(HttpRequest.request("/source").withMethod("GET"));
             consumerDataDestination.verify(HttpRequest.request("/destination").withBody(BinaryBody.binary("data".getBytes())));
@@ -109,7 +109,7 @@ class TransferPushEndToEndTest {
                     .withDestination(httpDataAddress("http://localhost:" + consumerDataDestination.getPort() + "/destination"))
                     .withTransferType("HttpData-PUSH").execute();
 
-            awaitTransferToBeInState(transferProcessId, COMPLETED);
+            awaitTransferToBeInState(CONSUMER, transferProcessId, COMPLETED);
 
             oauth2server.verify(HttpRequest.request("/token").withBody("grant_type=client_credentials&client_secret=supersecret&client_id=clientId"));
             providerDataSource.verify(HttpRequest.request("/source").withMethod("GET").withHeader("Authorization", "Bearer token"));

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferStreamingEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferStreamingEndToEndTest.java
@@ -146,7 +146,7 @@ public class TransferStreamingEndToEndTest {
 
                 PROVIDER_DATA_PLANE_RUNTIME.boot(false);
 
-                awaitTransferToBeInState(transferProcessId, STARTED);
+                CONSUMER.awaitTransferToBeInState(transferProcessId, STARTED);
                 assertMessagesAreSentTo(consumer);
             }
         }

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferStreamingEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferStreamingEndToEndTest.java
@@ -189,7 +189,7 @@ public class TransferStreamingEndToEndTest {
                 destinationServer.verify(request, atLeast(1));
             });
 
-            awaitTransferToBeInState(transferProcessId, TERMINATED);
+            awaitTransferToBeInState(CONSUMER, transferProcessId, TERMINATED);
 
             destinationServer.clear(request)
                     .when(request).respond(response());
@@ -218,7 +218,7 @@ public class TransferStreamingEndToEndTest {
                         .withDestination(kafkaSink()).withTransferType("Kafka-PUSH").execute();
                 assertMessagesAreSentTo(consumer);
 
-                awaitTransferToBeInState(transferProcessId, TERMINATED);
+                awaitTransferToBeInState(CONSUMER, transferProcessId, TERMINATED);
                 assertNoMoreMessagesAreSentTo(consumer);
             }
         }
@@ -236,11 +236,11 @@ public class TransferStreamingEndToEndTest {
                 assertMessagesAreSentTo(consumer);
 
                 CONSUMER.suspendTransfer(transferProcessId, "any kind of reason");
-                awaitTransferToBeInState(transferProcessId, SUSPENDED);
+                awaitTransferToBeInState(CONSUMER, transferProcessId, SUSPENDED);
                 assertNoMoreMessagesAreSentTo(consumer);
 
                 CONSUMER.resumeTransfer(transferProcessId);
-                awaitTransferToBeInState(transferProcessId, STARTED);
+                awaitTransferToBeInState(CONSUMER, transferProcessId, STARTED);
                 assertMessagesAreSentTo(consumer);
             }
         }

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferStreamingEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferStreamingEndToEndTest.java
@@ -189,7 +189,7 @@ public class TransferStreamingEndToEndTest {
                 destinationServer.verify(request, atLeast(1));
             });
 
-            awaitTransferToBeInState(CONSUMER, transferProcessId, TERMINATED);
+            CONSUMER.awaitTransferToBeInState(transferProcessId, TERMINATED);
 
             destinationServer.clear(request)
                     .when(request).respond(response());
@@ -218,7 +218,7 @@ public class TransferStreamingEndToEndTest {
                         .withDestination(kafkaSink()).withTransferType("Kafka-PUSH").execute();
                 assertMessagesAreSentTo(consumer);
 
-                awaitTransferToBeInState(CONSUMER, transferProcessId, TERMINATED);
+                CONSUMER.awaitTransferToBeInState(transferProcessId, TERMINATED);
                 assertNoMoreMessagesAreSentTo(consumer);
             }
         }
@@ -236,11 +236,11 @@ public class TransferStreamingEndToEndTest {
                 assertMessagesAreSentTo(consumer);
 
                 CONSUMER.suspendTransfer(transferProcessId, "any kind of reason");
-                awaitTransferToBeInState(CONSUMER, transferProcessId, SUSPENDED);
+                CONSUMER.awaitTransferToBeInState(transferProcessId, SUSPENDED);
                 assertNoMoreMessagesAreSentTo(consumer);
 
                 CONSUMER.resumeTransfer(transferProcessId);
-                awaitTransferToBeInState(CONSUMER, transferProcessId, STARTED);
+                CONSUMER.awaitTransferToBeInState(transferProcessId, STARTED);
                 assertMessagesAreSentTo(consumer);
             }
         }


### PR DESCRIPTION
## What this PR changes/adds

Adds a ```SUSPENDED``` state to the list of allowed states to be consumer started.

## Why it does that

When provider resume the transfer it initiate transitionStarted for the consumer from ```SUSPENDED``` state, that is currently not allowed, as a result consumer return an error for the provider and transfer move to ```TERMINATED``` state. 

## Further notes

To make possible create e2e test by provider commands, method awaitTransferToBeInState from TransferEndToEndTestBase need to be unified.

## Linked Issue(s)

Closes [#4591](https://github.com/eclipse-edc/Connector/issues/4591)
