### PR TITLE
feat: add `toBuilder()` methods

### DIFF
--- a/spi/common/verifiable-credentials-spi/src/main/java/org/eclipse/edc/iam/verifiablecredentials/spi/model/CredentialSubject.java
+++ b/spi/common/verifiable-credentials-spi/src/main/java/org/eclipse/edc/iam/verifiablecredentials/spi/model/CredentialSubject.java
@@ -62,15 +62,19 @@ public class CredentialSubject {
         return id;
     }
 
+    public Builder toBuilder() {
+        return new Builder(this);
+    }
+
     public static final class Builder {
         private final CredentialSubject instance;
 
-        private Builder() {
-            instance = new CredentialSubject();
+        private Builder(CredentialSubject instance) {
+            this.instance = instance;
         }
 
         public static Builder newInstance() {
-            return new Builder();
+            return new Builder(new CredentialSubject());
         }
 
         public Builder claims(Map<String, Object> claims) {

--- a/spi/common/verifiable-credentials-spi/src/main/java/org/eclipse/edc/iam/verifiablecredentials/spi/model/VerifiableCredential.java
+++ b/spi/common/verifiable-credentials-spi/src/main/java/org/eclipse/edc/iam/verifiablecredentials/spi/model/VerifiableCredential.java
@@ -119,6 +119,10 @@ public class VerifiableCredential {
         return dataModelVersion;
     }
 
+    public <T extends VerifiableCredential, B extends Builder<T, B>> Builder<T, B> toBuilder() {
+        return new Builder(this);
+    }
+
     public static class Builder<T extends VerifiableCredential, B extends Builder<T, B>> {
         protected final T instance;
 


### PR DESCRIPTION
## What this PR changes/adds

adds `toBuilder()` methods to several VC model classes

## Why it does that

to enable easy copying, and setting values. this is needed when updating credentials, e.g. status list credentials in IH

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
