### PR TITLE
feat: boostrap dsp protocol 2025

### DIFF
--- a/data-protocols/dsp/dsp-2025/build.gradle.kts
+++ b/data-protocols/dsp/dsp-2025/build.gradle.kts
@@ -1,0 +1,25 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(project(":data-protocols:dsp:dsp-2025:dsp-http-api-configuration-2025"))
+    api(project(":data-protocols:dsp:dsp-catalog:dsp-catalog-2025"))
+    api(project(":data-protocols:dsp:dsp-transfer-process:dsp-transfer-process-2025"))
+    api(project(":data-protocols:dsp:dsp-negotiation:dsp-negotiation-2025"))
+}

--- a/data-protocols/dsp/dsp-2025/dsp-http-api-configuration-2025/build.gradle.kts
+++ b/data-protocols/dsp/dsp-2025/dsp-http-api-configuration-2025/build.gradle.kts
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(project(":spi:common:core-spi"))
+    api(project(":spi:common:web-spi"))
+    api(project(":data-protocols:dsp:dsp-spi"))
+    api(project(":data-protocols:dsp:dsp-http-spi"))
+
+    implementation(project(":core:common:lib:transform-lib"))
+    implementation(project(":core:control-plane:control-plane-transform"))
+
+    testImplementation(project(":core:common:junit"))
+}

--- a/data-protocols/dsp/dsp-2025/dsp-http-api-configuration-2025/src/main/java/org/eclipse/edc/protocol/dsp/http/api/configuration/v2025/DspApiConfigurationV2025Extension.java
+++ b/data-protocols/dsp/dsp-2025/dsp-http-api-configuration-2025/src/main/java/org/eclipse/edc/protocol/dsp/http/api/configuration/v2025/DspApiConfigurationV2025Extension.java
@@ -1,0 +1,152 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.http.api.configuration.v2025;
+
+import jakarta.json.Json;
+import org.eclipse.edc.connector.controlplane.transform.edc.from.JsonObjectFromAssetTransformer;
+import org.eclipse.edc.connector.controlplane.transform.edc.to.JsonObjectToAssetTransformer;
+import org.eclipse.edc.connector.controlplane.transform.odrl.OdrlTransformersFactory;
+import org.eclipse.edc.connector.controlplane.transform.odrl.from.JsonObjectFromPolicyTransformer;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.participant.spi.ParticipantIdMapper;
+import org.eclipse.edc.protocol.dsp.http.spi.dispatcher.DspHttpRemoteMessageDispatcher;
+import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.runtime.metamodel.annotation.Settings;
+import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
+import org.eclipse.edc.spi.protocol.ProtocolWebhookRegistry;
+import org.eclipse.edc.spi.system.Hostname;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.transform.transformer.dspace.to.JsonObjectToDataAddressDspaceTransformer;
+import org.eclipse.edc.transform.transformer.dspace.v2024.from.JsonObjectFromDataAddressDspace2024Transformer;
+import org.eclipse.edc.transform.transformer.edc.from.JsonObjectFromCriterionTransformer;
+import org.eclipse.edc.transform.transformer.edc.from.JsonObjectFromQuerySpecTransformer;
+import org.eclipse.edc.transform.transformer.edc.to.JsonObjectToCriterionTransformer;
+import org.eclipse.edc.transform.transformer.edc.to.JsonObjectToQuerySpecTransformer;
+import org.eclipse.edc.transform.transformer.edc.to.JsonValueToGenericTypeTransformer;
+import org.eclipse.edc.web.spi.configuration.ApiContext;
+import org.eclipse.edc.web.spi.configuration.PortMapping;
+
+import java.util.Map;
+
+import static java.lang.String.format;
+import static java.util.Optional.ofNullable;
+import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_CONTEXT_2025_1;
+import static org.eclipse.edc.jsonld.spi.Namespaces.EDC_DSPACE_CONTEXT;
+import static org.eclipse.edc.protocol.dsp.http.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_SCOPE_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_TRANSFORMER_CONTEXT_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.version.DspVersions.V_2025_1_PATH;
+import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
+
+/**
+ * Configure 'protocol' api context.
+ */
+@Extension(value = DspApiConfigurationV2025Extension.NAME)
+public class DspApiConfigurationV2025Extension implements ServiceExtension {
+
+    public static final String NAME = "Dataspace Protocol 2025/1 API Configuration Extension";
+
+    static final String DEFAULT_PROTOCOL_PATH = "/api/protocol";
+    static final int DEFAULT_PROTOCOL_PORT = 8282;
+
+    @Setting(description = "Configures endpoint for reaching the Protocol API in the form \"<hostname:protocol.port/protocol.path>\"", key = "edc.dsp.callback.address", required = false)
+    private String callbackAddress;
+
+    @Configuration
+    private DspApiConfiguration apiConfiguration;
+
+    @Inject
+    private TypeManager typeManager;
+    @Inject
+    private JsonLd jsonLd;
+    @Inject
+    private TypeTransformerRegistry transformerRegistry;
+    @Inject
+    private ParticipantIdMapper participantIdMapper;
+    @Inject
+    private RemoteMessageDispatcherRegistry dispatcherRegistry;
+    @Inject
+    private DspHttpRemoteMessageDispatcher dispatcher;
+
+    @Inject
+    private ProtocolWebhookRegistry protocolWebhookRegistry;
+
+    @Inject
+    private Hostname hostname;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        var portMapping = new PortMapping(ApiContext.PROTOCOL, apiConfiguration.port(), apiConfiguration.path());
+
+        // registers ns for DSP 2025/1 scope
+        registerNamespaces();
+        registerTransformers();
+        dispatcherRegistry.register(DATASPACE_PROTOCOL_HTTP_V_2025_1, dispatcher);
+
+        var dspWebhookAddress = ofNullable(callbackAddress).orElseGet(() -> format("http://%s:%s%s", hostname.get(), portMapping.port(), portMapping.path()));
+
+        protocolWebhookRegistry.registerWebhook(DATASPACE_PROTOCOL_HTTP_V_2025_1, () -> dspWebhookAddress + V_2025_1_PATH);
+
+    }
+
+    private void registerNamespaces() {
+        jsonLd.registerContext(DSPACE_CONTEXT_2025_1, DSP_SCOPE_V_2025_1);
+        jsonLd.registerContext(EDC_DSPACE_CONTEXT, DSP_SCOPE_V_2025_1);
+    }
+
+    private void registerTransformers() {
+        var jsonBuilderFactory = Json.createBuilderFactory(Map.of());
+
+        // EDC model to JSON-LD transformers
+        var dspApiTransformerRegistry = transformerRegistry.forContext(DSP_TRANSFORMER_CONTEXT_V_2025_1);
+        dspApiTransformerRegistry.register(new JsonObjectFromAssetTransformer(jsonBuilderFactory, typeManager, JSON_LD));
+        dspApiTransformerRegistry.register(new JsonObjectFromQuerySpecTransformer(jsonBuilderFactory));
+        dspApiTransformerRegistry.register(new JsonObjectFromCriterionTransformer(jsonBuilderFactory, typeManager, JSON_LD));
+
+        // JSON-LD to EDC model transformers
+        // ODRL Transformers
+        OdrlTransformersFactory.jsonObjectToOdrlTransformers(participantIdMapper).forEach(dspApiTransformerRegistry::register);
+
+        dspApiTransformerRegistry.register(new JsonValueToGenericTypeTransformer(typeManager, JSON_LD));
+        dspApiTransformerRegistry.register(new JsonObjectToAssetTransformer());
+        dspApiTransformerRegistry.register(new JsonObjectToQuerySpecTransformer());
+        dspApiTransformerRegistry.register(new JsonObjectToCriterionTransformer());
+        dspApiTransformerRegistry.register(new JsonObjectToDataAddressDspaceTransformer(DSP_NAMESPACE_V_2025_1));
+        dspApiTransformerRegistry.register(new JsonObjectFromPolicyTransformer(jsonBuilderFactory, participantIdMapper, true));
+        dspApiTransformerRegistry.register(new JsonObjectFromDataAddressDspace2024Transformer(jsonBuilderFactory, typeManager, JSON_LD, DSP_NAMESPACE_V_2025_1));
+    }
+
+    @Settings
+    record DspApiConfiguration(
+            @Setting(key = "web.http." + ApiContext.PROTOCOL + ".port", description = "Port for " + ApiContext.PROTOCOL + " api context", defaultValue = DEFAULT_PROTOCOL_PORT + "")
+            int port,
+            @Setting(key = "web.http." + ApiContext.PROTOCOL + ".path", description = "Path for " + ApiContext.PROTOCOL + " api context", defaultValue = DEFAULT_PROTOCOL_PATH)
+            String path
+    ) {
+
+    }
+}

--- a/data-protocols/dsp/dsp-2025/dsp-http-api-configuration-2025/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/data-protocols/dsp/dsp-2025/dsp-http-api-configuration-2025/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2025 Metaform Systems, Inc.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Metaform Systems, Inc. - initial API and implementation
+#
+#
+
+org.eclipse.edc.protocol.dsp.http.api.configuration.v2025.DspApiConfigurationV2025Extension

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-2025/build.gradle.kts
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-2025/build.gradle.kts
@@ -1,0 +1,23 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(project(":data-protocols:dsp:dsp-catalog:dsp-catalog-2025:dsp-catalog-http-api-2025"))
+    api(project(":data-protocols:dsp:dsp-catalog:dsp-catalog-2025:dsp-catalog-transform-2025"))
+}

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-2025/dsp-catalog-http-api-2025/build.gradle.kts
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-2025/dsp-catalog-http-api-2025/build.gradle.kts
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+    id(libs.plugins.swagger.get().pluginId)
+}
+
+dependencies {
+    api(project(":data-protocols:dsp:dsp-spi"))
+    api(project(":data-protocols:dsp:dsp-http-spi"))
+    api(project(":spi:common:core-spi"))
+    api(project(":spi:common:web-spi"))
+    api(project(":spi:common:json-ld-spi"))
+
+    api(project(":spi:control-plane:control-plane-spi"))
+
+    implementation(project(":extensions:common:http:lib:jersey-providers-lib"))
+    implementation(project(":data-protocols:dsp:dsp-catalog:lib:dsp-catalog-validation-lib"))
+    implementation(project(":data-protocols:dsp:dsp-catalog:lib:dsp-catalog-http-api-lib"))
+
+    implementation(libs.jakarta.rsApi)
+
+    testImplementation(testFixtures(project(":extensions:common:http:jersey-core")))
+    testImplementation(project(":core:common:junit"))
+    testImplementation(libs.restAssured)
+    testImplementation(testFixtures(project(":data-protocols:dsp:dsp-catalog:lib:dsp-catalog-http-api-lib")))
+
+}
+
+edcBuild {
+    swagger {
+        apiGroup.set("dsp-api")
+    }
+}

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-2025/dsp-catalog-http-api-2025/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/v2025/DspCatalogApi2025Extension.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-2025/dsp-catalog-http-api-2025/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/v2025/DspCatalogApi2025Extension.java
@@ -1,0 +1,122 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.catalog.http.api.v2025;
+
+import org.eclipse.edc.connector.controlplane.catalog.spi.DataService;
+import org.eclipse.edc.connector.controlplane.catalog.spi.DataServiceRegistry;
+import org.eclipse.edc.connector.controlplane.services.spi.catalog.CatalogProtocolService;
+import org.eclipse.edc.connector.controlplane.services.spi.protocol.ProtocolVersionRegistry;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.protocol.dsp.catalog.http.api.decorator.Base64continuationTokenSerDes;
+import org.eclipse.edc.protocol.dsp.catalog.http.api.decorator.ContinuationTokenManagerImpl;
+import org.eclipse.edc.protocol.dsp.catalog.http.api.v2025.controller.DspCatalogApiController20251;
+import org.eclipse.edc.protocol.dsp.catalog.validation.CatalogRequestMessageValidator;
+import org.eclipse.edc.protocol.dsp.http.spi.message.ContinuationTokenManager;
+import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.protocol.ProtocolWebhookRegistry;
+import org.eclipse.edc.spi.query.CriterionOperatorRegistry;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.web.jersey.providers.jsonld.JerseyJsonLdInterceptor;
+import org.eclipse.edc.web.spi.WebService;
+import org.eclipse.edc.web.spi.configuration.ApiContext;
+
+import java.util.Objects;
+
+import static org.eclipse.edc.protocol.dsp.http.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspCatalogPropertyAndTypeNames.DSPACE_TYPE_CATALOG_REQUEST_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_SCOPE_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_TRANSFORMER_CONTEXT_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.version.DspVersions.V_2025_1;
+import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
+
+/**
+ * Creates and registers the controller for dataspace protocol catalog requests.
+ */
+@Extension(value = DspCatalogApi2025Extension.NAME)
+public class DspCatalogApi2025Extension implements ServiceExtension {
+
+    public static final String NAME = "Dataspace Protocol 2025/1 API Catalog Extension";
+
+    @Inject
+    private WebService webService;
+    @Inject
+    private CatalogProtocolService service;
+    @Inject
+    private DataServiceRegistry dataServiceRegistry;
+    @Inject
+    private JsonObjectValidatorRegistry validatorRegistry;
+    @Inject
+    private DspRequestHandler dspRequestHandler;
+    @Inject
+    private CriterionOperatorRegistry criterionOperatorRegistry;
+    @Inject
+    private ProtocolVersionRegistry versionRegistry;
+    @Inject
+    private TypeTransformerRegistry transformerRegistry;
+    @Inject
+    private Monitor monitor;
+    @Inject
+    private TypeManager typeManager;
+    @Inject
+    private JsonLd jsonLd;
+    @Inject
+    private ProtocolWebhookRegistry protocolWebhookRegistry;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        registerValidators();
+
+        webService.registerResource(ApiContext.PROTOCOL, new DspCatalogApiController20251(service, dspRequestHandler, continuationTokenManager(monitor)));
+        webService.registerDynamicResource(ApiContext.PROTOCOL, DspCatalogApiController20251.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, DSP_SCOPE_V_2025_1));
+
+        versionRegistry.register(V_2025_1);
+    }
+
+    private ContinuationTokenManager continuationTokenManager(Monitor monitor) {
+        var continuationTokenSerDes = new Base64continuationTokenSerDes(transformerRegistry.forContext(DSP_TRANSFORMER_CONTEXT_V_2025_1), jsonLd);
+        return new ContinuationTokenManagerImpl(continuationTokenSerDes, DSP_NAMESPACE_V_2025_1, monitor);
+    }
+
+    private void registerValidators() {
+        validatorRegistry.register(DSP_NAMESPACE_V_2025_1.toIri(DSPACE_TYPE_CATALOG_REQUEST_MESSAGE_TERM), CatalogRequestMessageValidator.instance(criterionOperatorRegistry, DSP_NAMESPACE_V_2025_1));
+    }
+
+    @Override
+    public void prepare() {
+        registerDataService();
+    }
+
+    private void registerDataService() {
+
+        var endpointUrl = Objects.requireNonNull(protocolWebhookRegistry.resolve(DATASPACE_PROTOCOL_HTTP_V_2025_1)).url();
+        dataServiceRegistry.register(DATASPACE_PROTOCOL_HTTP_V_2025_1, DataService.Builder.newInstance()
+                .endpointDescription("dspace:connector")
+                .endpointUrl(endpointUrl)
+                .build());
+    }
+}

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-2025/dsp-catalog-http-api-2025/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/v2025/controller/DspCatalogApiController20251.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-2025/dsp-catalog-http-api-2025/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/v2025/controller/DspCatalogApiController20251.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.catalog.http.api.v2025.controller;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import org.eclipse.edc.connector.controlplane.services.spi.catalog.CatalogProtocolService;
+import org.eclipse.edc.protocol.dsp.catalog.http.api.controller.BaseDspCatalogApiController;
+import org.eclipse.edc.protocol.dsp.http.spi.message.ContinuationTokenManager;
+import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
+
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.eclipse.edc.protocol.dsp.catalog.http.api.CatalogApiPaths.BASE_PATH;
+import static org.eclipse.edc.protocol.dsp.http.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.version.DspVersions.V_2025_1_PATH;
+
+/**
+ * Versioned Catalog endpoint for 2024/1 protocol version
+ */
+@Consumes({APPLICATION_JSON})
+@Produces({APPLICATION_JSON})
+@Path(V_2025_1_PATH + BASE_PATH)
+public class DspCatalogApiController20251 extends BaseDspCatalogApiController {
+
+    public DspCatalogApiController20251(CatalogProtocolService service, DspRequestHandler dspRequestHandler,
+                                        ContinuationTokenManager responseDecorator) {
+        super(service, dspRequestHandler, responseDecorator, DATASPACE_PROTOCOL_HTTP_V_2025_1, DSP_NAMESPACE_V_2025_1);
+    }
+}

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-2025/dsp-catalog-http-api-2025/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-2025/dsp-catalog-http-api-2025/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2025 Metaform Systems, Inc.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Metaform Systems, Inc. - initial API and implementation
+#
+#
+
+org.eclipse.edc.protocol.dsp.catalog.http.api.v2025.DspCatalogApi2025Extension

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-2025/dsp-catalog-http-api-2025/src/test/java/org/eclipse/edc/protocol/dsp/catalog/http/api/v2025/DspCatalogApi2025ExtensionTest.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-2025/dsp-catalog-http-api-2025/src/test/java/org/eclipse/edc/protocol/dsp/catalog/http/api/v2025/DspCatalogApi2025ExtensionTest.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.catalog.http.api.v2025;
+
+import org.eclipse.edc.connector.controlplane.services.spi.protocol.ProtocolVersionRegistry;
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.protocol.dsp.spi.transform.DspProtocolTypeTransformerRegistry;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.eclipse.edc.protocol.dsp.spi.type.DspCatalogPropertyAndTypeNames.DSPACE_TYPE_CATALOG_REQUEST_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.version.DspVersions.V_2025_1;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(DependencyInjectionExtension.class)
+class DspCatalogApi2025ExtensionTest {
+
+    private final JsonObjectValidatorRegistry validatorRegistry = mock();
+    private final ProtocolVersionRegistry versionRegistry = mock();
+    private final DspProtocolTypeTransformerRegistry dspTransformerRegistry = mock();
+
+    @BeforeEach
+    void setUp(ServiceExtensionContext context) {
+        context.registerService(JsonObjectValidatorRegistry.class, validatorRegistry);
+        context.registerService(ProtocolVersionRegistry.class, versionRegistry);
+        context.registerService(DspProtocolTypeTransformerRegistry.class, dspTransformerRegistry);
+
+        when(dspTransformerRegistry.forProtocol(any())).thenReturn(Result.success(mock()));
+    }
+
+    @Test
+    void shouldRegisterMessageValidator(DspCatalogApi2025Extension extension, ServiceExtensionContext context) {
+        extension.initialize(context);
+
+        verify(validatorRegistry).register(eq(DSP_NAMESPACE_V_2025_1.toIri(DSPACE_TYPE_CATALOG_REQUEST_MESSAGE_TERM)), any());
+    }
+
+    @Test
+    void shouldRegisterDspVersion(DspCatalogApi2025Extension extension, ServiceExtensionContext context) {
+        extension.initialize(context);
+
+        verify(versionRegistry).register(V_2025_1);
+    }
+}

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-2025/dsp-catalog-http-api-2025/src/test/java/org/eclipse/edc/protocol/dsp/catalog/http/api/v2025/controller/DspCatalogApiControllerV20251Test.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-2025/dsp-catalog-http-api-2025/src/test/java/org/eclipse/edc/protocol/dsp/catalog/http/api/v2025/controller/DspCatalogApiControllerV20251Test.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.catalog.http.api.v2025.controller;
+
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
+import org.eclipse.edc.junit.annotations.ApiTest;
+import org.eclipse.edc.protocol.dsp.catalog.http.api.controller.DspCatalogApiControllerTestBase;
+
+import static org.eclipse.edc.protocol.dsp.catalog.http.api.CatalogApiPaths.BASE_PATH;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.version.DspVersions.V_2025_1_PATH;
+
+@ApiTest
+public class DspCatalogApiControllerV20251Test extends DspCatalogApiControllerTestBase {
+
+    @Override
+    protected String basePath() {
+        return V_2025_1_PATH + BASE_PATH;
+    }
+
+    @Override
+    protected JsonLdNamespace namespace() {
+        return DSP_NAMESPACE_V_2025_1;
+    }
+
+    @Override
+    protected Object controller() {
+        return new DspCatalogApiController20251(service, dspRequestHandler, continuationTokenManager);
+    }
+}

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-2025/dsp-catalog-transform-2025/build.gradle.kts
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-2025/dsp-catalog-transform-2025/build.gradle.kts
@@ -1,0 +1,25 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(project(":spi:common:core-spi"))
+
+    implementation(project(":core:common:lib:transform-lib"))
+    implementation(project(":data-protocols:dsp:dsp-catalog:lib:dsp-catalog-transform-lib"))
+}

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-2025/dsp-catalog-transform-2025/src/main/java/org/eclipse/edc/protocol/dsp/catalog/transform/v2025/DspCatalogTransformV2025Extension.java
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-2025/dsp-catalog-transform-2025/src/main/java/org/eclipse/edc/protocol/dsp/catalog/transform/v2025/DspCatalogTransformV2025Extension.java
@@ -1,0 +1,81 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.catalog.transform.v2025;
+
+import jakarta.json.Json;
+import org.eclipse.edc.participant.spi.ParticipantIdMapper;
+import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromCatalogErrorTransformer;
+import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromCatalogRequestMessageTransformer;
+import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromDataServiceTransformer;
+import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromDatasetTransformer;
+import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromDistributionTransformer;
+import org.eclipse.edc.protocol.dsp.catalog.transform.to.JsonObjectToCatalogRequestMessageTransformer;
+import org.eclipse.edc.protocol.dsp.catalog.transform.v2024.from.JsonObjectFromCatalogV2024Transformer;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+
+import java.util.Map;
+
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_TRANSFORMER_CONTEXT_V_2025_1;
+import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
+
+/**
+ * Provides the transformers for catalog message types via the {@link TypeTransformerRegistry}.
+ */
+@Extension(value = DspCatalogTransformV2025Extension.NAME)
+public class DspCatalogTransformV2025Extension implements ServiceExtension {
+
+    public static final String NAME = "Dataspace Protocol 2025/1 Catalog Transform Extension";
+
+    @Inject
+    private TypeTransformerRegistry registry;
+
+    @Inject
+    private TypeManager typeManager;
+
+    @Inject
+    private ParticipantIdMapper participantIdMapper;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        registerTransformers();
+    }
+
+    private void registerTransformers() {
+        var jsonFactory = Json.createBuilderFactory(Map.of());
+
+        var dspApiTransformerRegistry = registry.forContext(DSP_TRANSFORMER_CONTEXT_V_2025_1);
+        dspApiTransformerRegistry.register(new JsonObjectFromCatalogRequestMessageTransformer(jsonFactory, DSP_NAMESPACE_V_2025_1));
+        dspApiTransformerRegistry.register(new JsonObjectToCatalogRequestMessageTransformer(DSP_NAMESPACE_V_2025_1));
+
+        dspApiTransformerRegistry.register(new JsonObjectFromCatalogV2024Transformer(jsonFactory, typeManager, JSON_LD, participantIdMapper, DSP_NAMESPACE_V_2025_1));
+        dspApiTransformerRegistry.register(new JsonObjectFromDatasetTransformer(jsonFactory, typeManager, JSON_LD));
+        dspApiTransformerRegistry.register(new JsonObjectFromDistributionTransformer(jsonFactory));
+        dspApiTransformerRegistry.register(new JsonObjectFromDataServiceTransformer(jsonFactory));
+        dspApiTransformerRegistry.register(new JsonObjectFromCatalogErrorTransformer(jsonFactory, DSP_NAMESPACE_V_2025_1));
+
+    }
+
+}

--- a/data-protocols/dsp/dsp-catalog/dsp-catalog-2025/dsp-catalog-transform-2025/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/data-protocols/dsp/dsp-catalog/dsp-catalog-2025/dsp-catalog-transform-2025/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2025 Metaform Systems, Inc.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Metaform Systems, Inc. - initial API and implementation
+#
+#
+
+org.eclipse.edc.protocol.dsp.catalog.transform.v2025.DspCatalogTransformV2025Extension

--- a/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/http/spi/types/HttpMessageProtocol.java
+++ b/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/http/spi/types/HttpMessageProtocol.java
@@ -25,5 +25,6 @@ public class HttpMessageProtocol {
     public static final String DATASPACE_PROTOCOL_HTTP = "dataspace-protocol-http";
     public static final String DATASPACE_PROTOCOL_HTTP_SEPARATOR = ":";
     public static final String DATASPACE_PROTOCOL_HTTP_V_2024_1 = DATASPACE_PROTOCOL_HTTP + DATASPACE_PROTOCOL_HTTP_SEPARATOR + DspVersions.V_2024_1_VERSION;
+    public static final String DATASPACE_PROTOCOL_HTTP_V_2025_1 = DATASPACE_PROTOCOL_HTTP + DATASPACE_PROTOCOL_HTTP_SEPARATOR + DspVersions.V_2025_1_VERSION;
 
 }

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-2025/build.gradle.kts
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-2025/build.gradle.kts
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(project(":data-protocols:dsp:dsp-negotiation:dsp-negotiation-2025:dsp-negotiation-http-api-2025"))
+    api(project(":data-protocols:dsp:dsp-negotiation:dsp-negotiation-2025:dsp-negotiation-transform-2025"))
+
+}

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-2025/dsp-negotiation-http-api-2025/build.gradle.kts
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-2025/dsp-negotiation-http-api-2025/build.gradle.kts
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+    id(libs.plugins.swagger.get().pluginId)
+}
+
+dependencies {
+    api(project(":data-protocols:dsp:dsp-spi"))
+    api(project(":data-protocols:dsp:dsp-http-spi"))
+    api(project(":spi:common:core-spi"))
+    api(project(":spi:common:web-spi"))
+    api(project(":spi:control-plane:control-plane-spi"))
+    api(project(":extensions:common:json-ld"))
+
+    implementation(project(":data-protocols:dsp:dsp-negotiation:lib:dsp-negotiation-validation-lib"))
+    implementation(project(":data-protocols:dsp:dsp-negotiation:lib:dsp-negotiation-http-api-lib"))
+    implementation(project(":extensions:common:http:lib:jersey-providers-lib"))
+
+    implementation(libs.jakarta.rsApi)
+
+    testImplementation(project(":core:common:junit"))
+    testImplementation(testFixtures(project(":extensions:common:http:jersey-core")))
+    testImplementation(libs.restAssured)
+    testImplementation(testFixtures(project(":data-protocols:dsp:dsp-negotiation:lib:dsp-negotiation-http-api-lib")))
+
+}
+
+edcBuild {
+    swagger {
+        apiGroup.set("dsp-api")
+    }
+}

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-2025/dsp-negotiation-http-api-2025/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/v2025/DspNegotiationApi2025Extension.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-2025/dsp-negotiation-http-api-2025/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/v2025/DspNegotiationApi2025Extension.java
@@ -1,0 +1,98 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.negotiation.http.api.v2025;
+
+import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationProtocolService;
+import org.eclipse.edc.connector.controlplane.services.spi.protocol.ProtocolVersionRegistry;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
+import org.eclipse.edc.protocol.dsp.negotiation.http.api.v2025.controller.DspNegotiationApiController20251;
+import org.eclipse.edc.protocol.dsp.negotiation.validation.ContractAgreementMessageValidator;
+import org.eclipse.edc.protocol.dsp.negotiation.validation.ContractAgreementVerificationMessageValidator;
+import org.eclipse.edc.protocol.dsp.negotiation.validation.ContractNegotiationEventMessageValidator;
+import org.eclipse.edc.protocol.dsp.negotiation.validation.ContractNegotiationTerminationMessageValidator;
+import org.eclipse.edc.protocol.dsp.negotiation.validation.ContractOfferMessageValidator;
+import org.eclipse.edc.protocol.dsp.negotiation.validation.ContractRequestMessageValidator;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.web.jersey.providers.jsonld.JerseyJsonLdInterceptor;
+import org.eclipse.edc.web.spi.WebService;
+import org.eclipse.edc.web.spi.configuration.ApiContext;
+
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_SCOPE_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_AGREEMENT_VERIFICATION_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_TERMINATION_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_OFFER_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.version.DspVersions.V_2025_1;
+import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
+
+/**
+ * Creates and registers the controller for dataspace protocol negotiation requests.
+ */
+@Extension(value = DspNegotiationApi2025Extension.NAME)
+public class DspNegotiationApi2025Extension implements ServiceExtension {
+
+    public static final String NAME = "Dataspace Protocol Negotiation Api";
+
+    @Inject
+    private WebService webService;
+    @Inject
+    private ContractNegotiationProtocolService protocolService;
+    @Inject
+    private JsonObjectValidatorRegistry validatorRegistry;
+    @Inject
+    private DspRequestHandler dspRequestHandler;
+    @Inject
+    private ProtocolVersionRegistry versionRegistry;
+
+    @Inject
+    private JsonLd jsonLd;
+
+    @Inject
+    private TypeManager typeManager;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        registerValidators();
+
+        webService.registerResource(ApiContext.PROTOCOL, new DspNegotiationApiController20251(protocolService, dspRequestHandler));
+        webService.registerDynamicResource(ApiContext.PROTOCOL, DspNegotiationApiController20251.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, DSP_SCOPE_V_2025_1));
+
+        versionRegistry.register(V_2025_1);
+    }
+
+
+    private void registerValidators() {
+        validatorRegistry.register(DSP_NAMESPACE_V_2025_1.toIri(DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE_TERM), ContractRequestMessageValidator.instance(DSP_NAMESPACE_V_2025_1));
+        validatorRegistry.register(DSP_NAMESPACE_V_2025_1.toIri(DSPACE_TYPE_CONTRACT_OFFER_MESSAGE_TERM), ContractOfferMessageValidator.instance(DSP_NAMESPACE_V_2025_1));
+        validatorRegistry.register(DSP_NAMESPACE_V_2025_1.toIri(DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE_TERM), ContractNegotiationEventMessageValidator.instance(DSP_NAMESPACE_V_2025_1));
+        validatorRegistry.register(DSP_NAMESPACE_V_2025_1.toIri(DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE_TERM), ContractAgreementMessageValidator.instance(DSP_NAMESPACE_V_2025_1));
+        validatorRegistry.register(DSP_NAMESPACE_V_2025_1.toIri(DSPACE_TYPE_CONTRACT_AGREEMENT_VERIFICATION_MESSAGE_TERM), ContractAgreementVerificationMessageValidator.instance(DSP_NAMESPACE_V_2025_1));
+        validatorRegistry.register(DSP_NAMESPACE_V_2025_1.toIri(DSPACE_TYPE_CONTRACT_NEGOTIATION_TERMINATION_MESSAGE_TERM), ContractNegotiationTerminationMessageValidator.instance(DSP_NAMESPACE_V_2025_1));
+    }
+}

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-2025/dsp-negotiation-http-api-2025/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/v2025/controller/DspNegotiationApiController20251.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-2025/dsp-negotiation-http-api-2025/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/v2025/controller/DspNegotiationApiController20251.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.negotiation.http.api.v2025.controller;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationProtocolService;
+import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
+import org.eclipse.edc.protocol.dsp.negotiation.http.api.controller.BaseDspNegotiationApiController;
+import org.eclipse.edc.protocol.dsp.spi.version.DspVersions;
+
+import static org.eclipse.edc.protocol.dsp.http.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.BASE_PATH;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_2025_1;
+
+/**
+ * Versioned Negotiation endpoint for 2024/1 protocol version
+ */
+@Consumes({MediaType.APPLICATION_JSON})
+@Produces({MediaType.APPLICATION_JSON})
+@Path(DspVersions.V_2025_1_PATH + BASE_PATH)
+public class DspNegotiationApiController20251 extends BaseDspNegotiationApiController {
+
+    public DspNegotiationApiController20251(ContractNegotiationProtocolService protocolService, DspRequestHandler dspRequestHandler) {
+        super(protocolService, dspRequestHandler, DATASPACE_PROTOCOL_HTTP_V_2025_1, DSP_NAMESPACE_V_2025_1);
+    }
+}

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-2025/dsp-negotiation-http-api-2025/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-2025/dsp-negotiation-http-api-2025/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2025 Metaform Systems, Inc.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Metaform Systems, Inc. - initial API and implementation
+#
+#
+
+org.eclipse.edc.protocol.dsp.negotiation.http.api.v2025.DspNegotiationApi2025Extension

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-2025/dsp-negotiation-http-api-2025/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/v2025/DspNegotiationApi2025ExtensionTest.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-2025/dsp-negotiation-http-api-2025/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/v2025/DspNegotiationApi2025ExtensionTest.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.negotiation.http.api.v2025;
+
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_AGREEMENT_VERIFICATION_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_TERMINATION_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_OFFER_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE_TERM;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(DependencyInjectionExtension.class)
+class DspNegotiationApi2025ExtensionTest {
+
+    private final JsonObjectValidatorRegistry validatorRegistry = mock();
+
+    @BeforeEach
+    void setUp(ServiceExtensionContext context) {
+        context.registerService(JsonObjectValidatorRegistry.class, validatorRegistry);
+    }
+
+    @Test
+    void shouldRegisterMessageValidators(DspNegotiationApi2025Extension extension, ServiceExtensionContext context) {
+        extension.initialize(context);
+
+        verify(validatorRegistry).register(eq(DSP_NAMESPACE_V_2025_1.toIri(DSPACE_TYPE_CONTRACT_REQUEST_MESSAGE_TERM)), any());
+        verify(validatorRegistry).register(eq(DSP_NAMESPACE_V_2025_1.toIri(DSPACE_TYPE_CONTRACT_OFFER_MESSAGE_TERM)), any());
+        verify(validatorRegistry).register(eq(DSP_NAMESPACE_V_2025_1.toIri(DSPACE_TYPE_CONTRACT_NEGOTIATION_EVENT_MESSAGE_TERM)), any());
+        verify(validatorRegistry).register(eq(DSP_NAMESPACE_V_2025_1.toIri(DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE_TERM)), any());
+        verify(validatorRegistry).register(eq(DSP_NAMESPACE_V_2025_1.toIri(DSPACE_TYPE_CONTRACT_AGREEMENT_VERIFICATION_MESSAGE_TERM)), any());
+        verify(validatorRegistry).register(eq(DSP_NAMESPACE_V_2025_1.toIri(DSPACE_TYPE_CONTRACT_NEGOTIATION_TERMINATION_MESSAGE_TERM)), any());
+    }
+}

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-2025/dsp-negotiation-http-api-2025/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/v2025/controller/DspNegotiationApiControllerV20251Test.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-2025/dsp-negotiation-http-api-2025/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/v2025/controller/DspNegotiationApiControllerV20251Test.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.negotiation.http.api.v2025.controller;
+
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
+import org.eclipse.edc.junit.annotations.ApiTest;
+import org.eclipse.edc.protocol.dsp.negotiation.http.api.controller.DspNegotiationApiControllerTestBase;
+
+import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.BASE_PATH;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.version.DspVersions.V_2025_1_PATH;
+
+@ApiTest
+class DspNegotiationApiControllerV20251Test extends DspNegotiationApiControllerTestBase {
+
+    @Override
+    protected String basePath() {
+        return V_2025_1_PATH + BASE_PATH;
+    }
+
+    @Override
+    protected JsonLdNamespace namespace() {
+        return DSP_NAMESPACE_V_2025_1;
+    }
+
+    @Override
+    protected Object controller() {
+        return new DspNegotiationApiController20251(protocolService, dspRequestHandler);
+    }
+}

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-2025/dsp-negotiation-transform-2025/build.gradle.kts
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-2025/dsp-negotiation-transform-2025/build.gradle.kts
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(project(":spi:common:core-spi"))
+    api(project(":spi:common:transform-spi"))
+
+    implementation(project(":data-protocols:dsp:dsp-negotiation:lib:dsp-negotiation-transform-lib"))
+}

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-2025/dsp-negotiation-transform-2025/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/v2025/DspNegotiationTransformV2025Extension.java
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-2025/dsp-negotiation-transform-2025/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/v2025/DspNegotiationTransformV2025Extension.java
@@ -1,0 +1,87 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.negotiation.transform.v2025;
+
+import jakarta.json.Json;
+import org.eclipse.edc.protocol.dsp.negotiation.transform.from.JsonObjectFromContractNegotiationErrorTransformer;
+import org.eclipse.edc.protocol.dsp.negotiation.transform.to.JsonObjectToContractAgreementMessageTransformer;
+import org.eclipse.edc.protocol.dsp.negotiation.transform.to.JsonObjectToContractAgreementVerificationMessageTransformer;
+import org.eclipse.edc.protocol.dsp.negotiation.transform.to.JsonObjectToContractNegotiationAckTransformer;
+import org.eclipse.edc.protocol.dsp.negotiation.transform.to.JsonObjectToContractNegotiationEventMessageTransformer;
+import org.eclipse.edc.protocol.dsp.negotiation.transform.to.JsonObjectToContractNegotiationTerminationMessageTransformer;
+import org.eclipse.edc.protocol.dsp.negotiation.transform.to.JsonObjectToContractOfferMessageTransformer;
+import org.eclipse.edc.protocol.dsp.negotiation.transform.to.JsonObjectToContractRequestMessageTransformer;
+import org.eclipse.edc.protocol.dsp.negotiation.transform.v2024.from.JsonObjectFromContractAgreementMessageV2024Transformer;
+import org.eclipse.edc.protocol.dsp.negotiation.transform.v2024.from.JsonObjectFromContractAgreementVerificationMessageV2024Transformer;
+import org.eclipse.edc.protocol.dsp.negotiation.transform.v2024.from.JsonObjectFromContractNegotiationEventMessageV2024Transformer;
+import org.eclipse.edc.protocol.dsp.negotiation.transform.v2024.from.JsonObjectFromContractNegotiationTerminationMessageV2024Transformer;
+import org.eclipse.edc.protocol.dsp.negotiation.transform.v2024.from.JsonObjectFromContractNegotiationV2024Transformer;
+import org.eclipse.edc.protocol.dsp.negotiation.transform.v2024.from.JsonObjectFromContractOfferMessageV2024Transformer;
+import org.eclipse.edc.protocol.dsp.negotiation.transform.v2024.from.JsonObjectFromContractRequestMessageV2024Transformer;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+
+import java.util.Map;
+
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_TRANSFORMER_CONTEXT_V_2025_1;
+
+/**
+ * Provides the transformers for negotiation message types via the {@link TypeTransformerRegistry}.
+ */
+@Extension(value = DspNegotiationTransformV2025Extension.NAME)
+public class DspNegotiationTransformV2025Extension implements ServiceExtension {
+
+    public static final String NAME = "Dataspace Protocol 2025/1 Negotiation Transform Extension";
+
+    @Inject
+    private TypeTransformerRegistry registry;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        registerTransformers();
+    }
+
+    private void registerTransformers() {
+        var builderFactory = Json.createBuilderFactory(Map.of());
+
+        var dspApiTransformerRegistry = registry.forContext(DSP_TRANSFORMER_CONTEXT_V_2025_1);
+        dspApiTransformerRegistry.register(new JsonObjectFromContractNegotiationErrorTransformer(builderFactory, DSP_NAMESPACE_V_2025_1));
+
+        dspApiTransformerRegistry.register(new JsonObjectToContractAgreementMessageTransformer(DSP_NAMESPACE_V_2025_1));
+        dspApiTransformerRegistry.register(new JsonObjectToContractAgreementVerificationMessageTransformer(DSP_NAMESPACE_V_2025_1));
+        dspApiTransformerRegistry.register(new JsonObjectToContractNegotiationEventMessageTransformer(DSP_NAMESPACE_V_2025_1));
+        dspApiTransformerRegistry.register(new JsonObjectToContractRequestMessageTransformer(DSP_NAMESPACE_V_2025_1));
+        dspApiTransformerRegistry.register(new JsonObjectToContractNegotiationTerminationMessageTransformer(DSP_NAMESPACE_V_2025_1));
+        dspApiTransformerRegistry.register(new JsonObjectToContractOfferMessageTransformer(DSP_NAMESPACE_V_2025_1));
+        dspApiTransformerRegistry.register(new JsonObjectToContractNegotiationAckTransformer(DSP_NAMESPACE_V_2025_1));
+
+        dspApiTransformerRegistry.register(new JsonObjectFromContractNegotiationV2024Transformer(builderFactory, DSP_NAMESPACE_V_2025_1));
+        dspApiTransformerRegistry.register(new JsonObjectFromContractRequestMessageV2024Transformer(builderFactory, DSP_NAMESPACE_V_2025_1));
+        dspApiTransformerRegistry.register(new JsonObjectFromContractOfferMessageV2024Transformer(builderFactory, DSP_NAMESPACE_V_2025_1));
+        dspApiTransformerRegistry.register(new JsonObjectFromContractAgreementMessageV2024Transformer(builderFactory, DSP_NAMESPACE_V_2025_1));
+        dspApiTransformerRegistry.register(new JsonObjectFromContractAgreementVerificationMessageV2024Transformer(builderFactory, DSP_NAMESPACE_V_2025_1));
+        dspApiTransformerRegistry.register(new JsonObjectFromContractNegotiationEventMessageV2024Transformer(builderFactory, DSP_NAMESPACE_V_2025_1));
+        dspApiTransformerRegistry.register(new JsonObjectFromContractNegotiationTerminationMessageV2024Transformer(builderFactory, DSP_NAMESPACE_V_2025_1));
+    }
+}

--- a/data-protocols/dsp/dsp-negotiation/dsp-negotiation-2025/dsp-negotiation-transform-2025/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/data-protocols/dsp/dsp-negotiation/dsp-negotiation-2025/dsp-negotiation-transform-2025/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2025 Metaform Systems, Inc.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Metaform Systems, Inc. - initial API and implementation
+#
+#
+
+org.eclipse.edc.protocol.dsp.negotiation.transform.v2025.DspNegotiationTransformV2025Extension

--- a/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/spi/type/DspConstants.java
+++ b/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/spi/type/DspConstants.java
@@ -18,8 +18,10 @@ import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 
 import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
 import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA_2024_1;
+import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA_2025_1;
 import static org.eclipse.edc.protocol.dsp.spi.version.DspVersions.V_08_VERSION;
 import static org.eclipse.edc.protocol.dsp.spi.version.DspVersions.V_2024_1_VERSION;
+import static org.eclipse.edc.protocol.dsp.spi.version.DspVersions.V_2025_1_VERSION;
 
 /**
  * Dataspace protocol constants.
@@ -30,10 +32,14 @@ public interface DspConstants {
     String DSP_SCOPE = "DSP";
     String DSP_SCOPE_V_08 = DSP_SCOPE + DSP_CONTEXT_SEPARATOR + V_08_VERSION;
     String DSP_SCOPE_V_2024_1 = DSP_SCOPE + DSP_CONTEXT_SEPARATOR + V_2024_1_VERSION;
+    String DSP_SCOPE_V_2025_1 = DSP_SCOPE + DSP_CONTEXT_SEPARATOR + V_2025_1_VERSION;
+
     String DSP_TRANSFORMER_CONTEXT = "dsp-api";
     String DSP_TRANSFORMER_CONTEXT_V_08 = DSP_TRANSFORMER_CONTEXT + DSP_CONTEXT_SEPARATOR + V_08_VERSION;
     String DSP_TRANSFORMER_CONTEXT_V_2024_1 = DSP_TRANSFORMER_CONTEXT + DSP_CONTEXT_SEPARATOR + V_2024_1_VERSION;
+    String DSP_TRANSFORMER_CONTEXT_V_2025_1 = DSP_TRANSFORMER_CONTEXT + DSP_CONTEXT_SEPARATOR + V_2025_1_VERSION;
 
     JsonLdNamespace DSP_NAMESPACE_V_08 = new JsonLdNamespace(DSPACE_SCHEMA);
     JsonLdNamespace DSP_NAMESPACE_V_2024_1 = new JsonLdNamespace(DSPACE_SCHEMA_2024_1);
+    JsonLdNamespace DSP_NAMESPACE_V_2025_1 = new JsonLdNamespace(DSPACE_SCHEMA_2025_1);
 }

--- a/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/spi/version/DspVersions.java
+++ b/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/spi/version/DspVersions.java
@@ -26,4 +26,9 @@ public interface DspVersions {
     String V_08_PATH = "/";
     ProtocolVersion V_08 = new ProtocolVersion(V_08_VERSION, V_08_PATH);
 
+
+    String V_2025_1_VERSION = "2025/1";
+    String V_2025_1_PATH = "/" + V_2025_1_VERSION;
+    ProtocolVersion V_2025_1 = new ProtocolVersion(V_2025_1_VERSION, V_2025_1_PATH);
+
 }

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-2025/build.gradle.kts
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-2025/build.gradle.kts
@@ -1,0 +1,23 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(project(":data-protocols:dsp:dsp-transfer-process:dsp-transfer-process-2025:dsp-transfer-process-http-api-2025"))
+    api(project(":data-protocols:dsp:dsp-transfer-process:dsp-transfer-process-2025:dsp-transfer-process-transform-2025"))
+}

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-2025/dsp-transfer-process-http-api-2025/build.gradle.kts
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-2025/dsp-transfer-process-http-api-2025/build.gradle.kts
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+    id(libs.plugins.swagger.get().pluginId)
+}
+
+dependencies {
+    api(project(":spi:common:web-spi"))
+    api(project(":spi:control-plane:transfer-spi"))
+    api(project(":spi:control-plane:control-plane-spi"))
+    api(project(":data-protocols:dsp:dsp-spi"))
+    api(project(":data-protocols:dsp:dsp-http-spi"))
+
+    implementation(project(":spi:common:json-ld-spi"))
+    implementation(project(":data-protocols:dsp:dsp-transfer-process:lib:dsp-transfer-process-validation-lib"))
+    implementation(project(":data-protocols:dsp:dsp-transfer-process:lib:dsp-transfer-process-http-api-lib"))
+    implementation(project(":extensions:common:http:lib:jersey-providers-lib"))
+
+    implementation(libs.jakarta.rsApi)
+
+    testImplementation(project(":core:common:junit"))
+    testImplementation(testFixtures(project(":extensions:common:http:jersey-core")))
+    testImplementation(testFixtures(project(":data-protocols:dsp:dsp-transfer-process:lib:dsp-transfer-process-http-api-lib")))
+
+    testImplementation(libs.restAssured)
+}
+
+edcBuild {
+    swagger {
+        apiGroup.set("dsp-api")
+    }
+}

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-2025/dsp-transfer-process-http-api-2025/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/v2025/DspTransferProcessApi2025Extension.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-2025/dsp-transfer-process-http-api-2025/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/v2025/DspTransferProcessApi2025Extension.java
@@ -1,0 +1,83 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.transferprocess.http.api.v2025;
+
+import org.eclipse.edc.connector.controlplane.services.spi.protocol.ProtocolVersionRegistry;
+import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessProtocolService;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
+import org.eclipse.edc.protocol.dsp.transferprocess.http.api.v2025.controller.DspTransferProcessApiController20251;
+import org.eclipse.edc.protocol.dsp.transferprocess.validation.TransferCompletionMessageValidator;
+import org.eclipse.edc.protocol.dsp.transferprocess.validation.TransferRequestMessageValidator;
+import org.eclipse.edc.protocol.dsp.transferprocess.validation.TransferStartMessageValidator;
+import org.eclipse.edc.protocol.dsp.transferprocess.validation.TransferTerminationMessageValidator;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.web.jersey.providers.jsonld.JerseyJsonLdInterceptor;
+import org.eclipse.edc.web.spi.WebService;
+import org.eclipse.edc.web.spi.configuration.ApiContext;
+
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_SCOPE_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_REQUEST_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_START_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_TERMINATION_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.version.DspVersions.V_2025_1;
+import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
+
+/**
+ * Creates and registers the controller for dataspace protocol transfer process requests.
+ */
+@Extension(value = DspTransferProcessApi2025Extension.NAME)
+public class DspTransferProcessApi2025Extension implements ServiceExtension {
+
+    public static final String NAME = "Dataspace Protocol 2025/1: TransferProcess API Extension";
+    @Inject
+    private WebService webService;
+    @Inject
+    private TransferProcessProtocolService transferProcessProtocolService;
+    @Inject
+    private DspRequestHandler dspRequestHandler;
+    @Inject
+    private JsonObjectValidatorRegistry validatorRegistry;
+    @Inject
+    private ProtocolVersionRegistry versionRegistry;
+    @Inject
+    private JsonLd jsonLd;
+    @Inject
+    private TypeManager typeManager;
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        registerValidators();
+
+        webService.registerResource(ApiContext.PROTOCOL, new DspTransferProcessApiController20251(transferProcessProtocolService, dspRequestHandler));
+        webService.registerDynamicResource(ApiContext.PROTOCOL, DspTransferProcessApiController20251.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, DSP_SCOPE_V_2025_1));
+
+        versionRegistry.register(V_2025_1);
+    }
+
+    private void registerValidators() {
+        validatorRegistry.register(DSP_NAMESPACE_V_2025_1.toIri(DSPACE_TYPE_TRANSFER_REQUEST_MESSAGE_TERM), TransferRequestMessageValidator.instance(DSP_NAMESPACE_V_2025_1));
+        validatorRegistry.register(DSP_NAMESPACE_V_2025_1.toIri(DSPACE_TYPE_TRANSFER_START_MESSAGE_TERM), TransferStartMessageValidator.instance(DSP_NAMESPACE_V_2025_1));
+        validatorRegistry.register(DSP_NAMESPACE_V_2025_1.toIri(DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE_TERM), TransferCompletionMessageValidator.instance(DSP_NAMESPACE_V_2025_1));
+        validatorRegistry.register(DSP_NAMESPACE_V_2025_1.toIri(DSPACE_TYPE_TRANSFER_TERMINATION_MESSAGE_TERM), TransferTerminationMessageValidator.instance(DSP_NAMESPACE_V_2025_1));
+    }
+}

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-2025/dsp-transfer-process-http-api-2025/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/v2025/controller/DspTransferProcessApiController20251.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-2025/dsp-transfer-process-http-api-2025/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/v2025/controller/DspTransferProcessApiController20251.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.transferprocess.http.api.v2025.controller;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessProtocolService;
+import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
+import org.eclipse.edc.protocol.dsp.spi.version.DspVersions;
+import org.eclipse.edc.protocol.dsp.transferprocess.http.api.controller.BaseDspTransferProcessApiController;
+
+import static org.eclipse.edc.protocol.dsp.http.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.transferprocess.http.api.TransferProcessApiPaths.BASE_PATH;
+
+
+/**
+ * Versioned Transfer endpoint for 2024/1 protocol version
+ */
+@Consumes({MediaType.APPLICATION_JSON})
+@Produces({MediaType.APPLICATION_JSON})
+@Path(DspVersions.V_2025_1_PATH + BASE_PATH)
+public class DspTransferProcessApiController20251 extends BaseDspTransferProcessApiController {
+
+    public DspTransferProcessApiController20251(TransferProcessProtocolService protocolService, DspRequestHandler dspRequestHandler) {
+        super(protocolService, dspRequestHandler, DATASPACE_PROTOCOL_HTTP_V_2025_1, DSP_NAMESPACE_V_2025_1);
+    }
+}

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-2025/dsp-transfer-process-http-api-2025/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-2025/dsp-transfer-process-http-api-2025/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2025 Metaform Systems, Inc.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Metaform Systems, Inc. - initial API and implementation
+#
+#
+
+org.eclipse.edc.protocol.dsp.transferprocess.http.api.v2025.DspTransferProcessApi2025Extension

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-2025/dsp-transfer-process-http-api-2025/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/v2025/DspTransferProcessApiExtension2025Test.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-2025/dsp-transfer-process-http-api-2025/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/v2025/DspTransferProcessApiExtension2025Test.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.transferprocess.http.api.v2025;
+
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_REQUEST_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_START_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_TERMINATION_MESSAGE_TERM;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(DependencyInjectionExtension.class)
+class DspTransferProcessApiExtension2025Test {
+
+    private final JsonObjectValidatorRegistry validatorRegistry = mock();
+
+    @BeforeEach
+    void setUp(ServiceExtensionContext context) {
+        context.registerService(JsonObjectValidatorRegistry.class, validatorRegistry);
+    }
+
+    @Test
+    void shouldRegisterMessageValidators(DspTransferProcessApi2025Extension extension, ServiceExtensionContext context) {
+        extension.initialize(context);
+
+        verify(validatorRegistry).register(eq(DSP_NAMESPACE_V_2025_1.toIri(DSPACE_TYPE_TRANSFER_REQUEST_MESSAGE_TERM)), any());
+        verify(validatorRegistry).register(eq(DSP_NAMESPACE_V_2025_1.toIri(DSPACE_TYPE_TRANSFER_START_MESSAGE_TERM)), any());
+        verify(validatorRegistry).register(eq(DSP_NAMESPACE_V_2025_1.toIri(DSPACE_TYPE_TRANSFER_COMPLETION_MESSAGE_TERM)), any());
+        verify(validatorRegistry).register(eq(DSP_NAMESPACE_V_2025_1.toIri(DSPACE_TYPE_TRANSFER_TERMINATION_MESSAGE_TERM)), any());
+    }
+
+}

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-2025/dsp-transfer-process-http-api-2025/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/v2025/controller/DspTransferProcessApiControllerV20251Test.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-2025/dsp-transfer-process-http-api-2025/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/v2025/controller/DspTransferProcessApiControllerV20251Test.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.transferprocess.http.api.v2025.controller;
+
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
+import org.eclipse.edc.junit.annotations.ApiTest;
+import org.eclipse.edc.protocol.dsp.transferprocess.http.api.controller.DspTransferProcessApiControllerBaseTest;
+
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.version.DspVersions.V_2025_1_PATH;
+import static org.eclipse.edc.protocol.dsp.transferprocess.http.api.TransferProcessApiPaths.BASE_PATH;
+
+@ApiTest
+class DspTransferProcessApiControllerV20251Test extends DspTransferProcessApiControllerBaseTest {
+
+    @Override
+    protected String basePath() {
+        return V_2025_1_PATH + BASE_PATH;
+    }
+
+    @Override
+    protected JsonLdNamespace namespace() {
+        return DSP_NAMESPACE_V_2025_1;
+    }
+
+    @Override
+    protected Object controller() {
+        return new DspTransferProcessApiController20251(protocolService, dspRequestHandler);
+    }
+
+}

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-2025/dsp-transfer-process-transform-2025/build.gradle.kts
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-2025/dsp-transfer-process-transform-2025/build.gradle.kts
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(project(":spi:control-plane:transfer-spi"))
+    api(project(":spi:common:transform-spi"))
+    api(project(":extensions:common:json-ld"))
+    api(project(":data-protocols:dsp:dsp-spi"))
+    api(project(":data-protocols:dsp:dsp-http-spi"))
+    implementation(project(":core:common:lib:transform-lib"))
+    implementation(project(":data-protocols:dsp:dsp-transfer-process:lib:dsp-transfer-process-transform-lib"))
+
+    testImplementation(project(":core:common:lib:json-ld-lib"))
+    testImplementation(project(":core:common:junit"))
+}
+

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-2025/dsp-transfer-process-transform-2025/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/v2025/DspTransferProcessTransformV2025Extension.java
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-2025/dsp-transfer-process-transform-2025/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/v2025/DspTransferProcessTransformV2025Extension.java
@@ -1,0 +1,90 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.transferprocess.transform.v2025;
+
+import jakarta.json.Json;
+import org.eclipse.edc.protocol.dsp.transferprocess.transform.type.from.JsonObjectFromTransferErrorTransformer;
+import org.eclipse.edc.protocol.dsp.transferprocess.transform.type.to.JsonObjectToTransferCompletionMessageTransformer;
+import org.eclipse.edc.protocol.dsp.transferprocess.transform.type.to.JsonObjectToTransferProcessAckTransformer;
+import org.eclipse.edc.protocol.dsp.transferprocess.transform.type.to.JsonObjectToTransferRequestMessageTransformer;
+import org.eclipse.edc.protocol.dsp.transferprocess.transform.type.to.JsonObjectToTransferStartMessageTransformer;
+import org.eclipse.edc.protocol.dsp.transferprocess.transform.type.to.JsonObjectToTransferSuspensionMessageTransformer;
+import org.eclipse.edc.protocol.dsp.transferprocess.transform.type.to.JsonObjectToTransferTerminationMessageTransformer;
+import org.eclipse.edc.protocol.dsp.transferprocess.transform.type.v2024.from.JsonObjectFromTransferCompletionMessageV2024Transformer;
+import org.eclipse.edc.protocol.dsp.transferprocess.transform.type.v2024.from.JsonObjectFromTransferProcessV2024Transformer;
+import org.eclipse.edc.protocol.dsp.transferprocess.transform.type.v2024.from.JsonObjectFromTransferRequestMessageV2024Transformer;
+import org.eclipse.edc.protocol.dsp.transferprocess.transform.type.v2024.from.JsonObjectFromTransferStartMessageV2024Transformer;
+import org.eclipse.edc.protocol.dsp.transferprocess.transform.type.v2024.from.JsonObjectFromTransferSuspensionMessageV2024Transformer;
+import org.eclipse.edc.protocol.dsp.transferprocess.transform.type.v2024.from.JsonObjectFromTransferTerminationMessageV2024Transformer;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+
+import java.util.Map;
+
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_TRANSFORMER_CONTEXT_V_2025_1;
+import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
+
+/**
+ * Provides the transformers for transferprocess message types via the {@link TypeTransformerRegistry}.
+ */
+@Extension(value = DspTransferProcessTransformV2025Extension.NAME)
+public class DspTransferProcessTransformV2025Extension implements ServiceExtension {
+
+    public static final String NAME = "Dataspace Protocol 2025/1 Transfer Process Transform Extension";
+
+    @Inject
+    private TypeTransformerRegistry registry;
+
+    @Inject
+    private TypeManager typeManager;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        registerTransformers();
+    }
+
+    private void registerTransformers() {
+        var builderFactory = Json.createBuilderFactory(Map.of());
+
+        var dspRegistry = registry.forContext(DSP_TRANSFORMER_CONTEXT_V_2025_1);
+
+        dspRegistry.register(new JsonObjectFromTransferErrorTransformer(builderFactory, DSP_NAMESPACE_V_2025_1));
+
+        dspRegistry.register(new JsonObjectToTransferRequestMessageTransformer(DSP_NAMESPACE_V_2025_1));
+        dspRegistry.register(new JsonObjectToTransferCompletionMessageTransformer(DSP_NAMESPACE_V_2025_1));
+        dspRegistry.register(new JsonObjectToTransferStartMessageTransformer(DSP_NAMESPACE_V_2025_1));
+        dspRegistry.register(new JsonObjectToTransferTerminationMessageTransformer(DSP_NAMESPACE_V_2025_1));
+        dspRegistry.register(new JsonObjectToTransferProcessAckTransformer(DSP_NAMESPACE_V_2025_1));
+        dspRegistry.register(new JsonObjectToTransferSuspensionMessageTransformer(typeManager, JSON_LD, DSP_NAMESPACE_V_2025_1));
+
+        dspRegistry.register(new JsonObjectFromTransferProcessV2024Transformer(builderFactory, DSP_NAMESPACE_V_2025_1));
+        dspRegistry.register(new JsonObjectFromTransferRequestMessageV2024Transformer(builderFactory, DSP_NAMESPACE_V_2025_1));
+        dspRegistry.register(new JsonObjectFromTransferStartMessageV2024Transformer(builderFactory, DSP_NAMESPACE_V_2025_1));
+        dspRegistry.register(new JsonObjectFromTransferCompletionMessageV2024Transformer(builderFactory, DSP_NAMESPACE_V_2025_1));
+        dspRegistry.register(new JsonObjectFromTransferTerminationMessageV2024Transformer(builderFactory, DSP_NAMESPACE_V_2025_1));
+        dspRegistry.register(new JsonObjectFromTransferSuspensionMessageV2024Transformer(builderFactory, DSP_NAMESPACE_V_2025_1));
+    }
+
+}

--- a/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-2025/dsp-transfer-process-transform-2025/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/data-protocols/dsp/dsp-transfer-process/dsp-transfer-process-2025/dsp-transfer-process-transform-2025/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2025 Metaform Systems, Inc.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Metaform Systems, Inc. - initial API and implementation
+#
+#
+
+org.eclipse.edc.protocol.dsp.transferprocess.transform.v2025.DspTransferProcessTransformV2025Extension

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/JsonLdExtension.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/JsonLdExtension.java
@@ -34,6 +34,9 @@ import java.net.URISyntaxException;
 import java.util.stream.Stream;
 
 import static java.lang.String.format;
+import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_CONTEXT_2025_1;
+import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_ODRL_PROFILE_2025_1;
+import static org.eclipse.edc.jsonld.spi.Namespaces.EDC_DSPACE_CONTEXT;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_CONNECTOR_MANAGEMENT_CONTEXT;
 import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
 
@@ -56,17 +59,14 @@ public class JsonLdExtension implements ServiceExtension {
     public static final String CONFIG_VALUE_URL = "url";
 
     private static final boolean DEFAULT_HTTP_HTTPS_RESOLUTION = false;
+    private static final boolean DEFAULT_AVOID_VOCAB_CONTEXT = false;
+    private static final boolean DEFAULT_CHECK_PREFIXES = true;
     @Setting(description = "If set enable http json-ld document resolution", defaultValue = DEFAULT_HTTP_HTTPS_RESOLUTION + "", key = "edc.jsonld.http.enabled")
     private boolean httpResolutionEnabled;
-
     @Setting(description = "If set enable https json-ld document resolution", type = "boolean", defaultValue = DEFAULT_HTTP_HTTPS_RESOLUTION + "", key = "edc.jsonld.https.enabled")
     private boolean httpsResolutionEnabled;
-
-    private static final boolean DEFAULT_AVOID_VOCAB_CONTEXT = false;
     @Setting(description = "If true disable the @vocab context definition. This could be used to avoid api breaking changes", defaultValue = DEFAULT_AVOID_VOCAB_CONTEXT + "", key = "edc.jsonld.vocab.disable")
     private boolean avoidVocab;
-
-    private static final boolean DEFAULT_CHECK_PREFIXES = true;
     @Setting(description = "If true a validation on expended object will be made against configured prefixes", type = "boolean", defaultValue = DEFAULT_CHECK_PREFIXES + "", key = "edc.jsonld.prefixes.check")
     private boolean checkPrefixes;
 
@@ -97,7 +97,10 @@ public class JsonLdExtension implements ServiceExtension {
         Stream.of(
                 new JsonLdContext("odrl.jsonld", "http://www.w3.org/ns/odrl.jsonld"),
                 new JsonLdContext("dspace.jsonld", "https://w3id.org/dspace/2024/1/context.json"),
-                new JsonLdContext("management-context-v1.jsonld", EDC_CONNECTOR_MANAGEMENT_CONTEXT)
+                new JsonLdContext("management-context-v1.jsonld", EDC_CONNECTOR_MANAGEMENT_CONTEXT),
+                new JsonLdContext("dspace-edc-context-v1.jsonld", EDC_DSPACE_CONTEXT),
+                new JsonLdContext("dspace-v2025-1.jsonld", DSPACE_CONTEXT_2025_1),
+                new JsonLdContext("dspace-v2025-1-odrl.jsonld", DSPACE_ODRL_PROFILE_2025_1)
         ).forEach(jsonLdContext -> getResourceUri("document/" + jsonLdContext.fileName())
                 .onSuccess(uri -> service.registerCachedDocument(jsonLdContext.url(), uri))
                 .onFailure(failure -> monitor.warning("Failed to register cached json-ld document: " + failure.getFailureDetail()))

--- a/extensions/common/json-ld/src/main/resources/document/dspace-edc-context-v1.jsonld
+++ b/extensions/common/json-ld/src/main/resources/document/dspace-edc-context-v1.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "edc": "https://w3id.org/edc/v0.0.1/ns/",
+    "QuerySpec": {
+      "@id": "edc:QuerySpec",
+      "@context": {
+        "sortOrder": "edc:sortOrder",
+        "sortField": "edc:sortField",
+        "offset": "edc:offset",
+        "limit": "edc:limit",
+        "filterExpression": {
+          "@id": "edc:filterExpression",
+          "@container": "@set"
+        }
+      }
+    },
+    "Criterion": {
+      "@id": "edc:Criterion",
+      "@context": {
+        "operandLeft": "edc:operandLeft",
+        "operator": "edc:operator",
+        "operandRight": "edc:operandRight"
+      }
+    },
+    "inForceDate": "edc:inForceDate",
+    "id": "edc:id",
+    "description": "edc:description",
+    "isCatalog": "edc:isCatalog"
+  }
+}

--- a/extensions/common/json-ld/src/main/resources/document/dspace-v2025-1-odrl.jsonld
+++ b/extensions/common/json-ld/src/main/resources/document/dspace-v2025-1-odrl.jsonld
@@ -1,0 +1,95 @@
+{
+  "@context": {
+    "odrl": "http://www.w3.org/ns/odrl/2/",
+    "Policy": "odrl:Policy",
+    "Rule": "odrl:Rule",
+    "profile": {
+      "@type": "@id",
+      "@id": "odrl:profile"
+    },
+    "prohibit": "odrl:prohibit",
+    "Agreement": "odrl:Agreement",
+    "Assertion": "odrl:Assertion",
+    "Offer": "odrl:Offer",
+    "Set": "odrl:Set",
+    "Asset": "odrl:Asset",
+    "hasPolicy": {
+      "@type": "@id",
+      "@id": "odrl:hasPolicy"
+    },
+    "target": {
+      "@type": "@id",
+      "@id": "odrl:target"
+    },
+    "assignee": {
+      "@type": "@id",
+      "@id": "odrl:assignee"
+    },
+    "assigner": {
+      "@type": "@id",
+      "@id": "odrl:assigner"
+    },
+    "Action": "odrl:Action",
+    "action": {
+      "@type": "@vocab",
+      "@id": "odrl:action"
+    },
+    "Permission": "odrl:Permission",
+    "permission": {
+      "@type": "@id",
+      "@id": "odrl:permission",
+      "@container": "@set"
+    },
+    "Prohibition": "odrl:Prohibition",
+    "prohibition": {
+      "@type": "@id",
+      "@id": "odrl:prohibition",
+      "@container": "@set"
+    },
+    "obligation": {
+      "@type": "@id",
+      "@id": "odrl:obligation",
+      "@container": "@set"
+    },
+    "use": "odrl:use",
+    "Duty": "odrl:Duty",
+    "duty": {
+      "@type": "@id",
+      "@id": "odrl:duty"
+    },
+    "Constraint": "odrl:Constraint",
+    "constraint": {
+      "@type": "@id",
+      "@id": "odrl:constraint",
+      "@container": "@set"
+    },
+    "Operator": "odrl:Operator",
+    "operator": {
+      "@type": "@vocab",
+      "@id": "odrl:operator"
+    },
+    "RightOperand": "odrl:RightOperand",
+    "rightOperand": "odrl:rightOperand",
+    "LeftOperand": "odrl:LeftOperand",
+    "leftOperand": {
+      "@type": "@vocab",
+      "@id": "odrl:leftOperand"
+    },
+    "eq": "odrl:eq",
+    "gt": "odrl:gt",
+    "gteq": "odrl:gteq",
+    "lt": "odrl:lt",
+    "lteq": "odrl:lteq",
+    "neq": "odrl:neq",
+    "isA": "odrl:isA",
+    "hasPart": "odrl:hasPart",
+    "isPartOf": "odrl:isPartOf",
+    "isAllOf": "odrl:isAllOf",
+    "isAnyOf": "odrl:isAnyOf",
+    "isNoneOf": "odrl:isNoneOf",
+    "or": "odrl:or",
+    "xone": "odrl:xone",
+    "and": "odrl:and",
+    "andSequence": "odrl:andSequence"
+  }
+}

--- a/extensions/common/json-ld/src/main/resources/document/dspace-v2025-1.jsonld
+++ b/extensions/common/json-ld/src/main/resources/document/dspace-v2025-1.jsonld
@@ -1,0 +1,452 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "dct": "http://purl.org/dc/terms/",
+    "dcat": "http://www.w3.org/ns/dcat#",
+    "odrl": "http://www.w3.org/ns/odrl/2/",
+    "dspace": "https://w3id.org/dspace/2025/1/",
+    "DatasetRequestMessage": {
+      "@id": "dspace:DatasetRequestMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "dataset": "dspace:dataset"
+      }
+    },
+    "CatalogRequestMessage": {
+      "@id": "dspace:CatalogRequestMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "filter": {
+          "@id": "dspace:filter",
+          "@container": "@set"
+        }
+      }
+    },
+    "CatalogError": {
+      "@id": "dspace:CatalogError",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "code": "dspace:code",
+        "reason": {
+          "@id": "dspace:reason",
+          "@container": "@set"
+        }
+      }
+    },
+    "ContractRequestMessage": {
+      "@id": "dspace:ContractRequestMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "@import": "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
+        "@propagate": true,
+        "callbackAddress": "dspace:callbackAddress",
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        },
+        "offer": {
+          "@type": "@id",
+          "@id": "dspace:offer"
+        }
+      }
+    },
+    "ContractOfferMessage": {
+      "@id": "dspace:ContractOfferMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "@import": "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
+        "@propagate": true,
+        "callbackAddress": "dspace:callbackAddress",
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        },
+        "offer": {
+          "@type": "@id",
+          "@id": "dspace:offer"
+        }
+      }
+    },
+    "ContractAgreementMessage": {
+      "@id": "dspace:ContractAgreementMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "@import": "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
+        "@propagate": true,
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        },
+        "agreement": {
+          "@id": "dspace:agreement",
+          "@type": "@id"
+        },
+        "callbackAddress": "dspace:callbackAddress",
+        "timestamp": "dspace:timestamp"
+      }
+    },
+    "ContractAgreementVerificationMessage": {
+      "@id": "dspace:ContractAgreementVerificationMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        }
+      }
+    },
+    "ContractNegotiationEventMessage": {
+      "@id": "dspace:ContractNegotiationEventMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        },
+        "eventType": {
+          "@type": "@vocab",
+          "@id": "dspace:eventType"
+        }
+      }
+    },
+    "ContractNegotiationTerminationMessage": {
+      "@id": "dspace:ContractNegotiationTerminationMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "code": "dspace:code",
+        "reason": {
+          "@id": "dspace:reason",
+          "@container": "@set"
+        },
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        }
+      }
+    },
+    "ContractNegotiation": {
+      "@id": "dspace:ContractNegotiation",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        },
+        "state": {
+          "@type": "@vocab",
+          "@id": "dspace:state"
+        }
+      }
+    },
+    "ContractNegotiationError": {
+      "@id": "dspace:ContractNegotiationError",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        },
+        "code": "dspace:code",
+        "reason": {
+          "@id": "dspace:reason",
+          "@container": "@set"
+        }
+      }
+    },
+    "TransferRequestMessage": {
+      "@id": "dspace:TransferRequestMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "callbackAddress": "dspace:callbackAddress",
+        "dataAddress": "dspace:dataAddress",
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        },
+        "format": {
+          "@type": "@vocab",
+          "@id": "dct:format"
+        },
+        "agreementId": {
+          "@type": "@id",
+          "@id": "dspace:agreementId"
+        }
+      }
+    },
+    "TransferStartMessage": {
+      "@id": "dspace:TransferStartMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        },
+        "dataAddress": "dspace:dataAddress"
+      }
+    },
+    "TransferCompletionMessage": {
+      "@id": "dspace:TransferCompletionMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        }
+      }
+    },
+    "TransferTerminationMessage": {
+      "@id": "dspace:TransferTerminationMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "code": "dspace:code",
+        "reason": {
+          "@id": "dspace:reason",
+          "@container": "@set"
+        },
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        }
+      }
+    },
+    "TransferSuspensionMessage": {
+      "@id": "dspace:TransferSuspensionMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "code": "dspace:code",
+        "reason": {
+          "@id": "dspace:reason",
+          "@container": "@set"
+        },
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        }
+      }
+    },
+    "TransferError": {
+      "@id": "dspace:TransferError",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "code": "dspace:code",
+        "consumerPid": "dspace:consumerPid",
+        "providerPid": "dspace:providerPid",
+        "reason": {
+          "@id": "dspace:reason",
+          "@container": "@set"
+        }
+      }
+    },
+    "DataAddress": {
+      "@id": "dspace:DataAddress",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "endpointType": {
+          "@type": "@vocab",
+          "@id": "dspace:endpointType"
+        },
+        "endpointProperties": {
+          "@id": "dspace:endpointProperties",
+          "@container": "@set"
+        },
+        "endpoint": "dspace:endpoint"
+      }
+    },
+    "EndpointProperty": {
+      "@id": "dspace:EndpointProperty",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "name": "dspace:name",
+        "value": "dspace:value"
+      }
+    },
+    "TransferProcess": {
+      "@id": "dspace:TransferProcess",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        },
+        "state": {
+          "@type": "@vocab",
+          "@id": "dspace:state"
+        }
+      }
+    },
+    "VersionsError": {
+      "@id": "dspace:VersionsError",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "code": "dspace:code",
+        "reason": {
+          "@id": "dspace:reason",
+          "@container": "@set"
+        }
+      }
+    },
+    "Catalog": {
+      "@id": "dcat:Catalog",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "service": {
+          "@id": "dcat:service",
+          "@container": "@set"
+        },
+        "participantId": {
+          "@type": "@id",
+          "@id": "dspace:participantId"
+        },
+        "catalog": {
+          "@id": "dcat:catalog",
+          "@container": "@set"
+        },
+        "dataset": {
+          "@id": "dcat:dataset",
+          "@container": "@set"
+        },
+        "distribution": {
+          "@id": "dcat:distribution",
+          "@container": "@set"
+        }
+      }
+    },
+    "Dataset": {
+      "@id": "dcat:Dataset",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "@import": "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
+        "@propagate": true,
+        "distribution": {
+          "@id": "dcat:distribution",
+          "@container": "@set"
+        },
+        "hasPolicy": {
+          "@id": "odrl:hasPolicy",
+          "@container": "@set"
+        }
+      }
+    },
+    "DataService": {
+      "@id": "dcat:DataService",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "endpointDescription": "dcat:endpointDescription",
+        "endpointURL": "dcat:endpointURL"
+      }
+    },
+    "Distribution": {
+      "@id": "dcat:Distribution",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "format": {
+          "@type": "@vocab",
+          "@id": "dct:format"
+        },
+        "accessService": {
+          "@id": "dcat:accessService"
+        }
+      }
+    },
+    "CatalogService": {
+      "@id": "dspace:CatalogService",
+      "@context": {
+        "id": "@id",
+        "type": "@type",
+        "serviceEndpoint": {
+          "@id": "https://www.w3.org/ns/did#serviceEndpoint",
+          "@type": "@id"
+        }
+      }
+    },
+    "ACCEPTED": "dspace:ACCEPTED",
+    "FINALIZED": "dspace:FINALIZED",
+    "REQUESTED": "dspace:REQUESTED",
+    "STARTED": "dspace:STARTED",
+    "COMPLETED": "dspace:COMPLETED",
+    "SUSPENDED": "dspace:SUSPENDED",
+    "TERMINATED": "dspace:TERMINATED",
+    "OFFERED": "dspace:OFFERED",
+    "AGREED": "dspace:AGREED",
+    "VERIFIED": "dspace:VERIFIED"
+  }
+}

--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/Participant.java
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/Participant.java
@@ -117,6 +117,14 @@ public class Participant {
         return id;
     }
 
+    public JsonLd getJsonLd() {
+        return jsonLd;
+    }
+
+    public void setJsonLd(JsonLd jsonLd) {
+        this.jsonLd = jsonLd;
+    }
+
     /**
      * Get the protocol URL of the participant which is the protocol base path + protocol version path (empty by default).
      *

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -110,6 +110,20 @@ include(":data-protocols:dsp:dsp-transfer-process:lib:dsp-transfer-process-http-
 include(":data-protocols:dsp:dsp-version:dsp-version-http-api")
 include(":data-protocols:dsp:dsp-version:dsp-version-http-dispatcher")
 
+// dsp version 2025/1
+
+include(":data-protocols:dsp:dsp-2025")
+include(":data-protocols:dsp:dsp-2025:dsp-http-api-configuration-2025")
+include(":data-protocols:dsp:dsp-catalog:dsp-catalog-2025")
+include(":data-protocols:dsp:dsp-catalog:dsp-catalog-2025:dsp-catalog-http-api-2025")
+include(":data-protocols:dsp:dsp-catalog:dsp-catalog-2025:dsp-catalog-transform-2025")
+include(":data-protocols:dsp:dsp-transfer-process:dsp-transfer-process-2025")
+include(":data-protocols:dsp:dsp-transfer-process:dsp-transfer-process-2025:dsp-transfer-process-http-api-2025")
+include(":data-protocols:dsp:dsp-transfer-process:dsp-transfer-process-2025:dsp-transfer-process-transform-2025")
+include("data-protocols:dsp:dsp-negotiation:dsp-negotiation-2025")
+include("data-protocols:dsp:dsp-negotiation:dsp-negotiation-2025:dsp-negotiation-http-api-2025")
+include("data-protocols:dsp:dsp-negotiation:dsp-negotiation-2025:dsp-negotiation-transform-2025")
+
 // modules for technology- or cloud-provider extensions --------------------------------------------
 include(":extensions:common:api:api-core")
 include(":extensions:common:api:api-observability")
@@ -289,6 +303,7 @@ include(":system-tests:management-api:management-api-test-runtime")
 include(":system-tests:version-api:version-api-test-runtime")
 include(":system-tests:version-api:version-api-test-runner")
 include(":system-tests:protocol-test")
+include(":system-tests:protocol-2025-test")
 include(":system-tests:sts-api:sts-api-test-runner")
 include(":system-tests:sts-api:sts-api-test-runtime")
 include(":system-tests:telemetry:telemetry-test-runner")

--- a/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/Namespaces.java
+++ b/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/Namespaces.java
@@ -30,4 +30,10 @@ public interface Namespaces {
     String DSPACE_PREFIX = "dspace";
     String DSPACE_SCHEMA = "https://w3id.org/dspace/v0.8/";
     String DSPACE_SCHEMA_2024_1 = "https://w3id.org/dspace/2024/1/";
+
+    String DSPACE_SCHEMA_2025_1 = "https://w3id.org/dspace/2025/1/";
+    String DSPACE_CONTEXT_2025_1 = "https://w3id.org/dspace/2025/1/context.jsonld";
+    String DSPACE_ODRL_PROFILE_2025_1 = "https://w3id.org/dspace/2025/1/odrl-profile.jsonld";
+
+    String EDC_DSPACE_CONTEXT = "https://w3id.org/edc/dspace/v0.0.1";
 }

--- a/system-tests/e2e-transfer-test/control-plane/build.gradle.kts
+++ b/system-tests/e2e-transfer-test/control-plane/build.gradle.kts
@@ -18,7 +18,14 @@ plugins {
 
 dependencies {
     implementation(project(":dist:bom:controlplane-base-bom"))
-
+    implementation(project(":core:common:edr-store-core"))
+    implementation(project(":core:common:token-core"))
+    implementation(project(":core:control-plane:control-plane-core"))
+    implementation(project(":data-protocols:dsp"))
+    implementation(project(":data-protocols:dsp:dsp-2025"))
+    implementation(project(":extensions:common:http"))
+    implementation(project(":extensions:common:api:control-api-configuration"))
+    implementation(project(":extensions:common:api:management-api-configuration"))
     implementation(project(":extensions:common:iam:iam-mock"))
     implementation(project(":extensions:control-plane:provision:provision-http"))
 }

--- a/system-tests/management-api/management-api-test-runner/build.gradle.kts
+++ b/system-tests/management-api/management-api-test-runner/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     testImplementation(project(":core:common:junit"))
     // gives access to the Json LD models, etc.
     testImplementation(project(":spi:common:json-ld-spi"))
+    testImplementation(project(":data-protocols:dsp:dsp-spi"))
     testImplementation(project(":spi:control-plane:asset-spi"))
     testImplementation(project(":spi:control-plane:contract-spi"))
     testImplementation(project(":spi:data-plane-selector:data-plane-selector-spi"))

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/DspSerdeEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/DspSerdeEndToEndTest.java
@@ -1,0 +1,392 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.e2e.managementapi;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.connector.controlplane.catalog.spi.CatalogError;
+import org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequestMessage;
+import org.eclipse.edc.connector.controlplane.catalog.spi.DataService;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Distribution;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreementMessage;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreementVerificationMessage;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractNegotiationEventMessage;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationError;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationTerminationMessage;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractOfferMessage;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequestMessage;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferCompletionMessage;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferError;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferRequestMessage;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferStartMessage;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferSuspensionMessage;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferTerminationMessage;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.junit.extensions.EmbeddedRuntime;
+import org.eclipse.edc.junit.extensions.RuntimeExtension;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.types.domain.message.ErrorMessage;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_ODRL_PROFILE_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_SCOPE_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_TRANSFORMER_CONTEXT_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_STATE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_PROCESS_TERM;
+import static org.eclipse.edc.test.e2e.managementapi.DspTestFunctions.catalogRequestObject;
+import static org.eclipse.edc.test.e2e.managementapi.DspTestFunctions.contractAgreementObject;
+import static org.eclipse.edc.test.e2e.managementapi.DspTestFunctions.contractAgreementVerificationObject;
+import static org.eclipse.edc.test.e2e.managementapi.DspTestFunctions.contractNegotiationEventObject;
+import static org.eclipse.edc.test.e2e.managementapi.DspTestFunctions.contractNegotiationTerminationObject;
+import static org.eclipse.edc.test.e2e.managementapi.DspTestFunctions.contractOfferObject;
+import static org.eclipse.edc.test.e2e.managementapi.DspTestFunctions.contractRequestObject;
+import static org.eclipse.edc.test.e2e.managementapi.DspTestFunctions.errorObject;
+import static org.eclipse.edc.test.e2e.managementapi.DspTestFunctions.inForceDatePolicy;
+import static org.eclipse.edc.test.e2e.managementapi.DspTestFunctions.transferCompletionObject;
+import static org.eclipse.edc.test.e2e.managementapi.DspTestFunctions.transferRequestObject;
+import static org.eclipse.edc.test.e2e.managementapi.DspTestFunctions.transferStartObject;
+import static org.eclipse.edc.test.e2e.managementapi.DspTestFunctions.transferSuspensionObject;
+import static org.eclipse.edc.test.e2e.managementapi.DspTestFunctions.transferTerminationObject;
+import static org.eclipse.edc.util.io.Ports.getFreePort;
+
+@EndToEndTest
+public class DspSerdeEndToEndTest {
+
+    @RegisterExtension
+    private static final RuntimeExtension RUNTIME = new SerdeRuntime();
+
+
+    @ParameterizedTest
+    @ValueSource(strings = {"REQUESTED", "STARTED", "COMPLETED", "SUSPENDED", "TERMINATED"})
+    void ser_TransferProcess(String state) {
+        var tp = TransferProcess.Builder.newInstance()
+                .type(TransferProcess.Type.PROVIDER)
+                .state(TransferProcessStates.valueOf(state).code())
+                .correlationId(UUID.randomUUID().toString())
+                .build();
+        var expanded = serialize(tp);
+
+        assertThat(expanded.getString(TYPE)).isEqualTo(toIri(DSPACE_TYPE_TRANSFER_PROCESS_TERM));
+        assertThat(expanded.getJsonObject(toIri(DSPACE_PROPERTY_STATE_TERM)).getString(ID)).isEqualTo(toIri(state));
+
+        var result = compact(expanded);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getString(TYPE)).isEqualTo("TransferProcess");
+        assertThat(result.getString("providerPid")).isEqualTo(tp.getId());
+        assertThat(result.getString("consumerPid")).isEqualTo(tp.getCorrelationId());
+        assertThat(result.getString("state")).isEqualTo(state);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"REQUESTED", "OFFERED", "ACCEPTED", "AGREED", "VERIFIED", "FINALIZED", "TERMINATED"})
+    void ser_ContractNegotiation(String state) {
+        var cn = ContractNegotiation.Builder.newInstance()
+                .type(ContractNegotiation.Type.PROVIDER)
+                .counterPartyId(UUID.randomUUID().toString())
+                .counterPartyAddress("address")
+                .protocol("protocol")
+                .state(ContractNegotiationStates.valueOf(state).code())
+                .correlationId(UUID.randomUUID().toString())
+                .build();
+
+        var expanded = serialize(cn);
+
+        assertThat(expanded.getString(TYPE)).isEqualTo(toIri(DSPACE_TYPE_CONTRACT_NEGOTIATION_TERM));
+        assertThat(expanded.getJsonObject(toIri(DSPACE_PROPERTY_STATE_TERM)).getString(ID)).isEqualTo(toIri(state));
+
+        var result = compact(expanded);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getString(TYPE)).isEqualTo("ContractNegotiation");
+        assertThat(result.getString("providerPid")).isEqualTo(cn.getId());
+        assertThat(result.getString("consumerPid")).isEqualTo(cn.getCorrelationId());
+        assertThat(result.getString("state")).isEqualTo(state);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ErrorProvider.class)
+    void ser_Errors(JsonObject error, ErrorMessage errorMessage) {
+
+        var expanded = serialize(errorMessage);
+
+        assertThat(expanded.getString(TYPE)).isEqualTo(toIri(error.getString(TYPE)));
+
+        var result = compact(expanded);
+
+        assertThat(result).isNotNull().isEqualTo(error);
+    }
+
+    @Test
+    void ser_Catalog() {
+
+        var policyJson = inForceDatePolicy();
+        var standAlonePolicy = Json.createObjectBuilder(inForceDatePolicy()).add(CONTEXT, DSPACE_ODRL_PROFILE_2025_1).build();
+
+        var offerId = policyJson.getString(ID);
+
+        var policy = deserialize(standAlonePolicy, Policy.class);
+
+        var dataService = DataService.Builder.newInstance().id(UUID.randomUUID().toString())
+                .endpointDescription("connector")
+                .endpointUrl("http://myconnector")
+                .build();
+
+        var distribution = Distribution.Builder.newInstance().format("HttpData-PULL")
+                .dataService(dataService)
+                .build();
+
+        var dataset = Dataset.Builder.newInstance().id(UUID.randomUUID().toString())
+                .offer(offerId, policy)
+                .distribution(distribution).build();
+
+        var catalog = Catalog.Builder.newInstance()
+                .participantId("participantId")
+                .dataService(dataService)
+                .dataset(dataset)
+                .build();
+        var result = serializeAndCompact(catalog);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getString(TYPE)).isEqualTo("Catalog");
+
+        assertThat(result.getString("participantId")).isEqualTo(catalog.getParticipantId());
+        assertThat(result.getJsonArray("distribution")).isEmpty();
+
+        assertThat(result.getJsonArray("service")).hasSize(1)
+                .first().satisfies(s -> {
+                    var service = s.asJsonObject();
+                    assertThat(service.getString(ID)).isEqualTo(dataService.getId());
+                    assertThat(service.getString(TYPE)).isEqualTo("DataService");
+                    assertThat(service.getString("endpointDescription")).isEqualTo(dataService.getEndpointDescription());
+                    assertThat(service.getString("endpointURL")).isEqualTo(dataService.getEndpointUrl());
+                });
+
+
+        var datasets = result.getJsonArray("dataset");
+        assertThat(datasets).hasSize(1);
+
+        var jsonDataset = datasets.getJsonObject(0).asJsonObject();
+        assertThat(jsonDataset.getString(ID)).isEqualTo(dataset.getId());
+        assertThat(jsonDataset.getString(TYPE)).isEqualTo("Dataset");
+
+        var distributions = jsonDataset.getJsonArray("distribution");
+        assertThat(distributions).hasSize(1);
+
+        var jsonDistribution = distributions.getJsonObject(0).asJsonObject();
+        assertThat(jsonDistribution.getString("format")).isEqualTo(distribution.getFormat());
+        assertThat(jsonDistribution.getJsonObject("accessService")).isNotNull();
+
+        var service = jsonDistribution.getJsonObject("accessService");
+
+        assertThat(service.getString(ID)).isEqualTo(dataService.getId());
+        assertThat(service.getString(TYPE)).isEqualTo("DataService");
+        assertThat(service.getString("endpointDescription")).isEqualTo(dataService.getEndpointDescription());
+        assertThat(service.getString("endpointURL")).isEqualTo(dataService.getEndpointUrl());
+
+
+        var policies = jsonDataset.getJsonArray("hasPolicy");
+        assertThat(policies).hasSize(1);
+
+        var jsonPolicy = policies.getJsonObject(0).asJsonObject();
+
+        assertThat(jsonPolicy).isEqualTo(policyJson);
+
+    }
+
+    /**
+     * Tests for entities that supports transformation from/to JsonObject
+     */
+    @ParameterizedTest(name = "{1}")
+    @ArgumentsSource(JsonInputProvider.class)
+    void serde(JsonObject inputObject, Class<?> klass, List<String> skipFields) {
+        var typeTransformerRegistry = RUNTIME.getService(TypeTransformerRegistry.class);
+        var jsonLd = RUNTIME.getService(JsonLd.class);
+        var registry = typeTransformerRegistry.forContext(DSP_TRANSFORMER_CONTEXT_V_2025_1);
+
+        // Expand the input
+        var expanded = jsonLd.expand(inputObject).orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+
+        // transform the expanded into the input klass type
+        var result = registry.transform(expanded, klass).orElseThrow(failure -> new RuntimeException(failure.getFailureDetail()));
+
+        // Compact the result
+        var compacted = serializeAndCompact(result);
+
+        assertThat(removeSkipFields(compacted, skipFields)).isEqualTo(removeSkipFields(inputObject, skipFields));
+    }
+
+    private JsonObject removeSkipFields(JsonObject inputObject, List<String> skipFields) {
+        var newElement = Json.createObjectBuilder(inputObject);
+        skipFields.forEach(newElement::remove);
+        return newElement.build();
+    }
+
+    private JsonObject serializeAndCompact(Object object) {
+        var result = serialize(object);
+        return compact(result);
+    }
+
+    private JsonObject serialize(Object object) {
+        var typeTransformerRegistry = RUNTIME.getService(TypeTransformerRegistry.class);
+        var registry = typeTransformerRegistry.forContext(DSP_TRANSFORMER_CONTEXT_V_2025_1);
+        return registry.transform(object, JsonObject.class).orElseThrow(failure -> new RuntimeException(failure.getFailureDetail()));
+    }
+
+    private JsonObject compact(JsonObject input) {
+        var jsonLd = RUNTIME.getService(JsonLd.class);
+        return jsonLd.compact(input, DSP_SCOPE_V_2025_1).orElseThrow(failure -> new RuntimeException(failure.getFailureDetail()));
+    }
+
+    private <T> T deserialize(JsonObject inputObject, Class<T> klass) {
+        return deserialize(inputObject, klass, DSP_TRANSFORMER_CONTEXT_V_2025_1);
+    }
+
+    private <T> T deserialize(JsonObject inputObject, Class<T> klass, String context) {
+        var typeTransformerRegistry = RUNTIME.getService(TypeTransformerRegistry.class);
+        var registry = typeTransformerRegistry.forContext(context);
+        var jsonLd = RUNTIME.getService(JsonLd.class);
+
+        var expanded = jsonLd.expand(inputObject).orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+
+
+        return registry.transform(expanded, klass).orElseThrow(failure -> new RuntimeException(failure.getFailureDetail()));
+    }
+
+    private String toIri(String term) {
+        return DSP_NAMESPACE_V_2025_1.toIri(term);
+    }
+
+    private static class ErrorProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+
+            var code = "code";
+            var messages = List.of("message1", "message2");
+
+            return Stream.of(
+                    Arguments.of(errorObject("CatalogError"), CatalogError.Builder.newInstance().code(code).messages(messages).build()),
+                    Arguments.of(errorObject("TransferError"), TransferError.Builder.newInstance().code(code).messages(messages).build()),
+                    Arguments.of(errorObject("ContractNegotiationError"), ContractNegotiationError.Builder.newInstance().code(code).messages(messages).build())
+
+            );
+        }
+    }
+
+    private static class JsonInputProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+
+
+            var skip = List.of("@id");
+            // TODO remove this. Currently the reason which is an array at protocol level but a single string in internal Objects
+            //      So the deserialization uses toString which ends up as a single string
+            //      "[{\"@value\":\"reason\"}]" instead of an actual array of strings ["reason"]
+            //      ref https://github.com/eclipse-edc/Connector/issues/2729
+
+            var skipForTermination = List.of("@id", "reason");
+
+            return Stream.of(
+                    Arguments.of(catalogRequestObject(), CatalogRequestMessage.class, List.of()),
+                    Arguments.of(transferRequestObject(), TransferRequestMessage.class, skip),
+                    Arguments.of(transferStartObject(), TransferStartMessage.class, skip),
+                    Arguments.of(transferCompletionObject(), TransferCompletionMessage.class, skip),
+                    Arguments.of(transferTerminationObject(), TransferTerminationMessage.class, skipForTermination),
+                    Arguments.of(transferSuspensionObject(), TransferSuspensionMessage.class, skip),
+                    Arguments.of(contractRequestObject(), ContractRequestMessage.class, skip),
+                    Arguments.of(contractOfferObject(), ContractOfferMessage.class, skip),
+                    Arguments.of(contractAgreementObject(), ContractAgreementMessage.class, skip),
+                    Arguments.of(contractAgreementVerificationObject(), ContractAgreementVerificationMessage.class, skip),
+                    Arguments.of(contractNegotiationEventObject("ACCEPTED"), ContractNegotiationEventMessage.class, skip),
+                    Arguments.of(contractNegotiationEventObject("FINALIZED"), ContractNegotiationEventMessage.class, skip),
+                    Arguments.of(contractNegotiationTerminationObject(), ContractNegotiationTerminationMessage.class, skipForTermination)
+            );
+        }
+
+        private JsonObject removeId(JsonObject compacted) {
+            var newElement = Json.createObjectBuilder(compacted);
+            newElement.remove("@id");
+            return newElement.build();
+        }
+
+        private JsonObject removeIdAndReason(JsonObject compacted) {
+            var newElement = Json.createObjectBuilder(removeId(compacted));
+            newElement.remove("reason");
+            return newElement.build();
+        }
+
+    }
+
+    static class SerdeRuntime extends ManagementEndToEndExtension {
+
+        protected SerdeRuntime() {
+            super(context());
+        }
+
+        private static ManagementEndToEndTestContext context() {
+            var managementPort = getFreePort();
+            var protocolPort = getFreePort();
+
+            var runtime = new EmbeddedRuntime(
+                    "control-plane",
+                    new HashMap<>() {
+                        {
+                            put("web.http.path", "/");
+                            put("web.http.port", String.valueOf(getFreePort()));
+                            put("web.http.protocol.path", "/protocol");
+                            put("web.http.protocol.port", String.valueOf(protocolPort));
+                            put("web.http.control.port", String.valueOf(getFreePort()));
+                            put("edc.dsp.callback.address", "http://localhost:" + protocolPort + "/protocol");
+                            put("web.http.management.path", "/management");
+                            put("web.http.management.port", String.valueOf(managementPort));
+                            put("edc.dsp.context.enabled", "true");
+                            put("edc.dsp.management.enabled", "true");
+                        }
+                    },
+                    ":system-tests:management-api:management-api-test-runtime"
+            );
+
+            return new ManagementEndToEndTestContext(runtime);
+        }
+
+    }
+
+}

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/DspTestFunctions.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/DspTestFunctions.java
@@ -1,0 +1,228 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.e2e.managementapi;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+
+import java.util.List;
+import java.util.UUID;
+
+import static jakarta.json.Json.createArrayBuilder;
+import static jakarta.json.Json.createObjectBuilder;
+import static java.time.Instant.ofEpochSecond;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_CONTEXT_2025_1;
+import static org.eclipse.edc.jsonld.spi.Namespaces.EDC_DSPACE_CONTEXT;
+import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.atomicConstraint;
+import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.embeddedQuerySpec;
+
+public class DspTestFunctions {
+
+    public static final String DSP_API_CONTEXT = "dsp-api";
+
+    public static JsonArrayBuilder createContextBuilder() {
+        return createArrayBuilder()
+                .add(DSPACE_CONTEXT_2025_1)
+                .add(EDC_DSPACE_CONTEXT);
+    }
+
+    public static JsonObject catalogRequestObject() {
+        return createObjectBuilder()
+                .add(CONTEXT, createContextBuilder().build())
+                .add(TYPE, "CatalogRequestMessage")
+                .add("filter", createArrayBuilder().add(embeddedQuerySpec()))
+                .build();
+    }
+
+    public static JsonObject transferRequestObject() {
+        return createObjectBuilder()
+                .add(CONTEXT, createContextBuilder().build())
+                .add(TYPE, "TransferRequestMessage")
+                .add("agreementId", "agreementId")
+                .add("consumerPid", "consumerPid")
+                .add("callbackAddress", "callbackAddress")
+                .add("format", "HttpData-PULL")
+                .build();
+    }
+
+    public static JsonObject transferStartObject() {
+        return createObjectBuilder()
+                .add(CONTEXT, createContextBuilder().build())
+                .add(TYPE, "TransferStartMessage")
+                .add("consumerPid", "consumerPid")
+                .add("providerPid", "consumerPid")
+                .add("dataAddress", dataAddress())
+                .build();
+    }
+
+    public static JsonObject transferCompletionObject() {
+        return createObjectBuilder()
+                .add(CONTEXT, createContextBuilder().build())
+                .add(TYPE, "TransferCompletionMessage")
+                .add("consumerPid", "consumerPid")
+                .add("providerPid", "consumerPid")
+                .build();
+    }
+
+    public static JsonObject transferTerminationObject() {
+        return createObjectBuilder()
+                .add(CONTEXT, createContextBuilder().build())
+                .add(TYPE, "TransferTerminationMessage")
+                .add("consumerPid", "consumerPid")
+                .add("providerPid", "consumerPid")
+                .add("reason", createArrayBuilder().add("reason"))
+                .add("code", "code")
+                .build();
+    }
+
+    public static JsonObject transferSuspensionObject() {
+        return createObjectBuilder()
+                .add(CONTEXT, createContextBuilder().build())
+                .add(TYPE, "TransferSuspensionMessage")
+                .add("consumerPid", "consumerPid")
+                .add("providerPid", "consumerPid")
+                .add("reason", createArrayBuilder().add("reason"))
+                .add("code", "code")
+                .build();
+    }
+
+    public static JsonObject contractRequestObject() {
+        return createObjectBuilder()
+                .add(CONTEXT, createContextBuilder().build())
+                .add(TYPE, "ContractRequestMessage")
+                .add("consumerPid", "consumerPid")
+                .add("callbackAddress", "callbackAddress")
+                .add("offer", inForceDatePolicy())
+                .add("providerPid", "providerPid")
+                .build();
+    }
+
+    public static JsonObject contractAgreementObject() {
+        return createObjectBuilder()
+                .add(CONTEXT, createContextBuilder().build())
+                .add(TYPE, "ContractAgreementMessage")
+                .add("consumerPid", "consumerPid")
+                .add("agreement", inForceDateAgreement())
+                .add("providerPid", "providerPid")
+                .build();
+    }
+
+    public static JsonObject contractAgreementVerificationObject() {
+        return createObjectBuilder()
+                .add(CONTEXT, createContextBuilder().build())
+                .add(TYPE, "ContractAgreementVerificationMessage")
+                .add("consumerPid", "consumerPid")
+                .add("providerPid", "providerPid")
+                .build();
+    }
+
+    public static JsonObject contractNegotiationEventObject(String eventType) {
+        return createObjectBuilder()
+                .add(CONTEXT, createContextBuilder().build())
+                .add(TYPE, "ContractNegotiationEventMessage")
+                .add("consumerPid", "consumerPid")
+                .add("providerPid", "providerPid")
+                .add("eventType", eventType)
+                .build();
+    }
+
+    public static JsonObject contractNegotiationTerminationObject() {
+        return createObjectBuilder()
+                .add(CONTEXT, createContextBuilder().build())
+                .add(TYPE, "ContractNegotiationTerminationMessage")
+                .add("consumerPid", "consumerPid")
+                .add("providerPid", "providerPid")
+                .add("reason", createArrayBuilder().add("reason"))
+                .add("code", "code")
+                .build();
+    }
+
+    public static JsonObject contractOfferObject() {
+        return createObjectBuilder()
+                .add(CONTEXT, createContextBuilder().build())
+                .add(TYPE, "ContractOfferMessage")
+                .add("consumerPid", "consumerPid")
+                .add("callbackAddress", "callbackAddress")
+                .add("offer", inForceDatePolicy())
+                .add("providerPid", "providerPid")
+                .build();
+    }
+
+    public static JsonObject errorObject(String type) {
+        return createObjectBuilder()
+                .add(CONTEXT, createContextBuilder().build())
+                .add(TYPE, type)
+                .add("code", "code")
+                .add("reason", Json.createArrayBuilder(List.of("message1", "message2")))
+                .build();
+    }
+
+    public static JsonObject inForceDatePolicy() {
+        return policy(inForceDatePermission("gteq", "contractAgreement+0s", "lteq", "contractAgreement+10s"), "Offer")
+                .add(ID, UUID.randomUUID().toString())
+                .build();
+    }
+
+    public static JsonObjectBuilder policy(JsonObject permission, String type) {
+        return createObjectBuilder()
+                .add(TYPE, type)
+                .add("obligation", createArrayBuilder().build())
+                .add("permission", createArrayBuilder().add(permission))
+                .add("target", "assetId")
+                .add("prohibition", createArrayBuilder().build());
+    }
+
+    public static JsonObject inForceDatePermission(String operatorStart, Object startDate, String operatorEnd, Object endDate) {
+        return createObjectBuilder()
+                .add("action", "use")
+                .add("constraint", createArrayBuilder().add(createObjectBuilder()
+                        .add("and", createArrayBuilder()
+                                .add(atomicConstraint("inForceDate", operatorStart, startDate))
+                                .add(atomicConstraint("inForceDate", operatorEnd, endDate))
+                                .build())
+                        .build()))
+                .build();
+    }
+
+    public static JsonObject inForceDateAgreement() {
+        return policy(inForceDatePermission("gteq", "contractAgreement+0s", "lteq", "contractAgreement+10s"), "Agreement")
+                .add(ID, UUID.randomUUID().toString())
+                .add("timestamp", ofEpochSecond(System.currentTimeMillis()).toString())
+                .add("assigner", "assigner")
+                .add("assignee", "assignee")
+                .build();
+    }
+
+    private static JsonObject dataAddress() {
+        return createObjectBuilder().add(TYPE, "DataAddress")
+                .add("endpointType", "https://w3id.org/idsa/v4.1/HTTP")
+                .add("endpointProperties", createArrayBuilder()
+                        .add(createObjectBuilder()
+                                .add(TYPE, "EndpointProperty")
+                                .add("name", "authorization")
+                                .add("value", "TOKEN-ABCDEFG"))
+                        .add(createObjectBuilder()
+                                .add(TYPE, "EndpointProperty")
+                                .add("name", "authType")
+                                .add("value", "bearer")))
+                .build();
+    }
+
+}

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TestFunctions.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TestFunctions.java
@@ -319,8 +319,12 @@ public class TestFunctions {
     }
 
     public static JsonObjectBuilder policy(JsonObject permission) {
+        return policy(permission, "Set");
+    }
+
+    public static JsonObjectBuilder policy(JsonObject permission, String type) {
         return createObjectBuilder()
-                .add(TYPE, "Set")
+                .add(TYPE, type)
                 .add("obligation", createArrayBuilder().build())
                 .add("permission", permission)
                 .add("target", "assetId")
@@ -328,6 +332,11 @@ public class TestFunctions {
     }
 
     public static JsonObject querySpecObject() {
+        return querySpecObject(createObjectBuilder()
+                .add(CONTEXT, createContextBuilder().build()));
+    }
+
+    public static JsonObject querySpecObject(JsonObjectBuilder builder) {
         var criterion = createObjectBuilder()
                 .add(TYPE, "Criterion")
                 .add("operandLeft", "foo")
@@ -335,8 +344,7 @@ public class TestFunctions {
                 .add("operandRight", "bar")
                 .build();
 
-        return createObjectBuilder()
-                .add(CONTEXT, createContextBuilder().build())
+        return builder
                 .add(TYPE, "QuerySpec")
                 .add("offset", 10)
                 .add("limit", 20)
@@ -345,6 +353,10 @@ public class TestFunctions {
                 .add("sortField", "fieldName")
                 .build();
 
+    }
+
+    public static JsonObject embeddedQuerySpec() {
+        return querySpecObject(createObjectBuilder());
     }
 
     public static JsonObject inForceDatePolicy(String operatorStart, Object startDate, String operatorEnd, Object endDate) {

--- a/system-tests/management-api/management-api-test-runtime/build.gradle.kts
+++ b/system-tests/management-api/management-api-test-runtime/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     implementation(project(":core:common:token-core"))
     implementation(project(":core:control-plane:control-plane-core"))
     implementation(project(":data-protocols:dsp"))
+    implementation(project(":data-protocols:dsp:dsp-2025"))
     implementation(project(":extensions:common:http"))
     implementation(project(":extensions:common:iam:iam-mock"))
     implementation(project(":extensions:common:json-ld"))

--- a/system-tests/protocol-2025-test/build.gradle.kts
+++ b/system-tests/protocol-2025-test/build.gradle.kts
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    java
+}
+
+dependencies {
+    testImplementation(project(":data-protocols:dsp:dsp-http-spi"))
+    testImplementation(project(":core:common:connector-core"))
+    testImplementation(project(":core:common:junit"))
+    testImplementation(project(":spi:common:json-ld-spi"))
+    testImplementation(project(":core:common:lib:json-ld-lib"))
+    testImplementation(project(":extensions:common:json-ld"))
+    testImplementation(libs.restAssured)
+}
+
+edcBuild {
+    publish.set(false)
+}

--- a/system-tests/protocol-2025-test/src/test/java/org/eclipse/edc/test/e2e/protocol/v2025/DspCatalogApi2025EndToEndTest.java
+++ b/system-tests/protocol-2025-test/src/test/java/org/eclipse/edc/test/e2e/protocol/v2025/DspCatalogApi2025EndToEndTest.java
@@ -1,0 +1,268 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.e2e.protocol.v2025;
+
+import jakarta.json.Json;
+import org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset;
+import org.eclipse.edc.connector.controlplane.asset.spi.index.AssetIndex;
+import org.eclipse.edc.connector.controlplane.contract.spi.offer.store.ContractDefinitionStore;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractDefinition;
+import org.eclipse.edc.connector.controlplane.policy.spi.PolicyDefinition;
+import org.eclipse.edc.connector.controlplane.policy.spi.store.PolicyDefinitionStore;
+import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.junit.extensions.EmbeddedRuntime;
+import org.eclipse.edc.junit.extensions.RuntimeExtension;
+import org.eclipse.edc.junit.extensions.RuntimePerClassExtension;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.util.io.Ports;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static jakarta.json.Json.createArrayBuilder;
+import static jakarta.json.Json.createObjectBuilder;
+import static java.util.Arrays.stream;
+import static java.util.stream.IntStream.range;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspCatalogPropertyAndTypeNames.DSPACE_PROPERTY_FILTER_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspCatalogPropertyAndTypeNames.DSPACE_TYPE_CATALOG_ERROR_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspCatalogPropertyAndTypeNames.DSPACE_TYPE_CATALOG_REQUEST_MESSAGE_TERM;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.not;
+
+@EndToEndTest
+public class DspCatalogApi2025EndToEndTest {
+
+    private static final int PROTOCOL_PORT = Ports.getFreePort();
+
+    @RegisterExtension
+    static RuntimeExtension runtime = new RuntimePerClassExtension(new EmbeddedRuntime(
+            "runtime",
+            Map.of(
+                    "web.http.protocol.path", "/protocol",
+                    "web.http.protocol.port", String.valueOf(PROTOCOL_PORT)
+            ),
+            ":data-protocols:dsp:dsp-catalog:dsp-catalog-http-api",
+            ":data-protocols:dsp:dsp-catalog:dsp-catalog-transform",
+            ":data-protocols:dsp:dsp-catalog:dsp-catalog-2025",
+            ":data-protocols:dsp:dsp-2025:dsp-http-api-configuration-2025",
+            ":data-protocols:dsp:dsp-http-api-configuration",
+            ":data-protocols:dsp:dsp-http-core",
+            ":extensions:common:iam:iam-mock",
+            ":core:control-plane:control-plane-aggregate-services",
+            ":core:control-plane:control-plane-core",
+            ":extensions:common:http"
+    ));
+
+    @ParameterizedTest
+    @ArgumentsSource(ProtocolVersionContextProvider.class)
+    void shouldExposeVersion(String basePath, List<String> context) {
+        given()
+                .port(PROTOCOL_PORT)
+                .basePath("/protocol")
+                .contentType(JSON)
+                .header("Authorization", "{\"region\": \"any\", \"audience\": \"any\", \"clientId\":\"any\"}")
+                .body(createObjectBuilder()
+                        .add(CONTEXT, createArrayBuilder(context))
+                        .add(TYPE, DSPACE_TYPE_CATALOG_REQUEST_MESSAGE_TERM)
+                        .build())
+                .post(basePath + "/catalog/request")
+                .then()
+                .log().ifValidationFails()
+                .statusCode(200)
+                .contentType(JSON)
+                .body("participantId", notNullValue())
+                .body("'@context'", equalTo(context));
+
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ProtocolVersionContextProvider.class)
+    void shouldPermitPaginationWithLinkHeader(String basePath, List<String> context) {
+        var assetIndex = runtime.getService(AssetIndex.class);
+
+        range(0, 8)
+                .mapToObj(i -> Asset.Builder.newInstance().id(i + "").dataAddress(DataAddress.Builder.newInstance().type("any").build()).build())
+                .forEach(assetIndex::create);
+        var policyDefinitionStore = runtime.getService(PolicyDefinitionStore.class);
+        policyDefinitionStore.create(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build())
+                .onSuccess(policy -> {
+                    var contractDefinition = ContractDefinition.Builder.newInstance().accessPolicyId(policy.getId()).contractPolicyId(policy.getId()).build();
+                    runtime.getService(ContractDefinitionStore.class).save(contractDefinition);
+                });
+
+        var link = given()
+                .port(PROTOCOL_PORT)
+                .basePath("/protocol")
+                .contentType(JSON)
+                .header("Authorization", "{\"region\": \"any\", \"audience\": \"any\", \"clientId\":\"any\"}")
+                .body(createObjectBuilder()
+                        .add(CONTEXT, createArrayBuilder(context))
+                        .add(TYPE, DSPACE_TYPE_CATALOG_REQUEST_MESSAGE_TERM)
+                        .add(DSPACE_PROPERTY_FILTER_TERM, Json.createObjectBuilder()
+                                .add(TYPE, "QuerySpec")
+                                .add("offset", 0)
+                                .add("limit", 5))
+                        .build())
+                .post(basePath + "/catalog/request")
+                .then()
+                .log().ifValidationFails()
+                .statusCode(200)
+                .contentType(JSON)
+                .body("dataset.size()", equalTo(5))
+                .body("'@context'", equalTo(context))
+                .header("Link", containsString(basePath + "/catalog/request"))
+                .header("Link", containsString("next"))
+                .header("Link", not(containsString("prev")))
+                .extract().header("Link");
+
+        var nextPageUrl = stream(link.split(", ")).filter(it -> it.endsWith("\"next\"")).findAny()
+                .map(it -> it.split(">;")).map(it -> it[0]).map(it -> it.substring(1))
+                .orElseThrow();
+
+        given()
+                .contentType(JSON)
+                .header("Authorization", "{\"region\": \"any\", \"audience\": \"any\", \"clientId\":\"any\"}")
+                .body(createObjectBuilder()
+                        .add(CONTEXT, createArrayBuilder(context))
+                        .add(TYPE, DSPACE_TYPE_CATALOG_REQUEST_MESSAGE_TERM)
+                        .build()
+                )
+                .post(nextPageUrl)
+                .then()
+                .log().ifValidationFails()
+                .body("dataset.size()", equalTo(3))
+                .body("@context", equalTo(context))
+                .statusCode(200)
+                .contentType(JSON)
+                .header("Link", containsString(basePath + "/catalog/request"))
+                .header("Link", containsString("prev"))
+                .header("Link", not(containsString("next")));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ProtocolVersionContextProvider.class)
+    void catalogRequest_shouldReturnError_whenNotAuthorized(String basePath, List<String> context) {
+
+        var authorizationHeader = """
+                {"region": "any", "audience": "any", "clientId":"faultyClientId"}"
+                """;
+        given()
+                .port(PROTOCOL_PORT)
+                .basePath("/protocol")
+                .contentType(JSON)
+                .header("Authorization", authorizationHeader)
+                .body(createObjectBuilder()
+                        .add(CONTEXT, createArrayBuilder(context))
+                        .add(TYPE, DSPACE_TYPE_CATALOG_REQUEST_MESSAGE_TERM)
+                        .build())
+                .post(basePath + "/catalog/request")
+                .then()
+                .log().ifValidationFails()
+                .statusCode(401)
+                .contentType(JSON)
+                .body("'@type'", equalTo(DSPACE_TYPE_CATALOG_ERROR_TERM))
+                .body("code", equalTo("401"))
+                .body("reason[0]", equalTo("Unauthorized"))
+                .body("'@context'", equalTo(context));
+
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ProtocolVersionContextProvider.class)
+    void catalogRequest_shouldReturnError_whenMissingToken(String basePath, List<String> context) {
+
+        given()
+                .port(PROTOCOL_PORT)
+                .basePath("/protocol")
+                .contentType(JSON)
+                .body(createObjectBuilder()
+                        .add(CONTEXT, createArrayBuilder(context))
+                        .add(TYPE, DSPACE_TYPE_CATALOG_REQUEST_MESSAGE_TERM)
+                        .build())
+                .post(basePath + "/catalog/request")
+                .then()
+                .log().ifValidationFails()
+                .statusCode(401)
+                .contentType(JSON)
+                .body("'@type'", equalTo(DSPACE_TYPE_CATALOG_ERROR_TERM))
+                .body("code", equalTo("401"))
+                .body("reason[0]", equalTo("Unauthorized."))
+                .body("'@context'", equalTo(context));
+
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ProtocolVersionContextProvider.class)
+    void catalogRequest_shouldReturnError_whenValidationFails(String basePath, List<String> context) {
+        var authorizationHeader = """
+                {"region": "any", "audience": "any", "clientId":"any"}"
+                """;
+        given()
+                .port(PROTOCOL_PORT)
+                .basePath("/protocol")
+                .header("Authorization", authorizationHeader)
+                .contentType(JSON)
+                .body(createObjectBuilder()
+                        .add(CONTEXT, createArrayBuilder(context))
+                        .add(TYPE, "FakeType")
+                        .build())
+                .post(basePath + "/catalog/request")
+                .then()
+                .log().ifValidationFails()
+                .statusCode(400)
+                .contentType(JSON)
+                .body("'@type'", equalTo(DSPACE_TYPE_CATALOG_ERROR_TERM))
+                .body("code", equalTo("400"))
+                .body("reason[0]", equalTo("Bad request."))
+                .body("'@context'", equalTo(context));
+
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ProtocolVersionContextProvider.class)
+    void shouldReturnError_whenDatasetNotFound(String basePath, List<String> context) {
+
+        var id = UUID.randomUUID().toString();
+        var authorizationHeader = """
+                {"region": "any", "audience": "any", "clientId":"any"}"
+                """;
+        given()
+                .port(PROTOCOL_PORT)
+                .basePath("/protocol")
+                .contentType(JSON)
+                .header("Authorization", authorizationHeader)
+                .get(basePath + "/catalog/datasets/" + id)
+                .then()
+                .log().ifValidationFails()
+                .statusCode(404)
+                .contentType(JSON)
+                .body("'@type'", equalTo(DSPACE_TYPE_CATALOG_ERROR_TERM))
+                .body("code", equalTo("404"))
+                .body("reason[0]", equalTo("Dataset %s does not exist".formatted(id)))
+                .body("'@context'", equalTo(context));
+
+    }
+}

--- a/system-tests/protocol-2025-test/src/test/java/org/eclipse/edc/test/e2e/protocol/v2025/DspNegotiationApi2025EndToEndTest.java
+++ b/system-tests/protocol-2025-test/src/test/java/org/eclipse/edc/test/e2e/protocol/v2025/DspNegotiationApi2025EndToEndTest.java
@@ -1,0 +1,207 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.e2e.protocol.v2025;
+
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractOffer;
+import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.junit.extensions.EmbeddedRuntime;
+import org.eclipse.edc.junit.extensions.RuntimeExtension;
+import org.eclipse.edc.junit.extensions.RuntimePerClassExtension;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.util.io.Ports;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static jakarta.json.Json.createArrayBuilder;
+import static jakarta.json.Json.createObjectBuilder;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.REQUESTED;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ASSIGNER_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_OFFER;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_TARGET_ATTRIBUTE;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_OFFER_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_ERROR_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_NEGOTIATION_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID_TERM;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+
+@EndToEndTest
+public class DspNegotiationApi2025EndToEndTest {
+
+    private static final int PROTOCOL_PORT = Ports.getFreePort();
+
+    @RegisterExtension
+    static RuntimeExtension runtime = new RuntimePerClassExtension(new EmbeddedRuntime(
+            "runtime",
+            Map.of(
+                    "web.http.protocol.path", "/protocol",
+                    "web.http.protocol.port", String.valueOf(PROTOCOL_PORT)
+            ),
+            ":data-protocols:dsp:dsp-negotiation:dsp-negotiation-http-api",
+            ":data-protocols:dsp:dsp-negotiation:dsp-negotiation-transform",
+            ":data-protocols:dsp:dsp-negotiation:dsp-negotiation-2025",
+            ":data-protocols:dsp:dsp-2025:dsp-http-api-configuration-2025",
+            ":data-protocols:dsp:dsp-http-api-configuration",
+            ":data-protocols:dsp:dsp-http-core",
+            ":extensions:common:iam:iam-mock",
+            ":core:control-plane:control-plane-aggregate-services",
+            ":core:control-plane:control-plane-core",
+            ":extensions:common:http"
+    ));
+
+    @ParameterizedTest
+    @ArgumentsSource(ProtocolVersionContextProvider.class)
+    void shouldExposeVersion(String basePath, List<String> context) {
+        var id = UUID.randomUUID().toString();
+        var negotiation = ContractNegotiation.Builder.newInstance()
+                .id(id).counterPartyId("any").counterPartyAddress("any").protocol("any").state(REQUESTED.code())
+                .correlationId(UUID.randomUUID().toString())
+                .contractOffer(ContractOffer.Builder.newInstance()
+                        .id(UUID.randomUUID().toString()).assetId(UUID.randomUUID().toString())
+                        .policy(Policy.Builder.newInstance().build())
+                        .build())
+                .build();
+        runtime.getService(ContractNegotiationStore.class).save(negotiation);
+
+        given()
+                .port(PROTOCOL_PORT)
+                .basePath("/protocol")
+                .contentType(JSON)
+                .header("Authorization", "{\"region\": \"any\", \"audience\": \"any\", \"clientId\":\"any\"}")
+                .get(basePath + "/negotiations/" + id)
+                .then()
+                .log().ifError()
+                .statusCode(200)
+                .contentType(JSON)
+                .body("'@type'", equalTo(DSPACE_TYPE_CONTRACT_NEGOTIATION_TERM))
+                .body("state", notNullValue())
+                .body("consumerPid", notNullValue())
+                .body("providerPid", notNullValue())
+                .body("'@context'", equalTo(context));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ProtocolVersionContextProvider.class)
+    void shouldReturnError_whenNotFound(String basePath, List<String> context) {
+        var id = UUID.randomUUID().toString();
+
+        given()
+                .port(PROTOCOL_PORT)
+                .basePath("/protocol")
+                .contentType(JSON)
+                .header("Authorization", "{\"region\": \"any\", \"audience\": \"any\", \"clientId\":\"any\"}")
+                .get(basePath + "/negotiations/" + id)
+                .then()
+                .log().ifError()
+                .statusCode(404)
+                .contentType(JSON)
+                .body("'@type'", equalTo(DSPACE_TYPE_CONTRACT_NEGOTIATION_ERROR_TERM))
+                .body("code", equalTo("404"))
+                .body("reason[0]", equalTo("No negotiation with id %s found".formatted(id)))
+                .body("'@context'", equalTo(context));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ProtocolVersionContextProvider.class)
+    void shouldReturnError_whenValidationFails(String basePath, List<String> context) {
+
+        given()
+                .port(PROTOCOL_PORT)
+                .basePath("/protocol")
+                .contentType(JSON)
+                .body(createObjectBuilder()
+                        .add(CONTEXT, createArrayBuilder(context))
+                        .add(TYPE, "WrongType")
+                        .add(DSPACE_PROPERTY_CONSUMER_PID_TERM, "any")
+                        .add(DSPACE_PROPERTY_CALLBACK_ADDRESS_TERM, "any")
+                        .add(DSPACE_PROPERTY_OFFER_TERM, createObjectBuilder()
+                                .add("@type", ODRL_POLICY_TYPE_OFFER)
+                                .add(ID, "offerId")
+                                .add(ODRL_TARGET_ATTRIBUTE, "target")
+                                .add(ODRL_ASSIGNER_ATTRIBUTE, "assigner")
+                                .build())
+                        .build())
+                .header("Authorization", "{\"region\": \"any\", \"audience\": \"any\", \"clientId\":\"any\"}")
+                .post(basePath + "/negotiations/request")
+                .then()
+                .log().ifError()
+                .statusCode(400)
+                .contentType(JSON)
+                .body("'@type'", equalTo(DSPACE_TYPE_CONTRACT_NEGOTIATION_ERROR_TERM))
+                .body("code", equalTo("400"))
+                .body("reason[0]", equalTo("Bad request."))
+                .body("'@context'", equalTo(context));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ProtocolVersionContextProvider.class)
+    void terminate_ShouldReturnError_whenMissingToken(String basePath, List<String> context) {
+        var id = UUID.randomUUID().toString();
+
+        given()
+                .port(PROTOCOL_PORT)
+                .basePath("/protocol")
+                .contentType(JSON)
+                .post(basePath + "/negotiations/" + id + "/termination")
+                .then()
+                .log().ifError()
+                .statusCode(401)
+                .contentType(JSON)
+                .body("'@type'", equalTo(DSPACE_TYPE_CONTRACT_NEGOTIATION_ERROR_TERM))
+                .body("code", equalTo("401"))
+                .body("reason[0]", equalTo("Unauthorized."))
+                .body("'@context'", equalTo(context));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ProtocolVersionContextProvider.class)
+    void terminate_ShouldReturnError_whenValidationFails(String basePath, List<String> context) {
+        var id = UUID.randomUUID().toString();
+
+        given()
+                .port(PROTOCOL_PORT)
+                .basePath("/protocol")
+                .contentType(JSON)
+                .header("Authorization", "{\"region\": \"any\", \"audience\": \"any\", \"clientId\":\"any\"}")
+                .body(createObjectBuilder()
+                        .add(CONTEXT, createArrayBuilder(context))
+                        .add(TYPE, "FakeType")
+                        .build())
+                .post(basePath + "/negotiations/" + id + "/termination")
+
+                .then()
+                .log().ifError()
+                .statusCode(400)
+                .contentType(JSON)
+                .body("'@type'", equalTo(DSPACE_TYPE_CONTRACT_NEGOTIATION_ERROR_TERM))
+                .body("code", equalTo("400"))
+                .body("reason[0]", equalTo("Bad request."))
+                .body("'@context'", equalTo(context));
+    }
+
+}

--- a/system-tests/protocol-2025-test/src/test/java/org/eclipse/edc/test/e2e/protocol/v2025/DspTransferApi2025EndToEndTest.java
+++ b/system-tests/protocol-2025-test/src/test/java/org/eclipse/edc/test/e2e/protocol/v2025/DspTransferApi2025EndToEndTest.java
@@ -1,0 +1,199 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.e2e.protocol.v2025;
+
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractOffer;
+import org.eclipse.edc.connector.controlplane.transfer.spi.store.TransferProcessStore;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
+import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.junit.extensions.EmbeddedRuntime;
+import org.eclipse.edc.junit.extensions.RuntimeExtension;
+import org.eclipse.edc.junit.extensions.RuntimePerClassExtension;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.util.io.Ports;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static jakarta.json.Json.createObjectBuilder;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.REQUESTED;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_PROPERTY_CONTRACT_AGREEMENT_ID_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_ERROR_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_PROCESS_TERM;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+
+@EndToEndTest
+public class DspTransferApi2025EndToEndTest {
+
+    private static final int PROTOCOL_PORT = Ports.getFreePort();
+
+    @RegisterExtension
+    static RuntimeExtension runtime = new RuntimePerClassExtension(new EmbeddedRuntime(
+            "runtime",
+            Map.of(
+                    "web.http.protocol.path", "/protocol",
+                    "web.http.protocol.port", String.valueOf(PROTOCOL_PORT)
+            ),
+            ":data-protocols:dsp:dsp-transfer-process:dsp-transfer-process-http-api",
+            ":data-protocols:dsp:dsp-transfer-process:dsp-transfer-process-transform",
+            ":data-protocols:dsp:dsp-transfer-process:dsp-transfer-process-2025",
+            ":data-protocols:dsp:dsp-2025:dsp-http-api-configuration-2025",
+            ":data-protocols:dsp:dsp-http-api-configuration",
+            ":data-protocols:dsp:dsp-http-core",
+            ":extensions:common:iam:iam-mock",
+            ":core:control-plane:control-plane-aggregate-services",
+            ":core:control-plane:control-plane-core",
+            ":extensions:common:http"
+    ));
+
+    private static ContractNegotiation createNegotiationWithAgreement(String contractId) {
+        return ContractNegotiation.Builder.newInstance()
+                .id(UUID.randomUUID().toString()).counterPartyId("any").counterPartyAddress("any").protocol("any").state(ContractNegotiationStates.REQUESTED.code())
+                .correlationId(UUID.randomUUID().toString())
+                .contractOffer(ContractOffer.Builder.newInstance()
+                        .id(UUID.randomUUID().toString()).assetId(UUID.randomUUID().toString())
+                        .policy(Policy.Builder.newInstance().build())
+                        .build())
+                .contractAgreement(ContractAgreement.Builder.newInstance()
+                        .id(contractId)
+                        .providerId("any")
+                        .consumerId("any")
+                        .assetId("any")
+                        .policy(Policy.Builder.newInstance().build())
+                        .build())
+                .build();
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ProtocolVersionContextProvider.class)
+    void shouldExposeVersion(String basePath, List<String> context) {
+        var id = UUID.randomUUID().toString();
+        var contractId = UUID.randomUUID().toString();
+        var transfer = TransferProcess.Builder.newInstance()
+                .id(id)
+                .contractId(contractId)
+                .dataDestination(DataAddress.Builder.newInstance().type("any").build())
+                .state(REQUESTED.code())
+                .build();
+        runtime.getService(TransferProcessStore.class).save(transfer);
+        runtime.getService(ContractNegotiationStore.class).save(createNegotiationWithAgreement(contractId));
+
+        given()
+                .port(PROTOCOL_PORT)
+                .basePath("/protocol")
+                .contentType(JSON)
+                .header("Authorization", "{\"region\": \"any\", \"audience\": \"any\", \"clientId\":\"any\"}")
+                .get(basePath + "/transfers/" + id)
+                .then()
+                .log().ifError()
+                .statusCode(200)
+                .contentType(JSON)
+                .body("'@type'", equalTo(DSPACE_TYPE_TRANSFER_PROCESS_TERM))
+                .body("state", notNullValue())
+                .body("consumerPid", notNullValue())
+                .body("'@context'", equalTo(context));
+
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ProtocolVersionContextProvider.class)
+    void shouldReturnError_whenValidationFails(String basePath, List<String> context) {
+
+        given()
+                .port(PROTOCOL_PORT)
+                .basePath("/protocol")
+                .contentType(JSON)
+                .body(createObjectBuilder()
+                        .add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
+                        .add(TYPE, "WrongType")
+                        .add(DSPACE_PROPERTY_CONSUMER_PID_TERM, "any")
+                        .add(DSPACE_PROPERTY_CONTRACT_AGREEMENT_ID_TERM, "any")
+                        .add(DSPACE_PROPERTY_CALLBACK_ADDRESS_TERM, "any")
+                        .add("format", "any")
+                        .build())
+                .header("Authorization", "{\"region\": \"any\", \"audience\": \"any\", \"clientId\":\"any\"}")
+                .post(basePath + "/transfers/request")
+                .then()
+                .log().ifError()
+                .statusCode(400)
+                .contentType(JSON)
+                .body("'@type'", equalTo(DSPACE_TYPE_TRANSFER_ERROR_TERM))
+                .body("code", equalTo("400"))
+                .body("reason[0]", equalTo("Bad request."))
+                .body("'@context'", equalTo(context));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ProtocolVersionContextProvider.class)
+    void shouldReturnError_whenNotFound(String basePath, List<String> context) {
+        var id = UUID.randomUUID().toString();
+
+        given()
+                .port(PROTOCOL_PORT)
+                .basePath("/protocol")
+                .contentType(JSON)
+                .header("Authorization", "{\"region\": \"any\", \"audience\": \"any\", \"clientId\":\"any\"}")
+                .get(basePath + "/transfers/" + id)
+                .then()
+                .log().ifError()
+                .statusCode(404)
+                .contentType(JSON)
+                .body("'@type'", equalTo(DSPACE_TYPE_TRANSFER_ERROR_TERM))
+                .body("code", equalTo("404"))
+                .body("reason[0]", equalTo("No transfer process with id %s found".formatted(id)))
+                .body("'@context'", equalTo(context));
+
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ProtocolVersionContextProvider.class)
+    void shouldReturnError_whenTokenIsMissing(String basePath, List<String> context) {
+        var id = UUID.randomUUID().toString();
+
+        given()
+                .port(PROTOCOL_PORT)
+                .basePath("/protocol")
+                .contentType(JSON)
+                .get(basePath + "/transfers/" + id)
+                .then()
+                .log().ifError()
+                .statusCode(401)
+                .contentType(JSON)
+                .body("'@type'", equalTo(DSPACE_TYPE_TRANSFER_ERROR_TERM))
+                .body("code", equalTo("401"))
+                .body("reason[0]", equalTo("Unauthorized."))
+                .body("'@context'", equalTo(context));
+
+    }
+
+}

--- a/system-tests/protocol-2025-test/src/test/java/org/eclipse/edc/test/e2e/protocol/v2025/ProtocolVersionContextProvider.java
+++ b/system-tests/protocol-2025-test/src/test/java/org/eclipse/edc/test/e2e/protocol/v2025/ProtocolVersionContextProvider.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.e2e.protocol.v2025;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_CONTEXT_2025_1;
+import static org.eclipse.edc.jsonld.spi.Namespaces.EDC_DSPACE_CONTEXT;
+import static org.eclipse.edc.protocol.dsp.spi.version.DspVersions.V_2025_1_PATH;
+
+public class ProtocolVersionContextProvider implements ArgumentsProvider {
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+
+        var contextV2025 = List.of(DSPACE_CONTEXT_2025_1, EDC_DSPACE_CONTEXT);
+
+        return Stream.of(
+                Arguments.of(V_2025_1_PATH, contextV2025)
+        );
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

Add initial implementation of the DSP protocol `2025/1`

by adding transformers, JSON-LD config and controllers for `2025/1`



## Why it does that

_Briefly state why the change was necessary._

## Further notes

To be done in future PRs

- `DspApiConfigurationV2025Extension` should be refactor as it currently inject the same config of `DspApiConfigurationExtension` for calculating the `callbackAddress`
- The `2025/1` implementation is pluggable but still rely on some central constants. This is valid also for `08` and `2024/1`. In order for a protocol to be pluggable by adding only modules (or a bom) it should not rely on central constants


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #4881 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
