### PR TITLE
chore: improve SerDes of CredentialStatus

### DIFF
--- a/spi/common/verifiable-credentials-spi/src/main/java/org/eclipse/edc/iam/verifiablecredentials/spi/model/CredentialStatus.java
+++ b/spi/common/verifiable-credentials-spi/src/main/java/org/eclipse/edc/iam/verifiablecredentials/spi/model/CredentialStatus.java
@@ -14,11 +14,15 @@
 
 package org.eclipse.edc.iam.verifiablecredentials.spi.model;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+
 import java.util.Map;
 
 import static java.util.Optional.ofNullable;
 
-public record CredentialStatus(String id, String type, Map<String, Object> additionalProperties) {
+public record CredentialStatus(String id, String type,
+                               @JsonAnySetter @JsonAnyGetter Map<String, Object> additionalProperties) {
     public static final String CREDENTIAL_STATUS_ID_PROPERTY = "@id";
     public static final String CREDENTIAL_STATUS_TYPE_PROPERTY = "@type";
 

--- a/spi/common/verifiable-credentials-spi/src/test/java/org/eclipse/edc/iam/verifiablecredentials/spi/model/CredentialStatusSerDesTest.java
+++ b/spi/common/verifiable-credentials-spi/src/test/java/org/eclipse/edc/iam/verifiablecredentials/spi/model/CredentialStatusSerDesTest.java
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.iam.verifiablecredentials.spi.model;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CredentialStatusSerDesTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void verifySerialization() throws JsonProcessingException {
+        var json = """
+                  {
+                    "id": "https://example.com/credentials/status/3#94567",
+                    "type": "BitstringStatusListEntry",
+                    "statusPurpose": "revocation",
+                    "statusListIndex": "94567",
+                    "statusListCredential": "https://example.com/credentials/status/3"
+                }
+                """;
+
+        var status = objectMapper.readValue(json, CredentialStatus.class);
+
+        assertThat(status).isNotNull();
+        assertThat(status.additionalProperties()).hasSize(3)
+                .containsEntry("statusPurpose", "revocation")
+                .containsEntry("statusListIndex", "94567")
+                .containsEntry("statusListCredential", "https://example.com/credentials/status/3");
+    }
+
+    @Test
+    void verifyDeserialization() throws JsonProcessingException {
+
+        var status = new CredentialStatus("test-id", "BitStringStatusListEntry", Map.of(
+                "statusPurpose", "revocation",
+                "statusListIndex", "94567",
+                "statusListCredential", "https://example.com/credentials/status/3"));
+
+        var json = objectMapper.writeValueAsString(status);
+        assertThat(json).isNotNull();
+        assertThat(json)
+                .matches(".*\"statusPurpose\":.*\"revocation\".*")
+                .matches(".*\"statusListIndex\":.*\"94567\".*")
+                .matches(".*\"statusListCredential\":.*\"https://example.com/credentials/status/3\".*");
+    }
+
+}


### PR DESCRIPTION
## What this PR changes/adds

this PR improves the serialization/deserialization of the `CredentialStatus` object, specifically when not using the JSON-LD 
transformers.

It does that by adding `@JsonAnySetter` and `@JsonAnyGetter` to the additional properties

## Why it does that


fix ser-des

## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
