### PR TITLE
fix: use numeric JWT claims instead of ISO-8601

### DIFF
--- a/core/common/token-core/src/test/java/org/eclipse/edc/jwt/rules/ExpirationIssuedAtValidationRuleTest.java
+++ b/core/common/token-core/src/test/java/org/eclipse/edc/jwt/rules/ExpirationIssuedAtValidationRuleTest.java
@@ -19,7 +19,6 @@ import org.eclipse.edc.token.rules.ExpirationIssuedAtValidationRule;
 import org.eclipse.edc.token.spi.TokenValidationRule;
 import org.junit.jupiter.api.Test;
 
-import java.sql.Date;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -39,7 +38,7 @@ class ExpirationIssuedAtValidationRuleTest {
     @Test
     void validationOk() {
         var token = ClaimToken.Builder.newInstance()
-                .claim(EXPIRATION_TIME, Date.from(now.plusSeconds(600)))
+                .claim(EXPIRATION_TIME, now.plusSeconds(600).getEpochSecond())
                 .build();
 
         var result = rule.checkRule(token, emptyMap());
@@ -50,7 +49,7 @@ class ExpirationIssuedAtValidationRuleTest {
     @Test
     void validationKoBecauseExpirationTimeNotRespected() {
         var token = ClaimToken.Builder.newInstance()
-                .claim(EXPIRATION_TIME, Date.from(now.minusSeconds(10)))
+                .claim(EXPIRATION_TIME, now.minusSeconds(10).getEpochSecond())
                 .build();
 
         var result = rule.checkRule(token, emptyMap());
@@ -85,8 +84,8 @@ class ExpirationIssuedAtValidationRuleTest {
     @Test
     void validationKoBecauseIssuedAtAfterExpires() {
         var token = ClaimToken.Builder.newInstance()
-                .claim(EXPIRATION_TIME, Date.from(now.plusSeconds(60)))
-                .claim(ISSUED_AT, Date.from(now.plusSeconds(65)))
+                .claim(EXPIRATION_TIME, now.plusSeconds(60).getEpochSecond())
+                .claim(ISSUED_AT, now.plusSeconds(65).getEpochSecond())
                 .build();
 
         var result = rule.checkRule(token, emptyMap());
@@ -98,8 +97,8 @@ class ExpirationIssuedAtValidationRuleTest {
     @Test
     void validationKoBecauseIssuedAtInFuture() {
         var token = ClaimToken.Builder.newInstance()
-                .claim(EXPIRATION_TIME, Date.from(now.plusSeconds(60)))
-                .claim(ISSUED_AT, Date.from(now.plusSeconds(10)))
+                .claim(EXPIRATION_TIME, now.plusSeconds(60).getEpochSecond())
+                .claim(ISSUED_AT, now.plusSeconds(10).getEpochSecond())
                 .build();
 
         var result = rule.checkRule(token, emptyMap());
@@ -113,8 +112,8 @@ class ExpirationIssuedAtValidationRuleTest {
         var rule = new ExpirationIssuedAtValidationRule(clock, 5, false);
 
         var token = ClaimToken.Builder.newInstance()
-                .claim(EXPIRATION_TIME, Date.from(now.plusSeconds(60)))
-                .claim(ISSUED_AT, Date.from(now.plusSeconds(10)))
+                .claim(EXPIRATION_TIME, now.plusSeconds(60).getEpochSecond())
+                .claim(ISSUED_AT, now.plusSeconds(10).getEpochSecond())
                 .build();
 
         var result = rule.checkRule(token, emptyMap());
@@ -128,8 +127,8 @@ class ExpirationIssuedAtValidationRuleTest {
         var rule = new ExpirationIssuedAtValidationRule(clock, 20, false);
 
         var token = ClaimToken.Builder.newInstance()
-                .claim(EXPIRATION_TIME, Date.from(now.plusSeconds(60)))
-                .claim(ISSUED_AT, Date.from(now.plusSeconds(10)))
+                .claim(EXPIRATION_TIME, now.plusSeconds(60).getEpochSecond())
+                .claim(ISSUED_AT, now.plusSeconds(10).getEpochSecond())
                 .build();
 
         var result = rule.checkRule(token, emptyMap());
@@ -155,8 +154,8 @@ class ExpirationIssuedAtValidationRuleTest {
         var rule = new ExpirationIssuedAtValidationRule(clock, 0, false);
 
         var token = ClaimToken.Builder.newInstance()
-                .claim(EXPIRATION_TIME, Date.from(expiresAt))
-                .claim(ISSUED_AT, Date.from(issuedAt))
+                .claim(EXPIRATION_TIME, expiresAt.getEpochSecond())
+                .claim(ISSUED_AT, expiresAt.getEpochSecond())
                 .build();
 
         var result = rule.checkRule(token, emptyMap());
@@ -183,8 +182,8 @@ class ExpirationIssuedAtValidationRuleTest {
         var rule = new ExpirationIssuedAtValidationRule(clock, 2, false);
 
         var token = ClaimToken.Builder.newInstance()
-                .claim(EXPIRATION_TIME, Date.from(expiresAt))
-                .claim(ISSUED_AT, Date.from(issuedAt))
+                .claim(EXPIRATION_TIME, expiresAt.getEpochSecond())
+                .claim(ISSUED_AT, issuedAt.getEpochSecond())
                 .build();
 
         var result = rule.checkRule(token, emptyMap());

--- a/core/common/token-core/src/test/java/org/eclipse/edc/jwt/rules/NotBeforeValidationRuleTest.java
+++ b/core/common/token-core/src/test/java/org/eclipse/edc/jwt/rules/NotBeforeValidationRuleTest.java
@@ -19,7 +19,6 @@ import org.eclipse.edc.token.rules.NotBeforeValidationRule;
 import org.eclipse.edc.token.spi.TokenValidationRule;
 import org.junit.jupiter.api.Test;
 
-import java.sql.Date;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -39,7 +38,7 @@ class NotBeforeValidationRuleTest {
     @Test
     void validNotBefore() {
         var token = ClaimToken.Builder.newInstance()
-                .claim(NOT_BEFORE, Date.from(now.plusSeconds(notBeforeLeeway)))
+                .claim(NOT_BEFORE, now.plusSeconds(notBeforeLeeway).getEpochSecond())
                 .build();
 
         var result = rule.checkRule(token, emptyMap());
@@ -50,7 +49,7 @@ class NotBeforeValidationRuleTest {
     @Test
     void validationKoBecauseNotBeforeTimeNotRespected() {
         var token = ClaimToken.Builder.newInstance()
-                .claim(NOT_BEFORE, Date.from(now.plusSeconds(notBeforeLeeway + 1)))
+                .claim(NOT_BEFORE, now.plusSeconds(notBeforeLeeway + 1).getEpochSecond())
                 .build();
 
         var result = rule.checkRule(token, emptyMap());

--- a/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/DcpDefaultServicesExtension.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/DcpDefaultServicesExtension.java
@@ -36,7 +36,6 @@ import org.eclipse.edc.spi.system.ServiceExtension;
 
 import java.time.Clock;
 import java.util.Map;
-import java.util.function.Consumer;
 
 import static org.eclipse.edc.spi.result.Result.success;
 
@@ -97,12 +96,6 @@ public class DcpDefaultServicesExtension implements ServiceExtension {
                     .claims(Map.of(CLAIMTOKEN_VC_KEY, credentials));
             return success(b.build());
         };
-    }
-
-    private void checkProperty(String key, String value, Consumer<String> onMissing) {
-        if (value == null) {
-            onMissing.accept("No setting found for key '%s'.".formatted(key));
-        }
     }
 
 }

--- a/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/service/IdentityAndTrustService.java
+++ b/extensions/common/iam/identity-trust/identity-trust-service/src/main/java/org/eclipse/edc/iam/identitytrust/service/IdentityAndTrustService.java
@@ -110,7 +110,7 @@ public class IdentityAndTrustService implements IdentityService {
         }
 
         // create claims for the STS
-        var claims = new HashMap<String, String>();
+        var claims = new HashMap<String, Object>();
         parameters.getClaims().forEach((k, v) -> claims.replace(k, v.toString()));
 
         claims.putAll(Map.of(
@@ -134,12 +134,12 @@ public class IdentityAndTrustService implements IdentityService {
         var accessToken = claimToken.getStringClaim(PRESENTATION_TOKEN_CLAIM);
         var issuer = claimToken.getStringClaim(ISSUER);
 
-        var siTokenClaims = Map.of(PRESENTATION_TOKEN_CLAIM, accessToken,
-                ISSUED_AT, Instant.now().toString(),
+        Map<String, Object> siTokenClaims = Map.of(PRESENTATION_TOKEN_CLAIM, accessToken,
+                ISSUED_AT, Instant.now().getEpochSecond(),
                 AUDIENCE, issuer,
                 ISSUER, myOwnDid,
                 SUBJECT, myOwnDid,
-                EXPIRATION_TIME, Instant.now().plus(5, ChronoUnit.MINUTES).toString());
+                EXPIRATION_TIME, Instant.now().plus(5, ChronoUnit.MINUTES).getEpochSecond());
         var siToken = secureTokenService.createToken(siTokenClaims, null);
         if (siToken.failed()) {
             return siToken.mapFailure();

--- a/extensions/common/iam/identity-trust/identity-trust-sts/lib/identity-trust-sts-remote-lib/src/main/java/org/eclipse/edc/iam/identitytrust/sts/remote/RemoteSecureTokenService.java
+++ b/extensions/common/iam/identity-trust/identity-trust-sts/lib/identity-trust-sts-remote-lib/src/main/java/org/eclipse/edc/iam/identitytrust/sts/remote/RemoteSecureTokenService.java
@@ -51,13 +51,13 @@ public class RemoteSecureTokenService implements SecureTokenService {
     }
 
     @Override
-    public Result<TokenRepresentation> createToken(Map<String, String> claims, @Nullable String bearerAccessScope) {
+    public Result<TokenRepresentation> createToken(Map<String, Object> claims, @Nullable String bearerAccessScope) {
         return createRequest(claims, bearerAccessScope)
                 .compose(oauth2Client::requestToken);
     }
 
     @NotNull
-    private Result<Oauth2CredentialsRequest> createRequest(Map<String, String> claims, @Nullable String bearerAccessScope) {
+    private Result<Oauth2CredentialsRequest> createRequest(Map<String, Object> claims, @Nullable String bearerAccessScope) {
 
         var secret = vault.resolveSecret(configuration.clientSecretAlias());
         if (secret != null) {

--- a/extensions/common/iam/oauth2/oauth2-client/src/main/java/org/eclipse/edc/iam/oauth2/client/Oauth2ClientImpl.java
+++ b/extensions/common/iam/oauth2/oauth2-client/src/main/java/org/eclipse/edc/iam/oauth2/client/Oauth2ClientImpl.java
@@ -63,7 +63,7 @@ public class Oauth2ClientImpl implements Oauth2Client {
         var builder = new FormBody.Builder();
         request.getParams().entrySet().stream()
                 .filter(entry -> entry.getValue() != null)
-                .forEach(entry -> builder.add(entry.getKey(), entry.getValue()));
+                .forEach(entry -> builder.add(entry.getKey(), entry.getValue().toString()));
         return builder.build();
     }
 

--- a/extensions/common/iam/oauth2/oauth2-client/src/test/java/org/eclipse/edc/iam/oauth2/client/Oauth2ClientImplTest.java
+++ b/extensions/common/iam/oauth2/oauth2-client/src/test/java/org/eclipse/edc/iam/oauth2/client/Oauth2ClientImplTest.java
@@ -55,7 +55,7 @@ class Oauth2ClientImplTest {
 
         var formParameters = new Parameters(
                 request.getParams().entrySet().stream()
-                        .map(entry -> Parameter.param(entry.getKey(), entry.getValue()))
+                        .map(entry -> Parameter.param(entry.getKey(), entry.getValue().toString()))
                         .collect(Collectors.toList())
         );
 
@@ -75,7 +75,7 @@ class Oauth2ClientImplTest {
 
         var formParameters = new Parameters(
                 request.getParams().entrySet().stream()
-                        .map(entry -> Parameter.param(entry.getKey(), entry.getValue()))
+                        .map(entry -> Parameter.param(entry.getKey(), entry.getValue().toString()))
                         .collect(Collectors.toList())
         );
 
@@ -97,7 +97,7 @@ class Oauth2ClientImplTest {
 
         var formParameters = new Parameters(
                 request.getParams().entrySet().stream()
-                        .map(entry -> Parameter.param(entry.getKey(), entry.getValue()))
+                        .map(entry -> Parameter.param(entry.getKey(), entry.getValue().toString()))
                         .collect(Collectors.toList())
         );
 
@@ -118,7 +118,7 @@ class Oauth2ClientImplTest {
 
         var formParameters = new Parameters(
                 request.getParams().entrySet().stream()
-                        .map(entry -> Parameter.param(entry.getKey(), entry.getValue()))
+                        .map(entry -> Parameter.param(entry.getKey(), entry.getValue().toString()))
                         .collect(Collectors.toList())
         );
 

--- a/extensions/data-plane/data-plane-http-oauth2-core/src/test/java/org/eclipse/edc/connector/dataplane/http/oauth2/Oauth2CredentialsRequestFactoryTest.java
+++ b/extensions/data-plane/data-plane-http-oauth2-core/src/test/java/org/eclipse/edc/connector/dataplane/http/oauth2/Oauth2CredentialsRequestFactoryTest.java
@@ -116,7 +116,7 @@ class Oauth2CredentialsRequestFactoryTest {
                 })
                 .extracting(PrivateKeyOauth2CredentialsRequest::getClientAssertion)
                 .satisfies(assertion -> {
-                    var assertionToken = SignedJWT.parse(assertion);
+                    var assertionToken = SignedJWT.parse(assertion.toString());
                     var now = clock.instant().truncatedTo(ChronoUnit.SECONDS);
                     assertThat(assertionToken.verify(new RSASSAVerifier(keyPair.toRSAPublicKey()))).isTrue();
                     assertThat(assertionToken.getJWTClaimsSet().getClaims())

--- a/extensions/data-plane/data-plane-iam/src/main/java/org/eclipse/edc/connector/dataplane/iam/service/DataPlaneAuthorizationServiceImpl.java
+++ b/extensions/data-plane/data-plane-iam/src/main/java/org/eclipse/edc/connector/dataplane/iam/service/DataPlaneAuthorizationServiceImpl.java
@@ -140,7 +140,7 @@ public class DataPlaneAuthorizationServiceImpl implements DataPlaneAuthorization
                 .claims(JwtRegisteredClaimNames.AUDIENCE, message.getParticipantId())
                 .claims(JwtRegisteredClaimNames.ISSUER, ownParticipantId)
                 .claims(JwtRegisteredClaimNames.SUBJECT, ownParticipantId)
-                .claims(JwtRegisteredClaimNames.ISSUED_AT, clock.instant().toEpochMilli()) // todo: milli or second?
+                .claims(JwtRegisteredClaimNames.ISSUED_AT, clock.instant().getEpochSecond())
                 .build();
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ kafkaClients = "4.0.0"
 testcontainers = "1.21.0"
 tink = "1.17.0"
 dsp-tck = "0.1.1-SNAPSHOT"
+dcp-tck = "0.1.1-SNAPSHOT"
 junit = "1.12.2"
 
 [libraries]
@@ -106,7 +107,7 @@ postgres = { module = "org.postgresql:postgresql", version.ref = "postgres" }
 kafkaClients = { module = "org.apache.kafka:kafka-clients", version.ref = "kafkaClients" }
 jsonschema = { module = "com.networknt:json-schema-validator", version = "1.5.6" }
 
-# DCP-TCK libraries
+# DSP-TCK libraries
 dsp-tck-runtime = { module = "org.eclipse.dataspacetck.dsp:tck-runtime", version.ref = "dsp-tck" }
 dsp-tck-core = { module = "org.eclipse.dataspacetck.dsp:core", version.ref = "dsp-tck" }
 dsp-tck-api = { module = "org.eclipse.dataspacetck.dsp:dsp-api", version.ref = "dsp-tck" }
@@ -114,6 +115,12 @@ dsp-tck-system = { module = "org.eclipse.dataspacetck.dsp:dsp-system", version.r
 dsp-tck-contractnegotiation = { module = "org.eclipse.dataspacetck.dsp:dsp-contract-negotiation", version.ref = "dsp-tck" }
 dsp-tck-transferprocess = { module = "org.eclipse.dataspacetck.dsp:dsp-transfer-process", version.ref = "dsp-tck" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit" }
+
+# DCP-TCK libraries
+dcp-testcases = { module = "org.eclipse.dataspacetck.dcp:dcp-testcases", version.ref = "dcp-tck" }
+dcp-tck-runtime = { module = "org.eclipse.dataspacetck.dsp:tck-runtime", version.ref = "dcp-tck" }
+dcp-system = { module = "org.eclipse.dataspacetck.dcp:dcp-system", version.ref = "dcp-tck" }
+dsp-core = { module = "org.eclipse.dataspacetck.dsp:core", version.ref = "dcp-tck" }
 
 [bundles]
 jackson = ["jackson-annotations", "jackson-databind"]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,6 @@ kafkaClients = "4.0.0"
 testcontainers = "1.21.0"
 tink = "1.17.0"
 dsp-tck = "0.1.1-SNAPSHOT"
-dcp-tck = "0.1.1-SNAPSHOT"
 junit = "1.12.2"
 
 [libraries]
@@ -115,12 +114,6 @@ dsp-tck-system = { module = "org.eclipse.dataspacetck.dsp:dsp-system", version.r
 dsp-tck-contractnegotiation = { module = "org.eclipse.dataspacetck.dsp:dsp-contract-negotiation", version.ref = "dsp-tck" }
 dsp-tck-transferprocess = { module = "org.eclipse.dataspacetck.dsp:dsp-transfer-process", version.ref = "dsp-tck" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit" }
-
-# DCP-TCK libraries
-dcp-testcases = { module = "org.eclipse.dataspacetck.dcp:dcp-testcases", version.ref = "dcp-tck" }
-dcp-tck-runtime = { module = "org.eclipse.dataspacetck.dsp:tck-runtime", version.ref = "dcp-tck" }
-dcp-system = { module = "org.eclipse.dataspacetck.dcp:dcp-system", version.ref = "dcp-tck" }
-dsp-core = { module = "org.eclipse.dataspacetck.dsp:core", version.ref = "dcp-tck" }
 
 [bundles]
 jackson = ["jackson-annotations", "jackson-databind"]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -340,6 +340,7 @@ include(":system-tests:bom-tests")
 include(":system-tests:dsp-compatibility-tests:connector-under-test")
 include(":system-tests:dsp-compatibility-tests:compatibility-test-runner")
 include(":system-tests:protocol-tck:tck-extension")
+include(":system-tests:dcp-tck-tests:presentation")
 
 // BOM modules ----------------------------------------------------------------
 include(":dist:bom:controlplane-base-bom")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -340,7 +340,6 @@ include(":system-tests:bom-tests")
 include(":system-tests:dsp-compatibility-tests:connector-under-test")
 include(":system-tests:dsp-compatibility-tests:compatibility-test-runner")
 include(":system-tests:protocol-tck:tck-extension")
-include(":system-tests:dcp-tck-tests:presentation")
 
 // BOM modules ----------------------------------------------------------------
 include(":dist:bom:controlplane-base-bom")

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/iam/ClaimToken.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/iam/ClaimToken.java
@@ -71,7 +71,7 @@ public class ClaimToken {
     }
 
     /**
-     * Get the date claim value by name converted to {@link Instant}
+     * Get the NumericDate claim value by name converted to {@link Instant}. The claim must be a long value.
      *
      * @param claimName the name of the claim
      * @return the claim value, null if it does not exist
@@ -79,13 +79,21 @@ public class ClaimToken {
     public Instant getInstantClaim(String claimName) {
         return Optional.of(claims)
                 .map(it -> it.get(claimName))
-                .map(Date.class::cast)
+                .map(o -> {
+                    if (o instanceof Long epoch) {
+                        return epoch;
+                    }
+                    if (o instanceof Date d) {
+                        return d.toInstant().getEpochSecond();
+                    }
+                    return null;
+                })
                 .map(this::convertToUtcTime)
                 .orElse(null);
     }
 
-    private Instant convertToUtcTime(Date date) {
-        return date.toInstant().atOffset(UTC).toInstant();
+    private Instant convertToUtcTime(Long epochSecond) {
+        return Instant.ofEpochSecond(epochSecond).atOffset(UTC).toInstant();
     }
 
     public static class Builder {

--- a/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/iam/identitytrust/spi/SecureTokenService.java
+++ b/spi/common/identity-trust-spi/src/main/java/org/eclipse/edc/iam/identitytrust/spi/SecureTokenService.java
@@ -34,6 +34,6 @@ public interface SecureTokenService {
      *                          if bearerAccessScope != null -> creates a {@code token} claim, which is another JWT containing the scope as claims.
      *                          if bearerAccessScope == null -> creates a normal JWT using all the claims in the map
      */
-    Result<TokenRepresentation> createToken(Map<String, String> claims, @Nullable String bearerAccessScope);
+    Result<TokenRepresentation> createToken(Map<String, Object> claims, @Nullable String bearerAccessScope);
 
 }

--- a/spi/common/oauth2-spi/src/main/java/org/eclipse/edc/iam/oauth2/spi/Oauth2AssertionDecorator.java
+++ b/spi/common/oauth2-spi/src/main/java/org/eclipse/edc/iam/oauth2/spi/Oauth2AssertionDecorator.java
@@ -20,7 +20,6 @@ import org.eclipse.edc.token.spi.KeyIdDecorator;
 import org.eclipse.edc.token.spi.TokenDecorator;
 
 import java.time.Clock;
-import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -51,8 +50,8 @@ public class Oauth2AssertionDecorator implements TokenDecorator {
                 .claims(ISSUER, clientId)
                 .claims(SUBJECT, clientId)
                 .claims(JWT_ID, UUID.randomUUID().toString())
-                .claims(ISSUED_AT, Date.from(clock.instant()))
-                .claims(EXPIRATION_TIME, Date.from(clock.instant().plusSeconds(validity)));
+                .claims(ISSUED_AT, clock.instant().getEpochSecond())
+                .claims(EXPIRATION_TIME, clock.instant().plusSeconds(validity).getEpochSecond());
     }
 
     public static class Builder {

--- a/spi/common/oauth2-spi/src/main/java/org/eclipse/edc/iam/oauth2/spi/client/Oauth2CredentialsRequest.java
+++ b/spi/common/oauth2-spi/src/main/java/org/eclipse/edc/iam/oauth2/spi/client/Oauth2CredentialsRequest.java
@@ -20,6 +20,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import static java.util.Optional.ofNullable;
+
 public abstract class Oauth2CredentialsRequest {
 
     private static final String GRANT_TYPE = "grant_type";
@@ -34,12 +36,12 @@ public abstract class Oauth2CredentialsRequest {
         return url;
     }
 
-    public Object getScope() {
-        return params.get(SCOPE);
+    public String getScope() {
+        return ofNullable(params.get(SCOPE)).map(Object::toString).orElse(null);
     }
 
-    public Object getGrantType() {
-        return params.get(GRANT_TYPE);
+    public String getGrantType() {
+        return ofNullable(params.get(GRANT_TYPE)).map(Object::toString).orElse(null);
     }
 
     /**
@@ -47,8 +49,8 @@ public abstract class Oauth2CredentialsRequest {
      *
      * @return The value of the resource form parameter.
      */
-    public Object getResource() {
-        return this.params.get(RESOURCE);
+    public String getResource() {
+        return ofNullable(params.get(RESOURCE)).map(Object::toString).orElse(null);
     }
 
     public Map<String, Object> getParams() {

--- a/spi/common/oauth2-spi/src/main/java/org/eclipse/edc/iam/oauth2/spi/client/Oauth2CredentialsRequest.java
+++ b/spi/common/oauth2-spi/src/main/java/org/eclipse/edc/iam/oauth2/spi/client/Oauth2CredentialsRequest.java
@@ -15,7 +15,6 @@
 package org.eclipse.edc.iam.oauth2.spi.client;
 
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -28,20 +27,18 @@ public abstract class Oauth2CredentialsRequest {
     private static final String RESOURCE = "resource";
 
     protected String url;
-    protected final Map<String, String> params = new HashMap<>();
+    protected final Map<String, Object> params = new HashMap<>();
 
     @NotNull
     public String getUrl() {
         return url;
     }
 
-    @Nullable
-    public String getScope() {
+    public Object getScope() {
         return params.get(SCOPE);
     }
 
-    @NotNull
-    public String getGrantType() {
+    public Object getGrantType() {
         return params.get(GRANT_TYPE);
     }
 
@@ -50,12 +47,11 @@ public abstract class Oauth2CredentialsRequest {
      *
      * @return The value of the resource form parameter.
      */
-    @Nullable
-    public String getResource() {
+    public Object getResource() {
         return this.params.get(RESOURCE);
     }
 
-    public Map<String, String> getParams() {
+    public Map<String, Object> getParams() {
         return params;
     }
 
@@ -81,12 +77,12 @@ public abstract class Oauth2CredentialsRequest {
             return self();
         }
 
-        public B param(String key, String value) {
+        public B param(String key, Object value) {
             request.params.put(key, value);
             return self();
         }
 
-        public B params(Map<String, String> params) {
+        public B params(Map<String, Object> params) {
             request.params.putAll(params);
             return self();
         }
@@ -95,8 +91,8 @@ public abstract class Oauth2CredentialsRequest {
          * Adds the resource form parameter to the request.
          *
          * @param targetedAudience The audience for which an access token will be requested.
-         * @see <a href="https://www.rfc-editor.org/rfc/rfc8707.html">RFC-8707</a>
          * @return this builder
+         * @see <a href="https://www.rfc-editor.org/rfc/rfc8707.html">RFC-8707</a>
          */
         public B resource(String targetedAudience) {
             return param(RESOURCE, targetedAudience);

--- a/spi/common/oauth2-spi/src/main/java/org/eclipse/edc/iam/oauth2/spi/client/PrivateKeyOauth2CredentialsRequest.java
+++ b/spi/common/oauth2-spi/src/main/java/org/eclipse/edc/iam/oauth2/spi/client/PrivateKeyOauth2CredentialsRequest.java
@@ -18,18 +18,20 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 
 import java.util.Objects;
 
+import static java.util.Optional.ofNullable;
+
 public class PrivateKeyOauth2CredentialsRequest extends Oauth2CredentialsRequest {
 
     private static final String CLIENT_ASSERTION = "client_assertion";
     private static final String CLIENT_ASSERTION_TYPE = "client_assertion_type";
     private static final String TYPE_JWT_BEARER = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
 
-    public Object getClientAssertion() {
-        return params.get(CLIENT_ASSERTION);
+    public String getClientAssertion() {
+        return ofNullable(params.get(CLIENT_ASSERTION)).map(Object::toString).orElse(null);
     }
 
-    public Object getClientAssertionType() {
-        return params.get(CLIENT_ASSERTION_TYPE);
+    public String getClientAssertionType() {
+        return ofNullable(params.get(CLIENT_ASSERTION_TYPE)).map(Object::toString).orElse(null);
     }
 
     public static class Builder<B extends PrivateKeyOauth2CredentialsRequest.Builder<B>> extends Oauth2CredentialsRequest.Builder<PrivateKeyOauth2CredentialsRequest, PrivateKeyOauth2CredentialsRequest.Builder<B>> {

--- a/spi/common/oauth2-spi/src/main/java/org/eclipse/edc/iam/oauth2/spi/client/PrivateKeyOauth2CredentialsRequest.java
+++ b/spi/common/oauth2-spi/src/main/java/org/eclipse/edc/iam/oauth2/spi/client/PrivateKeyOauth2CredentialsRequest.java
@@ -15,7 +15,6 @@
 package org.eclipse.edc.iam.oauth2.spi.client;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
@@ -25,13 +24,11 @@ public class PrivateKeyOauth2CredentialsRequest extends Oauth2CredentialsRequest
     private static final String CLIENT_ASSERTION_TYPE = "client_assertion_type";
     private static final String TYPE_JWT_BEARER = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
 
-    @NotNull
-    public String getClientAssertion() {
+    public Object getClientAssertion() {
         return params.get(CLIENT_ASSERTION);
     }
 
-    @NotNull
-    public String getClientAssertionType() {
+    public Object getClientAssertionType() {
         return params.get(CLIENT_ASSERTION_TYPE);
     }
 

--- a/spi/common/oauth2-spi/src/main/java/org/eclipse/edc/iam/oauth2/spi/client/SharedSecretOauth2CredentialsRequest.java
+++ b/spi/common/oauth2-spi/src/main/java/org/eclipse/edc/iam/oauth2/spi/client/SharedSecretOauth2CredentialsRequest.java
@@ -15,7 +15,6 @@
 package org.eclipse.edc.iam.oauth2.spi.client;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
@@ -24,13 +23,11 @@ public class SharedSecretOauth2CredentialsRequest extends Oauth2CredentialsReque
     private static final String CLIENT_ID = "client_id";
     private static final String CLIENT_SECRET = "client_secret";
 
-    @NotNull
-    public String getClientId() {
+    public Object getClientId() {
         return params.get(CLIENT_ID);
     }
 
-    @NotNull
-    public String getClientSecret() {
+    public Object getClientSecret() {
         return params.get(CLIENT_SECRET);
     }
 

--- a/spi/common/oauth2-spi/src/test/java/org/eclipse/edc/iam/oauth2/spi/Oauth2AssertionDecoratorTest.java
+++ b/spi/common/oauth2-spi/src/test/java/org/eclipse/edc/iam/oauth2/spi/Oauth2AssertionDecoratorTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Clock;
 import java.time.Instant;
-import java.util.Date;
 import java.util.UUID;
 
 import static java.time.ZoneOffset.UTC;
@@ -67,8 +66,8 @@ class Oauth2AssertionDecoratorTest {
                 .hasFieldOrPropertyWithValue(ISSUER, clientId)
                 .hasFieldOrPropertyWithValue(SUBJECT, clientId)
                 .containsKey(JWT_ID)
-                .hasEntrySatisfying(ISSUED_AT, issueDate -> assertThat((Date) issueDate).isEqualTo(now))
-                .hasEntrySatisfying(EXPIRATION_TIME, expiration -> assertThat((Date) expiration).isEqualTo(now.plusSeconds(TOKEN_EXPIRATION)));
+                .hasEntrySatisfying(ISSUED_AT, issueDate -> assertThat((Long) issueDate).isEqualTo(now.getEpochSecond()))
+                .hasEntrySatisfying(EXPIRATION_TIME, expiration -> assertThat((Long) expiration).isEqualTo(now.plusSeconds(TOKEN_EXPIRATION).getEpochSecond()));
     }
 
 }


### PR DESCRIPTION
## What this PR changes/adds

this PR changes the use of ISO-8601 strings as temporal JWT claims to be numeric date values.

## Why it does that

RFC 7519 requires them to be `NumericDate` values, i.e. Epoch seconds

## Further notes

The culprit is the Nimbus library, which fails to parse JSON Web tokens where the `nbf`, `exp` and `iat` claims are not numeric.


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #4991 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
