### PR TITLE
fix: fix broken protocol version api specification

### DIFF
--- a/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
+++ b/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
@@ -1,8 +1,8 @@
 [
   {
-    "version": "3.0.3",
+    "version": "3.0.4",
     "urlPath": "/v3",
-    "lastUpdated": "2024-07-12T10:14:00Z",
+    "lastUpdated": "2024-12-19T10:14:00Z",
     "maturity": "stable"
   },
   {

--- a/extensions/control-plane/api/management-api/protocol-version-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/protocolversion/v4alpha/ProtocolVersionApiV4alpha.java
+++ b/extensions/control-plane/api/management-api/protocol-version-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/protocolversion/v4alpha/ProtocolVersionApiV4alpha.java
@@ -37,12 +37,12 @@ public interface ProtocolVersionApiV4alpha {
 
     @Operation(
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ProtocolVersionRequestSchema.class))),
-            responses = { @ApiResponse(
+            responses = {@ApiResponse(
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ProtocolVersionSchema.class)
                     ),
-                    description = "Gets supported protocol versions of a single connector") }
+                    description = "Gets supported protocol versions of a single connector")}
     )
     void requestProtocolVersionV4alpha(JsonObject request, @Suspended AsyncResponse response);
 
@@ -70,7 +70,7 @@ public interface ProtocolVersionApiV4alpha {
                 """;
     }
 
-    @Schema(name = "Protocol Version", description = "Protocol Version", example = ProtocolVersionSchema.PROTOCOL_VERSION_EXAMPLE)
+    @Schema(name = "ProtocolVersion", description = "Protocol Version", example = ProtocolVersionSchema.PROTOCOL_VERSION_EXAMPLE)
     record ProtocolVersionSchema(
     ) {
         public static final String PROTOCOL_VERSION_EXAMPLE = """


### PR DESCRIPTION
## What this PR changes/adds

fix broken `ProtocolVersionApi` documentation that generates the swagger spec.

## Why it does that

Api documentation is incorrect, causing an invalid swagger spec to be generated.

![swagger_error](https://github.com/user-attachments/assets/d46d5bec-f132-4b14-a532-9debdd79806e)


## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
