### PR TITLE
feat: Add resource parameter to the OAuth2 token request to follow RFC-8707

### DIFF
--- a/extensions/common/iam/oauth2/oauth2-core/README.md
+++ b/extensions/common/iam/oauth2/oauth2-core/README.md
@@ -4,17 +4,18 @@ This extension provides an `IdentityService` implementation based on the OAuth2 
 
 ## Configuration
 
-| Parameter name                    | Description                                                                                | Mandatory | Default value                       |
-|:----------------------------------|:-------------------------------------------------------------------------------------------|:----------|:------------------------------------|
-| `edc.oauth.token.url`             | URL of the authorization server                                                            | true      | null                                |
-| `edc.oauth.provider.audience`     | Provider audience to be put in the outgoing token as 'aud' claim                           | false     | id of the connector                 |
-| `edc.oauth.endpoint.audience`     | Endpoint audience to verify incoming token 'aud' claim                                     | false     | `edc.oauth.provider.audience` value |
-| `edc.oauth.provider.jwks.url`     | URL from which well-known public keys of Authorization server can be fetched               | false     | http://localhost/empty_jwks_url     | 
-| `edc.oauth.certificate.alias`     | Alias of public associated with client certificate                                         | true      | null                                |
-| `edc.oauth.private.key.alias`     | Alias of private key (used to sign the token)                                              | true      | null                                |
-| `edc.oauth.provider.jwks.refresh` | Interval at which public keys are refreshed from Authorization server (in minutes)         | false     | 5                                   |
-| `edc.oauth.client.id`             | Public identifier of the client                                                            | true      | null                                |
-| `edc.oauth.validation.nbf.leeway` | Leeway in seconds added to current time to remedy clock skew on notBefore claim validation | false     | 10                                  |
+| Parameter name                     | Description                                                                                                          | Mandatory | Default value                       |
+|:-----------------------------------|:---------------------------------------------------------------------------------------------------------------------|:----------|:------------------------------------|
+| `edc.oauth.token.url`              | URL of the authorization server                                                                                      | true      | null                                |
+| `edc.oauth.provider.audience`      | Provider audience to be put in the outgoing token as 'aud' claim                                                     | false     | id of the connector                 |
+| `edc.oauth.endpoint.audience`      | Endpoint audience to verify incoming token 'aud' claim                                                               | false     | `edc.oauth.provider.audience` value |
+| `edc.oauth.provider.jwks.url`      | URL from which well-known public keys of Authorization server can be fetched                                         | false     | http://localhost/empty_jwks_url     | 
+| `edc.oauth.certificate.alias`      | Alias of public associated with client certificate                                                                   | true      | null                                |
+| `edc.oauth.private.key.alias`      | Alias of private key (used to sign the token)                                                                        | true      | null                                |
+| `edc.oauth.provider.jwks.refresh`  | Interval at which public keys are refreshed from Authorization server (in minutes)                                   | false     | 5                                   |
+| `edc.oauth.client.id`              | Public identifier of the client                                                                                      | true      | null                                |
+| `edc.oauth.validation.nbf.leeway`  | Leeway in seconds added to current time to remedy clock skew on notBefore claim validation                           | false     | 10                                  |
+| `edc.oauth.token.resource.enabled` | Adds `resource` form parameter in the access token request. Allows to specify an audience as defined in the RFC-8707 | false     | false                               |
 
 ## Extensions
 

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceConfiguration.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceConfiguration.java
@@ -52,6 +52,9 @@ public class Oauth2ServiceConfiguration {
     @Setting(description = "Token expiration in minutes. By default is 5 minutes", key = "edc.oauth.token.expiration", defaultValue = DEFAULT_TOKEN_EXPIRATION + "")
     private Long tokenExpiration;
 
+    @Setting(description = "Enable the connector to request a token with a specific audience as defined in the RFC-8707.", key = "edc.oauth.token.resource.enabled", defaultValue = "false")
+    private boolean tokenResourceEnabled;
+
     private Oauth2ServiceConfiguration() {
 
     }
@@ -90,6 +93,10 @@ public class Oauth2ServiceConfiguration {
 
     public Long getTokenExpiration() {
         return tokenExpiration;
+    }
+
+    public boolean isTokenResourceEnabled() {
+        return tokenResourceEnabled;
     }
 
     public int getProviderJwksRefresh() {
@@ -158,6 +165,11 @@ public class Oauth2ServiceConfiguration {
 
         public Builder tokenExpiration(long tokenExpiration) {
             configuration.tokenExpiration = tokenExpiration;
+            return this;
+        }
+
+        public Builder tokenResourceEnabled(boolean tokenResourceEnabled) {
+            configuration.tokenResourceEnabled = tokenResourceEnabled;
             return this;
         }
 

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceExtension.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/Oauth2ServiceExtension.java
@@ -159,7 +159,8 @@ public class Oauth2ServiceExtension implements ServiceExtension {
                 jwtDecoratorRegistry,
                 tokenValidationRulesRegistry,
                 tokenValidationService,
-                providerKeyResolver
+                providerKeyResolver,
+                configuration.isTokenResourceEnabled()
         );
     }
 

--- a/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/identity/Oauth2ServiceImpl.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/main/java/org/eclipse/edc/iam/oauth2/identity/Oauth2ServiceImpl.java
@@ -19,7 +19,7 @@ package org.eclipse.edc.iam.oauth2.identity;
 
 import org.eclipse.edc.iam.oauth2.spi.client.Oauth2Client;
 import org.eclipse.edc.iam.oauth2.spi.client.Oauth2CredentialsRequest;
-import org.eclipse.edc.iam.oauth2.spi.client.PrivateKeyOauth2CredentialsRequest;
+import org.eclipse.edc.iam.oauth2.spi.client.PrivateKeyOauth2CredentialsRequest.Builder;
 import org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames;
 import org.eclipse.edc.keys.spi.PublicKeyResolver;
 import org.eclipse.edc.spi.iam.ClaimToken;
@@ -54,6 +54,7 @@ public class Oauth2ServiceImpl implements IdentityService {
     private final TokenValidationService tokenValidationService;
     private final PublicKeyResolver publicKeyResolver;
     private final TokenValidationRulesRegistry tokenValidationRuleRegistry;
+    private final boolean tokenResourceEnabled;
 
     /**
      * Creates a new instance of the OAuth2 Service
@@ -63,10 +64,11 @@ public class Oauth2ServiceImpl implements IdentityService {
      * @param client                 client for Oauth2 server
      * @param jwtDecoratorRegistry   Registry containing the decorator for build the JWT
      * @param tokenValidationService Service used for token validation
+     * @param tokenResourceEnabled   Add support for generating access token request with resource parameter
      */
     public Oauth2ServiceImpl(String tokenUrl, TokenGenerationService tokenGenerationService, Supplier<String> privateKeyIdSupplier,
                              Oauth2Client client, TokenDecoratorRegistry jwtDecoratorRegistry, TokenValidationRulesRegistry tokenValidationRuleRegistry, TokenValidationService tokenValidationService,
-                             PublicKeyResolver publicKeyResolver) {
+                             PublicKeyResolver publicKeyResolver, boolean tokenResourceEnabled) {
         this.tokenUrl = tokenUrl;
         this.privateKeySupplier = privateKeyIdSupplier;
         this.client = client;
@@ -75,6 +77,7 @@ public class Oauth2ServiceImpl implements IdentityService {
         this.tokenGenerationService = tokenGenerationService;
         this.tokenValidationService = tokenValidationService;
         this.publicKeyResolver = publicKeyResolver;
+        this.tokenResourceEnabled = tokenResourceEnabled;
     }
 
     @Override
@@ -98,12 +101,16 @@ public class Oauth2ServiceImpl implements IdentityService {
 
     @NotNull
     private Oauth2CredentialsRequest createRequest(TokenParameters parameters, String assertion) {
-        return PrivateKeyOauth2CredentialsRequest.Builder.newInstance()
+        var builder = Builder.newInstance()
                 .url(tokenUrl)
                 .clientAssertion(assertion)
                 .scope(parameters.getStringClaim(JwtRegisteredClaimNames.SCOPE))
-                .grantType(GRANT_TYPE)
-                .build();
+                .grantType(GRANT_TYPE);
+
+        if (tokenResourceEnabled) {
+            builder.resource(parameters.getStringClaim(JwtRegisteredClaimNames.AUDIENCE));
+        }
+        return builder.build();
     }
 
 }

--- a/extensions/common/iam/oauth2/oauth2-core/src/test/java/org/eclipse/edc/iam/oauth2/identity/Oauth2ServiceImplTest.java
+++ b/extensions/common/iam/oauth2/oauth2-core/src/test/java/org/eclipse/edc/iam/oauth2/identity/Oauth2ServiceImplTest.java
@@ -101,6 +101,7 @@ class Oauth2ServiceImplTest {
                 .publicCertificateAlias(PUBLIC_CERTIFICATE_ALIAS)
                 .providerAudience(PROVIDER_AUDIENCE)
                 .endpointAudience(ENDPOINT_AUDIENCE)
+                .tokenResourceEnabled(true)
                 .build();
 
         var tokenValidationService = new TokenValidationServiceImpl();
@@ -114,7 +115,7 @@ class Oauth2ServiceImplTest {
         registry.addRule(OAUTH2_TOKEN_CONTEXT, new ExpirationIssuedAtValidationRule(Clock.systemUTC(), configuration.getIssuedAtLeeway()));
 
         authService = new Oauth2ServiceImpl(configuration.getTokenUrl(), tokenGenerationService, () -> TEST_PRIVATE_KEY_ID, client, jwtDecoratorRegistry, registry,
-                tokenValidationService, publicKeyResolverMock);
+                tokenValidationService, publicKeyResolverMock, configuration.isTokenResourceEnabled());
 
     }
 
@@ -143,6 +144,7 @@ class Oauth2ServiceImplTest {
         assertThat(capturedRequest.getScope()).isEqualTo("scope");
         assertThat(capturedRequest.getClientAssertion()).isEqualTo("assertionToken");
         assertThat(capturedRequest.getClientAssertionType()).isEqualTo("urn:ietf:params:oauth:client-assertion-type:jwt-bearer");
+        assertThat(capturedRequest.getResource()).isEqualTo("audience");
     }
 
 

--- a/spi/common/oauth2-spi/src/main/java/org/eclipse/edc/iam/oauth2/spi/client/Oauth2CredentialsRequest.java
+++ b/spi/common/oauth2-spi/src/main/java/org/eclipse/edc/iam/oauth2/spi/client/Oauth2CredentialsRequest.java
@@ -25,6 +25,7 @@ public abstract class Oauth2CredentialsRequest {
 
     private static final String GRANT_TYPE = "grant_type";
     private static final String SCOPE = "scope";
+    private static final String RESOURCE = "resource";
 
     protected String url;
     protected final Map<String, String> params = new HashMap<>();
@@ -42,6 +43,16 @@ public abstract class Oauth2CredentialsRequest {
     @NotNull
     public String getGrantType() {
         return params.get(GRANT_TYPE);
+    }
+
+    /**
+     * The audience for which an access token will be requested.
+     *
+     * @return The value of the resource form parameter.
+     */
+    @Nullable
+    public String getResource() {
+        return this.params.get(RESOURCE);
     }
 
     public Map<String, String> getParams() {
@@ -80,6 +91,17 @@ public abstract class Oauth2CredentialsRequest {
             return self();
         }
 
+        /**
+         * Adds the resource form parameter to the request.
+         *
+         * @param targetedAudience The audience for which an access token will be requested.
+         * @see <a href="https://www.rfc-editor.org/rfc/rfc8707.html">RFC-8707</a>
+         * @return this builder
+         */
+        public B resource(String targetedAudience) {
+            return param(RESOURCE, targetedAudience);
+        }
+
         public abstract B self();
 
         protected T build() {
@@ -87,5 +109,6 @@ public abstract class Oauth2CredentialsRequest {
             Objects.requireNonNull(request.params.get(GRANT_TYPE), GRANT_TYPE);
             return request;
         }
+
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

This PR makes the OAuth2 implementation ask for a token with a resource from param to follow the RFC-8707. 

## Why it does that

This allows an IDP to set the correct `aud` claim in the access token given to the connector.

## Further notes

## Linked Issue(s)

Closes #4668
