### PR TITLE
build: add missing control-plane-api and policy-monitor modules to boms

### DIFF
--- a/dist/bom/controlplane-base-bom/build.gradle.kts
+++ b/dist/bom/controlplane-base-bom/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     api(project(":core:common:token-core"))
     api(project(":core:control-plane:control-plane-core"))
     api(project(":core:data-plane-selector:data-plane-selector-core"))
+    api(project(":core:policy-monitor:policy-monitor-core"))
     api(project(":data-protocols:dsp"))
 
     // extension dependencies
@@ -38,7 +39,9 @@ dependencies {
     api(project(":extensions:common:api:api-observability"))
     api(project(":extensions:common:api:control-api-configuration"))
     api(project(":extensions:common:api:version-api"))
+
     api(project(":extensions:common:http"))
+    api(project(":extensions:control-plane:api:control-plane-api"))
     api(project(":extensions:control-plane:api:management-api"))
     api(project(":extensions:control-plane:transfer:transfer-data-plane-signaling"))
     api(project(":extensions:data-plane-selector:data-plane-selector-api"))

--- a/dist/bom/controlplane-feature-sql-bom/build.gradle.kts
+++ b/dist/bom/controlplane-feature-sql-bom/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     api(project(":extensions:common:store:sql:edr-index-sql"))
     api(project(":extensions:common:store:sql:jti-validation-store-sql"))
     api(project(":extensions:data-plane-selector:store:sql:data-plane-instance-store-sql"))
+    api(project(":extensions:policy-monitor:store:sql:policy-monitor-store-sql"))
 
     // other SQL dependencies - not strictly necessary, but could come in handy for BOM users
     api(project(":extensions:common:sql:sql-core"))

--- a/system-tests/e2e-transfer-test/control-plane/build.gradle.kts
+++ b/system-tests/e2e-transfer-test/control-plane/build.gradle.kts
@@ -20,10 +20,7 @@ dependencies {
     implementation(project(":dist:bom:controlplane-base-bom"))
 
     implementation(project(":extensions:common:iam:iam-mock"))
-    implementation(project(":extensions:control-plane:api:control-plane-api"))
     implementation(project(":extensions:control-plane:provision:provision-http"))
-
-    implementation(project(":core:policy-monitor:policy-monitor-core"))
 }
 
 edcBuild {

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ManagementEndToEndExtension.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ManagementEndToEndExtension.java
@@ -82,12 +82,7 @@ public abstract class ManagementEndToEndExtension extends RuntimePerClassExtensi
         private static EmbeddedRuntime runtime() {
             return new EmbeddedRuntime("control-plane",
                     ":system-tests:management-api:management-api-test-runtime",
-                    ":extensions:control-plane:store:sql:control-plane-sql",
-                    ":extensions:policy-monitor:store:sql:policy-monitor-store-sql",
-                    ":extensions:common:store:sql:edr-index-sql",
-                    ":extensions:data-plane:store:sql:data-plane-store-sql",
-                    ":extensions:common:sql:sql-pool:sql-pool-apache-commons",
-                    ":extensions:common:transaction:transaction-local")
+                    ":dist:bom:controlplane-feature-sql-bom")
                     .configurationProvider(ManagementEndToEndExtension::runtimeConfig);
         }
 


### PR DESCRIPTION
## What this PR changes/adds

Adds missing modules to the controlplane boms

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #4759 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
