### PR TITLE
refactor: introduce RetryProcessor

### DIFF
--- a/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/AsyncStatusResultRetryProcess.java
+++ b/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/AsyncStatusResultRetryProcess.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.spi.entity.StatefulEntity;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.response.ResponseFailure;
 import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.statemachine.retry.processor.RetryProcessor;
 
 import java.time.Clock;
 import java.util.concurrent.CompletableFuture;
@@ -27,7 +28,10 @@ import java.util.function.Supplier;
 
 /**
  * Provides retry capabilities to an asynchronous process that returns a {@link CompletableFuture} with a {@link StatusResult} content
+ *
+ * @deprecated use {@link RetryProcessor}.
  */
+@Deprecated(since = "0.12.0")
 public class AsyncStatusResultRetryProcess<E extends StatefulEntity<E>, C, SELF extends AsyncStatusResultRetryProcess<E, C, SELF>>
         extends CompletableFutureRetryProcess<E, StatusResult<C>, SELF> {
     private final Monitor monitor;

--- a/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/CompletableFutureRetryProcess.java
+++ b/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/CompletableFutureRetryProcess.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.statemachine.retry;
 
 import org.eclipse.edc.spi.entity.StatefulEntity;
 import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.statemachine.retry.processor.RetryProcessor;
 
 import java.time.Clock;
 import java.util.Optional;
@@ -28,7 +29,10 @@ import static java.lang.String.format;
 
 /**
  * Provides retry capabilities to an asynchronous process that returns a {@link CompletableFuture} object
+ *
+ * @deprecated use {@link RetryProcessor}.
  */
+@Deprecated(since = "0.12.0")
 public class CompletableFutureRetryProcess<E extends StatefulEntity<E>, C, SELF extends CompletableFutureRetryProcess<E, C, SELF>>
         extends RetryProcess<E, CompletableFutureRetryProcess<E, C, SELF>> {
     private final Supplier<CompletableFuture<C>> process;

--- a/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/EntityRetryProcessConfiguration.java
+++ b/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/EntityRetryProcessConfiguration.java
@@ -22,21 +22,6 @@ import java.util.function.Supplier;
 /**
  * Configure a {@link RetryProcess}
  */
-public class EntityRetryProcessConfiguration {
+public record EntityRetryProcessConfiguration(int retryLimit, Supplier<WaitStrategy> delayStrategySupplier) {
 
-    private final int retryLimit;
-    private final Supplier<WaitStrategy> delayStrategySupplier;
-
-    public EntityRetryProcessConfiguration(int retryLimit, Supplier<WaitStrategy> delayStrategySupplier) {
-        this.retryLimit = retryLimit;
-        this.delayStrategySupplier = delayStrategySupplier;
-    }
-
-    public int getRetryLimit() {
-        return retryLimit;
-    }
-
-    public Supplier<WaitStrategy> getDelayStrategySupplier() {
-        return delayStrategySupplier;
-    }
 }

--- a/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/EntityRetryProcessFactory.java
+++ b/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/EntityRetryProcessFactory.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.statemachine.retry;
 import org.eclipse.edc.spi.entity.StatefulEntity;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.statemachine.retry.processor.RetryProcessor;
 
 import java.time.Clock;
 import java.util.concurrent.CompletableFuture;
@@ -38,22 +39,41 @@ public class EntityRetryProcessFactory {
     }
 
     /**
-     * Initialize a synchronous process that needs to be retried if it does not succeed
+     * Initialize a {@link RetryProcessor} on the passed entity.
+     *
+     * @param entity the entity.
+     * @return a retry processor.
      */
+    public <E extends StatefulEntity<E>, C> RetryProcessor<E, C> retryProcessor(E entity) {
+        return new RetryProcessor<>(entity, monitor, clock, configuration);
+    }
+
+    /**
+     * Initialize a synchronous process that needs to be retried if it does not succeed
+     *
+     * @deprecated use {{@link #retryProcessor(StatefulEntity)}}
+     */
+    @Deprecated(since = "0.12.0")
     public <T extends StatefulEntity<T>, C> StatusResultRetryProcess<T, C> doSyncProcess(T entity, Supplier<StatusResult<C>> process) {
         return new StatusResultRetryProcess<>(entity, process, monitor, clock, configuration);
     }
 
     /**
      * Initialize an asynchronous process that needs to be retried if it does not succeed
+     *
+     * @deprecated use {{@link #retryProcessor(StatefulEntity)}}
      */
+    @Deprecated(since = "0.12.0")
     public <T extends StatefulEntity<T>, C, SELF extends CompletableFutureRetryProcess<T, C, SELF>> SELF doAsyncProcess(T entity, Supplier<CompletableFuture<C>> process) {
         return (SELF) new CompletableFutureRetryProcess<T, C, SELF>(entity, process, monitor, clock, configuration);
     }
 
     /**
      * Initialize an asynchronous process that will return a {@link StatusResult} and it will need to be handled
+     *
+     * @deprecated use {{@link #retryProcessor(StatefulEntity)}}
      */
+    @Deprecated(since = "0.12.0")
     public <T extends StatefulEntity<T>, C, SELF extends AsyncStatusResultRetryProcess<T, C, SELF>> SELF doAsyncStatusResultProcess(T entity, Supplier<CompletableFuture<StatusResult<C>>> process) {
         return (SELF) new AsyncStatusResultRetryProcess<T, C, SELF>(entity, process, monitor, clock, configuration);
     }

--- a/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/RetryProcess.java
+++ b/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/RetryProcess.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.statemachine.retry;
 
 import org.eclipse.edc.spi.entity.StatefulEntity;
 import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.statemachine.retry.processor.RetryProcessor;
 
 import java.time.Clock;
 import java.util.function.Consumer;
@@ -24,7 +25,10 @@ import java.util.function.Consumer;
  * Represent a process on a {@link StatefulEntity} that is retried after a certain delay if it fails.
  * This works only used on a state machine, where states are persisted.
  * The process is a unit of logic that can be executed on the entity.
+ *
+ * @deprecated use {@link RetryProcessor}.
  */
+@Deprecated(since = "0.12.0")
 public abstract class RetryProcess<E extends StatefulEntity<E>, SELF extends RetryProcess<E, SELF>> {
 
     private final E entity;
@@ -64,7 +68,7 @@ public abstract class RetryProcess<E extends StatefulEntity<E>, SELF extends Ret
                 }
                 return false;
             } else {
-                monitor.debug(String.format("Entity %s %s retry #%d of %d.", entity.getId(), entity.getClass().getSimpleName(), entity.getStateCount() - 1, configuration.getRetryLimit()));
+                monitor.debug(String.format("Entity %s %s retry #%d of %d.", entity.getId(), entity.getClass().getSimpleName(), entity.getStateCount() - 1, configuration.retryLimit()));
             }
         }
 
@@ -86,12 +90,12 @@ public abstract class RetryProcess<E extends StatefulEntity<E>, SELF extends Ret
      * @return {@code true} if the entity should not be sent anymore.
      */
     protected boolean retriesExhausted(E entity) {
-        return entity.getStateCount() > configuration.getRetryLimit();
+        return entity.getStateCount() > configuration.retryLimit();
     }
 
     private long delayMillis(E entity) {
         // Get a new instance of WaitStrategy.
-        var delayStrategy = configuration.getDelayStrategySupplier().get();
+        var delayStrategy = configuration.delayStrategySupplier().get();
 
         // Set the WaitStrategy to have observed <retryCount> previous failures.
         // This is relevant for stateful strategies such as exponential wait.

--- a/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/StatusResultRetryProcess.java
+++ b/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/StatusResultRetryProcess.java
@@ -18,6 +18,7 @@ import org.eclipse.edc.spi.entity.StatefulEntity;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.response.ResponseFailure;
 import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.statemachine.retry.processor.RetryProcessor;
 
 import java.time.Clock;
 import java.util.function.BiConsumer;
@@ -28,7 +29,10 @@ import static org.eclipse.edc.spi.response.ResponseStatus.ERROR_RETRY;
 
 /**
  * Provides retry capabilities to a synchronous process that returns a {@link StatusResult} object
+ *
+ * @deprecated use {@link RetryProcessor}.
  */
+@Deprecated(since = "0.12.0")
 public class StatusResultRetryProcess<E extends StatefulEntity<E>, C> extends RetryProcess<E, StatusResultRetryProcess<E, C>> {
     private final Supplier<StatusResult<C>> process;
     private final Monitor monitor;

--- a/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/processor/EntityStateException.java
+++ b/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/processor/EntityStateException.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.statemachine.retry.processor;
+
+import org.eclipse.edc.spi.entity.StatefulEntity;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Exception that describes generic failure in a process
+ */
+public class EntityStateException extends RuntimeException {
+
+    private final StatefulEntity<?> entity;
+    private final String processName;
+
+    public EntityStateException(StatefulEntity<?> entity, String processName, String message) {
+        super(message);
+        this.entity = entity;
+        this.processName = processName;
+    }
+
+    public StatefulEntity<?> getEntity() {
+        return entity;
+    }
+
+    public String getProcessName() {
+        return processName;
+    }
+
+    @NotNull String getRetryLimitExceededMessage() {
+        return "%s: ID %s. Attempt #%d failed to %s. Retry limit exceeded. Cause: %s".formatted(
+                entity.getClass().getSimpleName(),
+                entity.getId(),
+                entity.getStateCount(),
+                getProcessName(),
+                getMessage()
+        );
+    }
+
+    @NotNull String getRetryFailedMessage() {
+        return "%s: ID %s. Attempt #%d failed to %s. Cause: %s".formatted(
+                entity.getClass().getSimpleName(),
+                entity.getId(),
+                entity.getStateCount(),
+                getProcessName(),
+                getMessage()
+        );
+    }
+}

--- a/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/processor/FutureResultRetryProcess.java
+++ b/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/processor/FutureResultRetryProcess.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.statemachine.retry.processor;
+
+import org.eclipse.edc.spi.entity.StatefulEntity;
+import org.eclipse.edc.spi.response.StatusResult;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import static java.util.concurrent.CompletableFuture.failedFuture;
+
+/**
+ * Process implementation that handles a process that returns {@link CompletableFuture} with enclosed {@link StatusResult}
+ */
+public class FutureResultRetryProcess<E extends StatefulEntity<E>, I, O> implements Process<E, I, O> {
+
+    private final String name;
+    private final BiFunction<E, I, CompletableFuture<StatusResult<O>>> function;
+    private Function<String, E> entityReload;
+
+    public FutureResultRetryProcess(String name, BiFunction<E, I, CompletableFuture<StatusResult<O>>> function) {
+        this.name = name;
+        this.function = function;
+    }
+
+    @Override
+    public CompletableFuture<ProcessContext<E, O>> execute(ProcessContext<E, I> context) {
+        try {
+            return new FutureRetryProcess<>(name, function).entityReload(entityReload)
+                    .execute(context)
+                    .thenCompose(asyncContext -> new ResultRetryProcess<E, I, O>(name, (e, c) -> asyncContext.content())
+                    .execute(new ProcessContext<>(asyncContext.entity(), context.content())));
+        } catch (Throwable throwable) {
+            return failedFuture(new UnrecoverableEntityStateException(reloadEntity(context.entity()), name, throwable.getMessage()));
+        }
+    }
+
+    public FutureResultRetryProcess<E, I, O> entityReload(Function<String, E> entityReload) {
+        this.entityReload = entityReload;
+        return this;
+    }
+
+    private E reloadEntity(E entity) {
+        return entityReload == null ? entity : entityReload.apply(entity.getId());
+    }
+
+}

--- a/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/processor/FutureResultRetryProcess.java
+++ b/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/processor/FutureResultRetryProcess.java
@@ -25,6 +25,10 @@ import static java.util.concurrent.CompletableFuture.failedFuture;
 
 /**
  * Process implementation that handles a process that returns {@link CompletableFuture} with enclosed {@link StatusResult}
+ *
+ * @param <E> entity type.
+ * @param <I> process input type.
+ * @param <O> process output type.
  */
 public class FutureResultRetryProcess<E extends StatefulEntity<E>, I, O> implements Process<E, I, O> {
 

--- a/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/processor/FutureRetryProcess.java
+++ b/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/processor/FutureRetryProcess.java
@@ -24,6 +24,10 @@ import static java.util.concurrent.CompletableFuture.failedFuture;
 
 /**
  * Process implementation that handles a process that returns {@link CompletableFuture}
+ *
+ * @param <E> entity type.
+ * @param <I> process input type.
+ * @param <O> process output type.
  */
 public class FutureRetryProcess<E extends StatefulEntity<E>, I, O> implements Process<E, I, O> {
 

--- a/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/processor/FutureRetryProcess.java
+++ b/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/processor/FutureRetryProcess.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.statemachine.retry.processor;
+
+import org.eclipse.edc.spi.entity.StatefulEntity;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import static java.util.concurrent.CompletableFuture.failedFuture;
+
+/**
+ * Process implementation that handles a process that returns {@link CompletableFuture}
+ */
+public class FutureRetryProcess<E extends StatefulEntity<E>, I, O> implements Process<E, I, O> {
+
+    private final String name;
+    private final BiFunction<E, I, CompletableFuture<O>> function;
+    private Function<String, E> entityReload;
+
+    public FutureRetryProcess(String name, BiFunction<E, I, CompletableFuture<O>> function) {
+        this.name = name;
+        this.function = function;
+    }
+
+    @Override
+    public CompletableFuture<ProcessContext<E, O>> execute(ProcessContext<E, I> context) {
+        try {
+            return function.apply(context.entity(), context.content())
+                    .handle((content, throwable) -> {
+                        var reloadedEntity = reloadEntity(context.entity());
+                        if (throwable == null) {
+                            return new ProcessContext<>(reloadedEntity, content);
+                        } else {
+                            throw new EntityStateException(reloadedEntity, name, throwable.getMessage());
+                        }
+                    });
+        } catch (Throwable throwable) {
+            return failedFuture(new UnrecoverableEntityStateException(reloadEntity(context.entity()), name, throwable.getMessage()));
+        }
+    }
+
+    public FutureRetryProcess<E, I, O> entityReload(Function<String, E> entityReload) {
+        this.entityReload = entityReload;
+        return this;
+    }
+
+    private E reloadEntity(E entity) {
+        return entityReload == null ? entity : entityReload.apply(entity.getId());
+    }
+
+}

--- a/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/processor/Process.java
+++ b/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/processor/Process.java
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.statemachine.retry.processor;
+
+import org.eclipse.edc.spi.entity.StatefulEntity;
+import org.eclipse.edc.spi.response.StatusResult;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiFunction;
+
+/**
+ * Represent a single unit of processing on an entity
+ */
+public interface Process<E extends StatefulEntity<E>, I, O> {
+
+    /**
+     * Process that returns a {@link StatusResult}
+     *
+     * @param name the process name, will be used for logging.
+     * @param function that executes the process.
+     * @return the process instance.
+     */
+    static <E extends StatefulEntity<E>, I, O> Process<E, I, O> result(String name, BiFunction<E, I, StatusResult<O>> function) {
+        return new ResultRetryProcess<>(name, function);
+    }
+
+    /**
+     * Process that returns a {@link CompletableFuture}
+     *
+     * @param name the process name, will be used for logging.
+     * @param function that executes the process.
+     * @return the process instance.
+     */
+    static <E extends StatefulEntity<E>, I, O> Process<E, I, O> future(String name, BiFunction<E, I, CompletableFuture<O>> function) {
+        return new FutureRetryProcess<>(name, function);
+    }
+
+    /**
+     * Process that returns a {@link CompletableFuture} that encloses a {@link StatusResult}
+     *
+     * @param name the process name, will be used for logging.
+     * @param function that executes the process.
+     * @return the process instance.
+     */
+    static <E extends StatefulEntity<E>, I, O> Process<E, I, O> futureResult(String name, BiFunction<E, I, CompletableFuture<StatusResult<O>>> function) {
+        return new FutureResultRetryProcess<>(name, function);
+    }
+
+    /**
+     * Function that wraps the ecloses content type into a {@link CompletableFuture}
+     *
+     * @param context the process context.
+     * @return a future containing the response type.
+     */
+    CompletableFuture<ProcessContext<E, O>> execute(ProcessContext<E, I> context);
+
+}

--- a/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/processor/Process.java
+++ b/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/processor/Process.java
@@ -22,11 +22,15 @@ import java.util.function.BiFunction;
 
 /**
  * Represent a single unit of processing on an entity
+ *
+ * @param <E> entity type.
+ * @param <I> process input type.
+ * @param <O> process output type.
  */
 public interface Process<E extends StatefulEntity<E>, I, O> {
 
     /**
-     * Process that returns a {@link StatusResult}
+     * Instantiates a process that returns a {@link StatusResult}
      *
      * @param name the process name, will be used for logging.
      * @param function that executes the process.
@@ -37,7 +41,7 @@ public interface Process<E extends StatefulEntity<E>, I, O> {
     }
 
     /**
-     * Process that returns a {@link CompletableFuture}
+     * Instantiates a process that returns a {@link CompletableFuture}
      *
      * @param name the process name, will be used for logging.
      * @param function that executes the process.
@@ -48,7 +52,7 @@ public interface Process<E extends StatefulEntity<E>, I, O> {
     }
 
     /**
-     * Process that returns a {@link CompletableFuture} that encloses a {@link StatusResult}
+     * Instantiates a process that returns a {@link CompletableFuture} that encloses a {@link StatusResult}
      *
      * @param name the process name, will be used for logging.
      * @param function that executes the process.
@@ -59,7 +63,7 @@ public interface Process<E extends StatefulEntity<E>, I, O> {
     }
 
     /**
-     * Function that wraps the ecloses content type into a {@link CompletableFuture}
+     * Function that wraps the enclosed content type into a {@link CompletableFuture}
      *
      * @param context the process context.
      * @return a future containing the response type.

--- a/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/processor/ProcessContext.java
+++ b/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/processor/ProcessContext.java
@@ -1,0 +1,23 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.statemachine.retry.processor;
+
+import org.eclipse.edc.spi.entity.StatefulEntity;
+
+/**
+ * Data object that contains the entity and the content of a process.
+ */
+public record ProcessContext<E extends StatefulEntity<E>, C>(E entity, C content) {
+}

--- a/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/processor/ResultRetryProcess.java
+++ b/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/processor/ResultRetryProcess.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.statemachine.retry.processor;
+
+import org.eclipse.edc.spi.entity.StatefulEntity;
+import org.eclipse.edc.spi.response.StatusResult;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiFunction;
+
+/**
+ * Process implementation that handles a process that returns {@link StatusResult}
+ */
+public class ResultRetryProcess<E extends StatefulEntity<E>, I, O> implements Process<E, I, O> {
+
+    private final String name;
+    private final BiFunction<E, I, StatusResult<O>> function;
+
+    public ResultRetryProcess(String name, BiFunction<E, I, StatusResult<O>> function) {
+        this.name = name;
+        this.function = function;
+    }
+
+    @Override
+    public CompletableFuture<ProcessContext<E, O>> execute(ProcessContext<E, I> context) {
+        try {
+            var result = function.apply(context.entity(), context.content());
+
+            if (result.fatalError()) {
+                return CompletableFuture.failedFuture(new UnrecoverableEntityStateException(context.entity(), name, result.getFailureDetail()));
+            }
+
+            if (result.failed()) {
+                return CompletableFuture.failedFuture(new EntityStateException(context.entity(), name, result.getFailureDetail()));
+            }
+
+            return CompletableFuture.completedFuture(new ProcessContext<>(context.entity(), result.getContent()));
+        } catch (Throwable e) {
+            return CompletableFuture.failedFuture(e);
+        }
+
+    }
+}

--- a/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/processor/ResultRetryProcess.java
+++ b/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/processor/ResultRetryProcess.java
@@ -22,6 +22,10 @@ import java.util.function.BiFunction;
 
 /**
  * Process implementation that handles a process that returns {@link StatusResult}
+ *
+ * @param <E> entity type.
+ * @param <I> process input type.
+ * @param <O> process output type.
  */
 public class ResultRetryProcess<E extends StatefulEntity<E>, I, O> implements Process<E, I, O> {
 

--- a/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/processor/RetryProcessor.java
+++ b/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/processor/RetryProcessor.java
@@ -1,0 +1,145 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.statemachine.retry.processor;
+
+import org.eclipse.edc.spi.entity.StatefulEntity;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.statemachine.retry.EntityRetryProcessConfiguration;
+
+import java.time.Clock;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+/**
+ * Component that watches processes to be executed on entities in the state machine.
+ * One or more processes can either:
+ * <ul>
+ *   <li>not be executed because of retry policies not met</li>
+ *   <li>executed successfully</li>
+ *   <li>failed, to be retried on the next state machine iteration</li>
+ *   <li>failed exceeding the retry limit</li>
+ *   <li>failed with an unrecoverable error</li>
+ * </ul>
+ *
+ * The component has been designed with a process chain component on which multiple processes can be chained.
+ */
+public class RetryProcessor<E extends StatefulEntity<E>, C> {
+
+    private final E entity;
+    private final Monitor monitor;
+    private final Clock clock;
+    private final EntityRetryProcessConfiguration configuration;
+    private final Function<Void, CompletableFuture<ProcessContext<E, C>>> processChain;
+
+    private BiConsumer<E, C> onSuccess;
+    private BiConsumer<E, Throwable> onFailure;
+    private BiConsumer<E, Throwable> onFinalFailure;
+
+    public RetryProcessor(E entity, Monitor monitor, Clock clock, EntityRetryProcessConfiguration configuration) {
+        this(entity, monitor, clock, configuration, v -> CompletableFuture.completedFuture(new ProcessContext<>(entity, null)));
+    }
+
+    private RetryProcessor(E entity, Monitor monitor, Clock clock, EntityRetryProcessConfiguration configuration, Function<Void, CompletableFuture<ProcessContext<E, C>>> processChain) {
+        this.entity = entity;
+        this.monitor = monitor;
+        this.clock = clock;
+        this.configuration = configuration;
+        this.processChain = processChain;
+    }
+
+    public <C1> RetryProcessor<E, C1> doProcess(Process<E, C, C1> process) {
+        return new RetryProcessor<>(entity, monitor, clock, configuration, c -> processChain.apply(c).thenCompose(process::execute));
+    }
+
+    public RetryProcessor<E, C> onSuccess(BiConsumer<E, C> onSuccess) {
+        this.onSuccess = onSuccess;
+        return this;
+    }
+
+    public RetryProcessor<E, C> onFailure(BiConsumer<E, Throwable> onFailure) {
+        this.onFailure = onFailure;
+        return this;
+    }
+
+    public RetryProcessor<E, C> onFinalFailure(BiConsumer<E, Throwable> onFinalFailure) {
+        this.onFinalFailure = onFinalFailure;
+        return this;
+    }
+
+    /**
+     * Execute the processes applying eventual retry policy
+     * Will execute the onSuccess, onFailure, onFinalFailure handlers at need
+     *
+     * @return true if the process has been run, false otherwise.
+     */
+    public boolean execute() {
+        if (isRetry(entity)) {
+            var delay = delayMillis(entity);
+            if (delay > 0) {
+                monitor.debug(String.format("Entity %s %s retry #%d will not be attempted before %d ms.", entity.getId(), entity.getClass().getSimpleName(), entity.getStateCount() - 1, delay));
+                return false;
+            } else {
+                monitor.debug(String.format("Entity %s %s retry #%d of %d.", entity.getId(), entity.getClass().getSimpleName(), entity.getStateCount() - 1, configuration.retryLimit()));
+            }
+        }
+
+        processChain.apply(null)
+                .whenComplete((content, throwable) -> {
+                    if (throwable == null) {
+                        onSuccess.accept(content.entity(), content.content());
+                    } else {
+                        var cause = throwable.getCause();
+                        if (cause instanceof UnrecoverableEntityStateException unrecoverable) {
+                            monitor.severe(unrecoverable.getUnrecoverableMessage());
+                            onFinalFailure.accept(entity, unrecoverable);
+                        } else if (cause instanceof EntityStateException entityStateException) {
+                            var exceptionEntity = entityStateException.getEntity();
+                            if (exceptionEntity.getStateCount() > configuration.retryLimit()) {
+                                monitor.severe(entityStateException.getRetryLimitExceededMessage());
+                                onFinalFailure.accept(entity, entityStateException);
+                            } else {
+                                monitor.debug(entityStateException.getRetryFailedMessage());
+                                onFailure.accept(entity, entityStateException);
+                            }
+                        } else {
+                            monitor.severe("Runtime exception caught by retry processor: %s".formatted(cause.getMessage()), cause);
+                            onFinalFailure.accept(entity, cause);
+                        }
+                    }
+                });
+
+        return true;
+    }
+
+    private boolean isRetry(E entity) {
+        return entity.getStateCount() - 1 > 0;
+    }
+
+    private long delayMillis(E entity) {
+        // Get a new instance of WaitStrategy.
+        var delayStrategy = configuration.delayStrategySupplier().get();
+
+        // Set the WaitStrategy to have observed <retryCount> previous failures.
+        // This is relevant for stateful strategies such as exponential wait.
+        delayStrategy.failures(entity.getStateCount() - 1);
+
+        // Get the delay time following the number of failures.
+        var waitMillis = delayStrategy.retryInMillis();
+
+        return entity.getStateTimestamp() + waitMillis - clock.millis();
+    }
+
+}

--- a/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/processor/RetryProcessor.java
+++ b/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/processor/RetryProcessor.java
@@ -35,6 +35,10 @@ import java.util.function.Function;
  * </ul>
  *
  * The component has been designed with a process chain component on which multiple processes can be chained.
+ *
+ * @param <E> entity type.
+ * @param <C> content type that is returned by the {@link #processChain} and that will be available in the {@link #onSuccess} handler.
+ *
  */
 public class RetryProcessor<E extends StatefulEntity<E>, C> {
 

--- a/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/processor/UnrecoverableEntityStateException.java
+++ b/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/processor/UnrecoverableEntityStateException.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.statemachine.retry.processor;
+
+import org.eclipse.edc.spi.entity.StatefulEntity;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Exception that describes an unrecoverable failure in process.
+ */
+public class UnrecoverableEntityStateException extends EntityStateException {
+    public UnrecoverableEntityStateException(StatefulEntity<?> entity, String processName, String message) {
+        super(entity, processName, message);
+    }
+
+    @NotNull String getUnrecoverableMessage() {
+        return "%s: ID %s. Attempt #%d failed to %s. Fatal error occurred. Cause: %s".formatted(
+                getEntity().getClass().getSimpleName(),
+                getEntity().getId(),
+                getEntity().getStateCount(),
+                getProcessName(),
+                getMessage()
+        );
+    }
+}

--- a/core/common/lib/state-machine-lib/src/test/java/org/eclipse/edc/statemachine/retry/processor/FutureResultRetryProcessTest.java
+++ b/core/common/lib/state-machine-lib/src/test/java/org/eclipse/edc/statemachine/retry/processor/FutureResultRetryProcessTest.java
@@ -1,0 +1,129 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.statemachine.retry.processor;
+
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.statemachine.retry.TestEntity;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+
+import static java.time.temporal.ChronoUnit.SECONDS;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.spi.response.ResponseStatus.ERROR_RETRY;
+import static org.eclipse.edc.spi.response.ResponseStatus.FATAL_ERROR;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class FutureResultRetryProcessTest {
+
+    private final Duration timeout = Duration.of(1, SECONDS);
+
+    @Test
+    void shouldReturnSuccess_whenFunctionSucceeds() {
+        var entity = TestEntity.Builder.newInstance().id(UUID.randomUUID().toString()).build();
+        var retryProcess = new FutureResultRetryProcess<TestEntity, Object, String>("process", (e, i) -> completedFuture(StatusResult.success("content")));
+
+        var future = retryProcess.execute(new ProcessContext<>(entity, "any"));
+
+        assertThat(future).succeedsWithin(timeout).extracting(ProcessContext::content).isEqualTo("content");
+    }
+
+    @Test
+    void shouldReturnFailure_whenFunctionFails() {
+        var entity = TestEntity.Builder.newInstance().id(UUID.randomUUID().toString()).build();
+        var retryProcess = new FutureResultRetryProcess<TestEntity, Object, String>("process", (e, i) -> failedFuture(new EdcException("error")));
+
+        var future = retryProcess.execute(new ProcessContext<>(entity, "any"));
+
+        assertThat(future).failsWithin(timeout).withThrowableOfType(ExecutionException.class)
+                .extracting(Throwable::getCause).isInstanceOfSatisfying(EntityStateException.class, exception -> {
+                    assertThat(exception.getEntity()).isSameAs(entity);
+                    assertThat(exception.getProcessName()).isEqualTo("process");
+                    assertThat(exception.getMessage()).isEqualTo("error");
+                });
+    }
+
+    @Test
+    void shouldReturnUnrecoverable_whenFunctionThrowsException() {
+        var entity = TestEntity.Builder.newInstance().id(UUID.randomUUID().toString()).build();
+        var retryProcess = new FutureResultRetryProcess<TestEntity, Object, String>("process", (testEntity, o) -> {
+            throw new RuntimeException("unexpected exception");
+        });
+
+        var future = retryProcess.execute(new ProcessContext<>(entity, "any"));
+
+        assertThat(future).failsWithin(timeout).withThrowableOfType(ExecutionException.class)
+                .extracting(Throwable::getCause).isInstanceOfSatisfying(UnrecoverableEntityStateException.class, exception -> {
+                    assertThat(exception.getEntity()).isSameAs(entity);
+                    assertThat(exception.getProcessName()).isEqualTo("process");
+                    assertThat(exception.getMessage()).isEqualTo("unexpected exception");
+                });
+    }
+
+    @Test
+    void shouldReloadEntity_whenConfigured() {
+        var entityId = UUID.randomUUID().toString();
+        var entity = TestEntity.Builder.newInstance().id(entityId).build();
+        var reloadedEntity = TestEntity.Builder.newInstance().id(entityId).build();
+        Function<String, TestEntity> entityReload = mock();
+        when(entityReload.apply(any())).thenReturn(reloadedEntity);
+        var retryProcess = new FutureResultRetryProcess<TestEntity, Object, String>("process", (e, i) -> completedFuture(StatusResult.success("content")))
+                .entityReload(entityReload);
+
+        var future = retryProcess.execute(new ProcessContext<>(entity, "any"));
+
+        assertThat(future).succeedsWithin(timeout).extracting(ProcessContext::entity).isSameAs(reloadedEntity);
+        verify(entityReload).apply(entityId);
+    }
+
+    @Test
+    void shouldFail_whenResultFails() {
+        var entity = TestEntity.Builder.newInstance().id(UUID.randomUUID().toString()).build();
+        var retryProcess = new FutureResultRetryProcess<TestEntity, Object, String>("process", (e, i) -> completedFuture(StatusResult.failure(ERROR_RETRY, "error")));
+
+        var future = retryProcess.execute(new ProcessContext<>(entity, "any"));
+
+        assertThat(future).failsWithin(timeout).withThrowableOfType(ExecutionException.class)
+                .extracting(Throwable::getCause).isInstanceOfSatisfying(EntityStateException.class, exception -> {
+                    assertThat(exception.getEntity()).isSameAs(entity);
+                    assertThat(exception.getProcessName()).isEqualTo("process");
+                    assertThat(exception.getMessage()).isEqualTo("error");
+                });
+    }
+
+    @Test
+    void shouldFailUnrecoverable_whenResultFatalError() {
+        var entity = TestEntity.Builder.newInstance().id(UUID.randomUUID().toString()).build();
+        var retryProcess = new FutureResultRetryProcess<TestEntity, Object, String>("process", (e, i) -> completedFuture(StatusResult.failure(FATAL_ERROR, "error")));
+
+        var future = retryProcess.execute(new ProcessContext<>(entity, "any"));
+
+        assertThat(future).failsWithin(timeout).withThrowableOfType(ExecutionException.class)
+                .extracting(Throwable::getCause).isInstanceOfSatisfying(EntityStateException.class, exception -> {
+                    assertThat(exception.getEntity()).isSameAs(entity);
+                    assertThat(exception.getProcessName()).isEqualTo("process");
+                    assertThat(exception.getMessage()).isEqualTo("error");
+                });
+    }
+}

--- a/core/common/lib/state-machine-lib/src/test/java/org/eclipse/edc/statemachine/retry/processor/FutureRetryProcessTest.java
+++ b/core/common/lib/state-machine-lib/src/test/java/org/eclipse/edc/statemachine/retry/processor/FutureRetryProcessTest.java
@@ -1,0 +1,95 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.statemachine.retry.processor;
+
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.statemachine.retry.TestEntity;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+
+import static java.time.temporal.ChronoUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class FutureRetryProcessTest {
+
+    private final Duration timeout = Duration.of(1, SECONDS);
+
+    @Test
+    void shouldReturnSuccess_whenFunctionSucceeds() {
+        var entity = TestEntity.Builder.newInstance().id(UUID.randomUUID().toString()).build();
+        var retryProcess = new FutureRetryProcess<TestEntity, Object, String>("process", (e, i) -> CompletableFuture.completedFuture("content"));
+
+        var future = retryProcess.execute(new ProcessContext<>(entity, "any"));
+
+        assertThat(future).succeedsWithin(timeout).extracting(ProcessContext::content).isEqualTo("content");
+    }
+
+    @Test
+    void shouldReturnFailure_whenFunctionFails() {
+        var entity = TestEntity.Builder.newInstance().id(UUID.randomUUID().toString()).build();
+        var retryProcess = new FutureRetryProcess<TestEntity, Object, String>("process", (e, i) -> CompletableFuture.failedFuture(new EdcException("error")));
+
+        var future = retryProcess.execute(new ProcessContext<>(entity, "any"));
+
+        assertThat(future).failsWithin(timeout).withThrowableOfType(ExecutionException.class)
+                .extracting(Throwable::getCause).isInstanceOfSatisfying(EntityStateException.class, exception -> {
+                    assertThat(exception.getEntity()).isSameAs(entity);
+                    assertThat(exception.getProcessName()).isEqualTo("process");
+                    assertThat(exception.getMessage()).isEqualTo("error");
+                });
+    }
+
+    @Test
+    void shouldReturnUnrecoverable_whenFunctionThrowsException() {
+        var entity = TestEntity.Builder.newInstance().id(UUID.randomUUID().toString()).build();
+        var retryProcess = new FutureRetryProcess<TestEntity, Object, String>("process", (testEntity, o) -> {
+            throw new RuntimeException("unexpected exception");
+        });
+
+        var future = retryProcess.execute(new ProcessContext<>(entity, "any"));
+
+        assertThat(future).failsWithin(timeout).withThrowableOfType(ExecutionException.class)
+                .extracting(Throwable::getCause).isInstanceOfSatisfying(UnrecoverableEntityStateException.class, exception -> {
+                    assertThat(exception.getEntity()).isSameAs(entity);
+                    assertThat(exception.getProcessName()).isEqualTo("process");
+                    assertThat(exception.getMessage()).isEqualTo("unexpected exception");
+                });
+    }
+
+    @Test
+    void shouldReloadEntity_whenConfigured() {
+        var entityId = UUID.randomUUID().toString();
+        var entity = TestEntity.Builder.newInstance().id(entityId).build();
+        var reloadedEntity = TestEntity.Builder.newInstance().id(entityId).build();
+        Function<String, TestEntity> entityReload = mock();
+        when(entityReload.apply(any())).thenReturn(reloadedEntity);
+        var retryProcess = new FutureRetryProcess<TestEntity, Object, String>("process", (e, i) -> CompletableFuture.completedFuture("content"))
+                .entityReload(entityReload);
+
+        var future = retryProcess.execute(new ProcessContext<>(entity, "any"));
+
+        assertThat(future).succeedsWithin(timeout).extracting(ProcessContext::entity).isSameAs(reloadedEntity);
+        verify(entityReload).apply(entityId);
+    }
+}

--- a/core/common/lib/state-machine-lib/src/test/java/org/eclipse/edc/statemachine/retry/processor/ResultRetryProcessTest.java
+++ b/core/common/lib/state-machine-lib/src/test/java/org/eclipse/edc/statemachine/retry/processor/ResultRetryProcessTest.java
@@ -1,0 +1,89 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.statemachine.retry.processor;
+
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.statemachine.retry.TestEntity;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
+import static java.time.temporal.ChronoUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.spi.response.ResponseStatus.ERROR_RETRY;
+import static org.eclipse.edc.spi.response.ResponseStatus.FATAL_ERROR;
+
+class ResultRetryProcessTest {
+
+    private final Duration timeout = Duration.of(1, SECONDS);
+
+    @Test
+    void shouldComplete_whenResultSucceeds() {
+        var entity = TestEntity.Builder.newInstance().id(UUID.randomUUID().toString()).stateCount(1).build();
+        var retryProcess = new ResultRetryProcess<TestEntity, Object, Object>("description", (e, i) -> StatusResult.success("output"));
+
+        var future = retryProcess.execute(new ProcessContext<>(entity, "input"));
+
+        assertThat(future).succeedsWithin(timeout);
+    }
+
+    @Test
+    void shouldFail_whenResultFails() {
+        var entity = TestEntity.Builder.newInstance().id(UUID.randomUUID().toString()).stateCount(1).build();
+        var retryProcess = new ResultRetryProcess<TestEntity, Object, Object>("description", (e, i) -> StatusResult.failure(ERROR_RETRY, "error"));
+
+        var future = retryProcess.execute(new ProcessContext<>(entity, "input"));
+
+        assertThat(future).failsWithin(timeout).withThrowableOfType(ExecutionException.class)
+                .extracting(Throwable::getCause).isInstanceOfSatisfying(EntityStateException.class, exception -> {
+                    assertThat(exception.getEntity()).isSameAs(entity);
+                    assertThat(exception.getProcessName()).isEqualTo("description");
+                    assertThat(exception.getMessage()).isEqualTo("error");
+                });
+    }
+
+    @Test
+    void shouldFailUnrecoverable_whenResultFatalError() {
+        var entity = TestEntity.Builder.newInstance().id(UUID.randomUUID().toString()).stateCount(1).build();
+        var retryProcess = new ResultRetryProcess<TestEntity, Object, Object>("description", (e, i) -> StatusResult.failure(FATAL_ERROR, "error"));
+
+        var future = retryProcess.execute(new ProcessContext<>(entity, "input"));
+
+        assertThat(future).failsWithin(timeout).withThrowableOfType(ExecutionException.class)
+                .extracting(Throwable::getCause).isInstanceOfSatisfying(UnrecoverableEntityStateException.class, exception -> {
+                    assertThat(exception.getEntity()).isSameAs(entity);
+                    assertThat(exception.getProcessName()).isEqualTo("description");
+                    assertThat(exception.getMessage()).isEqualTo("error");
+                });
+    }
+
+    @Test
+    void shouldFailUnrecoverable_whenFunctionThrowsException() {
+        var entity = TestEntity.Builder.newInstance().id(UUID.randomUUID().toString()).stateCount(1).build();
+        var retryProcess = new ResultRetryProcess<TestEntity, Object, Object>("description", (testEntity, o) -> {
+            throw new RuntimeException("unexpected exception");
+        });
+
+        var future = retryProcess.execute(new ProcessContext<>(entity, "input"));
+
+        assertThat(future).failsWithin(timeout).withThrowableOfType(ExecutionException.class)
+                .extracting(Throwable::getCause).isInstanceOfSatisfying(RuntimeException.class, exception -> {
+                    assertThat(exception.getMessage()).isEqualTo("unexpected exception");
+                });
+    }
+
+}

--- a/core/common/lib/state-machine-lib/src/test/java/org/eclipse/edc/statemachine/retry/processor/RetryProcessorTest.java
+++ b/core/common/lib/state-machine-lib/src/test/java/org/eclipse/edc/statemachine/retry/processor/RetryProcessorTest.java
@@ -1,0 +1,205 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.statemachine.retry.processor;
+
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.retry.WaitStrategy;
+import org.eclipse.edc.statemachine.retry.EntityRetryProcessConfiguration;
+import org.eclipse.edc.statemachine.retry.TestEntity;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+
+import static java.time.ZoneOffset.UTC;
+import static java.util.concurrent.CompletableFuture.failedFuture;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.spi.response.ResponseStatus.ERROR_RETRY;
+import static org.eclipse.edc.statemachine.retry.processor.Process.future;
+import static org.eclipse.edc.statemachine.retry.processor.Process.result;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class RetryProcessorTest {
+
+    private static final long DELAY = 2L;
+    private final long millis = 123;
+    private final Monitor monitor = mock();
+    private final Clock clock = Clock.fixed(Instant.ofEpochMilli(millis), UTC);
+    private final long shouldDelayTime = millis - DELAY + 1;
+    private final long shouldNotDelayTime = millis - DELAY;
+    private final WaitStrategy fixedWaitStrategy = () -> DELAY;
+    private final int retryLimit = 2;
+    private final EntityRetryProcessConfiguration configuration = new EntityRetryProcessConfiguration(retryLimit, () -> fixedWaitStrategy);
+
+    private final BiConsumer<TestEntity, String> success = mock();
+    private final BiConsumer<TestEntity, Throwable> failure = mock();
+    private final BiConsumer<TestEntity, Throwable> finalFailure = mock();
+
+    @Test
+    void shouldExecuteAllTheStagesInTheRightOrder_whenItIsRetryButDoesNotDelay() {
+        var entity = TestEntity.Builder.newInstance().id(UUID.randomUUID().toString()).stateTimestamp(shouldDelayTime).stateCount(1).build();
+        BiFunction<TestEntity, Object, CompletableFuture<Integer>> firstProcess = mock();
+        when(firstProcess.apply(any(), any())).thenReturn(CompletableFuture.completedFuture(1));
+        BiFunction<TestEntity, Integer, StatusResult<String>> secondProcess = mock();
+        when(secondProcess.apply(any(), any())).thenAnswer(i -> StatusResult.success(i.getArgument(1) + " second"));
+
+        var processed = new RetryProcessor<>(entity, monitor, clock, configuration)
+                .doProcess(future("async process", firstProcess))
+                .doProcess(result("sync process", secondProcess))
+                .onSuccess(success)
+                .onFailure(failure)
+                .onFinalFailure(finalFailure)
+                .execute();
+
+        assertThat(processed).isTrue();
+        verify(success).accept(entity, "1 second");
+        verifyNoInteractions(failure, finalFailure);
+        var inOrder = inOrder(firstProcess, secondProcess);
+        inOrder.verify(firstProcess).apply(any(), any());
+        inOrder.verify(secondProcess).apply(any(), any());
+    }
+
+    @Test
+    void shouldNotProcess_whenItShouldDelay() {
+        var entity = TestEntity.Builder.newInstance().id(UUID.randomUUID().toString()).stateTimestamp(shouldDelayTime).stateCount(2).build();
+        BiFunction<TestEntity, Object, StatusResult<String>> process = mock();
+
+        var processed = new RetryProcessor<>(entity, monitor, clock, configuration)
+                .doProcess(result("mock", process))
+                .onSuccess(success).onFailure(failure).onFinalFailure(finalFailure)
+                .execute();
+
+        assertThat(processed).isFalse();
+        verify(monitor).debug(contains("not be attempted before"));
+        verifyNoInteractions(process, success, failure, finalFailure);
+    }
+
+    @Test
+    void shouldNotProcessSecond_whenFirstFails() {
+        var entity = TestEntity.Builder.newInstance().id(UUID.randomUUID().toString()).stateTimestamp(shouldDelayTime).stateCount(1).build();
+        BiFunction<TestEntity, Object, StatusResult<String>> first = mock();
+        when(first.apply(any(), any())).thenReturn(StatusResult.failure(ERROR_RETRY));
+        BiFunction<TestEntity, String, StatusResult<String>> second = mock();
+
+        var processed = new RetryProcessor<>(entity, monitor, clock, configuration)
+                .doProcess(result("first", first))
+                .doProcess(result("second", second))
+                .onSuccess(success)
+                .onFailure(failure)
+                .onFinalFailure(finalFailure)
+                .execute();
+
+        assertThat(processed).isTrue();
+        verify(failure).accept(same(entity), isA(Throwable.class));
+        verifyNoInteractions(second, success, finalFailure);
+    }
+
+    @Test
+    void shouldInvokeFailureHandler_whenFailureHappensAndRetryLimitNotExceeded() {
+        var entityId = UUID.randomUUID().toString();
+        var entity = TestEntity.Builder.newInstance().id(entityId).stateTimestamp(shouldNotDelayTime).build();
+
+        org.eclipse.edc.statemachine.retry.processor.Process<TestEntity, Object, String> process = context -> failedFuture(new EntityStateException(
+                        TestEntity.Builder.newInstance().id(entityId).stateCount(retryLimit).build(), "process", "generic error"));
+
+        var processed = new RetryProcessor<>(entity, monitor, clock, configuration)
+                .doProcess(process)
+                .onSuccess(success)
+                .onFailure(failure)
+                .onFinalFailure(finalFailure)
+                .execute();
+
+        assertThat(processed).isTrue();
+        verify(failure).accept(same(entity), isA(Throwable.class));
+        verify(monitor).debug(contains("failed to process. Cause: generic error"));
+        verifyNoInteractions(success, finalFailure);
+    }
+
+    @Test
+    void shouldInvokeFinalFailureHandler_whenRetryExhausted() {
+        var entityId = UUID.randomUUID().toString();
+        var entity = TestEntity.Builder.newInstance().id(entityId).stateTimestamp(shouldNotDelayTime).build();
+
+        org.eclipse.edc.statemachine.retry.processor.Process<TestEntity, Object, String> process = context -> failedFuture(new EntityStateException(
+                TestEntity.Builder.newInstance().id(entityId).stateCount(retryLimit + 1).build(), "process", "generic error"));
+
+        var processed = new RetryProcessor<>(entity, monitor, clock, configuration)
+                .doProcess(process)
+                .onSuccess(success)
+                .onFailure(failure)
+                .onFinalFailure(finalFailure)
+                .execute();
+
+        assertThat(processed).isTrue();
+        verify(monitor).severe(contains("failed to process. Retry limit exceeded. Cause: generic error"));
+        verify(finalFailure).accept(same(entity), isA(Throwable.class));
+        verifyNoInteractions(success, failure);
+    }
+
+    @Test
+    void shouldInvokeFinalFailureHandler_whenUnrecoverableException() {
+        var entityId = UUID.randomUUID().toString();
+        var entity = TestEntity.Builder.newInstance().id(entityId).stateTimestamp(shouldNotDelayTime).build();
+
+        org.eclipse.edc.statemachine.retry.processor.Process<TestEntity, Object, String> process = context -> failedFuture(new UnrecoverableEntityStateException(
+                TestEntity.Builder.newInstance().id(entityId).build(), "process", "fatal error"));
+
+        var processed = new RetryProcessor<>(entity, monitor, clock, configuration)
+                .doProcess(process)
+                .onSuccess(success)
+                .onFailure(failure)
+                .onFinalFailure(finalFailure)
+                .execute();
+
+        assertThat(processed).isTrue();
+        verify(monitor).severe(contains("failed to process. Fatal error occurred. Cause: fatal error"));
+        verify(finalFailure).accept(same(entity), isA(Throwable.class));
+        verifyNoInteractions(success, failure);
+    }
+
+    @Test
+    void shouldInvokeFinalFailureHandler_whenGenericException() {
+        var entity = TestEntity.Builder.newInstance().id(UUID.randomUUID().toString()).stateTimestamp(shouldDelayTime).stateCount(1).build();
+
+        var runtimeException = new RuntimeException("generic exception");
+        Process<TestEntity, Object, String> process = context -> failedFuture(runtimeException);
+
+        var processed = new RetryProcessor<>(entity, monitor, clock, configuration)
+                .doProcess(process)
+                .onSuccess(success)
+                .onFailure(failure)
+                .onFinalFailure(finalFailure)
+                .execute();
+
+        assertThat(processed).isTrue();
+        verify(monitor).severe(contains("generic exception"), same(runtimeException));
+        verify(finalFailure).accept(same(entity), isA(Throwable.class));
+        verifyNoInteractions(success, failure);
+    }
+
+}

--- a/core/control-plane/control-plane-transfer/src/test/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImplTest.java
+++ b/core/control-plane/control-plane-transfer/src/test/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImplTest.java
@@ -679,11 +679,11 @@ class TransferProcessManagerImplTest {
                     new DispatchFailure(TERMINATING, TERMINATED, genericError, b -> b.stateCount(RETRIES_EXHAUSTED)),
                     // fatal error, in this case retry should never be done
                     new DispatchFailure(REQUESTING, TERMINATED, fatalError, b -> b.stateCount(RETRIES_NOT_EXHAUSTED)),
-                    new DispatchFailure(STARTING, TERMINATED, fatalError, b -> b.type(PROVIDER).stateCount(RETRIES_NOT_EXHAUSTED)),
-                    new DispatchFailure(COMPLETING, TERMINATED, fatalError, b -> b.stateCount(RETRIES_NOT_EXHAUSTED)),
-                    new DispatchFailure(SUSPENDING, TERMINATED, fatalError, b -> b.stateCount(RETRIES_NOT_EXHAUSTED)),
-                    new DispatchFailure(RESUMING, TERMINATED, fatalError, b -> b.stateCount(RETRIES_NOT_EXHAUSTED).type(CONSUMER)),
-                    new DispatchFailure(RESUMING, TERMINATED, fatalError, b -> b.stateCount(RETRIES_NOT_EXHAUSTED).type(PROVIDER)),
+                    new DispatchFailure(STARTING, TERMINATING, fatalError, b -> b.type(PROVIDER).stateCount(RETRIES_NOT_EXHAUSTED)),
+                    new DispatchFailure(COMPLETING, TERMINATING, fatalError, b -> b.stateCount(RETRIES_NOT_EXHAUSTED)),
+                    new DispatchFailure(SUSPENDING, TERMINATING, fatalError, b -> b.stateCount(RETRIES_NOT_EXHAUSTED)),
+                    new DispatchFailure(RESUMING, TERMINATING, fatalError, b -> b.stateCount(RETRIES_NOT_EXHAUSTED).type(CONSUMER)),
+                    new DispatchFailure(RESUMING, TERMINATING, fatalError, b -> b.stateCount(RETRIES_NOT_EXHAUSTED).type(PROVIDER)),
                     new DispatchFailure(TERMINATING, TERMINATED, fatalError, b -> b.stateCount(RETRIES_NOT_EXHAUSTED))
             );
         }


### PR DESCRIPTION
## What this PR changes/adds

As a consequence of #4766 and related discussion, introduces the `RetryProcessor` concept, that will eventually replace the current `RetryProcess` (that has been deprecated for the time being).

## Why it does that

Please refer to the DR:
https://github.com/eclipse-edc/Connector/tree/main/docs/developer/decision-records/2025-02-05-state-machine-retry-processor-refactor

## Further notes

- the `RetryProcessor` has been used on `TransferProcess` as demonstration, PR to replace all the usages of `RetryProcess` around the codebase will come after this.

## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

PArt of #4592 
Closes #4792 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
