### PR TITLE
feat: download status list credential with EdcHttpClient

### DIFF
--- a/extensions/common/iam/identity-trust/identity-trust-core/src/test/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtensionTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/test/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtensionTest.java
@@ -66,10 +66,7 @@ class IdentityAndTrustExtensionTest {
 
     @Test
     void verifyCorrectService(ServiceExtensionContext context, ObjectFactory objectFactory) {
-
-
         var is = objectFactory.constructInstance(IdentityAndTrustExtension.class).createIdentityService(context);
-
         assertThat(is).isInstanceOf(IdentityAndTrustService.class);
     }
 

--- a/extensions/common/iam/verifiable-credentials/build.gradle.kts
+++ b/extensions/common/iam/verifiable-credentials/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     testImplementation(testFixtures(project(":spi:common:verifiable-credentials-spi")))
     testImplementation(libs.mockserver.netty)
     testImplementation(project(":tests:junit-base"))
+    testImplementation(project(":core:common:lib:http-lib"))
     testImplementation(project(":core:common:lib:util-lib"))
     testImplementation(testFixtures(project(":spi:common:identity-trust-spi"))) //test functions
 }


### PR DESCRIPTION
## What this PR changes/adds

use the `EdcHttpClient` to download instead of the `ObjectMapper`

## Why it does that

to be able to specify additional request parameters such as the `Accept` header

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.

## Linked Issue(s)

Closes #5029

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
