### PR TITLE
fix: fixes last two CN dsp-tck tests

### DIFF
--- a/core/control-plane/control-plane-contract/src/main/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/control-plane/control-plane-contract/src/main/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -116,10 +116,15 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
         var callbackAddress = protocolWebhookRegistry.resolve(negotiation.getProtocol());
 
         if (callbackAddress != null) {
+            var type = ContractRequestMessage.Type.INITIAL;
+            // if there are multiple offers, it's a counter-offer
+            if (negotiation.getContractOffers().size() > 1) {
+                type = ContractRequestMessage.Type.COUNTER_OFFER;
+            }
             var messageBuilder = ContractRequestMessage.Builder.newInstance()
                     .contractOffer(negotiation.getLastContractOffer())
                     .callbackAddress(callbackAddress.url())
-                    .type(ContractRequestMessage.Type.INITIAL);
+                    .type(type);
 
             return dispatch(messageBuilder, negotiation, ContractNegotiationAck.class, "[Consumer] send request")
                     .onSuccess(this::transitionToRequested)

--- a/core/control-plane/control-plane-contract/src/main/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/control-plane/control-plane-contract/src/main/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -117,7 +117,6 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
 
         if (callbackAddress != null) {
             var type = ContractRequestMessage.Type.INITIAL;
-            // if there are multiple offers, it's a counter-offer
             if (negotiation.getContractOffers().size() > 1) {
                 type = ContractRequestMessage.Type.COUNTER_OFFER;
             }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/negotiation/ContractNegotiation.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/negotiation/ContractNegotiation.java
@@ -169,7 +169,7 @@ public class ContractNegotiation extends StatefulEntity<ContractNegotiation> {
     }
 
     public boolean shouldIgnoreIncomingMessage(@NotNull String messageId) {
-        return protocolMessages.isAlreadyReceived(messageId) || ContractNegotiationStates.isFinal(state);
+        return protocolMessages.isAlreadyReceived(messageId);
     }
 
     public ProtocolMessages getProtocolMessages() {
@@ -265,7 +265,11 @@ public class ContractNegotiation extends StatefulEntity<ContractNegotiation> {
      * Transition to state ACCEPTED.
      */
     public void transitionAccepted() {
-        transition(ContractNegotiationStates.ACCEPTED, ContractNegotiationStates.ACCEPTED, ContractNegotiationStates.ACCEPTING, ContractNegotiationStates.OFFERED);
+        transition(ContractNegotiationStates.ACCEPTED, state -> canBeAccepted());
+    }
+
+    public boolean canBeAccepted() {
+        return currentStateIsOneOf(ContractNegotiationStates.ACCEPTED, ContractNegotiationStates.ACCEPTED, ContractNegotiationStates.ACCEPTING, ContractNegotiationStates.OFFERED);
     }
 
     /**

--- a/system-tests/dsp-compatibility-tests/compatibility-test-runner/src/test/java/org/eclipse/edc/tck/dsp/CompatibilityTests.java
+++ b/system-tests/dsp-compatibility-tests/compatibility-test-runner/src/test/java/org/eclipse/edc/tck/dsp/CompatibilityTests.java
@@ -18,11 +18,8 @@ import java.util.List;
 
 public interface CompatibilityTests {
 
-    // TODO remove all failures from this list when compliant error handling is implemented in the connector
     // TODO TP:01-01 is failing because we don't send endpoint in data address
     List<String> ALLOWED_FAILURES = List.of(
-            "CN:03-01",
-            "CN_C:01-02",
             "TP:01-01", "TP:01-02", "TP:01-03", "TP:01-04", "TP:01-05",
             "TP:02-01", "TP:02-02", "TP:02-03", "TP:02-04",
             "TP:03-03", "TP:03-04", "TP:03-05", "TP:03-06",


### PR DESCRIPTION
## What this PR changes/adds

Fixes the remaining two failing tests:

- `CN:03-01`
- `CN_C:01-02`


For `CN:03-01` additional checks on the protocol layer where added in order to return `conflict` when  the message cannot be processed. Previously messages were ignored when on final states which means that the response of the
connector was 200, which was not what `CN:03-01` test was expecting since the tests try to deliver a terminated message while the state is finalized.

For `CN_C:01-02` the fix was if when processing the requesting state in the consumer side there are more than 1 contract offer, then it's considered a counter offer from the consumer and it uses a process bound request endpoint.

## Why it does that

dsp compliance

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #4978 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
