### PR TITLE
chore: fix dsp negotiation 2025 path

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -120,9 +120,9 @@ include(":data-protocols:dsp:dsp-catalog:dsp-catalog-2025:dsp-catalog-transform-
 include(":data-protocols:dsp:dsp-transfer-process:dsp-transfer-process-2025")
 include(":data-protocols:dsp:dsp-transfer-process:dsp-transfer-process-2025:dsp-transfer-process-http-api-2025")
 include(":data-protocols:dsp:dsp-transfer-process:dsp-transfer-process-2025:dsp-transfer-process-transform-2025")
-include("data-protocols:dsp:dsp-negotiation:dsp-negotiation-2025")
-include("data-protocols:dsp:dsp-negotiation:dsp-negotiation-2025:dsp-negotiation-http-api-2025")
-include("data-protocols:dsp:dsp-negotiation:dsp-negotiation-2025:dsp-negotiation-transform-2025")
+include(":data-protocols:dsp:dsp-negotiation:dsp-negotiation-2025")
+include(":data-protocols:dsp:dsp-negotiation:dsp-negotiation-2025:dsp-negotiation-http-api-2025")
+include(":data-protocols:dsp:dsp-negotiation:dsp-negotiation-2025:dsp-negotiation-transform-2025")
 
 // modules for technology- or cloud-provider extensions --------------------------------------------
 include(":extensions:common:api:api-core")


### PR DESCRIPTION
## What this PR changes/adds

Fixes the path that makes the nightly to fail

https://github.com/eclipse-edc/Release/actions/runs/14119093762/job/39571341659

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
