### PR TITLE
fix: deprovision phase for provision-http

### DIFF
--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/Participant.java
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/Participant.java
@@ -489,6 +489,22 @@ public class Participant {
                 .statusCode(204);
     }
 
+    public void terminateTransfer(String id) {
+        var requestBodyBuilder = createObjectBuilder()
+                .add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
+                .add(TYPE, "TerminateTransfer")
+                .add("reason", "any reason");
+
+        managementEndpoint.baseRequest()
+                .contentType(JSON)
+                .body(requestBodyBuilder.build())
+                .when()
+                .post("/v3/transferprocesses/{id}/terminate", id)
+                .then()
+                .log().ifError()
+                .statusCode(204);
+    }
+
     /**
      * Get current state of a contract negotiation.
      *

--- a/extensions/control-plane/provision/provision-http/src/main/java/org/eclipse/edc/connector/controlplane/provision/http/impl/HttpProvisionerRequest.java
+++ b/extensions/control-plane/provision/provision-http/src/main/java/org/eclipse/edc/connector/controlplane/provision/http/impl/HttpProvisionerRequest.java
@@ -58,6 +58,10 @@ public class HttpProvisionerRequest {
         return resourceDefinitionId;
     }
 
+    public Type getType() {
+        return type;
+    }
+
     public enum Type {
         @JsonProperty("provision")
         PROVISION,


### PR DESCRIPTION
## What this PR changes/adds

Fixes deprovisioning for `provision-http` module by: 
- changing the too strict `canDeprovision` implementation 
- fix the serialization of the `type` field in `HttpProvisionerRequest`
- fixing the id passed in the deprovisioned response

## Why it does that

fix a broken feature

## Further notes

- the `provision-http` module is not tested in a comprehensive way, we should have some sort of "provision tests" that could be used by the modules that are providing a `Provisioner` implementation to being able to test a full `resource manifest -> provision -> deprovision` passing through the transfer process manager, because testing this thing in the e2e like we're doing looks not-optimal.

## Linked Issue(s)

Closes #4630

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
