### PR TITLE
fix: add runtime-core module to base-BOMs

### DIFF
--- a/dist/bom/controlplane-base-bom/build.gradle.kts
+++ b/dist/bom/controlplane-base-bom/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     api(project(":core:common:edr-store-core"))
     api(project(":core:common:runtime-core"))
     api(project(":core:common:token-core"))
+    api(project(":core:common:runtime-core"))
     api(project(":core:control-plane:control-plane-core"))
     api(project(":core:data-plane-selector:data-plane-selector-core"))
     api(project(":core:policy-monitor:policy-monitor-core"))

--- a/dist/bom/dataplane-base-bom/build.gradle.kts
+++ b/dist/bom/dataplane-base-bom/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     api(project(":core:common:connector-core"))
     api(project(":core:common:runtime-core"))
     api(project(":core:common:token-core"))
+    api(project(":core:common:runtime-core"))
     api(project(":core:data-plane:data-plane-core"))
 
     // extension dependencies


### PR DESCRIPTION
## What this PR changes/adds

adds the new runtime-core module to the base BOMs

## Why it does that

prevent runtime DI errors

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
