### PR TITLE
feat: permit default api context config to be used

### DIFF
--- a/data-protocols/dsp/dsp-catalog/lib/dsp-catalog-http-api-lib/src/test/java/org/eclipse/edc/web/spi/configuration/WebServiceSettingsTest.java
+++ b/data-protocols/dsp/dsp-catalog/lib/dsp-catalog-http-api-lib/src/test/java/org/eclipse/edc/web/spi/configuration/WebServiceSettingsTest.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2024 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.web.spi.configuration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WebServiceSettingsTest {
+
+    @Test
+    void shouldDefineDefaultPath_whenNotSet() {
+        var settings = WebServiceSettings.Builder.newInstance()
+                .defaultPort(9999)
+                .apiConfigKey("web.http.something")
+                .contextAlias("alias")
+                .build();
+
+        assertThat(settings.getDefaultPath()).isEqualTo("/api/alias");
+    }
+}

--- a/data-protocols/dsp/dsp-http-api-configuration/src/main/java/org/eclipse/edc/protocol/dsp/http/api/configuration/DspApiConfigurationExtension.java
+++ b/data-protocols/dsp/dsp-http-api-configuration/src/main/java/org/eclipse/edc/protocol/dsp/http/api/configuration/DspApiConfigurationExtension.java
@@ -86,9 +86,8 @@ public class DspApiConfigurationExtension implements ServiceExtension {
     public static final WebServiceSettings SETTINGS = WebServiceSettings.Builder.newInstance()
             .apiConfigKey(PROTOCOL_CONFIG_KEY)
             .contextAlias(ApiContext.PROTOCOL)
-            .defaultPath("/api/v1/dsp")
+            .defaultPath("/api/dsp")
             .defaultPort(8282)
-            .name("Protocol API")
             .build();
     @Setting(description = "Configures endpoint for reaching the Protocol API in the form \"<hostname:protocol.port/protocol.path>\"", key = "edc.dsp.callback.address", required = false)
     private String callbackAddress;

--- a/extensions/common/api/control-api-configuration/src/main/java/org/eclipse/edc/connector/api/control/configuration/ControlApiConfigurationExtension.java
+++ b/extensions/common/api/control-api-configuration/src/main/java/org/eclipse/edc/connector/api/control/configuration/ControlApiConfigurationExtension.java
@@ -68,16 +68,12 @@ public class ControlApiConfigurationExtension implements ServiceExtension {
     @Setting(description = "Configures endpoint for reaching the Control API. If it's missing it defaults to the hostname configuration.", key = "edc.control.endpoint", required = false)
     private String controlEndpoint;
     public static final String CONTROL_SCOPE = "CONTROL_API";
-    private static final String WEB_SERVICE_NAME = "Control API";
     @SettingContext("Control API context setting key")
     private static final String CONTROL_CONFIG_KEY = "web.http." + ApiContext.CONTROL;
     public static final WebServiceSettings SETTINGS = WebServiceSettings.Builder.newInstance()
             .apiConfigKey(CONTROL_CONFIG_KEY)
             .contextAlias(ApiContext.CONTROL)
-            .defaultPath("/api/v1/control")
             .defaultPort(9191)
-            .useDefaultContext(true)
-            .name(WEB_SERVICE_NAME)
             .build();
     private static final String API_VERSION_JSON_FILE = "control-api-version.json";
 

--- a/extensions/common/api/management-api-configuration/src/main/java/org/eclipse/edc/connector/api/management/configuration/ManagementApiConfigurationExtension.java
+++ b/extensions/common/api/management-api-configuration/src/main/java/org/eclipse/edc/connector/api/management/configuration/ManagementApiConfigurationExtension.java
@@ -81,7 +81,6 @@ public class ManagementApiConfigurationExtension implements ServiceExtension {
 
     public static final String API_VERSION_JSON_FILE = "management-api-version.json";
     public static final String NAME = "Management API configuration";
-    public static final String WEB_SERVICE_NAME = "Management API";
     public static final String MANAGEMENT_SCOPE = "MANAGEMENT_API";
 
     @SettingContext("Management API context setting key")
@@ -89,10 +88,7 @@ public class ManagementApiConfigurationExtension implements ServiceExtension {
     public static final WebServiceSettings SETTINGS = WebServiceSettings.Builder.newInstance()
             .apiConfigKey(MANAGEMENT_CONFIG_KEY)
             .contextAlias(ApiContext.MANAGEMENT)
-            .defaultPath("/api/v1/management")
             .defaultPort(8181)
-            .useDefaultContext(true)
-            .name(WEB_SERVICE_NAME)
             .build();
     private static final boolean DEFAULT_MANAGEMENT_API_ENABLE_CONTEXT = false;
     @Setting(description = "Configures endpoint for reaching the Management API, in the format \"<hostname:management.port/management.path>\"", key = "edc.management.endpoint", required = false)

--- a/extensions/common/api/version-api/src/main/java/org/eclipse/edc/connector/api/management/version/VersionApiExtension.java
+++ b/extensions/common/api/version-api/src/main/java/org/eclipse/edc/connector/api/management/version/VersionApiExtension.java
@@ -38,7 +38,6 @@ import java.util.stream.Stream;
 public class VersionApiExtension implements ServiceExtension {
 
     public static final String NAME = "Management API: Version Information";
-    private static final String WEB_SERVICE_NAME = "Version Information API";
 
     @SettingContext("Version API context setting key")
     private static final String VERSION_CONFIG_KEY = "web.http." + ApiContext.VERSION;
@@ -48,15 +47,11 @@ public class VersionApiExtension implements ServiceExtension {
             .contextAlias(ApiContext.VERSION)
             .defaultPath("/.well-known/api")
             .defaultPort(7171)
-            .useDefaultContext(false)
-            .name(WEB_SERVICE_NAME)
             .build();
 
     private static final String API_VERSION_JSON_FILE = "version-api-version.json";
     @Inject
     private WebService webService;
-
-
     @Inject
     private TypeManager typeManager;
     @Inject

--- a/extensions/common/http/jetty-core/src/main/java/org/eclipse/edc/web/jetty/WebServiceConfigurerImpl.java
+++ b/extensions/common/http/jetty-core/src/main/java/org/eclipse/edc/web/jetty/WebServiceConfigurerImpl.java
@@ -43,15 +43,13 @@ public class WebServiceConfigurerImpl implements WebServiceConfigurer {
             port = config.getInteger("port", port);
             path = config.getString("path", path);
         } else {
-            monitor.warning(format("Settings for [%s] and/or [%s] were not provided. Using default" +
-                    " value(s) instead.", apiConfig + ".path", apiConfig + ".path"));
+            monitor.warning("Settings for [%s] and/or [%s] were not provided. Using default value(s) instead."
+                    .formatted(apiConfig + ".path", apiConfig + ".path"));
 
-            if (!settings.useDefaultContext()) {
-                webServer.addPortMapping(contextAlias, port, path);
-            }
+            webServer.addPortMapping(contextAlias, port, path);
         }
 
-        monitor.debug(format("%s will be available under port=%s, path=%s", settings.getName(), port, path));
+        monitor.debug(format("%s API will be available under port=%s, path=%s", contextAlias, port, path));
 
         return WebServiceConfiguration.Builder.newInstance()
                 .path(path)

--- a/extensions/common/http/jetty-core/src/test/java/org/eclipse/edc/web/jetty/WebServiceConfigurerImplTest.java
+++ b/extensions/common/http/jetty-core/src/test/java/org/eclipse/edc/web/jetty/WebServiceConfigurerImplTest.java
@@ -27,7 +27,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
 
 public class WebServiceConfigurerImplTest {
 
@@ -48,8 +47,6 @@ public class WebServiceConfigurerImplTest {
                 .contextAlias(ALIAS)
                 .defaultPath(PATH)
                 .defaultPort(PORT)
-                .useDefaultContext(false)
-                .name("TEST")
                 .build();
 
         var actualConfig = configurator.configure(config, server, settings);
@@ -59,31 +56,6 @@ public class WebServiceConfigurerImplTest {
 
         assertThat(actualConfig.getPort()).isEqualTo(PORT);
         assertThat(actualConfig.getPath()).isEqualTo(PATH);
-
-    }
-
-    @Test
-    void verifyConfigure_whenDefaultAlias() {
-
-        var config = ConfigFactory.fromMap(new HashMap<>());
-        var defValue = "default";
-        when(server.getDefaultContextName()).thenReturn(defValue);
-
-        var settings = WebServiceSettings.Builder.newInstance()
-                .apiConfigKey(CONFIG)
-                .contextAlias(ALIAS)
-                .defaultPath(PATH)
-                .defaultPort(PORT)
-                .useDefaultContext(true)
-                .name("TEST")
-                .build();
-
-        var actualConfig = configurator.configure(config, server, settings);
-
-        verifyNoInteractions(server);
-        assertThat(actualConfig.getPort()).isEqualTo(PORT);
-        assertThat(actualConfig.getPath()).isEqualTo(PATH);
-
     }
 
     @Test
@@ -102,8 +74,6 @@ public class WebServiceConfigurerImplTest {
                 .contextAlias(ALIAS)
                 .defaultPath(PATH)
                 .defaultPort(PORT)
-                .useDefaultContext(false)
-                .name("TEST")
                 .build();
 
         var actualConfig = configurator.configure(config, server, settings);

--- a/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-accounts-api/src/main/java/org/eclipse/edc/api/iam/identitytrust/sts/accounts/StsAccountsApiConfigurationExtension.java
+++ b/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-accounts-api/src/main/java/org/eclipse/edc/api/iam/identitytrust/sts/accounts/StsAccountsApiConfigurationExtension.java
@@ -36,9 +36,7 @@ import java.util.stream.Stream;
 public class StsAccountsApiConfigurationExtension implements ServiceExtension {
 
     public static final String NAME = "Secure Token Service Accounts API configuration";
-    private static final String WEB_SERVICE_NAME = "STS Accounts API";
-    private static final int DEFAULT_STS_API_PORT = 9393;
-    private static final String DEFAULT_STS_API_CONTEXT_PATH = "/api/sts";
+    private static final int DEFAULT_STS_ACCOUNTS_API_PORT = 9393;
 
     @SettingContext("Sts API context setting key")
     private static final String STS_ACCOUNTS_CONFIG_KEY = "web.http." + ApiContext.STS_ACCOUNTS;
@@ -46,10 +44,7 @@ public class StsAccountsApiConfigurationExtension implements ServiceExtension {
     public static final WebServiceSettings SETTINGS = WebServiceSettings.Builder.newInstance()
             .apiConfigKey(STS_ACCOUNTS_CONFIG_KEY)
             .contextAlias(ApiContext.STS_ACCOUNTS)
-            .defaultPath(DEFAULT_STS_API_CONTEXT_PATH)
-            .defaultPort(DEFAULT_STS_API_PORT)
-            .useDefaultContext(false)
-            .name(WEB_SERVICE_NAME)
+            .defaultPort(DEFAULT_STS_ACCOUNTS_API_PORT)
             .build();
     private static final String API_VERSION_JSON_FILE = "sts-accounts-api-version.json";
 

--- a/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-api/src/main/java/org/eclipse/edc/api/iam/identitytrust/sts/StsApiConfigurationExtension.java
+++ b/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-api/src/main/java/org/eclipse/edc/api/iam/identitytrust/sts/StsApiConfigurationExtension.java
@@ -36,9 +36,7 @@ import java.util.stream.Stream;
 public class StsApiConfigurationExtension implements ServiceExtension {
 
     public static final String NAME = "Secure Token Service API configuration";
-    private static final String WEB_SERVICE_NAME = "STS API";
     private static final int DEFAULT_STS_API_PORT = 9292;
-    private static final String DEFAULT_STS_API_CONTEXT_PATH = "/api/v1/sts";
 
     @SettingContext("Sts API context setting key")
     private static final String STS_CONFIG_KEY = "web.http." + ApiContext.STS;
@@ -46,10 +44,7 @@ public class StsApiConfigurationExtension implements ServiceExtension {
     public static final WebServiceSettings SETTINGS = WebServiceSettings.Builder.newInstance()
             .apiConfigKey(STS_CONFIG_KEY)
             .contextAlias(ApiContext.STS)
-            .defaultPath(DEFAULT_STS_API_CONTEXT_PATH)
             .defaultPort(DEFAULT_STS_API_PORT)
-            .useDefaultContext(false)
-            .name(WEB_SERVICE_NAME)
             .build();
     private static final String API_VERSION_JSON_FILE = "sts-api-version.json";
 

--- a/extensions/data-plane/data-plane-public-api-v2/src/main/java/org/eclipse/edc/connector/dataplane/api/DataPlanePublicApiV2Extension.java
+++ b/extensions/data-plane/data-plane-public-api-v2/src/main/java/org/eclipse/edc/connector/dataplane/api/DataPlanePublicApiV2Extension.java
@@ -44,13 +44,11 @@ public class DataPlanePublicApiV2Extension implements ServiceExtension {
     public static final String NAME = "Data Plane Public API";
 
     private static final int DEFAULT_PUBLIC_PORT = 8185;
-    private static final String PUBLIC_CONTEXT_PATH = "/api/v2/public";
 
     @SettingContext("Public API context setting key")
     private static final String PUBLIC_CONFIG_KEY = "web.http." + ApiContext.PUBLIC;
 
-    @Setting(description = "Base url of the public API endpoint without the trailing slash. This should correspond to the values configured " +
-                           "in '" + DEFAULT_PUBLIC_PORT + "' and '" + PUBLIC_CONTEXT_PATH + "'.",
+    @Setting(description = "Base url of the public API endpoint without the trailing slash. This should point to the public endpoint configured.",
             required = false,
             key = "edc.dataplane.api.public.baseurl", warnOnMissingConfig = true)
     private String publicBaseUrl;
@@ -62,9 +60,7 @@ public class DataPlanePublicApiV2Extension implements ServiceExtension {
     private static final WebServiceSettings PUBLIC_SETTINGS = WebServiceSettings.Builder.newInstance()
             .apiConfigKey(PUBLIC_CONFIG_KEY)
             .contextAlias(ApiContext.PUBLIC)
-            .defaultPath(PUBLIC_CONTEXT_PATH)
             .defaultPort(DEFAULT_PUBLIC_PORT)
-            .name(NAME)
             .build();
 
     @Inject

--- a/spi/common/web-spi/src/main/java/org/eclipse/edc/web/spi/configuration/WebServiceSettings.java
+++ b/spi/common/web-spi/src/main/java/org/eclipse/edc/web/spi/configuration/WebServiceSettings.java
@@ -18,12 +18,10 @@ import java.util.Objects;
 
 public class WebServiceSettings {
 
-    private boolean useDefaultContext = false;
     private String apiConfigKey;
     private Integer defaultPort;
     private String defaultPath;
     private String contextAlias;
-    private String name;
 
     private WebServiceSettings() {
 
@@ -46,7 +44,6 @@ public class WebServiceSettings {
     /**
      * The default path if the config {@link WebServiceSettings#apiConfigKey()} is not found in {@link org.eclipse.edc.spi.system.ServiceExtensionContext#getConfig}
      */
-
     public String getDefaultPath() {
         return defaultPath;
     }
@@ -54,30 +51,13 @@ public class WebServiceSettings {
     /**
      * The name of the API context
      */
-
     public String getContextAlias() {
         return contextAlias;
     }
 
-    /**
-     * Returns true if the default context should be taken into consideration if there's not one context-specific
-     * configured
-     */
-    public boolean useDefaultContext() {
-        return useDefaultContext;
-    }
-
-    /**
-     * The name of the API settings. It's intended only for displaying the name of the Web Extension that
-     * will be configured by {@link WebServiceConfigurer}.
-     */
-    public String getName() {
-        return name;
-    }
-
     @Override
     public int hashCode() {
-        return Objects.hash(useDefaultContext, apiConfigKey, defaultPort, defaultPath, contextAlias, name);
+        return Objects.hash(apiConfigKey, defaultPort, defaultPath, contextAlias);
     }
 
     @Override
@@ -88,10 +68,10 @@ public class WebServiceSettings {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        WebServiceSettings that = (WebServiceSettings) o;
-        return useDefaultContext == that.useDefaultContext && apiConfigKey.equals(that.apiConfigKey) &&
+        var that = (WebServiceSettings) o;
+        return apiConfigKey.equals(that.apiConfigKey) &&
                 defaultPort.equals(that.defaultPort) && defaultPath.equals(that.defaultPath) &&
-                Objects.equals(contextAlias, that.contextAlias) && name.equals(that.name);
+                Objects.equals(contextAlias, that.contextAlias);
     }
 
     public static class Builder {
@@ -121,26 +101,19 @@ public class WebServiceSettings {
             return this;
         }
 
-        public Builder name(String name) {
-            settings.name = name;
-            return this;
-        }
-
         public Builder defaultPort(int defaultPort) {
             settings.defaultPort = defaultPort;
             return this;
         }
 
-        public Builder useDefaultContext(boolean useDefaultContext) {
-            settings.useDefaultContext = useDefaultContext;
-            return this;
-        }
-
         public WebServiceSettings build() {
             Objects.requireNonNull(settings.apiConfigKey);
-            Objects.requireNonNull(settings.defaultPath);
+            Objects.requireNonNull(settings.contextAlias);
             Objects.requireNonNull(settings.defaultPort);
-            Objects.requireNonNull(settings.name);
+
+            if (settings.defaultPath == null) {
+                settings.defaultPath = "/api/" + settings.contextAlias;
+            }
 
             return settings;
         }

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ManagementEndToEndExtension.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ManagementEndToEndExtension.java
@@ -76,11 +76,8 @@ public abstract class ManagementEndToEndExtension extends RuntimePerClassExtensi
                     "control-plane",
                     new HashMap<>() {
                         {
-                            put("web.http.path", "/");
-                            put("web.http.port", String.valueOf(getFreePort()));
                             put("web.http.protocol.path", "/protocol");
                             put("web.http.protocol.port", String.valueOf(protocolPort));
-                            put("web.http.control.port", String.valueOf(getFreePort()));
                             put("edc.dsp.callback.address", "http://localhost:" + protocolPort + "/protocol");
                             put("web.http.management.path", "/management");
                             put("web.http.management.port", String.valueOf(managementPort));


### PR DESCRIPTION
## What this PR changes/adds

Remove the `useDefaultContext` attribute from `WebServiceSettings`, because it's use was not clear and it didn't permit runtimes to start with default configuration.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

- removed also `name` because it was used only for logging, and for that `contextAlias` can be used as well
- uniformed the `defaultPath` value in the form of `/api/<context_alias>`
- the current design of the definition and use of these configurations is not really lean and it could deserve some more love

## Linked Issue(s)

Closes #4669 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
