### PR TITLE
feat: support for most of the TP tck test

### DIFF
--- a/extensions/data-plane/data-plane-iam/src/main/java/org/eclipse/edc/connector/dataplane/iam/service/DataPlaneAuthorizationServiceImpl.java
+++ b/extensions/data-plane/data-plane-iam/src/main/java/org/eclipse/edc/connector/dataplane/iam/service/DataPlaneAuthorizationServiceImpl.java
@@ -23,6 +23,7 @@ import org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames;
 import org.eclipse.edc.spi.iam.TokenParameters;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 
@@ -98,7 +99,7 @@ public class DataPlaneAuthorizationServiceImpl implements DataPlaneAuthorization
     }
 
     @Override
-    public Result<Void> revokeEndpointDataReference(String transferProcessId, String reason) {
+    public ServiceResult<Void> revokeEndpointDataReference(String transferProcessId, String reason) {
         return accessTokenService.revoke(transferProcessId, reason);
     }
 

--- a/extensions/data-plane/data-plane-iam/src/test/java/org/eclipse/edc/connector/dataplane/iam/DataPlaneAuthorizationServiceImplTest.java
+++ b/extensions/data-plane/data-plane-iam/src/test/java/org/eclipse/edc/connector/dataplane/iam/DataPlaneAuthorizationServiceImplTest.java
@@ -23,6 +23,7 @@ import org.eclipse.edc.connector.dataplane.spi.iam.PublicEndpointGeneratorServic
 import org.eclipse.edc.spi.iam.ClaimToken;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.eclipse.edc.spi.types.domain.transfer.FlowType;
@@ -166,7 +167,7 @@ class DataPlaneAuthorizationServiceImplTest {
 
     @Test
     void revoke() {
-        when(accessTokenService.revoke(eq("id"), eq("reason"))).thenReturn(Result.success());
+        when(accessTokenService.revoke(eq("id"), eq("reason"))).thenReturn(ServiceResult.success());
 
         assertThat(authorizationService.revokeEndpointDataReference("id", "reason")).isSucceeded();
 
@@ -176,7 +177,7 @@ class DataPlaneAuthorizationServiceImplTest {
 
     @Test
     void revoke_error() {
-        when(accessTokenService.revoke(eq("id"), eq("reason"))).thenReturn(Result.failure("failure"));
+        when(accessTokenService.revoke(eq("id"), eq("reason"))).thenReturn(ServiceResult.notFound("failure"));
 
         assertThat(authorizationService.revokeEndpointDataReference("id", "reason")).isFailed()
                 .detail().contains("failure");

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/iam/DataPlaneAccessTokenService.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/iam/DataPlaneAccessTokenService.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import org.eclipse.edc.spi.iam.TokenParameters;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 
 import java.util.Map;
@@ -59,6 +60,6 @@ public interface DataPlaneAccessTokenService {
      * @param reason            The reason for the revocation
      * @return Success if revoked, failure otherwise
      */
-    Result<Void> revoke(String transferProcessId, String reason);
+    ServiceResult<Void> revoke(String transferProcessId, String reason);
 
 }

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/iam/DataPlaneAuthorizationService.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/iam/DataPlaneAuthorizationService.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.connector.dataplane.spi.iam;
 
 import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 
@@ -87,5 +88,5 @@ public interface DataPlaneAuthorizationService {
      * @param reason            The reason of the revocation
      * @return Successful if revoked, fails otherwise
      */
-    Result<Void> revokeEndpointDataReference(String transferProcessId, String reason);
+    ServiceResult<Void> revokeEndpointDataReference(String transferProcessId, String reason);
 }

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/iam/NoOpDataPlaneAuthorizationService.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/iam/NoOpDataPlaneAuthorizationService.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.connector.dataplane.spi.iam;
 
 import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 
@@ -40,7 +41,7 @@ public class NoOpDataPlaneAuthorizationService implements DataPlaneAuthorization
     }
 
     @Override
-    public Result<Void> revokeEndpointDataReference(String transferProcessId, String reason) {
-        return FAILURE.mapEmpty();
+    public ServiceResult<Void> revokeEndpointDataReference(String transferProcessId, String reason) {
+        return ServiceResult.unexpected(FAILURE.getFailureDetail());
     }
 }

--- a/system-tests/dsp-compatibility-tests/compatibility-test-runner/src/test/java/org/eclipse/edc/tck/dsp/CompatibilityTests.java
+++ b/system-tests/dsp-compatibility-tests/compatibility-test-runner/src/test/java/org/eclipse/edc/tck/dsp/CompatibilityTests.java
@@ -18,12 +18,8 @@ import java.util.List;
 
 public interface CompatibilityTests {
 
-    // TODO TP:01-01 is failing because we don't send endpoint in data address
+    // TODO Those remaining failures are due the fact that EDC consider the DEPROVISIONED state completed while the TCK expects terminated.
     List<String> ALLOWED_FAILURES = List.of(
-            "TP:01-01", "TP:01-02", "TP:01-03", "TP:01-04", "TP:01-05",
-            "TP:02-01", "TP:02-02", "TP:02-03", "TP:02-04",
-            "TP:03-03", "TP:03-04", "TP:03-05", "TP:03-06",
-            "TP_C:01-04",
-            "TP_C:02-04");
+            "TP:01-01", "TP:01-03", "TP:01-05");
 
 }


### PR DESCRIPTION
## What this PR changes/adds

Removes  the allowed failure tests that previously failed caused by missing `endpoint`, since now it's not mandatory anymore.

Additionally for the tck tests `* -> suspended -> terminated` the EDC was throwing an exception due  the EDR being already revoked (removed by default implementation) and in  the subsequent `DataFlowManager#stop` invocation, the revocation failed (not found).

For this use case (PULL scenarion) if the `DataFlow` status is `Suspended` and the error from the revocation service is `not found`, the ``DataFlowManager#stop` will not fail.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #4977 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
