### PR TITLE
refactor: data-plane remote consumer provisioning

### DIFF
--- a/core/common/lib/transform-lib/src/main/java/org/eclipse/edc/transform/transformer/edc/from/JsonObjectFromDataPlaneInstanceTransformer.java
+++ b/core/common/lib/transform-lib/src/main/java/org/eclipse/edc/transform/transformer/edc/from/JsonObjectFromDataPlaneInstanceTransformer.java
@@ -30,6 +30,7 @@ import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlan
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_TRANSFER_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.DATAPLANE_INSTANCE_STATE;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.DATAPLANE_INSTANCE_STATE_TIMESTAMP;
+import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.DESTINATION_PROVISION_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.LAST_ACTIVE;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.PROPERTIES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.URL;
@@ -54,7 +55,12 @@ public class JsonObjectFromDataPlaneInstanceTransformer extends AbstractJsonLdTr
                 .add(ID, dataPlaneInstance.getId())
                 .add(TYPE, DataPlaneInstance.DATAPLANE_INSTANCE_TYPE)
                 .add(URL, dataPlaneInstance.getUrl().toString())
-                .add(LAST_ACTIVE, dataPlaneInstance.getLastActive());
+                .add(LAST_ACTIVE, dataPlaneInstance.getLastActive())
+                .add(DATAPLANE_INSTANCE_STATE_TIMESTAMP, dataPlaneInstance.getStateTimestamp())
+                .add(ALLOWED_SOURCE_TYPES, jsonFactory.createArrayBuilder(dataPlaneInstance.getAllowedSourceTypes()))
+                .add(ALLOWED_TRANSFER_TYPES, jsonFactory.createArrayBuilder(dataPlaneInstance.getAllowedTransferTypes()))
+                .add(DESTINATION_PROVISION_TYPES, jsonFactory.createArrayBuilder(dataPlaneInstance.getDestinationProvisionTypes()));
+
 
         if (dataPlaneInstance.getProperties() != null && !dataPlaneInstance.getProperties().isEmpty()) {
             var propBuilder = jsonFactory.createObjectBuilder();
@@ -62,19 +68,11 @@ public class JsonObjectFromDataPlaneInstanceTransformer extends AbstractJsonLdTr
             builder.add(PROPERTIES, propBuilder);
         }
 
-        var srcBldr = jsonFactory.createArrayBuilder(dataPlaneInstance.getAllowedSourceTypes());
-        builder.add(ALLOWED_SOURCE_TYPES, srcBldr);
-
-        var transferTypesBldr = jsonFactory.createArrayBuilder(dataPlaneInstance.getAllowedTransferTypes());
-        builder.add(ALLOWED_TRANSFER_TYPES, transferTypesBldr);
-
         var state = Optional.ofNullable(DataPlaneInstanceStates.from(dataPlaneInstance.getState()))
                 .map(Enum::name)
                 .orElse(null);
 
         addIfNotNull(state, DATAPLANE_INSTANCE_STATE, builder);
-
-        builder.add(DATAPLANE_INSTANCE_STATE_TIMESTAMP, dataPlaneInstance.getStateTimestamp());
 
         return builder.build();
     }

--- a/core/common/lib/transform-lib/src/main/java/org/eclipse/edc/transform/transformer/edc/from/JsonObjectFromDataPlaneInstanceV3Transformer.java
+++ b/core/common/lib/transform-lib/src/main/java/org/eclipse/edc/transform/transformer/edc/from/JsonObjectFromDataPlaneInstanceV3Transformer.java
@@ -31,6 +31,7 @@ import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlan
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.ALLOWED_TRANSFER_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.DATAPLANE_INSTANCE_STATE;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.DATAPLANE_INSTANCE_STATE_TIMESTAMP;
+import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.DESTINATION_PROVISION_TYPES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.LAST_ACTIVE;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.PROPERTIES;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.TURN_COUNT;
@@ -57,7 +58,12 @@ public class JsonObjectFromDataPlaneInstanceV3Transformer extends AbstractJsonLd
                 .add(TYPE, DataPlaneInstance.DATAPLANE_INSTANCE_TYPE)
                 .add(URL, dataPlaneInstance.getUrl().toString())
                 .add(LAST_ACTIVE, dataPlaneInstance.getLastActive())
-                .add(TURN_COUNT, dataPlaneInstance.getTurnCount());
+                .add(TURN_COUNT, dataPlaneInstance.getTurnCount())
+                .add(DATAPLANE_INSTANCE_STATE_TIMESTAMP, dataPlaneInstance.getStateTimestamp())
+                .add(ALLOWED_SOURCE_TYPES, jsonFactory.createArrayBuilder(dataPlaneInstance.getAllowedSourceTypes()))
+                .add(ALLOWED_DEST_TYPES, jsonFactory.createArrayBuilder(dataPlaneInstance.getAllowedDestTypes()))
+                .add(ALLOWED_TRANSFER_TYPES, jsonFactory.createArrayBuilder(dataPlaneInstance.getAllowedTransferTypes()))
+                .add(DESTINATION_PROVISION_TYPES, jsonFactory.createArrayBuilder(dataPlaneInstance.getDestinationProvisionTypes()));
 
         if (dataPlaneInstance.getProperties() != null && !dataPlaneInstance.getProperties().isEmpty()) {
             var propBuilder = jsonFactory.createObjectBuilder();
@@ -65,22 +71,11 @@ public class JsonObjectFromDataPlaneInstanceV3Transformer extends AbstractJsonLd
             builder.add(PROPERTIES, propBuilder);
         }
 
-        var srcBldr = jsonFactory.createArrayBuilder(dataPlaneInstance.getAllowedSourceTypes());
-        builder.add(ALLOWED_SOURCE_TYPES, srcBldr);
-
-        var dstBldr = jsonFactory.createArrayBuilder(dataPlaneInstance.getAllowedDestTypes());
-        builder.add(ALLOWED_DEST_TYPES, dstBldr);
-
-        var transferTypesBldr = jsonFactory.createArrayBuilder(dataPlaneInstance.getAllowedTransferTypes());
-        builder.add(ALLOWED_TRANSFER_TYPES, transferTypesBldr);
-
         var state = Optional.ofNullable(DataPlaneInstanceStates.from(dataPlaneInstance.getState()))
                 .map(Enum::name)
                 .orElse(null);
 
         addIfNotNull(state, DATAPLANE_INSTANCE_STATE, builder);
-
-        builder.add(DATAPLANE_INSTANCE_STATE_TIMESTAMP, dataPlaneInstance.getStateTimestamp());
 
         return builder.build();
     }

--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImpl.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImpl.java
@@ -107,7 +107,7 @@ public class DataPlaneManagerImpl extends AbstractStateEntityManager<DataFlow, D
     }
 
     @Override
-    public Result<DataFlowResponseMessage> provision(DataFlowProvisionMessage message) {
+    public StatusResult<DataFlowResponseMessage> provision(DataFlowProvisionMessage message) {
         var dataFlow = DataFlow.Builder.newInstance()
                 .id(message.getProcessId())
                 .destination(message.getDestination())
@@ -128,7 +128,7 @@ public class DataPlaneManagerImpl extends AbstractStateEntityManager<DataFlow, D
 
         update(dataFlow);
 
-        return Result.success(DataFlowResponseMessage.Builder.newInstance()
+        return StatusResult.success(DataFlowResponseMessage.Builder.newInstance()
                 .provisioning(!resources.isEmpty())
                 .build());
     }
@@ -229,7 +229,7 @@ public class DataPlaneManagerImpl extends AbstractStateEntityManager<DataFlow, D
                     flow.resourceProvisioned(List.of(provisionedResource));
 
                     if (flow.isProvisionCompleted()) {
-                        transferProcessClient.provisioned(flow.getId(), flow.provisionedDataAddress());
+                        transferProcessClient.provisioned(flow);
                     }
 
                     update(flow);
@@ -378,7 +378,7 @@ public class DataPlaneManagerImpl extends AbstractStateEntityManager<DataFlow, D
                     flow.resourceProvisioned(provisionedResources);
 
                     if (flow.isProvisionCompleted()) {
-                        transferProcessClient.provisioned(flow.getId(), flow.provisionedDataAddress());
+                        transferProcessClient.provisioned(flow);
                     }
 
                     if (provisionedResources.size() != results.size()) {

--- a/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImplTest.java
+++ b/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImplTest.java
@@ -415,7 +415,7 @@ class DataPlaneManagerImplTest {
 
             await().untilAsserted(() -> {
                 verify(provisionerManager).provision(List.of(resourceToBeProvisioned));
-                verify(transferProcessApiClient).provisioned(dataFlow.getId(), newDataAddress);
+                verify(transferProcessApiClient).provisioned(dataFlow);
                 var captor = ArgumentCaptor.forClass(DataFlow.class);
                 verify(store).save(captor.capture());
                 var storedDataFlow = captor.getValue();
@@ -511,7 +511,7 @@ class DataPlaneManagerImplTest {
 
             assertThat(result).isSucceeded();
             verify(store).save(argThat(saved -> saved.getState() == PROVISIONED.code()));
-            verify(transferProcessApiClient).provisioned(dataFlow.getId(), null);
+            verify(transferProcessApiClient).provisioned(dataFlow);
         }
 
         @Test

--- a/extensions/common/api/control-api-configuration/src/main/resources/control-api-version.json
+++ b/extensions/common/api/control-api-configuration/src/main/resources/control-api-version.json
@@ -1,8 +1,8 @@
 [
   {
-    "version": "1.0.2",
+    "version": "1.1.0",
     "urlPath": "/v1",
-    "lastUpdated": "2024-09-04T14:30:00Z",
+    "lastUpdated": "2025-06-25T14:45:00Z",
     "maturity": "stable"
   }
 ]

--- a/extensions/control-plane/api/control-plane-api-client/src/main/java/org/eclipse/edc/connector/controlplane/api/client/transferprocess/EmbeddedTransferProcessHttpClient.java
+++ b/extensions/control-plane/api/control-plane-api-client/src/main/java/org/eclipse/edc/connector/controlplane/api/client/transferprocess/EmbeddedTransferProcessHttpClient.java
@@ -17,11 +17,10 @@ package org.eclipse.edc.connector.controlplane.api.client.transferprocess;
 import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessService;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.CompleteProvisionCommand;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.TerminateTransferCommand;
+import org.eclipse.edc.connector.dataplane.spi.DataFlow;
 import org.eclipse.edc.connector.dataplane.spi.port.TransferProcessApiClient;
 import org.eclipse.edc.spi.response.StatusResult;
-import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.ServiceResult;
-import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 
 import java.util.function.Function;
@@ -50,18 +49,9 @@ public class EmbeddedTransferProcessHttpClient implements TransferProcessApiClie
     }
 
     @Override
-    public Result<Void> provisioned(String id, DataAddress newAddress) {
-        return transferProcessService.completeProvision(new CompleteProvisionCommand(id, newAddress)).flatMap(toResult());
-    }
-
-    private Function<ServiceResult<Void>, Result<Void>> toResult() {
-        return it -> {
-            if (it.succeeded()) {
-                return Result.success();
-            } else {
-                return Result.failure(it.getFailureDetail());
-            }
-        };
+    public StatusResult<Void> provisioned(DataFlow dataFlow) {
+        return transferProcessService.completeProvision(new CompleteProvisionCommand(dataFlow.getId(), dataFlow.provisionedDataAddress()))
+                .flatMap(toStatusResult());
     }
 
     private Function<ServiceResult<Void>, StatusResult<Void>> toStatusResult() {

--- a/extensions/control-plane/api/control-plane-api-client/src/test/java/org/eclipse/edc/connector/controlplane/api/client/transferprocess/EmbeddedTransferProcessHttpClientTest.java
+++ b/extensions/control-plane/api/control-plane-api-client/src/test/java/org/eclipse/edc/connector/controlplane/api/client/transferprocess/EmbeddedTransferProcessHttpClientTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.connector.controlplane.api.client.transferprocess;
 
 import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessService;
+import org.eclipse.edc.connector.dataplane.spi.DataFlow;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
@@ -71,7 +72,7 @@ class EmbeddedTransferProcessHttpClientTest {
             var serviceResult = ServiceResult.<Void>success();
             when(service.completeProvision(any())).thenReturn(serviceResult);
 
-            var result = client.provisioned("anyId", DataAddress.Builder.newInstance().type("any").build());
+            var result = client.provisioned(DataFlow.Builder.newInstance().id("anyId").build());
 
             assertThat(result).isSucceeded();
             verify(service).completeProvision(any());

--- a/extensions/control-plane/api/control-plane-api/src/main/java/org/eclipse/edc/connector/controlplane/api/transferprocess/TransferProcessControlApi.java
+++ b/extensions/control-plane/api/control-plane-api/src/main/java/org/eclipse/edc/connector/controlplane/api/transferprocess/TransferProcessControlApi.java
@@ -22,6 +22,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.eclipse.edc.connector.controlplane.api.transferprocess.model.TransferProcessFailStateDto;
+import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.web.spi.ApiErrorDetail;
 
 
@@ -46,6 +47,14 @@ public interface TransferProcessControlApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
             })
     void fail(String processId, TransferProcessFailStateDto request);
+
+    @Operation(description = "Notify provisioning completion.",
+            responses = {
+                    @ApiResponse(responseCode = "204"),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
+            })
+    void provisioned(String processId, DataAddress newDataAddress);
 
 
 }

--- a/extensions/data-plane/data-plane-integration-tests/src/test/java/org/eclipse/edc/connector/dataplane/http/DataPlaneHttpIntegrationTests.java
+++ b/extensions/data-plane/data-plane-integration-tests/src/test/java/org/eclipse/edc/connector/dataplane/http/DataPlaneHttpIntegrationTests.java
@@ -122,19 +122,23 @@ public class DataPlaneHttpIntegrationTests {
             )));
     private static ClientAndServer httpSourceMockServer;
     private static ClientAndServer httpSinkMockServer;
+    private static ClientAndServer fakeControlPlane;
     private final Duration timeout = Duration.ofSeconds(30);
 
     @BeforeAll
     public static void setUp() {
         httpSourceMockServer = startClientAndServer(HTTP_SOURCE_API_PORT);
         httpSinkMockServer = startClientAndServer(HTTP_SINK_API_PORT);
+        fakeControlPlane = startClientAndServer(getFreePort());
         when(DATA_PLANE_AUTHORIZATION_SERVICE.createEndpointDataReference(any())).thenReturn(Result.success(DataAddress.Builder.newInstance().type("type").build()));
+        fakeControlPlane.when(request()).respond(response());
     }
 
     @AfterAll
     public static void tearDown() {
         stopQuietly(httpSourceMockServer);
         stopQuietly(httpSinkMockServer);
+        stopQuietly(fakeControlPlane);
     }
 
     @AfterEach
@@ -361,6 +365,7 @@ public class DataPlaneHttpIntegrationTests {
                     )
                     .add("flowType", "PUSH")
                     .add("transferTypeDestination", "HttpData-PUSH")
+                    .add("callbackAddress", "http://localhost:" + fakeControlPlane.getPort())
                     .build();
         }
 

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-api/src/main/java/org/eclipse/edc/connector/dataplane/api/DataPlaneSignalingApiExtension.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-api/src/main/java/org/eclipse/edc/connector/dataplane/api/DataPlaneSignalingApiExtension.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.dataplane.api;
 
 import jakarta.json.Json;
 import org.eclipse.edc.connector.api.signaling.transform.from.JsonObjectFromDataFlowResponseMessageTransformer;
+import org.eclipse.edc.connector.api.signaling.transform.to.JsonObjectToDataFlowProvisionMessageTransformer;
 import org.eclipse.edc.connector.api.signaling.transform.to.JsonObjectToDataFlowStartMessageTransformer;
 import org.eclipse.edc.connector.api.signaling.transform.to.JsonObjectToDataFlowSuspendMessageTransformer;
 import org.eclipse.edc.connector.api.signaling.transform.to.JsonObjectToDataFlowTerminateMessageTransformer;
@@ -62,6 +63,7 @@ public class DataPlaneSignalingApiExtension implements ServiceExtension {
 
         var signalingApiTypeTransformerRegistry = transformerRegistry.forContext("signaling-api");
         signalingApiTypeTransformerRegistry.register(new JsonObjectToDataFlowStartMessageTransformer());
+        signalingApiTypeTransformerRegistry.register(new JsonObjectToDataFlowProvisionMessageTransformer());
         signalingApiTypeTransformerRegistry.register(new JsonObjectToDataFlowSuspendMessageTransformer());
         signalingApiTypeTransformerRegistry.register(new JsonObjectToDataFlowTerminateMessageTransformer());
         signalingApiTypeTransformerRegistry.register(new JsonObjectToDataAddressDspaceTransformer());

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-api/src/test/java/org/eclipse/edc/connector/dataplane/api/controller/v1/DataPlaneSignalingApiControllerTest.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-api/src/test/java/org/eclipse/edc/connector/dataplane/api/controller/v1/DataPlaneSignalingApiControllerTest.java
@@ -26,14 +26,15 @@ import org.eclipse.edc.spi.response.ResponseStatus;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowResponseMessage;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowSuspendMessage;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowTerminateMessage;
 import org.eclipse.edc.spi.types.domain.transfer.FlowType;
+import org.eclipse.edc.spi.types.domain.transfer.TransferType;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -42,15 +43,20 @@ import java.net.URI;
 
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 import static org.eclipse.edc.spi.response.ResponseStatus.ERROR_RETRY;
 import static org.eclipse.edc.spi.result.Result.failure;
 import static org.eclipse.edc.spi.result.Result.success;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage.EDC_DATA_FLOW_PROVISION_MESSAGE_TYPE;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_TYPE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
@@ -60,122 +66,156 @@ class DataPlaneSignalingApiControllerTest extends RestControllerTestBase {
     private final TypeTransformerRegistry transformerRegistry = mock();
     private final DataPlaneManager dataplaneManager = mock();
 
-    @DisplayName("Expect HTTP 200 and the correct EDR when a data flow is started")
-    @Test
-    void start() {
-        var flowStartMessage = createFlowStartMessage();
-        var flowResponse = DataFlowResponseMessage.Builder.newInstance().dataAddress(DataAddress.Builder.newInstance().type("test-edr").build()).build();
-        when(transformerRegistry.transform(isA(JsonObject.class), eq(DataFlowStartMessage.class)))
-                .thenReturn(success(flowStartMessage));
-        when(dataplaneManager.validate(any())).thenReturn(success());
-        when(dataplaneManager.start(any()))
-                .thenReturn(StatusResult.success(flowResponse));
+    @Nested
+    class Start {
 
-        when(transformerRegistry.transform(isA(DataFlowResponseMessage.class), eq(JsonObject.class)))
-                .thenReturn(success(Json.createObjectBuilder().add("foo", "bar").build()));
+        @Test
+        void shouldStartDataFlow() {
+            var flowStartMessage = createFlowStartMessage();
+            var flowResponse = DataFlowResponseMessage.Builder.newInstance().dataAddress(DataAddress.Builder.newInstance().type("test-edr").build()).build();
+            when(transformerRegistry.transform(isA(JsonObject.class), eq(DataFlowStartMessage.class)))
+                    .thenReturn(success(flowStartMessage));
+            when(dataplaneManager.validate(any())).thenReturn(success());
+            when(dataplaneManager.start(any()))
+                    .thenReturn(StatusResult.success(flowResponse));
+            when(transformerRegistry.transform(isA(DataFlowResponseMessage.class), eq(JsonObject.class)))
+                    .thenReturn(success(Json.createObjectBuilder().add("foo", "bar").build()));
+            when(transformerRegistry.transform(isA(DataAddress.class), eq(JsonObject.class)))
+                    .thenReturn(success(Json.createObjectBuilder().add("foo", "bar").build()));
 
-        when(transformerRegistry.transform(isA(DataAddress.class), eq(JsonObject.class)))
-                .thenReturn(success(Json.createObjectBuilder().add("foo", "bar").build()));
+            var result = baseRequest()
+                    .contentType(ContentType.JSON)
+                    .body(inputWithType(EDC_DATA_FLOW_START_MESSAGE_TYPE))
+                    .post("/v1/dataflows")
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(200)
+                    .extract().body().as(JsonObject.class);
 
-        var jsonObject = Json.createObjectBuilder().build();
-        var result = baseRequest()
-                .contentType(ContentType.JSON)
-                .body(jsonObject)
-                .post("/v1/dataflows")
-                .then()
-                .statusCode(200)
-                .extract().body().as(JsonObject.class);
+            assertThat(result).hasEntrySatisfying("foo", val -> assertThat(((JsonString) val).getString()).isEqualTo("bar"));
+            verify(dataplaneManager).start(eq(flowStartMessage));
+        }
 
-        assertThat(result).hasEntrySatisfying("foo", val -> assertThat(((JsonString) val).getString()).isEqualTo("bar"));
-        verify(dataplaneManager).start(eq(flowStartMessage));
-    }
+        @Test
+        void shouldProvisionDataFlow() {
+            var provisionMessage = createFlowProvisionMessage();
+            var flowResponse = DataFlowResponseMessage.Builder.newInstance().dataAddress(DataAddress.Builder.newInstance().type("test-edr").build()).build();
+            when(transformerRegistry.transform(isA(JsonObject.class), eq(DataFlowProvisionMessage.class)))
+                    .thenReturn(success(provisionMessage));
+            when(dataplaneManager.provision(any())).thenReturn(StatusResult.success(flowResponse));
+            when(transformerRegistry.transform(isA(DataFlowResponseMessage.class), eq(JsonObject.class)))
+                    .thenReturn(success(Json.createObjectBuilder().add("foo", "bar").build()));
 
-    @DisplayName("Expect HTTP 400 when DataFlowStartMessage is invalid")
-    @Test
-    @Disabled
-    void start_whenInvalidMessage() {
-        when(transformerRegistry.transform(isA(JsonObject.class), eq(DataFlowStartMessage.class)))
-                .thenReturn(success(createFlowStartMessage()));
-        when(dataplaneManager.validate(any())).thenReturn(Result.failure("foobar"));
+            var result = baseRequest()
+                    .contentType(ContentType.JSON)
+                    .body(inputWithType(EDC_DATA_FLOW_PROVISION_MESSAGE_TYPE))
+                    .post("/v1/dataflows")
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(200)
+                    .extract().body().as(JsonObject.class);
 
-        var jsonObject = Json.createObjectBuilder().build();
-        baseRequest()
-                .contentType(ContentType.JSON)
-                .body(jsonObject)
-                .post("/v1/dataflows")
-                .then()
-                .statusCode(400);
+            assertThat(result).hasEntrySatisfying("foo", val -> assertThat(((JsonString) val).getString()).isEqualTo("bar"));
+            verify(dataplaneManager).provision(same(provisionMessage));
+        }
 
-        verify(transformerRegistry).transform(isA(JsonObject.class), eq(DataFlowStartMessage.class));
-        verify(dataplaneManager).validate(any(DataFlowStartMessage.class));
-        verifyNoMoreInteractions(transformerRegistry, dataplaneManager);
+        @Test
+        void shouldReturnBadRequest_whenUnsupportedType() {
+            baseRequest()
+                    .contentType(ContentType.JSON)
+                    .body(inputWithType("unsupported"))
+                    .post("/v1/dataflows")
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(400);
 
-    }
+            verifyNoInteractions(transformerRegistry, dataplaneManager);
+        }
 
-    @DisplayName("Expect HTTP 400 when DataFlowStartMessage cannot be deserialized")
-    @Test
-    void start_whenTransformationFails() {
-        when(transformerRegistry.transform(isA(JsonObject.class), eq(DataFlowStartMessage.class))).thenReturn(Result.failure("foo-bar"));
+        @Test
+        void shouldReturnBadRequest_whenInvalidMessage() {
+            when(transformerRegistry.transform(isA(JsonObject.class), eq(DataFlowStartMessage.class)))
+                    .thenReturn(success(createFlowStartMessage()));
+            when(dataplaneManager.validate(any())).thenReturn(Result.failure("foobar"));
 
-        var jsonObject = Json.createObjectBuilder().build();
-        baseRequest()
-                .contentType(ContentType.JSON)
-                .body(jsonObject)
-                .post("/v1/dataflows")
-                .then()
-                .statusCode(400);
+            baseRequest()
+                    .contentType(ContentType.JSON)
+                    .body(inputWithType(EDC_DATA_FLOW_START_MESSAGE_TYPE))
+                    .post("/v1/dataflows")
+                    .then()
+                    .statusCode(400);
 
-        verify(transformerRegistry).transform(isA(JsonObject.class), eq(DataFlowStartMessage.class));
-        verifyNoMoreInteractions(transformerRegistry, dataplaneManager);
-    }
+            verify(transformerRegistry).transform(isA(JsonObject.class), eq(DataFlowStartMessage.class));
+            verify(dataplaneManager).validate(any(DataFlowStartMessage.class));
+            verifyNoMoreInteractions(transformerRegistry, dataplaneManager);
+        }
 
-    @DisplayName("Expect HTTP 400 when an EDR cannot be created")
-    @Test
-    void start_whenCreateEdrFails() {
-        when(transformerRegistry.transform(isA(JsonObject.class), eq(DataFlowStartMessage.class)))
-                .thenReturn(success(createFlowStartMessage()));
-        when(dataplaneManager.validate(any())).thenReturn(success());
-        when(dataplaneManager.start(any()))
-                .thenReturn(StatusResult.failure(ERROR_RETRY, "test-failure"));
+        @Test
+        void shouldReturnBadRequest_whenTransformationFails() {
+            when(transformerRegistry.transform(isA(JsonObject.class), eq(DataFlowStartMessage.class))).thenReturn(Result.failure("foo-bar"));
 
-        var jsonObject = Json.createObjectBuilder().build();
-        baseRequest()
-                .contentType(ContentType.JSON)
-                .body(jsonObject)
-                .post("/v1/dataflows")
-                .then()
-                .statusCode(400);
+            baseRequest()
+                    .contentType(ContentType.JSON)
+                    .body(inputWithType(EDC_DATA_FLOW_START_MESSAGE_TYPE))
+                    .post("/v1/dataflows")
+                    .then()
+                    .statusCode(400);
 
-        verify(transformerRegistry).transform(isA(JsonObject.class), eq(DataFlowStartMessage.class));
-        verify(dataplaneManager).validate(any());
-        verify(dataplaneManager).start(any());
-        verifyNoMoreInteractions(transformerRegistry, dataplaneManager);
-    }
+            verify(transformerRegistry).transform(isA(JsonObject.class), eq(DataFlowStartMessage.class));
+            verifyNoMoreInteractions(transformerRegistry, dataplaneManager);
+        }
 
-    @DisplayName("Expect HTTP 500 when the DataAddress cannot be serialized on egress")
-    @Test
-    void start_whenDataAddressTransformationFails() {
-        var flowStartMessage = createFlowStartMessage();
-        var flowResponse = DataFlowResponseMessage.Builder.newInstance().dataAddress(DataAddress.Builder.newInstance().type("test-edr").build()).build();
+        @Test
+        void shouldReturnBadRequest_whenCreateEdrFails() {
+            when(transformerRegistry.transform(isA(JsonObject.class), eq(DataFlowStartMessage.class)))
+                    .thenReturn(success(createFlowStartMessage()));
+            when(dataplaneManager.validate(any())).thenReturn(success());
+            when(dataplaneManager.start(any()))
+                    .thenReturn(StatusResult.failure(ERROR_RETRY, "test-failure"));
 
-        when(transformerRegistry.transform(isA(JsonObject.class), eq(DataFlowStartMessage.class)))
-                .thenReturn(success(flowStartMessage));
-        when(dataplaneManager.validate(any())).thenReturn(success());
-        when(dataplaneManager.start(any()))
-                .thenReturn(StatusResult.success(flowResponse));
+            baseRequest()
+                    .contentType(ContentType.JSON)
+                    .body(inputWithType(EDC_DATA_FLOW_START_MESSAGE_TYPE))
+                    .post("/v1/dataflows")
+                    .then()
+                    .statusCode(400);
 
-        when(transformerRegistry.transform(isA(DataAddress.class), eq(JsonObject.class)))
-                .thenReturn(failure("test-failure"));
+            verify(transformerRegistry).transform(isA(JsonObject.class), eq(DataFlowStartMessage.class));
+            verify(dataplaneManager).validate(any());
+            verify(dataplaneManager).start(any());
+            verifyNoMoreInteractions(transformerRegistry, dataplaneManager);
+        }
 
-        var jsonObject = Json.createObjectBuilder().build();
-        baseRequest()
-                .contentType(ContentType.JSON)
-                .body(jsonObject)
-                .post("/v1/dataflows")
-                .then()
-                .statusCode(500);
+        @Test
+        void shouldReturnInternalServerError_whenDataAddressTransformationFails() {
+            var flowStartMessage = createFlowStartMessage();
+            var flowResponse = DataFlowResponseMessage.Builder.newInstance().dataAddress(DataAddress.Builder.newInstance().type("test-edr").build()).build();
 
-        verify(dataplaneManager).start(eq(flowStartMessage));
+            when(transformerRegistry.transform(isA(JsonObject.class), eq(DataFlowStartMessage.class)))
+                    .thenReturn(success(flowStartMessage));
+            when(dataplaneManager.validate(any())).thenReturn(success());
+            when(dataplaneManager.start(any()))
+                    .thenReturn(StatusResult.success(flowResponse));
+
+            when(transformerRegistry.transform(isA(DataAddress.class), eq(JsonObject.class)))
+                    .thenReturn(failure("test-failure"));
+
+            baseRequest()
+                    .contentType(ContentType.JSON)
+                    .body(inputWithType(EDC_DATA_FLOW_START_MESSAGE_TYPE))
+                    .post("/v1/dataflows")
+                    .then()
+                    .statusCode(500);
+
+            verify(dataplaneManager).start(eq(flowStartMessage));
+        }
+
+        private String inputWithType(String type) {
+            return Json.createObjectBuilder()
+                    .add(TYPE, Json.createArrayBuilder().add(type))
+                    .build()
+                    .toString();
+        }
     }
 
     @DisplayName("Expect HTTP 200 and the correct response when getting the state")
@@ -289,6 +329,18 @@ class DataPlaneSignalingApiControllerTest extends RestControllerTestBase {
                 .callbackAddress(URI.create("http://localhost"))
                 .sourceDataAddress(DataAddress.Builder.newInstance().type("sourceType").build())
                 .destinationDataAddress(DataAddress.Builder.newInstance().type("destType").build())
+                .build();
+    }
+
+    private DataFlowProvisionMessage createFlowProvisionMessage() {
+        return DataFlowProvisionMessage.Builder.newInstance()
+                .processId("processId")
+                .assetId("assetId")
+                .agreementId("agreementId")
+                .participantId("participantId")
+                .transferType(new TransferType("any", FlowType.PULL))
+                .callbackAddress(URI.create("http://localhost"))
+                .destination(DataAddress.Builder.newInstance().type("destType").build())
                 .build();
     }
 

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/main/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClientTransformExtension.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/main/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClientTransformExtension.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.connector.dataplane.client;
 
 import jakarta.json.Json;
+import org.eclipse.edc.connector.api.signaling.transform.from.JsonObjectFromDataFlowProvisionMessageTransformer;
 import org.eclipse.edc.connector.api.signaling.transform.from.JsonObjectFromDataFlowStartMessageTransformer;
 import org.eclipse.edc.connector.api.signaling.transform.from.JsonObjectFromDataFlowSuspendMessageTransformer;
 import org.eclipse.edc.connector.api.signaling.transform.from.JsonObjectFromDataFlowTerminateMessageTransformer;
@@ -57,6 +58,7 @@ public class DataPlaneSignalingClientTransformExtension implements ServiceExtens
 
         var signalingApiTransformerRegistry = transformerRegistry.forContext("signaling-api");
         signalingApiTransformerRegistry.register(new JsonObjectFromDataFlowStartMessageTransformer(factory, typeManager, JSON_LD));
+        signalingApiTransformerRegistry.register(new JsonObjectFromDataFlowProvisionMessageTransformer(factory, typeManager, JSON_LD));
         signalingApiTransformerRegistry.register(new JsonObjectFromDataFlowSuspendMessageTransformer(factory));
         signalingApiTransformerRegistry.register(new JsonObjectFromDataFlowTerminateMessageTransformer(factory));
         signalingApiTransformerRegistry.register(new JsonObjectToDataFlowResponseMessageTransformer());

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/test/java/org/eclipse/edc/connector/dataplane/client/EmbeddedDataPlaneClientTest.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/test/java/org/eclipse/edc/connector/dataplane/client/EmbeddedDataPlaneClientTest.java
@@ -41,6 +41,7 @@ class EmbeddedDataPlaneClientTest {
 
     @Nested
     class Provision {
+
         @Test
         void shouldSucceed_whenFlowPreparedCorrectly() {
             var response = DataFlowResponseMessage.Builder.newInstance().dataAddress(DataAddress.Builder.newInstance().type("type").build()).build();
@@ -48,7 +49,7 @@ class EmbeddedDataPlaneClientTest {
                     .processId("456")
                     .destination(DataAddress.Builder.newInstance().type("test").build())
                     .build();
-            when(dataPlaneManager.provision(any())).thenReturn(Result.success(response));
+            when(dataPlaneManager.provision(any())).thenReturn(StatusResult.success(response));
 
             var result = client.provision(request);
 
@@ -61,7 +62,7 @@ class EmbeddedDataPlaneClientTest {
                     .processId("456")
                     .destination(DataAddress.Builder.newInstance().type("test").build())
                     .build();
-            when(dataPlaneManager.provision(any())).thenReturn(Result.failure("error"));
+            when(dataPlaneManager.provision(any())).thenReturn(StatusResult.failure(ResponseStatus.FATAL_ERROR, "error"));
 
             var result = client.provision(request);
 

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/main/java/org/eclipse/edc/connector/api/signaling/transform/from/JsonObjectFromDataFlowProvisionMessageTransformer.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/main/java/org/eclipse/edc/connector/api/signaling/transform/from/JsonObjectFromDataFlowProvisionMessageTransformer.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.signaling.transform.from;
+
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage.EDC_DATA_FLOW_PROVISION_MESSAGE_AGREEMENT_ID;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage.EDC_DATA_FLOW_PROVISION_MESSAGE_CALLBACK_ADDRESS;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage.EDC_DATA_FLOW_PROVISION_MESSAGE_DATASET_ID;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage.EDC_DATA_FLOW_PROVISION_MESSAGE_DESTINATION;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage.EDC_DATA_FLOW_PROVISION_MESSAGE_FLOW_TYPE;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage.EDC_DATA_FLOW_PROVISION_MESSAGE_PARTICIPANT_ID;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage.EDC_DATA_FLOW_PROVISION_MESSAGE_PROCESS_ID;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage.EDC_DATA_FLOW_PROVISION_MESSAGE_PROPERTIES;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage.EDC_DATA_FLOW_PROVISION_MESSAGE_TRANSFER_RESPONSE_CHANNEL;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage.EDC_DATA_FLOW_PROVISION_MESSAGE_TRANSFER_TYPE_DESTINATION;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage.EDC_DATA_FLOW_PROVISION_MESSAGE_TYPE;
+
+/**
+ * Converts from a {@link DataFlowProvisionMessage} to a {@link JsonObject} in JSON-LD expanded form .
+ */
+public class JsonObjectFromDataFlowProvisionMessageTransformer extends AbstractJsonLdTransformer<DataFlowProvisionMessage, JsonObject> {
+    private final JsonBuilderFactory jsonFactory;
+    private final TypeManager typeManager;
+    private final String typeContext;
+
+    public JsonObjectFromDataFlowProvisionMessageTransformer(JsonBuilderFactory jsonFactory, TypeManager typeManager, String typeContext) {
+        super(DataFlowProvisionMessage.class, JsonObject.class);
+        this.jsonFactory = jsonFactory;
+        this.typeManager = typeManager;
+        this.typeContext = typeContext;
+    }
+
+    @Override
+    public @Nullable JsonObject transform(@NotNull DataFlowProvisionMessage message, @NotNull TransformerContext context) {
+        var propertiesBuilder = jsonFactory.createObjectBuilder();
+        transformProperties(message.getProperties(), propertiesBuilder, typeManager.getMapper(typeContext), context);
+        var builder = jsonFactory.createObjectBuilder()
+                .add(TYPE, EDC_DATA_FLOW_PROVISION_MESSAGE_TYPE)
+                .add(EDC_DATA_FLOW_PROVISION_MESSAGE_TRANSFER_TYPE_DESTINATION, message.getTransferType().destinationType())
+                .add(EDC_DATA_FLOW_PROVISION_MESSAGE_FLOW_TYPE, message.getTransferType().flowType().toString())
+                .add(EDC_DATA_FLOW_PROVISION_MESSAGE_AGREEMENT_ID, message.getAgreementId())
+                .add(EDC_DATA_FLOW_PROVISION_MESSAGE_PROCESS_ID, message.getProcessId())
+                .add(EDC_DATA_FLOW_PROVISION_MESSAGE_DATASET_ID, message.getAssetId())
+                .add(EDC_DATA_FLOW_PROVISION_MESSAGE_PROPERTIES, propertiesBuilder)
+                .add(EDC_DATA_FLOW_PROVISION_MESSAGE_CALLBACK_ADDRESS, message.getCallbackAddress().toString())
+                .add(EDC_DATA_FLOW_PROVISION_MESSAGE_PARTICIPANT_ID, message.getParticipantId());
+
+        if (message.getDestination() != null) {
+            builder.add(EDC_DATA_FLOW_PROVISION_MESSAGE_DESTINATION, context.transform(message.getDestination(), JsonObject.class));
+        }
+
+        addIfNotNull(message.getTransferType().responseChannelType(), EDC_DATA_FLOW_PROVISION_MESSAGE_TRANSFER_RESPONSE_CHANNEL, builder);
+
+        return builder.build();
+    }
+}

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/main/java/org/eclipse/edc/connector/api/signaling/transform/from/JsonObjectFromDataFlowResponseMessageTransformer.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/main/java/org/eclipse/edc/connector/api/signaling/transform/from/JsonObjectFromDataFlowResponseMessageTransformer.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowResponseMessage.DATA_FLOW_RESPONSE_MESSAGE_DATA_ADDRESS;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowResponseMessage.DATA_FLOW_RESPONSE_MESSAGE_PROVISIONING;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowResponseMessage.DATA_FLOW_RESPONSE_MESSAGE_TYPE;
 
 /**
@@ -42,7 +43,8 @@ public class JsonObjectFromDataFlowResponseMessageTransformer extends AbstractJs
     @Override
     public @Nullable JsonObject transform(@NotNull DataFlowResponseMessage message, @NotNull TransformerContext context) {
         var builder = jsonFactory.createObjectBuilder()
-                .add(TYPE, DATA_FLOW_RESPONSE_MESSAGE_TYPE);
+                .add(TYPE, DATA_FLOW_RESPONSE_MESSAGE_TYPE)
+                .add(DATA_FLOW_RESPONSE_MESSAGE_PROVISIONING, message.isProvisioning());
 
         Optional.ofNullable(message.getDataAddress())
                 .ifPresent(dataAddress -> builder.add(DATA_FLOW_RESPONSE_MESSAGE_DATA_ADDRESS, context.transform(message.getDataAddress(), JsonObject.class)));

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/main/java/org/eclipse/edc/connector/api/signaling/transform/from/JsonObjectFromDataFlowStartMessageTransformer.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/main/java/org/eclipse/edc/connector/api/signaling/transform/from/JsonObjectFromDataFlowStartMessageTransformer.java
@@ -24,13 +24,13 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.DC_DATA_FLOW_START_MESSAGE_PROCESS_ID;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_AGREEMENT_ID;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_CALLBACK_ADDRESS;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_DATASET_ID;
-import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_DESTINATION_CALLBACK_ADDRESS;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_DESTINATION_DATA_ADDRESS;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_FLOW_TYPE;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_PARTICIPANT_ID;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_PROCESS_ID;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_PROPERTIES;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_SOURCE_DATA_ADDRESS;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_TRANSFER_RESPONSE_CHANNEL;
@@ -61,10 +61,10 @@ public class JsonObjectFromDataFlowStartMessageTransformer extends AbstractJsonL
                 .add(EDC_DATA_FLOW_START_MESSAGE_TRANSFER_TYPE_DESTINATION, message.getTransferType().destinationType())
                 .add(EDC_DATA_FLOW_START_MESSAGE_FLOW_TYPE, message.getTransferType().flowType().toString())
                 .add(EDC_DATA_FLOW_START_MESSAGE_AGREEMENT_ID, message.getAgreementId())
-                .add(DC_DATA_FLOW_START_MESSAGE_PROCESS_ID, message.getProcessId())
+                .add(EDC_DATA_FLOW_START_MESSAGE_PROCESS_ID, message.getProcessId())
                 .add(EDC_DATA_FLOW_START_MESSAGE_DATASET_ID, message.getAssetId())
                 .add(EDC_DATA_FLOW_START_MESSAGE_PROPERTIES, propertiesBuilder)
-                .add(EDC_DATA_FLOW_START_MESSAGE_DESTINATION_CALLBACK_ADDRESS, message.getCallbackAddress().toString())
+                .add(EDC_DATA_FLOW_START_MESSAGE_CALLBACK_ADDRESS, message.getCallbackAddress().toString())
                 .add(EDC_DATA_FLOW_START_MESSAGE_SOURCE_DATA_ADDRESS, context.transform(message.getSourceDataAddress(), JsonObject.class))
                 .add(EDC_DATA_FLOW_START_MESSAGE_PARTICIPANT_ID, message.getParticipantId());
 

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/main/java/org/eclipse/edc/connector/api/signaling/transform/to/JsonObjectToDataFlowProvisionMessageTransformer.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/main/java/org/eclipse/edc/connector/api/signaling/transform/to/JsonObjectToDataFlowProvisionMessageTransformer.java
@@ -1,0 +1,93 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.signaling.transform.to;
+
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage;
+import org.eclipse.edc.spi.types.domain.transfer.FlowType;
+import org.eclipse.edc.spi.types.domain.transfer.TransferType;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.net.URI;
+import java.util.Optional;
+
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage.Builder;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage.EDC_DATA_FLOW_PROVISION_MESSAGE_AGREEMENT_ID;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage.EDC_DATA_FLOW_PROVISION_MESSAGE_CALLBACK_ADDRESS;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage.EDC_DATA_FLOW_PROVISION_MESSAGE_DATASET_ID;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage.EDC_DATA_FLOW_PROVISION_MESSAGE_DESTINATION;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage.EDC_DATA_FLOW_PROVISION_MESSAGE_FLOW_TYPE;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage.EDC_DATA_FLOW_PROVISION_MESSAGE_PARTICIPANT_ID;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage.EDC_DATA_FLOW_PROVISION_MESSAGE_PROCESS_ID;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage.EDC_DATA_FLOW_PROVISION_MESSAGE_PROPERTIES;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage.EDC_DATA_FLOW_PROVISION_MESSAGE_TRANSFER_RESPONSE_CHANNEL;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage.EDC_DATA_FLOW_PROVISION_MESSAGE_TRANSFER_TYPE_DESTINATION;
+
+/**
+ * Converts from a {@link JsonObject} in JSON-LD expanded form to a {@link DataFlowProvisionMessage}.
+ */
+public class JsonObjectToDataFlowProvisionMessageTransformer extends AbstractJsonLdTransformer<JsonObject, DataFlowProvisionMessage> {
+
+    public JsonObjectToDataFlowProvisionMessageTransformer() {
+        super(JsonObject.class, DataFlowProvisionMessage.class);
+    }
+
+    @Override
+    public @Nullable DataFlowProvisionMessage transform(@NotNull JsonObject object, @NotNull TransformerContext context) {
+        var builder = Builder.newInstance();
+
+        var transferTypeDestination = object.get(EDC_DATA_FLOW_PROVISION_MESSAGE_TRANSFER_TYPE_DESTINATION);
+        var flowType = object.get(EDC_DATA_FLOW_PROVISION_MESSAGE_FLOW_TYPE);
+        if (transferTypeDestination != null && flowType != null) {
+            builder.transferType(new TransferType(
+                    transformString(transferTypeDestination, context),
+                    FlowType.valueOf(transformString(flowType, context)),
+                    transformString(object.get(EDC_DATA_FLOW_PROVISION_MESSAGE_TRANSFER_RESPONSE_CHANNEL), context))
+            );
+        } else {
+            context.problem().missingProperty().property("%s - %s".formatted(EDC_DATA_FLOW_PROVISION_MESSAGE_TRANSFER_TYPE_DESTINATION, EDC_DATA_FLOW_PROVISION_MESSAGE_FLOW_TYPE))
+                    .report();
+            return null;
+        }
+
+        visitProperties(object, (s, jsonValue) -> transformProperties(s, jsonValue, builder, context));
+
+        return builder.build();
+    }
+
+    private void transformProperties(String key, JsonValue jsonValue, Builder builder, TransformerContext context) {
+        switch (key) {
+            case EDC_DATA_FLOW_PROVISION_MESSAGE_PROCESS_ID -> builder.processId(transformString(jsonValue, context));
+            case EDC_DATA_FLOW_PROVISION_MESSAGE_AGREEMENT_ID -> builder.agreementId(transformString(jsonValue, context));
+            case EDC_DATA_FLOW_PROVISION_MESSAGE_DATASET_ID -> builder.assetId(transformString(jsonValue, context));
+            case EDC_DATA_FLOW_PROVISION_MESSAGE_CALLBACK_ADDRESS ->
+                    Optional.ofNullable(transformString(jsonValue, context)).map(URI::create).ifPresent(builder::callbackAddress);
+            case EDC_DATA_FLOW_PROVISION_MESSAGE_PROPERTIES -> {
+                var props = jsonValue.asJsonArray().getJsonObject(0);
+                visitProperties(props, (k, val) -> transformProperties(k, val, builder, context));
+            }
+            case EDC_DATA_FLOW_PROVISION_MESSAGE_PARTICIPANT_ID ->
+                    builder.participantId(transformString(jsonValue, context));
+            case EDC_DATA_FLOW_PROVISION_MESSAGE_DESTINATION ->
+                    builder.destination(transformObject(jsonValue, DataAddress.class, context));
+            default -> builder.property(key, transformString(jsonValue, context));
+        }
+    }
+}

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/main/java/org/eclipse/edc/connector/api/signaling/transform/to/JsonObjectToDataFlowResponseMessageTransformer.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/main/java/org/eclipse/edc/connector/api/signaling/transform/to/JsonObjectToDataFlowResponseMessageTransformer.java
@@ -25,6 +25,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Optional;
 
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowResponseMessage.DATA_FLOW_RESPONSE_MESSAGE_DATA_ADDRESS;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowResponseMessage.DATA_FLOW_RESPONSE_MESSAGE_PROVISIONING;
 
 /**
  * Converts from a {@link JsonObject} in JSON-LD expanded form to a {@link DataFlowResponseMessage}.
@@ -37,7 +38,8 @@ public class JsonObjectToDataFlowResponseMessageTransformer extends AbstractJson
 
     @Override
     public @Nullable DataFlowResponseMessage transform(@NotNull JsonObject object, @NotNull TransformerContext context) {
-        var builder = DataFlowResponseMessage.Builder.newInstance();
+        var builder = DataFlowResponseMessage.Builder.newInstance()
+                .provisioning(transformBoolean(object.get(DATA_FLOW_RESPONSE_MESSAGE_PROVISIONING), context));
 
         Optional.ofNullable(object.get(DATA_FLOW_RESPONSE_MESSAGE_DATA_ADDRESS))
                 .ifPresent(jsonValue -> builder.dataAddress(transformObject(jsonValue, DataAddress.class, context)));

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/main/java/org/eclipse/edc/connector/api/signaling/transform/to/JsonObjectToDataFlowStartMessageTransformer.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/main/java/org/eclipse/edc/connector/api/signaling/transform/to/JsonObjectToDataFlowStartMessageTransformer.java
@@ -29,13 +29,13 @@ import java.net.URI;
 import java.util.Optional;
 
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.Builder;
-import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.DC_DATA_FLOW_START_MESSAGE_PROCESS_ID;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_AGREEMENT_ID;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_CALLBACK_ADDRESS;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_DATASET_ID;
-import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_DESTINATION_CALLBACK_ADDRESS;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_DESTINATION_DATA_ADDRESS;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_FLOW_TYPE;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_PARTICIPANT_ID;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_PROCESS_ID;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_PROPERTIES;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_SOURCE_DATA_ADDRESS;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_TRANSFER_RESPONSE_CHANNEL;
@@ -75,10 +75,10 @@ public class JsonObjectToDataFlowStartMessageTransformer extends AbstractJsonLdT
 
     private void transformProperties(String key, JsonValue jsonValue, Builder builder, TransformerContext context) {
         switch (key) {
-            case DC_DATA_FLOW_START_MESSAGE_PROCESS_ID -> builder.processId(transformString(jsonValue, context));
+            case EDC_DATA_FLOW_START_MESSAGE_PROCESS_ID -> builder.processId(transformString(jsonValue, context));
             case EDC_DATA_FLOW_START_MESSAGE_AGREEMENT_ID -> builder.agreementId(transformString(jsonValue, context));
             case EDC_DATA_FLOW_START_MESSAGE_DATASET_ID -> builder.assetId(transformString(jsonValue, context));
-            case EDC_DATA_FLOW_START_MESSAGE_DESTINATION_CALLBACK_ADDRESS ->
+            case EDC_DATA_FLOW_START_MESSAGE_CALLBACK_ADDRESS ->
                     Optional.ofNullable(transformString(jsonValue, context)).map(URI::create).ifPresent(builder::callbackAddress);
             case EDC_DATA_FLOW_START_MESSAGE_PROPERTIES -> {
                 var props = jsonValue.asJsonArray().getJsonObject(0);

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/test/java/org/eclipse/edc/connector/api/signaling/transform/from/JsonObjectFromDataFlowProvisionMessageTransformerTest.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/test/java/org/eclipse/edc/connector/api/signaling/transform/from/JsonObjectFromDataFlowProvisionMessageTransformerTest.java
@@ -1,0 +1,88 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.signaling.transform.from;
+
+import jakarta.json.Json;
+import org.eclipse.edc.jsonld.util.JacksonJsonLd;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage;
+import org.eclipse.edc.spi.types.domain.transfer.FlowType;
+import org.eclipse.edc.spi.types.domain.transfer.TransferType;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage.EDC_DATA_FLOW_PROVISION_MESSAGE_AGREEMENT_ID;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage.EDC_DATA_FLOW_PROVISION_MESSAGE_CALLBACK_ADDRESS;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage.EDC_DATA_FLOW_PROVISION_MESSAGE_DATASET_ID;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage.EDC_DATA_FLOW_PROVISION_MESSAGE_DESTINATION;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage.EDC_DATA_FLOW_PROVISION_MESSAGE_FLOW_TYPE;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage.EDC_DATA_FLOW_PROVISION_MESSAGE_PARTICIPANT_ID;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage.EDC_DATA_FLOW_PROVISION_MESSAGE_PROCESS_ID;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage.EDC_DATA_FLOW_PROVISION_MESSAGE_TRANSFER_RESPONSE_CHANNEL;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage.EDC_DATA_FLOW_PROVISION_MESSAGE_TRANSFER_TYPE_DESTINATION;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage.EDC_DATA_FLOW_PROVISION_MESSAGE_TYPE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class JsonObjectFromDataFlowProvisionMessageTransformerTest {
+
+    private final TypeManager typeManager = mock();
+    private final TransformerContext context = mock();
+    private JsonObjectFromDataFlowProvisionMessageTransformer transformer;
+
+    @BeforeEach
+    void setUp() {
+        transformer = new JsonObjectFromDataFlowProvisionMessageTransformer(Json.createBuilderFactory(Map.of()), typeManager, "test");
+        when(context.transform(isA(DataAddress.class), any())).thenReturn(Json.createObjectBuilder().build());
+        when(typeManager.getMapper("test")).thenReturn(JacksonJsonLd.createObjectMapper());
+    }
+
+    @Test
+    void transform() {
+        var message = DataFlowProvisionMessage.Builder.newInstance()
+                .processId("processId")
+                .assetId("assetId")
+                .agreementId("agreementId")
+                .participantId("participantId")
+                .transferType(new TransferType("HttpData", FlowType.PUSH, "Websocket"))
+                .callbackAddress(URI.create("http://localhost"))
+                .destination(DataAddress.Builder.newInstance().type("destType").build())
+                .build();
+
+        var jsonObject = transformer.transform(message, context);
+
+        assertThat(jsonObject).isNotNull();
+        assertThat(jsonObject.getString(TYPE)).isEqualTo(EDC_DATA_FLOW_PROVISION_MESSAGE_TYPE);
+        assertThat(jsonObject.getString(EDC_DATA_FLOW_PROVISION_MESSAGE_PROCESS_ID)).isEqualTo(message.getProcessId());
+        assertThat(jsonObject.getString(EDC_DATA_FLOW_PROVISION_MESSAGE_DATASET_ID)).isEqualTo(message.getAssetId());
+        assertThat(jsonObject.getString(EDC_DATA_FLOW_PROVISION_MESSAGE_AGREEMENT_ID)).isEqualTo(message.getAgreementId());
+        assertThat(jsonObject.getString(EDC_DATA_FLOW_PROVISION_MESSAGE_PARTICIPANT_ID)).isEqualTo(message.getParticipantId());
+        assertThat(jsonObject.getString(EDC_DATA_FLOW_PROVISION_MESSAGE_CALLBACK_ADDRESS)).isEqualTo(message.getCallbackAddress().toString());
+        assertThat(jsonObject.getString(EDC_DATA_FLOW_PROVISION_MESSAGE_TRANSFER_TYPE_DESTINATION)).isEqualTo("HttpData");
+        assertThat(jsonObject.getString(EDC_DATA_FLOW_PROVISION_MESSAGE_FLOW_TYPE)).isEqualTo(message.getTransferType().flowType().toString());
+        assertThat(jsonObject.getString(EDC_DATA_FLOW_PROVISION_MESSAGE_TRANSFER_RESPONSE_CHANNEL)).isEqualTo("Websocket");
+        assertThat(jsonObject.get(EDC_DATA_FLOW_PROVISION_MESSAGE_DESTINATION)).isNotNull();
+    }
+
+}

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/test/java/org/eclipse/edc/connector/api/signaling/transform/from/JsonObjectFromDataFlowResponseMessageTransformerTest.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/test/java/org/eclipse/edc/connector/api/signaling/transform/from/JsonObjectFromDataFlowResponseMessageTransformerTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowResponseMessage.DATA_FLOW_RESPONSE_MESSAGE_DATA_ADDRESS;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowResponseMessage.DATA_FLOW_RESPONSE_MESSAGE_PROVISIONING;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowResponseMessage.DATA_FLOW_RESPONSE_MESSAGE_TYPE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -34,7 +35,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class JsonObjectFromDataFlowResponseMessageTransformerTest {
-
 
     private final TransformerContext context = mock(TransformerContext.class);
     private JsonObjectFromDataFlowResponseMessageTransformer transformer;
@@ -47,21 +47,21 @@ class JsonObjectFromDataFlowResponseMessageTransformerTest {
 
     @Test
     void transform() {
-
-        var message = DataFlowResponseMessage.Builder.newInstance().dataAddress(DataAddress.Builder.newInstance().type("type").build()).build();
+        var message = DataFlowResponseMessage.Builder.newInstance()
+                .dataAddress(DataAddress.Builder.newInstance().type("type").build())
+                .provisioning(true)
+                .build();
 
         var jsonObject = transformer.transform(message, context);
 
         assertThat(jsonObject).isNotNull();
-
         assertThat(jsonObject.getJsonString(TYPE).getString()).isEqualTo(DATA_FLOW_RESPONSE_MESSAGE_TYPE);
         assertThat(jsonObject.get(DATA_FLOW_RESPONSE_MESSAGE_DATA_ADDRESS)).isNotNull();
-
+        assertThat(jsonObject.getBoolean(DATA_FLOW_RESPONSE_MESSAGE_PROVISIONING)).isTrue();
     }
 
     @Test
     void transform_withoutDataAddress() {
-
         var message = DataFlowResponseMessage.Builder.newInstance().build();
 
         var jsonObject = transformer.transform(message, context);
@@ -70,7 +70,6 @@ class JsonObjectFromDataFlowResponseMessageTransformerTest {
 
         assertThat(jsonObject.getJsonString(TYPE).getString()).isEqualTo(DATA_FLOW_RESPONSE_MESSAGE_TYPE);
         assertThat(jsonObject.containsKey(DATA_FLOW_RESPONSE_MESSAGE_DATA_ADDRESS)).isFalse();
-
     }
 
 }

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/test/java/org/eclipse/edc/connector/api/signaling/transform/from/JsonObjectFromDataFlowStartMessageTransformerTest.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/test/java/org/eclipse/edc/connector/api/signaling/transform/from/JsonObjectFromDataFlowStartMessageTransformerTest.java
@@ -30,13 +30,13 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.DC_DATA_FLOW_START_MESSAGE_PROCESS_ID;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_AGREEMENT_ID;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_CALLBACK_ADDRESS;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_DATASET_ID;
-import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_DESTINATION_CALLBACK_ADDRESS;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_DESTINATION_DATA_ADDRESS;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_FLOW_TYPE;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_PARTICIPANT_ID;
+import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_PROCESS_ID;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_SOURCE_DATA_ADDRESS;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_TRANSFER_RESPONSE_CHANNEL;
 import static org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage.EDC_DATA_FLOW_START_MESSAGE_TRANSFER_TYPE_DESTINATION;
@@ -76,11 +76,11 @@ class JsonObjectFromDataFlowStartMessageTransformerTest {
 
         assertThat(jsonObject).isNotNull();
         assertThat(jsonObject.getJsonString(TYPE).getString()).isEqualTo(EDC_DATA_FLOW_START_MESSAGE_TYPE);
-        assertThat(jsonObject.getJsonString(DC_DATA_FLOW_START_MESSAGE_PROCESS_ID).getString()).isEqualTo(message.getProcessId());
+        assertThat(jsonObject.getJsonString(EDC_DATA_FLOW_START_MESSAGE_PROCESS_ID).getString()).isEqualTo(message.getProcessId());
         assertThat(jsonObject.getJsonString(EDC_DATA_FLOW_START_MESSAGE_DATASET_ID).getString()).isEqualTo(message.getAssetId());
         assertThat(jsonObject.getJsonString(EDC_DATA_FLOW_START_MESSAGE_AGREEMENT_ID).getString()).isEqualTo(message.getAgreementId());
         assertThat(jsonObject.getJsonString(EDC_DATA_FLOW_START_MESSAGE_PARTICIPANT_ID).getString()).isEqualTo(message.getParticipantId());
-        assertThat(jsonObject.getJsonString(EDC_DATA_FLOW_START_MESSAGE_DESTINATION_CALLBACK_ADDRESS).getString()).isEqualTo(message.getCallbackAddress().toString());
+        assertThat(jsonObject.getJsonString(EDC_DATA_FLOW_START_MESSAGE_CALLBACK_ADDRESS).getString()).isEqualTo(message.getCallbackAddress().toString());
         assertThat(jsonObject.getJsonString(EDC_DATA_FLOW_START_MESSAGE_TRANSFER_TYPE_DESTINATION).getString()).isEqualTo("HttpData");
         assertThat(jsonObject.getJsonString(EDC_DATA_FLOW_START_MESSAGE_FLOW_TYPE).getString()).isEqualTo(message.getFlowType().toString());
         assertThat(jsonObject.getJsonString(EDC_DATA_FLOW_START_MESSAGE_TRANSFER_RESPONSE_CHANNEL).getString()).isEqualTo("Websocket");

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/test/java/org/eclipse/edc/connector/api/signaling/transform/to/JsonObjectToDataFlowProvisionMessageTransformerTest.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/test/java/org/eclipse/edc/connector/api/signaling/transform/to/JsonObjectToDataFlowProvisionMessageTransformerTest.java
@@ -1,0 +1,93 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.signaling.transform.to;
+
+import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObjectBuilder;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage;
+import org.eclipse.edc.spi.types.domain.transfer.FlowType;
+import org.eclipse.edc.spi.types.domain.transfer.TransferType;
+import org.eclipse.edc.transform.spi.ProblemBuilder;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.connector.api.signaling.transform.TestFunctions.getExpanded;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_PREFIX;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class JsonObjectToDataFlowProvisionMessageTransformerTest {
+
+    private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
+    private final TransformerContext context = mock(TransformerContext.class);
+    private JsonObjectToDataFlowProvisionMessageTransformer transformer;
+
+    @BeforeEach
+    void setUp() {
+        transformer = new JsonObjectToDataFlowProvisionMessageTransformer();
+        when(context.transform(any(), eq(DataAddress.class))).thenReturn(DataAddress.Builder.newInstance().type("address-type").build());
+        when(context.problem()).thenReturn(new ProblemBuilder(context));
+    }
+
+    @Test
+    void transform() {
+        var jsonObj = jsonFactory.createObjectBuilder()
+                .add(CONTEXT, createContextBuilder().build())
+                .add(TYPE, DataFlowProvisionMessage.EDC_DATA_FLOW_PROVISION_MESSAGE_TYPE)
+                .add("processId", "processId")
+                .add("agreementId", "agreementId")
+                .add("datasetId", "datasetId")
+                .add("participantId", "participantId")
+                .add("transferTypeDestination", "transferTypeDestination")
+                .add("flowType", "PULL")
+                .add("responseChannel", "Websocket")
+                .add("destination", jsonFactory.createObjectBuilder().add("type", "address-type"))
+                .add("properties", jsonFactory.createObjectBuilder().add("foo", "bar"))
+                .add("callbackAddress", "http://localhost")
+                .build();
+
+        var message = transformer.transform(getExpanded(jsonObj), context);
+
+        assertThat(message).isNotNull();
+
+        assertThat(message.getProcessId()).isEqualTo("processId");
+        assertThat(message.getAssetId()).isEqualTo("datasetId");
+        assertThat(message.getAgreementId()).isEqualTo("agreementId");
+        assertThat(message.getParticipantId()).isEqualTo("participantId");
+        assertThat(message.getTransferType()).isEqualTo(new TransferType("transferTypeDestination", FlowType.PULL, "Websocket"));
+        assertThat(message.getDestination()).extracting(DataAddress::getType).isEqualTo("address-type");
+        assertThat(message.getProperties()).containsEntry(EDC_NAMESPACE + "foo", "bar");
+        assertThat(message.getCallbackAddress()).isEqualTo(URI.create("http://localhost"));
+    }
+
+    private JsonObjectBuilder createContextBuilder() {
+        return jsonFactory.createObjectBuilder()
+                .add(VOCAB, EDC_NAMESPACE)
+                .add(EDC_PREFIX, EDC_NAMESPACE);
+    }
+}

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/test/java/org/eclipse/edc/connector/api/signaling/transform/to/JsonObjectToDataFlowResponseMessageTransformerTest.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/src/test/java/org/eclipse/edc/connector/api/signaling/transform/to/JsonObjectToDataFlowResponseMessageTransformerTest.java
@@ -52,23 +52,22 @@ class JsonObjectToDataFlowResponseMessageTransformerTest {
 
     @Test
     void transform() {
-
         var jsonObj = jsonFactory.createObjectBuilder()
                 .add(CONTEXT, createContextBuilder().build())
                 .add(TYPE, DATA_FLOW_RESPONSE_MESSAGE_SIMPLE_TYPE)
+                .add("provisioning", true)
                 .add("dataAddress", jsonFactory.createObjectBuilder().build())
                 .build();
 
         var message = transformer.transform(getExpanded(jsonObj), context);
 
         assertThat(message).isNotNull();
-
         assertThat(message.getDataAddress()).isNotNull();
+        assertThat(message.isProvisioning()).isTrue();
     }
 
     @Test
     void transform_withoutDataAddress() {
-
         var jsonObj = jsonFactory.createObjectBuilder()
                 .add(CONTEXT, createContextBuilder().build())
                 .add(TYPE, DATA_FLOW_RESPONSE_MESSAGE_SIMPLE_TYPE)
@@ -77,7 +76,6 @@ class JsonObjectToDataFlowResponseMessageTransformerTest {
         var message = transformer.transform(getExpanded(jsonObj), context);
 
         assertThat(message).isNotNull();
-
         assertThat(message.getDataAddress()).isNull();
     }
 

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/transfer/DataFlowProvisionMessage.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/transfer/DataFlowProvisionMessage.java
@@ -21,10 +21,25 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+
 /**
  * Message that the consumer control plane uses to trigger data flow preparation on the data plane
  */
 public class DataFlowProvisionMessage {
+
+    public static final String EDC_DATA_FLOW_PROVISION_MESSAGE_SIMPLE_TYPE = "DataFlowProvisionMessage";
+    public static final String EDC_DATA_FLOW_PROVISION_MESSAGE_TYPE = EDC_NAMESPACE + EDC_DATA_FLOW_PROVISION_MESSAGE_SIMPLE_TYPE;
+    public static final String EDC_DATA_FLOW_PROVISION_MESSAGE_PROCESS_ID = EDC_NAMESPACE + "processId";
+    public static final String EDC_DATA_FLOW_PROVISION_MESSAGE_DATASET_ID = EDC_NAMESPACE + "datasetId";
+    public static final String EDC_DATA_FLOW_PROVISION_MESSAGE_PARTICIPANT_ID = EDC_NAMESPACE + "participantId";
+    public static final String EDC_DATA_FLOW_PROVISION_MESSAGE_AGREEMENT_ID = EDC_NAMESPACE + "agreementId";
+    public static final String EDC_DATA_FLOW_PROVISION_MESSAGE_DESTINATION = EDC_NAMESPACE + "destination";
+    public static final String EDC_DATA_FLOW_PROVISION_MESSAGE_CALLBACK_ADDRESS = EDC_NAMESPACE + "callbackAddress";
+    public static final String EDC_DATA_FLOW_PROVISION_MESSAGE_PROPERTIES = EDC_NAMESPACE + "properties";
+    public static final String EDC_DATA_FLOW_PROVISION_MESSAGE_FLOW_TYPE = EDC_NAMESPACE + "flowType";
+    public static final String EDC_DATA_FLOW_PROVISION_MESSAGE_TRANSFER_TYPE_DESTINATION = EDC_NAMESPACE + "transferTypeDestination";
+    public static final String EDC_DATA_FLOW_PROVISION_MESSAGE_TRANSFER_RESPONSE_CHANNEL = EDC_NAMESPACE + "responseChannel";
 
     private String id;
     private String processId;

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/transfer/DataFlowResponseMessage.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/transfer/DataFlowResponseMessage.java
@@ -26,6 +26,7 @@ public class DataFlowResponseMessage {
     public static final String DATA_FLOW_RESPONSE_MESSAGE_SIMPLE_TYPE = "DataFlowResponseMessage";
     public static final String DATA_FLOW_RESPONSE_MESSAGE_TYPE = EDC_NAMESPACE + DATA_FLOW_RESPONSE_MESSAGE_SIMPLE_TYPE;
     public static final String DATA_FLOW_RESPONSE_MESSAGE_DATA_ADDRESS = EDC_NAMESPACE + "dataAddress";
+    public static final String DATA_FLOW_RESPONSE_MESSAGE_PROVISIONING = EDC_NAMESPACE + "provisioning";
 
     private DataAddress dataAddress;
     private boolean provisioning;

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/transfer/DataFlowStartMessage.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/transfer/DataFlowStartMessage.java
@@ -37,7 +37,7 @@ import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 @JsonDeserialize(builder = DataFlowStartMessage.Builder.class)
 public class DataFlowStartMessage implements Polymorphic, TraceCarrier {
 
-    public static final String DC_DATA_FLOW_START_MESSAGE_PROCESS_ID = EDC_NAMESPACE + "processId";
+    public static final String EDC_DATA_FLOW_START_MESSAGE_PROCESS_ID = EDC_NAMESPACE + "processId";
     public static final String EDC_DATA_FLOW_START_MESSAGE_SIMPLE_TYPE = "DataFlowStartMessage";
     public static final String EDC_DATA_FLOW_START_MESSAGE_TYPE = EDC_NAMESPACE + EDC_DATA_FLOW_START_MESSAGE_SIMPLE_TYPE;
     public static final String EDC_DATA_FLOW_START_MESSAGE_FLOW_TYPE = EDC_NAMESPACE + "flowType";
@@ -48,7 +48,7 @@ public class DataFlowStartMessage implements Polymorphic, TraceCarrier {
     public static final String EDC_DATA_FLOW_START_MESSAGE_AGREEMENT_ID = EDC_NAMESPACE + "agreementId";
     public static final String EDC_DATA_FLOW_START_MESSAGE_SOURCE_DATA_ADDRESS = EDC_NAMESPACE + "sourceDataAddress";
     public static final String EDC_DATA_FLOW_START_MESSAGE_DESTINATION_DATA_ADDRESS = EDC_NAMESPACE + "destinationDataAddress";
-    public static final String EDC_DATA_FLOW_START_MESSAGE_DESTINATION_CALLBACK_ADDRESS = EDC_NAMESPACE + "callbackAddress";
+    public static final String EDC_DATA_FLOW_START_MESSAGE_CALLBACK_ADDRESS = EDC_NAMESPACE + "callbackAddress";
     public static final String EDC_DATA_FLOW_START_MESSAGE_PROPERTIES = EDC_NAMESPACE + "properties";
 
     private String id;

--- a/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/instance/DataPlaneInstance.java
+++ b/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/instance/DataPlaneInstance.java
@@ -51,6 +51,7 @@ public class DataPlaneInstance extends StatefulEntity<DataPlaneInstance> {
     public static final String PROPERTIES = EDC_NAMESPACE + "properties";
     public static final String ALLOWED_TRANSFER_TYPES = EDC_NAMESPACE + "allowedTransferTypes";
     public static final String ALLOWED_SOURCE_TYPES = EDC_NAMESPACE + "allowedSourceTypes";
+    public static final String DESTINATION_PROVISION_TYPES = EDC_NAMESPACE + "destinationProvisionTypes";
     @Deprecated(since = "management-api:v3")
     public static final String ALLOWED_DEST_TYPES = EDC_NAMESPACE + "allowedDestTypes";
 

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/manager/DataPlaneManager.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/manager/DataPlaneManager.java
@@ -46,7 +46,7 @@ public interface DataPlaneManager extends StateEntityManager {
      * @param request the request.
      * @return success if the provisioning went through, failed otherwise.
      */
-    Result<DataFlowResponseMessage> provision(DataFlowProvisionMessage request);
+    StatusResult<DataFlowResponseMessage> provision(DataFlowProvisionMessage request);
 
     /**
      * Starts a transfer for the data flow request. This method is non-blocking with respect to processing the request.

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/port/TransferProcessApiClient.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/port/TransferProcessApiClient.java
@@ -15,10 +15,9 @@
 package org.eclipse.edc.connector.dataplane.spi.port;
 
 
+import org.eclipse.edc.connector.dataplane.spi.DataFlow;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import org.eclipse.edc.spi.response.StatusResult;
-import org.eclipse.edc.spi.result.Result;
-import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 
 /**
@@ -34,6 +33,7 @@ public interface TransferProcessApiClient {
      * Mark the TransferProcess referenced by {@link DataFlowStartMessage#getProcessId()} as completed
      *
      * @param request The completed {@link DataFlowStartMessage}
+     * @return the result.
      */
     StatusResult<Void> completed(DataFlowStartMessage request);
 
@@ -41,16 +41,16 @@ public interface TransferProcessApiClient {
      * Mark the TransferProcess referenced by {@link DataFlowStartMessage#getProcessId()} as failed
      *
      * @param request The failed {@link DataFlowStartMessage}
+     * @return the result.
      */
     StatusResult<Void> failed(DataFlowStartMessage request, String reason);
 
     /**
      * Mark the TransferProcess as provisioned.
      *
-     * @param id transfer process id.
-     * @param newAddress the new address defined by the provisioning.
+     * @param dataFlow the data flow.
      * @return the result.
      */
-    Result<Void> provisioned(String id, DataAddress newAddress);
+    StatusResult<Void> provisioned(DataFlow dataFlow);
 
 }


### PR DESCRIPTION
## What this PR changes/adds

Supports provisioning on a remote data-plane.

## Why it does that

Moving provisioning to data plane

## Further notes
- provider side will be provided on a separated PR to keep this one as smallest as possible

## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Part of #4793 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
