### PR TITLE
build(test): drop and create database on e2e

### DIFF
--- a/extensions/common/sql/sql-test-fixtures/src/testFixtures/java/org/eclipse/edc/sql/testfixtures/PostgresqlEndToEndExtension.java
+++ b/extensions/common/sql/sql-test-fixtures/src/testFixtures/java/org/eclipse/edc/sql/testfixtures/PostgresqlEndToEndExtension.java
@@ -25,7 +25,6 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Map;
 
-import static java.lang.String.format;
 import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
 
 /**
@@ -86,9 +85,9 @@ public class PostgresqlEndToEndExtension implements BeforeAllCallback, AfterAllC
     public void createDatabase(String name) {
         var jdbcUrl = postgres.getJdbcUrl() + postgres.getDatabaseName();
         try (var connection = DriverManager.getConnection(jdbcUrl, postgres.getUsername(), postgres.getPassword())) {
-            connection.createStatement().execute(format("create database %s;", name));
+            connection.createStatement().execute("drop database if exists %s; create database %s;".formatted(name, name));
         } catch (SQLException e) {
-            // database could already exist
+            throw new RuntimeException(e);
         }
     }
 

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferStreamingEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferStreamingEndToEndTest.java
@@ -119,7 +119,6 @@ public class TransferStreamingEndToEndTest {
             POSTGRESQL_EXTENSION.createDatabase(PROVIDER.getName());
         };
 
-
         @RegisterExtension
         static final RuntimeExtension CONSUMER_CONTROL_PLANE = new RuntimePerClassExtension(
                 Runtimes.POSTGRES_CONTROL_PLANE.create("consumer-control-plane")


### PR DESCRIPTION
## What this PR changes/adds

E2E postgres tests are still flaky (ref #4761 ), destroy eventual existing dbs before creating new ones.

Tried in my fork, tests passed on 8 executions in a row

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #4761 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
