### PR TITLE
feat: add assetId and correlationId in ContractNegotiation response

### DIFF
--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/transform/JsonObjectFromContractNegotiationTransformer.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/transform/JsonObjectFromContractNegotiationTransformer.java
@@ -27,7 +27,9 @@ import org.jetbrains.annotations.Nullable;
 import static jakarta.json.stream.JsonCollectors.toJsonArray;
 import static java.util.Optional.ofNullable;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_AGREEMENT_ID;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_ASSET_ID;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_CALLBACK_ADDR;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_CORRELATION_ID;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_COUNTERPARTY_ADDR;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_COUNTERPARTY_ID;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_CREATED_AT;
@@ -66,7 +68,9 @@ public class JsonObjectFromContractNegotiationTransformer extends AbstractJsonLd
                 .add(CONTRACT_NEGOTIATION_CALLBACK_ADDR, callbackAddresses)
                 .add(CONTRACT_NEGOTIATION_CREATED_AT, contractNegotiation.getCreatedAt());
 
+        ofNullable(contractNegotiation.getLastContractOffer()).ifPresent(contractOffer -> builder.add(CONTRACT_NEGOTIATION_ASSET_ID, contractOffer.getAssetId()));
         ofNullable(contractNegotiation.getContractAgreement()).map(ContractAgreement::getId).ifPresent(s -> builder.add(CONTRACT_NEGOTIATION_AGREEMENT_ID, s));
+        ofNullable(contractNegotiation.getCorrelationId()).ifPresent(correlationId -> builder.add(CONTRACT_NEGOTIATION_CORRELATION_ID, correlationId));
         ofNullable(contractNegotiation.getErrorDetail()).ifPresent(s -> builder.add(CONTRACT_NEGOTIATION_ERRORDETAIL, s));
 
         return builder.build();

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/transform/JsonObjectFromContractNegotiationTransformerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/transform/JsonObjectFromContractNegotiationTransformerTest.java
@@ -18,6 +18,7 @@ import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 import org.eclipse.edc.transform.spi.TransformerContext;
@@ -25,9 +26,12 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_AGREEMENT_ID;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_ASSET_ID;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_CORRELATION_ID;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_COUNTERPARTY_ADDR;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_COUNTERPARTY_ID;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_CREATED_AT;
@@ -49,6 +53,7 @@ class JsonObjectFromContractNegotiationTransformerTest {
     @Test
     void transform() {
         when(context.transform(any(CallbackAddress.class), eq(JsonObject.class))).thenReturn(Json.createObjectBuilder().build());
+        var co = createContractOffer("asset-id");
         var cn = ContractNegotiation.Builder.newInstance()
                 .id("test-id")
                 .correlationId("correlation-id")
@@ -57,6 +62,7 @@ class JsonObjectFromContractNegotiationTransformerTest {
                 .contractAgreement(createContractAgreement("test-agreement"))
                 .state(REQUESTED.code())
                 .type(ContractNegotiation.Type.PROVIDER)
+                .contractOffers(List.of(co))
                 .callbackAddresses(List.of(
                         CallbackAddress.Builder.newInstance()
                                 .uri("local://test")
@@ -75,7 +81,17 @@ class JsonObjectFromContractNegotiationTransformerTest {
         assertThat(jsonObject.getString(CONTRACT_NEGOTIATION_AGREEMENT_ID)).isEqualTo("test-agreement");
         assertThat(jsonObject.getString(CONTRACT_NEGOTIATION_NEG_TYPE)).isEqualTo("PROVIDER");
         assertThat(jsonObject.getString(CONTRACT_NEGOTIATION_PROTOCOL)).isEqualTo("protocol");
+        assertThat(jsonObject.getString(CONTRACT_NEGOTIATION_CORRELATION_ID)).isEqualTo(cn.getCorrelationId());
+        assertThat(jsonObject.getString(CONTRACT_NEGOTIATION_ASSET_ID)).isEqualTo(co.getAssetId());
         assertThat(jsonObject.getJsonNumber(CONTRACT_NEGOTIATION_CREATED_AT).longValue()).isEqualTo(1234);
+    }
+
+    private ContractOffer createContractOffer(String assetId) {
+        return ContractOffer.Builder.newInstance()
+                .id(UUID.randomUUID().toString())
+                .assetId(assetId)
+                .policy(Policy.Builder.newInstance().build())
+                .build();
     }
 
     private ContractAgreement createContractAgreement(String id) {

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/negotiation/ContractNegotiation.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/negotiation/ContractNegotiation.java
@@ -60,6 +60,8 @@ public class ContractNegotiation extends StatefulEntity<ContractNegotiation> {
     public static final String CONTRACT_NEGOTIATION_STATE = EDC_NAMESPACE + "state";
     public static final String CONTRACT_NEGOTIATION_NEG_TYPE = EDC_NAMESPACE + "type";
     public static final String CONTRACT_NEGOTIATION_CALLBACK_ADDR = EDC_NAMESPACE + "callbackAddresses";
+    public static final String CONTRACT_NEGOTIATION_CORRELATION_ID = EDC_NAMESPACE + "correlationId";
+    public static final String CONTRACT_NEGOTIATION_ASSET_ID = EDC_NAMESPACE + "assetId";
     public static final String CONTRACT_NEGOTIATION_CREATED_AT = EDC_NAMESPACE + "createdAt";
 
     private List<CallbackAddress> callbackAddresses = new ArrayList<>();


### PR DESCRIPTION
## What this PR changes/adds

adds `assetId` and `correlationId` in `ContractNegotiation`.

## Why it does that

Convenience.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #4945 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
