### PR TITLE
fix: avoid exceptions on shutdown by adding cleanup extension phase

### DIFF
--- a/core/common/boot/src/test/java/org/eclipse/edc/boot/system/runtime/BaseRuntimeTest.java
+++ b/core/common/boot/src/test/java/org/eclipse/edc/boot/system/runtime/BaseRuntimeTest.java
@@ -87,10 +87,11 @@ public class BaseRuntimeTest {
     }
 
     @Test
-    void shouldShutdownAllExtensions_whenOneThrowsException() {
+    void shouldShutdownAllExtensionsAndCleanup_whenOneThrowsException() {
         ServiceExtension successful = mock();
         ServiceExtension unsuccessful = mock();
         doThrow(new RuntimeException("shutdown error")).when(unsuccessful).shutdown();
+        doThrow(new RuntimeException("shutdown error")).when(unsuccessful).cleanup();
 
         when(serviceLocator.loadImplementors(eq(ServiceExtension.class), anyBoolean()))
                 .thenReturn(mutableListOf(successful, unsuccessful));
@@ -99,7 +100,9 @@ public class BaseRuntimeTest {
 
         assertThatNoException().isThrownBy(runtime::shutdown);
         verify(successful).shutdown();
+        verify(successful).cleanup();
         verify(unsuccessful).shutdown();
+        verify(unsuccessful).cleanup();
     }
 
     @NotNull

--- a/extensions/common/sql/sql-pool/sql-pool-apache-commons/src/main/java/org/eclipse/edc/sql/pool/commons/CommonsConnectionPoolServiceExtension.java
+++ b/extensions/common/sql/sql-pool/sql-pool-apache-commons/src/main/java/org/eclipse/edc/sql/pool/commons/CommonsConnectionPoolServiceExtension.java
@@ -102,7 +102,7 @@ public class CommonsConnectionPoolServiceExtension implements ServiceExtension {
     }
 
     @Override
-    public void shutdown() {
+    public void cleanup() {
         commonsConnectionPools.forEach(CommonsConnectionPool::close);
     }
 

--- a/spi/common/boot-spi/src/main/java/org/eclipse/edc/spi/system/ServiceExtension.java
+++ b/spi/common/boot-spi/src/main/java/org/eclipse/edc/spi/system/ServiceExtension.java
@@ -27,6 +27,18 @@ public interface ServiceExtension extends SystemExtension {
     }
 
     /**
+     * Hook method to perform some additional preparatory work before the extension is started.
+     * All dependencies are guaranteed to be resolved, and all other extensions are guaranteed to have completed initialization.
+     * <p>
+     * Typical use cases include wanting to wait until all registrations of a {@code *Registry} have completed, perform some additional
+     * checking whether a service exists or not, etc.
+     * <p>
+     * <strong>Do NOT perform any service registration in this method!</strong>
+     */
+    default void prepare() {
+    }
+
+    /**
      * Signals the extension to prepare for the runtime to receive requests.
      */
     default void start() {
@@ -39,14 +51,8 @@ public interface ServiceExtension extends SystemExtension {
     }
 
     /**
-     * Hook method to perform some additional preparatory work before the extension is started.
-     * All dependencies are guaranteed to be resolved, and all other extensions are guaranteed to have completed initialization.
-     * <p>
-     * Typical use cases include wanting to wait until all registrations of a {@code *Registry} have completed, perform some additional
-     * checking whether a service exists or not, etc.
-     * <p>
-     * <strong>Do NOT perform any service registration in this method!</strong>
+     * Do further cleanup of resources that can be still needed during {@link #shutdown()} as database connections, websockets, ...
      */
-    default void prepare() {
+    default void cleanup() {
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Adds a `cleanup` method on `ServiceExtension` that will be called after all the `shutdown` will be completed.
Note that in the DR the idea was to call it `finalize`, forgetting that it is an already existing (and deprecated) method on the `Object` class.

## Why it does that

bugfix

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #4947 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
