### PR TITLE
feat: allow multiple validators per type

### DIFF
--- a/core/common/runtime-core/src/test/java/org/eclipse/edc/runtime/core/validator/JsonObjectValidatorRegistryImplTest.java
+++ b/core/common/runtime-core/src/test/java/org/eclipse/edc/runtime/core/validator/JsonObjectValidatorRegistryImplTest.java
@@ -24,6 +24,7 @@ import org.mockito.Mockito;
 import static jakarta.json.Json.createObjectBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.validator.spi.ValidationResult.failure;
 import static org.eclipse.edc.validator.spi.Violation.violation;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
@@ -34,25 +35,64 @@ class JsonObjectValidatorRegistryImplTest {
     private final JsonObjectValidatorRegistry registry = new JsonObjectValidatorRegistryImpl();
 
     @Test
-    void shouldSucceed_whenValidatorDoesNotExist() {
+    void validate_shouldSucceed_whenValidatorDoesNotExist() {
         var result = registry.validate("not-existent", createObjectBuilder().build());
 
         assertThat(result).isSucceeded();
     }
 
     @Test
-    void shouldExecuteRegisteredRule() {
+    void validate_shouldExecuteRegisteredRule() {
         var validator = Mockito.<Validator<JsonObject>>mock();
-        var failure = ValidationResult.failure(violation("validation error", "path"));
+        var failure = failure(violation("validation error", "path"));
         when(validator.validate(any())).thenReturn(failure);
         registry.register("type-name", validator);
         var input = createObjectBuilder().build();
 
         var result = registry.validate("type-name", input);
 
-        assertThat(result).isFailed().satisfies(f -> {
-            assertThat(f.getViolations()).hasSize(1).first().matches(it -> it.message().equals("validation error"));
-        });
+        assertThat(result).isFailed().satisfies(f ->
+                assertThat(f.getViolations()).hasSize(1).first().matches(it -> it.message().equals("validation error")));
         verify(validator).validate(input);
+    }
+
+    @Test
+    void validate_multipleRules_oneViolation() {
+        var failingValidator = Mockito.<Validator<JsonObject>>mock();
+        var failure = failure(violation("validation error", "path"));
+        when(failingValidator.validate(any())).thenReturn(failure);
+
+        var validator = Mockito.<Validator<JsonObject>>mock();
+        when(validator.validate(any())).thenReturn(ValidationResult.success());
+
+        registry.register("type-name", failingValidator);
+        registry.register("type-name", validator);
+
+        var result = registry.validate("type-name", createObjectBuilder().build());
+        assertThat(result).isFailed().satisfies(f ->
+                assertThat(f.getViolations()).hasSize(1).first().matches(it -> it.message().equals("validation error")));
+        verify(validator).validate(any());
+        verify(failingValidator).validate(any());
+    }
+
+    @Test
+    void validate_multipleRules_multipleViolations() {
+        var failingValidator1 = Mockito.<Validator<JsonObject>>mock();
+        var failure = failure(violation("validation error 1", "path"));
+        when(failingValidator1.validate(any())).thenReturn(failure);
+
+        var failingValidator2 = Mockito.<Validator<JsonObject>>mock();
+        var failure2 = failure(violation("validation error 2", "path"));
+        when(failingValidator2.validate(any())).thenReturn(failure2);
+
+        registry.register("type-name", failingValidator1);
+        registry.register("type-name", failingValidator2);
+
+        var result = registry.validate("type-name", createObjectBuilder().build());
+        assertThat(result).isFailed().satisfies(f -> assertThat(f.getViolations()).hasSize(2)
+                .anyMatch(it -> it.message().equals("validation error 1"))
+                .anyMatch(it -> it.message().equals("validation error 2")));
+        verify(failingValidator1).validate(any());
+        verify(failingValidator2).validate(any());
     }
 }

--- a/spi/common/validator-spi/src/main/java/org/eclipse/edc/validator/spi/JsonObjectValidatorRegistry.java
+++ b/spi/common/validator-spi/src/main/java/org/eclipse/edc/validator/spi/JsonObjectValidatorRegistry.java
@@ -22,17 +22,19 @@ import jakarta.json.JsonObject;
 public interface JsonObjectValidatorRegistry {
 
     /**
-     * Register a json object validator for a specific JsonLD @type
+     * Register a json object validator for a specific JsonLD @type. Validators are <em>composed</em>, that means adding multiple
+     * validators for the same type will simply execute them in sequence and return the compounded result.
      *
-     * @param type the JsonLD @type string.
+     * @param type      the JsonLD @type string.
      * @param validator the validator to be executed.
      */
     void register(String type, Validator<JsonObject> validator);
 
     /**
-     * Choose the correct validator and executes it on the input object
+     * Choose the correct validators and executes it on the input object. If multiple validators exist for a type, <em>all</em>
+     * of them are executed and their results merged.
      *
-     * @param type the JsonLD @type string.
+     * @param type  the JsonLD @type string.
      * @param input the input object.
      * @return the result of the validation.
      */


### PR DESCRIPTION

## What this PR changes/adds

this PR changes the `JsonObjectValidatorRegistryImpl` such that it now contains multiple validators per type and it merges all the results of the individual validations.

## Why it does that

to easily add custom validators to built-in ones

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #4892 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
