### PR TITLE
feat: Implement extension for priming the EDC under test

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -312,6 +312,7 @@ include(":system-tests:telemetry:telemetry-test-runtime")
 include(":system-tests:bom-tests")
 include(":system-tests:dsp-compatibility-tests:connector-under-test")
 include(":system-tests:dsp-compatibility-tests:compatibility-test-runner")
+include(":system-tests:protocol-tck:tck-extension")
 
 // BOM modules ----------------------------------------------------------------
 include(":dist:bom:controlplane-base-bom")

--- a/system-tests/protocol-tck/tck-extension/build.gradle.kts
+++ b/system-tests/protocol-tck/tck-extension/build.gradle.kts
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    java
+}
+
+dependencies {
+    implementation(project(":spi:common:core-spi"))
+    implementation(project(":spi:control-plane:contract-spi"))
+    implementation(project(":spi:control-plane:asset-spi"))
+    implementation(project(":spi:control-plane:control-plane-spi"))
+    implementation(project(":spi:common:web-spi"))
+    implementation(libs.jakarta.rsApi)
+}
+

--- a/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/controller/ContractNegotiationRequest.java
+++ b/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/controller/ContractNegotiationRequest.java
@@ -1,0 +1,25 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.tck.dsp.controller;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Initiates a negotiation request.
+ */
+public record ContractNegotiationRequest(@JsonProperty("providerId") String providerId,
+                                         @JsonProperty("connectorAddress") String connectorAddress,
+                                         @JsonProperty("offerId") String offerId) {
+}

--- a/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/controller/TckControllerExtension.java
+++ b/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/controller/TckControllerExtension.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.tck.dsp.controller;
+
+import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationService;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.web.spi.WebServer;
+import org.eclipse.edc.web.spi.WebService;
+import org.eclipse.edc.web.spi.configuration.PortMapping;
+import org.eclipse.edc.web.spi.configuration.PortMappingRegistry;
+
+/**
+ * Bootstraps the TCK web hook.
+ */
+public class TckControllerExtension implements ServiceExtension {
+    private static final String NAME = "DSP TCK Controller";
+    private static final String PROTOCOL = "tck";
+    private static final String PATH = "/tck";
+
+    @Inject
+    private PortMappingRegistry mappingRegistry;
+
+    @Inject
+    private WebService webService;
+
+    @Inject
+    private WebServer webServer;
+
+    @Inject
+    private ContractNegotiationService negotiationService;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        mappingRegistry.register(new PortMapping(PROTOCOL, 8687, PATH));
+
+        webService.registerResource(PROTOCOL, new TckWebhookController(negotiationService));
+    }
+}

--- a/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/controller/TckWebhookController.java
+++ b/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/controller/TckWebhookController.java
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.tck.dsp.controller;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequest;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractOffer;
+import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationService;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
+
+import java.util.List;
+
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+
+/**
+ * Implements TCK web hooks.
+ */
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
+@Path("/negotiations")
+public class TckWebhookController {
+
+    private ContractNegotiationService negotiationService;
+
+    public TckWebhookController(ContractNegotiationService negotiationService) {
+        this.negotiationService = negotiationService;
+    }
+
+    @POST
+    @Path("requests")
+    public void startNegotiation(ContractNegotiationRequest request) {
+
+        var contractOffer = ContractOffer.Builder.newInstance()
+                .id(request.offerId())
+                .assetId(request.offerId())
+                .policy(Policy.Builder.newInstance().assigner(request.providerId()).build())
+                .build();
+        var contractRequest = ContractRequest.Builder.newInstance()
+                .callbackAddresses(List.of(CallbackAddress.Builder.newInstance().uri(request.connectorAddress()).build()))
+                .counterPartyAddress(request.connectorAddress())
+                .contractOffer(contractOffer)
+                .protocol("dataspace-protocol-http")
+                .build();
+        negotiationService.initiateNegotiation(contractRequest);
+        System.out.println("Negotiation");
+    }
+}

--- a/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/data/DataAssembly.java
+++ b/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/data/DataAssembly.java
@@ -1,0 +1,165 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.tck.dsp.data;
+
+import org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset;
+import org.eclipse.edc.connector.controlplane.contract.spi.event.contractnegotiation.ContractNegotiationAccepted;
+import org.eclipse.edc.connector.controlplane.contract.spi.event.contractnegotiation.ContractNegotiationAgreed;
+import org.eclipse.edc.connector.controlplane.contract.spi.event.contractnegotiation.ContractNegotiationEvent;
+import org.eclipse.edc.connector.controlplane.contract.spi.event.contractnegotiation.ContractNegotiationOffered;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractDefinition;
+import org.eclipse.edc.connector.controlplane.policy.spi.PolicyDefinition;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.tck.dsp.guard.Trigger;
+import org.eclipse.edc.tck.dsp.recorder.StepRecorder;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import static java.util.stream.Collectors.toSet;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.REQUESTED;
+
+/**
+ * Assembles data for the TCK scenarios.
+ */
+public class DataAssembly {
+    private static final Set<String> ASSET_IDS = Set.of("ACN0101", "ACN0102", "ACN0103", "ACN0104",
+            "ACN0201", "ACN0202", "ACN0203", "ACN0204", "ACN0205", "ACN0206", "ACN0207",
+            "ACN0301", "ACN0302", "ACN0303", "ACN0304");
+
+    private static final String POLICY_ID = "P123";
+    private static final String CONTRACT_DEFINITION_ID = "CD123";
+
+    public static Set<Asset> createAssets() {
+        return ASSET_IDS.stream().map(DataAssembly::createAsset).collect(toSet());
+    }
+
+    public static Set<PolicyDefinition> createPolicyDefinitions() {
+        return Set.of(PolicyDefinition.Builder.newInstance()
+                .id(POLICY_ID)
+                .policy(Policy.Builder.newInstance().build())
+                .build());
+    }
+
+    public static Set<ContractDefinition> createContractDefinitions() {
+        return Set.of(ContractDefinition.Builder.newInstance()
+                .id(CONTRACT_DEFINITION_ID)
+                .accessPolicyId(POLICY_ID)
+                .contractPolicyId(POLICY_ID)
+                .build());
+    }
+
+    public static StepRecorder<ContractNegotiation> createNegotiationRecorder() {
+        var recorder = new StepRecorder<ContractNegotiation>();
+
+        record01NegotiationSequences(recorder);
+        record02NegotiationSequences(recorder);
+        record03NegotiationSequences(recorder);
+
+        recordC01NegotiationSequences(recorder);
+
+        return recorder.repeat();
+    }
+
+    private static void recordC01NegotiationSequences(StepRecorder<ContractNegotiation> recorder) {
+    }
+
+    private static void record01NegotiationSequences(StepRecorder<ContractNegotiation> recorder) {
+        recorder.record("ACN0101", ContractNegotiation::transitionOffering);
+
+        recorder.record("ACN0102", ContractNegotiation::transitionOffering)
+                .record("ACN0102", ContractNegotiation::transitionTerminating);
+
+        recorder.record("ACN0103", ContractNegotiation::transitionOffering)
+                .record("ACN0103", ContractNegotiation::transitionAgreeing)
+                .record("ACN0103", ContractNegotiation::transitionFinalizing);
+
+        recorder.record("ACN0104", ContractNegotiation::transitionAgreeing)
+                .record("ACN0104", ContractNegotiation::transitionFinalizing);
+    }
+
+    private static void record02NegotiationSequences(StepRecorder<ContractNegotiation> recorder) {
+        recorder.record("ACN0201", ContractNegotiation::transitionTerminating);
+
+        recorder.record("ACN0202", ContractNegotiation::transitionRequested);
+
+        recorder.record("ACN0203", ContractNegotiation::transitionAgreeing);
+
+        recorder.record("ACN0204", ContractNegotiation::transitionOffering);
+
+        recorder.record("ACN0205", ContractNegotiation::transitionOffering);
+
+        recorder.record("ACN0206", contractNegotiation -> {
+            // only transition if in requested
+            if (contractNegotiation.getState() == REQUESTED.code()) {
+                contractNegotiation.transitionOffering();
+            }
+        });
+
+        recorder.record("ACN0207", ContractNegotiation::transitionAgreeing)
+                .record("ACN0207", ContractNegotiation::transitionTerminating);
+    }
+
+    private static void record03NegotiationSequences(StepRecorder<ContractNegotiation> recorder) {
+        recorder.record("ACN0301", ContractNegotiation::transitionAgreeing)
+                .record("ACN0301", ContractNegotiation::transitionFinalizing);
+
+        recorder.record("ACN0302", ContractNegotiation::transitionOffering);
+        recorder.record("ACN0303", ContractNegotiation::transitionOffering)
+                .record("ACN0303", ContractNegotiation::transitionAccepting);
+
+        recorder.record("ACN0304", ContractNegotiation::transitionOffering);
+    }
+
+    public static List<Trigger<ContractNegotiation>> createNegotiationTriggers() {
+        return List.of(
+                createTrigger(ContractNegotiationOffered.class, "ACN0205", ContractNegotiation::transitionTerminating),
+                createTrigger(ContractNegotiationAccepted.class, "ACN0206", ContractNegotiation::transitionTerminating),
+                createTrigger(ContractNegotiationOffered.class, "C0101", contractNegotiation -> {
+                    contractNegotiation.transitionAccepting();
+                    contractNegotiation.setPending(false);
+                }),
+                createTrigger(ContractNegotiationAgreed.class, "C0101", contractNegotiation -> {
+                    contractNegotiation.transitionVerifying();
+                    contractNegotiation.setPending(false);
+                })
+
+        );
+    }
+
+    private static <E extends ContractNegotiationEvent> Trigger<ContractNegotiation> createTrigger(Class<E> type,
+                                                                                                   String assetId,
+                                                                                                   Consumer<ContractNegotiation> action) {
+        return new Trigger<>(event -> {
+            if (event.getClass().equals(type)) {
+                return assetId.equals(((ContractNegotiationEvent) event).getLastContractOffer().getAssetId());
+            }
+            return false;
+        }, action);
+    }
+
+    private DataAssembly() {
+    }
+
+    private static Asset createAsset(String id) {
+        return Asset.Builder.newInstance()
+                .id(id)
+                .dataAddress(DataAddress.Builder.newInstance().type("HTTP").build())
+                .build();
+    }
+}

--- a/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/guard/ContractNegotiationGuard.java
+++ b/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/guard/ContractNegotiationGuard.java
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.tck.dsp.guard;
+
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.ContractNegotiationPendingGuard;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.spi.persistence.StateEntityStore;
+
+import java.util.Set;
+import java.util.function.Consumer;
+
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.Type.PROVIDER;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.ACCEPTING;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.AGREEING;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.FINALIZING;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.INITIAL;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.OFFERING;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.REQUESTING;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.TERMINATING;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.VERIFYING;
+
+/**
+ * Contract negotiation guard for TCK testcases.
+ */
+public class ContractNegotiationGuard extends DelayedActionGuard<ContractNegotiation> implements ContractNegotiationPendingGuard {
+    // the states not to apply the guard to - i.e., to allow automatic transitions by the contract negotiation manager
+    private static final Set<Integer> PROVIDER_AUTOMATIC_STATES = Set.of(
+            OFFERING.code(),
+            AGREEING.code(),
+            TERMINATING.code(),
+            FINALIZING.code());
+
+    private static final Set<Integer> CONSUMER_AUTOMATIC_STATES = Set.of(
+            INITIAL.code(),
+            REQUESTING.code(),
+            ACCEPTING.code(),
+            VERIFYING.code()
+    );
+
+    public ContractNegotiationGuard(Consumer<ContractNegotiation> action, StateEntityStore<ContractNegotiation> store) {
+        super(cn -> cn.getType() == PROVIDER ?
+                !PROVIDER_AUTOMATIC_STATES.contains(cn.getState()) : !CONSUMER_AUTOMATIC_STATES.contains(cn.getState()), action, store);
+    }
+}

--- a/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/guard/ContractNegotiationTriggerRegistry.java
+++ b/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/guard/ContractNegotiationTriggerRegistry.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.tck.dsp.guard;
+
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
+
+/**
+ * Registers contract negotiation triggers.
+ */
+public interface ContractNegotiationTriggerRegistry {
+
+    void register(Trigger<ContractNegotiation> trigger);
+
+}

--- a/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/guard/ContractNegotiationTriggerSubscriber.java
+++ b/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/guard/ContractNegotiationTriggerSubscriber.java
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.tck.dsp.guard;
+
+import org.eclipse.edc.connector.controlplane.contract.spi.event.contractnegotiation.ContractNegotiationEvent;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.spi.event.Event;
+import org.eclipse.edc.spi.event.EventEnvelope;
+import org.eclipse.edc.spi.event.EventSubscriber;
+import org.eclipse.edc.spi.persistence.StateEntityStore;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Fires triggers based on negotiation events.
+ */
+public class ContractNegotiationTriggerSubscriber implements EventSubscriber, ContractNegotiationTriggerRegistry {
+    private StateEntityStore<ContractNegotiation> store;
+
+    private List<Trigger<ContractNegotiation>> triggers = new ArrayList<>();
+
+    public ContractNegotiationTriggerSubscriber(StateEntityStore<ContractNegotiation> store) {
+        this.store = store;
+    }
+
+    @Override
+    public void register(Trigger<ContractNegotiation> trigger) {
+        triggers.add(trigger);
+    }
+
+    @Override
+    public <E extends Event> void on(EventEnvelope<E> envelope) {
+        triggers.stream()
+                .filter(trigger -> trigger.predicate().test(envelope.getPayload()))
+                .forEach(trigger -> {
+                    var event = (ContractNegotiationEvent) envelope.getPayload();
+                    var negotiation = store.findByIdAndLease(event.getContractNegotiationId()).getContent();
+                    trigger.action().accept(negotiation);
+                    store.save(negotiation);
+                });
+    }
+
+}

--- a/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/guard/DelayedActionGuard.java
+++ b/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/guard/DelayedActionGuard.java
@@ -1,0 +1,113 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.tck.dsp.guard;
+
+import org.eclipse.edc.spi.entity.PendingGuard;
+import org.eclipse.edc.spi.entity.StatefulEntity;
+import org.eclipse.edc.spi.persistence.StateEntityStore;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.DelayQueue;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+/**
+ * A guard that performs actions on a stateful entity.
+ * <p>
+ * Note this implementation is not safe to use in a clustered environment since transitions are not performed in the context of
+ * a command handler.
+ */
+public class DelayedActionGuard<T extends StatefulEntity<T>> implements PendingGuard<T> {
+    private Predicate<T> filter;
+    private Consumer<T> action;
+    private StateEntityStore<T> store;
+    private DelayQueue<GuardDelay> queue;
+    private AtomicBoolean active = new AtomicBoolean();
+
+    private ExecutorService executor = Executors.newFixedThreadPool(1);
+
+    public DelayedActionGuard(Predicate<T> filter,
+                              Consumer<T> action,
+                              StateEntityStore<T> store) {
+        this.filter = filter;
+        this.action = action;
+        this.store = store;
+        queue = new DelayQueue<>();
+    }
+
+    public void start() {
+        active.set(true);
+        executor.submit(() -> {
+            while (active.get()) {
+                try {
+                    var entry = queue.poll(10, MILLISECONDS);
+                    if (entry != null) {
+                        action.accept(entry.entity);
+                        entry.entity.setPending(false);
+                        store.save(entry.entity);
+                    }
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                    Thread.interrupted();
+                    break;
+                }
+            }
+        });
+    }
+
+    public void stop() {
+        active.set(false);
+    }
+
+    @Override
+    public boolean test(T entity) {
+        if (filter.test(entity)) {
+            queue.put(new GuardDelay(entity));
+            return true;
+        }
+        return false;
+    }
+
+    protected class GuardDelay implements Delayed {
+        T entity;
+        private long start;
+
+        GuardDelay(T entity) {
+            this.entity = entity;
+            start = System.currentTimeMillis();
+        }
+
+        @Override
+        public int compareTo(@NotNull Delayed delayed) {
+            var millis = getDelay(MILLISECONDS) - delayed.getDelay(MILLISECONDS);
+            millis = Math.min(millis, 1);
+            millis = Math.max(millis, -1);
+            return (int) millis;
+        }
+
+        @Override
+        public long getDelay(@NotNull TimeUnit timeUnit) {
+            return timeUnit.convert(500 - (System.currentTimeMillis() - start), MILLISECONDS);
+        }
+
+    }
+}

--- a/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/guard/TckGuardExtension.java
+++ b/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/guard/TckGuardExtension.java
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.tck.dsp.guard;
+
+import org.eclipse.edc.connector.controlplane.contract.spi.event.contractnegotiation.ContractNegotiationEvent;
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.ContractNegotiationPendingGuard;
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.event.EventRouter;
+import org.eclipse.edc.spi.system.ServiceExtension;
+
+import static org.eclipse.edc.tck.dsp.data.DataAssembly.createNegotiationRecorder;
+import static org.eclipse.edc.tck.dsp.data.DataAssembly.createNegotiationTriggers;
+
+/**
+ * Loads the transition guard.
+ */
+public class TckGuardExtension implements ServiceExtension {
+    private static final String NAME = "DSP TCK Guard";
+
+    private ContractNegotiationGuard negotiationGuard;
+
+    @Inject
+    private ContractNegotiationStore store;
+
+    @Inject
+    private EventRouter router;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Provider
+    public ContractNegotiationPendingGuard negotiationGuard() {
+        var recorder = createNegotiationRecorder();
+
+        var registry = new ContractNegotiationTriggerSubscriber(store);
+        createNegotiationTriggers().forEach(registry::register);
+        router.register(ContractNegotiationEvent.class, registry);
+
+        negotiationGuard = new ContractNegotiationGuard(cn -> recorder.playNext(cn.getContractOffers().get(0).getAssetId(), cn), store);
+        return negotiationGuard;
+    }
+
+    @Override
+    public void prepare() {
+        if (negotiationGuard != null) {
+            negotiationGuard.start();
+        }
+    }
+
+    @Override
+    public void shutdown() {
+        if (negotiationGuard != null) {
+            negotiationGuard.stop();
+        }
+    }
+}

--- a/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/guard/Trigger.java
+++ b/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/guard/Trigger.java
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.tck.dsp.guard;
+
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+/**
+ * An action that is triggered when the predicate matches a condition.
+ */
+public record Trigger<T>(Predicate<Object> predicate, Consumer<T> action) {
+}

--- a/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/identity/NoopIdentityService.java
+++ b/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/identity/NoopIdentityService.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.tck.dsp.identity;
+
+import org.eclipse.edc.spi.iam.ClaimToken;
+import org.eclipse.edc.spi.iam.IdentityService;
+import org.eclipse.edc.spi.iam.TokenParameters;
+import org.eclipse.edc.spi.iam.TokenRepresentation;
+import org.eclipse.edc.spi.iam.VerificationContext;
+import org.eclipse.edc.spi.result.Result;
+
+/**
+ * No-op service.
+ */
+public class NoopIdentityService implements IdentityService {
+    private static final String TCK_PARTICIPANT_ID = "TCK_PARTICIPANT"; // the official TCK id
+
+    @Override
+    public Result<TokenRepresentation> obtainClientCredentials(TokenParameters tokenParameters) {
+        return Result.success(TokenRepresentation.Builder.newInstance().token("1234").expiresIn(Long.MAX_VALUE).build());
+    }
+
+    @Override
+    public Result<ClaimToken> verifyJwtToken(TokenRepresentation tokenRepresentation, VerificationContext verificationContext) {
+        return Result.success(ClaimToken.Builder.newInstance().claim("client_id", TCK_PARTICIPANT_ID).build());
+    }
+}

--- a/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/identity/TckIdentityExtension.java
+++ b/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/identity/TckIdentityExtension.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.tck.dsp.identity;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.iam.AudienceResolver;
+import org.eclipse.edc.spi.iam.IdentityService;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.system.ServiceExtension;
+
+/**
+ * Loads a no-op identity service.
+ */
+public class TckIdentityExtension implements ServiceExtension {
+    private static final String NAME = "DSP TCK Identity";
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Provider
+    public IdentityService identityService() {
+        return new NoopIdentityService();
+    }
+
+    @Provider
+    public AudienceResolver audienceResolver() {
+        return m -> Result.success(m.getCounterPartyId());
+    }
+}

--- a/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/recorder/StepRecorder.java
+++ b/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/recorder/StepRecorder.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.tck.dsp.recorder;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+/**
+ * Records and plays a sequence of steps. Sequences may be repeated if {@link #repeat()} is enabled.
+ */
+public class StepRecorder<T> {
+    private boolean repeat;
+    private int playIndex = 0;
+    private Map<String, List<Consumer<T>>> sequences = new HashMap<>();
+
+    public synchronized StepRecorder<T> playNext(String key, T entity) {
+        var sequence = sequences.get(key);
+        if (sequence == null) {
+            throw new AssertionError("No sequence found for key " + key);
+        }
+        if (sequence.isEmpty()) {
+            throw new IllegalStateException("No replay steps");
+        }
+        if (playIndex >= sequence.size()) {
+            throw new IllegalStateException("Exceeded replay steps");
+        }
+        sequence.get(playIndex).accept(entity);
+        if (repeat && playIndex == sequence.size() - 1) {
+            playIndex = 0;
+        } else {
+            playIndex++;
+        }
+        return this;
+    }
+
+    public synchronized StepRecorder<T> record(String key, Consumer<T> step) {
+        var sequence = sequences.computeIfAbsent(key, k -> new ArrayList<>());
+        sequence.add(step);
+        return this;
+    }
+
+    public synchronized StepRecorder<T> repeat() {
+        repeat = true;
+        return this;
+    }
+}

--- a/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/setup/TckSetupExtension.java
+++ b/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/setup/TckSetupExtension.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.tck.dsp.setup;
+
+import org.eclipse.edc.connector.controlplane.asset.spi.index.AssetIndex;
+import org.eclipse.edc.connector.controlplane.services.spi.contractdefinition.ContractDefinitionService;
+import org.eclipse.edc.connector.controlplane.services.spi.policydefinition.PolicyDefinitionService;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.system.ServiceExtension;
+
+import static org.eclipse.edc.tck.dsp.data.DataAssembly.createAssets;
+import static org.eclipse.edc.tck.dsp.data.DataAssembly.createContractDefinitions;
+import static org.eclipse.edc.tck.dsp.data.DataAssembly.createPolicyDefinitions;
+import static org.eclipse.edc.tck.dsp.setup.TckSetupExtension.NAME;
+
+/**
+ * Loads customizations and seed data for the TCK.
+ */
+@Extension(NAME)
+public class TckSetupExtension implements ServiceExtension {
+    public static final String NAME = "DSP TCK Setup";
+
+    @Inject
+    private AssetIndex assetIndex;
+
+    @Inject
+    private PolicyDefinitionService policyDefinitionService;
+
+    @Inject
+    private ContractDefinitionService contractDefinitionService;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void prepare() {
+        createAssets().forEach(asset -> assetIndex.create(asset));
+        createPolicyDefinitions().forEach(definition -> policyDefinitionService.create(definition));
+        createContractDefinitions().forEach(definition -> contractDefinitionService.create(definition));
+    }
+
+
+}

--- a/system-tests/protocol-tck/tck-extension/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/system-tests/protocol-tck/tck-extension/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,17 @@
+#
+#  Copyright (c) 2025 Metaform Systems, Inc.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+#
+#
+org.eclipse.edc.tck.dsp.guard.TckGuardExtension
+org.eclipse.edc.tck.dsp.setup.TckSetupExtension
+org.eclipse.edc.tck.dsp.identity.TckIdentityExtension
+org.eclipse.edc.tck.dsp.controller.TckControllerExtension

--- a/system-tests/protocol-tck/tck-extension/src/test/java/org/eclipse/edc/tck/dsp/recorder/StepRecorderTest.java
+++ b/system-tests/protocol-tck/tck-extension/src/test/java/org/eclipse/edc/tck/dsp/recorder/StepRecorderTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2025 Metaform Systems, Inc
+ *  Copyright (c) 2025 Metaform Systems, Inc.
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *      Metaform Systems, Inc - initial API and implementation
+ *       Metaform Systems, Inc. - initial API and implementation
  *
  */
 

--- a/system-tests/protocol-tck/tck-extension/src/test/java/org/eclipse/edc/tck/dsp/recorder/StepRecorderTest.java
+++ b/system-tests/protocol-tck/tck-extension/src/test/java/org/eclipse/edc/tck/dsp/recorder/StepRecorderTest.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *      Metaform Systems, Inc - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.tck.dsp.recorder;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+class StepRecorderTest {
+    private static final String KEY = "test";
+
+    @Test
+    void verifyRecordReplay() {
+        var recorder = new StepRecorder<Void>();
+        var counter = new int[1];
+        recorder.record(KEY, i -> assertThat(counter[0]++).isEqualTo(0));
+        recorder.record(KEY, i -> assertThat(counter[0]++).isEqualTo(1));
+
+        recorder.playNext(KEY, null);
+        recorder.playNext(KEY, null);
+        assertThat(counter[0]).isEqualTo(2);
+    }
+
+    @Test
+    void verifyRepeat() {
+        var recorder = new StepRecorder<Void>();
+        var counter = new int[1];
+        recorder.record(KEY, i -> counter[0]++);
+        recorder.repeat();
+
+        for (int i = 0; i < 4; i++) {
+            recorder.playNext(KEY, null);
+        }
+        assertThat(counter[0]).isEqualTo(4);
+    }
+
+    @Test
+    void verifyNoRepeat() {
+        var recorder = new StepRecorder<Void>();
+        var counter = new int[1];
+        recorder.record(KEY, i -> counter[0]++);
+
+        recorder.playNext(KEY, null);
+        assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> recorder.playNext(KEY, null));
+        assertThat(counter[0]).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

Adds an extension needed to prime and run an EDC for the DSP TCK tests.
