### PR TITLE
docs: decision record about toBuilder and copy

### DIFF
--- a/docs/developer/decision-records/2025-02-06-object_mutability_and_copying/README.md
+++ b/docs/developer/decision-records/2025-02-06-object_mutability_and_copying/README.md
@@ -1,0 +1,63 @@
+# Object mutability and copying
+
+## Decision
+
+Objects _may_ implement a `copy()` method, which creates a deep copy, and a `toBuilder()` method, which returns a
+`Builder` that operates on the original instance.
+
+## Rationale
+
+Mutable objects may need to be modified over their lifetime. To keep in line with the builder pattern, those objects may
+implement a `toBuilder()` method, that operates on the original instance thus making them mutable.
+
+To avoid unexpected runtime behaviour, all `copy()` implementations must create a deep copy of the original instance.
+This typically involves copying the entire object graph.
+
+## Approach
+
+For the `toBuilder()` method, the Builder must have a parameterized constructor, similar to how we already do it for
+inherited builders. The new `Builder` operates/modifies the original instance.
+
+```java
+public class TheObject {
+
+    // other methods
+
+    public Builder toBuilder() {
+        return new Builder(this);
+    }
+
+    public static final class Builder {
+        private final TheObject instance;
+
+        private Builder(TheObject instance) {
+            this.instance = instance;
+        }
+        // other builder methods
+    }
+}  
+```
+
+The `copy()` method must create a copy of every field, potentially invoking `copy()` of its member objects. Note that
+`AnotherObject#copy()` must also create a deep copy of `AnotherObject`. The original instance is left unmodified.
+
+```java
+public class TheObject {
+
+    private String aString;
+    private AnotherObject anotherObject;
+    private int anInt;
+
+    public TheObject copy() {
+        return TheObject.Builder.newInstance()
+                .aString(this.aString)
+                .anotherObject(this.anotherObject.copy())
+                .anInt(this.anInt)
+                .build();
+    }
+
+    //Builder not shown
+}
+```
+
+In the code base we currently have a bit of a mix of various implementations. These need to be harmonized as well.

--- a/docs/developer/decision-records/README.md
+++ b/docs/developer/decision-records/README.md
@@ -71,3 +71,4 @@
 - [2025-01-17 key management improvements](./2025-01-17-key-management-improvement)
 - [2025-01-21 Multiple Protocol Webhooks](./2025-01-21-multipe-protocol-webhooks)
 - [2025-01-28 Async Protocol Message Process](./2025-01-28-async-protocol-message-processing)
+- [2025-02-06 Object mutability and copying](./2025-02-06-object_mutability_and_copying)


### PR DESCRIPTION
## What this PR changes/adds

adds a decision record about `toBuilder()` and `copy()` implementations.

## Why it does that

traceable and transparent decision

## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #4797 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
