### PR TITLE
feat: enable nightly job for testing edc with dsp-tck 

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationEventDispatchTest.java
@@ -43,7 +43,7 @@ import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.iam.VerificationContext;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcher;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
-import org.eclipse.edc.spi.protocol.ProtocolWebhook;
+import org.eclipse.edc.spi.protocol.ProtocolWebhookRegistry;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.DataAddress;
@@ -78,6 +78,7 @@ class ContractNegotiationEventDispatchTest {
     private final ClaimToken token = ClaimToken.Builder.newInstance().claim(ParticipantAgentService.DEFAULT_IDENTITY_CLAIM_KEY, CONSUMER).build();
 
     private final TokenRepresentation tokenRepresentation = TokenRepresentation.Builder.newInstance().token(UUID.randomUUID().toString()).build();
+    protected ProtocolWebhookRegistry protocolWebhookRegistry = mock();
 
 
     @BeforeEach
@@ -89,10 +90,12 @@ class ContractNegotiationEventDispatchTest {
                 "edc.negotiation.provider.send.retry.limit", "0"
         ));
         extension.registerServiceMock(NegotiationWaitStrategy.class, () -> 1);
-        extension.registerServiceMock(ProtocolWebhook.class, mock());
+        extension.registerServiceMock(ProtocolWebhookRegistry.class, protocolWebhookRegistry);
         extension.registerServiceMock(DataPlaneInstanceStore.class, mock());
         extension.registerServiceMock(IdentityService.class, identityService);
         extension.registerServiceMock(DataPlaneClientFactory.class, mock());
+
+        when(protocolWebhookRegistry.resolve(any())).thenReturn(() -> "http://callback.address");
     }
 
     @Test

--- a/core/control-plane/control-plane-contract/src/main/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/control-plane/control-plane-contract/src/main/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -25,7 +25,6 @@ import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.Contr
 import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractNegotiationEventMessage;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractOfferMessage;
-import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.protocol.ContractNegotiationAck;
 import org.eclipse.edc.policy.model.PolicyType;
 import org.eclipse.edc.statemachine.StateMachineManager;
@@ -82,14 +81,8 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
             return true;
         }
 
-        var lastContractOffer = negotiation.getLastContractOffer();
-        var offer = ContractOffer.Builder.newInstance().id(lastContractOffer.getId())
-                .policy(lastContractOffer.getPolicy().toBuilder().type(PolicyType.OFFER).build())
-                .assetId(lastContractOffer.getAssetId())
-                .build();
-
         var messageBuilder = ContractOfferMessage.Builder.newInstance()
-                .contractOffer(offer)
+                .contractOffer(negotiation.getLastContractOffer())
                 .callbackAddress(callbackAddress.url());
 
         return dispatch(messageBuilder, negotiation, ContractNegotiationAck.class, "[Provider] send offer")
@@ -149,7 +142,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
                             .assetId(lastOffer.getAssetId())
                             .build();
                 });
-        
+
         var messageBuilder = ContractAgreementMessage.Builder.newInstance()
                 .callbackAddress(callbackAddress.url())
                 .contractAgreement(agreement);

--- a/core/control-plane/control-plane-contract/src/main/java/org/eclipse/edc/connector/controlplane/contract/validation/ContractValidationServiceImpl.java
+++ b/core/control-plane/control-plane-contract/src/main/java/org/eclipse/edc/connector/controlplane/contract/validation/ContractValidationServiceImpl.java
@@ -32,6 +32,7 @@ import org.eclipse.edc.connector.controlplane.contract.spi.validation.ValidatedC
 import org.eclipse.edc.participant.spi.ParticipantAgent;
 import org.eclipse.edc.policy.engine.spi.PolicyEngine;
 import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.policy.model.PolicyType;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.result.Result;
 import org.jetbrains.annotations.NotNull;
@@ -156,7 +157,8 @@ public class ContractValidationServiceImpl implements ContractValidationService 
         }
         return Result.success(ContractOffer.Builder.newInstance()
                 .id(contractOfferId.toString())
-                .policy(policy)
+                // we copy the policy and enforce it to be of type OFFER
+                .policy(policy.toBuilder().type(PolicyType.OFFER).build())
                 .assetId(contractOfferId.assetIdPart())
                 .build());
     }

--- a/core/control-plane/control-plane-contract/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
+++ b/core/control-plane/control-plane-contract/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
@@ -214,6 +214,7 @@ class ProviderContractNegotiationManagerImplTest {
         when(dispatcherRegistry.dispatch(any(), any())).thenReturn(completedFuture(StatusResult.success("any")));
         when(store.findById(negotiation.getId())).thenReturn(negotiation);
         when(policyStore.findById(any())).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).id("policyId").build());
+        when(protocolWebhookRegistry.resolve(negotiation.getProtocol())).thenReturn(() -> "http://callback.address");
 
         manager.start();
 
@@ -331,7 +332,7 @@ class ProviderContractNegotiationManagerImplTest {
     }
 
     private Criterion[] stateIs(int state) {
-        return aryEq(new Criterion[]{ hasState(state), isNotPending(), new Criterion("type", "=", "PROVIDER") });
+        return aryEq(new Criterion[]{hasState(state), isNotPending(), new Criterion("type", "=", "PROVIDER")});
     }
 
     private static class DispatchFailureArguments implements ArgumentsProvider {

--- a/core/control-plane/control-plane-contract/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
+++ b/core/control-plane/control-plane-contract/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
@@ -31,6 +31,7 @@ import org.eclipse.edc.connector.controlplane.contract.spi.types.protocol.Contra
 import org.eclipse.edc.connector.controlplane.policy.spi.PolicyDefinition;
 import org.eclipse.edc.connector.controlplane.policy.spi.store.PolicyDefinitionStore;
 import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.policy.model.PolicyType;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.protocol.ProtocolWebhookRegistry;
@@ -136,6 +137,7 @@ class ProviderContractNegotiationManagerImplTest {
             verify(dispatcherRegistry, only()).dispatch(any(), messageCaptor.capture());
             var message = messageCaptor.getValue();
             assertThat(message.getCallbackAddress()).isEqualTo("http://callback.address");
+            assertThat(message.getPolicy().getType()).isEqualTo(PolicyType.OFFER);
             verify(listener).offered(any());
         });
     }

--- a/core/control-plane/control-plane-contract/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
+++ b/core/control-plane/control-plane-contract/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
@@ -328,7 +328,7 @@ class ProviderContractNegotiationManagerImplTest {
     private ContractOffer contractOffer() {
         return ContractOffer.Builder.newInstance()
                 .id(ContractOfferId.create("1", "test-asset-id").toString())
-                .policy(Policy.Builder.newInstance().build())
+                .policy(Policy.Builder.newInstance().type(PolicyType.OFFER).build())
                 .assetId("assetId")
                 .build();
     }

--- a/core/control-plane/control-plane-contract/src/test/java/org/eclipse/edc/connector/controlplane/contract/validation/ContractValidationServiceImplTest.java
+++ b/core/control-plane/control-plane-contract/src/test/java/org/eclipse/edc/connector/controlplane/contract/validation/ContractValidationServiceImplTest.java
@@ -35,6 +35,7 @@ import org.eclipse.edc.policy.engine.spi.PolicyContext;
 import org.eclipse.edc.policy.engine.spi.PolicyEngine;
 import org.eclipse.edc.policy.model.Permission;
 import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.policy.model.PolicyType;
 import org.eclipse.edc.spi.result.Result;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
@@ -109,7 +110,9 @@ class ContractValidationServiceImplTest {
         assertThat(result.succeeded()).isTrue();
         var validatedOffer = result.getContent().getOffer();
         assertThat(validatedOffer.getPolicy()).isNotSameAs(originalPolicy); // verify the returned policy is the sanitized one
+        assertThat(validatedOffer.getPolicy().getType()).isEqualTo(PolicyType.OFFER); // verify the returned policy is of type OFFER
         assertThat(validatedOffer.getAssetId()).isEqualTo(asset.getId());
+
         assertThat(result.getContent().getConsumerIdentity()).isEqualTo(CONSUMER_ID); // verify the returned policy has the consumer id set, essential for later validation checks
 
         verify(assetIndex).findById("1");
@@ -191,7 +194,7 @@ class ContractValidationServiceImplTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { "malicious-actor" })
+    @ValueSource(strings = {"malicious-actor"})
     @NullSource
     void verifyContractAgreementValidation_failedIfInvalidCredentials(String counterPartyId) {
         var participantAgent = new ParticipantAgent(emptyMap(), counterPartyId != null ? Map.of(PARTICIPANT_IDENTITY, counterPartyId) : Map.of());
@@ -350,7 +353,7 @@ class ContractValidationServiceImplTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { PROVIDER_ID })
+    @ValueSource(strings = {PROVIDER_ID})
     @NullSource
     void validateConsumerRequest_failsInvalidCredentials(String counterPartyId) {
         var negotiation = ContractNegotiation.Builder.newInstance()

--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/odrl/from/JsonObjectFromPolicyTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/odrl/from/JsonObjectFromPolicyTransformer.java
@@ -77,7 +77,7 @@ import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_XONE_CONSTRAI
 public class JsonObjectFromPolicyTransformer extends AbstractJsonLdTransformer<Policy, JsonObject> {
     private final JsonBuilderFactory jsonFactory;
     private final ParticipantIdMapper participantIdMapper;
-    private TransformerConfig config;
+    private final TransformerConfig config;
 
     public JsonObjectFromPolicyTransformer(JsonBuilderFactory jsonFactory, ParticipantIdMapper participantIdMapper) {
         this(jsonFactory, participantIdMapper, new TransformerConfig());

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/odrl/from/JsonObjectFromPolicyTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/odrl/from/JsonObjectFromPolicyTransformerTest.java
@@ -374,7 +374,7 @@ class JsonObjectFromPolicyTransformerTest {
 
     @Test
     void transform_assigneeAndAssignerAsIds() {
-        var transformer = new JsonObjectFromPolicyTransformer(jsonFactory, participantIdMapper, true);
+        var transformer = new JsonObjectFromPolicyTransformer(jsonFactory, participantIdMapper, true, false);
         var policy = Policy.Builder.newInstance()
                 .target("target")
                 .assignee("assignee")
@@ -385,6 +385,26 @@ class JsonObjectFromPolicyTransformerTest {
 
         assertThat(result.getJsonObject(ODRL_ASSIGNEE_ATTRIBUTE).getString(ID)).isEqualTo("assignee");
         assertThat(result.getJsonObject(ODRL_ASSIGNER_ATTRIBUTE).getString(ID)).isEqualTo("assigner");
+
+        verify(context, never()).reportProblem(anyString());
+    }
+
+    @Test
+    void transform_omitEmptyRules() {
+        var transformer = new JsonObjectFromPolicyTransformer(jsonFactory, participantIdMapper, true, true);
+        var policy = Policy.Builder.newInstance()
+                .target("target")
+                .assignee("assignee")
+                .assigner("assigner")
+                .build();
+
+        var result = transformer.transform(policy, context);
+
+        assertThat(result.getJsonObject(ODRL_ASSIGNEE_ATTRIBUTE).getString(ID)).isEqualTo("assignee");
+        assertThat(result.getJsonObject(ODRL_ASSIGNER_ATTRIBUTE).getString(ID)).isEqualTo("assigner");
+        assertThat(result.get(ODRL_PERMISSION_ATTRIBUTE)).isNull();
+        assertThat(result.get(ODRL_OBLIGATION_ATTRIBUTE)).isNull();
+        assertThat(result.get(ODRL_PROHIBITION_ATTRIBUTE)).isNull();
 
         verify(context, never()).reportProblem(anyString());
     }

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/odrl/from/JsonObjectFromPolicyTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/odrl/from/JsonObjectFromPolicyTransformerTest.java
@@ -374,7 +374,7 @@ class JsonObjectFromPolicyTransformerTest {
 
     @Test
     void transform_assigneeAndAssignerAsIds() {
-        var transformer = new JsonObjectFromPolicyTransformer(jsonFactory, participantIdMapper, true, false);
+        var transformer = new JsonObjectFromPolicyTransformer(jsonFactory, participantIdMapper, new JsonObjectFromPolicyTransformer.TransformerConfig(true, false));
         var policy = Policy.Builder.newInstance()
                 .target("target")
                 .assignee("assignee")
@@ -391,7 +391,7 @@ class JsonObjectFromPolicyTransformerTest {
 
     @Test
     void transform_omitEmptyRules() {
-        var transformer = new JsonObjectFromPolicyTransformer(jsonFactory, participantIdMapper, true, true);
+        var transformer = new JsonObjectFromPolicyTransformer(jsonFactory, participantIdMapper, new JsonObjectFromPolicyTransformer.TransformerConfig(true, true));
         var policy = Policy.Builder.newInstance()
                 .target("target")
                 .assignee("assignee")

--- a/data-protocols/dsp/dsp-2024/dsp-http-api-configuration-2024/src/main/java/org/eclipse/edc/protocol/dsp/http/api/configuration/DspApiConfigurationV2024Extension.java
+++ b/data-protocols/dsp/dsp-2024/dsp-http-api-configuration-2024/src/main/java/org/eclipse/edc/protocol/dsp/http/api/configuration/DspApiConfigurationV2024Extension.java
@@ -92,7 +92,7 @@ public class DspApiConfigurationV2024Extension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
         var v2024Path = dspWebhookAddress.get() + (wellKnownPathEnabled ? "" : V_2024_1_PATH);
-        
+
         protocolWebhookRegistry.registerWebhook(DATASPACE_PROTOCOL_HTTP_V_2024_1, () -> v2024Path);
 
         // registers ns for DSP scope
@@ -127,8 +127,8 @@ public class DspApiConfigurationV2024Extension implements ServiceExtension {
         dspApiTransformerRegistry.register(new JsonObjectToQuerySpecTransformer());
         dspApiTransformerRegistry.register(new JsonObjectToCriterionTransformer());
         dspApiTransformerRegistry.register(new JsonObjectToDataAddressDspaceTransformer(DSP_NAMESPACE_V_2024_1));
-        
-        dspApiTransformerRegistry.register(new JsonObjectFromPolicyTransformer(jsonBuilderFactory, participantIdMapper, true));
+
+        dspApiTransformerRegistry.register(new JsonObjectFromPolicyTransformer(jsonBuilderFactory, participantIdMapper, new JsonObjectFromPolicyTransformer.TransformerConfig(true, false)));
         dspApiTransformerRegistry.register(new JsonObjectFromDataAddressDspace2024Transformer(jsonBuilderFactory, typeManager, JSON_LD));
     }
 }

--- a/data-protocols/dsp/dsp-2025/dsp-http-api-configuration-2025/src/main/java/org/eclipse/edc/protocol/dsp/http/api/configuration/v2025/DspApiConfigurationV2025Extension.java
+++ b/data-protocols/dsp/dsp-2025/dsp-http-api-configuration-2025/src/main/java/org/eclipse/edc/protocol/dsp/http/api/configuration/v2025/DspApiConfigurationV2025Extension.java
@@ -107,7 +107,7 @@ public class DspApiConfigurationV2025Extension implements ServiceExtension {
         dspApiTransformerRegistry.register(new JsonObjectToQuerySpecTransformer());
         dspApiTransformerRegistry.register(new JsonObjectToCriterionTransformer());
         dspApiTransformerRegistry.register(new JsonObjectToDataAddressDspaceTransformer(DSP_NAMESPACE_V_2025_1));
-        dspApiTransformerRegistry.register(new JsonObjectFromPolicyTransformer(jsonBuilderFactory, participantIdMapper, true, true));
+        dspApiTransformerRegistry.register(new JsonObjectFromPolicyTransformer(jsonBuilderFactory, participantIdMapper, new JsonObjectFromPolicyTransformer.TransformerConfig(true, true)));
         dspApiTransformerRegistry.register(new JsonObjectFromDataAddressDspace2024Transformer(jsonBuilderFactory, typeManager, JSON_LD, DSP_NAMESPACE_V_2025_1));
     }
 }

--- a/data-protocols/dsp/dsp-2025/dsp-http-api-configuration-2025/src/main/java/org/eclipse/edc/protocol/dsp/http/api/configuration/v2025/DspApiConfigurationV2025Extension.java
+++ b/data-protocols/dsp/dsp-2025/dsp-http-api-configuration-2025/src/main/java/org/eclipse/edc/protocol/dsp/http/api/configuration/v2025/DspApiConfigurationV2025Extension.java
@@ -107,7 +107,7 @@ public class DspApiConfigurationV2025Extension implements ServiceExtension {
         dspApiTransformerRegistry.register(new JsonObjectToQuerySpecTransformer());
         dspApiTransformerRegistry.register(new JsonObjectToCriterionTransformer());
         dspApiTransformerRegistry.register(new JsonObjectToDataAddressDspaceTransformer(DSP_NAMESPACE_V_2025_1));
-        dspApiTransformerRegistry.register(new JsonObjectFromPolicyTransformer(jsonBuilderFactory, participantIdMapper, true));
+        dspApiTransformerRegistry.register(new JsonObjectFromPolicyTransformer(jsonBuilderFactory, participantIdMapper, true, true));
         dspApiTransformerRegistry.register(new JsonObjectFromDataAddressDspace2024Transformer(jsonBuilderFactory, typeManager, JSON_LD, DSP_NAMESPACE_V_2025_1));
     }
 }

--- a/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-http-api-2025/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/v2025/controller/DspNegotiationApiController20251.java
+++ b/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-http-api-2025/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/v2025/controller/DspNegotiationApiController20251.java
@@ -14,17 +14,25 @@
 
 package org.eclipse.edc.protocol.dsp.negotiation.http.api.v2025.controller;
 
+import jakarta.json.JsonObject;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationProtocolService;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
 import org.eclipse.edc.protocol.dsp.negotiation.http.api.controller.BaseDspNegotiationApiController;
 import org.eclipse.edc.protocol.dsp.spi.version.DspVersions;
 
+import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static org.eclipse.edc.protocol.dsp.http.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP_V_2025_1;
 import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.BASE_PATH;
+import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.CONTRACT_OFFERS;
+import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.INITIAL_CONTRACT_OFFERS;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_2025_1;
 
 /**
@@ -37,5 +45,35 @@ public class DspNegotiationApiController20251 extends BaseDspNegotiationApiContr
 
     public DspNegotiationApiController20251(ContractNegotiationProtocolService protocolService, DspRequestHandler dspRequestHandler) {
         super(protocolService, dspRequestHandler, DATASPACE_PROTOCOL_HTTP_V_2025_1, DSP_NAMESPACE_V_2025_1);
+    }
+
+
+    /**
+     * Consumer-specific endpoint.
+     *
+     * @param id    of contract negotiation.
+     * @param body  dspace:ContractOfferMessage sent by a provider.
+     * @param token identity token.
+     * @return empty response or error.
+     */
+    @POST
+    @Path("{id}" + CONTRACT_OFFERS)
+    @Override
+    public Response providerOffer(@PathParam("id") String id, JsonObject body, @HeaderParam(AUTHORIZATION) String token) {
+        return super.providerOffer(id, body, token);
+    }
+
+    /**
+     * Consumer-specific endpoint.
+     *
+     * @param jsonObject dspace:ContractOfferMessage sent by a consumer.
+     * @param token      identity token.
+     * @return the created contract negotiation or an error.
+     */
+    @POST
+    @Path(INITIAL_CONTRACT_OFFERS)
+    @Override
+    public Response initialContractOffer(JsonObject jsonObject, @HeaderParam(AUTHORIZATION) String token) {
+        return super.initialContractOffer(jsonObject, token);
     }
 }

--- a/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-http-api-2025/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/v2025/controller/DspNegotiationApiControllerV20251Test.java
+++ b/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-http-api-2025/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/v2025/controller/DspNegotiationApiControllerV20251Test.java
@@ -19,6 +19,8 @@ import org.eclipse.edc.junit.annotations.ApiTest;
 import org.eclipse.edc.protocol.dsp.negotiation.http.api.controller.DspNegotiationApiControllerTestBase;
 
 import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.BASE_PATH;
+import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.CONTRACT_OFFERS;
+import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.INITIAL_CONTRACT_OFFERS;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_2025_1;
 import static org.eclipse.edc.protocol.dsp.spi.version.DspVersions.V_2025_1_PATH;
 
@@ -38,5 +40,16 @@ class DspNegotiationApiControllerV20251Test extends DspNegotiationApiControllerT
     @Override
     protected Object controller() {
         return new DspNegotiationApiController20251(protocolService, dspRequestHandler);
+    }
+
+
+    @Override
+    protected String initialOffersPath() {
+        return INITIAL_CONTRACT_OFFERS;
+    }
+
+    @Override
+    protected String offersPath() {
+        return CONTRACT_OFFERS;
     }
 }

--- a/data-protocols/dsp/dsp-lib/dsp-negotiation-lib/dsp-negotiation-http-api-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/NegotiationApiPaths.java
+++ b/data-protocols/dsp/dsp-lib/dsp-negotiation-lib/dsp-negotiation-http-api-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/NegotiationApiPaths.java
@@ -21,9 +21,13 @@ public interface NegotiationApiPaths {
 
     String BASE_PATH = "/negotiations/";
     String INITIAL_CONTRACT_REQUEST = "request";
+    @Deprecated(since = "0.13.0")
     String INITIAL_CONTRACT_OFFER = "offer";
+    String INITIAL_CONTRACT_OFFERS = "offers";
     String CONTRACT_REQUEST = "/" + INITIAL_CONTRACT_REQUEST;
+    @Deprecated(since = "0.13.0")
     String CONTRACT_OFFER = "/" + INITIAL_CONTRACT_OFFER;
+    String CONTRACT_OFFERS = "/" + INITIAL_CONTRACT_OFFERS;
     String EVENT = "/events";
     String AGREEMENT = "/agreement";
     String VERIFICATION = "/verification";

--- a/data-protocols/dsp/dsp-lib/dsp-negotiation-lib/dsp-negotiation-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractAgreementMessageTransformer.java
+++ b/data-protocols/dsp/dsp-lib/dsp-negotiation-lib/dsp-negotiation-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractAgreementMessageTransformer.java
@@ -36,6 +36,7 @@ import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTyp
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_ID_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_TIMESTAMP_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID_TERM;
 
@@ -99,6 +100,9 @@ public class JsonObjectToContractAgreementMessageTransformer extends AbstractNam
             return null;
         }
 
+        var callbackAddress = transformString(jsonAgreement.get(forNamespace(DSPACE_PROPERTY_CALLBACK_ADDRESS_TERM)), context);
+        messageBuilder.callbackAddress(callbackAddress);
+        
         messageBuilder.contractAgreement(agreement);
 
         return messageBuilder.build();

--- a/data-protocols/dsp/dsp-lib/dsp-negotiation-lib/dsp-negotiation-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/v2024/from/JsonObjectFromContractAgreementMessageV2024Transformer.java
+++ b/data-protocols/dsp/dsp-lib/dsp-negotiation-lib/dsp-negotiation-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/v2024/from/JsonObjectFromContractAgreementMessageV2024Transformer.java
@@ -33,6 +33,7 @@ import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_AGREEMENT_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_TIMESTAMP_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID_TERM;
 
@@ -76,13 +77,18 @@ public class JsonObjectFromContractAgreementMessageV2024Transformer extends Abst
                 .add(forNamespace(DSPACE_PROPERTY_TIMESTAMP_TERM), signing)
                 .build();
 
-        return jsonFactory.createObjectBuilder()
+        var builder = jsonFactory.createObjectBuilder()
                 .add(ID, agreementMessage.getId())
                 .add(TYPE, forNamespace(DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE_TERM))
                 .add(forNamespace(DSPACE_PROPERTY_PROVIDER_PID_TERM), createId(jsonFactory, agreementMessage.getProviderPid()))
                 .add(forNamespace(DSPACE_PROPERTY_CONSUMER_PID_TERM), createId(jsonFactory, agreementMessage.getConsumerPid()))
-                .add(forNamespace(DSPACE_PROPERTY_AGREEMENT_TERM), copiedPolicy)
-                .build();
+                .add(forNamespace(DSPACE_PROPERTY_AGREEMENT_TERM), copiedPolicy);
+
+        if (agreementMessage.getCallbackAddress() != null) {
+            builder.add(forNamespace(DSPACE_PROPERTY_CALLBACK_ADDRESS_TERM), agreementMessage.getCallbackAddress());
+        }
+
+        return builder.build();
     }
 
 }

--- a/extensions/common/api/management-api-configuration/src/main/java/org/eclipse/edc/connector/api/management/configuration/ManagementApiConfigurationExtension.java
+++ b/extensions/common/api/management-api-configuration/src/main/java/org/eclipse/edc/connector/api/management/configuration/ManagementApiConfigurationExtension.java
@@ -155,7 +155,7 @@ public class ManagementApiConfigurationExtension implements ServiceExtension {
 
         var managementApiTransformerRegistryV4Alpha = managementApiTransformerRegistry.forContext(MANAGEMENT_API_V_4_ALPHA);
 
-        managementApiTransformerRegistryV4Alpha.register(new JsonObjectFromPolicyTransformer(factory, participantIdMapper, true, false));
+        managementApiTransformerRegistryV4Alpha.register(new JsonObjectFromPolicyTransformer(factory, participantIdMapper, new JsonObjectFromPolicyTransformer.TransformerConfig(true, false)));
 
         registerVersionInfo(getClass().getClassLoader());
     }

--- a/extensions/common/api/management-api-configuration/src/main/java/org/eclipse/edc/connector/api/management/configuration/ManagementApiConfigurationExtension.java
+++ b/extensions/common/api/management-api-configuration/src/main/java/org/eclipse/edc/connector/api/management/configuration/ManagementApiConfigurationExtension.java
@@ -155,7 +155,7 @@ public class ManagementApiConfigurationExtension implements ServiceExtension {
 
         var managementApiTransformerRegistryV4Alpha = managementApiTransformerRegistry.forContext(MANAGEMENT_API_V_4_ALPHA);
 
-        managementApiTransformerRegistryV4Alpha.register(new JsonObjectFromPolicyTransformer(factory, participantIdMapper, true));
+        managementApiTransformerRegistryV4Alpha.register(new JsonObjectFromPolicyTransformer(factory, participantIdMapper, true, false));
 
         registerVersionInfo(getClass().getClassLoader());
     }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/agreement/ContractAgreementMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/agreement/ContractAgreementMessage.java
@@ -23,9 +23,14 @@ import java.util.Objects;
 public class ContractAgreementMessage extends ContractRemoteMessage {
 
     private ContractAgreement contractAgreement;
+    private String callbackAddress;
 
     public ContractAgreement getContractAgreement() {
         return contractAgreement;
+    }
+
+    public String getCallbackAddress() {
+        return callbackAddress;
     }
 
     public Policy getPolicy() {
@@ -44,6 +49,11 @@ public class ContractAgreementMessage extends ContractRemoteMessage {
 
         public Builder contractAgreement(ContractAgreement contractAgreement) {
             this.message.contractAgreement = contractAgreement;
+            return this;
+        }
+
+        public Builder callbackAddress(String callbackAddress) {
+            message.callbackAddress = callbackAddress;
             return this;
         }
 

--- a/system-tests/dsp-compatibility-tests/compatibility-test-runner/src/test/java/org/eclipse/edc/tck/dsp/EdcCompatibilityTest.java
+++ b/system-tests/dsp-compatibility-tests/compatibility-test-runner/src/test/java/org/eclipse/edc/tck/dsp/EdcCompatibilityTest.java
@@ -44,7 +44,7 @@ public class EdcCompatibilityTest {
 
     private static final GenericContainer<?> TCK_CONTAINER = new TckContainer<>("eclipsedataspacetck/dsp-tck-runtime:latest");
     @RegisterExtension
-    protected static RuntimeExtension runtime = new RuntimePerClassExtension(new EmbeddedRuntime("CUnT",
+    protected static RuntimeExtension runtime = new RuntimePerClassExtension(new EmbeddedRuntime("CUT",
             ":system-tests:dsp-compatibility-tests:connector-under-test"
     ).configurationProvider(EdcCompatibilityTest::runtimeConfiguration));
 

--- a/system-tests/dsp-compatibility-tests/compatibility-test-runner/src/test/java/org/eclipse/edc/tck/dsp/EdcCompatibilityTest.java
+++ b/system-tests/dsp-compatibility-tests/compatibility-test-runner/src/test/java/org/eclipse/edc/tck/dsp/EdcCompatibilityTest.java
@@ -20,7 +20,8 @@ import org.eclipse.edc.junit.extensions.RuntimeExtension;
 import org.eclipse.edc.junit.extensions.RuntimePerClassExtension;
 import org.eclipse.edc.junit.testfixtures.TestUtils;
 import org.eclipse.edc.spi.monitor.ConsoleMonitor;
-import org.junit.jupiter.api.Disabled;
+import org.eclipse.edc.spi.system.configuration.Config;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -32,57 +33,74 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.util.io.Ports.getFreePort;
 
-@Disabled(value = "Need to disable this test until the connector is 100% compliant with DSP")
 @NightlyTest
 @Testcontainers
 public class EdcCompatibilityTest {
 
     private static final GenericContainer<?> TCK_CONTAINER = new TckContainer<>("eclipsedataspacetck/dsp-tck-runtime:latest");
+    @RegisterExtension
+    protected static RuntimeExtension runtime = new RuntimePerClassExtension(new EmbeddedRuntime("CUnT",
+            ":system-tests:dsp-compatibility-tests:connector-under-test"
+    ).configurationProvider(EdcCompatibilityTest::runtimeConfiguration));
 
-    private static String resource(String s) {
-        return Path.of(TestUtils.getResource("docker.tck.properties")).toString();
+
+    private static Config runtimeConfiguration() {
+        return ConfigFactory.fromMap(new HashMap<>() {
+            {
+                put("edc.participant.id", "CONNECTOR_UNDER_TEST");
+                put("web.http.port", "8080");
+                put("web.http.path", "/api");
+                put("web.http.version.port", String.valueOf(getFreePort()));
+                put("web.http.version.path", "/api/version");
+                put("web.http.control.port", String.valueOf(getFreePort()));
+                put("web.http.control.path", "/api/control");
+                put("web.http.management.port", "8081");
+                put("web.http.management.path", "/api/management");
+                put("web.http.protocol.port", "8282"); // this must match the configured connector url in resources/docker.tck.properties
+                put("web.http.protocol.path", "/api/dsp"); // this must match the configured connector url in resources/docker.tck.properties
+                put("web.api.auth.key", "password");
+                put("edc.dsp.callback.address", "http://host.docker.internal:8282/api/dsp"); // host.docker.internal is required by the container to communicate with the host
+                put("edc.management.context.enabled", "true");
+                put("edc.hostname", "host.docker.internal");
+                put("edc.component.id", "DSP-compatibility-test");
+            }
+        });
     }
 
-    @RegisterExtension
-    protected static RuntimeExtension runtime =
-            new RuntimePerClassExtension(new EmbeddedRuntime("CUnT",
-                    new HashMap<>() {
-                        {
-                            put("edc.participant.id", "CONNECTOR_UNDER_TEST");
-                            put("web.http.port", "8080");
-                            put("web.http.path", "/api");
-                            put("web.http.version.port", String.valueOf(getFreePort()));
-                            put("web.http.version.path", "/api/version");
-                            put("web.http.control.port", String.valueOf(getFreePort()));
-                            put("web.http.control.path", "/api/control");
-                            put("web.http.management.port", "8081");
-                            put("web.http.management.path", "/api/management");
-                            put("web.http.protocol.port", "8282"); // this must match the configured connector url in resources/docker.tck.properties
-                            put("web.http.protocol.path", "/api/dsp"); // this must match the configured connector url in resources/docker.tck.properties
-                            put("web.api.auth.key", "password");
-                            put("edc.dsp.callback.address", "http://host.docker.internal:8282/api/dsp"); // host.docker.internal is required by the container to communicate with the host
-                            put("edc.management.context.enabled", "true");
-                            put("edc.hostname", "host.docker.internal");
-                            put("edc.component.id", "DSP-compatibility-test");
-                        }
-                    },
-                    ":system-tests:dsp-compatibility-tests:connector-under-test"
-            ));
+    private static String resourceConfig(String resource) {
+        return Path.of(TestUtils.getResource(resource)).toString();
+    }
 
     @Timeout(60)
     @Test
     void assertDspCompatibility() {
+        // TODO remove all failures from this list when compliant error handling is implemented in the connector
+        var allowedFailures = List.of("CN:03-01", "CN:03-02", "CN:03-03", "CN:03-04");
+
         // pipe the docker container's log to this console at the INFO level
         var monitor = new ConsoleMonitor(">>> TCK Runtime (Docker)", ConsoleMonitor.Level.INFO, true);
-        TCK_CONTAINER.addFileSystemBind(resource("docker.tck.properties"), "/etc/tck/config.properties", BindMode.READ_ONLY, SelinuxContext.SINGLE);
+        var reporter = new TckTestReporter();
+
+        TCK_CONTAINER.addFileSystemBind(resourceConfig("docker.tck.properties"), "/etc/tck/config.properties", BindMode.READ_ONLY, SelinuxContext.SINGLE);
+        TCK_CONTAINER.addFileSystemBind(resourceConfig("dspace-edc-context-v1.jsonld"), "/etc/tck/dspace-edc-context-v1.jsonld", BindMode.READ_ONLY, SelinuxContext.SINGLE);
+        TCK_CONTAINER.withExtraHost("host.docker.internal", "host-gateway");
         TCK_CONTAINER.withLogConsumer(outputFrame -> monitor.info(outputFrame.getUtf8String()));
+        TCK_CONTAINER.withLogConsumer(reporter);
         TCK_CONTAINER.waitingFor(new LogMessageWaitStrategy().withRegEx(".*Test run complete.*"));
         TCK_CONTAINER.start();
 
-        // todo: obtain test report from the container
+        var failures = reporter.failures();
+        failures.removeAll(allowedFailures);
+
+        assertThat(failures).isEmpty();
+
     }
+
+
 }
 

--- a/system-tests/dsp-compatibility-tests/compatibility-test-runner/src/test/java/org/eclipse/edc/tck/dsp/TckTestReporter.java
+++ b/system-tests/dsp-compatibility-tests/compatibility-test-runner/src/test/java/org/eclipse/edc/tck/dsp/TckTestReporter.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.tck.dsp;
+
+import org.testcontainers.containers.output.OutputFrame;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.regex.Pattern;
+
+public class TckTestReporter implements Consumer<OutputFrame> {
+
+    private final List<String> failures = new ArrayList<>();
+    private final Pattern failedRegex = Pattern.compile("FAILED: (\\w+:.*)");
+
+    public TckTestReporter() {
+    }
+
+    @Override
+    public void accept(OutputFrame outputFrame) {
+        var line = outputFrame.getUtf8String();
+        var failed = failedRegex.matcher(line);
+        if (failed.find()) {
+            failures.add(failed.group(1));
+        }
+    }
+
+    public List<String> failures() {
+        return new ArrayList<>(failures);
+    }
+
+}

--- a/system-tests/dsp-compatibility-tests/compatibility-test-runner/src/test/resources/docker.tck.properties
+++ b/system-tests/dsp-compatibility-tests/compatibility-test-runner/src/test/resources/docker.tck.properties
@@ -18,7 +18,8 @@ dataspacetck.dsp.connector.agent.id=CONNECTOR_UNDER_TEST
 dataspacetck.dsp.connector.http.url=http://host.docker.internal:8282/api/dsp/2025/1
 dataspacetck.dsp.connector.http.headers.authorization="{\"region\": \"any\", \"audience\": \"any\", \"clientId\":\"any\"}"
 dataspacetck.dsp.connector.negotiation.initiate.url=http://host.docker.internal:8687/tck/negotiations/requests
-dataspacetck.dsp.default.wait=15
+dataspacetck.dsp.connector.transfer.initiate.url=http://host.docker.internal:8687/tck/transfers/requests
+dataspacetck.dsp.default.wait=5
 dataspacetck.dsp.jsonld.context.edc.path=/etc/tck/dspace-edc-context-v1.jsonld
 dataspacetck.dsp.jsonld.context.edc.uri=https://w3id.org/edc/dspace/v0.0.1
 # must be 0.0.0.0 for docker inet binding to work
@@ -54,3 +55,9 @@ CN_03_03_DATASETID=ACN0303
 CN_03_03_OFFERID=CD123:ACN0303:456
 CN_03_04_DATASETID=ACN0304
 CN_03_04_OFFERID=CD123:ACN0304:456
+## transfer process provider
+TP_01_01_AGREEMENTID=ATP0101
+TP_01_01_FORMAT=HttpData-PULL
+## transfer process consumer
+TP_C_01_01_AGREEMENTID=ATPC0101
+TP_C_01_01_FORMAT=HttpData-PULL

--- a/system-tests/dsp-compatibility-tests/compatibility-test-runner/src/test/resources/docker.tck.properties
+++ b/system-tests/dsp-compatibility-tests/compatibility-test-runner/src/test/resources/docker.tck.properties
@@ -15,18 +15,19 @@
 dataspacetck.debug=true
 dataspacetck.dsp.local.connector=false
 dataspacetck.dsp.connector.agent.id=CONNECTOR_UNDER_TEST
-dataspacetck.dsp.connector.http.url=http://host.docker.internal:8282/api/dsp/
+dataspacetck.dsp.connector.http.url=http://host.docker.internal:8282/api/dsp/2025/1
 dataspacetck.dsp.connector.http.headers.authorization="{\"region\": \"any\", \"audience\": \"any\", \"clientId\":\"any\"}"
 dataspacetck.dsp.connector.negotiation.initiate.url=http://host.docker.internal:8687/tck/negotiations/requests
-dataspacetck.dsp.default.wait=10000000
+dataspacetck.dsp.default.wait=15
+dataspacetck.dsp.jsonld.context.edc.path=/etc/tck/dspace-edc-context-v1.jsonld
+dataspacetck.dsp.jsonld.context.edc.uri=https://w3id.org/edc/dspace/v0.0.1
 # must be 0.0.0.0 for docker inet binding to work
 dataspacetck.callback.address=http://0.0.0.0:8083
 # Sets the dataset and offer ids to use for contract negotiation scenarios
 CN_01_01_DATASETID=ACN0101
 CN_01_01_OFFERID=CD123:ACN0101:456
 CN_01_02_DATASETID=ACN0102
-CN_01_02_OFFERID=CD123:ACN\
-  0102:456
+CN_01_02_OFFERID=CD123:ACN0102:456
 CN_01_03_DATASETID=ACN0103
 CN_01_03_OFFERID=CD123:ACN0103:456
 CN_01_04_DATASETID=ACN0104

--- a/system-tests/dsp-compatibility-tests/compatibility-test-runner/src/test/resources/dspace-edc-context-v1.jsonld
+++ b/system-tests/dsp-compatibility-tests/compatibility-test-runner/src/test/resources/dspace-edc-context-v1.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "edc": "https://w3id.org/edc/v0.0.1/ns/",
+    "QuerySpec": {
+      "@id": "edc:QuerySpec",
+      "@context": {
+        "sortOrder": "edc:sortOrder",
+        "sortField": "edc:sortField",
+        "offset": "edc:offset",
+        "limit": "edc:limit",
+        "filterExpression": {
+          "@id": "edc:filterExpression",
+          "@container": "@set"
+        }
+      }
+    },
+    "Criterion": {
+      "@id": "edc:Criterion",
+      "@context": {
+        "operandLeft": "edc:operandLeft",
+        "operator": "edc:operator",
+        "operandRight": "edc:operandRight"
+      }
+    },
+    "inForceDate": "edc:inForceDate",
+    "id": "edc:id",
+    "description": "edc:description",
+    "isCatalog": "edc:isCatalog"
+  }
+}

--- a/system-tests/dsp-compatibility-tests/connector-under-test/build.gradle.kts
+++ b/system-tests/dsp-compatibility-tests/connector-under-test/build.gradle.kts
@@ -14,10 +14,15 @@
 
 plugins {
     `java-library`
+    id("application")
 }
 
+application {
+    mainClass.set("org.eclipse.edc.boot.system.runtime.BaseRuntime")
+}
 dependencies {
     api(project(":dist:bom:controlplane-base-bom"))
-    runtimeOnly(project(":extensions:tck-extension"))
+    api(project(":data-protocols:dsp:dsp-2025"))
+    runtimeOnly(project(":system-tests:protocol-tck:tck-extension"))
     runtimeOnly(libs.parsson)
 }

--- a/system-tests/dsp-compatibility-tests/connector-under-test/build.gradle.kts
+++ b/system-tests/dsp-compatibility-tests/connector-under-test/build.gradle.kts
@@ -14,14 +14,13 @@
 
 plugins {
     `java-library`
-    id("application")
 }
 
-application {
-    mainClass.set("org.eclipse.edc.boot.system.runtime.BaseRuntime")
-}
 dependencies {
     api(project(":dist:bom:controlplane-base-bom"))
+    api(project(":dist:bom:dataplane-base-bom")) {
+        exclude(module = "data-plane-selector-client")
+    }
     api(project(":data-protocols:dsp:dsp-2025"))
     runtimeOnly(project(":system-tests:protocol-tck:tck-extension"))
     runtimeOnly(libs.parsson)

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/DspTestFunctions.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/DspTestFunctions.java
@@ -183,10 +183,8 @@ public class DspTestFunctions {
     public static JsonObjectBuilder policy(JsonObject permission, String type) {
         return createObjectBuilder()
                 .add(TYPE, type)
-                .add("obligation", createArrayBuilder().build())
                 .add("permission", createArrayBuilder().add(permission))
-                .add("target", "assetId")
-                .add("prohibition", createArrayBuilder().build());
+                .add("target", "assetId");
     }
 
     public static JsonObject inForceDatePermission(String operatorStart, Object startDate, String operatorEnd, Object endDate) {

--- a/system-tests/protocol-tck/tck-extension/build.gradle.kts
+++ b/system-tests/protocol-tck/tck-extension/build.gradle.kts
@@ -22,6 +22,9 @@ dependencies {
     implementation(project(":spi:control-plane:asset-spi"))
     implementation(project(":spi:control-plane:control-plane-spi"))
     implementation(project(":spi:common:web-spi"))
+    implementation(project(":spi:data-plane:data-plane-spi"))
     implementation(libs.jakarta.rsApi)
+    implementation(libs.nimbus.jwt)
+
 }
 

--- a/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/controller/TckControllerExtension.java
+++ b/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/controller/TckControllerExtension.java
@@ -15,7 +15,9 @@
 package org.eclipse.edc.tck.dsp.controller;
 
 import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationService;
+import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessService;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.web.spi.WebServer;
@@ -43,6 +45,12 @@ public class TckControllerExtension implements ServiceExtension {
     @Inject
     private ContractNegotiationService negotiationService;
 
+    @Inject
+    private TransferProcessService transferProcessService;
+
+    @Inject
+    private Monitor monitor;
+
     @Override
     public String name() {
         return NAME;
@@ -52,6 +60,6 @@ public class TckControllerExtension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
         mappingRegistry.register(new PortMapping(PROTOCOL, 8687, PATH));
 
-        webService.registerResource(PROTOCOL, new TckWebhookController(negotiationService));
+        webService.registerResource(PROTOCOL, new TckWebhookController(monitor, negotiationService, transferProcessService));
     }
 }

--- a/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/controller/TckWebhookController.java
+++ b/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/controller/TckWebhookController.java
@@ -55,7 +55,7 @@ public class TckWebhookController {
                 .callbackAddresses(List.of(CallbackAddress.Builder.newInstance().uri(request.connectorAddress()).build()))
                 .counterPartyAddress(request.connectorAddress())
                 .contractOffer(contractOffer)
-                .protocol("dataspace-protocol-http")
+                .protocol("dataspace-protocol-http:2025/1")
                 .build();
         negotiationService.initiateNegotiation(contractRequest);
         System.out.println("Negotiation");

--- a/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/controller/TckWebhookController.java
+++ b/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/controller/TckWebhookController.java
@@ -21,7 +21,14 @@ import jakarta.ws.rs.Produces;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequest;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationService;
+import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessService;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest;
+import org.eclipse.edc.policy.model.Action;
+import org.eclipse.edc.policy.model.Permission;
 import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.policy.model.PolicyType;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 
 import java.util.List;
@@ -33,23 +40,31 @@ import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
  */
 @Consumes(APPLICATION_JSON)
 @Produces(APPLICATION_JSON)
-@Path("/negotiations")
+@Path("/")
 public class TckWebhookController {
 
-    private ContractNegotiationService negotiationService;
+    private final Monitor monitor;
+    private final ContractNegotiationService negotiationService;
+    private final TransferProcessService transferProcessService;
 
-    public TckWebhookController(ContractNegotiationService negotiationService) {
+
+    public TckWebhookController(Monitor monitor, ContractNegotiationService negotiationService, TransferProcessService transferProcessService) {
+        this.monitor = monitor;
         this.negotiationService = negotiationService;
+        this.transferProcessService = transferProcessService;
     }
 
     @POST
-    @Path("requests")
+    @Path("/negotiations/requests")
     public void startNegotiation(ContractNegotiationRequest request) {
 
         var contractOffer = ContractOffer.Builder.newInstance()
                 .id(request.offerId())
                 .assetId(request.offerId())
-                .policy(Policy.Builder.newInstance().assigner(request.providerId()).build())
+                .policy(Policy.Builder.newInstance().assigner(request.providerId())
+                        .type(PolicyType.OFFER)
+                        .permission(Permission.Builder.newInstance().action(Action.Builder.newInstance().type("http://www.w3.org/ns/odrl/2/use").build()).build())
+                        .build())
                 .build();
         var contractRequest = ContractRequest.Builder.newInstance()
                 .callbackAddresses(List.of(CallbackAddress.Builder.newInstance().uri(request.connectorAddress()).build()))
@@ -57,7 +72,24 @@ public class TckWebhookController {
                 .contractOffer(contractOffer)
                 .protocol("dataspace-protocol-http:2025/1")
                 .build();
+
+        monitor.debug("Starting contract negotiation for [provider, address, offer, asset]: [%s, %s, %s, %s]".formatted(request.providerId(), request.connectorAddress(), request.offerId(), request.offerId()));
+
         negotiationService.initiateNegotiation(contractRequest);
-        System.out.println("Negotiation");
+    }
+
+    @POST
+    @Path("/transfers/requests")
+    public void startTransfer(TransferProcessRequest request) {
+
+        var transferRequest = TransferRequest.Builder.newInstance()
+                .transferType(request.format())
+                .counterPartyAddress(request.connectorAddress())
+                .protocol("dataspace-protocol-http:2025/1")
+                .contractId(request.agreementId())
+                .build();
+
+        monitor.debug("Starting transfer process for [provider, address, agreement, format]: [%s, %s, %s, %s]".formatted(request.providerId(), request.connectorAddress(), request.agreementId(), request.format()));
+        transferProcessService.initiateTransfer(transferRequest).orElseThrow(f -> new EdcException(f.getFailureDetail()));
     }
 }

--- a/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/controller/TransferProcessRequest.java
+++ b/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/controller/TransferProcessRequest.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.tck.dsp.controller;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Initiates a transfer request.
+ */
+public record TransferProcessRequest(@JsonProperty("providerId") String providerId,
+                                     @JsonProperty("connectorAddress") String connectorAddress,
+                                     @JsonProperty("agreementId") String agreementId,
+                                     @JsonProperty("format") String format) {
+}

--- a/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/guard/ContractNegotiationTriggerSubscriber.java
+++ b/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/guard/ContractNegotiationTriggerSubscriber.java
@@ -28,9 +28,8 @@ import java.util.List;
  * Fires triggers based on negotiation events.
  */
 public class ContractNegotiationTriggerSubscriber implements EventSubscriber, ContractNegotiationTriggerRegistry {
-    private StateEntityStore<ContractNegotiation> store;
-
-    private List<Trigger<ContractNegotiation>> triggers = new ArrayList<>();
+    private final List<Trigger<ContractNegotiation>> triggers = new ArrayList<>();
+    private final StateEntityStore<ContractNegotiation> store;
 
     public ContractNegotiationTriggerSubscriber(StateEntityStore<ContractNegotiation> store) {
         this.store = store;

--- a/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/guard/DelayedActionGuard.java
+++ b/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/guard/DelayedActionGuard.java
@@ -37,13 +37,12 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  * a command handler.
  */
 public class DelayedActionGuard<T extends StatefulEntity<T>> implements PendingGuard<T> {
-    private Predicate<T> filter;
-    private Consumer<T> action;
-    private StateEntityStore<T> store;
-    private DelayQueue<GuardDelay> queue;
-    private AtomicBoolean active = new AtomicBoolean();
-
-    private ExecutorService executor = Executors.newFixedThreadPool(1);
+    private final Predicate<T> filter;
+    private final Consumer<T> action;
+    private final DelayQueue<GuardDelay> queue;
+    private final AtomicBoolean active = new AtomicBoolean();
+    private final ExecutorService executor = Executors.newFixedThreadPool(1);
+    private final StateEntityStore<T> store;
 
     public DelayedActionGuard(Predicate<T> filter,
                               Consumer<T> action,
@@ -88,8 +87,8 @@ public class DelayedActionGuard<T extends StatefulEntity<T>> implements PendingG
     }
 
     protected class GuardDelay implements Delayed {
+        private final long start;
         T entity;
-        private long start;
 
         GuardDelay(T entity) {
             this.entity = entity;

--- a/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/guard/TckGuardExtension.java
+++ b/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/guard/TckGuardExtension.java
@@ -17,6 +17,8 @@ package org.eclipse.edc.tck.dsp.guard;
 import org.eclipse.edc.connector.controlplane.contract.spi.event.contractnegotiation.ContractNegotiationEvent;
 import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.ContractNegotiationPendingGuard;
 import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
+import org.eclipse.edc.connector.controlplane.transfer.spi.event.TransferProcessEvent;
+import org.eclipse.edc.connector.controlplane.transfer.spi.store.TransferProcessStore;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.spi.event.EventRouter;
@@ -24,6 +26,7 @@ import org.eclipse.edc.spi.system.ServiceExtension;
 
 import static org.eclipse.edc.tck.dsp.data.DataAssembly.createNegotiationRecorder;
 import static org.eclipse.edc.tck.dsp.data.DataAssembly.createNegotiationTriggers;
+import static org.eclipse.edc.tck.dsp.data.DataAssembly.createTransferProcessTriggers;
 
 /**
  * Loads the transition guard.
@@ -35,6 +38,9 @@ public class TckGuardExtension implements ServiceExtension {
 
     @Inject
     private ContractNegotiationStore store;
+
+    @Inject
+    private TransferProcessStore transferProcessStore;
 
     @Inject
     private EventRouter router;
@@ -51,6 +57,10 @@ public class TckGuardExtension implements ServiceExtension {
         var registry = new ContractNegotiationTriggerSubscriber(store);
         createNegotiationTriggers().forEach(registry::register);
         router.register(ContractNegotiationEvent.class, registry);
+
+        var tpRegistry = new TransferProcessTriggerSubscriber(transferProcessStore);
+        createTransferProcessTriggers().forEach(tpRegistry::register);
+        router.register(TransferProcessEvent.class, tpRegistry);
 
         negotiationGuard = new ContractNegotiationGuard(cn -> recorder.playNext(cn.getContractOffers().get(0).getAssetId(), cn), store);
         return negotiationGuard;

--- a/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/guard/TransferProcessTriggerRegistry.java
+++ b/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/guard/TransferProcessTriggerRegistry.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.tck.dsp.guard;
+
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
+
+/**
+ * Registers transfer process triggers.
+ */
+public interface TransferProcessTriggerRegistry {
+
+    void register(Trigger<TransferProcess> trigger);
+
+}

--- a/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/guard/TransferProcessTriggerSubscriber.java
+++ b/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/guard/TransferProcessTriggerSubscriber.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.tck.dsp.guard;
+
+import org.eclipse.edc.connector.controlplane.transfer.spi.event.TransferProcessEvent;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
+import org.eclipse.edc.spi.event.Event;
+import org.eclipse.edc.spi.event.EventEnvelope;
+import org.eclipse.edc.spi.event.EventSubscriber;
+import org.eclipse.edc.spi.persistence.StateEntityStore;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Fires triggers based on transfer events.
+ */
+public class TransferProcessTriggerSubscriber implements EventSubscriber, TransferProcessTriggerRegistry {
+    private final List<Trigger<TransferProcess>> triggers = new ArrayList<>();
+    private final StateEntityStore<TransferProcess> store;
+
+    public TransferProcessTriggerSubscriber(StateEntityStore<TransferProcess> store) {
+        this.store = store;
+    }
+
+    @Override
+    public void register(Trigger<TransferProcess> trigger) {
+        triggers.add(trigger);
+    }
+
+    @Override
+    public <E extends Event> void on(EventEnvelope<E> envelope) {
+        triggers.stream()
+                .filter(trigger -> trigger.predicate().test(envelope.getPayload()))
+                .forEach(trigger -> {
+                    var event = (TransferProcessEvent) envelope.getPayload();
+                    var negotiation = store.findByIdAndLease(event.getTransferProcessId()).getContent();
+                    trigger.action().accept(negotiation);
+                    store.save(negotiation);
+                });
+    }
+
+}

--- a/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/recorder/StepRecorder.java
+++ b/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/recorder/StepRecorder.java
@@ -24,38 +24,53 @@ import java.util.function.Consumer;
  * Records and plays a sequence of steps. Sequences may be repeated if {@link #repeat()} is enabled.
  */
 public class StepRecorder<T> {
-    private boolean repeat;
-    private int playIndex = 0;
-    private Map<String, List<Consumer<T>>> sequences = new HashMap<>();
+    private final Map<String, Sequence<T>> sequences = new HashMap<>();
 
     public synchronized StepRecorder<T> playNext(String key, T entity) {
         var sequence = sequences.get(key);
         if (sequence == null) {
             throw new AssertionError("No sequence found for key " + key);
         }
-        if (sequence.isEmpty()) {
-            throw new IllegalStateException("No replay steps");
-        }
-        if (playIndex >= sequence.size()) {
-            throw new IllegalStateException("Exceeded replay steps");
-        }
-        sequence.get(playIndex).accept(entity);
-        if (repeat && playIndex == sequence.size() - 1) {
-            playIndex = 0;
-        } else {
-            playIndex++;
-        }
+        sequence.playNext(entity);
         return this;
     }
 
     public synchronized StepRecorder<T> record(String key, Consumer<T> step) {
-        var sequence = sequences.computeIfAbsent(key, k -> new ArrayList<>());
-        sequence.add(step);
+        var sequence = sequences.computeIfAbsent(key, k -> new Sequence<>());
+        sequence.addStep(step);
         return this;
     }
 
     public synchronized StepRecorder<T> repeat() {
-        repeat = true;
+        for (var sequence : sequences.values()) {
+            sequence.repeat = true;
+        }
         return this;
+    }
+
+
+    private static class Sequence<T> {
+        private final List<Consumer<T>> steps = new ArrayList<>();
+        private boolean repeat;
+        private int playIndex = 0;
+
+        public void addStep(Consumer<T> step) {
+            steps.add(step);
+        }
+
+        public void playNext(T entity) {
+            if (steps.isEmpty()) {
+                throw new IllegalStateException("No replay steps");
+            }
+            if (playIndex >= steps.size()) {
+                throw new IllegalStateException("Exceeded replay steps");
+            }
+            steps.get(playIndex).accept(entity);
+            if (repeat && playIndex == steps.size() - 1) {
+                playIndex = 0;
+            } else {
+                playIndex++;
+            }
+        }
     }
 }

--- a/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/setup/TckSetupExtension.java
+++ b/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/setup/TckSetupExtension.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.tck.dsp.setup;
 
 import org.eclipse.edc.connector.controlplane.asset.spi.index.AssetIndex;
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.connector.controlplane.services.spi.contractdefinition.ContractDefinitionService;
 import org.eclipse.edc.connector.controlplane.services.spi.policydefinition.PolicyDefinitionService;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
@@ -23,6 +24,7 @@ import org.eclipse.edc.spi.system.ServiceExtension;
 
 import static org.eclipse.edc.tck.dsp.data.DataAssembly.createAssets;
 import static org.eclipse.edc.tck.dsp.data.DataAssembly.createContractDefinitions;
+import static org.eclipse.edc.tck.dsp.data.DataAssembly.createContractNegotiations;
 import static org.eclipse.edc.tck.dsp.data.DataAssembly.createPolicyDefinitions;
 import static org.eclipse.edc.tck.dsp.setup.TckSetupExtension.NAME;
 
@@ -42,6 +44,9 @@ public class TckSetupExtension implements ServiceExtension {
     @Inject
     private ContractDefinitionService contractDefinitionService;
 
+    @Inject
+    private ContractNegotiationStore contractNegotiationStore;
+
     @Override
     public String name() {
         return NAME;
@@ -52,6 +57,7 @@ public class TckSetupExtension implements ServiceExtension {
         createAssets().forEach(asset -> assetIndex.create(asset));
         createPolicyDefinitions().forEach(definition -> policyDefinitionService.create(definition));
         createContractDefinitions().forEach(definition -> contractDefinitionService.create(definition));
+        createContractNegotiations().forEach(negotiation -> contractNegotiationStore.save(negotiation));
     }
 
 

--- a/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/transfer/TckDataPlaneExtension.java
+++ b/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/transfer/TckDataPlaneExtension.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.tck.dsp.transfer;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import org.eclipse.edc.connector.dataplane.spi.Endpoint;
+import org.eclipse.edc.connector.dataplane.spi.iam.DataPlaneAuthorizationService;
+import org.eclipse.edc.connector.dataplane.spi.iam.PublicEndpointGeneratorService;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+
+public class TckDataPlaneExtension implements ServiceExtension {
+    
+    @Inject
+    private DataPlaneAuthorizationService authorizationService;
+    @Inject
+    private PublicEndpointGeneratorService generatorService;
+
+    @Inject
+    private Vault vault;
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        generatorService.addGeneratorFunction("HttpData", address -> Endpoint.url("http://example.com"));
+
+        try {
+            var key = new ECKeyGenerator(Curve.P_256)
+                    .keyID("sign-key")
+                    .generate();
+            vault.storeSecret("private-key", key.toJSONString());
+            vault.storeSecret("public-key", key.toPublicJWK().toJSONString());
+        } catch (JOSEException e) {
+            throw new RuntimeException(e);
+        }
+
+
+    }
+}

--- a/system-tests/protocol-tck/tck-extension/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/system-tests/protocol-tck/tck-extension/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -15,3 +15,4 @@ org.eclipse.edc.tck.dsp.guard.TckGuardExtension
 org.eclipse.edc.tck.dsp.setup.TckSetupExtension
 org.eclipse.edc.tck.dsp.identity.TckIdentityExtension
 org.eclipse.edc.tck.dsp.controller.TckControllerExtension
+org.eclipse.edc.tck.dsp.transfer.TckDataPlaneExtension


### PR DESCRIPTION
## What this PR changes/adds

enable nightly job for testing edc with dsp-tck  + fixes for 2025 protocol testing

Changes to make the contract negotiation compliant:

- ` ProviderContractNegotiationManagerImpl#processOffering` changes the `PolicyType` to `Offer` currently can be `Set` since it's coming the contract definition contract policy.
-  `ContractAgreementMessage` as per spec the `callbackAddress` field has been added
- The policy serialization `JsonObjectFromPolicyTransformer` has an option to skip empty rules (permission, obligation, prohibition ) which allows the json-schema validation to pass (only applied to 2025)
- Fixes the `/offer` wrong path #4910 only for 2025
- Changes the tck integration `StepRecorder` in order to record steps for each sequence instead of global. This allow independent failure to not have side effect with the overall tck suite 

## Why it does that

dsp compliance

## Further notes

Currently the dsp tck compatibility tests run in a nightly job, some tests are still failing, specifically the negative tests which verifies illegal state changes. To make the overall tck testing suite green some of this tests are in an allowedFailure list:

- `CN:03-01`
- `CN:03-02`
- `CN:03-03` 
- `CN:03-04`

This should be fixed in future PR once the better handle invalid state transition as currently we throw an IllegalStateException

Also `TP:01-01` is failing due missing `endpoint` in dspace data address

## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #4961 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
