### PR TITLE
feat: populate assignee and assigner on contract policy

### DIFF
--- a/core/control-plane/control-plane-contract/src/main/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/control-plane/control-plane-contract/src/main/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -134,11 +134,16 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
                 .orElseGet(() -> {
                     var lastOffer = negotiation.getLastContractOffer();
 
+                    var contractPolicy = lastOffer.getPolicy().toBuilder().type(PolicyType.CONTRACT)
+                            .assignee(negotiation.getCounterPartyId())
+                            .assigner(participantId)
+                            .build();
+
                     return ContractAgreement.Builder.newInstance()
                             .contractSigningDate(clock.instant().getEpochSecond())
                             .providerId(participantId)
                             .consumerId(negotiation.getCounterPartyId())
-                            .policy(lastOffer.getPolicy().toBuilder().type(PolicyType.CONTRACT).build())
+                            .policy(contractPolicy)
                             .assetId(lastOffer.getAssetId())
                             .build();
                 });

--- a/core/control-plane/control-plane-contract/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
+++ b/core/control-plane/control-plane-contract/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
@@ -229,6 +229,8 @@ class ProviderContractNegotiationManagerImplTest {
             var stored = storedCaptor.getValue();
             assertThat(stored.getState()).isEqualTo(AGREED.code());
             assertThat(stored.getContractAgreement().getPolicy().getType()).isEqualTo(CONTRACT);
+            assertThat(stored.getContractAgreement().getPolicy().getAssignee()).isEqualTo(stored.getContractAgreement().getConsumerId());
+            assertThat(stored.getContractAgreement().getPolicy().getAssigner()).isEqualTo(stored.getContractAgreement().getProviderId());
             verify(listener).agreed(any());
         });
     }

--- a/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-transform-2025/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/v2025/DspNegotiationTransformV2025Extension.java
+++ b/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-transform-2025/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/v2025/DspNegotiationTransformV2025Extension.java
@@ -23,13 +23,13 @@ import org.eclipse.edc.protocol.dsp.negotiation.transform.to.JsonObjectToContrac
 import org.eclipse.edc.protocol.dsp.negotiation.transform.to.JsonObjectToContractNegotiationTerminationMessageTransformer;
 import org.eclipse.edc.protocol.dsp.negotiation.transform.to.JsonObjectToContractOfferMessageTransformer;
 import org.eclipse.edc.protocol.dsp.negotiation.transform.to.JsonObjectToContractRequestMessageTransformer;
-import org.eclipse.edc.protocol.dsp.negotiation.transform.v2024.from.JsonObjectFromContractAgreementMessageV2024Transformer;
 import org.eclipse.edc.protocol.dsp.negotiation.transform.v2024.from.JsonObjectFromContractAgreementVerificationMessageV2024Transformer;
 import org.eclipse.edc.protocol.dsp.negotiation.transform.v2024.from.JsonObjectFromContractNegotiationEventMessageV2024Transformer;
 import org.eclipse.edc.protocol.dsp.negotiation.transform.v2024.from.JsonObjectFromContractNegotiationTerminationMessageV2024Transformer;
 import org.eclipse.edc.protocol.dsp.negotiation.transform.v2024.from.JsonObjectFromContractNegotiationV2024Transformer;
 import org.eclipse.edc.protocol.dsp.negotiation.transform.v2024.from.JsonObjectFromContractOfferMessageV2024Transformer;
 import org.eclipse.edc.protocol.dsp.negotiation.transform.v2024.from.JsonObjectFromContractRequestMessageV2024Transformer;
+import org.eclipse.edc.protocol.dsp.negotiation.transform.v2025.from.JsonObjectFromContractAgreementMessageV2025Transformer;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.system.ServiceExtension;
@@ -79,7 +79,7 @@ public class DspNegotiationTransformV2025Extension implements ServiceExtension {
         dspApiTransformerRegistry.register(new JsonObjectFromContractNegotiationV2024Transformer(builderFactory, DSP_NAMESPACE_V_2025_1));
         dspApiTransformerRegistry.register(new JsonObjectFromContractRequestMessageV2024Transformer(builderFactory, DSP_NAMESPACE_V_2025_1));
         dspApiTransformerRegistry.register(new JsonObjectFromContractOfferMessageV2024Transformer(builderFactory, DSP_NAMESPACE_V_2025_1));
-        dspApiTransformerRegistry.register(new JsonObjectFromContractAgreementMessageV2024Transformer(builderFactory, DSP_NAMESPACE_V_2025_1));
+        dspApiTransformerRegistry.register(new JsonObjectFromContractAgreementMessageV2025Transformer(builderFactory, DSP_NAMESPACE_V_2025_1));
         dspApiTransformerRegistry.register(new JsonObjectFromContractAgreementVerificationMessageV2024Transformer(builderFactory, DSP_NAMESPACE_V_2025_1));
         dspApiTransformerRegistry.register(new JsonObjectFromContractNegotiationEventMessageV2024Transformer(builderFactory, DSP_NAMESPACE_V_2025_1));
         dspApiTransformerRegistry.register(new JsonObjectFromContractNegotiationTerminationMessageV2024Transformer(builderFactory, DSP_NAMESPACE_V_2025_1));

--- a/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-transform-2025/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/v2025/from/JsonObjectFromContractAgreementMessageV2025Transformer.java
+++ b/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-transform-2025/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/transform/v2025/from/JsonObjectFromContractAgreementMessageV2025Transformer.java
@@ -1,0 +1,90 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.negotiation.transform.v2025.from;
+
+import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreementMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static java.time.Instant.ofEpochSecond;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_NAMESPACE_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_AGREEMENT_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_TIMESTAMP_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CALLBACK_ADDRESS_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID_TERM;
+
+
+/**
+ * Creates a dspace:ContractAgreementMessage as {@link JsonObject} from {@link ContractAgreementMessage}.
+ */
+public class JsonObjectFromContractAgreementMessageV2025Transformer extends AbstractNamespaceAwareJsonLdTransformer<ContractAgreementMessage, JsonObject> {
+
+    private final JsonBuilderFactory jsonFactory;
+
+    public JsonObjectFromContractAgreementMessageV2025Transformer(JsonBuilderFactory jsonFactory) {
+        this(jsonFactory, DSP_NAMESPACE_V_2025_1);
+    }
+
+    public JsonObjectFromContractAgreementMessageV2025Transformer(JsonBuilderFactory jsonFactory, JsonLdNamespace namespace) {
+        super(ContractAgreementMessage.class, JsonObject.class, namespace);
+        this.jsonFactory = jsonFactory;
+    }
+
+    @Override
+    public @Nullable JsonObject transform(@NotNull ContractAgreementMessage agreementMessage, @NotNull TransformerContext context) {
+        var agreement = agreementMessage.getContractAgreement();
+
+        var policy = context.transform(agreement.getPolicy(), JsonObject.class);
+        if (policy == null) {
+            context.problem()
+                    .nullProperty()
+                    .type(ContractAgreementMessage.class)
+                    .property("policy")
+                    .report();
+            return null;
+        }
+
+        var signing = ofEpochSecond(agreement.getContractSigningDate()).toString();
+
+        var copiedPolicy = Json.createObjectBuilder(policy)
+                .add(ID, agreement.getId())
+                .add(forNamespace(DSPACE_PROPERTY_TIMESTAMP_TERM), signing)
+                .build();
+
+        var builder = jsonFactory.createObjectBuilder()
+                .add(ID, agreementMessage.getId())
+                .add(TYPE, forNamespace(DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE_TERM))
+                .add(forNamespace(DSPACE_PROPERTY_PROVIDER_PID_TERM), createId(jsonFactory, agreementMessage.getProviderPid()))
+                .add(forNamespace(DSPACE_PROPERTY_CONSUMER_PID_TERM), createId(jsonFactory, agreementMessage.getConsumerPid()))
+                .add(forNamespace(DSPACE_PROPERTY_AGREEMENT_TERM), copiedPolicy);
+
+        if (agreementMessage.getCallbackAddress() != null) {
+            builder.add(forNamespace(DSPACE_PROPERTY_CALLBACK_ADDRESS_TERM), agreementMessage.getCallbackAddress());
+        }
+
+        return builder.build();
+    }
+
+}

--- a/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-transform-2025/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/v2025/from/JsonObjectFromContractAgreementMessageV2025TransformerTest.java
+++ b/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-transform-2025/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/v2025/from/JsonObjectFromContractAgreementMessageV2025TransformerTest.java
@@ -1,0 +1,153 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.negotiation.transform.v2025.from;
+
+import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreementMessage;
+import org.eclipse.edc.policy.model.Action;
+import org.eclipse.edc.policy.model.Duty;
+import org.eclipse.edc.policy.model.Permission;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.policy.model.Prohibition;
+import org.eclipse.edc.transform.spi.ProblemBuilder;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ASSIGNEE_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_ASSIGNER_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_AGREEMENT;
+import static org.eclipse.edc.protocol.dsp.negotiation.transform.v2025.from.TestFunction2025.toIri;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_AGREEMENT_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_PROPERTY_TIMESTAMP_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspNegotiationPropertyAndTypeNames.DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_CONSUMER_PID_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID_TERM;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class JsonObjectFromContractAgreementMessageV2025TransformerTest {
+
+    public static final String AGREEMENT_ID = UUID.randomUUID().toString();
+    private static final String PROVIDER_ID = "providerId";
+    private static final String CONSUMER_ID = "consumerId";
+    private static final String TIMESTAMP = "1970-01-01T00:00:00Z";
+    private static final String DSP = "dsp";
+    private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
+    private final TransformerContext context = mock();
+
+    private final JsonObjectFromContractAgreementMessageV2025Transformer transformer =
+            new JsonObjectFromContractAgreementMessageV2025Transformer(jsonFactory);
+
+    @BeforeEach
+    void setUp() {
+        when(context.problem()).thenReturn(new ProblemBuilder(context));
+    }
+
+    @Test
+    void transform() {
+        var message = ContractAgreementMessage.Builder.newInstance()
+                .protocol(DSP)
+                .providerPid("providerPid")
+                .consumerPid("consumerPid")
+                .counterPartyAddress("https://example.com")
+                .contractAgreement(ContractAgreement.Builder.newInstance()
+                        .id(AGREEMENT_ID)
+                        .providerId(PROVIDER_ID)
+                        .consumerId(CONSUMER_ID)
+                        .assetId("assetId")
+                        .policy(policy()).build())
+                .build();
+        var policyObject = jsonFactory.createObjectBuilder()
+                .add(ID, "contractOfferId")
+                .add(TYPE, ODRL_POLICY_TYPE_AGREEMENT)
+                .add(ODRL_ASSIGNEE_ATTRIBUTE, jsonFactory.createObjectBuilder().add(ID, "consumerId"))
+                .add(ODRL_ASSIGNER_ATTRIBUTE, jsonFactory.createObjectBuilder().add(ID, "providerId"))
+                .build();
+
+        when(context.transform(any(Policy.class), eq(JsonObject.class))).thenReturn(policyObject);
+
+        var result = transformer.transform(message, context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getString(ID)).isNotNull();
+        assertThat(result.getString(ID)).isNotEmpty();
+        assertThat(result.getString(TYPE)).isEqualTo(toIri(DSPACE_TYPE_CONTRACT_AGREEMENT_MESSAGE_TERM));
+        assertThat(result.getJsonObject(toIri(DSPACE_PROPERTY_PROVIDER_PID_TERM)).getString(ID)).isEqualTo("providerPid");
+        assertThat(result.getJsonObject(toIri(DSPACE_PROPERTY_CONSUMER_PID_TERM)).getString(ID)).isEqualTo("consumerPid");
+
+        var jsonAgreement = result.getJsonObject(toIri(DSPACE_PROPERTY_AGREEMENT_TERM));
+        assertThat(jsonAgreement).isNotNull();
+        assertThat(jsonAgreement.getString(ID)).isEqualTo(AGREEMENT_ID);
+        assertThat(jsonAgreement.getString(TYPE)).isEqualTo(ODRL_POLICY_TYPE_AGREEMENT);
+        assertThat(jsonAgreement.getString(toIri(DSPACE_PROPERTY_TIMESTAMP_TERM))).isEqualTo(TIMESTAMP);
+        assertThat(jsonAgreement.getJsonObject(ODRL_ASSIGNEE_ATTRIBUTE).getString(ID)).isEqualTo(CONSUMER_ID);
+        assertThat(jsonAgreement.getJsonObject(ODRL_ASSIGNER_ATTRIBUTE).getString(ID)).isEqualTo(PROVIDER_ID);
+
+        verify(context, never()).reportProblem(anyString());
+    }
+
+    @Test
+    void transform_policyError() {
+        var message = ContractAgreementMessage.Builder.newInstance()
+                .protocol(DSP)
+                .processId("processId")
+                .providerPid("providerPid")
+                .consumerPid("consumerPid")
+                .counterPartyAddress("https://example.com")
+                .contractAgreement(ContractAgreement.Builder.newInstance()
+                        .id(AGREEMENT_ID)
+                        .providerId(PROVIDER_ID)
+                        .consumerId(CONSUMER_ID)
+                        .assetId("assetId")
+                        .policy(policy()).build())
+                .build();
+
+        when(context.transform(any(Policy.class), eq(JsonObject.class))).thenReturn(null);
+
+        assertThat(transformer.transform(message, context)).isNull();
+
+        verify(context, times(1)).reportProblem(anyString());
+    }
+
+    private Policy policy() {
+        var action = Action.Builder.newInstance().type("use").build();
+        var permission = Permission.Builder.newInstance().action(action).build();
+        var prohibition = Prohibition.Builder.newInstance().action(action).build();
+        var duty = Duty.Builder.newInstance().action(action).build();
+        return Policy.Builder.newInstance()
+                .permission(permission)
+                .prohibition(prohibition)
+                .assigner("providerId")
+                .assignee("consumerId")
+                .duty(duty)
+                .build();
+    }
+}

--- a/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-transform-2025/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/v2025/from/TestFunction2025.java
+++ b/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-transform-2025/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/v2025/from/TestFunction2025.java
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.negotiation.transform.v2025.from;
+
+import org.eclipse.edc.protocol.dsp.spi.type.DspConstants;
+
+public class TestFunction2025 {
+
+    public static String toIri(String term) {
+        return DspConstants.DSP_NAMESPACE_V_2025_1.toIri(term);
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

When the provider compose the contract policy now it populates also the `assignee` and assigner`. 

The transformer from `ContractAgreementMessage` to `JsonObject` has been introduced 2025 that assume those fields
are populated instead of overriding them from the `ContractAgreement`. 

## Why it does that

It will remove the need for fallback in the future in the `PolicyArchiveImpl` and it will make symmetric contract policy on consumer/provider

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #4968 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
