### PR TITLE
chore: add column name to JsonArrayTranslator

### DIFF
--- a/core/common/lib/sql-lib/src/main/java/org/eclipse/edc/sql/translation/JsonArrayTranslator.java
+++ b/core/common/lib/sql-lib/src/main/java/org/eclipse/edc/sql/translation/JsonArrayTranslator.java
@@ -34,13 +34,19 @@ import static org.eclipse.edc.sql.translation.FieldTranslator.toValuePlaceholder
  */
 public class JsonArrayTranslator implements FieldTranslator {
 
+    protected final String columnName;
+
+    public JsonArrayTranslator(String columnName) {
+        this.columnName = columnName;
+    }
+
     @Override
     public String getLeftOperand(List<PathItem> path, Class<?> rightOperandType) {
         if (Collection.class.isAssignableFrom(rightOperandType)) {
             throw new IllegalArgumentException("JsonArrayTranslator only supports scalar right-operands, found '%s' ".formatted(rightOperandType));
         }
         if (path.size() == 1) {
-            return path.get(0).toString();
+            return columnName;
         }
         throw new IllegalArgumentException("Invalid path for JsonArrayTranslator: must have one element, but found '%s'".formatted(path.size()));
     }

--- a/core/common/lib/sql-lib/src/test/java/org/eclipse/edc/sql/translation/JsonArrayTranslatorTest.java
+++ b/core/common/lib/sql-lib/src/test/java/org/eclipse/edc/sql/translation/JsonArrayTranslatorTest.java
@@ -25,7 +25,7 @@ import static org.eclipse.edc.spi.query.Criterion.criterion;
 
 class JsonArrayTranslatorTest {
 
-    private final JsonArrayTranslator translator = new JsonArrayTranslator();
+    private final JsonArrayTranslator translator = new JsonArrayTranslator("array");
 
     @Test
     void getLeftOperand() {


### PR DESCRIPTION
## What this PR changes/adds

Passes the column name of the `JsonArray` field to the `JsonArrayTranslator` since in some case the single element in the path might be camel case. 

## Why it does that

Allow usage of `JsonArrayTranslator` for camel case JSON Array properties

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
