### PR TITLE
docs: improve exception mappers for the JerseyRestService

### DIFF
--- a/extensions/common/http/jersey-core/README.md
+++ b/extensions/common/http/jersey-core/README.md
@@ -13,9 +13,8 @@ This extension provides a `Jersey` implementation for the `WebService` service.
 
 ## Exception handling
 
-The `JerseyService` provide 3 exception mappers:
+The `JerseyRestService` provide 2 exception mappers:
  - `EdcApiExceptionMapper`: catches all the `EdcApiException` exceptions, map them to a 4xx response code with a detailed response body
- - `ValidationExceptionMapper`: catches all the `ConstraintViolationException` exceptions thrown by the `jersey-bean-validation` module, it maps them to a 400 response code with a detailed response body
- - Exception mapper that catches all the exceptions that are not handled by the other mappers, for example:
+ - `UnexpectedExceptionMapper`: catches all the exceptions that are not handled by the other mappers, for example:
    - all the `java.lang` exceptions
-   - jakarta.ws.rs.WebApplicationException and subclasses
+   - `jakarta.ws.rs.WebApplicationException` and subclasses


### PR DESCRIPTION
## What this PR changes/adds

Improve exception mappers for the JerseyRestService.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #4958

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
