### PR TITLE
feat: add retry mechanism on dataflow completion

### DIFF
--- a/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImplTest.java
+++ b/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImplTest.java
@@ -393,7 +393,7 @@ class DataPlaneManagerImplTest {
     }
 
     @Test
-    void completed_whenRetryableError_shouldTransitionToCompleted() {
+    void completed_shouldTransitionToCompleted_whenRetryableError() {
         var dataFlow = dataFlowBuilder().state(COMPLETED.code()).build();
         when(store.nextNotLeased(anyInt(), stateIs(COMPLETED.code()))).thenReturn(List.of(dataFlow)).thenReturn(emptyList());
         when(transferProcessApiClient.completed(any())).thenReturn(StatusResult.failure(ERROR_RETRY));
@@ -407,7 +407,7 @@ class DataPlaneManagerImplTest {
     }
 
     @Test
-    void completed_whenFatalError_shouldTransitionToTerminated() {
+    void completed_shouldTransitionToTerminated_whenFatalError() {
         var dataFlow = dataFlowBuilder().state(COMPLETED.code()).build();
         when(store.nextNotLeased(anyInt(), stateIs(COMPLETED.code()))).thenReturn(List.of(dataFlow)).thenReturn(emptyList());
         when(transferProcessApiClient.completed(any())).thenReturn(StatusResult.failure(FATAL_ERROR));
@@ -437,7 +437,7 @@ class DataPlaneManagerImplTest {
     }
 
     @Test
-    void failed_whenRetryableError_shouldNotTransitionToFailed() {
+    void failed_shouldTransitionToFailed_whenRetryableError() {
         var dataFlow = dataFlowBuilder().state(FAILED.code()).errorDetail("an error").build();
         when(store.nextNotLeased(anyInt(), stateIs(FAILED.code()))).thenReturn(List.of(dataFlow)).thenReturn(emptyList());
         when(store.findById(any())).thenReturn(dataFlow);
@@ -453,7 +453,7 @@ class DataPlaneManagerImplTest {
     }
 
     @Test
-    void failed_whenFatalError_shouldNotTransitionToTerminated() {
+    void failed_shouldTransitionToTerminated_whenFatalError() {
         var dataFlow = dataFlowBuilder().state(FAILED.code()).errorDetail("an error").build();
         when(store.nextNotLeased(anyInt(), stateIs(FAILED.code()))).thenReturn(List.of(dataFlow)).thenReturn(emptyList());
         when(store.findById(any())).thenReturn(dataFlow);

--- a/extensions/control-plane/api/control-plane-api-client/src/main/java/org/eclipse/edc/connector/controlplane/api/client/transferprocess/EmbeddedTransferProcessHttpClient.java
+++ b/extensions/control-plane/api/control-plane-api-client/src/main/java/org/eclipse/edc/connector/controlplane/api/client/transferprocess/EmbeddedTransferProcessHttpClient.java
@@ -24,9 +24,10 @@ import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 
+import java.util.function.Function;
+
 import static org.eclipse.edc.spi.response.ResponseStatus.ERROR_RETRY;
 
-import java.util.function.Function;
 
 public class EmbeddedTransferProcessHttpClient implements TransferProcessApiClient {
 

--- a/extensions/control-plane/api/control-plane-api-client/src/main/java/org/eclipse/edc/connector/controlplane/api/client/transferprocess/TransferProcessHttpClient.java
+++ b/extensions/control-plane/api/control-plane-api-client/src/main/java/org/eclipse/edc/connector/controlplane/api/client/transferprocess/TransferProcessHttpClient.java
@@ -29,9 +29,9 @@ import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.jetbrains.annotations.NotNull;
 
-import static org.eclipse.edc.spi.response.ResponseStatus.ERROR_RETRY;
-
 import java.net.URI;
+
+import static org.eclipse.edc.spi.response.ResponseStatus.ERROR_RETRY;
 
 /**
  * Implementation of {@link TransferProcessApiClient} which talks to the Control Plane Transfer Process via HTTP APIs

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/port/TransferProcessApiClient.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/port/TransferProcessApiClient.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.dataplane.spi.port;
 
 
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
+import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
@@ -34,14 +35,14 @@ public interface TransferProcessApiClient {
      *
      * @param request The completed {@link DataFlowStartMessage}
      */
-    Result<Void> completed(DataFlowStartMessage request);
+    StatusResult<Void> completed(DataFlowStartMessage request);
 
     /**
      * Mark the TransferProcess referenced by {@link DataFlowStartMessage#getProcessId()} as failed
      *
      * @param request The failed {@link DataFlowStartMessage}
      */
-    Result<Void> failed(DataFlowStartMessage request, String reason);
+    StatusResult<Void> failed(DataFlowStartMessage request, String reason);
 
     /**
      * Mark the TransferProcess as provisioned.


### PR DESCRIPTION
## What this PR changes/adds

Applies a retry mechanism in the `DataFlowManagerImpl` when processing the `Dataflow`'s *COMPLETED* and *FAILED* states

## Why it does that

After the data transfer, the `DataFlow` transitions to either *COMPLETED* or *FAILED* depending on whether the transfer succeeded or failed. In either case, the data plane notifies the control plane of the transfer outcome. If this notification fails, the `DataFlow` transitions to its current state, causing the state machine manager to pick it up again and retry the process. Since there is no limit to the number of retries, this process could potentially continue forever.

## Further notes

Check this DR for more information: https://github.com/eclipse-edc/Connector/tree/main/docs/developer/decision-records/2025-03-17-retry-processor-on-dataflow-completion

## Who will sponsor this feature?

@ndr-brt

## Linked Issue(s)

Relates to https://github.com/eclipse-edc/Connector/issues/4860

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
