### PR TITLE
chore: deprecate 08 and 2024 protocol

### DIFF
--- a/data-protocols/dsp/dsp-08/dsp-spi-08/src/main/java/org/eclipse/edc/protocol/dsp/spi/type/Dsp08Constants.java
+++ b/data-protocols/dsp/dsp-08/dsp-spi-08/src/main/java/org/eclipse/edc/protocol/dsp/spi/type/Dsp08Constants.java
@@ -22,15 +22,22 @@ import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_CONTEXT_SEP
 import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_SCOPE;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_TRANSFORMER_CONTEXT;
 
+@Deprecated(since = "0.14.0")
 public interface Dsp08Constants {
 
+    @Deprecated(since = "0.14.0")
     String V_08_VERSION = "v0.8";
+    @Deprecated(since = "0.14.0")
     String V_08_PATH = "/";
+    @Deprecated(since = "0.14.0")
     ProtocolVersion V_08 = new ProtocolVersion(V_08_VERSION, V_08_PATH);
 
+    @Deprecated(since = "0.14.0")
     String DSP_SCOPE_V_08 = DSP_SCOPE + DSP_CONTEXT_SEPARATOR + V_08_VERSION;
 
+    @Deprecated(since = "0.14.0")
     String DSP_TRANSFORMER_CONTEXT_V_08 = DSP_TRANSFORMER_CONTEXT + DSP_CONTEXT_SEPARATOR + V_08_VERSION;
 
+    @Deprecated(since = "0.14.0")
     JsonLdNamespace DSP_NAMESPACE_V_08 = new JsonLdNamespace(DSPACE_SCHEMA);
 }

--- a/data-protocols/dsp/dsp-2024/dsp-spi-2024/src/main/java/org/eclipse/edc/protocol/dsp/spi/type/Dsp2024Constants.java
+++ b/data-protocols/dsp/dsp-2024/dsp-spi-2024/src/main/java/org/eclipse/edc/protocol/dsp/spi/type/Dsp2024Constants.java
@@ -23,19 +23,28 @@ import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_CONTEXT_SEP
 import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_SCOPE;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspConstants.DSP_TRANSFORMER_CONTEXT;
 
+@Deprecated(since = "0.14.0")
 public interface Dsp2024Constants {
 
+    @Deprecated(since = "0.14.0")
     String DSPACE_SCHEMA_2024_1 = "https://w3id.org/dspace/2024/1/";
 
+    @Deprecated(since = "0.14.0")
     String V_2024_1_VERSION = "2024/1";
+    @Deprecated(since = "0.14.0")
     String V_2024_1_PATH = "/" + V_2024_1_VERSION;
 
+    @Deprecated(since = "0.14.0")
     ProtocolVersion V_2024_1 = new ProtocolVersion(V_2024_1_VERSION, V_2024_1_PATH);
 
+    @Deprecated(since = "0.14.0")
     String DSP_SCOPE_V_2024_1 = DSP_SCOPE + DSP_CONTEXT_SEPARATOR + V_2024_1_VERSION;
+    @Deprecated(since = "0.14.0")
     String DSP_TRANSFORMER_CONTEXT_V_2024_1 = DSP_TRANSFORMER_CONTEXT + DSP_CONTEXT_SEPARATOR + V_2024_1_VERSION;
+    @Deprecated(since = "0.14.0")
     JsonLdNamespace DSP_NAMESPACE_V_2024_1 = new JsonLdNamespace(DSPACE_SCHEMA_2024_1);
 
+    @Deprecated(since = "0.14.0")
     String DATASPACE_PROTOCOL_HTTP_V_2024_1 = DATASPACE_PROTOCOL_HTTP + DATASPACE_PROTOCOL_HTTP_SEPARATOR + V_2024_1_VERSION;
 
 }


### PR DESCRIPTION
## What this PR changes/adds

Deprecates dsp 08 and 2024 protocol support since 
we have a in place an impl for the next 2025 dsp version that is also is being tested for compliance using the dsp tck in our nightly build. 

After the refactor done withing the story https://github.com/eclipse-edc/Connector/issues/4880. it should be easy to remove protocol implementations and if necessary plug other one (for backward compatibility requirements)

## Why it does that

future cleanup

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Relates to #4880 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
