### PR TITLE
docs: DR for retry processor on dataflow completion

### DIFF
--- a/docs/developer/decision-records/2025-03-17-retry-processor-on-dataflow-completion/README.md
+++ b/docs/developer/decision-records/2025-03-17-retry-processor-on-dataflow-completion/README.md
@@ -6,11 +6,39 @@ The retry mechanism will be applied in the `DataFlowManagerImpl` when processing
 
 ## Rationale
 
-The data plane notifies the control plane of the success or failure of the data transfer. As of right now, if this notification fails, the `DataFlow` transitions to its current state, being picked up again by the state machine manager and retrying the process. As there is no limit to the amount of retries, this process could possibly continue forever. By adding a `RetryProcessor`, we may define handlers for when the process is successful, when it fails but can be retried, and when it reaches final failure.
+The data plane notifies the control plane of the success or failure of the data transfer. As of right now, if this notification fails, the `DataFlow` transitions to its current state, being picked up again by the state machine manager and retrying the process. As there is no limit to the amount of retries, this process could possibly continue forever.
+
+```java
+private boolean processCompleted(DataFlow dataFlow) {
+    var response = transferProcessClient.completed(dataFlow.toRequest());
+    if (response.succeeded()) {
+        dataFlow.transitToNotified();
+        update(dataFlow);
+    } else {
+        dataFlow.transitToCompleted(); // Will retry while the process fails
+        update(dataFlow);
+    }
+    return true;
+}
+
+private boolean processFailed(DataFlow dataFlow) {
+    var response = transferProcessClient.failed(dataFlow.toRequest(), dataFlow.getErrorDetail());
+    if (response.succeeded()) {
+        dataFlow.transitToNotified();
+        update(dataFlow);
+    } else {
+        dataFlow.transitToFailed(dataFlow.getErrorDetail()); // Will retry while the process fails
+        update(dataFlow);
+    }
+    return true;
+}
+```
+
+By adding a `RetryProcessor`, we may define handlers for when the process is successful, when it fails but can be retried, and when it reaches final failure.
 
 ## Approach
 
-The call to the `TransferProcessApiClient` will be wrapped in a `Process`, so that a `RetryProcessor` may execute it.
+Both `TransferProcessApiClient` calls - `transferProcessClient.completed()` and `transferProcessClient.failed()` - will be wrapped in a `Process`, so that a `RetryProcessor` may execute it.
 
 - On success, the `DataFlow` will transition to *NOTIFIED*, keeping current successful behavior
 - On failure, the `DataFlow` will transition to it's current state, allowing the process to be retried

--- a/docs/developer/decision-records/2025-03-17-retry-processor-on-dataflow-completion/README.md
+++ b/docs/developer/decision-records/2025-03-17-retry-processor-on-dataflow-completion/README.md
@@ -6,35 +6,7 @@ The retry mechanism will be applied in the `DataFlowManagerImpl` when processing
 
 ## Rationale
 
-After the data transfer, the `DataFlow` transitions to *COMPLETED* or to *FAILED* if the transfer succeeded or failed, respectively. In either case, the data plane notifies the control plane of the transfer outcome using the `TransferProcessApiClient`. If the notification succeeds, the `DataFlow` correctly transitions to *NOTIFIED*. However, if the notification fails, the `DataFlow` transitions to its current state, causing the state machine manager to pick it up again and retry the process. Since there is no limit to the number of retries, this process could potentially continue forever. The following code block shows how the *COMPLETED* and *FAILED* states are processed by `DataPlaneManagerImpl`.
-
-```java
-private boolean processCompleted(DataFlow dataFlow) {
-    var response = transferProcessClient.completed(dataFlow.toRequest());
-    if (response.succeeded()) {
-        dataFlow.transitToNotified();
-        update(dataFlow);
-    } else {
-        dataFlow.transitToCompleted(); // Will retry while the process fails
-        update(dataFlow);
-    }
-    return true;
-}
-
-private boolean processFailed(DataFlow dataFlow) {
-    var response = transferProcessClient.failed(dataFlow.toRequest(), dataFlow.getErrorDetail());
-    if (response.succeeded()) {
-        dataFlow.transitToNotified();
-        update(dataFlow);
-    } else {
-        dataFlow.transitToFailed(dataFlow.getErrorDetail()); // Will retry while the process fails
-        update(dataFlow);
-    }
-    return true;
-}
-```
-
-Applying a `RetryProcessor` to both `processCompleted()` and `processFailed()` provides greater control over these processes, as it allows to define specific behavior after a configurable number of failed retry attempts.
+After the data transfer, the `DataFlow` transitions to either *COMPLETED* or *FAILED* depending on whether the transfer succeeded or failed. This transition triggers the `processCompleted()` or `processFailed()` methods from `DataFlowManagerImpl` respectively. In either case, the data plane notifies the control plane of the transfer outcome using the `TransferProcessApiClient`, invoking either `transferProcessClient.completed()` or `transferProcessClient.failed()`. If the notification succeeds, the `DataFlow` correctly transitions to *NOTIFIED*. However, if the notification fails, the `DataFlow` transitions to its current state, causing the state machine manager to pick it up again and retry the process. Since there is no limit to the number of retries, this process could potentially continue forever. Applying a `RetryProcessor` to both `processCompleted()` and `processFailed()` provides greater control over these processes, as it allows to define specific behavior after a configurable number of failed retry attempts.
 
 ## Approach
 
@@ -45,3 +17,43 @@ In each case, the process outcomes will be handled by event handlers managing su
 - On success, the `DataFlow` will transition to *NOTIFIED*, keeping current successful behavior
 - On failure, the `DataFlow` will transition to it's current state, allowing the process to be retried
 - On final failure, the `DataFlow` will transition to *TERMINATED*, so that it doesn't retry anymore
+
+The following code block represents how the `processCompleted()` and `processFailed()` methods will look like:
+
+```java
+private boolean processCompleted(DataFlow dataFlow) {
+    return entityRetryProcessFactory.retryProcessor(dataFlow)
+            .doProcess(Process.result("Complete data flow", (d, v) -> transferProcessClient.completed(dataFlow.toRequest())))
+            .onSuccess((d, v) -> {
+                dataFlow.transitToNotified();
+                update(dataFlow);
+            })
+            .onFailure((d, t) -> {
+                dataFlow.transitToCompleted();
+                update(dataFlow);
+            })
+            .onFinalFailure((d, t) -> {
+                dataFlow.transitToTerminated(t.getMessage());
+                update(dataFlow);
+            })
+            .execute();
+}
+
+private boolean processFailed(DataFlow dataFlow) {
+    return entityRetryProcessFactory.retryProcessor(dataFlow)
+            .doProcess(Process.result("Fail data flow", (d, v) -> transferProcessClient.failed(dataFlow.toRequest(), dataFlow.getErrorDetail())))
+            .onSuccess((d, v) -> {
+                dataFlow.transitToNotified();
+                update(dataFlow);
+            })
+            .onFailure((d, t) -> {
+                dataFlow.transitToFailed(dataFlow.getErrorDetail());
+                update(dataFlow);
+            })
+            .onFinalFailure((d, t) -> {
+                dataFlow.transitToTerminated(t.getMessage());
+                update(dataFlow);
+            })
+            .execute();
+}
+```

--- a/docs/developer/decision-records/2025-03-17-retry-processor-on-dataflow-completion/README.md
+++ b/docs/developer/decision-records/2025-03-17-retry-processor-on-dataflow-completion/README.md
@@ -1,0 +1,17 @@
+# Retry Processor on Dataflow Completion
+
+## Decision
+
+The retry mechanism will be applied in the `DataFlowManagerImpl` when processing the `Dataflow`'s *COMPLETED* and *FAILED* states.
+
+## Rationale
+
+The data plane notifies the control plane of the success or failure of the data transfer. As of right now, if this notification fails, the `DataFlow` transitions to its current state, being picked up again by the state machine manager and retrying the process. As there is no limit to the amount of retries, this process could possibly continue forever. By adding a `RetryProcessor`, we may define handlers for when the process is successful, when it fails but can be retried, and when it reaches final failure.
+
+## Approach
+
+The call to the `TransferProcessApiClient` will be wrapped in a `Process`, so that a `RetryProcessor` may execute it.
+
+- On success, the `DataFlow` will transition to *NOTIFIED*, keeping current successful behavior
+- On failure, the `DataFlow` will transition to it's current state, allowing the process to be retried
+- On final failure, the `DataFlow` will transition to *TERMINATED*, so that it doesn't retry anymore


### PR DESCRIPTION
## What this PR changes/adds

Add decision record for retry processor on dataflow completion

## Why it does that

State changes to be made to avoid infinite retries on `DataFlow` completion

## Linked Issue(s)

Closes https://github.com/eclipse-edc/Connector/issues/4860
