### PR TITLE
feat: add dsp tck metadata test integration

### DIFF
--- a/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/spi/version/DspVersions.java
+++ b/data-protocols/dsp/dsp-spi/src/main/java/org/eclipse/edc/protocol/dsp/spi/version/DspVersions.java
@@ -27,7 +27,7 @@ public interface DspVersions {
     ProtocolVersion V_08 = new ProtocolVersion(V_08_VERSION, V_08_PATH);
 
 
-    String V_2025_1_VERSION = "2025/1";
+    String V_2025_1_VERSION = "2025-1";
     String V_2025_1_PATH = "/" + V_2025_1_VERSION;
     ProtocolVersion V_2025_1 = new ProtocolVersion(V_2025_1_VERSION, V_2025_1_PATH);
 

--- a/system-tests/dsp-compatibility-tests/compatibility-test-runner/src/test/resources/docker.tck.properties
+++ b/system-tests/dsp-compatibility-tests/compatibility-test-runner/src/test/resources/docker.tck.properties
@@ -15,7 +15,8 @@
 dataspacetck.debug=true
 dataspacetck.dsp.local.connector=false
 dataspacetck.dsp.connector.agent.id=CONNECTOR_UNDER_TEST
-dataspacetck.dsp.connector.http.url=http://host.docker.internal:8282/api/dsp/2025/1
+dataspacetck.dsp.connector.http.url=http://host.docker.internal:8282/api/dsp/2025-1
+dataspacetck.dsp.connector.http.base.url=http://host.docker.internal:8282/api/dsp
 dataspacetck.dsp.connector.http.headers.authorization="{\"region\": \"any\", \"audience\": \"any\", \"clientId\":\"any\"}"
 dataspacetck.dsp.connector.negotiation.initiate.url=http://host.docker.internal:8687/tck/negotiations/requests
 dataspacetck.dsp.connector.transfer.initiate.url=http://host.docker.internal:8687/tck/transfers/requests

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferPullEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferPullEndToEndTest.java
@@ -550,8 +550,8 @@ class TransferPullEndToEndTest {
         static void beforeAll() {
             jsonLd = CONSUMER.getJsonLd();
             CONSUMER.setJsonLd(CONSUMER_CONTROL_PLANE.getService(JsonLd.class));
-            CONSUMER.setProtocol("dataspace-protocol-http:2025/1", "/2025/1");
-            PROVIDER.setProtocol("dataspace-protocol-http:2025/1", "/2025/1");
+            CONSUMER.setProtocol("dataspace-protocol-http:2025-1", "/2025-1");
+            PROVIDER.setProtocol("dataspace-protocol-http:2025-1", "/2025-1");
         }
 
         @AfterAll

--- a/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/controller/TckWebhookController.java
+++ b/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/controller/TckWebhookController.java
@@ -78,7 +78,7 @@ public class TckWebhookController {
                 .callbackAddresses(List.of(CallbackAddress.Builder.newInstance().uri(request.connectorAddress()).build()))
                 .counterPartyAddress(request.connectorAddress())
                 .contractOffer(contractOffer)
-                .protocol("dataspace-protocol-http:2025/1")
+                .protocol("dataspace-protocol-http:2025-1")
                 .build();
 
         monitor.debug("Starting contract negotiation for [provider, address, offer]: [%s, %s, %s]".formatted(request.providerId(), request.connectorAddress(), request.offerId()));
@@ -107,7 +107,7 @@ public class TckWebhookController {
                 .id(request.agreementId() + "_" + UUID.randomUUID())
                 .transferType(request.format())
                 .counterPartyAddress(request.connectorAddress())
-                .protocol("dataspace-protocol-http:2025/1")
+                .protocol("dataspace-protocol-http:2025-1")
                 .contractId(request.agreementId())
                 .build();
 


### PR DESCRIPTION
## What this PR changes/adds

Adds support for metadata (`.well-known/dspace-version`) test in dsp tck.

In order to do that the 2025 version naming has been aligned with the upstream DSP example

`2025-1` instead of `2025/1` which impacts the path where the version is exposed

`<connector-dsp>/2025-1`  instead of `<connector-dsp>/2025/1` 

and the protocol field 

`dataspace-protocol-http:2025-1` instead of `dataspace-protocol-http:2025/1`

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5034 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
