### PR TITLE
feat: move upsert into database for contract negotiation

### DIFF
--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/store/SqlContractNegotiationStore.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/store/SqlContractNegotiationStore.java
@@ -45,7 +45,6 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static java.lang.String.format;
-import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -123,13 +122,34 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
         var id = negotiation.getId();
         transactionContext.execute(() -> {
             try (var connection = getConnection()) {
-                var existing = findInternal(connection, id);
-                if (existing == null) {
-                    insert(connection, negotiation);
-                } else {
-                    leaseContext.withConnection(connection).breakLease(id);
-                    update(connection, id, negotiation);
+
+                if (negotiation.getContractAgreement() != null) {
+                    upsertAgreement(negotiation.getContractAgreement());
                 }
+
+                var stmt = statements.getUpsertNegotiationTemplate();
+
+                queryExecutor.execute(connection, stmt,
+                        negotiation.getId(),
+                        negotiation.getCorrelationId(),
+                        negotiation.getCounterPartyId(),
+                        negotiation.getCounterPartyAddress(),
+                        negotiation.getType().name(),
+                        negotiation.getProtocol(),
+                        negotiation.getState(),
+                        negotiation.getStateCount(),
+                        negotiation.getStateTimestamp(),
+                        negotiation.getErrorDetail(),
+                        negotiation.getContractAgreement() == null ? null : negotiation.getContractAgreement().getId(),
+                        toJson(negotiation.getContractOffers()),
+                        toJson(negotiation.getCallbackAddresses()),
+                        toJson(negotiation.getTraceContext()),
+                        negotiation.getCreatedAt(),
+                        negotiation.getUpdatedAt(),
+                        negotiation.isPending(),
+                        toJson(negotiation.getProtocolMessages()));
+
+                leaseContext.withConnection(connection).breakLease(id);
             } catch (SQLException e) {
                 throw new EdcPersistenceException(e);
             }
@@ -215,84 +235,19 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
         return queryExecutor.single(connection, false, contractNegotiationMapper(), sql, id);
     }
 
-    private void update(Connection connection, String negotiationId, ContractNegotiation updatedValues) {
-        var stmt = statements.getUpdateNegotiationTemplate();
-
-        if (updatedValues.getContractAgreement() != null) {
-            upsertAgreement(updatedValues.getContractAgreement());
-        }
-
-        queryExecutor.execute(connection, stmt,
-                updatedValues.getState(),
-                updatedValues.getStateCount(),
-                updatedValues.getStateTimestamp(),
-                updatedValues.getErrorDetail(),
-                toJson(updatedValues.getContractOffers()),
-                toJson(updatedValues.getCallbackAddresses()),
-                toJson(updatedValues.getTraceContext()),
-                ofNullable(updatedValues.getContractAgreement()).map(ContractAgreement::getId).orElse(null),
-                updatedValues.getUpdatedAt(),
-                updatedValues.isPending(),
-                updatedValues.getCorrelationId(),
-                toJson(updatedValues.getProtocolMessages()),
-                negotiationId);
-    }
-
-    private void insert(Connection connection, ContractNegotiation negotiation) {
-        String agrId = null;
-        var agreement = negotiation.getContractAgreement();
-        if (agreement != null) {
-            agrId = agreement.getId();
-            upsertAgreement(agreement);
-        }
-
-        var stmt = statements.getInsertNegotiationTemplate();
-        queryExecutor.execute(connection, stmt,
-                negotiation.getId(),
-                negotiation.getCorrelationId(),
-                negotiation.getCounterPartyId(),
-                negotiation.getCounterPartyAddress(),
-                negotiation.getType().name(),
-                negotiation.getProtocol(),
-                negotiation.getState(),
-                negotiation.getStateCount(),
-                negotiation.getStateTimestamp(),
-                negotiation.getErrorDetail(),
-                agrId,
-                toJson(negotiation.getContractOffers()),
-                toJson(negotiation.getCallbackAddresses()),
-                toJson(negotiation.getTraceContext()),
-                negotiation.getCreatedAt(),
-                negotiation.getUpdatedAt(),
-                negotiation.isPending(),
-                toJson(negotiation.getProtocolMessages()));
-    }
-
     private void upsertAgreement(ContractAgreement contractAgreement) {
         transactionContext.execute(() -> {
             try (var connection = getConnection()) {
-                var agrId = contractAgreement.getId();
+                var sql = statements.getUpsertAgreementTemplate();
 
-                if (findContractAgreement(agrId) == null) {
-                    // insert agreement
-                    var sql = statements.getInsertAgreementTemplate();
-                    queryExecutor.execute(connection, sql, contractAgreement.getId(),
-                            contractAgreement.getProviderId(),
-                            contractAgreement.getConsumerId(),
-                            contractAgreement.getContractSigningDate(),
-                            contractAgreement.getAssetId(),
-                            toJson(contractAgreement.getPolicy())
-                    );
-                } else {
-                    // update agreement
-                    var query = statements.getUpdateAgreementTemplate();
-                    queryExecutor.execute(connection, query, contractAgreement.getProviderId(),
-                            contractAgreement.getConsumerId(),
-                            contractAgreement.getContractSigningDate(),
-                            contractAgreement.getAssetId(),
-                            toJson(contractAgreement.getPolicy()),
-                            agrId);
-                }
+                queryExecutor.execute(connection, sql,
+                        contractAgreement.getId(),
+                        contractAgreement.getProviderId(),
+                        contractAgreement.getConsumerId(),
+                        contractAgreement.getContractSigningDate(),
+                        contractAgreement.getAssetId(),
+                        toJson(contractAgreement.getPolicy())
+                );
 
             } catch (SQLException e) {
                 throw new EdcPersistenceException(e);

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/store/schema/BaseSqlDialectStatements.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/store/schema/BaseSqlDialectStatements.java
@@ -94,13 +94,37 @@ public class BaseSqlDialectStatements implements ContractNegotiationStatements {
     }
 
     @Override
+    public String getUpsertNegotiationTemplate() {
+        return executeStatement()
+                .column(getIdColumn())
+                .column(getCorrelationIdColumn())
+                .column(getCounterPartyIdColumn())
+                .column(getCounterPartyAddressColumn())
+                .column(getTypeColumn())
+                .column(getProtocolColumn())
+                .column(getStateColumn())
+                .column(getStateCountColumn())
+                .column(getStateTimestampColumn())
+                .column(getErrorDetailColumn())
+                .column(getContractAgreementIdFkColumn())
+                .jsonColumn(getContractOffersColumn())
+                .jsonColumn(getCallbackAddressesColumn())
+                .jsonColumn(getTraceContextColumn())
+                .column(getCreatedAtColumn())
+                .column(getUpdatedAtColumn())
+                .column(getPendingColumn())
+                .jsonColumn(getProtocolMessagesColumn())
+                .upsertInto(getContractNegotiationTable(), getIdColumn());
+    }
+
+    @Override
     public String getSelectFromAgreementsTemplate() {
         // todo: add WHERE ... AND ... ORDER BY... statements here
         return format("SELECT * FROM %s", getContractAgreementTable());
     }
 
     @Override
-    public String getInsertAgreementTemplate() {
+    public String getUpsertAgreementTemplate() {
         return executeStatement()
                 .column(getContractAgreementIdColumn())
                 .column(getProviderAgentColumn())
@@ -108,19 +132,7 @@ public class BaseSqlDialectStatements implements ContractNegotiationStatements {
                 .column(getSigningDateColumn())
                 .column(getAssetIdColumn())
                 .jsonColumn(getPolicyColumn())
-                .insertInto(getContractAgreementTable());
-    }
-
-    @Override
-    public String getUpdateAgreementTemplate() {
-        return executeStatement()
-                .column(getProviderAgentColumn())
-                .column(getConsumerAgentColumn())
-                .column(getSigningDateColumn())
-                .column(getAssetIdColumn())
-                .jsonColumn(getPolicyColumn())
-                .update(getContractAgreementTable(), getContractAgreementIdColumn());
-
+                .upsertInto(getContractAgreementTable(), getContractAgreementIdColumn());
     }
 
     @Override

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/store/schema/ContractNegotiationStatements.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/store/schema/ContractNegotiationStatements.java
@@ -34,13 +34,13 @@ public interface ContractNegotiationStatements extends StatefulEntityStatements,
 
     String getDeleteTemplate();
 
+    String getUpsertNegotiationTemplate();
+
     String getSelectFromAgreementsTemplate();
 
-    String getInsertAgreementTemplate();
-
-    String getUpdateAgreementTemplate();
-
     String getSelectNegotiationsTemplate();
+
+    String getUpsertAgreementTemplate();
 
     default String getContractNegotiationTable() {
         return "edc_contract_negotiation";

--- a/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/controlplane/contract/spi/testfixtures/negotiation/store/ContractNegotiationStoreTestBase.java
+++ b/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/controlplane/contract/spi/testfixtures/negotiation/store/ContractNegotiationStoreTestBase.java
@@ -48,8 +48,8 @@ import java.util.stream.Collectors;
 import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.eclipse.edc.connector.controlplane.contract.spi.testfixtures.negotiation.store.TestFunctions.createContract;
-import static org.eclipse.edc.connector.controlplane.contract.spi.testfixtures.negotiation.store.TestFunctions.createContractBuilder;
+import static org.eclipse.edc.connector.controlplane.contract.spi.testfixtures.negotiation.store.TestFunctions.createAgreement;
+import static org.eclipse.edc.connector.controlplane.contract.spi.testfixtures.negotiation.store.TestFunctions.createAgreementBuilder;
 import static org.eclipse.edc.connector.controlplane.contract.spi.testfixtures.negotiation.store.TestFunctions.createNegotiation;
 import static org.eclipse.edc.connector.controlplane.contract.spi.testfixtures.negotiation.store.TestFunctions.createNegotiationBuilder;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.Type.CONSUMER;
@@ -127,7 +127,7 @@ public abstract class ContractNegotiationStoreTestBase {
         @Test
         @DisplayName("Find ContractAgreement by contract ID")
         void findContractAgreement() {
-            var agreement = createContract(ContractOfferId.create("test-cd1", "test-as1"));
+            var agreement = createAgreement(ContractOfferId.create("test-cd1", "test-as1"));
             var negotiation = createNegotiation("test-cn1", agreement);
             getContractNegotiationStore().save(negotiation);
 
@@ -181,9 +181,8 @@ public abstract class ContractNegotiationStoreTestBase {
         }
 
         @Test
-        @DisplayName("Verify that entity and related entities are stored")
-        void withContract() {
-            var agreement = createContract(ContractOfferId.create("definition", "asset"));
+        void shouldSave_whenAgreementExists() {
+            var agreement = createAgreement(ContractOfferId.create("definition", "asset"));
             var negotiation = createNegotiation("test-negotiation", agreement);
             getContractNegotiationStore().save(negotiation);
 
@@ -199,8 +198,7 @@ public abstract class ContractNegotiationStoreTestBase {
     @Nested
     class Update {
         @Test
-        @DisplayName("Verify that an existing entity is updated instead")
-        void save_exists_shouldUpdate() {
+        void shouldUpdate_whenEntityExists() {
             var id = "test-id1";
             var negotiation = createNegotiation(id);
             getContractNegotiationStore().save(negotiation);
@@ -248,7 +246,6 @@ public abstract class ContractNegotiationStoreTestBase {
 
             var next = getContractNegotiationStore().nextNotLeased(10, hasState(800));
             assertThat(next).usingRecursiveFieldByFieldElementComparatorIgnoringFields("updatedAt").containsOnly(newNegotiation);
-
         }
 
         @Test
@@ -284,7 +281,7 @@ public abstract class ContractNegotiationStoreTestBase {
             getContractNegotiationStore().save(negotiation);
 
             // now add the agreement
-            var agreement = createContract(ContractOfferId.create("definition", "asset"));
+            var agreement = createAgreement(ContractOfferId.create("definition", "asset"));
             var updatedNegotiation = createNegotiation(negotiationId, agreement);
 
             getContractNegotiationStore().save(updatedNegotiation); //should perform an update + insert
@@ -322,7 +319,7 @@ public abstract class ContractNegotiationStoreTestBase {
             getContractNegotiationStore().save(negotiation);
 
             // now add the agreement
-            var agreement = createContract(ContractOfferId.create("definition", "asset"));
+            var agreement = createAgreement(ContractOfferId.create("definition", "asset"));
             var updatedNegotiation = createNegotiation(negotiationId, agreement);
 
             getContractNegotiationStore().save(updatedNegotiation);
@@ -340,7 +337,7 @@ public abstract class ContractNegotiationStoreTestBase {
         @DisplayName("Should update the agreement when a negotiation is updated")
         void whenAgreementExists_shouldUpdate() {
             var negotiationId = "test-cn1";
-            var agreement = createContract(ContractOfferId.create("definition", "asset"));
+            var agreement = createAgreement(ContractOfferId.create("definition", "asset"));
             var negotiation = createNegotiation(negotiationId, null);
             getContractNegotiationStore().save(negotiation);
             var dbNegotiation = getContractNegotiationStore().findById(negotiationId);
@@ -400,7 +397,7 @@ public abstract class ContractNegotiationStoreTestBase {
         @DisplayName("Verify that attempting to delete a negotiation with a contract raises an exception")
         void contractExists() {
             var id = UUID.randomUUID().toString();
-            var contract = createContract(ContractOfferId.create("definition", "asset"));
+            var contract = createAgreement(ContractOfferId.create("definition", "asset"));
             var n = createNegotiation(id, contract);
             getContractNegotiationStore().save(n);
 
@@ -457,7 +454,7 @@ public abstract class ContractNegotiationStoreTestBase {
 
         @Test
         void withAgreementOnAsset_negotiationWithAgreement() {
-            var agreement = createContract(ContractOfferId.create("definition", "asset"));
+            var agreement = createAgreement(ContractOfferId.create("definition", "asset"));
             var negotiation = createNegotiation("negotiation1", agreement);
             var assetId = agreement.getAssetId();
 
@@ -491,8 +488,8 @@ public abstract class ContractNegotiationStoreTestBase {
         @Test
         void withAgreementOnAsset_multipleNegotiationsSameAsset() {
             var assetId = UUID.randomUUID().toString();
-            var negotiation1 = createNegotiation("negotiation1", createContractBuilder("contract1").assetId(assetId).build());
-            var negotiation2 = createNegotiation("negotiation2", createContractBuilder("contract2").assetId(assetId).build());
+            var negotiation1 = createNegotiation("negotiation1", createAgreementBuilder("contract1").assetId(assetId).build());
+            var negotiation2 = createNegotiation("negotiation2", createAgreementBuilder("contract2").assetId(assetId).build());
 
             getContractNegotiationStore().save(negotiation1);
             getContractNegotiationStore().save(negotiation2);
@@ -514,7 +511,7 @@ public abstract class ContractNegotiationStoreTestBase {
 
             range(0, 100)
                     .mapToObj(i -> {
-                        var agreement = createContract(ContractOfferId.create("definition" + 1, "asset"));
+                        var agreement = createAgreement(ContractOfferId.create("definition" + 1, "asset"));
                         return createNegotiation(String.valueOf(i), agreement);
                     })
                     .forEach(cn -> getContractNegotiationStore().save(cn));
@@ -542,8 +539,8 @@ public abstract class ContractNegotiationStoreTestBase {
         void byAgreementId() {
             var contractId1 = ContractOfferId.create("def1", "asset");
             var contractId2 = ContractOfferId.create("def2", "asset");
-            var negotiation1 = createNegotiation("neg1", createContract(contractId1));
-            var negotiation2 = createNegotiation("neg2", createContract(contractId2));
+            var negotiation1 = createNegotiation("neg1", createAgreement(contractId1));
+            var negotiation2 = createNegotiation("neg2", createAgreement(contractId2));
             getContractNegotiationStore().save(negotiation1);
             getContractNegotiationStore().save(negotiation2);
             var expression = criterion("contractAgreement.id", "=", contractId1.toString());
@@ -571,8 +568,8 @@ public abstract class ContractNegotiationStoreTestBase {
                             .build())
                     .build();
 
-            var agreement1 = createContractBuilder("agr1").policy(policy).build();
-            var agreement2 = createContractBuilder("agr2").policy(policy).build();
+            var agreement1 = createAgreementBuilder("agr1").policy(policy).build();
+            var agreement2 = createAgreementBuilder("agr2").policy(policy).build();
             var negotiation1 = createNegotiation("neg1", agreement1);
             var negotiation2 = createNegotiation("neg2", agreement2);
             getContractNegotiationStore().save(negotiation1);
@@ -588,7 +585,7 @@ public abstract class ContractNegotiationStoreTestBase {
         @Test
         void shouldReturnEmpty_whenCriteriaLeftOperandIsInvalid() {
             var contractId = ContractOfferId.create("definition", "asset");
-            var agreement1 = createContract(contractId);
+            var agreement1 = createAgreement(contractId);
             var negotiation1 = createNegotiation("neg1", agreement1);
             getContractNegotiationStore().save(negotiation1);
 
@@ -614,7 +611,7 @@ public abstract class ContractNegotiationStoreTestBase {
         @Test
         void shouldReturnAllItems_whenQuerySpecHasNoFilter() {
             range(0, 10).forEach(i -> {
-                var contractAgreement = createContract(ContractOfferId.create(UUID.randomUUID().toString(), ASSET_ID));
+                var contractAgreement = createAgreement(ContractOfferId.create(UUID.randomUUID().toString(), ASSET_ID));
                 var negotiation = createNegotiation(UUID.randomUUID().toString(), contractAgreement);
                 getContractNegotiationStore().save(negotiation);
             });
@@ -628,7 +625,7 @@ public abstract class ContractNegotiationStoreTestBase {
         void withQuerySpec() {
             range(0, 10).mapToObj(i -> "asset-" + i).forEach(assetId -> {
                 var contractId = ContractOfferId.create(UUID.randomUUID().toString(), assetId).toString();
-                var contractAgreement = createContractBuilder(contractId).assetId(assetId).build();
+                var contractAgreement = createAgreementBuilder(contractId).assetId(assetId).build();
                 var negotiation = createNegotiation(UUID.randomUUID().toString(), contractAgreement);
                 getContractNegotiationStore().save(negotiation);
             });
@@ -642,7 +639,7 @@ public abstract class ContractNegotiationStoreTestBase {
         @Test
         void verifyPaging() {
             range(0, 10).forEach(i -> {
-                var contractAgreement = createContract(ContractOfferId.create(UUID.randomUUID().toString(), ASSET_ID));
+                var contractAgreement = createAgreement(ContractOfferId.create(UUID.randomUUID().toString(), ASSET_ID));
                 var negotiation = createNegotiation(UUID.randomUUID().toString(), contractAgreement);
                 getContractNegotiationStore().save(negotiation);
             });
@@ -658,7 +655,7 @@ public abstract class ContractNegotiationStoreTestBase {
         void verifySorting() {
             range(0, 9).forEach(i -> {
                 var contractId = ContractOfferId.create(UUID.randomUUID().toString(), UUID.randomUUID().toString()).toString();
-                var contractAgreement = createContractBuilder(contractId).consumerId(String.valueOf(i)).build();
+                var contractAgreement = createAgreementBuilder(contractId).consumerId(String.valueOf(i)).build();
                 var negotiation = createNegotiationBuilder(UUID.randomUUID().toString()).contractAgreement(contractAgreement).build();
                 getContractNegotiationStore().save(negotiation);
             });
@@ -673,7 +670,7 @@ public abstract class ContractNegotiationStoreTestBase {
         @Test
         void shouldReturnEmpty_whenCriterionLeftOperandIsInvalid() {
             range(0, 10).mapToObj(i -> "asset-" + i).forEach(assetId -> {
-                var contractAgreement = createContractBuilder(ContractOfferId.create(UUID.randomUUID().toString(), assetId).toString())
+                var contractAgreement = createAgreementBuilder(ContractOfferId.create(UUID.randomUUID().toString(), assetId).toString())
                         .assetId(assetId)
                         .build();
                 var negotiation = createNegotiation(UUID.randomUUID().toString(), contractAgreement);
@@ -771,7 +768,7 @@ public abstract class ContractNegotiationStoreTestBase {
         @Test
         @DisplayName("Verify that nextNotLeased returns the agreement")
         void withAgreement() {
-            var contractAgreement = createContract(ContractOfferId.create(UUID.randomUUID().toString(), ASSET_ID));
+            var contractAgreement = createAgreement(ContractOfferId.create(UUID.randomUUID().toString(), ASSET_ID));
             var negotiation = createNegotiationBuilder(UUID.randomUUID().toString())
                     .contractAgreement(contractAgreement)
                     .state(ContractNegotiationStates.AGREED.code())

--- a/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/controlplane/contract/spi/testfixtures/negotiation/store/TestFunctions.java
+++ b/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/controlplane/contract/spi/testfixtures/negotiation/store/TestFunctions.java
@@ -49,12 +49,12 @@ public class TestFunctions {
                 .build();
     }
 
-    public static ContractAgreement createContract(ContractOfferId contractOfferId) {
-        return createContractBuilder(contractOfferId.toString())
+    public static ContractAgreement createAgreement(ContractOfferId contractOfferId) {
+        return createAgreementBuilder(contractOfferId.toString())
                 .build();
     }
 
-    public static ContractAgreement.Builder createContractBuilder(String id) {
+    public static ContractAgreement.Builder createAgreementBuilder(String id) {
         return ContractAgreement.Builder.newInstance()
                 .id(id)
                 .providerId("provider")


### PR DESCRIPTION
## What this PR changes/adds

Implements UPSERT mechanism in the database.
This PR is a sort of PoC to demonstrate how the refactor will look like, and it will applied on the whole codebase once agreement is reached.

Pros:
- faster (this is also the [suggested approach in the postgresql documentation](https://www.postgresql.org/docs/current/sql-insert.html#SQL-ON-CONFLICT)):
  > ON CONFLICT DO UPDATE guarantees an atomic INSERT or UPDATE outcome; provided there is no independent error, one of those two outcomes is guaranteed, even under high concurrency. This is also known as UPSERT — “UPDATE or INSERT”.
- less code :)

Cons:
- there's no way to tell if the break lease needs to be executed or not, so it will be executed anyway also for insertions. This is a little price to pay, given that the majority of the statements for stateful entities are updates in any case. I foresee two different solutions for this:
  - change the breakLease implementation from the "get the lease, if no ownership throw exception, delete the lease" logic into the "delete the lease only if the ownership is correct, no exception thrown". There's no real need to check for ownership, if there's no ownership, the delete could just be avoided. (this would be my choice, because it will also speed up the break lease operation)
  - add a `RETURNING` clause to the statement, so it will be possible for caller to understand if it was an insert or an update 


## Why it does that

Avoid unnecessary operations.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Part of #5051

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
