### PR TITLE
feat: prioritized transfer services

### DIFF
--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/registry/TransferServiceSelectionStrategy.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/registry/TransferServiceSelectionStrategy.java
@@ -26,7 +26,7 @@ import java.util.stream.Stream;
  * for serving a particular {@link DataFlowStartMessage}.
  *
  * @deprecated use transfer service prioritization, see
- * {@link org.eclipse.edc.connector.dataplane.spi.registry.TransferServiceRegistry#registerTransferService(int, TransferService)}.
+ *      {@link org.eclipse.edc.connector.dataplane.spi.registry.TransferServiceRegistry#registerTransferService(int, TransferService)}.
  */
 @Deprecated(since = "0.12.0", forRemoval = true)
 public interface TransferServiceSelectionStrategy {

--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/registry/TransferServiceSelectionStrategy.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/registry/TransferServiceSelectionStrategy.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - Initial implementation
+ *       Cofinity-X - prioritized transfer services
  *
  */
 
@@ -23,7 +24,11 @@ import java.util.stream.Stream;
 /**
  * Functional interface for selecting which of (potentially) multiple {@link TransferService}s to use
  * for serving a particular {@link DataFlowStartMessage}.
+ *
+ * @deprecated use transfer service prioritization, see
+ * {@link org.eclipse.edc.connector.dataplane.spi.registry.TransferServiceRegistry#registerTransferService(int, TransferService)}.
  */
+@Deprecated(since = "0.12.0", forRemoval = true)
 public interface TransferServiceSelectionStrategy {
     /**
      * Selects which of (potentially) multiple {@link TransferService}s to use

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/registry/TransferServiceRegistry.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/registry/TransferServiceRegistry.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Cofinity-X - prioritized transfer services
  *
  */
 
@@ -24,13 +25,23 @@ import org.jetbrains.annotations.Nullable;
  */
 @ExtensionPoint
 public interface TransferServiceRegistry {
+    
     /**
      * Adds a {@link TransferService} to the collection of services that can perform data transfers.
+     * The priority is set to 0.
      *
      * @param transferService the service to add.
      */
     void registerTransferService(TransferService transferService);
-
+    
+    /**
+     * Adds a {@link TransferService} with given priority to the collection of services that can
+     * perform data transfers. Higher priorities will be preferred during selection.
+     *
+     * @param priority the priority
+     * @param transferService the service to add.
+     */
+    void registerTransferService(int priority, TransferService transferService);
 
     /**
      * Resolves a {@link TransferService}s to use for serving a particular {@link DataFlowStartMessage}.


### PR DESCRIPTION
## What this PR changes/adds

Adds a prioritization for `TransferServices` and deprecates the `TransferServiceSelectionStrategy`. Until the latter is removed, keeps it as a fallback solution in case no prioritized `TransferServices` have been registered.

## Why it does that

To improve transfer service selection


## Who will sponsor this feature?

me


## Linked Issue(s)

Closes #4873 
