### PR TITLE
feat: adds support for dcp v1.0 in default credential service client

### DIFF
--- a/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtension.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtension.java
@@ -95,7 +95,7 @@ public class IdentityAndTrustExtension implements ServiceExtension {
     @Setting(description = "The period of the JTI entry reaper thread in seconds", defaultValue = DEFAULT_CLEANUP_PERIOD_SECONDS + "", key = "edc.sql.store.jti.cleanup.period")
     private long reaperCleanupPeriod;
 
-    @Setting(description = "If set enable the dcp v0.8 namespace will be used", key = "edc.dcp.v08.enabled", required = false, defaultValue = "false")
+    @Setting(description = "If set enable the dcp v0.8 namespace will be used", key = "edc.dcp.v08.forced", required = false, defaultValue = "false")
     private boolean enableDcpV08;
 
     @Inject

--- a/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/defaults/DefaultCredentialServiceClient.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/defaults/DefaultCredentialServiceClient.java
@@ -22,7 +22,6 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import org.eclipse.edc.http.spi.EdcHttpClient;
 import org.eclipse.edc.iam.identitytrust.spi.CredentialServiceClient;
-import org.eclipse.edc.iam.identitytrust.spi.DcpConstants;
 import org.eclipse.edc.iam.identitytrust.spi.model.PresentationQueryMessage;
 import org.eclipse.edc.iam.identitytrust.spi.model.PresentationResponseMessage;
 import org.eclipse.edc.iam.verifiablecredentials.spi.VcConstants;
@@ -55,8 +54,9 @@ public class DefaultCredentialServiceClient implements CredentialServiceClient {
     private final TypeTransformerRegistry transformerRegistry;
     private final JsonLd jsonLd;
     private final Monitor monitor;
+    private final String dcpContextUrl;
 
-    public DefaultCredentialServiceClient(EdcHttpClient httpClient, JsonBuilderFactory jsonFactory, TypeManager typeManager, String typeContext, TypeTransformerRegistry transformerRegistry, JsonLd jsonLd, Monitor monitor) {
+    public DefaultCredentialServiceClient(EdcHttpClient httpClient, JsonBuilderFactory jsonFactory, TypeManager typeManager, String typeContext, TypeTransformerRegistry transformerRegistry, JsonLd jsonLd, Monitor monitor, String dcpContextUrl) {
         this.httpClient = httpClient;
         this.jsonFactory = jsonFactory;
         this.typeManager = typeManager;
@@ -64,6 +64,7 @@ public class DefaultCredentialServiceClient implements CredentialServiceClient {
         this.transformerRegistry = transformerRegistry;
         this.jsonLd = jsonLd;
         this.monitor = monitor;
+        this.dcpContextUrl = dcpContextUrl;
     }
 
     @Override
@@ -154,7 +155,7 @@ public class DefaultCredentialServiceClient implements CredentialServiceClient {
         return jsonFactory.createObjectBuilder()
                 .add(JsonLdKeywords.CONTEXT, jsonFactory.createArrayBuilder()
                         .add(VcConstants.PRESENTATION_EXCHANGE_URL)
-                        .add(DcpConstants.DCP_CONTEXT_URL))
+                        .add(dcpContextUrl))
                 .add(JsonLdKeywords.TYPE, PresentationQueryMessage.PRESENTATION_QUERY_MESSAGE_TERM)
                 .add("scope", scopeArray.build())
                 .build();

--- a/extensions/common/iam/identity-trust/identity-trust-core/src/test/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtensionTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/test/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtensionTest.java
@@ -24,6 +24,7 @@ import org.eclipse.edc.spi.system.ExecutorInstrumentation;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,6 +34,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.eclipse.edc.iam.identitytrust.core.IdentityAndTrustExtension.DCP_CLIENT_CONTEXT;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -44,6 +46,7 @@ class IdentityAndTrustExtensionTest {
     private static final String CONNECTOR_DID_PROPERTY = "edc.iam.issuer.id";
     private static final String CLEANUP_PERIOD = "edc.sql.store.jti.cleanup.period";
     private final JtiValidationStore storeMock = mock();
+    private final TypeTransformerRegistry transformerRegistry = mock();
 
     @BeforeEach
     void setUp(ServiceExtensionContext context) {
@@ -51,12 +54,14 @@ class IdentityAndTrustExtensionTest {
         context.registerService(TypeManager.class, new JacksonTypeManager());
         context.registerService(JtiValidationStore.class, storeMock);
         context.registerService(ExecutorInstrumentation.class, ExecutorInstrumentation.noop());
+        context.registerService(TypeTransformerRegistry.class, transformerRegistry);
 
         var config = ConfigFactory.fromMap(Map.of(
                 CONNECTOR_DID_PROPERTY, "did:web:test",
                 CLEANUP_PERIOD, "1"
         ));
         when(context.getConfig()).thenReturn(config);
+        when(transformerRegistry.forContext(DCP_CLIENT_CONTEXT)).thenReturn(transformerRegistry);
     }
 
     @Test

--- a/extensions/common/iam/identity-trust/identity-trust-core/src/test/java/org/eclipse/edc/iam/identitytrust/core/defaults/DefaultCredentialServiceClientTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/test/java/org/eclipse/edc/iam/identitytrust/core/defaults/DefaultCredentialServiceClientTest.java
@@ -55,6 +55,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DSPACE_DCP_V_1_0_CONTEXT;
 import static org.eclipse.edc.junit.testfixtures.TestUtils.getResourceFileContentAsString;
 import static org.eclipse.edc.spi.result.Result.success;
 import static org.mockito.ArgumentMatchers.any;
@@ -96,7 +97,7 @@ class DefaultCredentialServiceClientTest {
         var jsonLdMock = mock(JsonLd.class);
         when(jsonLdMock.expand(any())).thenAnswer(a -> success(a.getArgument(0)));
         client = new DefaultCredentialServiceClient(httpClientMock, Json.createBuilderFactory(Map.of()),
-                typeManager, "test", transformerRegistry, jsonLdMock, mock());
+                typeManager, "test", transformerRegistry, jsonLdMock, mock(), DSPACE_DCP_V_1_0_CONTEXT);
 
         when(typeManager.getMapper("test")).thenReturn(JacksonJsonLd.createObjectMapper());
     }


### PR DESCRIPTION
## What this PR changes/adds

adds support for dcp v1.0 in default credential service client with backward compatibility option.

This is marked as breaking change just notify the change of switching by default to dcp v1.0.

The dcp client can still support for now the v0.8 version by applying the setting

```
edc.dcp.v08.enabled=true
```

## Why it does that

dcp v1.0 adoption

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #4765 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
