### PR TITLE
feat: provider data-plane provisioning/deprovisioning

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProtocolServiceImpl.java
@@ -176,7 +176,7 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
         if (transferProcess.getType() == CONSUMER && transferProcess.canBeStartedConsumer()) {
             observable.invokeForEach(l -> l.preStarted(transferProcess));
             transferProcess.protocolMessageReceived(message.getId());
-            transferProcess.transitionStarted(transferProcess.getDataPlaneId());
+            transferProcess.transitionStarted();
             update(transferProcess);
             var transferStartedData = TransferProcessStartedData.Builder.newInstance()
                     .dataAddress(message.getDataAddress())

--- a/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/command/handlers/CompleteProvisionCommandHandler.java
+++ b/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/command/handlers/CompleteProvisionCommandHandler.java
@@ -42,7 +42,12 @@ public class CompleteProvisionCommandHandler extends EntityCommandHandler<Comple
         if (command.getNewAddress() != null) {
             entity.updateDestination(command.getNewAddress());
         }
-        entity.transitionProvisioned();
+
+        if (entity.getType() == TransferProcess.Type.CONSUMER) {
+            entity.transitionProvisioned();
+        } else {
+            entity.transitionStarting();
+        }
         return true;
     }
 

--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/provision/ResourceDefinitionGeneratorManagerImpl.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/provision/ResourceDefinitionGeneratorManagerImpl.java
@@ -20,7 +20,6 @@ import org.eclipse.edc.connector.dataplane.spi.provision.ResourceDefinitionGener
 import org.eclipse.edc.connector.dataplane.spi.provision.ResourceDefinitionGeneratorManager;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -30,6 +29,7 @@ import static java.util.stream.Collectors.toSet;
 public class ResourceDefinitionGeneratorManagerImpl implements ResourceDefinitionGeneratorManager {
 
     private final List<ResourceDefinitionGenerator> consumerGenerators = new ArrayList<>();
+    private final List<ResourceDefinitionGenerator> providerGenerators = new ArrayList<>();
 
     @Override
     public void registerConsumerGenerator(ResourceDefinitionGenerator generator) {
@@ -38,7 +38,7 @@ public class ResourceDefinitionGeneratorManagerImpl implements ResourceDefinitio
 
     @Override
     public void registerProviderGenerator(ResourceDefinitionGenerator generator) {
-
+        providerGenerators.add(generator);
     }
 
     @Override
@@ -52,7 +52,11 @@ public class ResourceDefinitionGeneratorManagerImpl implements ResourceDefinitio
 
     @Override
     public List<ProvisionResource> generateProviderResourceDefinition(DataFlow dataFlow) {
-        return Collections.emptyList();
+        return providerGenerators.stream()
+                .filter(g -> g.supportedType().equals(dataFlow.getDestination().getType()))
+                .map(g -> g.generate(dataFlow))
+                .filter(Objects::nonNull)
+                .toList();
     }
 
     @Override

--- a/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/provision/ResourceDefinitionGeneratorManagerImplTest.java
+++ b/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/provision/ResourceDefinitionGeneratorManagerImplTest.java
@@ -63,4 +63,29 @@ class ResourceDefinitionGeneratorManagerImplTest {
         }
     }
 
+    @Nested
+    class Provider {
+
+        private final ResourceDefinitionGenerator supportedGenerator = mock();
+
+        @BeforeEach
+        void setUp() {
+            when(supportedGenerator.supportedType()).thenReturn("supportedType");
+            when(supportedGenerator.generate(any())).thenReturn(new ProvisionResource());
+
+            manager.registerProviderGenerator(supportedGenerator);
+        }
+
+        @Test
+        void generate_shouldGenerateResources() {
+            var destination = DataAddress.Builder.newInstance().type("supportedType").build();
+            var dataFlow = DataFlow.Builder.newInstance().destination(destination).build();
+
+            var definitions = manager.generateProviderResourceDefinition(dataFlow);
+
+            assertThat(definitions).hasSize(1);
+        }
+
+    }
+
 }

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-api/src/test/java/org/eclipse/edc/connector/dataplane/api/controller/v1/DataPlaneSignalingApiControllerTest.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-api/src/test/java/org/eclipse/edc/connector/dataplane/api/controller/v1/DataPlaneSignalingApiControllerTest.java
@@ -43,6 +43,7 @@ import java.net.URI;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+import static org.eclipse.edc.spi.response.ResponseStatus.ERROR_RETRY;
 import static org.eclipse.edc.spi.result.Result.failure;
 import static org.eclipse.edc.spi.result.Result.success;
 import static org.mockito.ArgumentMatchers.any;
@@ -68,7 +69,7 @@ class DataPlaneSignalingApiControllerTest extends RestControllerTestBase {
                 .thenReturn(success(flowStartMessage));
         when(dataplaneManager.validate(any())).thenReturn(success());
         when(dataplaneManager.start(any()))
-                .thenReturn(success(flowResponse));
+                .thenReturn(StatusResult.success(flowResponse));
 
         when(transformerRegistry.transform(isA(DataFlowResponseMessage.class), eq(JsonObject.class)))
                 .thenReturn(success(Json.createObjectBuilder().add("foo", "bar").build()));
@@ -135,7 +136,7 @@ class DataPlaneSignalingApiControllerTest extends RestControllerTestBase {
                 .thenReturn(success(createFlowStartMessage()));
         when(dataplaneManager.validate(any())).thenReturn(success());
         when(dataplaneManager.start(any()))
-                .thenReturn(Result.failure("test-failure"));
+                .thenReturn(StatusResult.failure(ERROR_RETRY, "test-failure"));
 
         var jsonObject = Json.createObjectBuilder().build();
         baseRequest()
@@ -161,7 +162,7 @@ class DataPlaneSignalingApiControllerTest extends RestControllerTestBase {
                 .thenReturn(success(flowStartMessage));
         when(dataplaneManager.validate(any())).thenReturn(success());
         when(dataplaneManager.start(any()))
-                .thenReturn(success(flowResponse));
+                .thenReturn(StatusResult.success(flowResponse));
 
         when(transformerRegistry.transform(isA(DataAddress.class), eq(JsonObject.class)))
                 .thenReturn(failure("test-failure"));

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/test/java/org/eclipse/edc/connector/dataplane/client/EmbeddedDataPlaneClientTest.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/test/java/org/eclipse/edc/connector/dataplane/client/EmbeddedDataPlaneClientTest.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.dataplane.client;
 
 import org.eclipse.edc.connector.dataplane.selector.spi.client.DataPlaneClient;
 import org.eclipse.edc.connector.dataplane.spi.manager.DataPlaneManager;
+import org.eclipse.edc.spi.response.ResponseStatus;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.DataAddress;
@@ -73,7 +74,7 @@ class EmbeddedDataPlaneClientTest {
         var response = DataFlowResponseMessage.Builder.newInstance().dataAddress(DataAddress.Builder.newInstance().type("type").build()).build();
         var request = createDataFlowRequest();
         when(dataPlaneManager.validate(any())).thenReturn(Result.success());
-        when(dataPlaneManager.start(any())).thenReturn(Result.success(response));
+        when(dataPlaneManager.start(any())).thenReturn(StatusResult.success(response));
 
         var result = client.start(request);
 
@@ -88,7 +89,7 @@ class EmbeddedDataPlaneClientTest {
         var errorMsg = "error";
         var request = createDataFlowRequest();
         when(dataPlaneManager.validate(any())).thenReturn(Result.failure(errorMsg));
-        when(dataPlaneManager.start(any())).thenReturn(Result.success(DataFlowResponseMessage.Builder.newInstance().build()));
+        when(dataPlaneManager.start(any())).thenReturn(StatusResult.success(DataFlowResponseMessage.Builder.newInstance().build()));
 
         var result = client.start(request);
 
@@ -103,7 +104,7 @@ class EmbeddedDataPlaneClientTest {
         var errorMsg = "error";
         var request = createDataFlowRequest();
         when(dataPlaneManager.validate(any())).thenReturn(Result.success());
-        when(dataPlaneManager.start(any())).thenReturn(Result.failure(errorMsg));
+        when(dataPlaneManager.start(any())).thenReturn(StatusResult.failure(ResponseStatus.ERROR_RETRY, errorMsg));
 
         var result = client.start(request);
 

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/transfer/DataFlowStartMessage.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/transfer/DataFlowStartMessage.java
@@ -242,7 +242,9 @@ public class DataFlowStartMessage implements Polymorphic, TraceCarrier {
         }
 
         public Builder properties(Map<String, String> value) {
-            request.properties = value == null ? null : Map.copyOf(value);
+            if (value != null) {
+                request.properties.putAll(value);
+            }
             return this;
         }
 

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferProcess.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferProcess.java
@@ -62,6 +62,7 @@ import static org.eclipse.edc.connector.controlplane.transfer.spi.types.Transfer
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.RESUMING;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.STARTED;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.STARTING;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.STARTUP_REQUESTED;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.SUSPENDED;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.SUSPENDING;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.SUSPENDING_REQUESTED;
@@ -287,18 +288,17 @@ public class TransferProcess extends StatefulEntity<TransferProcess> {
     }
 
     public void transitionStarting() {
-        transition(STARTING, PROVISIONED, STARTING, SUSPENDED);
+        transition(STARTING, PROVISIONED, STARTING, SUSPENDED, STARTUP_REQUESTED);
     }
 
     public boolean canBeStartedConsumer() {
         return currentStateIsOneOf(STARTED, REQUESTED, STARTING, RESUMED, SUSPENDED);
     }
 
-    public void transitionStarted(String dataPlaneId) {
+    public void transitionStarted() {
         if (type == CONSUMER) {
             transition(STARTED, state -> canBeStartedConsumer());
         } else {
-            this.dataPlaneId = dataPlaneId;
             transition(STARTED, STARTED, STARTING, SUSPENDED, RESUMING);
         }
     }
@@ -345,8 +345,8 @@ public class TransferProcess extends StatefulEntity<TransferProcess> {
 
     public boolean canBeTerminated() {
         return currentStateIsOneOf(INITIAL, PROVISIONING, PROVISIONING_REQUESTED, PROVISIONED, REQUESTING, REQUESTED,
-                STARTING, STARTED, COMPLETING, COMPLETING_REQUESTED, SUSPENDING, SUSPENDING_REQUESTED, SUSPENDED,
-                RESUMING, TERMINATING, TERMINATING_REQUESTED);
+                STARTING, STARTUP_REQUESTED, STARTED, COMPLETING, COMPLETING_REQUESTED, SUSPENDING, SUSPENDING_REQUESTED,
+                SUSPENDED, RESUMING, TERMINATING, TERMINATING_REQUESTED);
     }
 
     public void transitionTerminating(@Nullable String errorDetail) {
@@ -409,6 +409,10 @@ public class TransferProcess extends StatefulEntity<TransferProcess> {
 
     public void transitionSuspended() {
         transition(SUSPENDED, state -> canBeSuspended());
+    }
+
+    public void transitionStartupRequested() {
+        transition(STARTUP_REQUESTED, STARTING);
     }
 
     public boolean currentStateIsOneOf(TransferProcessStates... states) {

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferProcessStates.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferProcessStates.java
@@ -29,6 +29,7 @@ public enum TransferProcessStates {
     REQUESTING(400),
     REQUESTED(500),
     STARTING(550),
+    STARTUP_REQUESTED(570),
     STARTED(600),
     SUSPENDING(650),
     SUSPENDING_REQUESTED(675),

--- a/spi/control-plane/transfer-spi/src/test/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferProcessTest.java
+++ b/spi/control-plane/transfer-spi/src/test/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferProcessTest.java
@@ -98,12 +98,12 @@ class TransferProcessTest {
         process.transitionRequested();
 
         assertThrows(IllegalStateException.class, process::transitionStarting, "STARTING is not a valid state for consumer");
-        process.transitionStarted("dataPlaneId");
+        process.transitionStarted();
 
         process.transitionSuspending("suspension");
         process.transitionSuspended();
 
-        process.transitionStarted("dataPlaneId");
+        process.transitionStarted();
 
         process.transitionCompleting();
         process.transitionCompleted();
@@ -121,7 +121,7 @@ class TransferProcessTest {
                 .state(fromState.code())
                 .build();
 
-        process.transitionStarted("dataPlaneId");
+        process.transitionStarted();
 
         assertThat(process.stateAsString()).isEqualTo(STARTED.name());
         assertThat(process.getDataPlaneId()).isNull();
@@ -138,10 +138,7 @@ class TransferProcessTest {
         assertThrows(IllegalStateException.class, process::transitionRequested, "REQUESTED is not a valid state for provider");
 
         process.transitionStarting();
-        process.transitionStarted("dataPlaneId");
-        // should set the data plane id
-        assertThat(process.getDataPlaneId()).isEqualTo("dataPlaneId");
-
+        process.transitionStarted();
 
         process.transitionCompleting();
         process.transitionCompleted();

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/iam/DataPlaneAuthorizationService.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/iam/DataPlaneAuthorizationService.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.connector.dataplane.spi.iam;
 
+import org.eclipse.edc.connector.dataplane.spi.DataFlow;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.types.domain.DataAddress;
@@ -57,10 +58,10 @@ public interface DataPlaneAuthorizationService {
      * <p>
      * In order to do so, the {@link DataPlaneAuthorizationService} delegates to the {@link DataPlaneAccessTokenService} to create the token.
      *
-     * @param message The message that was received from the control plane to initiate the transfer.
+     * @param dataFlow the data flow.
      * @return A result containing the {@link DataAddress}, or a failure indicating the cause.
      */
-    Result<DataAddress> createEndpointDataReference(DataFlowStartMessage message);
+    Result<DataAddress> createEndpointDataReference(DataFlow dataFlow);
 
     /**
      * Restores the original resource context (= {@link DataAddress}) for which the token was issued. Note that this correlation
@@ -72,7 +73,7 @@ public interface DataPlaneAuthorizationService {
      * or query params, etc.
      * <p>
      * The result (if successful) of this method is the original {@link DataAddress} that was passed to a previous invocation of
-     * {@link DataPlaneAuthorizationService#createEndpointDataReference(DataFlowStartMessage)}, i.e. {@link DataFlowStartMessage#getSourceDataAddress()}.
+     * {@link DataPlaneAuthorizationService#createEndpointDataReference(DataFlow)}, i.e. {@link DataFlowStartMessage#getSourceDataAddress()}.
      *
      * @param token       The raw, encoded token, e.g. serialized JWT
      * @param requestData Additional information about the request, such as a URL, query params, headers, etc.
@@ -82,7 +83,7 @@ public interface DataPlaneAuthorizationService {
 
 
     /**
-     * Revokes the {@link DataAddress} created with {@link #createEndpointDataReference(DataFlowStartMessage)}
+     * Revokes the {@link DataAddress} created with {@link #createEndpointDataReference(DataFlow)}
      *
      * @param transferProcessId The id of the transfer process associated to the {@link DataAddress}
      * @param reason            The reason of the revocation

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/iam/NoOpDataPlaneAuthorizationService.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/iam/NoOpDataPlaneAuthorizationService.java
@@ -14,10 +14,10 @@
 
 package org.eclipse.edc.connector.dataplane.spi.iam;
 
+import org.eclipse.edc.connector.dataplane.spi.DataFlow;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 
 import java.util.Map;
 
@@ -31,7 +31,7 @@ public class NoOpDataPlaneAuthorizationService implements DataPlaneAuthorization
             .failure("PULL transfers are not supported unless a proper DataPlaneAuthorizationService is registered");
 
     @Override
-    public Result<DataAddress> createEndpointDataReference(DataFlowStartMessage message) {
+    public Result<DataAddress> createEndpointDataReference(DataFlow dataFlow) {
         return FAILURE;
     }
 

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/manager/DataPlaneManager.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/manager/DataPlaneManager.java
@@ -50,11 +50,12 @@ public interface DataPlaneManager extends StateEntityManager {
 
     /**
      * Starts a transfer for the data flow request. This method is non-blocking with respect to processing the request.
+     * The implementation must be idempotent.
      *
      * @param startMessage The {@link DataFlowStartMessage}
      * @return success with the {@link DataFlowResponseMessage} if the request was correctly processed, failure otherwise
      */
-    Result<DataFlowResponseMessage> start(DataFlowStartMessage startMessage);
+    StatusResult<DataFlowResponseMessage> start(DataFlowStartMessage startMessage);
 
     /**
      * Returns the transfer state for the process.

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/port/TransferProcessApiClient.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/port/TransferProcessApiClient.java
@@ -52,4 +52,5 @@ public interface TransferProcessApiClient {
      * @return the result.
      */
     Result<Void> provisioned(String id, DataAddress newAddress);
+
 }

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/provision/Deprovisioner.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/provision/Deprovisioner.java
@@ -32,13 +32,13 @@ public interface Deprovisioner {
     String supportedType();
 
     /**
-     * Asynchronously deprovisions a resource used to perform the data transfer.
-     * Implementations must be idempotent.
-     * Implementations should not throw exceptions. If an unexpected exception occurs and the flow should be re-attempted, return
-     * {@link ResponseStatus#ERROR_RETRY}. If an exception occurs and re-tries should not be re-attempted, return
-     * {@link ResponseStatus#FATAL_ERROR}.
+     * Asynchronously deprovisions a resource used to perform the data transfer. Secrets cleanup needs to be done as well.
+     * Implementation must be idempotent and it should not throw exceptions.
+     * If an unexpected exception occurs and the flow should be re-attempted, return {@link ResponseStatus#ERROR_RETRY}.
+     * If an exception occurs and re-tries should not be re-attempted, return {@link ResponseStatus#FATAL_ERROR}.
      *
      * @param provisionResource that contains metadata associated with the provision operation
+     * @return the future containing the result
      */
     CompletableFuture<StatusResult<DeprovisionedResource>> deprovision(ProvisionResource provisionResource);
 

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/provision/ProvisionedResource.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/provision/ProvisionedResource.java
@@ -46,7 +46,7 @@ public class ProvisionedResource {
 
     public static class Builder {
 
-        private ProvisionedResource resource;
+        private final ProvisionedResource resource;
 
         public static Builder newInstance() {
             return new Builder();

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/provision/Provisioner.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/provision/Provisioner.java
@@ -32,13 +32,14 @@ public interface Provisioner {
     String supportedType();
 
     /**
-     * Asynchronously provisions a resource required to perform the data transfer.
-     * Implementations must be idempotent.
-     * Implementations should not throw exceptions. If an unexpected exception occurs and the flow should be re-attempted, return
-     * {@link ResponseStatus#ERROR_RETRY}. If an exception occurs and re-tries should not be re-attempted, return
-     * {@link ResponseStatus#FATAL_ERROR}.
+     * Asynchronously provisions a resource required to perform the data transfer. It can store secrets as well, that
+     * will need to be cleaned up by the {@link Deprovisioner}.
+     * Implementation must be idempotent and it should not throw exceptions.
+     * If an unexpected exception occurs and the flow should be re-attempted, return {@link ResponseStatus#ERROR_RETRY}.
+     * If an exception occurs and re-tries should not be re-attempted, return {@link ResponseStatus#FATAL_ERROR}.
      *
      * @param provisionResource that contains metadata associated with the provision operation
+     * @return the future containing the result
      */
     CompletableFuture<StatusResult<ProvisionedResource>> provision(ProvisionResource provisionResource);
 

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/provision/ProvisioningTransferConsumerEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/provision/ProvisioningTransferConsumerEndToEndTest.java
@@ -1,0 +1,293 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.e2e.provision;
+
+import okhttp3.Request;
+import org.eclipse.edc.connector.dataplane.spi.DataFlow;
+import org.eclipse.edc.connector.dataplane.spi.DataFlowStates;
+import org.eclipse.edc.connector.dataplane.spi.manager.DataPlaneManager;
+import org.eclipse.edc.connector.dataplane.spi.provision.DeprovisionedResource;
+import org.eclipse.edc.connector.dataplane.spi.provision.Deprovisioner;
+import org.eclipse.edc.connector.dataplane.spi.provision.ProvisionResource;
+import org.eclipse.edc.connector.dataplane.spi.provision.ProvisionedResource;
+import org.eclipse.edc.connector.dataplane.spi.provision.Provisioner;
+import org.eclipse.edc.connector.dataplane.spi.provision.ProvisionerManager;
+import org.eclipse.edc.connector.dataplane.spi.provision.ResourceDefinitionGenerator;
+import org.eclipse.edc.connector.dataplane.spi.provision.ResourceDefinitionGeneratorManager;
+import org.eclipse.edc.connector.dataplane.spi.store.DataPlaneStore;
+import org.eclipse.edc.http.spi.EdcHttpClient;
+import org.eclipse.edc.junit.extensions.RuntimeExtension;
+import org.eclipse.edc.junit.extensions.RuntimePerMethodExtension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.entity.StatefulEntity;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.test.e2e.Runtimes;
+import org.eclipse.edc.test.e2e.TransferEndToEndParticipant;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockserver.integration.ClientAndServer;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+
+import static jakarta.json.Json.createObjectBuilder;
+import static java.util.Collections.emptyList;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.eclipse.edc.connector.controlplane.test.system.utils.PolicyFixtures.noConstraintPolicy;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.COMPLETED;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+import static org.eclipse.edc.util.io.Ports.getFreePort;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+public class ProvisioningTransferConsumerEndToEndTest {
+
+    private static final TransferEndToEndParticipant CONSUMER = TransferEndToEndParticipant.Builder.newInstance()
+            .name("consumer")
+            .id("urn:connector:consumer")
+            .build();
+    private static final TransferEndToEndParticipant PROVIDER = TransferEndToEndParticipant.Builder.newInstance()
+            .name("provider")
+            .id("urn:connector:provider")
+            .build();
+    private static final int DESTINATION_BACKEND_PORT = getFreePort();
+
+    @RegisterExtension
+    @Order(0)
+    private final RuntimeExtension consumerControlPlane = new RuntimePerMethodExtension(
+            Runtimes.IN_MEMORY_CONTROL_PLANE_EMBEDDED_DATA_PLANE.create("consumer-control-plane")
+                    .configurationProvider(CONSUMER::controlPlaneEmbeddedDataPlaneConfig)
+                    .registerSystemExtension(ServiceExtension.class, new TestConsumerProvisionerExtension())
+    );
+
+    @RegisterExtension
+    @Order(0)
+    private final RuntimeExtension providerControlPlane = new RuntimePerMethodExtension(
+            Runtimes.IN_MEMORY_CONTROL_PLANE_EMBEDDED_DATA_PLANE.create("provider-control-plane")
+                    .configurationProvider(PROVIDER::controlPlaneEmbeddedDataPlaneConfig)
+    );
+
+    @Test
+    void shouldExecuteConsumerProvisioningAndDeprovisioning() {
+        var source = ClientAndServer.startClientAndServer(getFreePort());
+        source.when(request("/source")).respond(response("data"));
+        var destination = ClientAndServer.startClientAndServer(DESTINATION_BACKEND_PORT);
+        destination.when(request()).respond(response());
+        destination.when(request("/deprovision")).respond(response());
+
+        var assetId = UUID.randomUUID().toString();
+        var sourceDataAddress = Map.<String, Object>of(
+                EDC_NAMESPACE + "name", "transfer-test",
+                EDC_NAMESPACE + "baseUrl", "http://localhost:%d/source".formatted(source.getPort()),
+                EDC_NAMESPACE + "type", "HttpData"
+        );
+
+        createResourcesOnProvider(assetId, sourceDataAddress);
+
+        var consumerTransferProcessId = CONSUMER.requestAssetFrom(assetId, PROVIDER)
+                .withTransferType("HttpData-PUSH")
+                .withDestination(createObjectBuilder()
+                        .add(TYPE, EDC_NAMESPACE + "DataAddress")
+                        .add(EDC_NAMESPACE + "type", "HttpData")
+                        .add(EDC_NAMESPACE + "baseUrl", "http://localhost:%d/destination".formatted(destination.getPort()))
+                        .build()
+                )
+                .execute();
+
+        CONSUMER.awaitTransferToBeInState(consumerTransferProcessId, COMPLETED);
+
+        destination.verify(request().withHeader("provisionHeader", "value"));
+
+        await().untilAsserted(() -> destination.verify(request("/deprovision")));
+        await().untilAsserted(() -> {
+            var dataFlow = consumerControlPlane.getService(DataPlaneStore.class).findById(consumerTransferProcessId);
+            assertThat(dataFlow).isNotNull().extracting(StatefulEntity::getState).isEqualTo(DataFlowStates.DEPROVISIONED.code());
+        });
+
+        source.stop();
+        destination.stop();
+    }
+
+    private void createResourcesOnProvider(String assetId, Map<String, Object> dataAddressProperties) {
+        PROVIDER.createAsset(assetId, Map.of("description", "description"), dataAddressProperties);
+        var noConstraintPolicyId = PROVIDER.createPolicyDefinition(noConstraintPolicy());
+        PROVIDER.createContractDefinition(assetId, UUID.randomUUID().toString(), noConstraintPolicyId, noConstraintPolicyId);
+    }
+
+    private static class TestConsumerProvisionerExtension implements ServiceExtension {
+
+        @Inject
+        private ResourceDefinitionGeneratorManager resourceDefinitionGeneratorManager;
+
+        @Inject
+        private ProvisionerManager provisionerManager;
+
+        @Inject
+        private EdcHttpClient httpClient;
+
+        @Inject
+        private DataPlaneManager dataPlaneManager;
+
+        @Override
+        public void initialize(ServiceExtensionContext context) {
+            resourceDefinitionGeneratorManager.registerConsumerGenerator(new AddHeaderResourceGenerator());
+            resourceDefinitionGeneratorManager.registerConsumerGenerator(new AsyncResourceGenerator());
+
+            provisionerManager.register(new AddHeaderProvisioner());
+            provisionerManager.register(new CallEndpointDeprovisioner(httpClient));
+            provisionerManager.register(new AsyncProvisioner(dataPlaneManager));
+            provisionerManager.register(new AsyncDeprovisioner());
+        }
+
+        private static class CallEndpointDeprovisioner implements Deprovisioner {
+
+            private final EdcHttpClient httpClient;
+
+            CallEndpointDeprovisioner(EdcHttpClient httpClient) {
+                this.httpClient = httpClient;
+            }
+
+            @Override
+            public String supportedType() {
+                return "AddHeader";
+            }
+
+            @Override
+            public CompletableFuture<StatusResult<DeprovisionedResource>> deprovision(ProvisionResource definition) {
+                var deprovisionEndpoint = definition.getProperty("deprovisionEndpoint");
+                return httpClient.executeAsync(new Request.Builder().url((String) deprovisionEndpoint).build(), emptyList())
+                        .thenCompose(response -> {
+                            if (response.isSuccessful()) {
+                                return CompletableFuture.completedFuture(StatusResult.success(DeprovisionedResource.Builder.from(definition).build()));
+                            } else {
+                                return CompletableFuture.failedFuture(new EdcException("Deprovision failed"));
+                            }
+                        });
+            }
+        }
+
+        private static class AddHeaderProvisioner implements Provisioner {
+
+            @Override
+            public String supportedType() {
+                return "AddHeader";
+            }
+
+            @Override
+            public CompletableFuture<StatusResult<ProvisionedResource>> provision(ProvisionResource provisionResource) {
+                var provisionedResource = ProvisionedResource.Builder.from(provisionResource)
+                        .dataAddress(DataAddress.Builder.newInstance()
+                                .properties(provisionResource.getDataAddress().getProperties())
+                                .property("header:provisionHeader", "value")
+                                .build())
+                        .build();
+                return CompletableFuture.completedFuture(StatusResult.success(provisionedResource));
+            }
+
+        }
+
+        private static class AddHeaderResourceGenerator implements ResourceDefinitionGenerator {
+
+            @Override
+            public String supportedType() {
+                return "HttpData";
+            }
+
+            @Override
+            public ProvisionResource generate(DataFlow dataFlow) {
+                return ProvisionResource.Builder
+                        .newInstance()
+                        .flowId(dataFlow.getId())
+                        .dataAddress(dataFlow.getDestination())
+                        .type("AddHeader")
+                        .property("deprovisionEndpoint", "http://localhost:%d/deprovision".formatted(DESTINATION_BACKEND_PORT))
+                        .build();
+            }
+        }
+
+        private static class AsyncResourceGenerator implements ResourceDefinitionGenerator {
+
+            @Override
+            public String supportedType() {
+                return "HttpData";
+            }
+
+            @Override
+            public ProvisionResource generate(DataFlow dataFlow) {
+                return ProvisionResource.Builder
+                        .newInstance()
+                        .flowId(dataFlow.getId())
+                        .type("AsyncResource")
+                        .build();
+            }
+        }
+
+        /**
+         * Fake Async provisioner that schedules the response delivery after 2 seconds
+         */
+        private static class AsyncProvisioner implements Provisioner {
+
+            private final DataPlaneManager dataPlaneManager;
+
+            AsyncProvisioner(DataPlaneManager dataPlaneManager) {
+                this.dataPlaneManager = dataPlaneManager;
+            }
+
+            @Override
+            public String supportedType() {
+                return "AsyncResource";
+            }
+
+            @Override
+            public CompletableFuture<StatusResult<ProvisionedResource>> provision(ProvisionResource provisionResource) {
+                Executors.newScheduledThreadPool(1).schedule(() -> {
+                    var actualProvisionedResource = ProvisionedResource.Builder.from(provisionResource).build();
+                    return dataPlaneManager.resourceProvisioned(actualProvisionedResource);
+                }, 2, SECONDS);
+                var asyncProvisionedResource = ProvisionedResource.Builder.from(provisionResource).pending(true).build();
+                return CompletableFuture.completedFuture(StatusResult.success(asyncProvisionedResource));
+            }
+        }
+
+        private class AsyncDeprovisioner implements Deprovisioner {
+
+            @Override
+            public String supportedType() {
+                return "AsyncResource";
+            }
+
+            @Override
+            public CompletableFuture<StatusResult<DeprovisionedResource>> deprovision(ProvisionResource provisionResource) {
+                Executors.newScheduledThreadPool(1).schedule(() -> {
+                    var actualProvisionedResource = DeprovisionedResource.Builder.from(provisionResource).build();
+                    return dataPlaneManager.resourceDeprovisioned(actualProvisionedResource);
+                }, 2, SECONDS);
+                var resource = DeprovisionedResource.Builder.from(provisionResource).pending(true).build();
+                return CompletableFuture.completedFuture(StatusResult.success(resource));
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
## What this PR changes/adds

Implement data-plane provisioning/deprovisioning.

## Why it does that

Migrating provisioning from control-plane to data-plane

## Further notes
- create new status `STARTUP_REQUESTED`, that is symmetrical with the `PROVISION_REQUESTED`, but on the provider side: if there's any resource to be provisioned, the TP will be put in such state, waiting for the provisioning completion, at that point, the `STARTING` action will be triggered again, the eventual EDR will be created by the Data-Plane and the message will be sent to the consumer.
- `DataPlaneManager.start(DataFlowStartMessage startMessage)` is now idempotent: if the flow has already been created and provisioned, it will trigger the data flow, creating the eventual EDR to be returned to the control-plane and sent to the consumer.


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Part of #4793

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
