### PR TITLE
fix: use correct context for JtiValidationRule

### DIFF
--- a/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtension.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/main/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtension.java
@@ -177,7 +177,7 @@ public class IdentityAndTrustExtension implements ServiceExtension {
         rulesRegistry.addRule(JWT_VC_TOKEN_CONTEXT, new HasSubjectRule());
 
         if (activateJtiValidation) {
-            rulesRegistry.addRule(JWT_VC_TOKEN_CONTEXT, new JtiValidationRule(jtiValidationStore, context.getMonitor()));
+            rulesRegistry.addRule(DCP_SELF_ISSUED_TOKEN_CONTEXT, new JtiValidationRule(jtiValidationStore, context.getMonitor()));
         }
 
         try {

--- a/extensions/common/iam/identity-trust/identity-trust-core/src/test/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtensionTest.java
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/test/java/org/eclipse/edc/iam/identitytrust/core/IdentityAndTrustExtensionTest.java
@@ -24,17 +24,30 @@ import org.eclipse.edc.spi.system.ExecutorInstrumentation;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.token.TokenValidationRulesRegistryImpl;
+import org.eclipse.edc.token.rules.AudienceValidationRule;
+import org.eclipse.edc.token.rules.ExpirationIssuedAtValidationRule;
+import org.eclipse.edc.token.rules.NotBeforeValidationRule;
+import org.eclipse.edc.token.spi.TokenValidationRule;
+import org.eclipse.edc.token.spi.TokenValidationRulesRegistry;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.verifiablecredentials.jwt.rules.IssuerEqualsSubjectRule;
+import org.eclipse.edc.verifiablecredentials.jwt.rules.JtiValidationRule;
+import org.eclipse.edc.verifiablecredentials.jwt.rules.SubJwkIsNullRule;
+import org.eclipse.edc.verifiablecredentials.jwt.rules.TokenNotNullRule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.eclipse.edc.iam.identitytrust.core.IdentityAndTrustExtension.DCP_CLIENT_CONTEXT;
+import static org.eclipse.edc.iam.identitytrust.core.IdentityAndTrustExtension.DCP_SELF_ISSUED_TOKEN_CONTEXT;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -47,6 +60,7 @@ class IdentityAndTrustExtensionTest {
     private static final String CLEANUP_PERIOD = "edc.sql.store.jti.cleanup.period";
     private final JtiValidationStore storeMock = mock();
     private final TypeTransformerRegistry transformerRegistry = mock();
+    private final TokenValidationRulesRegistry rulesRegistry = new TokenValidationRulesRegistryImpl();
 
     @BeforeEach
     void setUp(ServiceExtensionContext context) {
@@ -55,10 +69,12 @@ class IdentityAndTrustExtensionTest {
         context.registerService(JtiValidationStore.class, storeMock);
         context.registerService(ExecutorInstrumentation.class, ExecutorInstrumentation.noop());
         context.registerService(TypeTransformerRegistry.class, transformerRegistry);
+        context.registerService(TokenValidationRulesRegistry.class, rulesRegistry);
 
         var config = ConfigFactory.fromMap(Map.of(
                 CONNECTOR_DID_PROPERTY, "did:web:test",
                 CLEANUP_PERIOD, "1"
+
         ));
         when(context.getConfig()).thenReturn(config);
         when(transformerRegistry.forContext(DCP_CLIENT_CONTEXT)).thenReturn(transformerRegistry);
@@ -68,6 +84,54 @@ class IdentityAndTrustExtensionTest {
     void verifyCorrectService(ServiceExtensionContext context, ObjectFactory objectFactory) {
         var is = objectFactory.constructInstance(IdentityAndTrustExtension.class).createIdentityService(context);
         assertThat(is).isInstanceOf(IdentityAndTrustService.class);
+    }
+
+    // unfortunately, this cannot be a parameterized test, because then we'd have 2 competing parameter resolvers: DependencyInjectionExtension and
+    // the Parameterized test method resolver
+    @Test
+    void verifyCorrectRules_jtiValidationActive(ServiceExtensionContext context, ObjectFactory objectFactory) {
+        var oldConfig = context.getConfig();
+        var newConfig = new HashMap<>(oldConfig.getEntries());
+        newConfig.put("edc.iam.accesstoken.jti.validation", "true");
+        when(context.getConfig()).thenReturn(ConfigFactory.fromMap(newConfig));
+
+        var expectedRules = Arrays.asList(IssuerEqualsSubjectRule.class,
+                SubJwkIsNullRule.class,
+                AudienceValidationRule.class,
+                ExpirationIssuedAtValidationRule.class,
+                TokenNotNullRule.class,
+                JtiValidationRule.class,
+                NotBeforeValidationRule.class);
+
+        var extension = objectFactory.constructInstance(IdentityAndTrustExtension.class);
+        extension.initialize(context);
+        assertThat(rulesRegistry.getRules(DCP_SELF_ISSUED_TOKEN_CONTEXT))
+                .extracting(TokenValidationRule::getClass)
+                .containsExactlyInAnyOrderElementsOf(expectedRules);
+
+    }
+
+    @Test
+    void verifyCorrectRules_jtiValidationNotActive(ServiceExtensionContext context, ObjectFactory objectFactory) {
+        var oldConfig = context.getConfig();
+        var newConfig = new HashMap<>(oldConfig.getEntries());
+        newConfig.put("edc.iam.accesstoken.jti.validation", "false");
+        when(context.getConfig()).thenReturn(ConfigFactory.fromMap(newConfig));
+
+        var expectedRules = Arrays.asList(IssuerEqualsSubjectRule.class,
+                SubJwkIsNullRule.class,
+                AudienceValidationRule.class,
+                ExpirationIssuedAtValidationRule.class,
+                TokenNotNullRule.class,
+                // JtiValidationRule.class, should not be present when jti validation is disabled
+                NotBeforeValidationRule.class);
+
+        var extension = objectFactory.constructInstance(IdentityAndTrustExtension.class);
+        extension.initialize(context);
+        assertThat(rulesRegistry.getRules(DCP_SELF_ISSUED_TOKEN_CONTEXT))
+                .extracting(TokenValidationRule::getClass)
+                .containsExactlyInAnyOrderElementsOf(expectedRules);
+
     }
 
     @Test


### PR DESCRIPTION
## What this PR changes/adds

register the JtiValidationRule in the `DCP_SELF_ISSUED_TOKEN_CONTEXT` instead of the `JWT_VC_TOKEN_CONTEXT`

## Why it does that

by definition, VCs encoded as JWT will have a JTI that contains the credential ID, so the JTI will be "constant".
In addition, DCP only requires the JTI of a Self-issued ID token be validated.


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.

## Linked Issue(s)

Closes

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
