### PR TITLE
feat: removes JSON-LD requirements in dsp version endpoint

### DIFF
--- a/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/spi/type/DspVersionPropertyAndTypeNames.java
+++ b/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/spi/type/DspVersionPropertyAndTypeNames.java
@@ -14,17 +14,14 @@
 
 package org.eclipse.edc.protocol.dsp.spi.type;
 
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
-
 /**
  * Dataspace protocol types and attributes for version request.
  */
 public interface DspVersionPropertyAndTypeNames {
 
-    String DSPACE_PROPERTY_PROTOCOL_VERSIONS = DSPACE_SCHEMA + "protocolVersions";
+    String DSPACE_PROPERTY_PROTOCOL_VERSIONS = "protocolVersions";
 
-    String DSPACE_TYPE_VERSIONS_ERROR = DSPACE_SCHEMA + "VersionsError";
-    String DSPACE_PROPERTY_VERSION = DSPACE_SCHEMA + "version";
-    String DSPACE_PROPERTY_PATH = DSPACE_SCHEMA + "path";
+    String DSPACE_PROPERTY_VERSION = "version";
+    String DSPACE_PROPERTY_PATH = "path";
 
 }

--- a/data-protocols/dsp/dsp-version/dsp-version-http-api/src/main/java/org/eclipse/edc/protocol/dsp/version/http/api/DspVersionApiExtension.java
+++ b/data-protocols/dsp/dsp-version/dsp-version-http-api/src/main/java/org/eclipse/edc/protocol/dsp/version/http/api/DspVersionApiExtension.java
@@ -26,15 +26,12 @@ import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
-import org.eclipse.edc.web.jersey.providers.jsonld.JerseyJsonLdInterceptor;
 import org.eclipse.edc.web.spi.WebService;
 import org.eclipse.edc.web.spi.configuration.ApiContext;
 
 import java.util.Map;
 
-import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_SCOPE_V_08;
 import static org.eclipse.edc.protocol.dsp.version.http.api.DspVersionApiExtension.NAME;
-import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
 
 /**
  * Provide API for the protocol versions.
@@ -69,13 +66,13 @@ public class DspVersionApiExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var jsonLdMapper = typeManager.getMapper(JSON_LD);
 
-        transformerRegistry.register(new JsonObjectFromProtocolVersionsTransformer());
-        transformerRegistry.register(new JsonObjectFromVersionsError(Json.createBuilderFactory(Map.of())));
+        var jsonFactory = Json.createBuilderFactory(Map.of());
+        
+        transformerRegistry.register(new JsonObjectFromProtocolVersionsTransformer(jsonFactory));
+        transformerRegistry.register(new JsonObjectFromVersionsError(jsonFactory));
 
         webService.registerResource(ApiContext.PROTOCOL, new DspVersionApiController(requestHandler, service));
-        webService.registerDynamicResource(ApiContext.PROTOCOL, DspVersionApiController.class, new JerseyJsonLdInterceptor(jsonLd, jsonLdMapper, DSP_SCOPE_V_08));
     }
 
 }

--- a/data-protocols/dsp/dsp-version/dsp-version-http-api/src/main/java/org/eclipse/edc/protocol/dsp/version/http/api/transformer/JsonObjectFromProtocolVersionsTransformer.java
+++ b/data-protocols/dsp/dsp-version/dsp-version-http-api/src/main/java/org/eclipse/edc/protocol/dsp/version/http/api/transformer/JsonObjectFromProtocolVersionsTransformer.java
@@ -14,11 +14,11 @@
 
 package org.eclipse.edc.protocol.dsp.version.http.api.transformer;
 
-import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.services.spi.protocol.ProtocolVersions;
-import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
+import org.eclipse.edc.transform.spi.TypeTransformer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -30,21 +30,33 @@ import static org.eclipse.edc.protocol.dsp.spi.type.DspVersionPropertyAndTypeNam
 /**
  * Transform {@link ProtocolVersions} into {@link JsonObject}
  */
-public class JsonObjectFromProtocolVersionsTransformer extends AbstractJsonLdTransformer<ProtocolVersions, JsonObject> {
+public class JsonObjectFromProtocolVersionsTransformer implements TypeTransformer<ProtocolVersions, JsonObject> {
 
-    public JsonObjectFromProtocolVersionsTransformer() {
-        super(ProtocolVersions.class, JsonObject.class);
+    private final JsonBuilderFactory jsonFactory;
+
+    public JsonObjectFromProtocolVersionsTransformer(JsonBuilderFactory jsonFactory) {
+        this.jsonFactory = jsonFactory;
+    }
+
+    @Override
+    public Class<ProtocolVersions> getInputType() {
+        return ProtocolVersions.class;
+    }
+
+    @Override
+    public Class<JsonObject> getOutputType() {
+        return JsonObject.class;
     }
 
     @Override
     public @Nullable JsonObject transform(@NotNull ProtocolVersions protocolVersions, @NotNull TransformerContext context) {
         var versions = protocolVersions.protocolVersions().stream()
-                .map(version -> Json.createObjectBuilder()
+                .map(version -> jsonFactory.createObjectBuilder()
                         .add(DSPACE_PROPERTY_VERSION, version.version())
                         .add(DSPACE_PROPERTY_PATH, version.path())
                         .build())
                 .collect(toJsonArray());
 
-        return Json.createObjectBuilder().add(DSPACE_PROPERTY_PROTOCOL_VERSIONS, versions).build();
+        return jsonFactory.createObjectBuilder().add(DSPACE_PROPERTY_PROTOCOL_VERSIONS, versions).build();
     }
 }

--- a/data-protocols/dsp/dsp-version/dsp-version-http-api/src/main/java/org/eclipse/edc/protocol/dsp/version/http/api/transformer/JsonObjectFromVersionsError.java
+++ b/data-protocols/dsp/dsp-version/dsp-version-http-api/src/main/java/org/eclipse/edc/protocol/dsp/version/http/api/transformer/JsonObjectFromVersionsError.java
@@ -17,34 +17,40 @@ package org.eclipse.edc.protocol.dsp.version.http.api.transformer;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.services.spi.protocol.VersionsError;
-import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
+import org.eclipse.edc.transform.spi.TypeTransformer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CODE_IRI;
-import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_REASON_IRI;
-import static org.eclipse.edc.protocol.dsp.spi.type.DspVersionPropertyAndTypeNames.DSPACE_TYPE_VERSIONS_ERROR;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CODE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_REASON_TERM;
 
 /**
  * Transforms a {@link VersionsError} to a {@link JsonObject} in JSON-LD expanded form.
  */
-public class JsonObjectFromVersionsError extends AbstractJsonLdTransformer<VersionsError, JsonObject> {
+public class JsonObjectFromVersionsError implements TypeTransformer<VersionsError, JsonObject> {
 
     private final JsonBuilderFactory jsonFactory;
 
     public JsonObjectFromVersionsError(JsonBuilderFactory jsonFactory) {
-        super(VersionsError.class, JsonObject.class);
         this.jsonFactory = jsonFactory;
+    }
+
+    @Override
+    public Class<VersionsError> getInputType() {
+        return VersionsError.class;
+    }
+
+    @Override
+    public Class<JsonObject> getOutputType() {
+        return JsonObject.class;
     }
 
     @Override
     public @Nullable JsonObject transform(@NotNull VersionsError error, @NotNull TransformerContext context) {
         return jsonFactory.createObjectBuilder()
-                .add(TYPE, DSPACE_TYPE_VERSIONS_ERROR)
-                .add(DSPACE_PROPERTY_CODE_IRI, error.getCode())
-                .add(DSPACE_PROPERTY_REASON_IRI, jsonFactory.createArrayBuilder(error.getMessages()))
+                .add(DSPACE_PROPERTY_CODE_TERM, error.getCode())
+                .add(DSPACE_PROPERTY_REASON_TERM, jsonFactory.createArrayBuilder(error.getMessages()))
                 .build();
     }
 }

--- a/data-protocols/dsp/dsp-version/dsp-version-http-api/src/test/java/org/eclipse/edc/protocol/dsp/version/http/api/transformer/JsonObjectFromProtocolVersionsTransformerTest.java
+++ b/data-protocols/dsp/dsp-version/dsp-version-http-api/src/test/java/org/eclipse/edc/protocol/dsp/version/http/api/transformer/JsonObjectFromProtocolVersionsTransformerTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.protocol.dsp.version.http.api.transformer;
 
+import jakarta.json.Json;
 import jakarta.json.JsonValue;
 import org.eclipse.edc.connector.controlplane.services.spi.protocol.ProtocolVersion;
 import org.eclipse.edc.connector.controlplane.services.spi.protocol.ProtocolVersions;
@@ -21,6 +22,7 @@ import org.eclipse.edc.transform.spi.TransformerContext;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspVersionPropertyAndTypeNames.DSPACE_PROPERTY_PATH;
@@ -32,7 +34,7 @@ class JsonObjectFromProtocolVersionsTransformerTest {
 
     private final TransformerContext context = mock();
     private final JsonObjectFromProtocolVersionsTransformer transformer =
-            new JsonObjectFromProtocolVersionsTransformer();
+            new JsonObjectFromProtocolVersionsTransformer(Json.createBuilderFactory(Map.of()));
 
     @Test
     void shouldTransform() {

--- a/data-protocols/dsp/dsp-version/dsp-version-http-api/src/test/java/org/eclipse/edc/protocol/dsp/version/http/api/transformer/JsonObjectFromVersionsErrorTransformerTest.java
+++ b/data-protocols/dsp/dsp-version/dsp-version-http-api/src/test/java/org/eclipse/edc/protocol/dsp/version/http/api/transformer/JsonObjectFromVersionsErrorTransformerTest.java
@@ -25,10 +25,8 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CODE_IRI;
-import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_REASON_IRI;
-import static org.eclipse.edc.protocol.dsp.spi.type.DspVersionPropertyAndTypeNames.DSPACE_TYPE_VERSIONS_ERROR;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CODE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_REASON_TERM;
 import static org.mockito.Mockito.mock;
 
 class JsonObjectFromVersionsErrorTransformerTest {
@@ -54,8 +52,7 @@ class JsonObjectFromVersionsErrorTransformerTest {
         var result = transformer.transform(error, context);
 
         assertThat(result).isNotNull();
-        assertThat(result.getJsonString(TYPE).getString()).isEqualTo(DSPACE_TYPE_VERSIONS_ERROR);
-        assertThat(result.getString(DSPACE_PROPERTY_CODE_IRI)).isEqualTo("code");
-        assertThat(result.getJsonArray(DSPACE_PROPERTY_REASON_IRI)).contains(Json.createValue("message"));
+        assertThat(result.getString(DSPACE_PROPERTY_CODE_TERM)).isEqualTo("code");
+        assertThat(result.getJsonArray(DSPACE_PROPERTY_REASON_TERM)).contains(Json.createValue("message"));
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

removes JSON-LD requirements in dsp version endpoint as required by [this](https://github.com/eclipse-dataspace-protocol-base/DataspaceProtocol/issues/37)

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #4654 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
