### PR TITLE
fix: transfer type resolution on dp self registration

### DIFF
--- a/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/flow/TransferTypeParserImpl.java
+++ b/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/flow/TransferTypeParserImpl.java
@@ -25,7 +25,7 @@ public class TransferTypeParserImpl implements TransferTypeParser {
 
     /**
      * Parses a compose transfer type string into a {@link TransferType}:
-     * {@code DESTTYPE-{PUSH|PULL}(-RESPONSETYPE)}, for example {@code HttpData-PULL/Websocket}
+     * {@code DESTTYPE-{PUSH|PULL}(-RESPONSETYPE)}, for example {@code HttpData-PULL-Websocket}
      *
      * @param transferType the transfer type string representation.
      * @return a {@link TransferType}

--- a/extensions/data-plane/data-plane-self-registration/src/main/java/org/eclipse/edc/connector/dataplane/registration/DataplaneSelfRegistrationExtension.java
+++ b/extensions/data-plane/data-plane-self-registration/src/main/java/org/eclipse/edc/connector/dataplane/registration/DataplaneSelfRegistrationExtension.java
@@ -119,7 +119,7 @@ public class DataplaneSelfRegistrationExtension implements ServiceExtension {
 
     private @NotNull Stream<String> toTransferTypes(FlowType pull, Set<String> types, Set<String> responseTypes) {
         Stream<String> transferTypes = types.stream().map(it -> "%s-%s".formatted(it, pull));
-        return Stream.concat(transferTypes, responseTypes.stream().flatMap(responseType -> types.stream().map(it -> "%s-%s/%s".formatted(it, pull, responseType))));
+        return Stream.concat(transferTypes, responseTypes.stream().flatMap(responseType -> types.stream().map(it -> "%s-%s-%s".formatted(it, pull, responseType))));
     }
 
     private class DataPlaneHealthCheck implements LivenessProvider, ReadinessProvider, StartupStatusProvider {

--- a/extensions/data-plane/data-plane-self-registration/src/test/java/org/eclipse/edc/connector/dataplane/registration/DataplaneSelfRegistrationExtensionTest.java
+++ b/extensions/data-plane/data-plane-self-registration/src/test/java/org/eclipse/edc/connector/dataplane/registration/DataplaneSelfRegistrationExtensionTest.java
@@ -75,6 +75,7 @@ class DataplaneSelfRegistrationExtensionTest {
         when(pipelineService.supportedSinkTypes()).thenReturn(Set.of("sinkType", "anotherSinkType"));
         when(pipelineService.supportedSourceTypes()).thenReturn(Set.of("sourceType", "anotherSourceType"));
         when(publicEndpointGeneratorService.supportedDestinationTypes()).thenReturn(Set.of("pullDestType", "anotherPullDestType"));
+        when(publicEndpointGeneratorService.supportedResponseTypes()).thenReturn(Set.of("responseType", "anotherResponseType"));
         when(dataPlaneSelectorService.addInstance(any())).thenReturn(ServiceResult.success());
 
         extension.initialize(context);
@@ -88,7 +89,18 @@ class DataplaneSelfRegistrationExtensionTest {
         assertThat(dataPlaneInstance.getAllowedSourceTypes()).containsExactlyInAnyOrder("sourceType", "anotherSourceType");
         assertThat(dataPlaneInstance.getAllowedDestTypes()).containsExactlyInAnyOrder("sinkType", "anotherSinkType");
         assertThat(dataPlaneInstance.getAllowedTransferTypes())
-                .containsExactlyInAnyOrder("pullDestType-PULL", "anotherPullDestType-PULL", "sinkType-PUSH", "anotherSinkType-PUSH");
+                .containsExactlyInAnyOrder("anotherPullDestType-PULL-anotherResponseType",
+                        "anotherSinkType-PUSH-anotherResponseType",
+                        "anotherPullDestType-PULL",
+                        "anotherSinkType-PUSH-responseType",
+                        "anotherSinkType-PUSH",
+                        "pullDestType-PULL",
+                        "anotherPullDestType-PULL-responseType",
+                        "pullDestType-PULL-anotherResponseType",
+                        "sinkType-PUSH-anotherResponseType",
+                        "pullDestType-PULL-responseType",
+                        "sinkType-PUSH-responseType",
+                        "sinkType-PUSH");
 
         verify(healthCheckService).addStartupStatusProvider(any());
         verify(healthCheckService).addLivenessProvider(any());

--- a/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/instance/DataPlaneInstance.java
+++ b/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/instance/DataPlaneInstance.java
@@ -101,7 +101,7 @@ public class DataPlaneInstance extends StatefulEntity<DataPlaneInstance> {
     public boolean canHandle(DataAddress sourceAddress, @Nullable String transferType) {
         Objects.requireNonNull(sourceAddress, "source cannot be null!");
         Objects.requireNonNull(transferType, "transferType cannot be null!");
-        // startsWith: the allowed transferType could be HttpData-PULL/someResponseChannel, and we only need to match the HttpData-PULL
+        // startsWith: the allowed transferType could be HttpData-PULL-someResponseChannel, and we only need to match the HttpData-PULL
         return allowedSourceTypes.contains(sourceAddress.getType()) && allowedTransferTypes.contains(transferType);
     }
 


### PR DESCRIPTION
## What this PR changes/adds

The responseType is now concatenated to the transferType as expected.

## Why it does that

It was not being correctly concatenated.

## Further notes

Also fixed some code docs lying around that had "HttpData-PULL/Websocket"

## Linked Issue(s)

Closes #4686 

