### PR TITLE
fix: add endpoint allowing a connector to remove terminated contract negotiation #4952

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationServiceImpl.java
@@ -101,17 +101,15 @@ public class ContractNegotiationServiceImpl implements ContractNegotiationServic
     }
 
     @Override
-    public ServiceResult<Void> removeNegotiation(String negotiationId) {
-        String state = getState(negotiationId);
-        if (!ContractNegotiationStates.TERMINATED.name().equals(state)) {
-            return ServiceResult.unauthorized(format("Error validating the contract negotiation state: %s", state));
-        }
-        try {
-            store.delete(negotiationId);
+    public ServiceResult<Void> delete(String negotiationId) {
+        return transactionContext.execute(() -> {
+            var state = getState(negotiationId);
+            if (!ContractNegotiationStates.TERMINATED.name().equals(state)) {
+                return ServiceResult.conflict(format("Cannot delete negotiation in state: %s".formatted(state)));
+            }
+            store.deleteNegociation(negotiationId);
             return ServiceResult.success();
-        } catch (IllegalStateException e) {
-            return ServiceResult.unauthorized(e.getMessage());
-        }
+        });
     }
 
 }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationServiceImpl.java
@@ -103,12 +103,18 @@ public class ContractNegotiationServiceImpl implements ContractNegotiationServic
     @Override
     public ServiceResult<Void> delete(String negotiationId) {
         return transactionContext.execute(() -> {
-            var state = getState(negotiationId);
-            if (!ContractNegotiationStates.TERMINATED.name().equals(state)) {
+            var existing = findbyId(negotiationId);
+            if (existing == null) {
+                return ServiceResult.notFound(format("ContractNegotiation %s not found", negotiationId));
+            }
+            if (existing.getContractAgreement() != null) {
+                return ServiceResult.conflict(format("Cannot delete ContractNegotiation [ID=%s] - ContractAgreement already created.", negotiationId));
+            }
+            var state = existing.getState();
+            if (state != ContractNegotiationStates.TERMINATED.code()) {
                 return ServiceResult.conflict(format("Cannot delete negotiation in state: %s".formatted(state)));
             }
-            store.deleteNegociation(negotiationId);
-            return ServiceResult.success();
+            return ServiceResult.from(store.deleteById(negotiationId));
         });
     }
 

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationServiceImpl.java
@@ -100,4 +100,18 @@ public class ContractNegotiationServiceImpl implements ContractNegotiationServic
         });
     }
 
+    @Override
+    public ServiceResult<Void> removeNegotiation(String negotiationId) {
+        String state = getState(negotiationId);
+        if (!ContractNegotiationStates.TERMINATED.name().equals(state)) {
+            return ServiceResult.unauthorized(format("Error validating the contract negotiation state: %s", state));
+        }
+        try {
+            store.delete(negotiationId);
+            return ServiceResult.success();
+        } catch (IllegalStateException e) {
+            return ServiceResult.unauthorized(e.getMessage());
+        }
+    }
+
 }

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationServiceImplTest.java
@@ -42,14 +42,20 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.list;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.AGREED;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.REQUESTED;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.TERMINATED;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.spi.query.Criterion.criterion;
 import static org.eclipse.edc.spi.result.ServiceFailure.Reason.NOT_FOUND;
+import static org.eclipse.edc.spi.result.ServiceFailure.Reason.UNAUTHORIZED;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -209,6 +215,48 @@ class ContractNegotiationServiceImplTest {
         var result = service.terminate(command);
 
         assertThat(result).isFailed().extracting(ServiceFailure::getReason).isEqualTo(NOT_FOUND);
+    }
+
+    @Test
+    void removeNegotiation_shouldSucceed() {
+        var negotiation = createContractNegotiationBuilder("negotiationId")
+                .state(TERMINATED.code())
+                .build();
+        when(store.findById("negotiationId")).thenReturn(negotiation);
+
+        var result = service.removeNegotiation("negotiationId");
+
+        assertThat(result).isSucceeded();
+        verify(store).delete("negotiationId");
+    }
+
+    @Test
+    void removeNegotiation_shouldFailDueToWrongState() {
+        var negotiation = createContractNegotiationBuilder("negotiationId")
+                .state(AGREED.code())
+                .build();
+        when(store.findById("negotiationId")).thenReturn(negotiation);
+
+        var result = service.removeNegotiation("negotiationId");
+
+        assertThat(result).isFailed();
+        assertThat(result.reason()).isEqualTo(UNAUTHORIZED);
+        verify(store, never()).delete(any());
+    }
+
+    @Test
+    void removeNegotiation_shouldFailDueToExistingContractAgreement() {
+        var negotiation = createContractNegotiationBuilder("negotiationId")
+                .state(TERMINATED.code())
+                .build();
+        when(store.findById("negotiationId")).thenReturn(negotiation);
+        doThrow(new IllegalStateException("Cannot delete ContractNegotiation [ID=negotiationId] - ContractAgreement already created.")).when(store).delete("negotiationId");
+
+        var result = service.removeNegotiation("negotiationId");
+
+        assertThat(result).isFailed();
+        assertThat(result.reason()).isEqualTo(UNAUTHORIZED);
+        verify(store, times(1)).delete("negotiationId");
     }
 
     private static class InvalidFilters implements ArgumentsProvider {

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/controlplane/defaults/storage/contractnegotiation/InMemoryContractNegotiationStore.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/controlplane/defaults/storage/contractnegotiation/InMemoryContractNegotiationStore.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.Con
 import org.eclipse.edc.spi.query.CriterionOperatorRegistry;
 import org.eclipse.edc.spi.query.QueryResolver;
 import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.StoreResult;
 import org.eclipse.edc.store.InMemoryStatefulEntityStore;
 import org.eclipse.edc.store.ReflectionBasedQueryResolver;
 import org.jetbrains.annotations.NotNull;
@@ -61,12 +62,13 @@ public class InMemoryContractNegotiationStore extends InMemoryStatefulEntityStor
     }
 
     @Override
-    public void delete(String negotiationId) {
+    public StoreResult<Void> deleteNegociation(String negotiationId) {
         var negotiation = findById(negotiationId);
         if (negotiation != null && negotiation.getContractAgreement() != null) {
             throw new IllegalStateException(format("Cannot delete ContractNegotiation [%s]: ContractAgreement already created.", negotiationId));
         }
         super.delete(negotiationId);
+        return StoreResult.success();
     }
 
     @Override

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/controlplane/defaults/storage/contractnegotiation/InMemoryContractNegotiationStore.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/controlplane/defaults/storage/contractnegotiation/InMemoryContractNegotiationStore.java
@@ -62,10 +62,10 @@ public class InMemoryContractNegotiationStore extends InMemoryStatefulEntityStor
     }
 
     @Override
-    public StoreResult<Void> deleteNegociation(String negotiationId) {
-        var negotiation = findById(negotiationId);
-        if (negotiation != null && negotiation.getContractAgreement() != null) {
-            throw new IllegalStateException(format("Cannot delete ContractNegotiation [%s]: ContractAgreement already created.", negotiationId));
+    public StoreResult<Void> deleteById(String negotiationId) {
+        var existing = findById(negotiationId);
+        if (existing == null) {
+            return StoreResult.notFound(format("ContractNegotiation %s not found", negotiationId));
         }
         super.delete(negotiationId);
         return StoreResult.success();

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/BaseContractNegotiationApiController.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/BaseContractNegotiationApiController.java
@@ -128,8 +128,8 @@ public class BaseContractNegotiationApiController {
         service.terminate(command).orElseThrow(exceptionMapper(ContractNegotiation.class, id));
     }
 
-    public void removeNegotiation(String id) {
-        service.removeNegotiation(id).orElseThrow(exceptionMapper(ContractNegotiation.class, id));
+    public void delete(String id) {
+        service.delete(id).orElseThrow(exceptionMapper(ContractNegotiation.class, id));
     }
 
     private void logIfError(Result<?> result) {

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/BaseContractNegotiationApiController.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/BaseContractNegotiationApiController.java
@@ -128,6 +128,10 @@ public class BaseContractNegotiationApiController {
         service.terminate(command).orElseThrow(exceptionMapper(ContractNegotiation.class, id));
     }
 
+    public void removeNegotiation(String id) {
+        service.removeNegotiation(id).orElseThrow(exceptionMapper(ContractNegotiation.class, id));
+    }
+
     private void logIfError(Result<?> result) {
         result.onFailure(f -> monitor.warning(f.getFailureDetail()));
     }

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v3/ContractNegotiationApiV3.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v3/ContractNegotiationApiV3.java
@@ -125,7 +125,9 @@ public interface ContractNegotiationApiV3 {
                             links = @Link(name = "poll-state", operationId = "getNegotiationStateV3")),
                     @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
-                    @ApiResponse(responseCode = "409", description = "A contract negotiation with the given ID does not exist or is in a wrong state",
+                    @ApiResponse(responseCode = "404", description = "A contract negotiation with the given ID does not exist",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
+                    @ApiResponse(responseCode = "409", description = "The given contract negotiation cannot be deleted due to a wrong state or has existing contract agreement",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             }
     )

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v3/ContractNegotiationApiV3.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v3/ContractNegotiationApiV3.java
@@ -125,11 +125,11 @@ public interface ContractNegotiationApiV3 {
                             links = @Link(name = "poll-state", operationId = "getNegotiationStateV3")),
                     @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
-                    @ApiResponse(responseCode = "403", description = "A contract negotiation with the given ID does not exist or is in a wrong state",
+                    @ApiResponse(responseCode = "409", description = "A contract negotiation with the given ID does not exist or is in a wrong state",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             }
     )
-    void removeNegotiationV3(String id);
+    void deleteNegotiationV3(String id);
 
     @Schema(name = "ContractRequest", example = ContractRequestSchema.CONTRACT_REQUEST_EXAMPLE)
     record ContractRequestSchema(

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v3/ContractNegotiationApiV3.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v3/ContractNegotiationApiV3.java
@@ -119,6 +119,18 @@ public interface ContractNegotiationApiV3 {
     )
     void terminateNegotiationV3(String id, JsonObject terminateNegotiation);
 
+    @Operation(description = "Removes the contract negotiation with the given ID.",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "ContractNegotiation is removed",
+                            links = @Link(name = "poll-state", operationId = "getNegotiationStateV3")),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
+                    @ApiResponse(responseCode = "403", description = "A contract negotiation with the given ID does not exist or is in a wrong state",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
+            }
+    )
+    void removeNegotiationV3(String id);
+
     @Schema(name = "ContractRequest", example = ContractRequestSchema.CONTRACT_REQUEST_EXAMPLE)
     record ContractRequestSchema(
             @Schema(name = CONTEXT, requiredMode = REQUIRED)

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v3/ContractNegotiationApiV3Controller.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v3/ContractNegotiationApiV3Controller.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.connector.controlplane.api.management.contractnegotiatio
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -77,5 +78,12 @@ public class ContractNegotiationApiV3Controller extends BaseContractNegotiationA
     @Override
     public void terminateNegotiationV3(@PathParam("id") String id, JsonObject terminateNegotiation) {
         terminateNegotiation(id, terminateNegotiation);
+    }
+
+    @DELETE
+    @Path("/{id}")
+    @Override
+    public void removeNegotiationV3(@PathParam("id") String id) {
+        removeNegotiation(id);
     }
 }

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v3/ContractNegotiationApiV3Controller.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v3/ContractNegotiationApiV3Controller.java
@@ -83,7 +83,7 @@ public class ContractNegotiationApiV3Controller extends BaseContractNegotiationA
     @DELETE
     @Path("/{id}")
     @Override
-    public void removeNegotiationV3(@PathParam("id") String id) {
-        removeNegotiation(id);
+    public void deleteNegotiationV3(@PathParam("id") String id) {
+        delete(id);
     }
 }

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/BaseContractNegotiationApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/BaseContractNegotiationApiControllerTest.java
@@ -475,6 +475,19 @@ public abstract class BaseContractNegotiationApiControllerTest extends RestContr
         verify(service).delete("cn1");
     }
 
+    @Test
+    void delete_shouldFailDueToNegotiationNotFound() {
+        when(service.delete(any())).thenReturn(ServiceResult.notFound("ContractNegotiation negotiationId not found"));
+
+        baseRequest()
+                .contentType(JSON)
+                .delete("/cn1")
+                .then()
+                .statusCode(404);
+
+        verify(service).delete("cn1");
+    }
+
     protected abstract RequestSpecification baseRequest();
 
     private ContractNegotiation createContractNegotiation(String negotiationId) {

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/BaseContractNegotiationApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/BaseContractNegotiationApiControllerTest.java
@@ -450,8 +450,8 @@ public abstract class BaseContractNegotiationApiControllerTest extends RestContr
     }
 
     @Test
-    void removeNegotiation_shouldCallService() {
-        when(service.removeNegotiation(any())).thenReturn(ServiceResult.success());
+    void delete_shouldCallService() {
+        when(service.delete(any())).thenReturn(ServiceResult.success());
 
         baseRequest()
                 .contentType(JSON)
@@ -459,20 +459,20 @@ public abstract class BaseContractNegotiationApiControllerTest extends RestContr
                 .then()
                 .statusCode(204);
 
-        verify(service).removeNegotiation("cn1");
+        verify(service).delete("cn1");
     }
 
     @Test
-    void removeNegotiation_shouldFailDueToWrongState() {
-        when(service.removeNegotiation(any())).thenReturn(ServiceResult.unauthorized(format("Error validating the contract negotiation state: %s", ContractNegotiationStates.AGREED.name())));
+    void delete_shouldFailDueToWrongState() {
+        when(service.delete(any())).thenReturn(ServiceResult.conflict(format("Cannot delete negotiation in state: %s".formatted(ContractNegotiationStates.AGREED.name()))));
 
         baseRequest()
                 .contentType(JSON)
                 .delete("/cn1")
                 .then()
-                .statusCode(403);
+                .statusCode(409);
 
-        verify(service).removeNegotiation("cn1");
+        verify(service).delete("cn1");
     }
 
     protected abstract RequestSpecification baseRequest();

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/BaseContractNegotiationApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/BaseContractNegotiationApiControllerTest.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.connector.controlplane.api.management.contractnegotiation
 import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.command.TerminateNegotiationCommand;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequest;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationService;
@@ -40,6 +41,7 @@ import java.util.List;
 
 import static io.restassured.http.ContentType.JSON;
 import static jakarta.json.Json.createObjectBuilder;
+import static java.lang.String.format;
 import static java.util.UUID.randomUUID;
 import static org.eclipse.edc.api.model.IdResponse.ID_RESPONSE_TYPE;
 import static org.eclipse.edc.connector.controlplane.api.management.contractnegotiation.model.NegotiationState.NEGOTIATION_STATE_TYPE;
@@ -445,6 +447,32 @@ public abstract class BaseContractNegotiationApiControllerTest extends RestContr
 
         verify(validatorRegistry).validate(eq(TERMINATE_NEGOTIATION_TYPE), any());
         verifyNoInteractions(transformerRegistry, service);
+    }
+
+    @Test
+    void removeNegotiation_shouldCallService() {
+        when(service.removeNegotiation(any())).thenReturn(ServiceResult.success());
+
+        baseRequest()
+                .contentType(JSON)
+                .delete("/cn1")
+                .then()
+                .statusCode(204);
+
+        verify(service).removeNegotiation("cn1");
+    }
+
+    @Test
+    void removeNegotiation_shouldFailDueToWrongState() {
+        when(service.removeNegotiation(any())).thenReturn(ServiceResult.unauthorized(format("Error validating the contract negotiation state: %s", ContractNegotiationStates.AGREED.name())));
+
+        baseRequest()
+                .contentType(JSON)
+                .delete("/cn1")
+                .then()
+                .statusCode(403);
+
+        verify(service).removeNegotiation("cn1");
     }
 
     protected abstract RequestSpecification baseRequest();

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/store/SqlContractNegotiationStore.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/store/SqlContractNegotiationStore.java
@@ -149,8 +149,8 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
     }
 
     @Override
-    public void delete(String negotiationId) {
-        transactionContext.execute(() -> {
+    public StoreResult<Void> deleteNegociation(String negotiationId) {
+        return transactionContext.execute(() -> {
             var existing = findById(negotiationId);
 
             //if exists, attempt delete
@@ -174,6 +174,7 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
                     throw new EdcPersistenceException(e);
                 }
             }
+            return StoreResult.success();
         });
     }
 

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/store/SqlContractNegotiationStore.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/store/SqlContractNegotiationStore.java
@@ -149,32 +149,30 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
     }
 
     @Override
-    public StoreResult<Void> deleteNegociation(String negotiationId) {
+    public StoreResult<Void> deleteById(String negotiationId) {
+
         return transactionContext.execute(() -> {
             var existing = findById(negotiationId);
-
-            //if exists, attempt delete
-            if (existing != null) {
-                if (existing.getContractAgreement() != null) {
-                    throw new IllegalStateException(format("Cannot delete ContractNegotiation [ID=%s] - ContractAgreement already created.", negotiationId));
-                }
-                try (var connection = getConnection()) {
-
-                    // attempt to acquire lease - should fail if someone else holds the lease
-                    leaseContext.withConnection(connection).acquireLease(negotiationId);
-
-                    var stmt = statements.getDeleteTemplate();
-                    queryExecutor.execute(connection, stmt, negotiationId);
-
-                    //necessary to delete the row in edc_lease
-                    leaseContext.withConnection(connection).breakLease(negotiationId);
-
-                    // return existing;
-                } catch (SQLException e) {
-                    throw new EdcPersistenceException(e);
-                }
+            if (existing == null) {
+                return StoreResult.notFound(format("ContractNegotiation %s not found", negotiationId));
             }
-            return StoreResult.success();
+            //if exists, attempt delete
+            try (var connection = getConnection()) {
+
+                // attempt to acquire lease - should fail if someone else holds the lease
+                leaseContext.withConnection(connection).acquireLease(negotiationId);
+
+                var stmt = statements.getDeleteTemplate();
+                queryExecutor.execute(connection, stmt, negotiationId);
+
+                //necessary to delete the row in edc_lease
+                leaseContext.withConnection(connection).breakLease(negotiationId);
+
+                // return existing;
+                return StoreResult.success();
+            } catch (SQLException e) {
+                throw new EdcPersistenceException(e);
+            }
         });
     }
 

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/negotiation/store/ContractNegotiationStore.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/negotiation/store/ContractNegotiationStore.java
@@ -42,7 +42,7 @@ public interface ContractNegotiationStore extends StateEntityStore<ContractNegot
     /**
      * Removes a contract negotiation for the given id.
      */
-    StoreResult<Void> deleteNegociation(String negotiationId);
+    StoreResult<Void> deleteById(String negotiationId);
 
     /**
      * Finds all contract negotiations that are covered by a specific {@link QuerySpec}. If no

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/negotiation/store/ContractNegotiationStore.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/negotiation/store/ContractNegotiationStore.java
@@ -20,6 +20,7 @@ import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.Con
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import org.eclipse.edc.spi.persistence.StateEntityStore;
 import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.StoreResult;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -41,7 +42,7 @@ public interface ContractNegotiationStore extends StateEntityStore<ContractNegot
     /**
      * Removes a contract negotiation for the given id.
      */
-    void delete(String negotiationId);
+    StoreResult<Void> deleteNegociation(String negotiationId);
 
     /**
      * Finds all contract negotiations that are covered by a specific {@link QuerySpec}. If no

--- a/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/controlplane/contract/spi/testfixtures/negotiation/store/ContractNegotiationStoreTestBase.java
+++ b/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/controlplane/contract/spi/testfixtures/negotiation/store/ContractNegotiationStoreTestBase.java
@@ -367,7 +367,7 @@ public abstract class ContractNegotiationStoreTestBase {
 
             assertThat(getContractNegotiationStore().findById(id)).isNotNull().usingRecursiveComparison().isEqualTo(n);
 
-            getContractNegotiationStore().delete(id);
+            getContractNegotiationStore().deleteNegociation(id);
 
             assertThat(getContractNegotiationStore().findById(id)).isNull();
         }
@@ -381,7 +381,7 @@ public abstract class ContractNegotiationStoreTestBase {
 
             leaseEntity(id, CONNECTOR_NAME);
 
-            assertThatThrownBy(() -> getContractNegotiationStore().delete(id)).isInstanceOf(IllegalStateException.class);
+            assertThatThrownBy(() -> getContractNegotiationStore().deleteNegociation(id)).isInstanceOf(IllegalStateException.class);
         }
 
         @Test
@@ -393,7 +393,7 @@ public abstract class ContractNegotiationStoreTestBase {
 
             leaseEntity(id, "someone-else");
 
-            assertThatThrownBy(() -> getContractNegotiationStore().delete(id)).isInstanceOf(IllegalStateException.class);
+            assertThatThrownBy(() -> getContractNegotiationStore().deleteNegociation(id)).isInstanceOf(IllegalStateException.class);
         }
 
         @Test
@@ -405,7 +405,7 @@ public abstract class ContractNegotiationStoreTestBase {
             getContractNegotiationStore().save(n);
 
             assertThat(getContractNegotiationStore().findById(id)).isNotNull().usingRecursiveComparison().isEqualTo(n);
-            assertThatThrownBy(() -> getContractNegotiationStore().delete(id)).isInstanceOf(IllegalStateException.class)
+            assertThatThrownBy(() -> getContractNegotiationStore().deleteNegociation(id)).isInstanceOf(IllegalStateException.class)
                     .hasMessageContaining("Cannot delete ContractNegotiation")
                     .hasMessageContaining("ContractAgreement already created.");
         }

--- a/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/controlplane/contract/spi/testfixtures/negotiation/store/ContractNegotiationStoreTestBase.java
+++ b/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/controlplane/contract/spi/testfixtures/negotiation/store/ContractNegotiationStoreTestBase.java
@@ -367,7 +367,7 @@ public abstract class ContractNegotiationStoreTestBase {
 
             assertThat(getContractNegotiationStore().findById(id)).isNotNull().usingRecursiveComparison().isEqualTo(n);
 
-            getContractNegotiationStore().deleteNegociation(id);
+            getContractNegotiationStore().deleteById(id);
 
             assertThat(getContractNegotiationStore().findById(id)).isNull();
         }
@@ -381,7 +381,7 @@ public abstract class ContractNegotiationStoreTestBase {
 
             leaseEntity(id, CONNECTOR_NAME);
 
-            assertThatThrownBy(() -> getContractNegotiationStore().deleteNegociation(id)).isInstanceOf(IllegalStateException.class);
+            assertThatThrownBy(() -> getContractNegotiationStore().deleteById(id)).isInstanceOf(IllegalStateException.class);
         }
 
         @Test
@@ -393,22 +393,9 @@ public abstract class ContractNegotiationStoreTestBase {
 
             leaseEntity(id, "someone-else");
 
-            assertThatThrownBy(() -> getContractNegotiationStore().deleteNegociation(id)).isInstanceOf(IllegalStateException.class);
+            assertThatThrownBy(() -> getContractNegotiationStore().deleteById(id)).isInstanceOf(IllegalStateException.class);
         }
 
-        @Test
-        @DisplayName("Verify that attempting to delete a negotiation with a contract raises an exception")
-        void contractExists() {
-            var id = UUID.randomUUID().toString();
-            var contract = createContract(ContractOfferId.create("definition", "asset"));
-            var n = createNegotiation(id, contract);
-            getContractNegotiationStore().save(n);
-
-            assertThat(getContractNegotiationStore().findById(id)).isNotNull().usingRecursiveComparison().isEqualTo(n);
-            assertThatThrownBy(() -> getContractNegotiationStore().deleteNegociation(id)).isInstanceOf(IllegalStateException.class)
-                    .hasMessageContaining("Cannot delete ContractNegotiation")
-                    .hasMessageContaining("ContractAgreement already created.");
-        }
     }
 
     @Nested
@@ -719,7 +706,7 @@ public abstract class ContractNegotiationStoreTestBase {
                     .state(REQUESTED.code())
                     .type(CONSUMER)
                     .build()).forEach(getContractNegotiationStore()::save);
-            var criteria = new Criterion[]{ hasState(REQUESTED.code()), new Criterion("type", "=", "CONSUMER") };
+            var criteria = new Criterion[] {hasState(REQUESTED.code()), new Criterion("type", "=", "CONSUMER")};
 
             var result = getContractNegotiationStore().nextNotLeased(10, criteria);
 

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/controlplane/services/spi/contractnegotiation/ContractNegotiationService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/controlplane/services/spi/contractnegotiation/ContractNegotiationService.java
@@ -80,5 +80,5 @@ public interface ContractNegotiationService {
      * @param negotiationId the id of contract negotiation.
      * @return successful result if the contract negotiation is removed correctly, failure otherwise
      */
-    ServiceResult<Void> removeNegotiation(String negotiationId);
+    ServiceResult<Void> delete(String negotiationId);
 }

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/controlplane/services/spi/contractnegotiation/ContractNegotiationService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/controlplane/services/spi/contractnegotiation/ContractNegotiationService.java
@@ -73,4 +73,12 @@ public interface ContractNegotiationService {
      * @return successful result if the contract negotiation is terminated correctly, failure otherwise
      */
     ServiceResult<Void> terminate(TerminateNegotiationCommand command);
+
+    /**
+     * Remove a contract negotiation
+     *
+     * @param negotiationId the id of contract negotiation.
+     * @return successful result if the contract negotiation is removed correctly, failure otherwise
+     */
+    ServiceResult<Void> removeNegotiation(String negotiationId);
 }

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractNegotiationApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractNegotiationApiEndToEndTest.java
@@ -210,7 +210,7 @@ public class ContractNegotiationApiEndToEndTest {
                     .contentType(JSON)
                     .delete("/v3/contractnegotiations/cn1")
                     .then()
-                    .statusCode(403);
+                    .statusCode(409);
 
             Assertions.assertNotNull(store.findById("cn1"));
         }
@@ -276,7 +276,8 @@ public class ContractNegotiationApiEndToEndTest {
     @Nested
     @EndToEndTest
     @ExtendWith(ManagementEndToEndExtension.InMemory.class)
-    class InMemory extends Tests { }
+    class InMemory extends Tests {
+    }
 
     @Nested
     @PostgresqlIntegrationTest


### PR DESCRIPTION
## What this PR changes/adds

add an endpoint in order for a connector to be able to remove a terminated contract negotiation

## Why it does that

Currently the connector does not provide any endpoint enabling to remove terminated contract negotiations, as described in the DSP specification: https://docs.internationaldataspaces.org/ids-knowledgebase/dataspace-protocol/contract-negotiation/contract.negotiation.protocol#id-2.6-contract-negotiation-termination-message

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

@bscholtes1A 


## Linked Issue(s)

Closes #4952  

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
