### PR TITLE
refactor: deprecate 'pre' methods in TransferProcessListener

### DIFF
--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/observe/TransferProcessListener.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/observe/TransferProcessListener.java
@@ -32,7 +32,9 @@ public interface TransferProcessListener {
      * {@link TransferProcessStates#INITIAL INITIAL}, but before the change is persisted.
      *
      * @param process the transfer process whose state has changed.
+     * @deprecated will be removed soon.
      */
+    @Deprecated(since = "0.14.0")
     default void preCreated(TransferProcess process) {
     }
 
@@ -41,7 +43,9 @@ public interface TransferProcessListener {
      * {@link TransferProcessStates#PROVISIONING PROVISIONING}, but before the change is persisted.
      *
      * @param process the transfer process whose state has changed.
+     * @deprecated will be removed soon.
      */
+    @Deprecated(since = "0.14.0")
     default void preProvisioning(TransferProcess process) {
     }
 
@@ -50,7 +54,9 @@ public interface TransferProcessListener {
      * {@link TransferProcessStates#PROVISIONED PROVISIONED}, but before the change is persisted.
      *
      * @param process the transfer process whose state has changed.
+     * @deprecated will be removed soon.
      */
+    @Deprecated(since = "0.14.0")
     default void preProvisioned(TransferProcess process) {
     }
 
@@ -59,7 +65,9 @@ public interface TransferProcessListener {
      * {@link TransferProcessStates#REQUESTING REQUESTING}, but before the change is persisted.
      *
      * @param process the transfer process whose state has changed.
+     * @deprecated will be removed soon.
      */
+    @Deprecated(since = "0.14.0")
     default void preRequesting(TransferProcess process) {
     }
 
@@ -68,7 +76,9 @@ public interface TransferProcessListener {
      * {@link TransferProcessStates#REQUESTED REQUESTED}, but before the change is persisted.
      *
      * @param process the transfer process whose state has changed.
+     * @deprecated will be removed soon.
      */
+    @Deprecated(since = "0.14.0")
     default void preRequested(TransferProcess process) {
     }
 
@@ -77,7 +87,9 @@ public interface TransferProcessListener {
      * {@link TransferProcessStates#STARTED}, but before the change is persisted.
      *
      * @param process the transfer process whose state has changed.
+     * @deprecated will be removed soon.
      */
+    @Deprecated(since = "0.14.0")
     default void preStarted(TransferProcess process) {
     }
 
@@ -86,7 +98,9 @@ public interface TransferProcessListener {
      * {@link TransferProcessStates#COMPLETED COMPLETED}, but before the change is persisted.
      *
      * @param process the transfer process whose state has changed.
+     * @deprecated will be removed soon.
      */
+    @Deprecated(since = "0.14.0")
     default void preCompleted(TransferProcess process) {
     }
 
@@ -95,7 +109,9 @@ public interface TransferProcessListener {
      * {@link TransferProcessStates#DEPROVISIONING DEPROVISIONING}, but before the change is persisted.
      *
      * @param process the transfer process whose state has changed.
+     * @deprecated will be removed soon.
      */
+    @Deprecated(since = "0.14.0")
     default void preDeprovisioning(TransferProcess process) {
     }
 
@@ -104,7 +120,9 @@ public interface TransferProcessListener {
      * {@link TransferProcessStates#DEPROVISIONED DEPROVISIONED}, but before the change is persisted.
      *
      * @param process the transfer process whose state has changed.
+     * @deprecated will be removed soon.
      */
+    @Deprecated(since = "0.14.0")
     default void preDeprovisioned(TransferProcess process) {
     }
 
@@ -113,7 +131,9 @@ public interface TransferProcessListener {
      * {@link TransferProcessStates#TERMINATED}, but before the change is persisted.
      *
      * @param process the transfer process whose state has changed.
+     * @deprecated will be removed soon.
      */
+    @Deprecated(since = "0.14.0")
     default void preTerminated(TransferProcess process) {
     }
 


### PR DESCRIPTION
## What this PR changes/adds

Deprecated "pre" methods, as outlined in the DR (#5057 )

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5056


_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
