### PR TITLE
fix(configuration): nightly-tests

### DIFF
--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -1,7 +1,7 @@
 name: "Run Nightly Tests"
 on:
   schedule:
-    - "0 0 * * *" # run at 00:00 UTC
+    - cron: "0 0 * * *" # run at 00:00 UTC
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## What this PR changes/adds
added missing cron: prefix to nightly-tests.yaml configuration

## Why it does that
In order to fix trigger mechanism of nightly tests, from being run every push to run scheduled at 00:00 AM

## Further notes
Documentation chapter:
https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule

## Linked Issue(s)

Closes #4683