### PR TITLE
refactor: replace all the RetryProcess usages with RetryProcessor

### DIFF
--- a/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/EntityRetryProcessConfiguration.java
+++ b/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/EntityRetryProcessConfiguration.java
@@ -16,11 +16,12 @@
 package org.eclipse.edc.statemachine.retry;
 
 import org.eclipse.edc.spi.retry.WaitStrategy;
+import org.eclipse.edc.statemachine.retry.processor.RetryProcessor;
 
 import java.util.function.Supplier;
 
 /**
- * Configure a {@link RetryProcess}
+ * Configure a {@link RetryProcessor}
  */
 public record EntityRetryProcessConfiguration(int retryLimit, Supplier<WaitStrategy> delayStrategySupplier) {
 

--- a/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/EntityRetryProcessFactory.java
+++ b/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/EntityRetryProcessFactory.java
@@ -24,8 +24,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
 /**
- * Permits to instance {@link RetryProcess} implementations, that will permit a certain process acting on a {@link StatefulEntity}
- * to be tried again in case of failure. Please look at {@link RetryProcess} for further details.
+ * Permit to instantiate a {@link RetryProcessor}. Please look at {@link RetryProcessor} for further details.
  */
 public class EntityRetryProcessFactory {
     private final Monitor monitor;

--- a/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/processor/Process.java
+++ b/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/processor/Process.java
@@ -47,7 +47,7 @@ public interface Process<E extends StatefulEntity<E>, I, O> {
      * @param function that executes the process.
      * @return the process instance.
      */
-    static <E extends StatefulEntity<E>, I, O> Process<E, I, O> future(String name, BiFunction<E, I, CompletableFuture<O>> function) {
+    static <E extends StatefulEntity<E>, I, O> FutureRetryProcess<E, I, O> future(String name, BiFunction<E, I, CompletableFuture<O>> function) {
         return new FutureRetryProcess<>(name, function);
     }
 

--- a/core/common/lib/state-machine-lib/src/test/java/org/eclipse/edc/statemachine/retry/processor/FutureResultRetryProcessTest.java
+++ b/core/common/lib/state-machine-lib/src/test/java/org/eclipse/edc/statemachine/retry/processor/FutureResultRetryProcessTest.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.statemachine.retry.processor;
 
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.result.StoreResult;
 import org.eclipse.edc.statemachine.retry.TestEntity;
 import org.junit.jupiter.api.Test;
 
@@ -86,8 +87,8 @@ class FutureResultRetryProcessTest {
         var entityId = UUID.randomUUID().toString();
         var entity = TestEntity.Builder.newInstance().id(entityId).build();
         var reloadedEntity = TestEntity.Builder.newInstance().id(entityId).build();
-        Function<String, TestEntity> entityReload = mock();
-        when(entityReload.apply(any())).thenReturn(reloadedEntity);
+        Function<String, StoreResult<TestEntity>> entityReload = mock();
+        when(entityReload.apply(any())).thenReturn(StoreResult.success(reloadedEntity));
         var retryProcess = new FutureResultRetryProcess<TestEntity, Object, String>("process", (e, i) -> completedFuture(StatusResult.success("content")))
                 .entityReload(entityReload);
 

--- a/core/control-plane/control-plane-contract/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
+++ b/core/control-plane/control-plane-contract/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
@@ -381,9 +381,9 @@ class ConsumerContractNegotiationManagerImplTest {
                     new DispatchFailure(VERIFYING, TERMINATING, failedFuture(new EdcException("error")), b -> b.stateCount(RETRIES_EXHAUSTED).contractAgreement(createContractAgreement())),
                     new DispatchFailure(TERMINATING, TERMINATED, failedFuture(new EdcException("error")), b -> b.stateCount(RETRIES_EXHAUSTED).errorDetail("an error").contractOffer(contractOffer())),
                     // fatal error, in this case retry should never be done
-                    new DispatchFailure(REQUESTING, TERMINATED, completedFuture(StatusResult.failure(FATAL_ERROR)), b -> b.stateCount(RETRIES_NOT_EXHAUSTED).contractOffer(contractOffer())),
-                    new DispatchFailure(ACCEPTING, TERMINATED, completedFuture(StatusResult.failure(FATAL_ERROR)), b -> b.stateCount(RETRIES_NOT_EXHAUSTED).contractOffer(contractOffer())),
-                    new DispatchFailure(VERIFYING, TERMINATED, completedFuture(StatusResult.failure(FATAL_ERROR)), b -> b.stateCount(RETRIES_NOT_EXHAUSTED).contractAgreement(createContractAgreement())),
+                    new DispatchFailure(REQUESTING, TERMINATING, completedFuture(StatusResult.failure(FATAL_ERROR)), b -> b.stateCount(RETRIES_NOT_EXHAUSTED).contractOffer(contractOffer())),
+                    new DispatchFailure(ACCEPTING, TERMINATING, completedFuture(StatusResult.failure(FATAL_ERROR)), b -> b.stateCount(RETRIES_NOT_EXHAUSTED).contractOffer(contractOffer())),
+                    new DispatchFailure(VERIFYING, TERMINATING, completedFuture(StatusResult.failure(FATAL_ERROR)), b -> b.stateCount(RETRIES_NOT_EXHAUSTED).contractAgreement(createContractAgreement())),
                     new DispatchFailure(TERMINATING, TERMINATED, completedFuture(StatusResult.failure(FATAL_ERROR)), b -> b.stateCount(RETRIES_NOT_EXHAUSTED).errorDetail("an error").contractOffer(contractOffer()))
             );
         }

--- a/core/control-plane/control-plane-contract/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
+++ b/core/control-plane/control-plane-contract/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
@@ -353,9 +353,9 @@ class ProviderContractNegotiationManagerImplTest {
                     new DispatchFailure(FINALIZING, TERMINATING, failedFuture(new EdcException("error")), b -> b.stateCount(RETRIES_EXHAUSTED).contractOffer(contractOffer()).contractAgreement(createContractAgreement())),
                     new DispatchFailure(TERMINATING, TERMINATED, failedFuture(new EdcException("error")), b -> b.stateCount(RETRIES_EXHAUSTED).errorDetail("an error").contractOffer(contractOffer())),
                     // fatal error, in this case retry should never be done
-                    new DispatchFailure(OFFERING, TERMINATED, completedFuture(StatusResult.failure(FATAL_ERROR)), b -> b.stateCount(RETRIES_NOT_EXHAUSTED).contractOffer(contractOffer())),
-                    new DispatchFailure(AGREEING, TERMINATED, completedFuture(StatusResult.failure(FATAL_ERROR)), b -> b.stateCount(RETRIES_NOT_EXHAUSTED).contractOffer(contractOffer())),
-                    new DispatchFailure(FINALIZING, TERMINATED, completedFuture(StatusResult.failure(FATAL_ERROR)), b -> b.stateCount(RETRIES_NOT_EXHAUSTED).contractOffer(contractOffer()).contractAgreement(createContractAgreement())),
+                    new DispatchFailure(OFFERING, TERMINATING, completedFuture(StatusResult.failure(FATAL_ERROR)), b -> b.stateCount(RETRIES_NOT_EXHAUSTED).contractOffer(contractOffer())),
+                    new DispatchFailure(AGREEING, TERMINATING, completedFuture(StatusResult.failure(FATAL_ERROR)), b -> b.stateCount(RETRIES_NOT_EXHAUSTED).contractOffer(contractOffer())),
+                    new DispatchFailure(FINALIZING, TERMINATING, completedFuture(StatusResult.failure(FATAL_ERROR)), b -> b.stateCount(RETRIES_NOT_EXHAUSTED).contractOffer(contractOffer()).contractAgreement(createContractAgreement())),
                     new DispatchFailure(TERMINATING, TERMINATED, completedFuture(StatusResult.failure(FATAL_ERROR)), b -> b.stateCount(RETRIES_NOT_EXHAUSTED).errorDetail("an error").contractOffer(contractOffer()))
             );
         }


### PR DESCRIPTION
## What this PR changes/adds

Switch all the deprecated `RetryProcess` usages to `RetryProcessor`

## Why it does that

refactor

## Further notes

- switched the `entityReload` return type to `StoreResult<E>` because the usage of it requires a leased entity, and the `StateEntityStore.findByIdAndLease` returns a result

## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #4815 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
