### PR TITLE
fix: expire cached DidDocuments

### DIFF
--- a/core/common/lib/util-lib/src/main/java/org/eclipse/edc/util/collection/TimestampedValue.java
+++ b/core/common/lib/util-lib/src/main/java/org/eclipse/edc/util/collection/TimestampedValue.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Cofinity-X - change access modifier
  *
  */
 
@@ -30,6 +31,10 @@ public record TimestampedValue<V>(V value, Instant lastUpdatedAt, long validityM
 
     public TimestampedValue(V value) {
         this(value, Instant.now(), DEFAULT_VALIDITY_MILLIS);
+    }
+
+    public TimestampedValue(V value, long validityMillis) {
+        this(value, Instant.now(), validityMillis);
     }
 
     public boolean isExpired(Clock clock) {

--- a/core/common/lib/util-lib/src/main/java/org/eclipse/edc/util/collection/TimestampedValue.java
+++ b/core/common/lib/util-lib/src/main/java/org/eclipse/edc/util/collection/TimestampedValue.java
@@ -25,10 +25,10 @@ import java.time.temporal.ChronoUnit;
  * @param lastUpdatedAt  The {@link Instant} when the value was last updated.
  * @param validityMillis The time in milliseconds how long the entry is valid. Defaults to {@link TimestampedValue#DEFAULT_VALIDITY_MILLIS} (= 5 minutes)
  */
-record TimestampedValue<V>(V value, Instant lastUpdatedAt, long validityMillis) {
+public record TimestampedValue<V>(V value, Instant lastUpdatedAt, long validityMillis) {
     public static final long DEFAULT_VALIDITY_MILLIS = 5 * 60 * 1000L; // 5 minutes
 
-    TimestampedValue(V value) {
+    public TimestampedValue(V value) {
         this(value, Instant.now(), DEFAULT_VALIDITY_MILLIS);
     }
 

--- a/extensions/common/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/edc/iam/did/IdentityDidCoreExtension.java
+++ b/extensions/common/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/edc/iam/did/IdentityDidCoreExtension.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.keys.spi.KeyParserRegistry;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provides;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 
@@ -33,6 +34,8 @@ import java.time.Clock;
 public class IdentityDidCoreExtension implements ServiceExtension {
 
     public static final String NAME = "Identity Did Core";
+    @Setting(description = "Expiry time for caching DID Documents in milliseconds", key = "edc.did.resolver.cache.expiry", defaultValue = 1000 * 60 * 5 + "")
+    private long didCacheExpiryMillis;
     @Inject
     private KeyParserRegistry keyParserRegistry;
 
@@ -46,7 +49,7 @@ public class IdentityDidCoreExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var didResolverRegistry = new DidResolverRegistryImpl(clock);
+        var didResolverRegistry = new DidResolverRegistryImpl(clock, didCacheExpiryMillis);
         context.registerService(DidResolverRegistry.class, didResolverRegistry);
 
         var publicKeyResolver = new DidPublicKeyResolverImpl(keyParserRegistry, didResolverRegistry);

--- a/extensions/common/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/edc/iam/did/IdentityDidCoreExtension.java
+++ b/extensions/common/iam/decentralized-identity/identity-did-core/src/main/java/org/eclipse/edc/iam/did/IdentityDidCoreExtension.java
@@ -25,14 +25,19 @@ import org.eclipse.edc.runtime.metamodel.annotation.Provides;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 
+import java.time.Clock;
 
-@Provides({ DidResolverRegistry.class, DidPublicKeyResolver.class })
+
+@Provides({DidResolverRegistry.class, DidPublicKeyResolver.class})
 @Extension(value = IdentityDidCoreExtension.NAME)
 public class IdentityDidCoreExtension implements ServiceExtension {
 
     public static final String NAME = "Identity Did Core";
     @Inject
     private KeyParserRegistry keyParserRegistry;
+
+    @Inject
+    private Clock clock;
 
     @Override
     public String name() {
@@ -41,7 +46,7 @@ public class IdentityDidCoreExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var didResolverRegistry = new DidResolverRegistryImpl();
+        var didResolverRegistry = new DidResolverRegistryImpl(clock);
         context.registerService(DidResolverRegistry.class, didResolverRegistry);
 
         var publicKeyResolver = new DidPublicKeyResolverImpl(keyParserRegistry, didResolverRegistry);

--- a/extensions/common/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/edc/iam/did/resolution/DidResolverRegistryImplTest.java
+++ b/extensions/common/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/edc/iam/did/resolution/DidResolverRegistryImplTest.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Cofinity-X - added tests
  *
  */
 
@@ -43,12 +44,13 @@ import static org.mockito.Mockito.when;
  */
 class DidResolverRegistryImplTest {
     public static final String FOO_METHOD = "foo";
+    public static final int CACHE_VALIDITY = 1000 * 60 * 5;
     private DidResolverRegistryImpl registry;
 
 
     @BeforeEach
     void setUp() {
-        registry = new DidResolverRegistryImpl(Clock.systemUTC());
+        registry = new DidResolverRegistryImpl(Clock.systemUTC(), CACHE_VALIDITY);
     }
 
     @Test
@@ -100,7 +102,7 @@ class DidResolverRegistryImplTest {
 
     @Test
     void resolve_whenCacheExpired() {
-        registry = new DidResolverRegistryImpl(Clock.fixed(Instant.now().plus(1, ChronoUnit.DAYS), ZoneId.systemDefault()));
+        registry = new DidResolverRegistryImpl(Clock.fixed(Instant.now().plus(1, ChronoUnit.DAYS), ZoneId.systemDefault()), CACHE_VALIDITY);
         var resolver = mock(DidResolver.class);
         when(resolver.getMethod()).thenReturn(FOO_METHOD);
         when(resolver.resolve(any())).thenReturn(Result.success(DidDocument.Builder.newInstance().build()));

--- a/extensions/common/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/edc/iam/did/resolution/DidResolverRegistryImplTest.java
+++ b/extensions/common/iam/decentralized-identity/identity-did-core/src/test/java/org/eclipse/edc/iam/did/resolution/DidResolverRegistryImplTest.java
@@ -21,9 +21,22 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Verifies {@link DidResolverRegistryImpl}.
@@ -32,9 +45,10 @@ class DidResolverRegistryImplTest {
     public static final String FOO_METHOD = "foo";
     private DidResolverRegistryImpl registry;
 
+
     @BeforeEach
     void setUp() {
-        registry = new DidResolverRegistryImpl();
+        registry = new DidResolverRegistryImpl(Clock.systemUTC());
     }
 
     @Test
@@ -67,6 +81,37 @@ class DidResolverRegistryImplTest {
         assertThat(registry.isSupported("did:unsupported:whatever")).isFalse();
     }
 
+    @Test
+    void resolve_whenCached() {
+        var resolver = mock(DidResolver.class);
+        when(resolver.getMethod()).thenReturn(FOO_METHOD);
+        when(resolver.resolve(any())).thenReturn(Result.success(DidDocument.Builder.newInstance().build()));
+        registry.register(resolver);
+
+        var result = registry.resolve("did:foo:id");
+
+        assertThat(result).isSucceeded();
+
+        assertThat(registry.resolve("did:foo:id")).isSucceeded(); //doc is cached
+
+        verify(resolver, times(1)).resolve(anyString());
+
+    }
+
+    @Test
+    void resolve_whenCacheExpired() {
+        registry = new DidResolverRegistryImpl(Clock.fixed(Instant.now().plus(1, ChronoUnit.DAYS), ZoneId.systemDefault()));
+        var resolver = mock(DidResolver.class);
+        when(resolver.getMethod()).thenReturn(FOO_METHOD);
+        when(resolver.resolve(any())).thenReturn(Result.success(DidDocument.Builder.newInstance().build()));
+        registry.register(resolver);
+
+        assertThat(registry.resolve("did:foo:id")).isSucceeded();
+        assertThat(registry.resolve("did:foo:id")).isSucceeded(); //cache entry is expired
+
+        verify(resolver, times(2)).resolve(anyString());
+    }
+
     /**
      * Mock resolver class.
      */
@@ -80,7 +125,7 @@ class DidResolverRegistryImplTest {
         @Override
         @NotNull
         public Result<DidDocument> resolve(String didKey) {
-            return Result.success(DidDocument.Builder.newInstance().build());
+            return Result.success(DidDocument.Builder.newInstance().id(UUID.randomUUID().toString()).build());
         }
     }
 


### PR DESCRIPTION
## What this PR changes/adds

Cached DidDocuments in the `DidResolverRegistry` expire after a configurable amount of time and are re-resolved after expiry.

## Why it does that

up until now, DidDocuemnts are cached forever, until the runtime restarts. this will prevent updated did documents (e.g. after a key rotation, updated service endpoints...) from being re-downloaded.

expiring the docs will cause them to eventually get updated.

## Further notes

I decided against using a reaper thread, and for evicting the entries lazily, because changes are expected to be few and far between, so a reaper would spin empty most of the time.

## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
