### PR TITLE
fix: Improve BitString class (url-decoder, multibase)

### DIFF
--- a/extensions/common/iam/verifiable-credentials/src/main/java/org/eclipse/edc/iam/verifiablecredentials/revocation/bitstring/BitstringStatusListRevocationService.java
+++ b/extensions/common/iam/verifiable-credentials/src/main/java/org/eclipse/edc/iam/verifiablecredentials/revocation/bitstring/BitstringStatusListRevocationService.java
@@ -24,7 +24,6 @@ import org.eclipse.edc.iam.verifiablecredentials.spi.model.revocation.bitstrings
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.revocation.bitstringstatuslist.StatusMessage;
 import org.eclipse.edc.spi.result.Result;
 
-import java.util.Base64;
 import java.util.Collection;
 
 import static org.eclipse.edc.spi.result.Result.success;
@@ -57,15 +56,8 @@ public class BitstringStatusListRevocationService extends BaseRevocationListServ
         var bitStringCredential = bitStringCredentialResult.getContent();
 
         var bitString = bitStringCredential.encodedList();
-        var decoder = Base64.getDecoder();
-        if (bitString.charAt(0) == 'u') { // base64 url
-            decoder = Base64.getUrlDecoder();
-            bitString = bitString.substring(1); //chop off header
-        } else if (bitString.charAt(0) == 'z') { //base58btc
-            return Result.failure("The encoded list is using the Base58-BTC alphabet ('z' multibase header), which is not supported.");
-        }
 
-        var compressedBitstring = BitString.Parser.newInstance().decoder(decoder).parse(bitString);
+        var compressedBitstring = BitString.Parser.newInstance().parse(bitString);
         if (compressedBitstring.failed()) {
             return compressedBitstring.mapEmpty();
         }

--- a/extensions/common/iam/verifiable-credentials/src/test/java/org/eclipse/edc/iam/verifiablecredentials/revocation/bitstring/BitstringStatusListRevocationServiceTest.java
+++ b/extensions/common/iam/verifiable-credentials/src/test/java/org/eclipse/edc/iam/verifiablecredentials/revocation/bitstring/BitstringStatusListRevocationServiceTest.java
@@ -82,7 +82,7 @@ class BitstringStatusListRevocationServiceTest {
         var bitstring = BitString.Builder.newInstance().size(1024 * 16).build();
         bitstring.set(index, value != 0);
 
-        return "u" + BitString.Writer.newInstance().encoder(Base64.getUrlEncoder().withoutPadding()).write(bitstring).getContent();
+        return BitString.Writer.newInstance().encoder(Base64.getUrlEncoder().withoutPadding()).writeMultibase(bitstring).getContent();
     }
 
     @Nested


### PR DESCRIPTION
## What this PR changes/adds

This PR does two things:

- makes the `BitString.Parser` slightly more intelligent in that it automatically uses a Base64UrlDecode without padding if the encoded list is prefixed with the `"u"` character
- adds a `writeMultibase` method to the `BitString.Writer` which preprends the `"u"` character upon encoding.

## Why it does that

convenient use of multibase encoding and Base64 decoding

## Further notes

in the `BitstringStatusListRevocationService` I removed the section of code that previously handled the different Base64 prefixes. Those were moved to the `BitString.Parser`

## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.

## Linked Issue(s)

Closes #5047

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
