### PR TITLE
refactor(test): make `Participant` lazy

### DIFF
--- a/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/EmbeddedRuntime.java
+++ b/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/EmbeddedRuntime.java
@@ -125,11 +125,11 @@ public class EmbeddedRuntime extends BaseRuntime {
         });
 
         try {
-            if (!latch.await(20, SECONDS)) {
+            if (!latch.await(30, SECONDS)) {
                 throw new EdcException("Failed to start EDC runtime", runtimeThrowable.get());
             }
         } catch (InterruptedException e) {
-            throw new EdcException("Failed to start EDC runtime", runtimeThrowable.get());
+            throw new EdcException("Failed to start EDC runtime: interrupted", runtimeThrowable.get());
         }
 
         monitor.info("Runtime %s started".formatted(name));

--- a/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/RuntimePerClassExtension.java
+++ b/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/RuntimePerClassExtension.java
@@ -18,15 +18,13 @@ import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-import static java.util.Collections.emptyMap;
-
 /**
  * Spin up a static runtime to be used for multiple tests
  */
 public class RuntimePerClassExtension extends RuntimeExtension implements BeforeAllCallback, AfterAllCallback {
 
     public RuntimePerClassExtension() {
-        this(new EmbeddedRuntime("runtime", emptyMap()));
+        this(new EmbeddedRuntime("runtime"));
     }
 
     public RuntimePerClassExtension(EmbeddedRuntime runtime) {

--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/build.gradle.kts
@@ -30,4 +30,5 @@ dependencies {
     testFixturesImplementation(libs.assertj)
     testFixturesImplementation(libs.restAssured)
     testFixturesImplementation(libs.awaitility)
+    testFixturesImplementation(libs.mockito.core)
 }

--- a/system-tests/e2e-dataplane-tests/tests/src/test/java/org/eclipse/edc/test/e2e/participant/DataPlaneParticipant.java
+++ b/system-tests/e2e-dataplane-tests/tests/src/test/java/org/eclipse/edc/test/e2e/participant/DataPlaneParticipant.java
@@ -87,13 +87,6 @@ public class DataPlaneParticipant extends Participant {
             return new Builder();
         }
 
-        @Override
-        public DataPlaneParticipant build() {
-            super.managementEndpoint(new Endpoint(URI.create("http://localhost:" + getFreePort() + "/api/management")));
-            super.protocolEndpoint(new Endpoint(URI.create("http://localhost:" + getFreePort() + "/protocol")));
-            super.build();
-            return participant;
-        }
     }
 
 }

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferEndToEndParticipant.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferEndToEndParticipant.java
@@ -53,13 +53,13 @@ public class TransferEndToEndParticipant extends Participant {
                 put(PARTICIPANT_ID, id);
                 put("web.http.port", String.valueOf(getFreePort()));
                 put("web.http.path", "/api");
-                put("web.http.protocol.port", String.valueOf(protocolEndpoint.getUrl().getPort()));
-                put("web.http.protocol.path", protocolEndpoint.getUrl().getPath());
-                put("web.http.management.port", String.valueOf(managementEndpoint.getUrl().getPort()));
-                put("web.http.management.path", managementEndpoint.getUrl().getPath());
+                put("web.http.protocol.port", String.valueOf(controlPlaneProtocol.get().getPort()));
+                put("web.http.protocol.path", controlPlaneProtocol.get().getPath());
+                put("web.http.management.port", String.valueOf(controlPlaneManagement.get().getPort()));
+                put("web.http.management.path", controlPlaneManagement.get().getPath());
                 put("web.http.control.port", String.valueOf(controlPlaneControl.get().getPort()));
                 put("web.http.control.path", controlPlaneControl.get().getPath());
-                put("edc.dsp.callback.address", protocolEndpoint.getUrl().toString());
+                put("edc.dsp.callback.address", controlPlaneProtocol.get().toString());
                 put("edc.keystore", resourceAbsolutePath("certs/cert.pfx"));
                 put("edc.keystore.password", "123456");
                 put("edc.transfer.proxy.endpoint", dataPlanePublic.get().toString());
@@ -128,7 +128,7 @@ public class TransferEndToEndParticipant extends Participant {
      * @return The cached {@link DataAddress}
      */
     public DataAddress getEdr(String transferProcessId) {
-        var dataAddressRaw = managementEndpoint.baseRequest()
+        var dataAddressRaw = baseManagementRequest()
                 .contentType(JSON)
                 .when()
                 .get("/v3/edrs/{id}/dataaddress", transferProcessId)
@@ -189,13 +189,6 @@ public class TransferEndToEndParticipant extends Participant {
             return new Builder();
         }
 
-        @Override
-        public TransferEndToEndParticipant build() {
-            super.managementEndpoint(new Endpoint(URI.create("http://localhost:" + getFreePort() + "/api/management")));
-            super.protocolEndpoint(new Endpoint(URI.create("http://localhost:" + getFreePort() + "/protocol")));
-            super.build();
-            return participant;
-        }
     }
 
 }


### PR DESCRIPTION
## What this PR changes/adds

Completes the work done in #4712 by making `Participant` class lazy in creating port configurations.

## Why it does that

avoid testcontainers flaky tests

## Further notes

- `Endpoint` class has been deprecated, as it was just an unnecessary wrapper around RestAssured's `RequestSpecification`. with the addition of a `enrichManagementRequest` adopters can eventually enrich the management request used by tests object (e.g. by adding authentication headers, as it [is currently done in the tractusx-edc tests](https://github.com/eclipse-tractusx/tractusx-edc/blob/86461ba9cc41c9c7f1cf71c9726615e36d7097af/edc-tests/e2e-fixtures/src/testFixtures/java/org/eclipse/tractusx/edc/tests/participant/TractusxParticipantBase.java#L263)).
- no need to keep a request object for `protocol` endpoint, as it is not supposed to be called in E2E tests that are meant to be "management api user" facing.
- had to raise the `EmbeddedRuntime` startup timeout because the "restart data flows" activity is making data-plane slower to start

## Linked Issue(s)

Closes #4710 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
