### PR TITLE
feat: add initial support for DCP namespace v1.0

### DIFF
--- a/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/defaults/DefaultCredentialServiceClient.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/defaults/DefaultCredentialServiceClient.java
@@ -155,7 +155,7 @@ public class DefaultCredentialServiceClient implements CredentialServiceClient {
                 .add(JsonLdKeywords.CONTEXT, jsonFactory.createArrayBuilder()
                         .add(VcConstants.PRESENTATION_EXCHANGE_URL)
                         .add(DcpConstants.DCP_CONTEXT_URL))
-                .add(JsonLdKeywords.TYPE, PresentationQueryMessage.PRESENTATION_QUERY_MESSAGE_TYPE)
+                .add(JsonLdKeywords.TYPE, PresentationQueryMessage.PRESENTATION_QUERY_MESSAGE_TERM)
                 .add("scope", scopeArray.build())
                 .build();
     }

--- a/extensions/common/iam/identity-trust/identity-trust-core/src/main/resources/document/dcp.v1.0.jsonld
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/main/resources/document/dcp.v1.0.jsonld
@@ -1,0 +1,137 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+    "dcp": "https://w3id.org/dspace-dcp/v1.0/",
+    "cred": "https://www.w3.org/2018/credentials/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "id": "@id",
+    "type": "@type",
+    "CredentialContainer": {
+      "@id": "dcp:CredentialContainer",
+      "@context": {
+        "payload": {
+          "@id": "dcp:payload",
+          "@type": "xsd:string"
+        }
+      }
+    },
+    "CredentialMessage": {
+      "@id": "dcp:CredentialMessage",
+      "@context": {
+        "credentials": {
+          "@id": "dcp:credentials",
+          "@container": "@set"
+        },
+        "requestId": {
+          "@id": "dcp:requestId",
+          "@type": "@id"
+        }
+      }
+    },
+    "CredentialObject": {
+      "@id": "dcp:CredentialObject",
+      "@context": {
+        "credentialType": {
+          "@id": "dcp:credentialType",
+          "@container": "@set"
+        },
+        "offerReason": {
+          "@id": "dcp:offerReason",
+          "@type": "xsd:string"
+        },
+        "bindingMethods": {
+          "@id": "dcp:bindingMethods",
+          "@type": "xsd:string",
+          "@container": "@set"
+        },
+        "profiles": {
+          "@id": "dcp:profiles",
+          "@type": "xsd:string",
+          "@container": "@set"
+        },
+        "issuancePolicy": {
+          "@id": "dcp:issuancePolicy",
+          "@type": "@json"
+        }
+      }
+    },
+    "CredentialOfferMessage": {
+      "@id": "dcp:CredentialOfferMessage",
+      "@context": {
+        "credentialIssuer": "cred:issuer",
+        "credentials": {
+          "@id": "dcp:credentials",
+          "@container": "@set"
+        }
+      }
+    },
+    "CredentialRequestMessage": {
+      "@id": "dcp:CredentialRequestMessage",
+      "@context": {
+        "format": "dcp:format",
+        "credentialType": {
+          "@id": "dcp:credentialType",
+          "@type": "@vocab",
+          "@container": "@set"
+        }
+      }
+    },
+    "CredentialService": "dcp:CredentialService",
+    "CredentialStatus": {
+      "@id": "dcp:CredentialStatus",
+      "@context": {
+        "requestId": {
+          "@id": "dcp:requestId",
+          "@type": "@id"
+        },
+        "status": {
+          "@id": "dcp:status",
+          "@type": "@vocab"
+        },
+        "RECEIVED": "dcp:RECEIVED",
+        "REJECTED": "dcp:REJECTED",
+        "ISSUED": "dcp:ISSUED"
+      }
+    },
+    "IssuerMetadata": {
+      "@id": "dcp:IssuerMetadata",
+      "@context": {
+        "credentialIssuer": "cred:issuer",
+        "credentialsSupported": {
+          "@id": "dcp:credentialsSupported",
+          "@container": "@set"
+        }
+      }
+    },
+    "IssuerService": "dcp:IssuerService",
+    "PresentationQueryMessage": {
+      "@id": "dcp:PresentationQueryMessage",
+      "@context": {
+        "presentationDefinition": {
+          "@id": "dcp:presentationDefinition",
+          "@type": "@json"
+        },
+        "scope": {
+          "@id": "dcp:scope",
+          "@type": "xsd:string",
+          "@container": "@set"
+        }
+      }
+    },
+    "PresentationResponseMessage": {
+      "@id": "dcp:PresentationResponseMessage",
+      "@context": {
+        "presentation": {
+          "@id": "dcp:presentation",
+          "@container": "@set",
+          "@type": "@json"
+        },
+        "presentationSubmission": {
+          "@id": "dcp:presentationSubmission",
+          "@type": "@json"
+        }
+      }
+    }
+  }
+}

--- a/extensions/common/iam/identity-trust/identity-trust-transform/src/main/java/org/eclipse/edc/iam/identitytrust/transform/from/JsonObjectFromPresentationResponseMessageTransformer.java
+++ b/extensions/common/iam/identity-trust/identity-trust-transform/src/main/java/org/eclipse/edc/iam/identitytrust/transform/from/JsonObjectFromPresentationResponseMessageTransformer.java
@@ -18,30 +18,36 @@ import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.iam.identitytrust.spi.model.PresentationResponseMessage;
 import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
-import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import static org.eclipse.edc.iam.identitytrust.spi.model.PresentationResponseMessage.PRESENTATION_RESPONSE_MESSAGE_PRESENTATION_PROPERTY;
-import static org.eclipse.edc.iam.identitytrust.spi.model.PresentationResponseMessage.PRESENTATION_RESPONSE_MESSAGE_TYPE_PROPERTY;
+import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DSPACE_DCP_NAMESPACE_V_0_8;
+import static org.eclipse.edc.iam.identitytrust.spi.model.PresentationResponseMessage.PRESENTATION_RESPONSE_MESSAGE_PRESENTATION_TERM;
+import static org.eclipse.edc.iam.identitytrust.spi.model.PresentationResponseMessage.PRESENTATION_RESPONSE_MESSAGE_TYPE_TERM;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 
 
 /**
  * Transforms a {@link PresentationResponseMessage} into a {@link JsonObject} object.
  */
-public class JsonObjectFromPresentationResponseMessageTransformer extends AbstractJsonLdTransformer<PresentationResponseMessage, JsonObject> {
+public class JsonObjectFromPresentationResponseMessageTransformer extends AbstractNamespaceAwareJsonLdTransformer<PresentationResponseMessage, JsonObject> {
     public JsonObjectFromPresentationResponseMessageTransformer() {
-        super(PresentationResponseMessage.class, JsonObject.class);
+        this(DSPACE_DCP_NAMESPACE_V_0_8);
+    }
+
+    public JsonObjectFromPresentationResponseMessageTransformer(JsonLdNamespace namespace) {
+        super(PresentationResponseMessage.class, JsonObject.class, namespace);
     }
 
     @Override
     public @Nullable JsonObject transform(@NotNull PresentationResponseMessage responseMessage, @NotNull TransformerContext context) {
         // Presentation Submission not supported yet
         return Json.createObjectBuilder()
-                .add(TYPE, PRESENTATION_RESPONSE_MESSAGE_TYPE_PROPERTY)
-                .add(PRESENTATION_RESPONSE_MESSAGE_PRESENTATION_PROPERTY, createJson(responseMessage))
+                .add(TYPE, forNamespace(PRESENTATION_RESPONSE_MESSAGE_TYPE_TERM))
+                .add(forNamespace(PRESENTATION_RESPONSE_MESSAGE_PRESENTATION_TERM), createJson(responseMessage))
                 .build();
     }
 

--- a/extensions/common/iam/identity-trust/identity-trust-transform/src/test/java/org/eclipse/edc/iam/identitytrust/transform/TestContextProvider.java
+++ b/extensions/common/iam/identity-trust/identity-trust-transform/src/test/java/org/eclipse/edc/iam/identitytrust/transform/TestContextProvider.java
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.iam.identitytrust.transform;
+
+import org.eclipse.edc.jsonld.TitaniumJsonLd;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
+import org.eclipse.edc.junit.testfixtures.TestUtils;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+import java.util.stream.Stream;
+
+import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DCP_CONTEXT_URL;
+import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DSPACE_DCP_NAMESPACE_V_0_8;
+import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DSPACE_DCP_NAMESPACE_V_1_0;
+import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DSPACE_DCP_V_1_0_CONTEXT;
+import static org.mockito.Mockito.mock;
+
+public class TestContextProvider implements ArgumentsProvider {
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+        return Stream.of(
+                Arguments.of(new TestContext(DCP_CONTEXT_URL, DSPACE_DCP_NAMESPACE_V_0_8, createJsonLd(DCP_CONTEXT_URL))),
+                Arguments.of(new TestContext(DSPACE_DCP_V_1_0_CONTEXT, DSPACE_DCP_NAMESPACE_V_1_0, createJsonLd(DSPACE_DCP_V_1_0_CONTEXT))));
+    }
+
+    private JsonLd createJsonLd(String activeContext) {
+        var jsonLd = new TitaniumJsonLd(mock());
+        jsonLd.registerCachedDocument("https://identity.foundation/presentation-exchange/submission/v1", TestUtils.getFileFromResourceName("presentation_ex.json").toURI());
+        jsonLd.registerCachedDocument(DCP_CONTEXT_URL, TestUtils.getFileFromResourceName("document/dcp.v08.jsonld").toURI());
+        jsonLd.registerCachedDocument(DSPACE_DCP_V_1_0_CONTEXT, TestUtils.getFileFromResourceName("document/dcp.v1.0.jsonld").toURI());
+        jsonLd.registerContext(activeContext);
+        return jsonLd;
+    }
+
+    public record TestContext(String context, JsonLdNamespace namespace, JsonLd jsonLd) {
+
+        public String toIri(String term) {
+            return namespace.toIri(term);
+        }
+    }
+}

--- a/extensions/common/iam/identity-trust/identity-trust-transform/src/test/java/org/eclipse/edc/iam/identitytrust/transform/from/JsonObjectFromPresentationQueryTransformerTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-transform/src/test/java/org/eclipse/edc/iam/identitytrust/transform/from/JsonObjectFromPresentationQueryTransformerTest.java
@@ -1,0 +1,85 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.iam.identitytrust.transform.from;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.json.Json;
+import org.eclipse.edc.iam.identitytrust.spi.model.PresentationQueryMessage;
+import org.eclipse.edc.iam.identitytrust.transform.TestContextProvider;
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.presentationdefinition.PresentationDefinition;
+import org.eclipse.edc.jsonld.util.JacksonJsonLd;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.iam.identitytrust.spi.model.PresentationQueryMessage.PRESENTATION_QUERY_MESSAGE_DEFINITION_TERM;
+import static org.eclipse.edc.iam.identitytrust.spi.model.PresentationQueryMessage.PRESENTATION_QUERY_MESSAGE_SCOPE_TERM;
+import static org.eclipse.edc.iam.identitytrust.spi.model.PresentationQueryMessage.PRESENTATION_QUERY_MESSAGE_TERM;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class JsonObjectFromPresentationQueryTransformerTest {
+
+    private final TransformerContext context = mock();
+    private final ObjectMapper mapper = JacksonJsonLd.createObjectMapper();
+    private final TypeManager typeManager = mock();
+
+    @BeforeEach
+    void setUp() {
+        when(typeManager.getMapper("test")).thenReturn(mapper);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(TestContextProvider.class)
+    void transform(TestContextProvider.TestContext ctx) {
+
+        var transformer = new JsonObjectFromPresentationQueryTransformer(typeManager, "test", ctx.namespace());
+        var response = PresentationQueryMessage.Builder.newinstance().scopes(List.of("scope")).build();
+
+        var json = transformer.transform(response, context);
+
+        assertThat(json).isNotNull();
+        assertThat(json.getJsonString(TYPE).getString()).isEqualTo(ctx.toIri(PRESENTATION_QUERY_MESSAGE_TERM));
+        assertThat(json.getJsonArray(ctx.toIri(PRESENTATION_QUERY_MESSAGE_SCOPE_TERM)))
+                .hasSize(1)
+                .contains(Json.createValue("scope"));
+
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(TestContextProvider.class)
+    void transform_withPresentationDefinition(TestContextProvider.TestContext ctx) {
+
+        var transformer = new JsonObjectFromPresentationQueryTransformer(typeManager, "test", ctx.namespace());
+        var response = PresentationQueryMessage.Builder.newinstance()
+                .presentationDefinition(PresentationDefinition.Builder.newInstance()
+                        .id("id")
+                        .build()).build();
+
+        var json = transformer.transform(response, context);
+
+        assertThat(json).isNotNull();
+        assertThat(json.getJsonString(TYPE).getString()).isEqualTo(ctx.toIri(PRESENTATION_QUERY_MESSAGE_TERM));
+        assertThat(json.getJsonObject(ctx.toIri(PRESENTATION_QUERY_MESSAGE_DEFINITION_TERM)))
+                .isNotNull();
+
+    }
+}

--- a/extensions/common/iam/identity-trust/identity-trust-transform/src/test/java/org/eclipse/edc/iam/identitytrust/transform/from/JsonObjectFromPresentationResponseMessageTransformerTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-transform/src/test/java/org/eclipse/edc/iam/identitytrust/transform/from/JsonObjectFromPresentationResponseMessageTransformerTest.java
@@ -16,36 +16,38 @@ package org.eclipse.edc.iam.identitytrust.transform.from;
 
 import jakarta.json.Json;
 import org.eclipse.edc.iam.identitytrust.spi.model.PresentationResponseMessage;
+import org.eclipse.edc.iam.identitytrust.transform.TestContextProvider;
 import org.eclipse.edc.transform.spi.TransformerContext;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.iam.identitytrust.spi.model.PresentationResponseMessage.PRESENTATION_RESPONSE_MESSAGE_PRESENTATION_PROPERTY;
-import static org.eclipse.edc.iam.identitytrust.spi.model.PresentationResponseMessage.PRESENTATION_RESPONSE_MESSAGE_TYPE_PROPERTY;
+import static org.eclipse.edc.iam.identitytrust.spi.model.PresentationResponseMessage.PRESENTATION_RESPONSE_MESSAGE_PRESENTATION_TERM;
+import static org.eclipse.edc.iam.identitytrust.spi.model.PresentationResponseMessage.PRESENTATION_RESPONSE_MESSAGE_TYPE_TERM;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
 import static org.mockito.Mockito.mock;
 
 public class JsonObjectFromPresentationResponseMessageTransformerTest {
 
-    private final JsonObjectFromPresentationResponseMessageTransformer transformer = new JsonObjectFromPresentationResponseMessageTransformer();
-
     private final TransformerContext context = mock();
 
-    @Test
-    void transform() {
+    @ParameterizedTest
+    @ArgumentsSource(TestContextProvider.class)
+    void transform(TestContextProvider.TestContext ctx) {
 
+        var transformer = new JsonObjectFromPresentationResponseMessageTransformer(ctx.namespace());
         var response = PresentationResponseMessage.Builder.newinstance().presentation(List.of("jwt")).build();
 
         var json = transformer.transform(response, context);
 
         assertThat(json).isNotNull();
-        assertThat(json.getJsonString(TYPE).getString()).isEqualTo(PRESENTATION_RESPONSE_MESSAGE_TYPE_PROPERTY);
+        assertThat(json.getJsonString(TYPE).getString()).isEqualTo(ctx.toIri(PRESENTATION_RESPONSE_MESSAGE_TYPE_TERM));
 
-        assertThat(json.getJsonObject(PRESENTATION_RESPONSE_MESSAGE_PRESENTATION_PROPERTY))
+        assertThat(json.getJsonObject(ctx.toIri(PRESENTATION_RESPONSE_MESSAGE_PRESENTATION_TERM)))
                 .extracting(object -> object.get(VALUE).asJsonArray())
                 .satisfies(arr -> {
                     assertThat(arr).hasSize(1)
@@ -55,8 +57,11 @@ public class JsonObjectFromPresentationResponseMessageTransformerTest {
 
     }
 
-    @Test
-    void transform_withJson() {
+    @ParameterizedTest
+    @ArgumentsSource(TestContextProvider.class)
+    void transform_withJson(TestContextProvider.TestContext ctx) {
+        var transformer = new JsonObjectFromPresentationResponseMessageTransformer(ctx.namespace());
+
         var response = PresentationResponseMessage.Builder.newinstance()
                 .presentation(List.of(Map.of("@context", List.of())))
                 .build();
@@ -64,14 +69,14 @@ public class JsonObjectFromPresentationResponseMessageTransformerTest {
         var json = transformer.transform(response, context);
 
         assertThat(json).isNotNull();
-        assertThat(json.getJsonString(TYPE).getString()).isEqualTo(PRESENTATION_RESPONSE_MESSAGE_TYPE_PROPERTY);
+        assertThat(json.getJsonString(TYPE).getString()).isEqualTo(ctx.toIri(PRESENTATION_RESPONSE_MESSAGE_TYPE_TERM));
 
         var expected = Json.createObjectBuilder()
                 .add("@context", Json.createArrayBuilder().build())
                 .build();
 
 
-        assertThat(json.getJsonObject(PRESENTATION_RESPONSE_MESSAGE_PRESENTATION_PROPERTY))
+        assertThat(json.getJsonObject(ctx.toIri(PRESENTATION_RESPONSE_MESSAGE_PRESENTATION_TERM)))
                 .extracting(object -> object.get(VALUE).asJsonArray())
                 .satisfies(arr -> {
                     assertThat(arr).hasSize(1)
@@ -81,21 +86,24 @@ public class JsonObjectFromPresentationResponseMessageTransformerTest {
 
     }
 
-    @Test
-    void transform_withStringAndJson() {
+    @ParameterizedTest
+    @ArgumentsSource(TestContextProvider.class)
+    void transform_withStringAndJson(TestContextProvider.TestContext ctx) {
+        var transformer = new JsonObjectFromPresentationResponseMessageTransformer(ctx.namespace());
+
         var response = PresentationResponseMessage.Builder.newinstance()
                 .presentation(List.of("jwt", Map.of("@context", List.of())))
                 .build();
         var json = transformer.transform(response, context);
 
         assertThat(json).isNotNull();
-        assertThat(json.getJsonString(TYPE).getString()).isEqualTo(PRESENTATION_RESPONSE_MESSAGE_TYPE_PROPERTY);
+        assertThat(json.getJsonString(TYPE).getString()).isEqualTo(ctx.toIri(PRESENTATION_RESPONSE_MESSAGE_TYPE_TERM));
 
         var complex = Json.createObjectBuilder()
                 .add("@context", Json.createArrayBuilder().build())
                 .build();
 
-        assertThat(json.getJsonObject(PRESENTATION_RESPONSE_MESSAGE_PRESENTATION_PROPERTY))
+        assertThat(json.getJsonObject(ctx.toIri(PRESENTATION_RESPONSE_MESSAGE_PRESENTATION_TERM)))
                 .extracting(object -> object.get(VALUE).asJsonArray())
                 .satisfies(arr -> {
                     assertThat(arr).hasSize(2).containsExactly(Json.createValue("jwt"), complex);

--- a/extensions/common/iam/identity-trust/identity-trust-transform/src/test/java/org/eclipse/edc/iam/identitytrust/transform/to/JsonObjectToPresentationResponseMessageTransformerTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-transform/src/test/java/org/eclipse/edc/iam/identitytrust/transform/to/JsonObjectToPresentationResponseMessageTransformerTest.java
@@ -17,10 +17,8 @@ package org.eclipse.edc.iam.identitytrust.transform.to;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.json.JsonObject;
-import org.eclipse.edc.jsonld.TitaniumJsonLd;
-import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.iam.identitytrust.transform.TestContextProvider;
 import org.eclipse.edc.jsonld.util.JacksonJsonLd;
-import org.eclipse.edc.junit.testfixtures.TestUtils;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.transform.TransformerContextImpl;
 import org.eclipse.edc.transform.TypeTransformerRegistryImpl;
@@ -28,46 +26,42 @@ import org.eclipse.edc.transform.spi.TransformerContext;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.transform.transformer.edc.to.JsonValueToGenericTypeTransformer;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DCP_CONTEXT_URL;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class JsonObjectToPresentationResponseMessageTransformerTest {
     private final ObjectMapper mapper = JacksonJsonLd.createObjectMapper();
     private final TypeManager typeManager = mock();
-    private final JsonObjectToPresentationResponseMessageTransformer transformer = new JsonObjectToPresentationResponseMessageTransformer(typeManager, "test");
-    private final JsonLd jsonLd = new TitaniumJsonLd(mock());
     private final TypeTransformerRegistry trr = new TypeTransformerRegistryImpl();
     private final TransformerContext context = new TransformerContextImpl(trr);
 
     @BeforeEach
     void setUp() {
-        jsonLd.registerCachedDocument("https://identity.foundation/presentation-exchange/submission/v1", TestUtils.getFileFromResourceName("presentation_ex.json").toURI());
-        jsonLd.registerCachedDocument(DCP_CONTEXT_URL, TestUtils.getFileFromResourceName("document/dcp.v08.jsonld").toURI());
-        // delegate to the generic transformer
-
         trr.register(new JsonValueToGenericTypeTransformer(typeManager, "test"));
         when(typeManager.getMapper("test")).thenReturn(mapper);
     }
 
-    @Test
-    void transform() throws JsonProcessingException {
+    @ParameterizedTest
+    @ArgumentsSource(TestContextProvider.class)
+    void transform(TestContextProvider.TestContext ctx) throws JsonProcessingException {
+        var transformer = new JsonObjectToPresentationResponseMessageTransformer(typeManager, "test", ctx.namespace());
         var obj = """
                 {
                   "@context": [
-                    "https://w3id.org/tractusx-trust/v0.8"
+                    "%s"
                   ],
                   "@type": "PresentationResponseMessage",
                   "presentation": "jwtPresentation"
                 }
-                """;
+                """.formatted(ctx.context());
         var json = mapper.readValue(obj, JsonObject.class);
-        var jo = jsonLd.expand(json);
+        var jo = ctx.jsonLd().expand(json);
         assertThat(jo.succeeded()).withFailMessage(jo::getFailureDetail).isTrue();
 
         var query = transformer.transform(jo.getContent(), context);
@@ -77,19 +71,21 @@ class JsonObjectToPresentationResponseMessageTransformerTest {
         assertThat(query.getPresentationSubmission()).isNull();
     }
 
-    @Test
-    void transform_MultipleJwt() throws JsonProcessingException {
+    @ParameterizedTest
+    @ArgumentsSource(TestContextProvider.class)
+    void transform_MultipleJwt(TestContextProvider.TestContext ctx) throws JsonProcessingException {
+        var transformer = new JsonObjectToPresentationResponseMessageTransformer(typeManager, "test", ctx.namespace());
         var obj = """
                 {
                   "@context": [
-                    "https://w3id.org/tractusx-trust/v0.8"
+                    "%s"
                   ],
                   "@type": "PresentationResponseMessage",
                   "presentation": ["firstJwtPresentation", "secondJwtPresentation"]
                 }
-                """;
+                """.formatted(ctx.context());
         var json = mapper.readValue(obj, JsonObject.class);
-        var jo = jsonLd.expand(json);
+        var jo = ctx.jsonLd().expand(json);
         assertThat(jo.succeeded()).withFailMessage(jo::getFailureDetail).isTrue();
 
         var query = transformer.transform(jo.getContent(), context);
@@ -100,12 +96,15 @@ class JsonObjectToPresentationResponseMessageTransformerTest {
     }
 
 
-    @Test
-    void transform_singleJson() throws JsonProcessingException {
+    @ParameterizedTest
+    @ArgumentsSource(TestContextProvider.class)
+    void transform_singleJson(TestContextProvider.TestContext ctx) throws JsonProcessingException {
+        var transformer = new JsonObjectToPresentationResponseMessageTransformer(typeManager, "test", ctx.namespace());
+
         var obj = """
                 {
                       "@context": [
-                          "https://w3id.org/tractusx-trust/v0.8"
+                           "%s"
                       ],
                       "@type": "PresentationResponseMessage",
                       "presentation": {
@@ -117,9 +116,9 @@ class JsonObjectToPresentationResponseMessageTransformerTest {
                           ]
                       }
                   }
-                """;
+                """.formatted(ctx.context());
         var json = mapper.readValue(obj, JsonObject.class);
-        var jo = jsonLd.expand(json);
+        var jo = ctx.jsonLd().expand(json);
         assertThat(jo.succeeded()).withFailMessage(jo::getFailureDetail).isTrue();
 
         var query = transformer.transform(jo.getContent(), context);
@@ -130,12 +129,15 @@ class JsonObjectToPresentationResponseMessageTransformerTest {
         assertThat(query.getPresentationSubmission()).isNull();
     }
 
-    @Test
-    void transform_multipleJson() throws JsonProcessingException {
+    @ParameterizedTest
+    @ArgumentsSource(TestContextProvider.class)
+    void transform_multipleJson(TestContextProvider.TestContext ctx) throws JsonProcessingException {
+        var transformer = new JsonObjectToPresentationResponseMessageTransformer(typeManager, "test", ctx.namespace());
+
         var obj = """
                 {
                          "@context": [
-                             "https://w3id.org/tractusx-trust/v0.8"
+                              "%s"
                          ],
                          "@type": "PresentationResponseMessage",
                          "presentation": [
@@ -157,9 +159,9 @@ class JsonObjectToPresentationResponseMessageTransformerTest {
                              }
                          ]
                      }
-                """;
+                """.formatted(ctx.context());
         var json = mapper.readValue(obj, JsonObject.class);
-        var jo = jsonLd.expand(json);
+        var jo = ctx.jsonLd().expand(json);
         assertThat(jo.succeeded()).withFailMessage(jo::getFailureDetail).isTrue();
 
         var query = transformer.transform(jo.getContent(), context);
@@ -171,12 +173,15 @@ class JsonObjectToPresentationResponseMessageTransformerTest {
         assertThat(query.getPresentationSubmission()).isNull();
     }
 
-    @Test
-    void transform_mixed() throws JsonProcessingException {
+    @ParameterizedTest
+    @ArgumentsSource(TestContextProvider.class)
+    void transform_mixed(TestContextProvider.TestContext ctx) throws JsonProcessingException {
+        var transformer = new JsonObjectToPresentationResponseMessageTransformer(typeManager, "test", ctx.namespace());
+
         var obj = """
                 {
                          "@context": [
-                             "https://w3id.org/tractusx-trust/v0.8"
+                              "%s"
                          ],
                          "@type": "PresentationResponseMessage",
                          "presentation": [
@@ -191,9 +196,9 @@ class JsonObjectToPresentationResponseMessageTransformerTest {
                              "jwtPresentation"
                          ]
                      }
-                """;
+                """.formatted(ctx.context());
         var json = mapper.readValue(obj, JsonObject.class);
-        var jo = jsonLd.expand(json);
+        var jo = ctx.jsonLd().expand(json);
         assertThat(jo.succeeded()).withFailMessage(jo::getFailureDetail).isTrue();
 
         var query = transformer.transform(jo.getContent(), context);

--- a/extensions/common/iam/identity-trust/identity-trust-transform/src/test/resources/document/dcp.v1.0.jsonld
+++ b/extensions/common/iam/identity-trust/identity-trust-transform/src/test/resources/document/dcp.v1.0.jsonld
@@ -1,0 +1,137 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+    "dcp": "https://w3id.org/dspace-dcp/v1.0/",
+    "cred": "https://www.w3.org/2018/credentials/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "id": "@id",
+    "type": "@type",
+    "CredentialContainer": {
+      "@id": "dcp:CredentialContainer",
+      "@context": {
+        "payload": {
+          "@id": "dcp:payload",
+          "@type": "xsd:string"
+        }
+      }
+    },
+    "CredentialMessage": {
+      "@id": "dcp:CredentialMessage",
+      "@context": {
+        "credentials": {
+          "@id": "dcp:credentials",
+          "@container": "@set"
+        },
+        "requestId": {
+          "@id": "dcp:requestId",
+          "@type": "@id"
+        }
+      }
+    },
+    "CredentialObject": {
+      "@id": "dcp:CredentialObject",
+      "@context": {
+        "credentialType": {
+          "@id": "dcp:credentialType",
+          "@container": "@set"
+        },
+        "offerReason": {
+          "@id": "dcp:offerReason",
+          "@type": "xsd:string"
+        },
+        "bindingMethods": {
+          "@id": "dcp:bindingMethods",
+          "@type": "xsd:string",
+          "@container": "@set"
+        },
+        "profiles": {
+          "@id": "dcp:profiles",
+          "@type": "xsd:string",
+          "@container": "@set"
+        },
+        "issuancePolicy": {
+          "@id": "dcp:issuancePolicy",
+          "@type": "@json"
+        }
+      }
+    },
+    "CredentialOfferMessage": {
+      "@id": "dcp:CredentialOfferMessage",
+      "@context": {
+        "credentialIssuer": "cred:issuer",
+        "credentials": {
+          "@id": "dcp:credentials",
+          "@container": "@set"
+        }
+      }
+    },
+    "CredentialRequestMessage": {
+      "@id": "dcp:CredentialRequestMessage",
+      "@context": {
+        "format": "dcp:format",
+        "credentialType": {
+          "@id": "dcp:credentialType",
+          "@type": "@vocab",
+          "@container": "@set"
+        }
+      }
+    },
+    "CredentialService": "dcp:CredentialService",
+    "CredentialStatus": {
+      "@id": "dcp:CredentialStatus",
+      "@context": {
+        "requestId": {
+          "@id": "dcp:requestId",
+          "@type": "@id"
+        },
+        "status": {
+          "@id": "dcp:status",
+          "@type": "@vocab"
+        },
+        "RECEIVED": "dcp:RECEIVED",
+        "REJECTED": "dcp:REJECTED",
+        "ISSUED": "dcp:ISSUED"
+      }
+    },
+    "IssuerMetadata": {
+      "@id": "dcp:IssuerMetadata",
+      "@context": {
+        "credentialIssuer": "cred:issuer",
+        "credentialsSupported": {
+          "@id": "dcp:credentialsSupported",
+          "@container": "@set"
+        }
+      }
+    },
+    "IssuerService": "dcp:IssuerService",
+    "PresentationQueryMessage": {
+      "@id": "dcp:PresentationQueryMessage",
+      "@context": {
+        "presentationDefinition": {
+          "@id": "dcp:presentationDefinition",
+          "@type": "@json"
+        },
+        "scope": {
+          "@id": "dcp:scope",
+          "@type": "xsd:string",
+          "@container": "@set"
+        }
+      }
+    },
+    "PresentationResponseMessage": {
+      "@id": "dcp:PresentationResponseMessage",
+      "@context": {
+        "presentation": {
+          "@id": "dcp:presentation",
+          "@container": "@set",
+          "@type": "@json"
+        },
+        "presentationSubmission": {
+          "@id": "dcp:presentationSubmission",
+          "@type": "@json"
+        }
+      }
+    }
+  }
+}

--- a/spi/common/identity-trust-spi/build.gradle.kts
+++ b/spi/common/identity-trust-spi/build.gradle.kts
@@ -21,6 +21,7 @@ plugins {
 dependencies {
     api(project(":spi:common:core-spi"))
     api(project(":spi:common:token-spi"))
+    api(project(":spi:common:json-ld-spi"))
     api(project(":spi:common:participant-spi"))
     api(project(":spi:common:policy:request-policy-context-spi"))
     api(project(":spi:common:policy-engine-spi"))

--- a/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/iam/identitytrust/spi/DcpConstants.java
+++ b/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/iam/identitytrust/spi/DcpConstants.java
@@ -14,9 +14,17 @@
 
 package org.eclipse.edc.iam.identitytrust.spi;
 
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
+
 public interface DcpConstants {
 
-
+    @Deprecated(since = "0.12.0")
     String DCP_CONTEXT_URL = "https://w3id.org/tractusx-trust/v0.8";
+    @Deprecated(since = "0.12.0")
     String DCP_PREFIX = DCP_CONTEXT_URL + "/";
+    @Deprecated(since = "0.12.0")
+    JsonLdNamespace DSPACE_DCP_NAMESPACE_V_0_8 = new JsonLdNamespace(DCP_PREFIX);
+
+    String DSPACE_DCP_V_1_0_CONTEXT = "https://w3id.org/dspace-dcp/v1.0/dcp.jsonld";
+    JsonLdNamespace DSPACE_DCP_NAMESPACE_V_1_0 = new JsonLdNamespace("https://w3id.org/dspace-dcp/v1.0/");
 }

--- a/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/iam/identitytrust/spi/model/PresentationQueryMessage.java
+++ b/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/iam/identitytrust/spi/model/PresentationQueryMessage.java
@@ -29,10 +29,15 @@ import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DCP_PREFIX;
  * @see <a href="https://github.com/eclipse-tractusx/identity-trust/blob/main/specifications/M1/verifiable.presentation.protocol.md#411-query-for-presentations">DCP Specification</a>
  */
 public class PresentationQueryMessage {
+    @Deprecated(since = "0.12.0", forRemoval = true)
     public static final String PRESENTATION_QUERY_MESSAGE_SCOPE_PROPERTY = DCP_PREFIX + "scope";
+    public static final String PRESENTATION_QUERY_MESSAGE_SCOPE_TERM = "scope";
+    @Deprecated(since = "0.12.0", forRemoval = true)
     public static final String PRESENTATION_QUERY_MESSAGE_DEFINITION_PROPERTY = DCP_PREFIX + "presentationDefinition";
-    public static final String PRESENTATION_QUERY_MESSAGE_TYPE = "PresentationQueryMessage";
-    public static final String PRESENTATION_QUERY_MESSAGE_TYPE_PROPERTY = DCP_PREFIX + PRESENTATION_QUERY_MESSAGE_TYPE;
+    public static final String PRESENTATION_QUERY_MESSAGE_DEFINITION_TERM = "presentationDefinition";
+    public static final String PRESENTATION_QUERY_MESSAGE_TERM = "PresentationQueryMessage";
+    @Deprecated(since = "0.12.0", forRemoval = true)
+    public static final String PRESENTATION_QUERY_MESSAGE_TYPE_PROPERTY = DCP_PREFIX + PRESENTATION_QUERY_MESSAGE_TERM;
 
     private final List<String> scopes = new ArrayList<>();
     private PresentationDefinition presentationDefinition;

--- a/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/iam/identitytrust/spi/model/PresentationResponseMessage.java
+++ b/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/iam/identitytrust/spi/model/PresentationResponseMessage.java
@@ -31,9 +31,15 @@ import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DCP_PREFIX;
  */
 public class PresentationResponseMessage {
 
+    @Deprecated(since = "0.12.0", forRemoval = true)
     public static final String PRESENTATION_RESPONSE_MESSAGE_PRESENTATION_PROPERTY = DCP_PREFIX + "presentation";
+    public static final String PRESENTATION_RESPONSE_MESSAGE_PRESENTATION_TERM = "presentation";
+    @Deprecated(since = "0.12.0", forRemoval = true)
     public static final String PRESENTATION_RESPONSE_MESSAGE_PRESENTATION_SUBMISSION_PROPERTY = DCP_PREFIX + "presentationSubmission";
+    public static final String PRESENTATION_RESPONSE_MESSAGE_PRESENTATION_SUBMISSION_TERM = "presentationSubmission";
+    @Deprecated(since = "0.12.0", forRemoval = true)
     public static final String PRESENTATION_RESPONSE_MESSAGE_TYPE_PROPERTY = DCP_PREFIX + "PresentationResponseMessage";
+    public static final String PRESENTATION_RESPONSE_MESSAGE_TYPE_TERM = "PresentationResponseMessage";
 
     private List<Object> presentation = new ArrayList<>();
 


### PR DESCRIPTION
## What this PR changes/adds

add initial support for DCP namespace v1.0:

- introduces `JsonLdNamespace` for dcp 0.8 and 1.0
- Transformers can be configured to used different namespace
- Introduced cached dcp 1.0 JSON-LD context
- Changed transformers tests to target both dcp namespace

## Why it does that

dcp v1.0 adoption

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #4764 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
