### PR TITLE
feat: switch JTI validation to black-listing

### DIFF
--- a/extensions/common/crypto/jwt-verifiable-credentials/src/test/java/org/eclipse/edc/verifiablecredentials/jwt/rules/JtiValidationRuleTest.java
+++ b/extensions/common/crypto/jwt-verifiable-credentials/src/test/java/org/eclipse/edc/verifiablecredentials/jwt/rules/JtiValidationRuleTest.java
@@ -17,14 +17,19 @@ package org.eclipse.edc.verifiablecredentials.jwt.rules;
 import org.eclipse.edc.jwt.validation.jti.JtiValidationEntry;
 import org.eclipse.edc.jwt.validation.jti.JtiValidationStore;
 import org.eclipse.edc.spi.iam.ClaimToken;
+import org.eclipse.edc.spi.result.StoreResult;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.util.Map;
 
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class JtiValidationRuleTest {
@@ -32,28 +37,52 @@ class JtiValidationRuleTest {
     private final JtiValidationStore store = mock();
     private final JtiValidationRule rule = new JtiValidationRule(store, mock());
 
+    @BeforeEach
+    void setUp() {
+        when(store.storeEntry(any())).thenReturn(StoreResult.success());
+    }
+
     @Test
     void checkRule_noExpiration_success() {
         when(store.findById(eq("test-id"))).thenReturn(new JtiValidationEntry("test-id"));
-        assertThat(rule.checkRule(ClaimToken.Builder.newInstance().claim("jti", "test-id").build(), Map.of())).isSucceeded();
+        assertThat(rule.checkRule(ClaimToken.Builder.newInstance().claim("jti", "test-id").build(), Map.of())).isFailed()
+                .detail().isEqualTo("The JWT id 'test-id' was already used.");
+        verify(store).storeEntry(any());
     }
 
     @Test
     void checkRule_withExpiration_success() {
         when(store.findById(eq("test-id"))).thenReturn(new JtiValidationEntry("test-id", Instant.now().plusSeconds(3600).toEpochMilli()));
-        assertThat(rule.checkRule(ClaimToken.Builder.newInstance().claim("jti", "test-id").build(), Map.of())).isSucceeded();
+        assertThat(rule.checkRule(ClaimToken.Builder.newInstance().claim("jti", "test-id").build(), Map.of())).isFailed()
+                .detail().isEqualTo("The JWT id 'test-id' was already used.");
+        verify(store).storeEntry(any());
     }
 
     @Test
     void checkRule_withExpiration_alreadyExpired() {
         when(store.findById(eq("test-id"))).thenReturn(new JtiValidationEntry("test-id", Instant.now().minusSeconds(3600).toEpochMilli()));
         assertThat(rule.checkRule(ClaimToken.Builder.newInstance().claim("jti", "test-id").build(), Map.of())).isSucceeded();
+        verify(store).storeEntry(any());
     }
 
     @Test
     void checkRule_entryNotFound_success() {
         when(store.findById(eq("test-id"))).thenReturn(null);
+        assertThat(rule.checkRule(ClaimToken.Builder.newInstance().claim("jti", "test-id").build(), Map.of())).isSucceeded();
+        verify(store).storeEntry(any());
+    }
+
+    @Test
+    void checkRule_entryNotFound_storeFails_failure() {
+        when(store.findById(eq("test-id"))).thenReturn(null);
+        when(store.storeEntry(any())).thenReturn(StoreResult.duplicateKeys("foobar"));
         assertThat(rule.checkRule(ClaimToken.Builder.newInstance().claim("jti", "test-id").build(), Map.of())).isFailed()
-                .detail().isEqualTo("The JWT id 'test-id' was not found");
+                .detail().isEqualTo("foobar");
+    }
+
+    @Test
+    void checkRule_whenClaimTokenNoKid() {
+        assertThat(rule.checkRule(ClaimToken.Builder.newInstance().build(), Map.of())).isSucceeded();
+        verify(store, never()).storeEntry(any());
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

this PR changes the JTI validation from white-listing to black-listing

## Why it does that

avoid coupling of the token issuer and the token verifier at the database layer

## Further notes

- another PR in IdentityHub will fix the token issuer side.

## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #4836

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
