### PR TITLE
Fixed Action building logic in JsonObjectFromPolicyTransformer

### DIFF
--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/odrl/from/JsonObjectFromPolicyTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/odrl/from/JsonObjectFromPolicyTransformer.java
@@ -264,16 +264,14 @@ public class JsonObjectFromPolicyTransformer extends AbstractJsonLdTransformer<P
             if (action == null) {
                 return actionBuilder.build();
             }
+            actionBuilder.add(ID, action.getType());
             if (action.getIncludedIn() != null || action.getConstraint() != null) {
-                actionBuilder.add(ODRL_ACTION_ATTRIBUTE, jsonFactory.createObjectBuilder().add(ID, action.getType()));
                 if (action.getIncludedIn() != null) {
                     actionBuilder.add(ODRL_INCLUDED_IN_ATTRIBUTE, action.getIncludedIn());
                 }
                 if (action.getConstraint() != null) {
                     actionBuilder.add(ODRL_REFINEMENT_ATTRIBUTE, action.getConstraint().accept(this));
                 }
-            } else {
-                actionBuilder.add(ID, action.getType());
             }
             return actionBuilder.build();
         }


### PR DESCRIPTION
## What this PR changes/adds

Fixes #4838.

## Why it does that

The `action` is wrapped into another `action` under certain circumstances, which, according to our understanding of the ODRL IM, seems to be an error.

## Linked Issue(s)

Closes #4838 
