### PR TITLE
refactor: move DSP base webhook and port mapping to separate module

### DIFF
--- a/data-protocols/dsp/build.gradle.kts
+++ b/data-protocols/dsp/build.gradle.kts
@@ -9,9 +9,9 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Cofinity-X - extract webhook and port mapping creation
  *
  */
-
 
 plugins {
     `java-library`
@@ -19,6 +19,7 @@ plugins {
 
 dependencies {
     api(project(":data-protocols:dsp:dsp-http-api-configuration"))
+    api(project(":data-protocols:dsp:dsp-http-api-base-configuration"))
     api(project(":data-protocols:dsp:dsp-catalog"))
     api(project(":data-protocols:dsp:dsp-http-core"))
     api(project(":data-protocols:dsp:dsp-http-spi"))

--- a/data-protocols/dsp/dsp-2025/build.gradle.kts
+++ b/data-protocols/dsp/dsp-2025/build.gradle.kts
@@ -19,6 +19,7 @@ plugins {
 
 dependencies {
     api(project(":data-protocols:dsp:dsp-2025:dsp-http-api-configuration-2025"))
+    api(project(":data-protocols:dsp:dsp-http-api-base-configuration"))
     api(project(":data-protocols:dsp:dsp-catalog:dsp-catalog-2025"))
     api(project(":data-protocols:dsp:dsp-transfer-process:dsp-transfer-process-2025"))
     api(project(":data-protocols:dsp:dsp-negotiation:dsp-negotiation-2025"))

--- a/data-protocols/dsp/dsp-2025/dsp-http-api-configuration-2025/src/main/java/org/eclipse/edc/protocol/dsp/http/api/configuration/v2025/DspApiConfigurationV2025Extension.java
+++ b/data-protocols/dsp/dsp-2025/dsp-http-api-configuration-2025/src/main/java/org/eclipse/edc/protocol/dsp/http/api/configuration/v2025/DspApiConfigurationV2025Extension.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Metaform Systems, Inc. - initial API and implementation
+ *       Cofinity-X - extract webhook and port mapping creation
  *
  */
 
@@ -21,15 +22,12 @@ import org.eclipse.edc.connector.controlplane.transform.odrl.OdrlTransformersFac
 import org.eclipse.edc.connector.controlplane.transform.odrl.from.JsonObjectFromPolicyTransformer;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.participant.spi.ParticipantIdMapper;
+import org.eclipse.edc.protocol.dsp.http.spi.api.DspBaseWebhookAddress;
 import org.eclipse.edc.protocol.dsp.http.spi.dispatcher.DspHttpRemoteMessageDispatcher;
-import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
-import org.eclipse.edc.runtime.metamodel.annotation.Setting;
-import org.eclipse.edc.runtime.metamodel.annotation.Settings;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.protocol.ProtocolWebhookRegistry;
-import org.eclipse.edc.spi.system.Hostname;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
@@ -41,13 +39,9 @@ import org.eclipse.edc.transform.transformer.edc.from.JsonObjectFromQuerySpecTra
 import org.eclipse.edc.transform.transformer.edc.to.JsonObjectToCriterionTransformer;
 import org.eclipse.edc.transform.transformer.edc.to.JsonObjectToQuerySpecTransformer;
 import org.eclipse.edc.transform.transformer.edc.to.JsonValueToGenericTypeTransformer;
-import org.eclipse.edc.web.spi.configuration.ApiContext;
-import org.eclipse.edc.web.spi.configuration.PortMapping;
 
 import java.util.Map;
 
-import static java.lang.String.format;
-import static java.util.Optional.ofNullable;
 import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_CONTEXT_2025_1;
 import static org.eclipse.edc.jsonld.spi.Namespaces.EDC_DSPACE_CONTEXT;
 import static org.eclipse.edc.protocol.dsp.http.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP_V_2025_1;
@@ -65,15 +59,6 @@ public class DspApiConfigurationV2025Extension implements ServiceExtension {
 
     public static final String NAME = "Dataspace Protocol 2025/1 API Configuration Extension";
 
-    static final String DEFAULT_PROTOCOL_PATH = "/api/protocol";
-    static final int DEFAULT_PROTOCOL_PORT = 8282;
-
-    @Setting(description = "Configures endpoint for reaching the Protocol API in the form \"<hostname:protocol.port/protocol.path>\"", key = "edc.dsp.callback.address", required = false)
-    private String callbackAddress;
-
-    @Configuration
-    private DspApiConfiguration apiConfiguration;
-
     @Inject
     private TypeManager typeManager;
     @Inject
@@ -86,12 +71,10 @@ public class DspApiConfigurationV2025Extension implements ServiceExtension {
     private RemoteMessageDispatcherRegistry dispatcherRegistry;
     @Inject
     private DspHttpRemoteMessageDispatcher dispatcher;
-
+    @Inject
+    private DspBaseWebhookAddress dspWebhookAddress;
     @Inject
     private ProtocolWebhookRegistry protocolWebhookRegistry;
-
-    @Inject
-    private Hostname hostname;
 
     @Override
     public String name() {
@@ -100,17 +83,12 @@ public class DspApiConfigurationV2025Extension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var portMapping = new PortMapping(ApiContext.PROTOCOL, apiConfiguration.port(), apiConfiguration.path());
-
         // registers ns for DSP 2025/1 scope
         registerNamespaces();
         registerTransformers();
         dispatcherRegistry.register(DATASPACE_PROTOCOL_HTTP_V_2025_1, dispatcher);
 
-        var dspWebhookAddress = ofNullable(callbackAddress).orElseGet(() -> format("http://%s:%s%s", hostname.get(), portMapping.port(), portMapping.path()));
-
-        protocolWebhookRegistry.registerWebhook(DATASPACE_PROTOCOL_HTTP_V_2025_1, () -> dspWebhookAddress + V_2025_1_PATH);
-
+        protocolWebhookRegistry.registerWebhook(DATASPACE_PROTOCOL_HTTP_V_2025_1, () -> dspWebhookAddress.get() + V_2025_1_PATH);
     }
 
     private void registerNamespaces() {
@@ -138,15 +116,5 @@ public class DspApiConfigurationV2025Extension implements ServiceExtension {
         dspApiTransformerRegistry.register(new JsonObjectToDataAddressDspaceTransformer(DSP_NAMESPACE_V_2025_1));
         dspApiTransformerRegistry.register(new JsonObjectFromPolicyTransformer(jsonBuilderFactory, participantIdMapper, true));
         dspApiTransformerRegistry.register(new JsonObjectFromDataAddressDspace2024Transformer(jsonBuilderFactory, typeManager, JSON_LD, DSP_NAMESPACE_V_2025_1));
-    }
-
-    @Settings
-    record DspApiConfiguration(
-            @Setting(key = "web.http." + ApiContext.PROTOCOL + ".port", description = "Port for " + ApiContext.PROTOCOL + " api context", defaultValue = DEFAULT_PROTOCOL_PORT + "")
-            int port,
-            @Setting(key = "web.http." + ApiContext.PROTOCOL + ".path", description = "Path for " + ApiContext.PROTOCOL + " api context", defaultValue = DEFAULT_PROTOCOL_PATH)
-            String path
-    ) {
-
     }
 }

--- a/data-protocols/dsp/dsp-http-api-base-configuration/build.gradle.kts
+++ b/data-protocols/dsp/dsp-http-api-base-configuration/build.gradle.kts
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(project(":spi:common:web-spi"))
+    api(project(":data-protocols:dsp:dsp-http-spi"))
+
+    implementation(project(":extensions:common:http:lib:jersey-providers-lib"))
+
+    testImplementation(project(":core:common:junit"))
+}

--- a/data-protocols/dsp/dsp-http-api-base-configuration/src/main/java/org/eclipse/edc/protocol/dsp/http/api/configuration/DspApiBaseConfigurationExtension.java
+++ b/data-protocols/dsp/dsp-http-api-base-configuration/src/main/java/org/eclipse/edc/protocol/dsp/http/api/configuration/DspApiBaseConfigurationExtension.java
@@ -1,0 +1,99 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.http.api.configuration;
+
+import org.eclipse.edc.policy.model.AtomicConstraint;
+import org.eclipse.edc.policy.model.LiteralExpression;
+import org.eclipse.edc.protocol.dsp.http.spi.api.DspBaseWebhookAddress;
+import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.runtime.metamodel.annotation.Settings;
+import org.eclipse.edc.spi.system.Hostname;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.web.jersey.providers.jsonld.ObjectMapperProvider;
+import org.eclipse.edc.web.spi.WebService;
+import org.eclipse.edc.web.spi.configuration.ApiContext;
+import org.eclipse.edc.web.spi.configuration.PortMapping;
+import org.eclipse.edc.web.spi.configuration.PortMappingRegistry;
+
+import static java.lang.String.format;
+import static java.util.Optional.ofNullable;
+import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
+
+@Extension(DspApiBaseConfigurationExtension.NAME)
+public class DspApiBaseConfigurationExtension implements ServiceExtension {
+    
+    public static final String NAME = "Dataspace Protocol API Base Configuration Extension";
+    
+    static final String DEFAULT_PROTOCOL_PATH = "/api/protocol";
+    static final int DEFAULT_PROTOCOL_PORT = 8282;
+    
+    @Setting(description = "Configures endpoint for reaching the Protocol API in the form \"<hostname:protocol.port/protocol.path>\"", key = "edc.dsp.callback.address", required = false)
+    private String callbackAddress;
+    
+    @Configuration
+    private DspApiConfiguration apiConfiguration;
+    
+    @Inject
+    private Hostname hostname;
+    @Inject
+    private PortMappingRegistry portMappingRegistry;
+    @Inject
+    private WebService webService;
+    @Inject
+    private TypeManager typeManager;
+    
+    @Override
+    public String name() {
+        return NAME;
+    }
+    
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        var portMapping = new PortMapping(ApiContext.PROTOCOL, apiConfiguration.port(), apiConfiguration.path());
+        portMappingRegistry.register(portMapping);
+        
+        webService.registerResource(ApiContext.PROTOCOL, new ObjectMapperProvider(typeManager, JSON_LD));
+    }
+    
+    @Override
+    public void prepare() {
+        var mapper = typeManager.getMapper(JSON_LD);
+        mapper.registerSubtypes(AtomicConstraint.class, LiteralExpression.class);
+    }
+    
+    @Provider
+    public DspBaseWebhookAddress dspBaseWebhookAddress() {
+        var dspWebhookAddress = ofNullable(callbackAddress)
+                .orElseGet(() -> format("http://%s:%s%s", hostname.get(), apiConfiguration.port(), apiConfiguration.path()));
+        
+        return () -> dspWebhookAddress;
+    }
+    
+    @Settings
+    record DspApiConfiguration(
+            @Setting(key = "web.http." + ApiContext.PROTOCOL + ".port", description = "Port for " + ApiContext.PROTOCOL + " api context", defaultValue = DEFAULT_PROTOCOL_PORT + "")
+            int port,
+            @Setting(key = "web.http." + ApiContext.PROTOCOL + ".path", description = "Path for " + ApiContext.PROTOCOL + " api context", defaultValue = DEFAULT_PROTOCOL_PATH)
+            String path
+    ) {
+    
+    }
+}

--- a/data-protocols/dsp/dsp-http-api-base-configuration/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/data-protocols/dsp/dsp-http-api-base-configuration/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,14 @@
+#
+#  Copyright (c) 2025 Cofinity-X
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Cofinity-X - initial API and implementation
+#
+
+org.eclipse.edc.protocol.dsp.http.api.configuration.DspApiBaseConfigurationExtension

--- a/data-protocols/dsp/dsp-http-api-base-configuration/src/test/java/org/eclipse/edc/protocol/dsp/http/api/configuration/DspApiBaseConfigurationExtensionTest.java
+++ b/data-protocols/dsp/dsp-http-api-base-configuration/src/test/java/org/eclipse/edc/protocol/dsp/http/api/configuration/DspApiBaseConfigurationExtensionTest.java
@@ -1,0 +1,88 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.http.api.configuration;
+
+import org.eclipse.edc.boot.system.injection.ObjectFactory;
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.spi.system.Hostname;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+import org.eclipse.edc.web.jersey.providers.jsonld.ObjectMapperProvider;
+import org.eclipse.edc.web.spi.WebService;
+import org.eclipse.edc.web.spi.configuration.ApiContext;
+import org.eclipse.edc.web.spi.configuration.PortMapping;
+import org.eclipse.edc.web.spi.configuration.PortMappingRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.protocol.dsp.http.api.configuration.DspApiBaseConfigurationExtension.DEFAULT_PROTOCOL_PATH;
+import static org.eclipse.edc.protocol.dsp.http.api.configuration.DspApiBaseConfigurationExtension.DEFAULT_PROTOCOL_PORT;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(DependencyInjectionExtension.class)
+class DspApiBaseConfigurationExtensionTest {
+    
+    private final PortMappingRegistry portMappingRegistry = mock();
+    private final WebService webService = mock();
+    
+    @BeforeEach
+    void setUp(ServiceExtensionContext context) {
+        context.registerService(Hostname.class, () -> "hostname");
+        context.registerService(PortMappingRegistry.class, portMappingRegistry);
+        context.registerService(WebService.class, webService);
+    }
+    
+    @Test
+    void shouldComposeProtocolWebhook_whenNotConfigured(DspApiBaseConfigurationExtension extension, ServiceExtensionContext context) {
+        when(context.getConfig()).thenReturn(ConfigFactory.empty());
+        var expectedWebhook = "http://hostname:%s%s".formatted(DEFAULT_PROTOCOL_PORT, DEFAULT_PROTOCOL_PATH);
+        
+        extension.initialize(context);
+        
+        verify(portMappingRegistry).register(new PortMapping(ApiContext.PROTOCOL, DEFAULT_PROTOCOL_PORT, DEFAULT_PROTOCOL_PATH));
+        assertThat(extension.dspBaseWebhookAddress().get()).isEqualTo(expectedWebhook);
+    }
+    
+    @Test
+    void shouldUseConfiguredProtocolWebhook(ServiceExtensionContext context, ObjectFactory factory) {
+        var webhookAddress = "http://webhook";
+        when(context.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of(
+                "web.http.protocol.port", String.valueOf(1234),
+                "web.http.protocol.path", "/path",
+                "edc.dsp.callback.address", webhookAddress))
+        );
+        var extension = factory.constructInstance(DspApiBaseConfigurationExtension.class);
+        
+        extension.initialize(context);
+        
+        verify(portMappingRegistry).register(new PortMapping(ApiContext.PROTOCOL, 1234, "/path"));
+        assertThat(extension.dspBaseWebhookAddress().get()).isEqualTo(webhookAddress);
+    }
+    
+    @Test
+    void initialize_shouldRegisterWebServiceProviders(DspApiBaseConfigurationExtension extension, ServiceExtensionContext context) {
+        extension.initialize(context);
+        
+        verify(webService).registerResource(eq(ApiContext.PROTOCOL), isA(ObjectMapperProvider.class));
+    }
+}

--- a/data-protocols/dsp/dsp-http-api-configuration/build.gradle.kts
+++ b/data-protocols/dsp/dsp-http-api-configuration/build.gradle.kts
@@ -22,7 +22,6 @@ dependencies {
     api(project(":data-protocols:dsp:dsp-spi"))
     api(project(":data-protocols:dsp:dsp-http-spi"))
 
-    implementation(project(":extensions:common:http:lib:jersey-providers-lib"))
     implementation(project(":core:common:lib:transform-lib"))
     implementation(project(":core:control-plane:control-plane-transform"))
 

--- a/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/http/spi/api/DspBaseWebhookAddress.java
+++ b/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/http/spi/api/DspBaseWebhookAddress.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.http.spi.api;
+
+/**
+ * The base webhook address for the DSP API. Should be used as the base for DSP-version-specific
+ * webhooks.
+ */
+@FunctionalInterface
+public interface DspBaseWebhookAddress {
+    
+    /**
+     * Provides the base DSP webhook address.
+     *
+     * @return the base DSP webhook address
+     */
+    String get();
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -84,6 +84,7 @@ include(":core:policy-monitor:policy-monitor-core")
 
 // modules that provide implementations for data ingress/egress ------------------------------------
 include(":data-protocols:dsp:dsp-http-api-configuration")
+include(":data-protocols:dsp:dsp-http-api-base-configuration")
 include(":data-protocols:dsp:dsp-catalog")
 include(":data-protocols:dsp:dsp-catalog:dsp-catalog-http-api")
 include(":data-protocols:dsp:dsp-catalog:dsp-catalog-http-dispatcher")

--- a/system-tests/protocol-2025-test/src/test/java/org/eclipse/edc/test/e2e/protocol/v2025/Dsp2025Runtime.java
+++ b/system-tests/protocol-2025-test/src/test/java/org/eclipse/edc/test/e2e/protocol/v2025/Dsp2025Runtime.java
@@ -26,7 +26,7 @@ public interface Dsp2025Runtime {
     static EmbeddedRuntime createRuntimeWith(int protocolPort, String... additionalModules) {
         var baseModules = Stream.of(
                 ":data-protocols:dsp:dsp-2025:dsp-http-api-configuration-2025",
-                ":data-protocols:dsp:dsp-http-api-configuration",
+                ":data-protocols:dsp:dsp-http-api-base-configuration",
                 ":data-protocols:dsp:dsp-http-core",
                 ":extensions:common:iam:iam-mock",
                 ":core:control-plane:control-plane-aggregate-services",

--- a/system-tests/protocol-test/src/test/java/org/eclipse/edc/test/e2e/protocol/DspRuntime.java
+++ b/system-tests/protocol-test/src/test/java/org/eclipse/edc/test/e2e/protocol/DspRuntime.java
@@ -26,6 +26,7 @@ public interface DspRuntime {
     static EmbeddedRuntime createRuntimeWith(int protocolPort, String... additionalModules) {
         var baseModules = Stream.of(
                 ":data-protocols:dsp:dsp-http-api-configuration",
+                ":data-protocols:dsp:dsp-http-api-base-configuration",
                 ":data-protocols:dsp:dsp-http-core",
                 ":extensions:common:iam:iam-mock",
                 ":core:control-plane:control-plane-aggregate-services",


### PR DESCRIPTION
## What this PR changes/adds

Refactors the DSP api configuration modules. Moves common code to a new  module `dsp-http-api-base-configuration`. This includes:
- creation & registration of port mapping/API context
- registration of `ObjectMapperProvider` for the API context
- creating the base webhook address
- registering subtypes on the JSON-LD object mapper

Introduces an interface for the DSP base webhook, which is provided by the new extension and injected into the existing DSP api config extensions. The existing API config extensions now only perform version-specific configurations/registrations. Includes the new module into the build files for `dsp` and `dsp-2025`.

## Why it does that
To remove the duplicated code for creating the base webhook. Also, previously the port mapping was only registered in `DspApiConfigurationExtension`, meaning the `DspApiConfigurationV2025Extension` relied on the `DspApiConfigurationExtension` to create the port mapping.


## Who will sponsor this feature?

me


## Linked Issue(s)

Closes #4891 
