### PR TITLE
fix: Add missing audience validation when accessing management api with oauth

### DIFF
--- a/extensions/common/auth/auth-delegated/src/test/java/org/eclipse/edc/api/auth/delegated/DelegatedAuthenticationExtensionTest.java
+++ b/extensions/common/auth/auth-delegated/src/test/java/org/eclipse/edc/api/auth/delegated/DelegatedAuthenticationExtensionTest.java
@@ -9,25 +9,36 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Dawex Systems - Add audience validation
  *
  */
 
 package org.eclipse.edc.api.auth.delegated;
 
+import org.eclipse.edc.boot.system.injection.ObjectFactory;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.configuration.Config;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+import org.eclipse.edc.token.rules.AudienceValidationRule;
+import org.eclipse.edc.token.spi.TokenValidationRulesRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.util.Map;
+
 import static com.nimbusds.jose.jwk.source.JWKSourceBuilder.DEFAULT_CACHE_TIME_TO_LIVE;
 import static org.eclipse.edc.api.auth.delegated.DelegatedAuthenticationExtension.AUTH_CACHE_VALIDITY_MS;
 import static org.eclipse.edc.api.auth.delegated.DelegatedAuthenticationExtension.AUTH_KEY_URL;
+import static org.eclipse.edc.api.auth.delegated.DelegatedAuthenticationService.MANAGEMENT_API_CONTEXT;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -35,11 +46,13 @@ import static org.mockito.Mockito.when;
 class DelegatedAuthenticationExtensionTest {
 
     private final Monitor monitor = mock();
+    private TokenValidationRulesRegistry tokenValidationRulesRegistry = mock();
 
     @BeforeEach
     void setUp(ServiceExtensionContext context) {
         when(monitor.withPrefix(anyString())).thenReturn(monitor);
         when(context.getMonitor()).thenReturn(monitor);
+        context.registerService(TokenValidationRulesRegistry.class, tokenValidationRulesRegistry);
     }
 
     @Test
@@ -56,5 +69,27 @@ class DelegatedAuthenticationExtensionTest {
         verify(config).getString(AUTH_KEY_URL);
         verify(config).getLong(AUTH_CACHE_VALIDITY_MS, DEFAULT_CACHE_TIME_TO_LIVE);
 
+    }
+
+    @Test
+    void initializeWithAudience(ServiceExtensionContext context, ObjectFactory factory) {
+        var audience = "http://consumer";
+        when(context.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of(
+                "web.http.management.auth.dac.audience", audience))
+        );
+        var extension = factory.constructInstance(DelegatedAuthenticationExtension.class);
+
+        extension.initialize(context);
+
+        verify(monitor, never()).warning("No audience configured for delegated authentication, defaulting to the participantId");
+        verify(tokenValidationRulesRegistry).addRule(eq(MANAGEMENT_API_CONTEXT), any(AudienceValidationRule.class));
+
+    }
+
+    @Test
+    public void initializeWithNoAudience(DelegatedAuthenticationExtension extension, ServiceExtensionContext context) {
+        extension.initialize(context);
+        verify(monitor).warning("No audience configured for delegated authentication, defaulting to the participantId");
+        verify(tokenValidationRulesRegistry).addRule(eq(MANAGEMENT_API_CONTEXT), any(AudienceValidationRule.class));
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

This PR add the audience Validation for the API management context

## Why it does that

Not validating audience is a security risk.

## Further notes

I have added some tests to validate the modification in the extension. But I could not find a way to change the value of an injected configuration field annotated by `@Settings`. So I can't unit test that when I set an audience, everything works as expected.

I have validated the code manually though. 


## Who will sponsor this feature?

@paullatzelsperger 


## Linked Issue(s)

Closes #4768 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
