### PR TITLE
feat: add provisioning phase for consumer on data plane

### DIFF
--- a/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/flow/DataFlowManagerImpl.java
+++ b/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/flow/DataFlowManagerImpl.java
@@ -58,6 +58,17 @@ public class DataFlowManagerImpl implements DataFlowManager {
         controllers.add(new PrioritizedDataFlowController(priority, controller));
     }
 
+    @Override
+    public @NotNull StatusResult<DataFlowResponse> provision(TransferProcess transferProcess, Policy policy) {
+        try {
+            return chooseControllerAndApply(transferProcess, controller -> controller.provision(transferProcess, policy));
+        } catch (Exception e) {
+            var message = runtimeException(transferProcess.getId(), e.getMessage());
+            monitor.severe(message, e);
+            return StatusResult.failure(FATAL_ERROR, message);
+        }
+    }
+
     @WithSpan
     @Override
     public @NotNull StatusResult<DataFlowResponse> start(TransferProcess transferProcess, Policy policy) {

--- a/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImpl.java
+++ b/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImpl.java
@@ -204,6 +204,15 @@ public class TransferProcessManagerImpl extends AbstractStateEntityManager<Trans
 
         ResourceManifest manifest;
         if (process.getType() == CONSUMER) {
+            var provisioning = dataFlowManager.provision(process, policy);
+            if (provisioning.succeeded()) {
+                var response = provisioning.getContent();
+                process.setDataPlaneId(response.getDataPlaneId());
+                process.transitionRequesting();
+                update(process);
+                return true;
+            }
+
             var manifestResult = manifestGenerator.generateConsumerResourceManifest(process, policy);
             if (manifestResult.failed()) {
                 transitionToTerminated(process, format("Resource manifest for process %s cannot be modified to fulfil policy. %s", process.getId(), manifestResult.getFailureMessages()));

--- a/core/control-plane/control-plane-transfer/src/test/java/org/eclipse/edc/connector/controlplane/transfer/flow/DataFlowManagerImplTest.java
+++ b/core/control-plane/control-plane-transfer/src/test/java/org/eclipse/edc/connector/controlplane/transfer/flow/DataFlowManagerImplTest.java
@@ -119,6 +119,27 @@ class DataFlowManagerImplTest {
     }
 
     @Nested
+    class Provision {
+        @Test
+        void shouldChooseControllerAndProvision() {
+            var controller = mock(DataFlowController.class);
+            var dataDestination = DataAddress.Builder.newInstance().type("test-dest-type").build();
+            var dataAddress = DataAddress.Builder.newInstance().type("test-type").build();
+            var transferProcess = TransferProcess.Builder.newInstance().dataDestination(dataDestination).contentDataAddress(dataAddress).build();
+            var policy = Policy.Builder.newInstance().build();
+
+            when(controller.canHandle(any())).thenReturn(true);
+            when(controller.provision(any(), any())).thenReturn(StatusResult.success(DataFlowResponse.Builder.newInstance().build()));
+            manager.register(controller);
+
+            var result = manager.provision(transferProcess, policy);
+
+            assertThat(result).isSucceeded();
+            verify(controller).provision(transferProcess, policy);
+        }
+    }
+
+    @Nested
     class Suspend {
         @Test
         void shouldChooseControllerAndSuspend() {

--- a/core/control-plane/control-plane-transfer/src/test/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImplIntegrationTest.java
+++ b/core/control-plane/control-plane-transfer/src/test/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImplIntegrationTest.java
@@ -78,6 +78,7 @@ import static org.eclipse.edc.connector.controlplane.transfer.spi.types.Transfer
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.STARTING;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.TERMINATING;
 import static org.eclipse.edc.spi.response.ResponseStatus.ERROR_RETRY;
+import static org.eclipse.edc.spi.response.ResponseStatus.FATAL_ERROR;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -136,6 +137,7 @@ class TransferProcessManagerImplIntegrationTest {
     @DisplayName("Verify that no process 'starves' during two consecutive runs, when the batch size > number of processes")
     void verifyProvision_shouldNotStarve() {
         var numProcesses = TRANSFER_MANAGER_BATCH_SIZE * 2;
+        when(dataFlowManager.provision(any(), any())).thenReturn(StatusResult.failure(FATAL_ERROR));
         when(provisionManager.provision(any(), any(Policy.class))).thenAnswer(i -> completedFuture(List.of(
                 ProvisionResponse.Builder.newInstance()
                         .resource(new TestProvisionedDataDestinationResource("any", "1"))

--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/DataPlaneDefaultServicesExtension.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/DataPlaneDefaultServicesExtension.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.connector.dataplane.framework;
 
 import org.eclipse.edc.connector.dataplane.framework.pipeline.PipelineServiceImpl;
+import org.eclipse.edc.connector.dataplane.framework.provision.ResourceDefinitionGeneratorManagerImpl;
 import org.eclipse.edc.connector.dataplane.framework.registry.TransferServiceSelectionStrategy;
 import org.eclipse.edc.connector.dataplane.framework.store.InMemoryAccessTokenDataStore;
 import org.eclipse.edc.connector.dataplane.framework.store.InMemoryDataPlaneStore;
@@ -22,6 +23,7 @@ import org.eclipse.edc.connector.dataplane.spi.iam.DataPlaneAuthorizationService
 import org.eclipse.edc.connector.dataplane.spi.iam.NoOpDataPlaneAuthorizationService;
 import org.eclipse.edc.connector.dataplane.spi.iam.PublicEndpointGeneratorService;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.PipelineService;
+import org.eclipse.edc.connector.dataplane.spi.provision.ResourceDefinitionGeneratorManager;
 import org.eclipse.edc.connector.dataplane.spi.store.AccessTokenDataStore;
 import org.eclipse.edc.connector.dataplane.spi.store.DataPlaneStore;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
@@ -77,5 +79,10 @@ public class DataPlaneDefaultServicesExtension implements ServiceExtension {
     public DataPlaneAuthorizationService dataPlaneAuthorizationService(ServiceExtensionContext context) {
         context.getMonitor().info("No proper DataPlaneAuthorizationService provided. The data-plane won't support PULL transfer types.");
         return new NoOpDataPlaneAuthorizationService();
+    }
+
+    @Provider
+    public ResourceDefinitionGeneratorManager resourceDefinitionGeneratorManager() {
+        return new ResourceDefinitionGeneratorManagerImpl();
     }
 }

--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/DataPlaneFrameworkExtension.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/DataPlaneFrameworkExtension.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.connector.dataplane.spi.iam.DataPlaneAuthorizationService
 import org.eclipse.edc.connector.dataplane.spi.manager.DataPlaneManager;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.DataTransferExecutorServiceContainer;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.PipelineService;
+import org.eclipse.edc.connector.dataplane.spi.provision.ResourceDefinitionGeneratorManager;
 import org.eclipse.edc.connector.dataplane.spi.registry.TransferServiceRegistry;
 import org.eclipse.edc.connector.dataplane.spi.store.DataPlaneStore;
 import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
@@ -114,6 +115,8 @@ public class DataPlaneFrameworkExtension implements ServiceExtension {
     private PipelineService pipelineService;
     @Inject
     private DataPlaneAuthorizationService authorizationService;
+    @Inject
+    private ResourceDefinitionGeneratorManager resourceDefinitionGeneratorManager;
 
     @Override
     public String name() {
@@ -144,6 +147,7 @@ public class DataPlaneFrameworkExtension implements ServiceExtension {
                 .telemetry(telemetry)
                 .runtimeId(context.getRuntimeId())
                 .flowLeaseConfiguration(flowLeaseConfiguration)
+                .resourceDefinitionGeneratorManager(resourceDefinitionGeneratorManager)
                 .build();
 
         context.registerService(DataPlaneManager.class, dataPlaneManager);
@@ -168,11 +172,6 @@ public class DataPlaneFrameworkExtension implements ServiceExtension {
         var executorService = Executors.newFixedThreadPool(numThreads);
         return new DataTransferExecutorServiceContainer(
                 executorInstrumentation.instrument(executorService, "Data plane transfers"));
-    }
-
-    @NotNull
-    private EntityRetryProcessConfiguration getEntityRetryProcessConfiguration() {
-        return new EntityRetryProcessConfiguration(sendRetryLimit, () -> new ExponentialWaitStrategy(sendRetryBaseDelay));
     }
 
     @Settings
@@ -201,5 +200,11 @@ public class DataPlaneFrameworkExtension implements ServiceExtension {
         public long abandonTime() {
             return time * factor;
         }
+
+    }
+
+    @NotNull
+    private EntityRetryProcessConfiguration getEntityRetryProcessConfiguration() {
+        return new EntityRetryProcessConfiguration(sendRetryLimit, () -> new ExponentialWaitStrategy(sendRetryBaseDelay));
     }
 }

--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/provision/ResourceDefinitionGeneratorManagerImpl.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/provision/ResourceDefinitionGeneratorManagerImpl.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.framework.provision;
+
+import org.eclipse.edc.connector.dataplane.spi.DataFlow;
+import org.eclipse.edc.connector.dataplane.spi.provision.ProvisionResourceDefinition;
+import org.eclipse.edc.connector.dataplane.spi.provision.ResourceDefinitionGenerator;
+import org.eclipse.edc.connector.dataplane.spi.provision.ResourceDefinitionGeneratorManager;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import static java.util.stream.Collectors.toSet;
+
+public class ResourceDefinitionGeneratorManagerImpl implements ResourceDefinitionGeneratorManager {
+
+    private final List<ResourceDefinitionGenerator> consumerGenerators = new ArrayList<>();
+
+    @Override
+    public void registerConsumerGenerator(ResourceDefinitionGenerator generator) {
+        consumerGenerators.add(generator);
+    }
+
+    @Override
+    public void registerProviderGenerator(ResourceDefinitionGenerator generator) {
+
+    }
+
+    @Override
+    public List<ProvisionResourceDefinition> generateConsumerResourceDefinition(DataFlow dataFlow) {
+        return consumerGenerators.stream()
+                .filter(g -> g.supportedType().equals(dataFlow.getDestination().getType()))
+                .map(g -> g.generate(dataFlow))
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    @Override
+    public List<ProvisionResourceDefinition> generateProviderResourceDefinition(DataFlow dataFlow) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Set<String> destinationTypes() {
+        return consumerGenerators.stream().map(ResourceDefinitionGenerator::supportedType).collect(toSet());
+    }
+}

--- a/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/provision/ResourceDefinitionGeneratorManagerImplTest.java
+++ b/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/provision/ResourceDefinitionGeneratorManagerImplTest.java
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.framework.provision;
+
+import org.eclipse.edc.connector.dataplane.spi.DataFlow;
+import org.eclipse.edc.connector.dataplane.spi.provision.ProvisionResourceDefinition;
+import org.eclipse.edc.connector.dataplane.spi.provision.ResourceDefinitionGenerator;
+import org.eclipse.edc.connector.dataplane.spi.provision.ResourceDefinitionGeneratorManager;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ResourceDefinitionGeneratorManagerImplTest {
+
+    private final ResourceDefinitionGeneratorManager manager = new ResourceDefinitionGeneratorManagerImpl();
+
+    @Nested
+    class Consumer {
+
+        private final ResourceDefinitionGenerator supportedGenerator = mock();
+
+        @BeforeEach
+        void setUp() {
+            when(supportedGenerator.supportedType()).thenReturn("supportedType");
+            when(supportedGenerator.generate(any())).thenReturn(new ProvisionResourceDefinition());
+
+            manager.registerConsumerGenerator(supportedGenerator);
+        }
+
+        @Test
+        void generate_shouldGenerateResources() {
+            var destination = DataAddress.Builder.newInstance().type("supportedType").build();
+            var dataFlow = DataFlow.Builder.newInstance().destination(destination).build();
+
+            var definitions = manager.generateConsumerResourceDefinition(dataFlow);
+
+            assertThat(definitions).hasSize(1);
+        }
+
+        @Test
+        void destinationTypes_shouldReturnRegisteredDestinationTypes() {
+            var types = manager.destinationTypes();
+
+            assertThat(types).containsOnly("supportedType");
+        }
+    }
+
+}

--- a/extensions/data-plane-selector/data-plane-selector-client/src/main/java/org/eclipse/edc/connector/dataplane/selector/RemoteDataPlaneSelectorService.java
+++ b/extensions/data-plane-selector/data-plane-selector-client/src/main/java/org/eclipse/edc/connector/dataplane/selector/RemoteDataPlaneSelectorService.java
@@ -36,6 +36,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 import static jakarta.json.Json.createObjectBuilder;
 import static okhttp3.internal.Util.EMPTY_REQUEST;
@@ -82,6 +83,11 @@ public class RemoteDataPlaneSelectorService implements DataPlaneSelectorService 
                         .map(Result::getContent)
                         .toList()
                 );
+    }
+
+    @Override
+    public ServiceResult<DataPlaneInstance> select(@Nullable String selectionStrategy, Predicate<DataPlaneInstance> filter) {
+        return ServiceResult.unexpected("RemoteDataPlaneSelectorService.select for consumer not implemented yet");
     }
 
     @Override

--- a/extensions/data-plane/data-plane-self-registration/src/main/java/org/eclipse/edc/connector/dataplane/registration/DataplaneSelfRegistrationExtension.java
+++ b/extensions/data-plane/data-plane-self-registration/src/main/java/org/eclipse/edc/connector/dataplane/registration/DataplaneSelfRegistrationExtension.java
@@ -18,6 +18,7 @@ import org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService
 import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
 import org.eclipse.edc.connector.dataplane.spi.iam.PublicEndpointGeneratorService;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.PipelineService;
+import org.eclipse.edc.connector.dataplane.spi.provision.ResourceDefinitionGeneratorManager;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
@@ -63,6 +64,8 @@ public class DataplaneSelfRegistrationExtension implements ServiceExtension {
     private PublicEndpointGeneratorService publicEndpointGeneratorService;
     @Inject
     private HealthCheckService healthCheckService;
+    @Inject
+    private ResourceDefinitionGeneratorManager resourceDefinitionGeneratorManager;
 
     private ServiceExtensionContext context;
 
@@ -88,6 +91,7 @@ public class DataplaneSelfRegistrationExtension implements ServiceExtension {
                 .url(controlApiUrl.get().toString() + "/v1/dataflows")
                 .allowedSourceTypes(pipelineService.supportedSourceTypes())
                 .allowedTransferType(transferTypes.collect(toSet()))
+                .destinationProvisionTypes(resourceDefinitionGeneratorManager.destinationTypes())
                 .build();
 
         var monitor = context.getMonitor().withPrefix("DataPlaneHealthCheck");

--- a/extensions/data-plane/data-plane-self-registration/src/test/java/org/eclipse/edc/connector/dataplane/registration/DataplaneSelfRegistrationExtensionTest.java
+++ b/extensions/data-plane/data-plane-self-registration/src/test/java/org/eclipse/edc/connector/dataplane/registration/DataplaneSelfRegistrationExtensionTest.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService
 import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
 import org.eclipse.edc.connector.dataplane.spi.iam.PublicEndpointGeneratorService;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.PipelineService;
+import org.eclipse.edc.connector.dataplane.spi.provision.ResourceDefinitionGeneratorManager;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
@@ -55,6 +56,7 @@ class DataplaneSelfRegistrationExtensionTest {
     private final PipelineService pipelineService = mock();
     private final PublicEndpointGeneratorService publicEndpointGeneratorService = mock();
     private final HealthCheckService healthCheckService = mock();
+    private final ResourceDefinitionGeneratorManager resourceDefinitionGeneratorManager = mock();
 
     @BeforeEach
     void setUp(ServiceExtensionContext context) {
@@ -66,6 +68,7 @@ class DataplaneSelfRegistrationExtensionTest {
         when(monitor.withPrefix(anyString())).thenReturn(monitor);
         context.registerService(Monitor.class, monitor);
         context.registerService(HealthCheckService.class, healthCheckService);
+        context.registerService(ResourceDefinitionGeneratorManager.class, resourceDefinitionGeneratorManager);
     }
 
     @Test
@@ -76,6 +79,7 @@ class DataplaneSelfRegistrationExtensionTest {
         when(pipelineService.supportedSourceTypes()).thenReturn(Set.of("sourceType", "anotherSourceType"));
         when(publicEndpointGeneratorService.supportedDestinationTypes()).thenReturn(Set.of("pullDestType", "anotherPullDestType"));
         when(publicEndpointGeneratorService.supportedResponseTypes()).thenReturn(Set.of("responseType", "anotherResponseType"));
+        when(resourceDefinitionGeneratorManager.destinationTypes()).thenReturn(Set.of("supportedDestinationProvisionType"));
         when(dataPlaneSelectorService.addInstance(any())).thenReturn(ServiceResult.success());
 
         extension.initialize(context);
@@ -100,6 +104,7 @@ class DataplaneSelfRegistrationExtensionTest {
                         "pullDestType-PULL-responseType",
                         "sinkType-PUSH-responseType",
                         "sinkType-PUSH");
+        assertThat(dataPlaneInstance.getDestinationProvisionTypes()).containsOnly("supportedDestinationProvisionType");
 
         verify(healthCheckService).addStartupStatusProvider(any());
         verify(healthCheckService).addLivenessProvider(any());

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/main/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClient.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/main/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClient.java
@@ -29,6 +29,7 @@ import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.ServiceFailure;
 import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowResponseMessage;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowSuspendMessage;
@@ -70,6 +71,11 @@ public class DataPlaneSignalingClient implements DataPlaneClient {
 
     private static <T> @NotNull StatusResult<T> failedResult(String processId, ServiceFailure failure) {
         return StatusResult.failure(FATAL_ERROR, format("Transfer request for process %s failed: %s", processId, failure.getFailureDetail()));
+    }
+
+    @Override
+    public StatusResult<DataFlowResponseMessage> provision(DataFlowProvisionMessage message) {
+        return StatusResult.failure(FATAL_ERROR, "remote data flow preparation not implemented yet.");
     }
 
     @WithSpan

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/main/java/org/eclipse/edc/connector/dataplane/client/EmbeddedDataPlaneClient.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/main/java/org/eclipse/edc/connector/dataplane/client/EmbeddedDataPlaneClient.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.connector.dataplane.selector.spi.client.DataPlaneClient;
 import org.eclipse.edc.connector.dataplane.spi.manager.DataPlaneManager;
 import org.eclipse.edc.spi.response.ResponseStatus;
 import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowResponseMessage;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 
@@ -34,6 +35,15 @@ public class EmbeddedDataPlaneClient implements DataPlaneClient {
 
     public EmbeddedDataPlaneClient(DataPlaneManager dataPlaneManager) {
         this.dataPlaneManager = Objects.requireNonNull(dataPlaneManager, "Data plane manager");
+    }
+
+    @Override
+    public StatusResult<DataFlowResponseMessage> provision(DataFlowProvisionMessage request) {
+        var provisioning = dataPlaneManager.provision(request);
+        if (provisioning.failed()) {
+            return StatusResult.failure(ResponseStatus.FATAL_ERROR, provisioning.getFailureDetail());
+        }
+        return StatusResult.success(provisioning.getContent());
     }
 
     @WithSpan

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/transfer/DataFlowProvisionMessage.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/transfer/DataFlowProvisionMessage.java
@@ -1,0 +1,142 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.spi.types.domain.transfer;
+
+import org.eclipse.edc.spi.types.domain.DataAddress;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Message that the consumer control plane uses to trigger data flow preparation on the data plane
+ */
+public class DataFlowProvisionMessage {
+
+    private String id;
+    private String processId;
+
+    private String assetId;
+    private String participantId;
+    private String agreementId;
+
+    private DataAddress destination;
+    private URI callbackAddress;
+
+    private Map<String, String> properties = new HashMap<>();
+    private TransferType transferType;
+
+    public String getId() {
+        return id;
+    }
+
+    public String getProcessId() {
+        return processId;
+    }
+
+    public String getAgreementId() {
+        return agreementId;
+    }
+
+    public String getAssetId() {
+        return assetId;
+    }
+
+    public DataAddress getDestination() {
+        return destination;
+    }
+
+    public URI getCallbackAddress() {
+        return callbackAddress;
+    }
+
+    public TransferType getTransferType() {
+        return transferType;
+    }
+
+    public String getParticipantId() {
+        return participantId;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    public static class Builder {
+
+        private final DataFlowProvisionMessage message;
+
+        private Builder() {
+            message = new DataFlowProvisionMessage();
+        }
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public DataFlowProvisionMessage build() {
+            if (message.id == null) {
+                message.id = UUID.randomUUID().toString();
+            }
+            return message;
+        }
+
+        public Builder destination(DataAddress destination) {
+            message.destination = destination;
+            return this;
+        }
+
+        public Builder processId(String id) {
+            message.processId = id;
+            return this;
+        }
+
+        public Builder transferType(TransferType transferType) {
+            message.transferType = transferType;
+            return this;
+        }
+
+        public Builder agreementId(String agreementId) {
+            message.agreementId = agreementId;
+            return this;
+        }
+
+        public Builder participantId(String participantId) {
+            message.participantId = participantId;
+            return this;
+        }
+
+        public Builder assetId(String assetId) {
+            message.assetId = assetId;
+            return this;
+        }
+
+        public Builder properties(Map<String, String> value) {
+            message.properties = value == null ? null : Map.copyOf(value);
+            return this;
+        }
+
+        public Builder property(String key, String value) {
+            message.properties.put(key, value);
+            return this;
+        }
+
+        public Builder callbackAddress(URI callbackAddress) {
+            message.callbackAddress = callbackAddress;
+            return this;
+        }
+    }
+}

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/flow/DataFlowController.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/flow/DataFlowController.java
@@ -37,6 +37,8 @@ public interface DataFlowController {
      */
     boolean canHandle(TransferProcess transferProcess);
 
+    StatusResult<DataFlowResponse> provision(TransferProcess transferProcess, Policy policy);
+
     /**
      * Initiate a data flow.
      *

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/flow/DataFlowManager.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/flow/DataFlowManager.java
@@ -46,7 +46,17 @@ public interface DataFlowManager {
     void register(int priority, DataFlowController controller);
 
     /**
-     * Initiates a data flow.
+     * Prepare a consumer data flow.
+     *
+     * @param transferProcess the transfer process
+     * @param policy          the contract agreement usage policy for the asset being transferred
+     * @return succeeded StatusResult if flow has been initiated correctly, failed one otherwise.
+     */
+    @NotNull
+    StatusResult<DataFlowResponse> provision(TransferProcess transferProcess, Policy policy);
+
+    /**
+     * Starts a provider data flow.
      *
      * @param transferProcess the transfer process
      * @param policy          the contract agreement usage policy for the asset being transferred

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferProcess.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferProcess.java
@@ -274,7 +274,7 @@ public class TransferProcess extends StatefulEntity<TransferProcess> {
         if (Type.PROVIDER == type) {
             throw new IllegalStateException("Provider processes have no REQUESTING state");
         }
-        transition(REQUESTING, PROVISIONED, REQUESTING);
+        transition(REQUESTING, INITIAL, PROVISIONED, REQUESTING);
     }
 
     public void transitionRequested() {
@@ -472,6 +472,10 @@ public class TransferProcess extends StatefulEntity<TransferProcess> {
 
     public String getDataPlaneId() {
         return dataPlaneId;
+    }
+
+    public void setDataPlaneId(String dataPlaneId) {
+        this.dataPlaneId = dataPlaneId;
     }
 
     @Override

--- a/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/DataPlaneSelectorService.java
+++ b/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/DataPlaneSelectorService.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.function.Predicate;
 
 /**
  * Main interaction interface for an EDC runtime (=control plane) to communicate with the DPF selector.
@@ -37,12 +38,21 @@ public interface DataPlaneSelectorService {
     ServiceResult<List<DataPlaneInstance>> getAll();
 
     /**
+     * Select the {@link DataPlaneInstance} that satisfies the predicate using the selection strategy.
+     *
+     * @param selectionStrategy the selection strategy.
+     * @param filter the predicate.
+     * @return the data plane, empty otherwise
+     */
+    ServiceResult<DataPlaneInstance> select(@Nullable String selectionStrategy, Predicate<DataPlaneInstance> filter);
+
+    /**
      * Select the {@link DataPlaneInstance} that can handle the source and the transferType using the passed strategy
      *
      * @param source            the source.
      * @param transferType      the transfer type.
      * @param selectionStrategy the selection strategy.
-     * @return the DataPlaneInstance, null if not found.
+     * @return success if data plane is found, failure otherwise.
      */
     ServiceResult<DataPlaneInstance> select(DataAddress source, String transferType, @Nullable String selectionStrategy);
 

--- a/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/client/DataPlaneClient.java
+++ b/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/client/DataPlaneClient.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.dataplane.selector.spi.client;
 
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowResponseMessage;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 
@@ -24,6 +25,14 @@ import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
  */
 @ExtensionPoint
 public interface DataPlaneClient {
+
+    /**
+     * Prepare the data flow through provisioning
+     *
+     * @param request the request.
+     * @return success if the data flow preparation has been triggered/executed, failure otherwise
+     */
+    StatusResult<DataFlowResponseMessage> provision(DataFlowProvisionMessage request);
 
     /**
      * Delegates data transfer to the Data Plane.

--- a/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/instance/DataPlaneInstance.java
+++ b/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/instance/DataPlaneInstance.java
@@ -61,6 +61,7 @@ public class DataPlaneInstance extends StatefulEntity<DataPlaneInstance> {
     private Map<String, Object> properties = new HashMap<>();
     private Set<String> allowedTransferTypes = new HashSet<>();
     private Set<String> allowedSourceTypes = new HashSet<>();
+    private final Set<String> destinationProvisionTypes = new HashSet<>();
     @Deprecated(since = "management-api:v3")
     private Set<String> allowedDestTypes = new HashSet<>();
     @Deprecated(since = "management-api:v3")
@@ -80,7 +81,8 @@ public class DataPlaneInstance extends StatefulEntity<DataPlaneInstance> {
                 .allowedDestTypes(allowedDestTypes)
                 .allowedSourceTypes(allowedSourceTypes)
                 .allowedTransferType(allowedTransferTypes)
-                .properties(properties);
+                .properties(properties)
+                .destinationProvisionTypes(destinationProvisionTypes);
 
         return copy(builder);
     }
@@ -133,6 +135,14 @@ public class DataPlaneInstance extends StatefulEntity<DataPlaneInstance> {
 
     public Set<String> getAllowedTransferTypes() {
         return Collections.unmodifiableSet(allowedTransferTypes);
+    }
+
+    public Set<String> getDestinationProvisionTypes() {
+        return destinationProvisionTypes;
+    }
+
+    public boolean canProvisionDestination(DataAddress destination) {
+        return destinationProvisionTypes.contains(destination.getType());
     }
 
     public void transitionToRegistered() {
@@ -231,6 +241,11 @@ public class DataPlaneInstance extends StatefulEntity<DataPlaneInstance> {
 
         public Builder properties(Map<String, Object> properties) {
             entity.properties = properties;
+            return this;
+        }
+
+        public Builder destinationProvisionTypes(Set<String> types) {
+            entity.destinationProvisionTypes.addAll(types);
             return this;
         }
 

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/DataFlow.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/DataFlow.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.dataplane.spi;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.connector.dataplane.spi.provision.ProvisionResourceDefinition;
 import org.eclipse.edc.spi.entity.StatefulEntity;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
@@ -23,14 +24,17 @@ import org.eclipse.edc.spi.types.domain.transfer.TransferType;
 import org.jetbrains.annotations.Nullable;
 
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
 import static org.eclipse.edc.connector.dataplane.spi.DataFlowStates.COMPLETED;
 import static org.eclipse.edc.connector.dataplane.spi.DataFlowStates.FAILED;
 import static org.eclipse.edc.connector.dataplane.spi.DataFlowStates.NOTIFIED;
+import static org.eclipse.edc.connector.dataplane.spi.DataFlowStates.PROVISIONING;
 import static org.eclipse.edc.connector.dataplane.spi.DataFlowStates.RECEIVED;
 import static org.eclipse.edc.connector.dataplane.spi.DataFlowStates.STARTED;
 import static org.eclipse.edc.connector.dataplane.spi.DataFlowStates.SUSPENDED;
@@ -49,6 +53,7 @@ public class DataFlow extends StatefulEntity<DataFlow> {
     private Map<String, String> properties = new HashMap<>();
     private TransferType transferType;
     private String runtimeId;
+    private List<ProvisionResourceDefinition> resourceDefinitions = new ArrayList<>();
 
     @Override
     public DataFlow copy() {
@@ -105,6 +110,11 @@ public class DataFlow extends StatefulEntity<DataFlow> {
                 .build();
     }
 
+    public void transitionToProvisioning(List<ProvisionResourceDefinition> resourceDefinitions) {
+        this.resourceDefinitions.addAll(resourceDefinitions);
+        transitionTo(PROVISIONING.code());
+    }
+
     public void transitToCompleted() {
         transitionTo(COMPLETED.code());
     }
@@ -136,6 +146,10 @@ public class DataFlow extends StatefulEntity<DataFlow> {
 
     public void transitToSuspended() {
         transitionTo(SUSPENDED.code());
+    }
+
+    public List<ProvisionResourceDefinition> getResourceDefinitions() {
+        return resourceDefinitions;
     }
 
     @JsonPOJOBuilder(withPrefix = "")

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/DataFlowStates.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/DataFlowStates.java
@@ -21,7 +21,9 @@ import java.util.Arrays;
  */
 public enum DataFlowStates {
 
-    NOT_TRACKED(0),
+    @Deprecated(since = "0.12.0") NOT_TRACKED(0),
+    PROVISIONING(25),
+    PROVISIONED(50),
     RECEIVED(100),
     STARTED(150),
     COMPLETED(200),

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/manager/DataPlaneManager.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/manager/DataPlaneManager.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import org.eclipse.edc.spi.entity.StateEntityManager;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowResponseMessage;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.jetbrains.annotations.Nullable;
@@ -36,6 +37,14 @@ public interface DataPlaneManager extends StateEntityManager {
      * Determines if the data flow request is valid and can be processed by this runtime.
      */
     Result<Boolean> validate(DataFlowStartMessage dataRequest);
+
+    /**
+     * Provision a data flow on the consumer side.
+     *
+     * @param request the request.
+     * @return success if the provisioning went through, failed otherwise.
+     */
+    Result<DataFlowResponseMessage> provision(DataFlowProvisionMessage request);
 
     /**
      * Starts a transfer for the data flow request. This method is non-blocking with respect to processing the request.

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/provision/ProvisionResourceDefinition.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/provision/ProvisionResourceDefinition.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.spi.provision;
+
+import org.eclipse.edc.spi.types.domain.DataAddress;
+
+import java.util.UUID;
+
+public class ProvisionResourceDefinition {
+
+    private String id;
+    private DataAddress dataAddress;
+
+    public DataAddress getDataAddress() {
+        return dataAddress;
+    }
+
+    public static class Builder {
+
+        private ProvisionResourceDefinition definition;
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        private Builder() {
+            definition = new ProvisionResourceDefinition();
+        }
+
+        public ProvisionResourceDefinition build() {
+            if (definition.id == null) {
+                definition.id = UUID.randomUUID().toString();
+            }
+            return definition;
+        }
+
+        public Builder dataAddress(DataAddress dataAddress) {
+            definition.dataAddress = dataAddress;
+            return this;
+        }
+    }
+}

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/provision/ResourceDefinitionGenerator.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/provision/ResourceDefinitionGenerator.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.spi.provision;
+
+import org.eclipse.edc.connector.dataplane.spi.DataFlow;
+
+/**
+ * Generates a resource definition for a data flow request.
+ */
+public interface ResourceDefinitionGenerator {
+
+    /**
+     * Return the supported DataAddress type.
+     *
+     * @return supported DataAddress type.
+     */
+    String supportedType();
+
+    /**
+     * Generates a resource definition. If no resource definition is generated, return null.
+     *
+     * @param dataFlow the data flow
+     */
+    ProvisionResourceDefinition generate(DataFlow dataFlow);
+
+}

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/provision/ResourceDefinitionGeneratorManager.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/provision/ResourceDefinitionGeneratorManager.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.spi.provision;
+
+import org.eclipse.edc.connector.dataplane.spi.DataFlow;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Generates resource definitions for data flow requests.
+ * Implementations are responsible for enforcing policy constraints associated with transfer requests.
+ */
+public interface ResourceDefinitionGeneratorManager {
+
+    /**
+     * Registers a consumer-side provisioner.
+     *
+     * @param generator the generator
+     */
+    void registerConsumerGenerator(ResourceDefinitionGenerator generator);
+
+    /**
+     * Registers a provider-side provisioner.
+     *
+     * @param generator the generator
+     */
+    void registerProviderGenerator(ResourceDefinitionGenerator generator);
+
+    /**
+     * Generates resource definitions for a consumer-side transfer. Operations must be idempotent.
+     *
+     * @param dataFlow the data flow
+     * @return succeeded if generation went through, failure otherwise
+     */
+    List<ProvisionResourceDefinition> generateConsumerResourceDefinition(DataFlow dataFlow);
+
+    /**
+     * Generates resource definitions for a provider-side transfer. Operations must be idempotent.
+     *
+     * @param dataFlow the data flow
+     * @return succeeded if generation went through, failure otherwise
+     */
+    List<ProvisionResourceDefinition> generateProviderResourceDefinition(DataFlow dataFlow);
+
+    /**
+     * Return a set of the supported destination types
+     *
+     * @return supported destination types.
+     */
+    Set<String> destinationTypes();
+}

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/ProvisioningTransferEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/ProvisioningTransferEndToEndTest.java
@@ -1,0 +1,132 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.e2e;
+
+import org.eclipse.edc.connector.dataplane.spi.DataFlow;
+import org.eclipse.edc.connector.dataplane.spi.provision.ProvisionResourceDefinition;
+import org.eclipse.edc.connector.dataplane.spi.provision.ResourceDefinitionGenerator;
+import org.eclipse.edc.connector.dataplane.spi.provision.ResourceDefinitionGeneratorManager;
+import org.eclipse.edc.junit.extensions.RuntimeExtension;
+import org.eclipse.edc.junit.extensions.RuntimePerMethodExtension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static jakarta.json.Json.createObjectBuilder;
+import static org.eclipse.edc.connector.controlplane.test.system.utils.PolicyFixtures.noConstraintPolicy;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.STARTED;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+public class ProvisioningTransferEndToEndTest {
+
+    private static final TransferEndToEndParticipant CONSUMER = TransferEndToEndParticipant.Builder.newInstance()
+            .name("consumer")
+            .id("urn:connector:consumer")
+            .build();
+    private static final TransferEndToEndParticipant PROVIDER = TransferEndToEndParticipant.Builder.newInstance()
+            .name("provider")
+            .id("urn:connector:provider")
+            .build();
+
+    private final ResourceDefinitionGenerator consumerResourceDefinitionGenerator = spy(new ConsumerResourceDefinitionGenerator());
+
+    @RegisterExtension
+    @Order(0)
+    private final RuntimeExtension consumerControlPlane = new RuntimePerMethodExtension(
+            Runtimes.IN_MEMORY_CONTROL_PLANE_EMBEDDED_DATA_PLANE.create("consumer-control-plane")
+                    .configurationProvider(CONSUMER::controlPlaneEmbeddedDataPlaneConfig)
+                    .registerSystemExtension(ServiceExtension.class, new RegisterConsumerResourceDefinitionGenerator())
+    );
+
+
+    @RegisterExtension
+    @Order(0)
+    private final RuntimeExtension providerControlPlane = new RuntimePerMethodExtension(
+            Runtimes.IN_MEMORY_CONTROL_PLANE_EMBEDDED_DATA_PLANE.create("provider-control-plane")
+                    .configurationProvider(PROVIDER::controlPlaneEmbeddedDataPlaneConfig)
+
+    );
+
+    @Test
+    void shouldExecuteConsumerProvisioning() {
+        var assetId = UUID.randomUUID().toString();
+        var sourceDataAddress = Map.<String, Object>of(
+                EDC_NAMESPACE + "name", "transfer-test",
+                EDC_NAMESPACE + "baseUrl", "http://any/source",
+                EDC_NAMESPACE + "type", "HttpData"
+        );
+
+        createResourcesOnProvider(assetId, sourceDataAddress);
+
+        var consumerTransferProcessId = CONSUMER.requestAssetFrom(assetId, PROVIDER)
+                .withTransferType("HttpData-PUSH")
+                .withDestination(createObjectBuilder()
+                        .add(TYPE, EDC_NAMESPACE + "DataAddress")
+                        .add(EDC_NAMESPACE + "type", "HttpData")
+                        .add(EDC_NAMESPACE + "baseUrl", "http://localhost:9999/any")
+                        .build()
+                )
+                .execute();
+
+        CONSUMER.awaitTransferToBeInState(consumerTransferProcessId, STARTED);
+
+        verify(consumerResourceDefinitionGenerator).generate(any());
+    }
+
+    protected void createResourcesOnProvider(String assetId, Map<String, Object> dataAddressProperties) {
+        PROVIDER.createAsset(assetId, Map.of("description", "description"), dataAddressProperties);
+        var noConstraintPolicyId = PROVIDER.createPolicyDefinition(noConstraintPolicy());
+        PROVIDER.createContractDefinition(assetId, UUID.randomUUID().toString(), noConstraintPolicyId, noConstraintPolicyId);
+    }
+
+    private static class ConsumerResourceDefinitionGenerator implements ResourceDefinitionGenerator {
+
+        @Override
+        public String supportedType() {
+            return "HttpData";
+        }
+
+        @Override
+        public ProvisionResourceDefinition generate(DataFlow dataFlow) {
+            var dataAddress = DataAddress.Builder.newInstance().type("HttpData")
+                    .property(EDC_NAMESPACE + "baseUrl", "http://localhost:11111/any").build();
+            return ProvisionResourceDefinition.Builder.newInstance()
+                    .dataAddress(dataAddress)
+                    .build();
+        }
+    }
+
+    private class RegisterConsumerResourceDefinitionGenerator implements ServiceExtension {
+
+        @Inject
+        private ResourceDefinitionGeneratorManager resourceDefinitionGeneratorManager;
+
+        @Override
+        public void initialize(ServiceExtensionContext context) {
+            resourceDefinitionGeneratorManager.registerConsumerGenerator(consumerResourceDefinitionGenerator);
+        }
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

First part of #4793 :
adds consumer resource definition generation phase on data-plane.
some assumptions (missing parts will be implemented in a separated PR)
- actual data-plane provisioning is not triggered
- current control-plane provisioning will be triggered as fallback in case data-plane provisioning cannot happen
- only embedded client implementation (both data-plane-selector and data-plane)

## Why it does that

refactoring

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

- in addition to the unit-tests, the whole functionality is covered by the `ProvisioningTransferEndToEndTest`, that will change and grow with the forthcoming PRs.


## Linked Issue(s)

Part of #4793 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
