### PR TITLE
fix: use `nbf` claim for issuance date

### DIFF
--- a/extensions/common/iam/identity-trust/identity-trust-transform/src/main/java/org/eclipse/edc/iam/identitytrust/transform/to/JwtToVerifiableCredentialTransformer.java
+++ b/extensions/common/iam/identity-trust/identity-trust-transform/src/main/java/org/eclipse/edc/iam/identitytrust/transform/to/JwtToVerifiableCredentialTransformer.java
@@ -96,7 +96,7 @@ public class JwtToVerifiableCredentialTransformer extends AbstractJwtTransformer
                 extractDate(vc.get(EXPIRATION_DATE_PROPERTY), claims.getExpirationTime()).or(() -> extractDate(vc.get(VALID_UNTIL_PROPERTY), claims.getExpirationTime())).ifPresent(builder::expirationDate);
 
                 // issuance date
-                extractDate(vc.get(ISSUANCE_DATE_PROPERTY), claims.getIssueTime()).or(() -> extractDate(vc.get(VALID_FROM_PROPERTY), claims.getIssueTime())).ifPresent(builder::issuanceDate);
+                extractDate(vc.get(ISSUANCE_DATE_PROPERTY), claims.getNotBeforeTime()).or(() -> extractDate(vc.get(VALID_FROM_PROPERTY), claims.getNotBeforeTime())).ifPresent(builder::issuanceDate);
 
                 // take issuer from JWT claim of from VC object
                 var issuer = ofNullable(claims.getIssuer()).or(() -> ofNullable(vc.get("issuer")).map(Object::toString)).orElse(null);

--- a/extensions/common/iam/identity-trust/identity-trust-transform/src/test/java/org/eclipse/edc/iam/identitytrust/transform/TestData.java
+++ b/extensions/common/iam/identity-trust/identity-trust-transform/src/test/java/org/eclipse/edc/iam/identitytrust/transform/TestData.java
@@ -339,23 +339,25 @@ public interface TestData {
             """;
 
     String EXAMPLE_JWT_VC_NO_DATES = """
-            eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImRpZDpleGFtcGxlOmFiZmUxM2Y3MTI
-            xMjA0MzFjMjc2ZTEyZWNhYiNrZXlzLTEifQ.eyJzdWIiOiJkaWQ6ZXhhbXBsZTplYmZlYjFmNzE
-            yZWJjNmYxYzI3NmUxMmVjMjEiLCJqdGkiOiJodHRwOi8vZXhhbXBsZS5lZHUvY3JlZGVudGlhbH
-            MvMzczMiIsImlzcyI6Imh0dHBzOi8vZXhhbXBsZS5jb20va2V5cy9mb28uandrIiwibmJmIjoxN
-            TQxNDkzNzI0LCJpYXQiOjE1NDE0OTM3MjQsImV4cCI6MTU3MzAyOTcyMywibm9uY2UiOiI2NjAh
-            NjM0NUZTZXIiLCJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmV
-            kZW50aWFscy92MSIsImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL2V4YW1wbG
-            VzL3YxIl0sInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJVbml2ZXJzaXR5RGVncmVlQ
-            3JlZGVudGlhbCJdLCJjcmVkZW50aWFsU3ViamVjdCI6eyJkZWdyZWUiOnsidHlwZSI6IkJhY2hl
-            bG9yRGVncmVlIiwibmFtZSI6IjxzcGFuIGxhbmc9J2ZyLUNBJz5CYWNjYWxhdXLDqWF0IGVuIG1
-            1c2lxdWVzIG51bcOpcmlxdWVzPC9zcGFuPiJ9fX19.KLJo5GAyBND3LDTn9H7FQokEsUEi8jKwX
-            hGvoN3JtRa51xrNDgXDb0cq1UTYB-rK4Ft9YVmR1NI_ZOF8oGc_7wAp8PHbF2HaWodQIoOBxxT-
-            4WNqAxft7ET6lkH-4S6Ux3rSGAmczMohEEf8eCeN-jC8WekdPl6zKZQj0YPB1rx6X0-xlFBs7cl
-            6Wt8rfBP_tZ9YgVWrQmUWypSioc0MUyiphmyEbLZagTyPlUyflGlEdqrZAv6eSe6RtxJy6M1-lD
-            7a5HTzanYTWBPAUHDZGyGKXdJw-W_x0IWChBzI8t3kpG253fg6V3tPgHeKXE94fz_QpYfg--7kL
-            syBAfQGbg
+            eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkaWQ6ZXhhbXBsZTplYmZlYjFmNzEyZWJjNmYxYzI3NmUxMmVjMjEiLCJqdGk
+            iOiJodHRwOi8vZXhhbXBsZS5lZHUvY3JlZGVudGlhbHMvMzczMiIsImlzcyI6Imh0dHBzOi8vZXhhbXBsZS5jb20va2V5cy9mb28uandrIiw
+            ibmJmIjoxNTQxNDkzNzI0LCJleHAiOjE1NzMwMjk3MjMsIm5vbmNlIjoiNjYwITYzNDVGU2VyIiwidmMiOnsiQGNvbnRleHQiOlsiaHR0cHM
+            6Ly93d3cudzMub3JnLzIwMTgvY3JlZGVudGlhbHMvdjEiLCJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy9leGFtcGxlcy9
+            2MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiVW5pdmVyc2l0eURlZ3JlZUNyZWRlbnRpYWwiXSwiY3JlZGVudGlhbFN1Ymp
+            lY3QiOnsiZGVncmVlIjp7InR5cGUiOiJCYWNoZWxvckRlZ3JlZSIsIm5hbWUiOiI8c3BhbiBsYW5nPSdmci1DQSc-QmFjY2FsYXVyw6lhdCB
+            lbiBtdXNpcXVlcyBudW3DqXJpcXVlczwvc3Bhbj4ifX19fQ.rm37S4oLVa6j2gc-LGHqJj5G9Yph2b9cyN7DEpwvy_4
             """;
+
+    String EXAMPLE_JWT_VC_NO_NBF = """
+            eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkaWQ6ZXhhbXBsZTplYmZlYjFmNzEyZWJjNmYxYzI3NmUxMmVjMjEiLCJqdGk
+            iOiJodHRwOi8vZXhhbXBsZS5lZHUvY3JlZGVudGlhbHMvMzczMiIsImlzcyI6Imh0dHBzOi8vZXhhbXBsZS5jb20va2V5cy9mb28uandrIiw
+            iZXhwIjoxNTczMDI5NzIzLCJub25jZSI6IjY2MCE2MzQ1RlNlciIsInZjIjp7IkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy8yMDE
+            4L2NyZWRlbnRpYWxzL3YxIiwiaHR0cHM6Ly93d3cudzMub3JnLzIwMTgvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjEiXSwidHlwZSI6WyJWZXJ
+            pZmlhYmxlQ3JlZGVudGlhbCIsIlVuaXZlcnNpdHlEZWdyZWVDcmVkZW50aWFsIl0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImRlZ3JlZSI6eyJ
+            0eXBlIjoiQmFjaGVsb3JEZWdyZWUiLCJuYW1lIjoiPHNwYW4gbGFuZz0nZnItQ0EnPkJhY2NhbGF1csOpYXQgZW4gbXVzaXF1ZXMgbnVtw6l
+            yaXF1ZXM8L3NwYW4-In19fX0.mEU-6y1RYGbpxubTTOyq53fJgp5yQvVmly-fXD-vT44
+            """;
+
     String EXAMPLE_ENVELOPED_PRESENTATION = """
             eyJraWQiOiJ2cC1zaWduIiwiYWxnIjoiRVMyNTYifQ.eyJpZCI6ImRhdGE6YXBwbGljYXRpb24vdn
             Arand0LGV5SnJhV1FpT2lKMmNDMXphV2R1SWl3aVlXeG5Jam9pUlZNeU5UWWlmUS5leUowZVhCbEl

--- a/extensions/common/iam/identity-trust/identity-trust-transform/src/test/java/org/eclipse/edc/iam/identitytrust/transform/to/JwtToVerifiableCredentialTransformerTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-transform/src/test/java/org/eclipse/edc/iam/identitytrust/transform/to/JwtToVerifiableCredentialTransformerTest.java
@@ -22,8 +22,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.edc.iam.identitytrust.transform.TestData.EXAMPLE_JWT_VC;
 import static org.eclipse.edc.iam.identitytrust.transform.TestData.EXAMPLE_JWT_VC_NO_DATES;
+import static org.eclipse.edc.iam.identitytrust.transform.TestData.EXAMPLE_JWT_VC_NO_NBF;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -53,7 +55,7 @@ class JwtToVerifiableCredentialTransformerTest {
     }
 
     @Test
-    @DisplayName("VC claims do not contain dates, but JWT 'iat' and 'exp' are used as fallbacks")
+    @DisplayName("VC claims do not contain dates, but JWT 'nbf' and 'exp' are used as fallbacks")
     void transform_credentialHasNoDates() {
         var vc = transformer.transform(EXAMPLE_JWT_VC_NO_DATES, context);
 
@@ -63,6 +65,13 @@ class JwtToVerifiableCredentialTransformerTest {
         assertThat(vc.getIssuanceDate()).isBefore(vc.getExpirationDate());
 
         verifyNoInteractions(context);
+    }
+
+    @Test
+    void transform_jwtHasNoNbf_expectError() {
+        assertThatThrownBy(() -> transformer.transform(EXAMPLE_JWT_VC_NO_NBF, context))
+                .hasMessageContaining("Credential must contain `issuanceDate`/`validFrom` property.");
+
     }
 
     @Test


### PR DESCRIPTION

## What this PR changes/adds

the JWT VC [specification](https://www.w3.org/TR/vc-data-model/#jwt-encoding) mandates that the credentials issuance date be taken from the `nbf` claim.

before, our code took it from the `iat` claim, and this PR fixes that.

## Why it does that

mandated by the spec, although it seems wrong...




## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #4754

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
