### PR TITLE
docs: contract agreement policy scope DR

### DIFF
--- a/dist/bom/controlplane-base-bom/build.gradle.kts
+++ b/dist/bom/controlplane-base-bom/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
     api(project(":extensions:common:api:version-api"))
 
     api(project(":extensions:common:http"))
+    api(project(":extensions:common:validator:validator-data-address-http-data"))
     api(project(":extensions:control-plane:api:control-plane-api"))
     api(project(":extensions:control-plane:api:management-api"))
     api(project(":extensions:control-plane:transfer:transfer-data-plane-signaling"))
@@ -52,6 +53,7 @@ dependencies {
     api(project(":extensions:control-plane:callback:callback-http-dispatcher"))
     api(project(":extensions:control-plane:callback:callback-static-endpoint"))
     api(project(":extensions:control-plane:edr:edr-store-receiver"))
+
 
     // libs
     api(project(":core:common:lib:transform-lib"))

--- a/docs/developer/decision-records/2025-04-25-agreement-policy-scope/README.md
+++ b/docs/developer/decision-records/2025-04-25-agreement-policy-scope/README.md
@@ -1,0 +1,73 @@
+# Contract Agreement policy scope
+
+## Decision
+
+We will add a `contract.agreement` policy scope, that will be evaluated by the provider before the automatic agreement.
+
+## Rationale
+
+The negotiation flow is at the moment an automatic one: a negotiation can happen if the `contract.negotiation` policy 
+scope evaluation succeeds, or it gets terminated if the evaluation fails.
+
+To implement "manual negotiation approval", the `PendingGuard` service can be used, but this doesn't permit to
+
+## Approach
+
+There will be a new policy scope/context to permit the new `PolicyEngine` evaluation, the class will look like:
+
+```java
+public class ContractAgreementPolicyContext extends PolicyContextImpl {
+
+    @PolicyScope
+    public static final String AGREEMENT_SCOPE = "contract.agreement";
+
+    @Override
+    public String scope() {
+        return AGREEMENT_SCOPE;
+    }
+}
+```
+
+An additional evaluation of the `PolicyEngine` will be added in the `ProviderContractNegotiationManager` in the
+`processRequested` method, so that every negotiation that gets `REQUESTED` can be pass through policy functions:
+```java
+    @WithSpan
+    private boolean processRequested(ContractNegotiation negotiation) {
+        var evaluation = policyEngine.evaluate(negotiation.getLastContractOffer().getPolicy(), new ContractAgreementPolicyContext());
+        if (evaluation.succeeded()) {
+            transitionToAgreeing(negotiation);
+        } else {
+            negotiation.setPending(true);
+            observable.invokeForEach(l -> l.manualInteractionRequired());
+            update(negotiation);
+        }
+    }
+```
+
+By doing this in the case the evaulation goes through the behavior will be the same (automatic agreement), otherwise the
+negotiation will be put as "pending", that's the flag that prevent it to be taken into consideration from the state
+machine.
+The `observable` call will be used to generate an event, so that the client could get notified about the negotiation
+waiting for manual interaction.
+
+The policy function could be bind to an ODRL `Duty` constraint in the `Permission` with the [`reviewPolicy` `Action`](https://www.w3.org/TR/odrl-vocab/#term-reviewPolicy).
+Example:
+```java
+{
+  "@context": "http://www.w3.org/ns/odrl.jsonld",
+  "@type": "Offer",
+  "permission": [{
+    "action": "use",
+    "duty": [{
+      "action": "reviewPolicy"
+    }]
+  }]
+}
+```
+
+The `reviewPolicy` type will be bound to the `contract.agreement` scope and a dedicated `PolicyRuleFunction` will be registered
+on the PolicyEngine.
+This function will always return `false`, because when invoked it means that the negotiation needs to manually validated.
+
+Possible follow up for this proposal would be endpoints and commands to approve or reject the negotiation, but they are
+not part of this proposal.

--- a/docs/developer/decision-records/2025-04-25-agreement-policy-scope/README.md
+++ b/docs/developer/decision-records/2025-04-25-agreement-policy-scope/README.md
@@ -9,7 +9,8 @@ We will add a `contract.agreement` policy scope, that will be evaluated by the p
 The negotiation flow is at the moment an automatic one: a negotiation can happen if the `contract.negotiation` policy 
 scope evaluation succeeds, or it gets terminated if the evaluation fails.
 
-To implement "manual negotiation approval", the `PendingGuard` service can be used, but this doesn't permit to
+To implement "manual negotiation approval", the `PendingGuard` service can be used, but this doesn't permit to leverage
+on the flexibility and extensibility of the policy engine. 
 
 ## Approach
 

--- a/docs/developer/decision-records/2025-04-25-agreement-policy-scope/README.md
+++ b/docs/developer/decision-records/2025-04-25-agreement-policy-scope/README.md
@@ -45,30 +45,12 @@ An additional evaluation of the `PolicyEngine` will be added in the `ProviderCon
     }
 ```
 
-By doing this in the case the evaulation goes through the behavior will be the same (automatic agreement), otherwise the
+By doing this in the case the evaluation goes through the behavior will be the same (automatic agreement), otherwise the
 negotiation will be put as "pending", that's the flag that prevent it to be taken into consideration from the state
 machine.
 The `observable` call will be used to generate an event, so that the client could get notified about the negotiation
 waiting for manual interaction.
 
-The policy function could be bind to an ODRL `Duty` constraint in the `Permission` with the [`reviewPolicy` `Action`](https://www.w3.org/TR/odrl-vocab/#term-reviewPolicy).
-Example:
-```java
-{
-  "@context": "http://www.w3.org/ns/odrl.jsonld",
-  "@type": "Offer",
-  "permission": [{
-    "action": "use",
-    "duty": [{
-      "action": "reviewPolicy"
-    }]
-  }]
-}
-```
-
-The `reviewPolicy` type will be bound to the `contract.agreement` scope and a dedicated `PolicyRuleFunction` will be registered
-on the PolicyEngine.
-This function will always return `false`, because when invoked it means that the negotiation needs to manually validated.
 
 Possible follow up for this proposal would be endpoints and commands to approve or reject the negotiation, but they are
 not part of this proposal.

--- a/docs/developer/decision-records/README.md
+++ b/docs/developer/decision-records/README.md
@@ -77,4 +77,5 @@
 - [2025-02-07 Deprecation of HTTP Proxy in the Data Plane](./2025-02-07-http-proxy-data-plane-deprecation)
 - [2025-02-27 Move provisioning phase in the Data Plane](./2025-02-27-move-provisioning-phase-data-plane)
 - [2025-03-14 Prioritized Transfer Services](./2025-03-14-prioritized-transfer-services)
+- [2025-04-15 Contract Agreement policy scope](./2025-04-25-agreement-policy-scope)
 - [2025-04-30 Finalize phase](./2025-04-30-finalize-phase)


### PR DESCRIPTION
## What this PR changes/adds

Provides DR for introducing `contract.agreement` policy scope.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Part of #4919

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
