### PR TITLE
feat: make data address handle complex properties

### DIFF
--- a/core/common/lib/transform-lib/src/main/java/org/eclipse/edc/transform/transformer/edc/to/JsonObjectToDataAddressTransformer.java
+++ b/core/common/lib/transform-lib/src/main/java/org/eclipse/edc/transform/transformer/edc/to/JsonObjectToDataAddressTransformer.java
@@ -23,7 +23,6 @@ import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import static jakarta.json.JsonValue.ValueType.STRING;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 
 
@@ -52,17 +51,7 @@ public class JsonObjectToDataAddressTransformer extends AbstractJsonLdTransforme
             visitProperties(props, (k, val) -> transformProperties(k, val, builder, context));
         } else {
             var object = transformGenericProperty(jsonValue, context);
-            if (object instanceof String) {
-                builder.property(key, object.toString());
-            } else {
-                context.problem()
-                        .unexpectedType()
-                        .type("property")
-                        .property(key)
-                        .actual(object == null ? "null" : object.toString())
-                        .expected(STRING)
-                        .report();
-            }
+            builder.property(key, object);
         }
 
     }

--- a/extensions/common/api/management-api-configuration/src/main/java/org/eclipse/edc/connector/api/management/configuration/ManagementApiConfigurationExtension.java
+++ b/extensions/common/api/management-api-configuration/src/main/java/org/eclipse/edc/connector/api/management/configuration/ManagementApiConfigurationExtension.java
@@ -140,7 +140,7 @@ public class ManagementApiConfigurationExtension implements ServiceExtension {
 
         var factory = Json.createBuilderFactory(Map.of());
         managementApiTransformerRegistry.register(new JsonObjectFromContractAgreementTransformer(factory));
-        managementApiTransformerRegistry.register(new JsonObjectFromDataAddressTransformer(factory));
+        managementApiTransformerRegistry.register(new JsonObjectFromDataAddressTransformer(factory, typeManager.getMapper(JSON_LD)));
         managementApiTransformerRegistry.register(new JsonObjectFromAssetTransformer(factory, typeManager, JSON_LD));
         managementApiTransformerRegistry.register(new JsonObjectFromPolicyTransformer(factory, participantIdMapper));
         managementApiTransformerRegistry.register(new JsonObjectFromQuerySpecTransformer(factory));

--- a/extensions/data-plane-selector/data-plane-selector-client/src/main/java/org/eclipse/edc/connector/dataplane/selector/DataPlaneSelectorClientExtension.java
+++ b/extensions/data-plane-selector/data-plane-selector-client/src/main/java/org/eclipse/edc/connector/dataplane/selector/DataPlaneSelectorClientExtension.java
@@ -67,7 +67,7 @@ public class DataPlaneSelectorClientExtension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
         var builderFactory = Json.createBuilderFactory(emptyMap());
         typeTransformerRegistry.register(new JsonObjectFromDataPlaneInstanceTransformer(builderFactory, typeManager, JSON_LD));
-        typeTransformerRegistry.register(new JsonObjectFromDataAddressTransformer(builderFactory));
+        typeTransformerRegistry.register(new JsonObjectFromDataAddressTransformer(builderFactory, typeManager.getMapper(JSON_LD)));
         typeTransformerRegistry.register(new JsonObjectToDataPlaneInstanceTransformer());
         typeTransformerRegistry.register(new JsonObjectToDataAddressTransformer());
         typeTransformerRegistry.register(new JsonValueToGenericTypeTransformer(typeManager, JSON_LD));

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/DataAddress.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/DataAddress.java
@@ -44,7 +44,7 @@ public class DataAddress {
     public static final String SIMPLE_KEY_NAME = "keyName";
     public static final String EDC_DATA_ADDRESS_TYPE = EDC_NAMESPACE + "DataAddress";
     public static final String EDC_DATA_ADDRESS_TYPE_PROPERTY = EDC_NAMESPACE + SIMPLE_TYPE;
-    public static final String EDC_DATA_ADDRESS_KEY_NAME = EDC_NAMESPACE + "keyName";
+    public static final String EDC_DATA_ADDRESS_KEY_NAME = EDC_NAMESPACE + SIMPLE_KEY_NAME;
     public static final String EDC_DATA_ADDRESS_SECRET = EDC_NAMESPACE + "secret";
 
     protected final Map<String, Object> properties = new HashMap<>();
@@ -70,11 +70,16 @@ public class DataAddress {
 
     @Nullable
     public String getStringProperty(String key, String defaultValue) {
-        var value = Optional.ofNullable(properties.get(EDC_NAMESPACE + key)).orElseGet(() -> properties.get(key));
+        var value = getProperty(key);
         if (value != null) {
             return (String) value;
         }
         return defaultValue;
+    }
+
+    @Nullable
+    public Object getProperty(String key) {
+        return Optional.ofNullable(properties.get(EDC_NAMESPACE + key)).orElseGet(() -> properties.get(key));
     }
 
     public Map<String, Object> getProperties() {


### PR DESCRIPTION
## What this PR changes/adds

Changes the `DataAddress` to and from transformers to allow complex attributes such as json objects or json arrays to be used.

## Who will sponsor this feature?

@jimmarino 
@ndr-brt 

## Linked Issue(s)

Closes #4986 
