### PR TITLE
refactor: removes hardcoded AuthenticationRequestFilter

### DIFF
--- a/extensions/common/api/control-api-configuration/src/main/java/org/eclipse/edc/connector/api/control/configuration/ControlApiConfigurationExtension.java
+++ b/extensions/common/api/control-api-configuration/src/main/java/org/eclipse/edc/connector/api/control/configuration/ControlApiConfigurationExtension.java
@@ -15,7 +15,6 @@
 package org.eclipse.edc.connector.api.control.configuration;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
-import org.eclipse.edc.api.auth.spi.AuthenticationRequestFilter;
 import org.eclipse.edc.api.auth.spi.registry.ApiAuthenticationRegistry;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
@@ -105,8 +104,6 @@ public class ControlApiConfigurationExtension implements ServiceExtension {
         jsonLd.registerNamespace(ODRL_PREFIX, ODRL_SCHEMA, CONTROL_SCOPE);
         jsonLd.registerNamespace(DSPACE_PREFIX, DSPACE_SCHEMA, CONTROL_SCOPE);
 
-        var authenticationRequestFilter = new AuthenticationRequestFilter(authenticationRegistry, "control-api");
-        webService.registerResource(ApiContext.CONTROL, authenticationRequestFilter);
         webService.registerResource(ApiContext.CONTROL, new ObjectMapperProvider(jsonLdMapper));
         webService.registerResource(ApiContext.CONTROL, new JerseyJsonLdInterceptor(jsonLd, jsonLdMapper, CONTROL_SCOPE));
 
@@ -129,7 +126,7 @@ public class ControlApiConfigurationExtension implements ServiceExtension {
 
     private ControlApiUrl controlApiUrl(ServiceExtensionContext context, PortMapping config) {
         var callbackAddress = ofNullable(controlEndpoint).orElseGet(() -> format("http://%s:%s%s", hostname.get(), config.port(), config.path()));
-        
+
         try {
             var url = URI.create(callbackAddress);
             return () -> url;

--- a/extensions/common/api/control-api-configuration/src/test/java/org/eclipse/edc/connector/api/control/configuration/ControlApiConfigurationExtensionTest.java
+++ b/extensions/common/api/control-api-configuration/src/test/java/org/eclipse/edc/connector/api/control/configuration/ControlApiConfigurationExtensionTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.connector.api.control.configuration;
 
-import org.eclipse.edc.api.auth.spi.AuthenticationRequestFilter;
 import org.eclipse.edc.boot.system.injection.ObjectFactory;
 import org.eclipse.edc.json.JacksonTypeManager;
 import org.eclipse.edc.jsonld.spi.JsonLd;
@@ -47,8 +46,6 @@ import static org.eclipse.edc.policy.model.OdrlNamespace.ODRL_PREFIX;
 import static org.eclipse.edc.policy.model.OdrlNamespace.ODRL_SCHEMA;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_PREFIX;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -99,13 +96,6 @@ public class ControlApiConfigurationExtensionTest {
         var extension = objectFactory.constructInstance(ControlApiConfigurationExtension.class);
 
         assertThatThrownBy(() -> extension.initialize(context)).isInstanceOf(EdcException.class);
-    }
-
-    @Test
-    void shouldRegisterAuthenticationFilter(ControlApiConfigurationExtension extension, ServiceExtensionContext context) {
-        extension.initialize(context);
-
-        verify(webService).registerResource(any(), isA(AuthenticationRequestFilter.class));
     }
 
     @Test

--- a/extensions/common/api/management-api-configuration/src/main/java/org/eclipse/edc/connector/api/management/configuration/ManagementApiConfigurationExtension.java
+++ b/extensions/common/api/management-api-configuration/src/main/java/org/eclipse/edc/connector/api/management/configuration/ManagementApiConfigurationExtension.java
@@ -16,7 +16,6 @@ package org.eclipse.edc.connector.api.management.configuration;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import jakarta.json.Json;
-import org.eclipse.edc.api.auth.spi.AuthenticationRequestFilter;
 import org.eclipse.edc.api.auth.spi.registry.ApiAuthenticationRegistry;
 import org.eclipse.edc.connector.api.management.configuration.transform.JsonObjectFromContractAgreementTransformer;
 import org.eclipse.edc.connector.controlplane.transform.edc.from.JsonObjectFromAssetTransformer;
@@ -112,6 +111,7 @@ public class ManagementApiConfigurationExtension implements ServiceExtension {
     @Inject
     private ApiVersionService apiVersionService;
 
+
     @Override
     public String name() {
         return NAME;
@@ -124,8 +124,6 @@ public class ManagementApiConfigurationExtension implements ServiceExtension {
 
         context.registerService(ManagementApiUrl.class, managementApiUrl(context, portMapping));
 
-        var authenticationFilter = new AuthenticationRequestFilter(authenticationRegistry, "management-api");
-        webService.registerResource(ApiContext.MANAGEMENT, authenticationFilter);
 
         if (managementApiContextEnabled) {
             jsonLd.registerContext(EDC_CONNECTOR_MANAGEMENT_CONTEXT, MANAGEMENT_SCOPE);

--- a/extensions/common/api/management-api-configuration/src/test/java/org/eclipse/edc/connector/api/management/configuration/ManagementApiConfigurationExtensionTest.java
+++ b/extensions/common/api/management-api-configuration/src/test/java/org/eclipse/edc/connector/api/management/configuration/ManagementApiConfigurationExtensionTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.connector.api.management.configuration;
 
-import org.eclipse.edc.api.auth.spi.AuthenticationRequestFilter;
 import org.eclipse.edc.boot.system.DefaultServiceExtensionContext;
 import org.eclipse.edc.boot.system.injection.ObjectFactory;
 import org.eclipse.edc.json.JacksonTypeManager;
@@ -86,7 +85,6 @@ class ManagementApiConfigurationExtensionTest {
         extension.initialize(context);
 
         verify(portMappingRegistry).register(new PortMapping(ApiContext.MANAGEMENT, DEFAULT_MANAGEMENT_PORT, DEFAULT_MANAGEMENT_PATH));
-        verify(webService).registerResource(eq(ApiContext.MANAGEMENT), isA(AuthenticationRequestFilter.class));
         verify(webService).registerResource(eq(ApiContext.MANAGEMENT), isA(JerseyJsonLdInterceptor.class));
         verify(webService).registerResource(eq(ApiContext.MANAGEMENT), isA(ObjectMapperProvider.class));
 

--- a/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-accounts-api/src/main/java/org/eclipse/edc/api/iam/identitytrust/sts/accounts/StsAccountsApiExtension.java
+++ b/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-accounts-api/src/main/java/org/eclipse/edc/api/iam/identitytrust/sts/accounts/StsAccountsApiExtension.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.api.iam.identitytrust.sts.accounts;
 
-import org.eclipse.edc.api.auth.spi.AuthenticationRequestFilter;
 import org.eclipse.edc.api.auth.spi.registry.ApiAuthenticationRegistry;
 import org.eclipse.edc.api.iam.identitytrust.sts.accounts.controller.StsAccountsApiController;
 import org.eclipse.edc.iam.identitytrust.sts.spi.service.StsAccountService;
@@ -60,9 +59,6 @@ public class StsAccountsApiExtension implements ServiceExtension {
             throw new EdcException(message);
         }
 
-        var authenticationFilter = new AuthenticationRequestFilter(authenticationRegistry, STS_ACCOUNTS_API_CONTEXT);
-
         webService.registerResource(ApiContext.STS_ACCOUNTS, new StsAccountsApiController(clientService));
-        webService.registerResource(ApiContext.STS_ACCOUNTS, authenticationFilter);
     }
 }

--- a/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-accounts-api/src/test/java/org/eclipse/edc/api/iam/identitytrust/sts/accounts/StsAccountsApiExtensionTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-sts/identity-trust-sts-accounts-api/src/test/java/org/eclipse/edc/api/iam/identitytrust/sts/accounts/StsAccountsApiExtensionTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.api.iam.identitytrust.sts.accounts;
 
-import org.eclipse.edc.api.auth.spi.AuthenticationRequestFilter;
 import org.eclipse.edc.api.iam.identitytrust.sts.accounts.controller.StsAccountsApiController;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.security.Vault;
@@ -52,7 +51,6 @@ class StsAccountsApiExtensionTest {
         extension.initialize(context);
 
         verify(webService).registerResource(eq(STS_ACCOUNTS), isA(StsAccountsApiController.class));
-        verify(webService).registerResource(eq(STS_ACCOUNTS), isA(AuthenticationRequestFilter.class));
     }
 
 }


### PR DESCRIPTION


## What this PR changes/adds

removes hardcoded `AuthenticationRequestFilter` in each web context.

## Why it does that

cleanup after #4726 



## Linked Issue(s)

Closes #4753 _

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
