### PR TITLE
feat: improve dataplane transfer process logs

### DIFF
--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/pipeline/PipelineServiceImpl.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/pipeline/PipelineServiceImpl.java
@@ -107,7 +107,8 @@ public class PipelineServiceImpl implements PipelineService {
 
         var source = sourceFactory.createSource(request);
         sources.put(request.getProcessId(), source);
-        monitor.debug(() -> format("Transferring from %s to %s.", request.getSourceDataAddress().getType(), request.getDestinationDataAddress().getType()));
+        monitor.debug(() -> format("DataFlow %s Transferring from %s to %s.",
+                request.getProcessId(), request.getSourceDataAddress().getType(), request.getDestinationDataAddress().getType()));
         return sink.transfer(source)
                 .thenApply(result -> {
                     terminate(request.getProcessId());
@@ -177,12 +178,14 @@ public class PipelineServiceImpl implements PipelineService {
 
     @NotNull
     private CompletableFuture<StreamResult<Object>> noSourceFactory(DataFlowStartMessage request) {
-        return completedFuture(StreamResult.error("Unknown data source type: " + request.getSourceDataAddress().getType()));
+        return completedFuture(StreamResult.error("DataFlow %s Unknown data source type: %s.".formatted(
+                request.getProcessId(), request.getSourceDataAddress().getType())));
     }
 
     @NotNull
     private CompletableFuture<StreamResult<Object>> noSinkFactory(DataFlowStartMessage request) {
-        return completedFuture(StreamResult.error("Unknown data sink type: " + request.getDestinationDataAddress().getType()));
+        return completedFuture(StreamResult.error("DataFlow %s Unknown data sink type: %s.".formatted(
+                request.getProcessId(), request.getDestinationDataAddress().getType())));
     }
 
 

--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/pipeline/PipelineServiceImpl.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/pipeline/PipelineServiceImpl.java
@@ -107,7 +107,7 @@ public class PipelineServiceImpl implements PipelineService {
 
         var source = sourceFactory.createSource(request);
         sources.put(request.getProcessId(), source);
-        monitor.debug(() -> format("DataFlow %s Transferring from %s to %s.",
+        monitor.debug(() -> format("Transferring from %s to %s for flow id: %s.",
                 request.getProcessId(), request.getSourceDataAddress().getType(), request.getDestinationDataAddress().getType()));
         return sink.transfer(source)
                 .thenApply(result -> {
@@ -178,13 +178,13 @@ public class PipelineServiceImpl implements PipelineService {
 
     @NotNull
     private CompletableFuture<StreamResult<Object>> noSourceFactory(DataFlowStartMessage request) {
-        return completedFuture(StreamResult.error("DataFlow %s Unknown data source type: %s.".formatted(
+        return completedFuture(StreamResult.error("Unknown data source type %s for flow id: %s.".formatted(
                 request.getProcessId(), request.getSourceDataAddress().getType())));
     }
 
     @NotNull
     private CompletableFuture<StreamResult<Object>> noSinkFactory(DataFlowStartMessage request) {
-        return completedFuture(StreamResult.error("DataFlow %s Unknown data sink type: %s.".formatted(
+        return completedFuture(StreamResult.error("Unknown data sink type %s for flow id: %s.".formatted(
                 request.getProcessId(), request.getDestinationDataAddress().getType())));
     }
 


### PR DESCRIPTION
## What this PR changes/adds

This PR adds logic to allow to filter a transfer process flow from a single id (TP ID) for dataplane by adding said id in the logs.

## Why it does that

This will improve troubleshooting scenarios of a transfer process and improve overall traceability.

## FURTHER NOTES

Logs updated are:
- Transfer from source to destination;
- Unknown data source type;
- Unknown data sink type.

This PR does not add any breaking changes and for better examples of expected logs, please check the issue related.

## Linked Issue(s)

Closes #https://github.com/eclipse-edc/Connector/issues/4732