### PR TITLE
feat: fixes most of the remaining CN dsp-tck tests

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
@@ -47,6 +47,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
 
+import static java.lang.String.format;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.Type.CONSUMER;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.Type.PROVIDER;
 
@@ -90,15 +91,21 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
                                     ? createNegotiation(message, validatedOffer.getConsumerIdentity(), PROVIDER, message.getCallbackAddress())
                                     : getAndLeaseNegotiation(message.getProviderPid());
 
-                            return result.onSuccess(negotiation -> {
+                            return result.compose(negotiation -> {
                                 if (negotiation.shouldIgnoreIncomingMessage(message.getId())) {
-                                    return;
+                                    return ServiceResult.success(negotiation);
                                 }
-                                negotiation.protocolMessageReceived(message.getId());
-                                negotiation.addContractOffer(validatedOffer.getOffer());
-                                negotiation.transitionRequested();
-                                update(negotiation);
-                                observable.invokeForEach(l -> l.requested(negotiation));
+                                if (negotiation.getType().equals(PROVIDER) && negotiation.canBeRequestedProvider()) {
+                                    negotiation.protocolMessageReceived(message.getId());
+                                    negotiation.addContractOffer(validatedOffer.getOffer());
+                                    negotiation.transitionRequested();
+                                    update(negotiation);
+                                    observable.invokeForEach(l -> l.requested(negotiation));
+                                    return ServiceResult.success(negotiation);
+                                } else {
+                                    return ServiceResult.conflict(format("Cannot process %s because %s", message.getClass().getSimpleName(), "negotiation cannot be requested"));
+                                }
+
                             });
                         })
                 ));
@@ -115,15 +122,21 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
                             : getAndLeaseNegotiation(message.getConsumerPid())
                             .compose(negotiation -> validateRequest(agent, negotiation).map(it -> negotiation));
 
-                    return result.onSuccess(negotiation -> {
+                    return result.compose(negotiation -> {
                         if (negotiation.shouldIgnoreIncomingMessage(message.getId())) {
-                            return;
+                            return ServiceResult.success(negotiation);
                         }
-                        negotiation.protocolMessageReceived(message.getId());
-                        negotiation.addContractOffer(message.getContractOffer());
-                        negotiation.transitionOffered();
-                        update(negotiation);
-                        observable.invokeForEach(l -> l.offered(negotiation));
+                        if (negotiation.getType().equals(CONSUMER) && negotiation.canBeOfferedConsumer()) {
+                            negotiation.protocolMessageReceived(message.getId());
+                            negotiation.addContractOffer(message.getContractOffer());
+                            negotiation.transitionOffered();
+                            update(negotiation);
+                            observable.invokeForEach(l -> l.offered(negotiation));
+
+                            return ServiceResult.success(negotiation);
+                        } else {
+                            return ServiceResult.conflict(format("Cannot process %s because %s", message.getClass().getSimpleName(), "negotiation cannot be offered"));
+                        }
                     });
                 }));
     }
@@ -274,30 +287,43 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
 
     @NotNull
     private ServiceResult<ContractNegotiation> agreedAction(ContractAgreementMessage message, ContractNegotiation negotiation) {
-        negotiation.protocolMessageReceived(message.getId());
-        negotiation.setContractAgreement(message.getContractAgreement());
-        negotiation.transitionAgreed();
-        update(negotiation);
-        observable.invokeForEach(l -> l.agreed(negotiation));
-        return ServiceResult.success(negotiation);
+        if (negotiation.getType().equals(CONSUMER) && negotiation.canBeAgreedConsumer()) {
+            negotiation.protocolMessageReceived(message.getId());
+            negotiation.setContractAgreement(message.getContractAgreement());
+            negotiation.transitionAgreed();
+            update(negotiation);
+            observable.invokeForEach(l -> l.agreed(negotiation));
+            return ServiceResult.success(negotiation);
+        } else {
+            return ServiceResult.conflict(format("Cannot process %s because %s", message.getClass().getSimpleName(), "negotiation cannot be agreed"));
+        }
     }
 
     @NotNull
     private ServiceResult<ContractNegotiation> verifiedAction(ContractAgreementVerificationMessage message, ContractNegotiation negotiation) {
-        negotiation.protocolMessageReceived(message.getId());
-        negotiation.transitionVerified();
-        update(negotiation);
-        observable.invokeForEach(l -> l.verified(negotiation));
-        return ServiceResult.success(negotiation);
+        if (negotiation.getType().equals(PROVIDER) && negotiation.canBeVerifiedProvider()) {
+            negotiation.protocolMessageReceived(message.getId());
+            negotiation.transitionVerified();
+            update(negotiation);
+            observable.invokeForEach(l -> l.verified(negotiation));
+            return ServiceResult.success(negotiation);
+        } else {
+            return ServiceResult.conflict(format("Cannot process %s because %s", message.getClass().getSimpleName(), "negotiation cannot be verified"));
+        }
     }
 
     @NotNull
     private ServiceResult<ContractNegotiation> finalizedAction(ContractNegotiationEventMessage message, ContractNegotiation negotiation) {
-        negotiation.protocolMessageReceived(message.getId());
-        negotiation.transitionFinalized();
-        update(negotiation);
-        observable.invokeForEach(l -> l.finalized(negotiation));
-        return ServiceResult.success(negotiation);
+        if (negotiation.getType().equals(CONSUMER) && negotiation.canBeFinalized()) {
+            negotiation.protocolMessageReceived(message.getId());
+            negotiation.transitionFinalized();
+            update(negotiation);
+            observable.invokeForEach(l -> l.finalized(negotiation));
+            return ServiceResult.success(negotiation);
+        } else {
+            return ServiceResult.conflict(format("Cannot process %s because %s", message.getClass().getSimpleName(), "negotiation cannot be finialized"));
+        }
+
     }
 
     @NotNull

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
@@ -214,7 +214,7 @@ class ContractNegotiationProtocolServiceImplTest {
     @Test
     void notifyFinalized_shouldTransitionToFinalized() {
         var contractOffer = contractOffer();
-        var negotiation = contractNegotiationBuilder().id("negotiationId").type(PROVIDER).contractOffer(contractOffer).state(VERIFIED.code()).build();
+        var negotiation = contractNegotiationBuilder().id("negotiationId").type(CONSUMER).contractOffer(contractOffer).state(VERIFIED.code()).build();
 
         var message = ContractNegotiationEventMessage.Builder.newInstance()
                 .type(ContractNegotiationEventMessage.Type.FINALIZED)

--- a/system-tests/dsp-compatibility-tests/compatibility-test-runner/src/test/java/org/eclipse/edc/tck/dsp/CompatibilityTests.java
+++ b/system-tests/dsp-compatibility-tests/compatibility-test-runner/src/test/java/org/eclipse/edc/tck/dsp/CompatibilityTests.java
@@ -21,9 +21,8 @@ public interface CompatibilityTests {
     // TODO remove all failures from this list when compliant error handling is implemented in the connector
     // TODO TP:01-01 is failing because we don't send endpoint in data address
     List<String> ALLOWED_FAILURES = List.of(
-            "CN:03-01", "CN:03-02", "CN:03-03", "CN:03-04",
+            "CN:03-01",
             "CN_C:01-02",
-            "CN_C:03-01", "CN_C:03-02", "CN_C:03-03", "CN_C:03-04", "CN_C:03-05", "CN_C:03-06",
             "TP:01-01", "TP:01-02", "TP:01-03", "TP:01-04", "TP:01-05",
             "TP:02-01", "TP:02-02", "TP:02-03", "TP:02-04",
             "TP:03-03", "TP:03-04", "TP:03-05", "TP:03-06",

--- a/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/data/DataAssembly.java
+++ b/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/data/DataAssembly.java
@@ -156,18 +156,21 @@ public class DataAssembly {
                 .record("ACN0301", ContractNegotiation::transitionFinalizing);
 
         recorder.record("ACN0302", ContractNegotiation::transitionOffering);
-        recorder.record("ACN0303", ContractNegotiation::transitionOffering)
-                // TODO hack for making the process sleep once 03 tests are supported this can be removed
-                .record("ACN0303", ContractNegotiation::transitionTerminating);
-
+        recorder.record("ACN0303", ContractNegotiation::transitionOffering);
 
         recorder.record("ACN0304", ContractNegotiation::transitionOffering);
+
     }
 
     public static List<Trigger<ContractNegotiation>> createNegotiationTriggers() {
         return List.of(
                 createTrigger(ContractNegotiationOffered.class, "ACN0205", ContractNegotiation::transitionTerminating),
                 createTrigger(ContractNegotiationAccepted.class, "ACN0206", ContractNegotiation::transitionTerminating),
+
+                createTrigger(ContractNegotiationAccepted.class, "ACN0303", cn -> {
+                    cn.setPending(true);
+                }),
+
                 createTrigger(ContractNegotiationOffered.class, "ACNC0101", contractNegotiation -> {
                     contractNegotiation.transitionAccepting();
                     contractNegotiation.setPending(false);
@@ -195,6 +198,7 @@ public class DataAssembly {
                     contractNegotiation.transitionVerifying();
                     contractNegotiation.setPending(false);
                 }),
+
                 createTrigger(ContractNegotiationOffered.class, "ACNC0304", contractNegotiation -> {
                     contractNegotiation.transitionAccepting();
                     contractNegotiation.setPending(false);
@@ -206,6 +210,9 @@ public class DataAssembly {
                 createTrigger(ContractNegotiationOffered.class, "ACNC0306", contractNegotiation -> {
                     contractNegotiation.transitionAccepting();
                     contractNegotiation.setPending(false);
+                }),
+                createTrigger(ContractNegotiationAgreed.class, "ACNC0306", contractNegotiation -> {
+                    contractNegotiation.setPending(true);
                 })
 
         );


### PR DESCRIPTION
## What this PR changes/adds

Fixes contract negotiation tests:

- `CN:03-02` 
- `CN:03-03`
- `CN:03-04`
- `CN_C:03-01`
- `CN_C:03-02` 
- `CN_C:03-03`
- `CN_C:03-04` 
- `CN_C:03-05`
- `CN_C:03-06`

By applying a check upon receiving DSP messages if the state transition is allowed and returning `conflict` if not

Fixes also this two invalid state transition

consumer: Agreed -> Finalized
provider: Accepted -> Verified

## Why it does that

dsp compliance

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Part of #4978 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
