### PR TITLE
chore: pin tck deps to 1.0.0-RC4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,8 +38,8 @@ titanium = "1.6.0"
 kafkaClients = "4.0.0"
 testcontainers = "1.21.3"
 tink = "1.18.0"
-dsp-tck = "1.0.0-SNAPSHOT"
-dcp-tck = "1.0.0-SNAPSHOT"
+dsp-tck = "1.0.0-RC4"
+dcp-tck = "1.0.0-RC4"
 junit = "1.13.2"
 
 [libraries]

--- a/system-tests/dcp-tck-tests/presentation/src/test/java/org/eclipse/edc/test/e2e/tck/presentation/DcpPresentationFlowWithDockerTest.java
+++ b/system-tests/dcp-tck-tests/presentation/src/test/java/org/eclipse/edc/test/e2e/tck/presentation/DcpPresentationFlowWithDockerTest.java
@@ -123,9 +123,9 @@ public class DcpPresentationFlowWithDockerTest {
         var didDocumentJson = createDidDocumentJson();
         server.when(request().withMethod("GET").withPath("/verifier/did.json"))
                 .respond(response()
-                                 .withHeader("Content-Type", "application/json")
-                                 .withStatusCode(200)
-                                 .withBody(didDocumentJson));
+                        .withHeader("Content-Type", "application/json")
+                        .withStatusCode(200)
+                        .withBody(didDocumentJson));
 
         when(STS_MOCK.createToken(anyMap(), isNull()))
                 .thenAnswer(i -> {
@@ -140,8 +140,8 @@ public class DcpPresentationFlowWithDockerTest {
                     claims.put("nbf", Instant.now().getEpochSecond());
 
                     var claimsSet = new JWTClaimsSet.Builder(JWTClaimsSet.parse(claims))
-                                            .jwtID(UUID.randomUUID().toString())
-                                            .build();
+                            .jwtID(UUID.randomUUID().toString())
+                            .build();
                     var jwt = new SignedJWT(hdr, claimsSet);
                     jwt.sign(new ECDSASigner(verifierKey));
                     var tr = TokenRepresentation.Builder.newInstance().token(jwt.serialize()).build();
@@ -151,17 +151,17 @@ public class DcpPresentationFlowWithDockerTest {
 
     private String createDidDocumentJson() {
         var ddoc = DidDocument.Builder.newInstance()
-                           .id(VERIFIER_DID)
-                           .verificationMethod(List.of(
-                                   VerificationMethod.Builder.newInstance()
-                                           .type("assertionMethod")
-                                           .controller(VERIFIER_DID)
-                                           .publicKeyJwk(verifierKey.toJSONObject())
-                                           .id(verifierKey.getKeyID())
-                                           .build()
-                           ))
-                           .service(List.of(new Service(UUID.randomUUID().toString(), "CredentialService", "https://example.com/credentialservice")))
-                           .build();
+                .id(VERIFIER_DID)
+                .verificationMethod(List.of(
+                        VerificationMethod.Builder.newInstance()
+                                .type("assertionMethod")
+                                .controller(VERIFIER_DID)
+                                .publicKeyJwk(verifierKey.toJSONObject())
+                                .id(verifierKey.getKeyID())
+                                .build()
+                ))
+                .service(List.of(new Service(UUID.randomUUID().toString(), "CredentialService", "https://example.com/credentialservice")))
+                .build();
         try {
             return new ObjectMapper().writeValueAsString(ddoc);
         } catch (JsonProcessingException e) {
@@ -179,18 +179,18 @@ public class DcpPresentationFlowWithDockerTest {
         var thirdPartyDid = "did:web:0.0.0.0%3A" + CALLBACK_PORT + ":thirdparty";
         var baseCallbackUrl = "http://0.0.0.0:%s".formatted(CALLBACK_PORT);
 
-        try (var tckContainer = new GenericContainer<>("eclipsedataspacetck/dcp-tck-runtime:1.0.0-RC3")
-                                        .withExtraHost("host.docker.internal", "host-gateway")
-                                        .withExposedPorts(CALLBACK_PORT)
-                                        .withEnv(Map.of(
-                                                "dataspacetck.callback.address", baseCallbackUrl,
-                                                "dataspacetck.launcher", "org.eclipse.dataspacetck.dcp.system.DcpSystemLauncher",
-                                                "dataspacetck.did.verifier", VERIFIER_DID,
-                                                "dataspacetck.did.holder", holderDid,
-                                                "dataspacetck.did.thirdparty", thirdPartyDid,
-                                                "dataspacetck.test.package", "org.eclipse.dataspacetck.dcp.verification.presentation.verifier",
-                                                "dataspacetck.vpp.trigger.endpoint", "http://host.docker.internal:%s%s".formatted(PROTOCOL_API_PORT, triggerPath)
-                                        ))
+        try (var tckContainer = new GenericContainer<>("eclipsedataspacetck/dcp-tck-runtime:1.0.0-RC4")
+                .withExtraHost("host.docker.internal", "host-gateway")
+                .withExposedPorts(CALLBACK_PORT)
+                .withEnv(Map.of(
+                        "dataspacetck.callback.address", baseCallbackUrl,
+                        "dataspacetck.launcher", "org.eclipse.dataspacetck.dcp.system.DcpSystemLauncher",
+                        "dataspacetck.did.verifier", VERIFIER_DID,
+                        "dataspacetck.did.holder", holderDid,
+                        "dataspacetck.did.thirdparty", thirdPartyDid,
+                        "dataspacetck.test.package", "org.eclipse.dataspacetck.dcp.verification.presentation.verifier",
+                        "dataspacetck.vpp.trigger.endpoint", "http://host.docker.internal:%s%s".formatted(PROTOCOL_API_PORT, triggerPath)
+                ))
         ) {
             tckContainer.setPortBindings(List.of("%s:%s".formatted(CALLBACK_PORT, CALLBACK_PORT)));
             tckContainer.start();

--- a/system-tests/dsp-compatibility-tests/compatibility-test-runner/src/test/java/org/eclipse/edc/tck/dsp/EdcCompatibilityDockerTest.java
+++ b/system-tests/dsp-compatibility-tests/compatibility-test-runner/src/test/java/org/eclipse/edc/tck/dsp/EdcCompatibilityDockerTest.java
@@ -44,7 +44,7 @@ import static org.eclipse.edc.util.io.Ports.getFreePort;
 @Testcontainers
 public class EdcCompatibilityDockerTest {
 
-    private static final GenericContainer<?> TCK_CONTAINER = new TckContainer<>("eclipsedataspacetck/dsp-tck-runtime:latest");
+    private static final GenericContainer<?> TCK_CONTAINER = new TckContainer<>("eclipsedataspacetck/dsp-tck-runtime:1.0.0-RC4");
     @RegisterExtension
     protected static RuntimeExtension runtime = new RuntimePerClassExtension(new EmbeddedRuntime("CUT",
             ":system-tests:dsp-compatibility-tests:connector-under-test"


### PR DESCRIPTION
## What this PR changes/adds

pin tck deps to 1.0.0-RC4

## Why it does that



## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
