### PR TITLE
feat: filter state by string

### DIFF
--- a/core/common/lib/sql-lib/src/main/java/org/eclipse/edc/sql/translation/EntityStateFieldTranslator.java
+++ b/core/common/lib/sql-lib/src/main/java/org/eclipse/edc/sql/translation/EntityStateFieldTranslator.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.sql.translation;
+
+import org.eclipse.edc.spi.entity.StateResolver;
+import org.eclipse.edc.spi.query.Criterion;
+
+import java.util.Collection;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Supports the string representation of a state, that will be converted into int by the {@link #stateResolver}.
+ */
+public class EntityStateFieldTranslator extends PlainColumnFieldTranslator {
+
+    private final StateResolver stateResolver;
+
+    public EntityStateFieldTranslator(String columnName, StateResolver stateResolver) {
+        super(columnName);
+        this.stateResolver = stateResolver;
+    }
+
+    @Override
+    public Collection<Object> toParameters(Criterion criterion) {
+        return super.toParameters(criterion)
+                .stream()
+                .map(it -> it instanceof String stringState ? stateResolver.resolve(stringState) : it)
+                .collect(toList());
+    }
+}

--- a/core/common/lib/sql-lib/src/main/java/org/eclipse/edc/sql/translation/FieldTranslator.java
+++ b/core/common/lib/sql-lib/src/main/java/org/eclipse/edc/sql/translation/FieldTranslator.java
@@ -50,14 +50,7 @@ public interface FieldTranslator {
      */
     WhereClause toWhereClause(List<PathItem> path, Criterion criterion, SqlOperator operator);
 
-    static String toValuePlaceholder(Criterion criterion) {
-        if (criterion.getOperandRight() instanceof Collection<?> collection) {
-            return format("(%s)", String.join(",", nCopies(collection.size(), PREPARED_STATEMENT_PLACEHOLDER)));
-        }
-        return PREPARED_STATEMENT_PLACEHOLDER;
-    }
-
-    static Collection<Object> toParameters(Criterion criterion) {
+    default Collection<Object> toParameters(Criterion criterion) {
         var operandRight = criterion.getOperandRight();
         if (operandRight == null) {
             return emptyList();
@@ -66,6 +59,13 @@ public interface FieldTranslator {
         } else {
             return List.of(operandRight);
         }
+    }
+
+    static String toValuePlaceholder(Criterion criterion) {
+        if (criterion.getOperandRight() instanceof Collection<?> collection) {
+            return format("(%s)", String.join(",", nCopies(collection.size(), PREPARED_STATEMENT_PLACEHOLDER)));
+        }
+        return PREPARED_STATEMENT_PLACEHOLDER;
     }
 
 }

--- a/core/common/lib/sql-lib/src/main/java/org/eclipse/edc/sql/translation/JsonArrayTranslator.java
+++ b/core/common/lib/sql-lib/src/main/java/org/eclipse/edc/sql/translation/JsonArrayTranslator.java
@@ -20,7 +20,6 @@ import org.eclipse.edc.util.reflection.PathItem;
 import java.util.Collection;
 import java.util.List;
 
-import static org.eclipse.edc.sql.translation.FieldTranslator.toParameters;
 import static org.eclipse.edc.sql.translation.FieldTranslator.toValuePlaceholder;
 
 /**

--- a/core/common/lib/sql-lib/src/main/java/org/eclipse/edc/sql/translation/JsonFieldTranslator.java
+++ b/core/common/lib/sql-lib/src/main/java/org/eclipse/edc/sql/translation/JsonFieldTranslator.java
@@ -22,7 +22,6 @@ import java.util.Optional;
 
 import static java.lang.String.format;
 import static java.util.stream.IntStream.range;
-import static org.eclipse.edc.sql.translation.FieldTranslator.toParameters;
 import static org.eclipse.edc.sql.translation.FieldTranslator.toValuePlaceholder;
 
 public class JsonFieldTranslator implements FieldTranslator {

--- a/core/common/lib/sql-lib/src/main/java/org/eclipse/edc/sql/translation/PlainColumnFieldTranslator.java
+++ b/core/common/lib/sql-lib/src/main/java/org/eclipse/edc/sql/translation/PlainColumnFieldTranslator.java
@@ -19,7 +19,6 @@ import org.eclipse.edc.util.reflection.PathItem;
 
 import java.util.List;
 
-import static org.eclipse.edc.sql.translation.FieldTranslator.toParameters;
 import static org.eclipse.edc.sql.translation.FieldTranslator.toValuePlaceholder;
 
 public class PlainColumnFieldTranslator implements FieldTranslator {

--- a/core/common/lib/sql-lib/src/test/java/org/eclipse/edc/sql/translation/EntityStateFieldTranslatorTest.java
+++ b/core/common/lib/sql-lib/src/test/java/org/eclipse/edc/sql/translation/EntityStateFieldTranslatorTest.java
@@ -1,0 +1,85 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.sql.translation;
+
+import org.eclipse.edc.spi.entity.StateResolver;
+import org.eclipse.edc.util.reflection.PathItem;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.spi.query.Criterion.criterion;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class EntityStateFieldTranslatorTest {
+
+    private final StateResolver stateResolver = mock();
+    private final EntityStateFieldTranslator translator = new EntityStateFieldTranslator("column_name", stateResolver);
+
+    @Test
+    void shouldReturnWhereClause_whenOperatorSpecified() {
+        var path = PathItem.parse("any");
+
+        var result = translator.toWhereClause(path, criterion("field", "=", 100), createOperator());
+
+        assertThat(result.sql()).isEqualTo("column_name any ?");
+        assertThat(result.parameters()).containsExactly(100);
+    }
+
+    @Test
+    void shouldMapMultipleParameters_whenRightOperandIsCollection() {
+        var path = PathItem.parse("any");
+
+        var result = translator.toWhereClause(path, criterion("field", "in", List.of(100, 200)), createOperator());
+
+        assertThat(result.sql()).isEqualTo("column_name any (?,?)");
+        assertThat(result.parameters()).containsExactly(100, 200);
+    }
+
+    @Test
+    void shouldTranslateStateToCode_whenInputTypeIsString() {
+        when(stateResolver.resolve(any())).thenReturn(100);
+        var path = PathItem.parse("any");
+
+        var result = translator.toWhereClause(path, criterion("field", "=", "STATE"), createOperator());
+
+        assertThat(result.sql()).isEqualTo("column_name any ?");
+        assertThat(result.parameters()).containsExactly(100);
+        verify(stateResolver).resolve("STATE");
+    }
+
+    @Test
+    void shouldMapMultipleParametersToCode_whenRightOperandIsStringCollection() {
+        when(stateResolver.resolve(any())).thenReturn(100).thenReturn(200);
+        var path = PathItem.parse("any");
+
+        var result = translator.toWhereClause(path, criterion("field", "in", List.of("STATE", "ANOTHER_STATE")), createOperator());
+
+        assertThat(result.sql()).isEqualTo("column_name any (?,?)");
+        assertThat(result.parameters()).containsExactly(100, 200);
+        verify(stateResolver).resolve("STATE");
+        verify(stateResolver).resolve("ANOTHER_STATE");
+    }
+
+    @NotNull
+    private static SqlOperator createOperator() {
+        return new SqlOperator("any", Object.class);
+    }
+}

--- a/core/common/lib/store-lib/src/main/java/org/eclipse/edc/store/AndOperatorCriteriaToPredicate.java
+++ b/core/common/lib/store-lib/src/main/java/org/eclipse/edc/store/AndOperatorCriteriaToPredicate.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.store;
+
+import org.eclipse.edc.spi.query.CriteriaToPredicate;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.query.CriterionOperatorRegistry;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * Converts criteria to a Predicate that converts all the criterion to predicate using the passed {@link #criterionOperatorRegistry}
+ * and joins them with "and" operator.
+ *
+ * @param <T> the object type
+ */
+public class AndOperatorCriteriaToPredicate<T> implements CriteriaToPredicate<T> {
+
+    private final CriterionOperatorRegistry criterionOperatorRegistry;
+
+    public AndOperatorCriteriaToPredicate(CriterionOperatorRegistry criterionOperatorRegistry) {
+        this.criterionOperatorRegistry = criterionOperatorRegistry;
+    }
+
+    @Override
+    public Predicate<T> convert(List<Criterion> criteria) {
+        return criteria.stream()
+                .map(criterionOperatorRegistry::<T>toPredicate)
+                .reduce(x -> true, Predicate::and);
+    }
+}

--- a/core/common/lib/store-lib/src/main/java/org/eclipse/edc/store/InMemoryStatefulEntityStore.java
+++ b/core/common/lib/store-lib/src/main/java/org/eclipse/edc/store/InMemoryStatefulEntityStore.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.store;
 
+import org.eclipse.edc.spi.entity.StateResolver;
 import org.eclipse.edc.spi.entity.StatefulEntity;
 import org.eclipse.edc.spi.persistence.Lease;
 import org.eclipse.edc.spi.persistence.StateEntityStore;
@@ -55,8 +56,8 @@ public class InMemoryStatefulEntityStore<T extends StatefulEntity<T>> implements
     private final Map<String, Lease> leases = new HashMap<>();
     protected final CriterionOperatorRegistry criterionOperatorRegistry;
 
-    public InMemoryStatefulEntityStore(Class<T> clazz, String lockId, Clock clock, CriterionOperatorRegistry criterionOperatorRegistry) {
-        queryResolver = new ReflectionBasedQueryResolver<>(clazz, criterionOperatorRegistry);
+    public InMemoryStatefulEntityStore(Class<T> clazz, String lockId, Clock clock, CriterionOperatorRegistry criterionOperatorRegistry, StateResolver stateResolver) {
+        this.queryResolver = new ReflectionBasedQueryResolver<>(clazz, new StatefulEntityCriteriaToPredicate<>(criterionOperatorRegistry, stateResolver));
         this.lockId = lockId;
         this.clock = clock;
         this.criterionOperatorRegistry = criterionOperatorRegistry;

--- a/core/common/lib/store-lib/src/main/java/org/eclipse/edc/store/StatefulEntityCriteriaToPredicate.java
+++ b/core/common/lib/store-lib/src/main/java/org/eclipse/edc/store/StatefulEntityCriteriaToPredicate.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.store;
+
+import org.eclipse.edc.spi.entity.StateResolver;
+import org.eclipse.edc.spi.entity.StatefulEntity;
+import org.eclipse.edc.spi.query.CriteriaToPredicate;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.query.CriterionOperatorRegistry;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import static org.eclipse.edc.spi.query.Criterion.criterion;
+
+/**
+ * Convert criteria to predicate for stateful entities.
+ *
+ * @param <E> entity type
+ */
+public class StatefulEntityCriteriaToPredicate<E extends StatefulEntity<E>> implements CriteriaToPredicate<E> {
+
+    private final CriterionOperatorRegistry criterionOperatorRegistry;
+    private final StateResolver stateResolver;
+
+    public StatefulEntityCriteriaToPredicate(CriterionOperatorRegistry criterionOperatorRegistry, StateResolver stateResolver) {
+        this.criterionOperatorRegistry = criterionOperatorRegistry;
+        this.stateResolver = stateResolver;
+    }
+
+    @Override
+    public Predicate<E> convert(List<Criterion> criteria) {
+        return criteria.stream()
+                .map(criterion -> {
+                    if (criterion.getOperandLeft().equals("state") && criterion.getOperandRight() instanceof String stateString) {
+                        return criterion(criterion.getOperandLeft(), criterion.getOperator(), stateResolver.resolve(stateString));
+                    }
+                    return criterion;
+                })
+                .map(criterionOperatorRegistry::<E>toPredicate)
+                .reduce(x -> true, Predicate::and);
+    }
+}

--- a/core/common/lib/store-lib/src/test/java/org/eclipse/edc/store/ReflectionBasedQueryResolverTest.java
+++ b/core/common/lib/store-lib/src/test/java/org/eclipse/edc/store/ReflectionBasedQueryResolverTest.java
@@ -25,7 +25,6 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -55,16 +54,6 @@ class ReflectionBasedQueryResolverTest {
         var spec = QuerySpec.Builder.newInstance().filter(criterion("name", "=", "Alice")).build();
         assertThat(queryResolver.query(stream, spec)).hasSize(5).extracting(FakeItem::getName).containsOnly("Alice");
 
-    }
-
-    @Test
-    void verifyQuery_equalStringProperty_accumulateOr() {
-        var stream = Stream.concat(
-                IntStream.range(0, 5).mapToObj(i -> new FakeItem(i, "Alice")),
-                IntStream.range(5, 10).mapToObj(i -> new FakeItem(i, "Bob")));
-
-        var spec = QuerySpec.Builder.newInstance().filter(List.of(criterion("name", "=", "Alice"), criterion("name", "=", "Bob"))).build();
-        assertThat(queryResolver.query(stream, spec, Predicate::or, x -> false)).hasSize(10).extracting(FakeItem::getName).containsOnly("Bob", "Alice");
     }
 
     @Test

--- a/core/common/lib/store-lib/src/test/java/org/eclipse/edc/store/StatefulEntityCriteriaToPredicateTest.java
+++ b/core/common/lib/store-lib/src/test/java/org/eclipse/edc/store/StatefulEntityCriteriaToPredicateTest.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.store;
+
+import org.eclipse.edc.spi.entity.StateResolver;
+import org.eclipse.edc.spi.query.CriterionOperatorRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.eclipse.edc.spi.query.Criterion.criterion;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class StatefulEntityCriteriaToPredicateTest {
+
+    private final CriterionOperatorRegistry operatorRegistry = mock();
+    private final StateResolver stateResolver = mock();
+    private final StatefulEntityCriteriaToPredicate<?> criteriaToPredicate = new StatefulEntityCriteriaToPredicate<>(operatorRegistry, stateResolver);
+
+    @BeforeEach
+    void setUp() {
+        when(operatorRegistry.toPredicate(any())).thenReturn(mock());
+    }
+
+    @Test
+    void shouldNotResolveState_whenItIsInteger() {
+        var criterion = criterion("state", "=", 600);
+
+        criteriaToPredicate.convert(List.of(criterion));
+
+        verify(operatorRegistry).toPredicate(criterion);
+        verifyNoInteractions(stateResolver);
+    }
+
+    @Test
+    void shouldResolveState_whenItIsString() {
+        when(stateResolver.resolve(any())).thenReturn(600);
+        var criterion = criterion("state", "=", "STATE_NAME");
+
+        criteriaToPredicate.convert(List.of(criterion));
+
+        verify(operatorRegistry).toPredicate(criterion("state", "=", 600));
+        verify(stateResolver).resolve("STATE_NAME");
+    }
+}

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/controlplane/defaults/storage/contractnegotiation/InMemoryContractNegotiationStore.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/controlplane/defaults/storage/contractnegotiation/InMemoryContractNegotiationStore.java
@@ -18,6 +18,7 @@ package org.eclipse.edc.connector.controlplane.defaults.storage.contractnegotiat
 import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates;
 import org.eclipse.edc.spi.query.CriterionOperatorRegistry;
 import org.eclipse.edc.spi.query.QueryResolver;
 import org.eclipse.edc.spi.query.QuerySpec;
@@ -38,7 +39,6 @@ import static java.lang.String.format;
  */
 public class InMemoryContractNegotiationStore extends InMemoryStatefulEntityStore<ContractNegotiation> implements ContractNegotiationStore {
 
-    private final QueryResolver<ContractNegotiation> negotiationQueryResolver;
     private final QueryResolver<ContractAgreement> agreementQueryResolver;
 
     public InMemoryContractNegotiationStore(Clock clock, CriterionOperatorRegistry criterionOperatorRegistry) {
@@ -46,9 +46,8 @@ public class InMemoryContractNegotiationStore extends InMemoryStatefulEntityStor
     }
 
     public InMemoryContractNegotiationStore(String leaseHolder, Clock clock, CriterionOperatorRegistry criterionOperatorRegistry) {
-        super(ContractNegotiation.class, leaseHolder, clock, criterionOperatorRegistry);
+        super(ContractNegotiation.class, leaseHolder, clock, criterionOperatorRegistry, state -> ContractNegotiationStates.valueOf(state).code());
         agreementQueryResolver = new ReflectionBasedQueryResolver<>(ContractAgreement.class, criterionOperatorRegistry);
-        negotiationQueryResolver = new ReflectionBasedQueryResolver<>(ContractNegotiation.class, criterionOperatorRegistry);
     }
 
     @Override
@@ -72,7 +71,7 @@ public class InMemoryContractNegotiationStore extends InMemoryStatefulEntityStor
 
     @Override
     public @NotNull Stream<ContractNegotiation> queryNegotiations(QuerySpec querySpec) {
-        return negotiationQueryResolver.query(super.findAll(), querySpec);
+        return super.findAll(querySpec);
     }
 
     @Override

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/controlplane/defaults/storage/transferprocess/InMemoryTransferProcessStore.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/controlplane/defaults/storage/transferprocess/InMemoryTransferProcessStore.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.controlplane.defaults.storage.transferprocess;
 
 import org.eclipse.edc.connector.controlplane.transfer.spi.store.TransferProcessStore;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates;
 import org.eclipse.edc.spi.query.CriterionOperatorRegistry;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.store.InMemoryStatefulEntityStore;
@@ -23,7 +24,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.time.Clock;
 import java.util.UUID;
-import java.util.stream.Stream;
 
 import static org.eclipse.edc.spi.query.Criterion.criterion;
 
@@ -37,7 +37,7 @@ public class InMemoryTransferProcessStore extends InMemoryStatefulEntityStore<Tr
     }
 
     public InMemoryTransferProcessStore(String leaserId, Clock clock, CriterionOperatorRegistry criterionOperatorRegistry) {
-        super(TransferProcess.class, leaserId, clock, criterionOperatorRegistry);
+        super(TransferProcess.class, leaserId, clock, criterionOperatorRegistry, state -> TransferProcessStates.valueOf(state).code());
     }
 
     @Override
@@ -45,16 +45,6 @@ public class InMemoryTransferProcessStore extends InMemoryStatefulEntityStore<Tr
         var querySpec = QuerySpec.Builder.newInstance().filter(criterion("correlationId", "=", correlationId)).build();
 
         return super.findAll(querySpec).findFirst().orElse(null);
-    }
-
-    @Override
-    public void delete(String id) {
-        super.delete(id);
-    }
-
-    @Override
-    public Stream<TransferProcess> findAll(QuerySpec querySpec) {
-        return super.findAll(querySpec);
     }
 
 }

--- a/core/data-plane-selector/data-plane-selector-core/src/main/java/org/eclipse/edc/connector/dataplane/selector/store/InMemoryDataPlaneInstanceStore.java
+++ b/core/data-plane-selector/data-plane-selector-core/src/main/java/org/eclipse/edc/connector/dataplane/selector/store/InMemoryDataPlaneInstanceStore.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.connector.dataplane.selector.store;
 
 import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
+import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstanceStates;
 import org.eclipse.edc.connector.dataplane.selector.spi.store.DataPlaneInstanceStore;
 import org.eclipse.edc.spi.query.CriterionOperatorRegistry;
 import org.eclipse.edc.spi.result.StoreResult;
@@ -34,7 +35,7 @@ public class InMemoryDataPlaneInstanceStore extends InMemoryStatefulEntityStore<
     }
 
     public InMemoryDataPlaneInstanceStore(String owner, Clock clock, CriterionOperatorRegistry criterionOperatorRegistry) {
-        super(DataPlaneInstance.class, owner, clock, criterionOperatorRegistry);
+        super(DataPlaneInstance.class, owner, clock, criterionOperatorRegistry, state -> DataPlaneInstanceStates.valueOf(state).code());
     }
 
     @Override

--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/store/InMemoryDataPlaneStore.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/store/InMemoryDataPlaneStore.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.connector.dataplane.framework.store;
 
 import org.eclipse.edc.connector.dataplane.spi.DataFlow;
+import org.eclipse.edc.connector.dataplane.spi.DataFlowStates;
 import org.eclipse.edc.connector.dataplane.spi.store.DataPlaneStore;
 import org.eclipse.edc.spi.query.CriterionOperatorRegistry;
 import org.eclipse.edc.store.InMemoryStatefulEntityStore;
@@ -32,6 +33,6 @@ public class InMemoryDataPlaneStore extends InMemoryStatefulEntityStore<DataFlow
     }
 
     public InMemoryDataPlaneStore(String connectorName, Clock clock, CriterionOperatorRegistry criterionOperatorRegistry) {
-        super(DataFlow.class, connectorName, clock, criterionOperatorRegistry);
+        super(DataFlow.class, connectorName, clock, criterionOperatorRegistry, state -> DataFlowStates.valueOf(state).code());
     }
 }

--- a/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/store/sql/InMemoryPolicyMonitorStore.java
+++ b/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/store/sql/InMemoryPolicyMonitorStore.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.connector.policy.monitor.store.sql;
 
 import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntry;
+import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntryStates;
 import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorStore;
 import org.eclipse.edc.spi.query.CriterionOperatorRegistry;
 import org.eclipse.edc.store.InMemoryStatefulEntityStore;
@@ -32,6 +33,6 @@ public class InMemoryPolicyMonitorStore extends InMemoryStatefulEntityStore<Poli
     }
 
     public InMemoryPolicyMonitorStore(String owner, Clock clock, CriterionOperatorRegistry criterionOperatorRegistry) {
-        super(PolicyMonitorEntry.class, owner, clock, criterionOperatorRegistry);
+        super(PolicyMonitorEntry.class, owner, clock, criterionOperatorRegistry, state -> PolicyMonitorEntryStates.valueOf(state).code());
     }
 }

--- a/extensions/common/sql/sql-lease/src/main/java/org/eclipse/edc/sql/lease/StatefulEntityMapping.java
+++ b/extensions/common/sql/sql-lease/src/main/java/org/eclipse/edc/sql/lease/StatefulEntityMapping.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.edc.sql.lease;
 
+import org.eclipse.edc.spi.entity.StateResolver;
+import org.eclipse.edc.sql.translation.EntityStateFieldTranslator;
 import org.eclipse.edc.sql.translation.JsonFieldTranslator;
 import org.eclipse.edc.sql.translation.TranslationMapping;
 
@@ -23,9 +25,9 @@ import org.eclipse.edc.sql.translation.TranslationMapping;
  */
 public class StatefulEntityMapping extends TranslationMapping {
 
-    protected StatefulEntityMapping(StatefulEntityStatements statements) {
+    protected StatefulEntityMapping(StatefulEntityStatements statements, StateResolver stateResolver) {
         add("id", statements.getIdColumn());
-        add("state", statements.getStateColumn());
+        add("state", new EntityStateFieldTranslator(statements.getStateColumn(), stateResolver));
         add("stateCount", statements.getStateCountColumn());
         add("stateTimestamp", statements.getStateTimestampColumn());
         add("createdAt", statements.getCreatedAtColumn());

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/store/schema/postgres/ContractNegotiationMapping.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/store/schema/postgres/ContractNegotiationMapping.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.connector.controlplane.store.sql.contractnegotiation.store.schema.postgres;
 
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates;
 import org.eclipse.edc.connector.controlplane.store.sql.contractnegotiation.store.schema.ContractNegotiationStatements;
 import org.eclipse.edc.sql.lease.StatefulEntityMapping;
 
@@ -33,7 +34,7 @@ class ContractNegotiationMapping extends StatefulEntityMapping {
     private static final String FIELD_PENDING = "pending";
 
     ContractNegotiationMapping(ContractNegotiationStatements statements) {
-        super(statements);
+        super(statements, state -> ContractNegotiationStates.valueOf(state).code());
         add(FIELD_CORRELATION_ID, statements.getCorrelationIdColumn());
         add(FIELD_COUNTER_PARTY_ID, statements.getCounterPartyIdColumn());
         add(FIELD_COUNTERPARTY_ADDRESS, statements.getCounterPartyAddressColumn());

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/transferprocess/store/schema/postgres/TransferProcessMapping.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/transferprocess/store/schema/postgres/TransferProcessMapping.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.controlplane.store.sql.transferprocess.store.s
 
 import org.eclipse.edc.connector.controlplane.store.sql.transferprocess.store.schema.TransferProcessStoreStatements;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates;
 import org.eclipse.edc.sql.lease.StatefulEntityMapping;
 import org.eclipse.edc.sql.translation.JsonFieldTranslator;
 
@@ -46,7 +47,7 @@ public class TransferProcessMapping extends StatefulEntityMapping {
     private static final String FIELD_DATA_DESTINATION = "dataDestination";
 
     public TransferProcessMapping(TransferProcessStoreStatements statements) {
-        super(statements);
+        super(statements, state -> TransferProcessStates.valueOf(state).code());
         add(FIELD_TYPE, statements.getTypeColumn());
         add(FIELD_CREATED_TIMESTAMP, statements.getCreatedAtColumn());
         add(FIELD_CORRELATION_ID, statements.getCorrelationIdColumn());

--- a/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/selector/store/sql/schema/DataPlaneInstanceMapping.java
+++ b/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/selector/store/sql/schema/DataPlaneInstanceMapping.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.connector.dataplane.selector.store.sql.schema;
 
+import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstanceStates;
 import org.eclipse.edc.sql.lease.StatefulEntityMapping;
 import org.eclipse.edc.sql.translation.JsonFieldTranslator;
 
@@ -24,7 +25,7 @@ import org.eclipse.edc.sql.translation.JsonFieldTranslator;
 public class DataPlaneInstanceMapping extends StatefulEntityMapping {
 
     public DataPlaneInstanceMapping(DataPlaneInstanceStatements statements) {
-        super(statements);
+        super(statements, state -> DataPlaneInstanceStates.valueOf(state).code());
         var data = new JsonFieldTranslator(statements.getDataColumn());
         add("state", data);
         add("stateCount", data);

--- a/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/schema/postgres/DataFlowMapping.java
+++ b/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/schema/postgres/DataFlowMapping.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.connector.dataplane.store.sql.schema.postgres;
 
 import org.eclipse.edc.connector.dataplane.spi.DataFlow;
+import org.eclipse.edc.connector.dataplane.spi.DataFlowStates;
 import org.eclipse.edc.connector.dataplane.store.sql.schema.DataFlowStatements;
 import org.eclipse.edc.sql.lease.StatefulEntityMapping;
 import org.eclipse.edc.sql.translation.TranslationMapping;
@@ -26,7 +27,7 @@ import org.eclipse.edc.sql.translation.TranslationMapping;
 public class DataFlowMapping extends StatefulEntityMapping {
 
     public DataFlowMapping(DataFlowStatements statements) {
-        super(statements);
+        super(statements, state -> DataFlowStates.valueOf(state).code());
         add("transferType", new TransferTypeMapping(statements));
         add("runtimeId", statements.getRuntimeIdColumn());
     }

--- a/extensions/policy-monitor/store/sql/policy-monitor-store-sql/src/main/java/org/eclipse/edc/connector/policy/monitor/store/sql/schema/PolicyMonitorMapping.java
+++ b/extensions/policy-monitor/store/sql/policy-monitor-store-sql/src/main/java/org/eclipse/edc/connector/policy/monitor/store/sql/schema/PolicyMonitorMapping.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.connector.policy.monitor.store.sql.schema;
 
+import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntryStates;
 import org.eclipse.edc.sql.lease.StatefulEntityMapping;
 
 /**
@@ -23,7 +24,7 @@ import org.eclipse.edc.sql.lease.StatefulEntityMapping;
 public class PolicyMonitorMapping extends StatefulEntityMapping {
 
     public PolicyMonitorMapping(PolicyMonitorStatements statements) {
-        super(statements);
+        super(statements, state -> PolicyMonitorEntryStates.valueOf(state).code());
         add("contractId", statements.getContractIdColumn());
     }
 

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/entity/StateResolver.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/entity/StateResolver.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.spi.entity;
+
+/**
+ * Function that returns the int status representation given the String one
+ */
+@FunctionalInterface
+public interface StateResolver {
+
+    /**
+     * Returns the int state giving its String representation.
+     *
+     * @param stringState string state representation.
+     * @return the int state.
+     */
+    int resolve(String stringState);
+
+}

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/CriteriaToPredicate.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/CriteriaToPredicate.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.spi.query;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * Converts a criterion list to a {@link Predicate}.
+ *
+ * @param <T> the predicate enclosed type.
+ */
+public interface CriteriaToPredicate<T> {
+
+    /**
+     * Convert a criteria into a predicate
+     *
+     * @param criteria the criteria.
+     * @return the predicate.
+     */
+    Predicate<T> convert(List<Criterion> criteria);
+
+}

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/QueryResolver.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/query/QueryResolver.java
@@ -33,9 +33,7 @@ public interface QueryResolver<T> {
      * @param spec   query specification.
      * @return stream result from queries.
      */
-    default Stream<T> query(Stream<T> stream, QuerySpec spec) {
-        return query(stream, spec, Predicate::and, x -> true);
-    }
+    Stream<T> query(Stream<T> stream, QuerySpec spec);
 
     /**
      * Method to query a stream by provided specification, using the provided accumulator
@@ -44,6 +42,10 @@ public interface QueryResolver<T> {
      * @param spec        query specification.
      * @param accumulator binary accumulation operator, e.g. Predicate::and, Predicate::or, etc.
      * @return stream result from queries.
+     * @deprecated use {@link #query(Stream, QuerySpec)}, the accumulator should be passed as collaborator.
      */
-    Stream<T> query(Stream<T> stream, QuerySpec spec, BinaryOperator<Predicate<Object>> accumulator, Predicate<Object> fallback);
+    @Deprecated(since = "0.12.0")
+    default Stream<T> query(Stream<T> stream, QuerySpec spec, BinaryOperator<Predicate<Object>> accumulator, Predicate<Object> fallback) {
+        return query(stream, spec);
+    }
 }

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/PolicyDefinitionApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/PolicyDefinitionApiEndToEndTest.java
@@ -20,6 +20,7 @@ import org.eclipse.edc.connector.controlplane.policy.spi.store.PolicyDefinitionS
 import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.junit.annotations.PostgresqlIntegrationTest;
 import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -409,9 +410,8 @@ public class PolicyDefinitionApiEndToEndTest {
     class ValidationTests {
 
         @RegisterExtension
-        static ManagementEndToEndExtension.InMemory runtime = ManagementEndToEndExtension.InMemory.withConfig(Map.of(
-                "edc.policy.validation.enabled", "true"
-        ));
+        static ManagementEndToEndExtension.InMemory runtime = ManagementEndToEndExtension.InMemory.withConfig(() ->
+                ConfigFactory.fromMap(Map.of("edc.policy.validation.enabled", "true")));
 
         @Test
         void shouldNotStorePolicyDefinition_whenValidationFails(ManagementEndToEndTestContext context) {


### PR DESCRIPTION
## What this PR changes/adds

Supports filtering stateful entities by the `state` string representation. 

The concept evolves around an interface that provides a way to convert a `String` state representation into `int`:
```java
public interface StateResolver {

    int resolve(String stringState);

}
```

Different paths have been followed for in memory and sql stores.

### In memory
The logic of the `ReflectionBasedQueryResolver` that takes care to apply a `QuerySpec` to a `Stream` was quite coupled, so a `CriteriaToPredicate` interface was introduced, it just converts a `List<Criterion>` into a `Predicate<ENTITY>`.
The default implementation has the same logic that was in the resolver:
```java
    @Override
    public Predicate<T> convert(List<Criterion> criteria) {
        return criteria.stream()
                .map(criterionOperatorRegistry::<T>toPredicate)
                .reduce(x -> true, Predicate::and);
    }
```

The "stateful" implementation relies on a `StateResolver` to map the string status to int:
```java
    @Override
    public Predicate<E> convert(List<Criterion> criteria) {
        return criteria.stream()
                .map(criterion -> {
                    if (criterion.getOperandLeft().equals("state") && criterion.getOperandRight() instanceof String stateString) {
                        return criterion(criterion.getOperandLeft(), criterion.getOperator(), stateResolver.resolve(stateString));
                    }
                    return criterion;
                })
                .map(criterionOperatorRegistry::<E>toPredicate)
                .reduce(x -> true, Predicate::and);
    }
```

### Sql
The implementation for this branch is much easier because the design of the `FieldTranslator` permitted to implement an `EntityStateFieldTranslator` that, with the help of the `StateResolver` collaborator it provides the translation quite easily:
```java
public class EntityStateFieldTranslator extends PlainColumnFieldTranslator {

    private final StateResolver stateResolver;

    public EntityStateFieldTranslator(String columnName, StateResolver stateResolver) {
        super(columnName);
        this.stateResolver = stateResolver;
    }

    @Override
    public Collection<Object> toParameters(Criterion criterion) {
        return super.toParameters(criterion)
                .stream()
                .map(it -> it instanceof String stringState ? stateResolver.resolve(stringState) : it)
                .collect(toList());
    }
}
```

## Why it does that

permit entities `state` field to be queried both by the actual type `int` and by their `String` representation. 

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #4785

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
