### PR TITLE
refactor: cleanup test dependencies

### DIFF
--- a/core/common/boot/build.gradle.kts
+++ b/core/common/boot/build.gradle.kts
@@ -23,7 +23,6 @@ dependencies {
     implementation(project(":core:common:lib:boot-lib"))
 
     implementation(libs.opentelemetry.api)
-    testImplementation(libs.junit.jupiter.api)
 }
 
 

--- a/core/common/connector-core/build.gradle.kts
+++ b/core/common/connector-core/build.gradle.kts
@@ -46,7 +46,6 @@ dependencies {
 
     testImplementation(project(":core:common:junit"))
     testImplementation(libs.awaitility)
-    testImplementation(libs.junit.jupiter.api)
     testImplementation(libs.mockserver.netty)
 }
 

--- a/core/common/junit/build.gradle.kts
+++ b/core/common/junit/build.gradle.kts
@@ -30,10 +30,7 @@ dependencies {
     implementation(project(":spi:common:http-spi"))
     implementation(libs.okhttp)
     implementation(libs.mockito.core)
-    implementation(libs.assertj)
     implementation(libs.junit.jupiter.api)
-
-    runtimeOnly(libs.junit.jupiter.engine)
 
     implementation(libs.testcontainers.junit)
     testImplementation(project(":core:common:connector-core"))

--- a/core/common/lib/http-lib/build.gradle.kts
+++ b/core/common/lib/http-lib/build.gradle.kts
@@ -29,8 +29,6 @@ dependencies {
     testImplementation(project(":core:common:lib:json-lib"))
     testImplementation(project(":core:common:lib:util-lib"))
     testImplementation(libs.mockserver.netty)
-
-    testFixturesImplementation(libs.mockito.core)
 }
 
 

--- a/data-protocols/dsp/dsp-catalog/lib/dsp-catalog-http-api-lib/build.gradle.kts
+++ b/data-protocols/dsp/dsp-catalog/lib/dsp-catalog-http-api-lib/build.gradle.kts
@@ -30,6 +30,4 @@ dependencies {
     testFixturesApi(project(":core:common:junit"))
     testFixturesImplementation(testFixtures(project(":extensions:common:http:jersey-core")))
     testFixturesImplementation(libs.restAssured)
-    testFixturesImplementation(libs.assertj)
-    testFixturesImplementation(libs.mockito.core)
 }

--- a/data-protocols/dsp/dsp-http-spi/build.gradle.kts
+++ b/data-protocols/dsp/dsp-http-spi/build.gradle.kts
@@ -28,6 +28,4 @@ dependencies {
 
     testFixturesApi(project(":core:common:junit"))
     testFixturesApi(project(":spi:common:json-ld-spi"))
-    testFixturesImplementation(libs.mockito.core)
-    testFixturesImplementation(libs.assertj)
 }

--- a/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-http-api-lib/build.gradle.kts
+++ b/data-protocols/dsp/dsp-negotiation/lib/dsp-negotiation-http-api-lib/build.gradle.kts
@@ -25,7 +25,4 @@ dependencies {
     testFixturesImplementation(project(":core:common:junit"))
     testFixturesImplementation(testFixtures(project(":extensions:common:http:jersey-core")))
     testFixturesImplementation(libs.restAssured)
-    testFixturesImplementation(libs.assertj)
-    testFixturesImplementation(libs.mockito.core)
-    testFixturesImplementation(libs.junit.jupiter.params)
 }

--- a/data-protocols/dsp/dsp-transfer-process/lib/dsp-transfer-process-http-api-lib/build.gradle.kts
+++ b/data-protocols/dsp/dsp-transfer-process/lib/dsp-transfer-process-http-api-lib/build.gradle.kts
@@ -25,7 +25,4 @@ dependencies {
     testFixturesImplementation(project(":core:common:junit"))
     testFixturesImplementation(testFixtures(project(":extensions:common:http:jersey-core")))
     testFixturesImplementation(libs.restAssured)
-    testFixturesImplementation(libs.assertj)
-    testFixturesImplementation(libs.mockito.core)
-    testFixturesImplementation(libs.junit.jupiter.params)
 }

--- a/extensions/common/http/jersey-core/build.gradle.kts
+++ b/extensions/common/http/jersey-core/build.gradle.kts
@@ -37,8 +37,6 @@ dependencies {
     testFixturesImplementation(project(":extensions:common:http:lib:jersey-providers-lib"))
     testFixturesApi(libs.jakarta.rsApi)
     testFixturesApi(libs.jackson.datatype.jakarta.jsonp)
-    testFixturesApi(libs.junit.jupiter.api)
-    testFixturesApi(libs.mockito.core)
 }
 
 

--- a/extensions/common/sql/sql-bootstrapper/build.gradle.kts
+++ b/extensions/common/sql/sql-bootstrapper/build.gradle.kts
@@ -23,9 +23,8 @@ dependencies {
     api(project(":spi:common:transaction-spi"))
     implementation(project(":spi:common:transaction-datasource-spi"))
     implementation(project(":core:common:lib:sql-lib"))
-//
+
     testImplementation(project(":core:common:junit"))
-    testImplementation(libs.assertj)
 }
 
 

--- a/extensions/common/sql/sql-lease/build.gradle.kts
+++ b/extensions/common/sql/sql-lease/build.gradle.kts
@@ -28,7 +28,6 @@ dependencies {
     testImplementation(project(":extensions:common:transaction:transaction-local"))
     testImplementation(testFixtures(project(":extensions:common:sql:sql-test-fixtures")))
     testImplementation(libs.postgres)
-    testImplementation(libs.assertj)
 
     testFixturesImplementation(project(":core:common:lib:sql-lib")) // TODO: these fixtures could finish in sql-testfixtures module
 }

--- a/extensions/common/sql/sql-test-fixtures/build.gradle.kts
+++ b/extensions/common/sql/sql-test-fixtures/build.gradle.kts
@@ -25,8 +25,6 @@ dependencies {
     testFixturesImplementation(project(":core:common:lib:sql-lib"))
     testFixturesImplementation(project(":extensions:common:sql:sql-lease"))
 
-    testFixturesImplementation(libs.junit.jupiter.api)
-    testFixturesImplementation(libs.mockito.core)
     testFixturesImplementation(libs.postgres)
     testFixturesImplementation(libs.testcontainers.junit)
     testFixturesImplementation(libs.testcontainers.postgres)

--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/build.gradle.kts
@@ -25,10 +25,6 @@ dependencies {
     testFixturesApi(project(":core:common:lib:util-lib"))
     testFixturesApi(project(":core:common:lib:json-ld-lib"))
 
-    testFixturesApi(libs.junit.jupiter.api)
-
-    testFixturesImplementation(libs.assertj)
     testFixturesImplementation(libs.restAssured)
     testFixturesImplementation(libs.awaitility)
-    testFixturesImplementation(libs.mockito.core)
 }

--- a/extensions/control-plane/store/sql/asset-index-sql/build.gradle.kts
+++ b/extensions/control-plane/store/sql/asset-index-sql/build.gradle.kts
@@ -30,7 +30,6 @@ dependencies {
     testImplementation(project(":core:common:junit"))
 
     testImplementation(project(":spi:common:policy-model"))
-    testImplementation(libs.assertj)
     testImplementation(testFixtures(project(":spi:control-plane:asset-spi")))
     testImplementation(testFixtures(project(":extensions:common:sql:sql-test-fixtures")))
     testImplementation(libs.postgres)

--- a/extensions/control-plane/store/sql/contract-definition-store-sql/build.gradle.kts
+++ b/extensions/control-plane/store/sql/contract-definition-store-sql/build.gradle.kts
@@ -27,7 +27,6 @@ dependencies {
 
     testImplementation(project(":core:common:junit"))
     testImplementation(project(":spi:common:policy-model"))
-    testImplementation(libs.assertj)
     testImplementation(testFixtures(project(":extensions:common:sql:sql-test-fixtures")))
     testImplementation(testFixtures(project(":spi:control-plane:contract-spi")))
     testImplementation(libs.postgres)

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/build.gradle.kts
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/build.gradle.kts
@@ -28,7 +28,6 @@ dependencies {
 
 
     testImplementation(project(":core:common:junit"))
-    testImplementation(libs.assertj)
     testImplementation(testFixtures(project(":spi:control-plane:contract-spi")))
     testImplementation(testFixtures(project(":extensions:common:sql:sql-test-fixtures")))
     testImplementation(libs.postgres)

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/build.gradle.kts
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/build.gradle.kts
@@ -28,7 +28,6 @@ dependencies {
     implementation(project(":extensions:common:sql:sql-bootstrapper"))
 
     testImplementation(project(":core:common:junit"))
-    testImplementation(libs.assertj)
     testImplementation(libs.awaitility)
     testImplementation(libs.postgres)
     testImplementation(testFixtures(project(":spi:control-plane:transfer-spi")))

--- a/extensions/data-plane/data-plane-integration-tests/build.gradle.kts
+++ b/extensions/data-plane/data-plane-integration-tests/build.gradle.kts
@@ -17,9 +17,7 @@ plugins {
 }
 
 dependencies {
-    testImplementation(libs.bundles.jupiter)
     testImplementation(libs.restAssured)
-    testImplementation(libs.assertj)
     testImplementation(libs.awaitility)
     testImplementation(libs.mockserver.netty)
     testImplementation(libs.mockserver.client)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -71,8 +71,6 @@ jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "j
 jetty-jakarta-servlet-api = { module = "org.eclipse.jetty.toolchain:jetty-jakarta-servlet-api", version.ref = "jetty-jakarta-servlet-api" }
 jetty-websocket = { module = "org.eclipse.jetty.websocket:websocket-jakarta-server", version.ref = "jetty" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "jupiter" }
-junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "jupiter" }
-junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "jupiter" }
 junit-pioneer = { module = "org.junit-pioneer:junit-pioneer", version.ref = "junit-pioneer" }
 micrometer = { module = "io.micrometer:micrometer-core", version.ref = "micrometer" }
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
@@ -106,9 +104,8 @@ jsonschema = { module = "com.networknt:json-schema-validator", version = "1.5.6"
 
 
 [bundles]
-jackson = ["jackson.annotations", "jackson.databind"]
-jersey-core = ["jersey.server", "jersey.common", "jersey.jackson", "jersey.multipart", "jersey.inject", "jersey.servlet", "jersey.servletcore"]
-jupiter = ["junit-jupiter-api", "junit-jupiter-params"]
+jackson = ["jackson-annotations", "jackson-databind"]
+jersey-core = ["jersey-server", "jersey-common", "jersey-jackson", "jersey-multipart", "jersey-inject", "jersey-servlet", "jersey-servletcore"]
 
 [plugins]
 shadow = { id = "com.gradleup.shadow", version = "8.3.6" }

--- a/spi/common/core-spi/build.gradle.kts
+++ b/spi/common/core-spi/build.gradle.kts
@@ -27,11 +27,6 @@ dependencies {
 
     testImplementation(project(":tests:junit-base"))
     testImplementation(project(":core:common:lib:json-lib"))
-
-    testFixturesImplementation(libs.bundles.jupiter)
-    testFixturesImplementation(libs.mockito.core)
-    testFixturesImplementation(libs.assertj)
-    testFixturesRuntimeOnly(libs.junit.jupiter.engine)
 }
 
 

--- a/spi/common/edr-store-spi/build.gradle.kts
+++ b/spi/common/edr-store-spi/build.gradle.kts
@@ -20,12 +20,7 @@ plugins {
 dependencies {
     api(project(":spi:common:core-spi"))
 
-    // needed by the abstract test spec located in testFixtures
-    testFixturesImplementation(libs.bundles.jupiter)
-    testFixturesImplementation(libs.mockito.core)
-    testFixturesImplementation(libs.assertj)
     testFixturesImplementation(project(":core:common:junit"))
-    testFixturesRuntimeOnly(libs.junit.jupiter.engine)
 }
 
 

--- a/spi/common/jwt-spi/build.gradle.kts
+++ b/spi/common/jwt-spi/build.gradle.kts
@@ -21,8 +21,6 @@ plugins {
 dependencies {
     implementation(libs.edc.runtime.metamodel)
     api(project(":spi:common:core-spi"))
-    testFixturesImplementation(libs.bundles.jupiter)
-    testFixturesImplementation(libs.assertj)
     testFixturesImplementation(project(":tests:junit-base"))
 }
 

--- a/spi/control-plane/asset-spi/build.gradle.kts
+++ b/spi/control-plane/asset-spi/build.gradle.kts
@@ -23,12 +23,6 @@ dependencies {
 
     testImplementation(project(":tests:junit-base"))
     testImplementation(project(":core:common:lib:json-lib"))
-
-    // needed by the abstract test spec located in testFixtures
-    testFixturesImplementation(libs.bundles.jupiter)
-    testFixturesImplementation(libs.mockito.core)
-    testFixturesImplementation(libs.assertj)
-    testFixturesRuntimeOnly(libs.junit.jupiter.engine)
 }
 
 

--- a/spi/control-plane/contract-spi/build.gradle.kts
+++ b/spi/control-plane/contract-spi/build.gradle.kts
@@ -27,13 +27,8 @@ dependencies {
     testImplementation(project(":tests:junit-base"))
     testImplementation(project(":core:common:lib:json-lib"))
 
-    // needed by the abstract test spec located in testFixtures
     testFixturesImplementation(project(":spi:control-plane:asset-spi"))
-    testFixturesImplementation(libs.bundles.jupiter)
-    testFixturesImplementation(libs.mockito.core)
-    testFixturesImplementation(libs.assertj)
     testFixturesImplementation(project(":core:common:junit"))
-    testFixturesRuntimeOnly(libs.junit.jupiter.engine)
 }
 
 

--- a/spi/control-plane/policy-spi/build.gradle.kts
+++ b/spi/control-plane/policy-spi/build.gradle.kts
@@ -22,9 +22,6 @@ dependencies {
     api(project(":spi:common:core-spi"))
 
     testImplementation(project(":core:common:lib:json-lib"))
-
-    testFixturesImplementation(libs.bundles.jupiter)
-    testFixturesImplementation(libs.assertj)
 }
 
 

--- a/spi/control-plane/transfer-spi/build.gradle.kts
+++ b/spi/control-plane/transfer-spi/build.gradle.kts
@@ -28,8 +28,6 @@ dependencies {
     testImplementation(project(":core:common:lib:json-lib"))
 
     testFixturesImplementation(project(":core:common:junit"))
-    testFixturesImplementation(libs.bundles.jupiter)
-    testFixturesImplementation(libs.assertj)
     testFixturesImplementation(libs.awaitility)
 }
 

--- a/spi/data-plane-selector/data-plane-selector-spi/build.gradle.kts
+++ b/spi/data-plane-selector/data-plane-selector-spi/build.gradle.kts
@@ -25,11 +25,7 @@ dependencies {
     testImplementation(project(":core:common:lib:json-lib"))
 
     testFixturesImplementation(testFixtures(project(":core:common:junit")))
-    testFixturesImplementation(libs.bundles.jupiter)
-    testFixturesImplementation(libs.mockito.core)
-    testFixturesImplementation(libs.assertj)
     testFixturesImplementation(libs.awaitility)
-    testFixturesRuntimeOnly(libs.junit.jupiter.engine)
 }
 
 

--- a/spi/data-plane/data-plane-http-spi/build.gradle.kts
+++ b/spi/data-plane/data-plane-http-spi/build.gradle.kts
@@ -20,9 +20,6 @@ plugins {
 dependencies {
     api(project(":spi:common:core-spi"))
     api(project(":spi:common:data-address:data-address-http-data-spi"))
-
-    testFixturesImplementation(libs.bundles.jupiter)
-    testFixturesImplementation(libs.assertj)
 }
 
 

--- a/spi/data-plane/data-plane-spi/build.gradle.kts
+++ b/spi/data-plane/data-plane-spi/build.gradle.kts
@@ -21,8 +21,6 @@ dependencies {
     api(project(":spi:common:core-spi"))
 
     testFixturesApi(project(":core:common:junit"))
-    testFixturesImplementation(libs.bundles.jupiter)
-    testFixturesImplementation(libs.assertj)
     testFixturesImplementation(libs.awaitility)
 }
 

--- a/spi/policy-monitor/policy-monitor-spi/build.gradle.kts
+++ b/spi/policy-monitor/policy-monitor-spi/build.gradle.kts
@@ -23,8 +23,6 @@ dependencies {
     api(project(":spi:control-plane:contract-spi"))
 
     testFixturesApi(project(":core:common:junit"))
-    testFixturesImplementation(libs.bundles.jupiter)
-    testFixturesImplementation(libs.assertj)
     testFixturesImplementation(libs.awaitility)
 }
 

--- a/system-tests/bom-tests/build.gradle.kts
+++ b/system-tests/bom-tests/build.gradle.kts
@@ -20,7 +20,6 @@ dependencies {
     testImplementation(project(":core:common:junit"))
     testImplementation(project(":core:common:lib:boot-lib"))
     testImplementation(libs.restAssured)
-    testImplementation(libs.assertj)
     testImplementation(libs.awaitility)
     testImplementation(libs.mockserver.netty)
     testImplementation(libs.mockserver.client)

--- a/system-tests/dsp-compatibility-tests/compatibility-test-runner/build.gradle.kts
+++ b/system-tests/dsp-compatibility-tests/compatibility-test-runner/build.gradle.kts
@@ -18,7 +18,6 @@ plugins {
 
 dependencies {
     testImplementation(project(":core:common:junit"))
-    testImplementation(libs.assertj)
     testImplementation(libs.awaitility)
     testImplementation(libs.testcontainers.junit)
     runtimeOnly(libs.parsson)

--- a/system-tests/e2e-dataplane-tests/tests/build.gradle.kts
+++ b/system-tests/e2e-dataplane-tests/tests/build.gradle.kts
@@ -28,9 +28,7 @@ dependencies {
     testImplementation(testFixtures(project(":extensions:control-plane:api:management-api:management-api-test-fixtures")))
 
     testImplementation(libs.restAssured)
-    testImplementation(libs.assertj)
     testImplementation(libs.awaitility)
-    testImplementation(libs.junit.jupiter.api)
     testImplementation(libs.mockserver.netty)
     testImplementation(libs.mockserver.client)
     testImplementation(libs.testcontainers.postgres)

--- a/system-tests/e2e-transfer-test/runner/build.gradle.kts
+++ b/system-tests/e2e-transfer-test/runner/build.gradle.kts
@@ -32,9 +32,7 @@ dependencies {
 
     testImplementation(libs.postgres)
     testImplementation(libs.restAssured)
-    testImplementation(libs.assertj)
     testImplementation(libs.awaitility)
-    testImplementation(libs.junit.jupiter.api)
     testImplementation(libs.mockserver.netty)
     testImplementation(libs.mockserver.client)
     testImplementation(libs.kafkaClients)

--- a/system-tests/management-api/management-api-test-runner/build.gradle.kts
+++ b/system-tests/management-api/management-api-test-runner/build.gradle.kts
@@ -35,9 +35,7 @@ dependencies {
     testImplementation(project(":extensions:common:json-ld"))
 
     testImplementation(libs.restAssured)
-    testImplementation(libs.assertj)
     testImplementation(libs.awaitility)
-    testImplementation(libs.junit.jupiter.api)
     testImplementation(testFixtures(project(":extensions:common:sql:sql-test-fixtures")))
     testImplementation(project(":extensions:common:transaction:transaction-local"))
     testImplementation(libs.testcontainers.junit)

--- a/system-tests/telemetry/telemetry-test-runner/build.gradle.kts
+++ b/system-tests/telemetry/telemetry-test-runner/build.gradle.kts
@@ -24,9 +24,7 @@ dependencies {
     testImplementation(project(":core:common:connector-core"))
 
     testImplementation(libs.restAssured)
-    testImplementation(libs.assertj)
     testImplementation(libs.awaitility)
-    testImplementation(libs.junit.jupiter.api)
     testImplementation(libs.mockserver.netty)
     testImplementation(libs.mockserver.client)
     testImplementation(libs.opentelemetry.proto)

--- a/system-tests/version-api/version-api-test-runner/build.gradle.kts
+++ b/system-tests/version-api/version-api-test-runner/build.gradle.kts
@@ -36,9 +36,7 @@ dependencies {
     testImplementation(project(":extensions:common:json-ld"))
 
     testImplementation(libs.restAssured)
-    testImplementation(libs.assertj)
     testImplementation(libs.awaitility)
-    testImplementation(libs.junit.jupiter.api)
     testImplementation(testFixtures(project(":extensions:common:sql:sql-test-fixtures")))
     testImplementation(project(":extensions:common:transaction:transaction-local"))
     testImplementation(libs.testcontainers.junit)

--- a/tests/junit-base/build.gradle.kts
+++ b/tests/junit-base/build.gradle.kts
@@ -19,11 +19,9 @@ plugins {
 }
 
 dependencies {
-
     api(project(":spi:common:boot-spi"))
 
     implementation(libs.assertj)
-    implementation(libs.junit.jupiter.api)
     implementation(libs.testcontainers.junit)
 }
 

--- a/tests/junit-base/src/main/java/org/eclipse/edc/junit/testfixtures/TestUtils.java
+++ b/tests/junit-base/src/main/java/org/eclipse/edc/junit/testfixtures/TestUtils.java
@@ -14,8 +14,6 @@
 
 package org.eclipse.edc.junit.testfixtures;
 
-import org.opentest4j.AssertionFailedError;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -37,12 +35,12 @@ public class TestUtils {
     public static URI getResource(String name) {
         var resource = Thread.currentThread().getContextClassLoader().getResource(name);
         if (resource == null) {
-            throw new AssertionFailedError("Cannot find resource " + name);
+            throw new AssertionError("Cannot find resource " + name);
         }
         try {
             return resource.toURI();
         } catch (URISyntaxException e) {
-            throw new AssertionFailedError("Cannot find resource " + name, e);
+            throw new AssertionError("Cannot find resource " + name, e);
         }
     }
 


### PR DESCRIPTION
## What this PR changes/adds

Cleanup test dependencies

## Why it does that

After this was merged (https://github.com/eclipse-edc/GradlePlugins/pull/319) there's no need to explicit define test dependencies for assertJ, junit and mockito, also for test fixtures

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
