### PR TITLE
fix: data flow restart mechanism

### DIFF
--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/DataFlow.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/DataFlow.java
@@ -127,7 +127,8 @@ public class DataFlow extends StatefulEntity<DataFlow> {
         transitionTo(COMPLETED.code());
     }
 
-    public void transitToReceived() {
+    public void transitToReceived(String runtimeId) {
+        this.runtimeId = runtimeId;
         transitionTo(RECEIVED.code());
     }
 


### PR DESCRIPTION
## What this PR changes/adds

Fix the `restartFlow` mechanism in `DataPlaneManager`, unifying the behavior with the `start` method.

## Why it does that

fix bug, avoid duplication

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #4975 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
