### PR TITLE
fix: reintroduce web.http.default config group as deprecated

### DIFF
--- a/extensions/common/http/jetty-core/README.md
+++ b/extensions/common/http/jetty-core/README.md
@@ -34,8 +34,6 @@ web.http.path=/api
 
 That will expose any resource under `http://<host>:8181/api/*`.
 
-_Please note that under the hood `web.http.*` gets expanded to `web.http.default.*`_
-
 In some situations it is required to expose a part of the public API under another port or path, which can be achieved
 by using port mappings. First, a "named"
 property group needs to be created using the following configuration. The example will create a port mapping with the

--- a/extensions/common/http/jetty-core/build.gradle.kts
+++ b/extensions/common/http/jetty-core/build.gradle.kts
@@ -17,16 +17,13 @@ plugins {
     `java-library`
 }
 
-
 dependencies {
-    implementation(libs.jetty.websocket)
-
     api(project(":spi:common:core-spi"))
     api(project(":spi:common:web-spi"))
 
+    implementation(libs.jetty.websocket)
+
     testImplementation(libs.restAssured)
-    testImplementation(project(":tests:junit-base"));
+    testImplementation(project(":core:common:junit"));
 
 }
-
-

--- a/extensions/common/http/jetty-core/src/test/java/org/eclipse/edc/web/jetty/JettyExtensionTest.java
+++ b/extensions/common/http/jetty-core/src/test/java/org/eclipse/edc/web/jetty/JettyExtensionTest.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.web.jetty;
+
+import org.eclipse.edc.boot.system.injection.ObjectFactory;
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+import org.eclipse.edc.web.spi.configuration.PortMapping;
+import org.eclipse.edc.web.spi.configuration.PortMappingRegistry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(DependencyInjectionExtension.class)
+class JettyExtensionTest {
+
+    private final Monitor monitor = mock();
+
+    @Test
+    void setup(ServiceExtensionContext context) {
+        context.registerService(Monitor.class, monitor);
+    }
+
+    @Test
+    void shouldRegisterPortMapping(ServiceExtensionContext context, ObjectFactory objectFactory) {
+        var settings = Map.of("web.http.port", "11111", "web.http.path", "/path");
+        when(context.getConfig()).thenReturn(ConfigFactory.fromMap(settings));
+
+        var extension = objectFactory.constructInstance(JettyExtension.class);
+
+        extension.initialize(context);
+
+        assertThat(extension).extracting("portMappingRegistry", type(PortMappingRegistry.class)).satisfies(portMappingRegistry -> {
+            assertThat(portMappingRegistry.getAll()).containsOnly(new PortMapping("default", 11111, "/path"));
+        });
+        verify(context.getMonitor(), never()).warning(contains("web.http"));
+    }
+
+    @Deprecated(since = "0.11.0")
+    @Test
+    void shouldRegisterDeprecatedPortMapping(ServiceExtensionContext context, ObjectFactory objectFactory) {
+        var settings = Map.of("web.http.default.port", "11111", "web.http.default.path", "/path");
+        when(context.getConfig()).thenReturn(ConfigFactory.fromMap(settings));
+
+        var extension = objectFactory.constructInstance(JettyExtension.class);
+
+        extension.initialize(context);
+
+        assertThat(extension).extracting("portMappingRegistry", type(PortMappingRegistry.class)).satisfies(portMappingRegistry -> {
+            assertThat(portMappingRegistry.getAll()).containsOnly(new PortMapping("default", 11111, "/path"));
+        });
+        verify(context.getMonitor()).warning(contains("web.http.default"));
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

Ensures that `web.http.default` config group is still supported, though deprecated.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #4718

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
