### PR TITLE
feat: support DSP correct state in deprovisioning

### DIFF
--- a/data-protocols/dsp/dsp-lib/dsp-transfer-process-lib/dsp-transfer-process-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/type/v2024/from/JsonObjectFromTransferProcessV2024Transformer.java
+++ b/data-protocols/dsp/dsp-lib/dsp-transfer-process-lib/dsp-transfer-process-transform-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/type/v2024/from/JsonObjectFromTransferProcessV2024Transformer.java
@@ -55,7 +55,7 @@ public class JsonObjectFromTransferProcessV2024Transformer extends AbstractNames
         var builder = jsonBuilderFactory.createObjectBuilder()
                 .add(ID, transferProcess.getId())
                 .add(TYPE, forNamespace(DSPACE_TYPE_TRANSFER_PROCESS_TERM))
-                .add(forNamespace(DSPACE_PROPERTY_STATE_TERM), createId(jsonBuilderFactory, state(transferProcess.getState(), context)));
+                .add(forNamespace(DSPACE_PROPERTY_STATE_TERM), createId(jsonBuilderFactory, state(transferProcess.getState(), transferProcess.getErrorDetail(), context)));
 
         if (transferProcess.getType() == TransferProcess.Type.PROVIDER) {
             builder.add(forNamespace(DSPACE_PROPERTY_PROVIDER_PID_TERM), createId(jsonBuilderFactory, transferProcess.getId()));
@@ -68,7 +68,7 @@ public class JsonObjectFromTransferProcessV2024Transformer extends AbstractNames
         return builder.build();
     }
 
-    private String state(Integer state, TransformerContext context) {
+    private String state(Integer state, String errorDetails, TransformerContext context) {
         var transferProcessState = TransferProcessStates.from(state);
         if (transferProcessState == null) {
             context.problem()
@@ -84,8 +84,16 @@ public class JsonObjectFromTransferProcessV2024Transformer extends AbstractNames
             case STARTING, STARTED -> forNamespace(DSPACE_VALUE_TRANSFER_STATE_STARTED_TERM);
             case SUSPENDING, SUSPENDED, SUSPENDING_REQUESTED, RESUMING, RESUMED ->
                     forNamespace(DSPACE_VALUE_TRANSFER_STATE_SUSPENDED_TERM);
-            case COMPLETING, COMPLETING_REQUESTED, COMPLETED, DEPROVISIONING, DEPROVISIONING_REQUESTED, DEPROVISIONED ->
+            case COMPLETING, COMPLETING_REQUESTED, COMPLETED ->
                     forNamespace(DSPACE_VALUE_TRANSFER_STATE_COMPLETED_TERM);
+
+            case DEPROVISIONING, DEPROVISIONING_REQUESTED, DEPROVISIONED -> {
+                if (errorDetails != null) {
+                    yield forNamespace(DSPACE_VALUE_TRANSFER_STATE_TERMINATED_TERM);
+                } else {
+                    yield forNamespace(DSPACE_VALUE_TRANSFER_STATE_COMPLETED_TERM);
+                }
+            }
             case TERMINATING, TERMINATING_REQUESTED, TERMINATED ->
                     forNamespace(DSPACE_VALUE_TRANSFER_STATE_TERMINATED_TERM);
             default -> {

--- a/data-protocols/dsp/dsp-lib/dsp-transfer-process-lib/dsp-transfer-process-transform-lib/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/v2024/from/JsonObjectFromTransferProcessV2024TransformerTest.java
+++ b/data-protocols/dsp/dsp-lib/dsp-transfer-process-lib/dsp-transfer-process-transform-lib/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/v2024/from/JsonObjectFromTransferProcessV2024TransformerTest.java
@@ -139,7 +139,7 @@ class JsonObjectFromTransferProcessV2024TransformerTest {
 
     @ParameterizedTest
     @ArgumentsSource(Status.class)
-    void transform_status(TransferProcessStates inputState, String expectedDspState) {
+    void transform_status(TransferProcessStates inputState, String expectedDspState, String errorDetail) {
         var dataAddress = DataAddress.Builder.newInstance()
                 .keyName("dataAddressId")
                 .property("type", "TestValueProperty")
@@ -151,6 +151,7 @@ class JsonObjectFromTransferProcessV2024TransformerTest {
                 .dataDestination(dataAddress)
                 .state(inputState.code())
                 .contentDataAddress(dataAddress)
+                .errorDetail(errorDetail)
                 .build();
 
         var result = transformer.transform(transferProcess, context);
@@ -166,24 +167,27 @@ class JsonObjectFromTransferProcessV2024TransformerTest {
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
             return Stream.of(
-                    arguments(REQUESTING, toIri(DSPACE_VALUE_TRANSFER_STATE_REQUESTED_TERM)),
-                    arguments(REQUESTED, toIri(DSPACE_VALUE_TRANSFER_STATE_REQUESTED_TERM)),
-                    arguments(STARTING, toIri(DSPACE_VALUE_TRANSFER_STATE_STARTED_TERM)),
-                    arguments(STARTED, toIri(DSPACE_VALUE_TRANSFER_STATE_STARTED_TERM)),
-                    arguments(SUSPENDING, toIri(DSPACE_VALUE_TRANSFER_STATE_SUSPENDED_TERM)),
-                    arguments(SUSPENDING_REQUESTED, toIri(DSPACE_VALUE_TRANSFER_STATE_SUSPENDED_TERM)),
-                    arguments(SUSPENDED, toIri(DSPACE_VALUE_TRANSFER_STATE_SUSPENDED_TERM)),
-                    arguments(RESUMING, toIri(DSPACE_VALUE_TRANSFER_STATE_SUSPENDED_TERM)),
-                    arguments(RESUMED, toIri(DSPACE_VALUE_TRANSFER_STATE_SUSPENDED_TERM)),
-                    arguments(COMPLETING, toIri(DSPACE_VALUE_TRANSFER_STATE_COMPLETED_TERM)),
-                    arguments(COMPLETING_REQUESTED, toIri(DSPACE_VALUE_TRANSFER_STATE_COMPLETED_TERM)),
-                    arguments(COMPLETED, toIri(DSPACE_VALUE_TRANSFER_STATE_COMPLETED_TERM)),
-                    arguments(DEPROVISIONING, toIri(DSPACE_VALUE_TRANSFER_STATE_COMPLETED_TERM)),
-                    arguments(DEPROVISIONING_REQUESTED, toIri(DSPACE_VALUE_TRANSFER_STATE_COMPLETED_TERM)),
-                    arguments(DEPROVISIONED, toIri(DSPACE_VALUE_TRANSFER_STATE_COMPLETED_TERM)),
-                    arguments(TERMINATING, toIri(DSPACE_VALUE_TRANSFER_STATE_TERMINATED_TERM)),
-                    arguments(TERMINATING_REQUESTED, toIri(DSPACE_VALUE_TRANSFER_STATE_TERMINATED_TERM)),
-                    arguments(TERMINATED, toIri(DSPACE_VALUE_TRANSFER_STATE_TERMINATED_TERM))
+                    arguments(REQUESTING, toIri(DSPACE_VALUE_TRANSFER_STATE_REQUESTED_TERM), null),
+                    arguments(REQUESTED, toIri(DSPACE_VALUE_TRANSFER_STATE_REQUESTED_TERM), null),
+                    arguments(STARTING, toIri(DSPACE_VALUE_TRANSFER_STATE_STARTED_TERM), null),
+                    arguments(STARTED, toIri(DSPACE_VALUE_TRANSFER_STATE_STARTED_TERM), null),
+                    arguments(SUSPENDING, toIri(DSPACE_VALUE_TRANSFER_STATE_SUSPENDED_TERM), null),
+                    arguments(SUSPENDING_REQUESTED, toIri(DSPACE_VALUE_TRANSFER_STATE_SUSPENDED_TERM), null),
+                    arguments(SUSPENDED, toIri(DSPACE_VALUE_TRANSFER_STATE_SUSPENDED_TERM), null),
+                    arguments(RESUMING, toIri(DSPACE_VALUE_TRANSFER_STATE_SUSPENDED_TERM), null),
+                    arguments(RESUMED, toIri(DSPACE_VALUE_TRANSFER_STATE_SUSPENDED_TERM), null),
+                    arguments(COMPLETING, toIri(DSPACE_VALUE_TRANSFER_STATE_COMPLETED_TERM), null),
+                    arguments(COMPLETING_REQUESTED, toIri(DSPACE_VALUE_TRANSFER_STATE_COMPLETED_TERM), null),
+                    arguments(COMPLETED, toIri(DSPACE_VALUE_TRANSFER_STATE_COMPLETED_TERM), null),
+                    arguments(DEPROVISIONING, toIri(DSPACE_VALUE_TRANSFER_STATE_COMPLETED_TERM), null),
+                    arguments(DEPROVISIONING_REQUESTED, toIri(DSPACE_VALUE_TRANSFER_STATE_COMPLETED_TERM), null),
+                    arguments(DEPROVISIONED, toIri(DSPACE_VALUE_TRANSFER_STATE_COMPLETED_TERM), null),
+                    arguments(DEPROVISIONING, toIri(DSPACE_VALUE_TRANSFER_STATE_TERMINATED_TERM), "error`"),
+                    arguments(DEPROVISIONING_REQUESTED, toIri(DSPACE_VALUE_TRANSFER_STATE_TERMINATED_TERM), "error"),
+                    arguments(DEPROVISIONED, toIri(DSPACE_VALUE_TRANSFER_STATE_TERMINATED_TERM), "error"),
+                    arguments(TERMINATING, toIri(DSPACE_VALUE_TRANSFER_STATE_TERMINATED_TERM), null),
+                    arguments(TERMINATING_REQUESTED, toIri(DSPACE_VALUE_TRANSFER_STATE_TERMINATED_TERM), null),
+                    arguments(TERMINATED, toIri(DSPACE_VALUE_TRANSFER_STATE_TERMINATED_TERM), null)
             );
         }
     }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferProcess.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferProcess.java
@@ -308,14 +308,17 @@ public class TransferProcess extends StatefulEntity<TransferProcess> {
     }
 
     public void transitionCompleting() {
+        this.errorDetail = null;
         transition(COMPLETING, state -> canBeCompleted());
     }
 
     public void transitionCompletingRequested() {
+        this.errorDetail = null;
         transition(COMPLETING_REQUESTED, state -> canBeCompleted());
     }
 
     public void transitionCompleted() {
+        this.errorDetail = null;
         transition(COMPLETED, COMPLETED, COMPLETING, COMPLETING_REQUESTED, STARTED);
     }
 

--- a/spi/control-plane/transfer-spi/src/test/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferProcessTest.java
+++ b/spi/control-plane/transfer-spi/src/test/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferProcessTest.java
@@ -107,13 +107,14 @@ class TransferProcessTest {
 
         process.transitionCompleting();
         process.transitionCompleted();
-
+        assertThat(process.getErrorDetail()).isNull();
+        
         process.transitionDeprovisioning();
         process.transitionDeprovisioned();
     }
 
     @ParameterizedTest
-    @EnumSource(value = TransferProcessStates.class, mode = INCLUDE, names = { "STARTING", "SUSPENDED" })
+    @EnumSource(value = TransferProcessStates.class, mode = INCLUDE, names = {"STARTING", "SUSPENDED"})
     void shouldNotSetDataPlaneIdOnStart_whenTransferIsConsumer(TransferProcessStates fromState) {
         var process = TransferProcess.Builder.newInstance()
                 .id(UUID.randomUUID().toString()).type(CONSUMER)
@@ -145,6 +146,7 @@ class TransferProcessTest {
         process.transitionCompleting();
         process.transitionCompleted();
 
+
         process.transitionDeprovisioning();
         process.transitionDeprovisioned();
     }
@@ -153,7 +155,7 @@ class TransferProcessTest {
     @EnumSource(
             value = TransferProcessStates.class,
             mode = EXCLUDE,
-            names = { "COMPLETED", "TERMINATED", "DEPROVISIONING", "DEPROVISIONING_REQUESTED", "DEPROVISIONED", "RESUMED" }
+            names = {"COMPLETED", "TERMINATED", "DEPROVISIONING", "DEPROVISIONING_REQUESTED", "DEPROVISIONED", "RESUMED"}
     )
     void verifyTerminating_validStates(TransferProcessStates state) {
         var transferProcess = TransferProcess.Builder.newInstance()
@@ -167,7 +169,7 @@ class TransferProcessTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = TransferProcessStates.class, mode = INCLUDE, names = { "COMPLETED", "TERMINATED" })
+    @EnumSource(value = TransferProcessStates.class, mode = INCLUDE, names = {"COMPLETED", "TERMINATED"})
     void verifyTerminating_invalidStates(TransferProcessStates state) {
         var process = TransferProcess.Builder.newInstance()
                 .id(UUID.randomUUID().toString())

--- a/system-tests/dsp-compatibility-tests/compatibility-test-runner/src/test/java/org/eclipse/edc/tck/dsp/CompatibilityTests.java
+++ b/system-tests/dsp-compatibility-tests/compatibility-test-runner/src/test/java/org/eclipse/edc/tck/dsp/CompatibilityTests.java
@@ -18,8 +18,6 @@ import java.util.List;
 
 public interface CompatibilityTests {
 
-    // TODO Those remaining failures are due the fact that EDC consider the DEPROVISIONED state completed while the TCK expects terminated.
-    List<String> ALLOWED_FAILURES = List.of(
-            "TP:01-01", "TP:01-03", "TP:01-05");
+    List<String> ALLOWED_FAILURES = List.of();
 
 }

--- a/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/data/DataAssembly.java
+++ b/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/data/DataAssembly.java
@@ -237,7 +237,7 @@ public class DataAssembly {
         recorder.record("ATP0102", TransferProcess::transitionStarting);
         recorder.record("ATP0103", TransferProcess::transitionStarting);
         recorder.record("ATP0104", TransferProcess::transitionStarting);
-        recorder.record("ATP0105", TransferProcess::transitionTerminating);
+        recorder.record("ATP0105", tp -> tp.transitionTerminating("error"));
 
     }
 
@@ -282,7 +282,7 @@ public class DataAssembly {
 
     public static List<Trigger<TransferProcess>> createTransferProcessTriggers() {
         return List.of(
-                createTransferTrigger(TransferProcessStarted.class, "ATP0101", TransferProcess::transitionTerminating),
+                createTransferTrigger(TransferProcessStarted.class, "ATP0101", tp -> tp.transitionTerminating("error")),
                 createTransferTrigger(TransferProcessStarted.class, "ATP0102", TransferProcess::transitionCompleting),
                 createTransferTrigger(TransferProcessStarted.class, "ATP0103", (process) -> process.transitionSuspending("suspending")),
                 createTransferTrigger(TransferProcessSuspended.class, "ATP0103", (process) -> process.transitionTerminating("terminating")),


### PR DESCRIPTION
## What this PR changes/adds

Fixes dsp-tck tests:

- `TP:01-01`
- `TP:01-03`
- `TP:01-05`

We will base the decision if a TP is `TERMINATED` or `COMPLETED` only by checking the `errorDetail` field as a temporary workaround. This will not require any changes for users.

We can  revisit this behavior once https://github.com/eclipse-edc/Connector/issues/4793 is in.

## Why it does that

dsp-compliance

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5032 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
