### PR TITLE
fix: support VP without VCs in IdentityAndTrustService

### DIFF
--- a/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/DcpDefaultServicesExtension.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/DcpDefaultServicesExtension.java
@@ -45,7 +45,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
-import static org.eclipse.edc.spi.result.Result.failure;
 import static org.eclipse.edc.spi.result.Result.success;
 
 @Extension("Identity And Trust Extension to register default services")
@@ -123,9 +122,6 @@ public class DcpDefaultServicesExtension implements ServiceExtension {
     @Provider(isDefault = true)
     public ClaimTokenCreatorFunction defaultClaimTokenFunction() {
         return credentials -> {
-            if (credentials.isEmpty()) {
-                return failure("No VerifiableCredentials were found on VP");
-            }
             var b = ClaimToken.Builder.newInstance()
                     .claims(Map.of(CLAIMTOKEN_VC_KEY, credentials));
             return success(b.build());

--- a/extensions/common/iam/verifiable-credentials/src/test/java/org/eclipse/edc/iam/verifiablecredentials/VerifiableCredentialValidationServiceImplTest.java
+++ b/extensions/common/iam/verifiable-credentials/src/test/java/org/eclipse/edc/iam/verifiablecredentials/VerifiableCredentialValidationServiceImplTest.java
@@ -124,6 +124,19 @@ class VerifiableCredentialValidationServiceImplTest {
     }
 
     @Test
+    void verify_singlePresentation_noCredential() {
+        var presentation = createPresentationBuilder()
+                .holder(CONSUMER_DID)
+                .type("VerifiablePresentation")
+                .credentials(List.of())
+                .build();
+        var vpContainer = new VerifiablePresentationContainer("test-vp", CredentialFormat.VC1_0_LD, presentation);
+        when(verifier.verifyPresentation(any())).thenReturn(success());
+        var result = validationService.validate(List.of(vpContainer));
+        assertThat(result).isSucceeded();
+    }
+
+    @Test
     void verify_singlePresentation_singleCredential() {
         var presentation = createPresentationBuilder()
                 .holder(CONSUMER_DID)


### PR DESCRIPTION
## What this PR changes/adds

Support VPs without VCs in IdentityAndTrustService.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #4807 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
