### PR TITLE
refactor: uniform state machine configurations

### DIFF
--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/ConfigurationInjectionPoint.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/ConfigurationInjectionPoint.java
@@ -16,7 +16,6 @@ package org.eclipse.edc.boot.system.injection;
 
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.runtime.metamodel.annotation.SettingContext;
-import org.eclipse.edc.runtime.metamodel.annotation.Settings;
 import org.eclipse.edc.spi.result.AbstractResult;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
@@ -24,7 +23,6 @@ import org.eclipse.edc.spi.system.ValueProvider;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;

--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/ConfigurationInjectionPoint.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/ConfigurationInjectionPoint.java
@@ -15,6 +15,8 @@
 package org.eclipse.edc.boot.system.injection;
 
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.runtime.metamodel.annotation.SettingContext;
+import org.eclipse.edc.runtime.metamodel.annotation.Settings;
 import org.eclipse.edc.spi.result.AbstractResult;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
@@ -22,6 +24,7 @@ import org.eclipse.edc.spi.system.ValueProvider;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -105,7 +108,7 @@ public class ConfigurationInjectionPoint<T> implements InjectionPoint<T> {
     public Object resolve(ServiceExtensionContext context, DefaultServiceSupplier defaultServiceSupplier) {
 
         // all fields annotated with the @Setting annotation
-        var settingsFields = resolveSettingsFields(context, configurationObject.getType().getDeclaredFields());
+        var settingsFields = resolveSettingsFields(context, configurationObject.getType().getDeclaredFields(), configurationObject.getAnnotation(SettingContext.class));
 
         // records are treated specially, because they only contain final fields, and must be constructed with a non-default CTOR
         // where every constructor arg MUST be named the same as the field value. We can't rely on this with normal classes
@@ -153,7 +156,7 @@ public class ConfigurationInjectionPoint<T> implements InjectionPoint<T> {
 
     @Override
     public Result<List<InjectionContainer<T>>> getProviders(Map<Class<?>, List<InjectionContainer<T>>> dependencyMap, ServiceExtensionContext context) {
-        var violators = injectionPointsFrom(configurationObject.getType().getDeclaredFields())
+        var violators = injectionPointsFrom(configurationObject.getType().getDeclaredFields(), null)
                 .map(ip -> ip.getProviders(dependencyMap, context))
                 .filter(Result::failed)
                 .map(AbstractResult::getFailureDetail)
@@ -179,8 +182,8 @@ public class ConfigurationInjectionPoint<T> implements InjectionPoint<T> {
 
     }
 
-    private @NotNull List<FieldValue> resolveSettingsFields(ServiceExtensionContext context, Field[] fields) {
-        return injectionPointsFrom(fields)
+    private @NotNull List<FieldValue> resolveSettingsFields(ServiceExtensionContext context, Field[] fields, SettingContext settingContext) {
+        return injectionPointsFrom(fields, settingContext)
                 .map(ip -> {
                     var val = ip.resolve(context, new InjectionPointDefaultServiceSupplier());
                     var fieldName = ip.getTargetField().getName();
@@ -189,10 +192,16 @@ public class ConfigurationInjectionPoint<T> implements InjectionPoint<T> {
                 .toList();
     }
 
-    private @NotNull Stream<ValueInjectionPoint<T>> injectionPointsFrom(Field[] fields) {
+    private @NotNull Stream<ValueInjectionPoint<T>> injectionPointsFrom(Field[] fields, SettingContext settingContext) {
         return Arrays.stream(fields)
                 .filter(f -> f.getAnnotation(Setting.class) != null)
-                .map(f -> new ValueInjectionPoint<>(null, f, f.getAnnotation(Setting.class), targetInstance.getClass()));
+                .map(f -> {
+                    if (settingContext == null) {
+                        return new ValueInjectionPoint<>(null, f, f.getAnnotation(Setting.class), targetInstance.getClass());
+                    } else {
+                        return new ValueInjectionPoint<>(null, f, f.getAnnotation(Setting.class), targetInstance.getClass(), settingContext);
+                    }
+                });
     }
 
     private record FieldValue(String fieldName, Object value) {

--- a/core/common/boot/src/test/java/org/eclipse/edc/boot/system/injection/ConfigurationInjectionPointTest.java
+++ b/core/common/boot/src/test/java/org/eclipse/edc/boot/system/injection/ConfigurationInjectionPointTest.java
@@ -18,6 +18,7 @@ import org.eclipse.edc.boot.system.testextensions.ConfigurationObject;
 import org.eclipse.edc.boot.system.testextensions.ExtensionWithConfigObject;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -31,91 +32,124 @@ import static org.mockito.Mockito.when;
 class ConfigurationInjectionPointTest {
 
     private final ExtensionWithConfigObject targetInstance = new ExtensionWithConfigObject();
-    private final ConfigurationInjectionPoint<ExtensionWithConfigObject> injectionPoint = new ConfigurationInjectionPoint<>(targetInstance, getDeclaredField(ExtensionWithConfigObject.class, "configurationObject"));
 
-    @Test
-    void getTargetInstance() {
-        assertThat(injectionPoint.getTargetInstance()).isEqualTo(targetInstance);
+    @Nested
+    class InjectConfigurationObject {
+        private final ConfigurationInjectionPoint<ExtensionWithConfigObject> injectionPoint = new ConfigurationInjectionPoint<>(
+                targetInstance, getDeclaredField(ExtensionWithConfigObject.class, "configurationObject"));
+
+        @Test
+        void getTargetInstance() {
+            assertThat(injectionPoint.getTargetInstance()).isEqualTo(targetInstance);
+        }
+
+        @Test
+        void getType() {
+            assertThat(injectionPoint.getType()).isEqualTo(ConfigurationObject.class);
+        }
+
+        @Test
+        void isRequired() {
+            assertThat(injectionPoint.isRequired()).isTrue();
+        }
+
+        @Test
+        void setTargetValue() {
+            var result = injectionPoint.setTargetValue(new ConfigurationObject("foo", 42L, null, 3.14159));
+
+            assertThat(result.succeeded()).isTrue();
+        }
+
+        @Test
+        void getDefaultValueProvider() {
+            assertThat(injectionPoint.getDefaultValueProvider()).isNull();
+        }
+
+        @Test
+        void resolve_record_isRequired_notResolved() {
+            var context = mock(ServiceExtensionContext.class);
+            when(context.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of()));
+            assertThatThrownBy(() -> injectionPoint.resolve(context, mock())).isInstanceOf(EdcInjectionException.class);
+        }
+
+        @Test
+        void resolve_objectIsRecord() {
+            var context = mock(ServiceExtensionContext.class);
+            when(context.getMonitor()).thenReturn(mock());
+            when(context.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of("foo.bar.baz", "asdf",
+                    "test.key3", "42")));
+
+            var res = injectionPoint.resolve(context, mock());
+            assertThat(res).isInstanceOf(ConfigurationObject.class);
+        }
+
+        @Test
+        void getProviders() {
+            var context = mock(ServiceExtensionContext.class);
+            when(context.getMonitor()).thenReturn(mock());
+            when(context.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of("foo.bar.baz", "asdf",
+                    "test.key3", "42")));
+
+            assertThat(injectionPoint.getProviders(Map.of(), context).succeeded()).isTrue();
+        }
+
+        @Test
+        void getProviders_hasViolations() {
+            var context = mock(ServiceExtensionContext.class);
+            when(context.getMonitor()).thenReturn(mock());
+            when(context.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of()));
+
+            var result = injectionPoint.getProviders(Map.of(), context);
+            assertThat(result.succeeded()).isFalse();
+            assertThat(result.getFailureDetail()).isEqualTo("Configuration object \"configurationObject\" of type [class org.eclipse.edc.boot.system.testextensions.ConfigurationObject], " +
+                    "through nested settings [Configuration value \"requiredVal\" of type [class java.lang.String] (property 'foo.bar.baz')]");
+        }
+
     }
 
-    @Test
-    void getType() {
-        assertThat(injectionPoint.getType()).isEqualTo(ConfigurationObject.class);
+    @Nested
+    class InjectOptionalConfigurationObject {
+
+        @Test
+        void resolve_objectIsClass() {
+            var injectionPoint = new ConfigurationInjectionPoint<>(targetInstance, getDeclaredField(ExtensionWithConfigObject.class, "optionalConfigurationObject"));
+            var context = mock(ServiceExtensionContext.class);
+            when(context.getMonitor()).thenReturn(mock());
+            when(context.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of("optional.key", "asdf")));
+
+            var result = injectionPoint.resolve(context, mock());
+
+            assertThat(result).isInstanceOf(ExtensionWithConfigObject.OptionalConfigurationObject.class);
+            assertThat(((ExtensionWithConfigObject.OptionalConfigurationObject) result).getVal()).isEqualTo("asdf");
+        }
+
+        @Test
+        void isRequired() {
+            var injectionPoint = new ConfigurationInjectionPoint<>(targetInstance, getDeclaredField(ExtensionWithConfigObject.class, "optionalConfigurationObject"));
+
+            assertThat(injectionPoint.isRequired()).isFalse();
+        }
     }
 
-    @Test
-    void isRequired() {
-        assertThat(injectionPoint.isRequired()).isTrue();
-        var ip = new ConfigurationInjectionPoint<>(targetInstance, getDeclaredField(ExtensionWithConfigObject.class, "optionalConfigurationObject"));
-        assertThat(ip.isRequired()).isFalse();
+    @Nested
+    class InjectConfigurationObjectWithContext {
+
+        @Test
+        void shouldPrependContextInSetting() {
+            var injectionPoint = new ConfigurationInjectionPoint<>(
+                    targetInstance, getDeclaredField(ExtensionWithConfigObject.class, "configurationObjectWithContext"));
+            var context = mock(ServiceExtensionContext.class);
+            when(context.getMonitor()).thenReturn(mock());
+            when(context.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of(
+                    "custom.context.foo.bar.baz", "asdf",
+                    "custom.context.test.key3", "42"
+            )));
+
+            var result = injectionPoint.resolve(context, mock());
+
+            assertThat(result).isInstanceOf(ConfigurationObject.class);
+        }
+
     }
 
-    @Test
-    void setTargetValue() throws IllegalAccessException {
-        assertThat(injectionPoint.setTargetValue(new ConfigurationObject("foo", 42L, null, 3.14159)).succeeded())
-                .isTrue();
-    }
-
-    @Test
-    void getDefaultValueProvider() {
-        assertThat(injectionPoint.getDefaultValueProvider()).isNull();
-    }
-
-    @Test
-    void setDefaultValueProvider() {
-        //noop
-    }
-
-    @Test
-    void resolve_record_isRequired_notResolved() {
-        var context = mock(ServiceExtensionContext.class);
-        when(context.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of()));
-        assertThatThrownBy(() -> injectionPoint.resolve(context, mock())).isInstanceOf(EdcInjectionException.class);
-    }
-
-    @Test
-    void resolve_objectIsRecord() {
-        var context = mock(ServiceExtensionContext.class);
-        when(context.getMonitor()).thenReturn(mock());
-        when(context.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of("foo.bar.baz", "asdf",
-                "test.key3", "42")));
-
-        var res = injectionPoint.resolve(context, mock());
-        assertThat(res).isInstanceOf(ConfigurationObject.class);
-    }
-
-    @Test
-    void resolve_objectIsClass() {
-        var ip = new ConfigurationInjectionPoint<>(targetInstance, getDeclaredField(ExtensionWithConfigObject.class, "optionalConfigurationObject"));
-        var context = mock(ServiceExtensionContext.class);
-        when(context.getMonitor()).thenReturn(mock());
-        when(context.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of("optional.key", "asdf")));
-
-        var result = ip.resolve(context, mock());
-
-        assertThat(result).isInstanceOf(ExtensionWithConfigObject.OptionalConfigurationObject.class);
-        assertThat(((ExtensionWithConfigObject.OptionalConfigurationObject) result).getVal()).isEqualTo("asdf");
-    }
-
-    @Test
-    void getProviders() {
-        var context = mock(ServiceExtensionContext.class);
-        when(context.getMonitor()).thenReturn(mock());
-        when(context.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of("foo.bar.baz", "asdf",
-                "test.key3", "42")));
-
-        assertThat(injectionPoint.getProviders(Map.of(), context).succeeded()).isTrue();
-    }
-
-    @Test
-    void getProviders_hasViolations() {
-        var context = mock(ServiceExtensionContext.class);
-        when(context.getMonitor()).thenReturn(mock());
-        when(context.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of()));
-
-        var result = injectionPoint.getProviders(Map.of(), context);
-        assertThat(result.succeeded()).isFalse();
-        assertThat(result.getFailureDetail()).isEqualTo("Configuration object \"configurationObject\" of type [class org.eclipse.edc.boot.system.testextensions.ConfigurationObject], " +
-                                                        "through nested settings [Configuration value \"requiredVal\" of type [class java.lang.String] (property 'foo.bar.baz')]");
-    }
 }

--- a/core/common/boot/src/test/java/org/eclipse/edc/boot/system/testextensions/ExtensionWithConfigObject.java
+++ b/core/common/boot/src/test/java/org/eclipse/edc/boot/system/testextensions/ExtensionWithConfigObject.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.boot.system.testextensions;
 
 import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.runtime.metamodel.annotation.SettingContext;
 import org.eclipse.edc.runtime.metamodel.annotation.Settings;
 import org.eclipse.edc.spi.system.ServiceExtension;
 
@@ -26,6 +27,10 @@ public class ExtensionWithConfigObject implements ServiceExtension {
 
     @Configuration // is optional because all @Settings within are optionsl
     private OptionalConfigurationObject optionalConfigurationObject;
+
+    @SettingContext("custom.context")
+    @Configuration
+    private ConfigurationObject configurationObjectWithContext;
 
     public ConfigurationObject getConfigurationObject() {
         return configurationObject;

--- a/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/AbstractStateEntityManager.java
+++ b/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/AbstractStateEntityManager.java
@@ -37,14 +37,9 @@ import java.util.Objects;
  */
 public abstract class AbstractStateEntityManager<E extends StatefulEntity<E>, S extends StateEntityStore<E>> implements StateEntityManager {
 
-    public static final long DEFAULT_ITERATION_WAIT = 1000;
-    public static final int DEFAULT_BATCH_SIZE = 20;
-    public static final int DEFAULT_SEND_RETRY_LIMIT = 7;
-    public static final long DEFAULT_SEND_RETRY_BASE_DELAY = 1000L;
-
     protected Monitor monitor;
-    protected int batchSize = DEFAULT_BATCH_SIZE;
-    protected WaitStrategy waitStrategy = () -> DEFAULT_ITERATION_WAIT;
+    protected int batchSize = StateMachineConfiguration.DEFAULT_BATCH_SIZE;
+    protected WaitStrategy waitStrategy = () -> StateMachineConfiguration.DEFAULT_ITERATION_WAIT;
     protected ExecutorInstrumentation executorInstrumentation = ExecutorInstrumentation.noop();
     protected Telemetry telemetry = new Telemetry();
     protected EntityRetryProcessConfiguration entityRetryProcessConfiguration = defaultEntityRetryProcessConfiguration();
@@ -79,7 +74,10 @@ public abstract class AbstractStateEntityManager<E extends StatefulEntity<E>, S 
 
     @NotNull
     private EntityRetryProcessConfiguration defaultEntityRetryProcessConfiguration() {
-        return new EntityRetryProcessConfiguration(DEFAULT_SEND_RETRY_LIMIT, () -> new ExponentialWaitStrategy(DEFAULT_SEND_RETRY_BASE_DELAY));
+        return new EntityRetryProcessConfiguration(
+                StateMachineConfiguration.DEFAULT_SEND_RETRY_LIMIT,
+                () -> new ExponentialWaitStrategy(StateMachineConfiguration.DEFAULT_SEND_RETRY_BASE_DELAY)
+        );
     }
 
     protected void update(E entity) {

--- a/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/StateMachineConfiguration.java
+++ b/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/StateMachineConfiguration.java
@@ -19,7 +19,9 @@ import org.eclipse.edc.runtime.metamodel.annotation.Settings;
 import org.eclipse.edc.spi.retry.ExponentialWaitStrategy;
 import org.eclipse.edc.statemachine.retry.EntityRetryProcessConfiguration;
 
-// TODO: document
+/**
+ * Defines basic configuration for a {@link StateMachineManager}.
+ */
 @Settings
 public record StateMachineConfiguration(
 

--- a/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/StateMachineConfiguration.java
+++ b/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/StateMachineConfiguration.java
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.statemachine;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.runtime.metamodel.annotation.Settings;
+import org.eclipse.edc.spi.retry.ExponentialWaitStrategy;
+import org.eclipse.edc.statemachine.retry.EntityRetryProcessConfiguration;
+
+// TODO: document
+@Settings
+public record StateMachineConfiguration(
+
+        @Setting(
+                description = "The iteration wait time in milliseconds in the state machine.",
+                key = "state-machine.iteration-wait-millis",
+                defaultValue = DEFAULT_ITERATION_WAIT + ""
+        )
+        long iterationWaitMillis,
+
+        @Setting(
+                description = "The number of entities to be processed on every iteration.",
+                key = "state-machine.batch-size",
+                defaultValue = DEFAULT_BATCH_SIZE + ""
+        )
+        int batchSize,
+
+        @Setting(
+                description = "How many times a specific operation must be tried before failing with error",
+                key = "send.retry.limit",
+                defaultValue = DEFAULT_SEND_RETRY_LIMIT + ""
+        )
+        int sendRetryLimit,
+
+        @Setting(
+                description = "The base delay for the consumer negotiation retry mechanism in millisecond",
+                key = "send.retry.base-delay.ms",
+                defaultValue = DEFAULT_SEND_RETRY_BASE_DELAY + ""
+        )
+        int sendRetryBaseDelayMs
+
+) {
+
+    public static final long DEFAULT_ITERATION_WAIT = 1000;
+    public static final int DEFAULT_BATCH_SIZE = 20;
+    public static final int DEFAULT_SEND_RETRY_LIMIT = 7;
+    public static final long DEFAULT_SEND_RETRY_BASE_DELAY = 1000L;
+
+    public ExponentialWaitStrategy baseDelayExponentialWaitStrategy() {
+        return new ExponentialWaitStrategy(sendRetryBaseDelayMs);
+    }
+
+    public EntityRetryProcessConfiguration entityRetryProcessConfiguration() {
+        return new EntityRetryProcessConfiguration(sendRetryLimit, this::baseDelayExponentialWaitStrategy);
+    }
+
+    public ExponentialWaitStrategy iterationWaitExponentialWaitStrategy() {
+        return new ExponentialWaitStrategy(iterationWaitMillis);
+    }
+}

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferEndToEndParticipant.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferEndToEndParticipant.java
@@ -59,18 +59,16 @@ public class TransferEndToEndParticipant extends Participant {
                 put("web.http.control.port", String.valueOf(controlPlaneControl.get().getPort()));
                 put("web.http.control.path", controlPlaneControl.get().getPath());
                 put("edc.dsp.callback.address", controlPlaneProtocol.get().toString());
-                put("edc.keystore", resourceAbsolutePath("certs/cert.pfx"));
-                put("edc.keystore.password", "123456");
                 put("edc.transfer.send.retry.limit", "1");
                 put("edc.transfer.send.retry.base-delay.ms", "100");
                 put("edc.negotiation.consumer.send.retry.limit", "1");
                 put("edc.negotiation.provider.send.retry.limit", "1");
                 put("edc.negotiation.consumer.send.retry.base-delay.ms", "100");
                 put("edc.negotiation.provider.send.retry.base-delay.ms", "100");
-
                 put("edc.negotiation.consumer.state-machine.iteration-wait-millis", "50");
                 put("edc.negotiation.provider.state-machine.iteration-wait-millis", "50");
                 put("edc.transfer.state-machine.iteration-wait-millis", "50");
+                put("edc.data.plane.selector.state-machine.iteration-wait-millis", "100");
 
                 put("provisioner.http.entries.default.provisioner.type", "provider");
                 put("provisioner.http.entries.default.endpoint", "http://localhost:%d/provision".formatted(httpProvisionerPort.get()));
@@ -88,8 +86,6 @@ public class TransferEndToEndParticipant extends Participant {
                 put("web.http.path", "/api");
                 put("web.http.control.port", String.valueOf(dataPlaneControl.get().getPort()));
                 put("web.http.control.path", dataPlaneControl.get().getPath());
-                put("edc.keystore", resourceAbsolutePath("certs/cert.pfx"));
-                put("edc.keystore.password", "123456");
                 put("edc.transfer.proxy.token.signer.privatekey.alias", "private-key");
                 put("edc.transfer.proxy.token.verifier.publickey.alias", "public-key");
                 put("edc.dataplane.http.sink.partition.size", "1");


### PR DESCRIPTION
## What this PR changes/adds

Extract the `StateMachineConfiguration` record, that represent the configuration for a generic state machine.
To have this working I had to implement the `SettingContext` functionality in the configuration injection.

It's now possibile to define common configuration structure appliable to different contexts.

## Why it does that

cleanup

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5046 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
