### PR TITLE
refactor: add publish Event method on EventRouter

### DIFF
--- a/core/common/runtime-core/src/main/java/org/eclipse/edc/runtime/core/RuntimeCoreServicesExtension.java
+++ b/core/common/runtime-core/src/main/java/org/eclipse/edc/runtime/core/RuntimeCoreServicesExtension.java
@@ -41,6 +41,7 @@ import org.eclipse.edc.transform.TypeTransformerRegistryImpl;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 
+import java.time.Clock;
 import java.util.concurrent.Executors;
 
 import static org.eclipse.edc.runtime.core.RuntimeDefaultCoreServicesExtension.NAME;
@@ -63,6 +64,8 @@ public class RuntimeCoreServicesExtension implements ServiceExtension {
     private OkHttpClient okHttpClient;
     @Inject
     private RetryPolicy<Response> retryPolicy;
+    @Inject
+    private Clock clock;
 
     @Override
     public String name() {
@@ -79,7 +82,6 @@ public class RuntimeCoreServicesExtension implements ServiceExtension {
         return () -> hostname;
     }
 
-
     @Provider
     public EdcHttpClient edcHttpClient(ServiceExtensionContext context) {
         return new EdcHttpClientImpl(okHttpClient, retryPolicy, context.getMonitor());
@@ -92,7 +94,7 @@ public class RuntimeCoreServicesExtension implements ServiceExtension {
 
     @Provider
     public EventRouter eventRouter(ServiceExtensionContext context) {
-        return new EventRouterImpl(context.getMonitor(), Executors.newFixedThreadPool(1));
+        return new EventRouterImpl(context.getMonitor(), Executors.newFixedThreadPool(1), clock);
     }
 
     @Provider

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
@@ -203,7 +203,7 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     @Provider
     public AssetService assetService() {
         var assetObservable = new AssetObservableImpl();
-        assetObservable.registerListener(new AssetEventListener(clock, eventRouter));
+        assetObservable.registerListener(new AssetEventListener(eventRouter));
         return new AssetServiceImpl(assetIndex, contractNegotiationStore, transactionContext, assetObservable,
                 dataAddressValidator, new AssetQueryValidator());
     }
@@ -211,7 +211,7 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     @Provider
     public SecretService secretService() {
         var secretObservable = new SecretObservableImpl();
-        secretObservable.registerListener(new SecretEventListener(clock, eventRouter));
+        secretObservable.registerListener(new SecretEventListener(eventRouter));
         return new SecretServiceImpl(vault, secretObservable);
     }
 
@@ -234,7 +234,7 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     @Provider
     public ContractDefinitionService contractDefinitionService() {
         var contractDefinitionObservable = new ContractDefinitionObservableImpl();
-        contractDefinitionObservable.registerListener(new ContractDefinitionEventListener(clock, eventRouter));
+        contractDefinitionObservable.registerListener(new ContractDefinitionEventListener(eventRouter));
         return new ContractDefinitionServiceImpl(contractDefinitionStore, transactionContext, contractDefinitionObservable, QueryValidators.contractDefinition());
     }
 
@@ -254,7 +254,7 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     @Provider
     public PolicyDefinitionService policyDefinitionService() {
         var policyDefinitionObservable = new PolicyDefinitionObservableImpl();
-        policyDefinitionObservable.registerListener(new PolicyDefinitionEventListener(clock, eventRouter));
+        policyDefinitionObservable.registerListener(new PolicyDefinitionEventListener(eventRouter));
         return new PolicyDefinitionServiceImpl(transactionContext, policyDefinitionStore, contractDefinitionStore,
                 policyDefinitionObservable, policyEngine, QueryValidators.policyDefinition(), validatePolicy);
     }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/asset/AssetEventListener.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/asset/AssetEventListener.java
@@ -17,23 +17,17 @@ package org.eclipse.edc.connector.controlplane.services.asset;
 import org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset;
 import org.eclipse.edc.connector.controlplane.asset.spi.event.AssetCreated;
 import org.eclipse.edc.connector.controlplane.asset.spi.event.AssetDeleted;
-import org.eclipse.edc.connector.controlplane.asset.spi.event.AssetEvent;
 import org.eclipse.edc.connector.controlplane.asset.spi.event.AssetUpdated;
 import org.eclipse.edc.connector.controlplane.asset.spi.observe.AssetListener;
-import org.eclipse.edc.spi.event.EventEnvelope;
 import org.eclipse.edc.spi.event.EventRouter;
-
-import java.time.Clock;
 
 /**
  * Listener responsible for creating and publishing events regarding Asset state changes
  */
 public class AssetEventListener implements AssetListener {
-    private final Clock clock;
     private final EventRouter eventRouter;
 
-    public AssetEventListener(Clock clock, EventRouter eventRouter) {
-        this.clock = clock;
+    public AssetEventListener(EventRouter eventRouter) {
         this.eventRouter = eventRouter;
     }
 
@@ -43,7 +37,7 @@ public class AssetEventListener implements AssetListener {
                 .assetId(asset.getId())
                 .build();
 
-        publish(event);
+        eventRouter.publish(event);
     }
 
     @Override
@@ -52,7 +46,7 @@ public class AssetEventListener implements AssetListener {
                 .assetId(asset.getId())
                 .build();
 
-        publish(event);
+        eventRouter.publish(event);
     }
 
     @Override
@@ -61,14 +55,7 @@ public class AssetEventListener implements AssetListener {
                 .assetId(asset.getId())
                 .build();
 
-        publish(event);
+        eventRouter.publish(event);
     }
 
-    private void publish(AssetEvent event) {
-        var envelope = EventEnvelope.Builder.newInstance()
-                .payload(event)
-                .at(clock.millis())
-                .build();
-        eventRouter.publish(envelope);
-    }
 }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/contractdefinition/ContractDefinitionEventListener.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/contractdefinition/ContractDefinitionEventListener.java
@@ -17,23 +17,17 @@ package org.eclipse.edc.connector.controlplane.services.contractdefinition;
 import org.eclipse.edc.connector.controlplane.contract.spi.definition.observe.ContractDefinitionListener;
 import org.eclipse.edc.connector.controlplane.contract.spi.event.contractdefinition.ContractDefinitionCreated;
 import org.eclipse.edc.connector.controlplane.contract.spi.event.contractdefinition.ContractDefinitionDeleted;
-import org.eclipse.edc.connector.controlplane.contract.spi.event.contractdefinition.ContractDefinitionEvent;
 import org.eclipse.edc.connector.controlplane.contract.spi.event.contractdefinition.ContractDefinitionUpdated;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractDefinition;
-import org.eclipse.edc.spi.event.EventEnvelope;
 import org.eclipse.edc.spi.event.EventRouter;
-
-import java.time.Clock;
 
 /**
  * Listener responsible for creating and publishing events regarding ContractDefinition state changes
  */
 public class ContractDefinitionEventListener implements ContractDefinitionListener {
-    private final Clock clock;
     private final EventRouter eventRouter;
 
-    public ContractDefinitionEventListener(Clock clock, EventRouter eventRouter) {
-        this.clock = clock;
+    public ContractDefinitionEventListener(EventRouter eventRouter) {
         this.eventRouter = eventRouter;
     }
 
@@ -43,7 +37,7 @@ public class ContractDefinitionEventListener implements ContractDefinitionListen
                 .contractDefinitionId(contractDefinition.getId())
                 .build();
 
-        publish(event);
+        eventRouter.publish(event);
     }
 
     @Override
@@ -52,7 +46,7 @@ public class ContractDefinitionEventListener implements ContractDefinitionListen
                 .contractDefinitionId(contractDefinition.getId())
                 .build();
 
-        publish(event);
+        eventRouter.publish(event);
     }
 
     @Override
@@ -61,15 +55,7 @@ public class ContractDefinitionEventListener implements ContractDefinitionListen
                 .contractDefinitionId(contractDefinition.getId())
                 .build();
 
-        publish(event);
+        eventRouter.publish(event);
     }
 
-    private void publish(ContractDefinitionEvent event) {
-        var envelope = EventEnvelope.Builder.newInstance()
-                .payload(event)
-                .at(clock.millis())
-                .build();
-
-        eventRouter.publish(envelope);
-    }
 }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/policydefinition/PolicyDefinitionEventListener.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/policydefinition/PolicyDefinitionEventListener.java
@@ -17,23 +17,17 @@ package org.eclipse.edc.connector.controlplane.services.policydefinition;
 import org.eclipse.edc.connector.controlplane.policy.spi.PolicyDefinition;
 import org.eclipse.edc.connector.controlplane.policy.spi.event.PolicyDefinitionCreated;
 import org.eclipse.edc.connector.controlplane.policy.spi.event.PolicyDefinitionDeleted;
-import org.eclipse.edc.connector.controlplane.policy.spi.event.PolicyDefinitionEvent;
 import org.eclipse.edc.connector.controlplane.policy.spi.event.PolicyDefinitionUpdated;
 import org.eclipse.edc.connector.controlplane.policy.spi.observe.PolicyDefinitionListener;
-import org.eclipse.edc.spi.event.EventEnvelope;
 import org.eclipse.edc.spi.event.EventRouter;
-
-import java.time.Clock;
 
 /**
  * Listener responsible for creating and publishing events regarding PolicyDefinition state changes
  */
 public class PolicyDefinitionEventListener implements PolicyDefinitionListener {
-    private final Clock clock;
     private final EventRouter eventRouter;
 
-    public PolicyDefinitionEventListener(Clock clock, EventRouter eventRouter) {
-        this.clock = clock;
+    public PolicyDefinitionEventListener(EventRouter eventRouter) {
         this.eventRouter = eventRouter;
     }
 
@@ -43,7 +37,7 @@ public class PolicyDefinitionEventListener implements PolicyDefinitionListener {
                 .policyDefinitionId(policyDefinition.getId())
                 .build();
 
-        publish(event);
+        eventRouter.publish(event);
     }
 
     @Override
@@ -52,7 +46,7 @@ public class PolicyDefinitionEventListener implements PolicyDefinitionListener {
                 .policyDefinitionId(policyDefinition.getId())
                 .build();
 
-        publish(event);
+        eventRouter.publish(event);
     }
 
     @Override
@@ -61,14 +55,7 @@ public class PolicyDefinitionEventListener implements PolicyDefinitionListener {
                 .policyDefinitionId(policyDefinition.getId())
                 .build();
 
-        publish(event);
+        eventRouter.publish(event);
     }
 
-    private void publish(PolicyDefinitionEvent event) {
-        var envelope = EventEnvelope.Builder.newInstance()
-                .payload(event)
-                .at(clock.millis())
-                .build();
-        eventRouter.publish(envelope);
-    }
 }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/secret/SecretEventListener.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/secret/SecretEventListener.java
@@ -16,24 +16,18 @@ package org.eclipse.edc.connector.controlplane.services.secret;
 
 import org.eclipse.edc.connector.secret.spi.event.SecretCreated;
 import org.eclipse.edc.connector.secret.spi.event.SecretDeleted;
-import org.eclipse.edc.connector.secret.spi.event.SecretEvent;
 import org.eclipse.edc.connector.secret.spi.event.SecretUpdated;
 import org.eclipse.edc.connector.secret.spi.observe.SecretListener;
-import org.eclipse.edc.spi.event.EventEnvelope;
 import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.types.domain.secret.Secret;
-
-import java.time.Clock;
 
 /**
  * Listener responsible for creating and publishing events regarding Secret state changes
  */
 public class SecretEventListener implements SecretListener {
-    private final Clock clock;
     private final EventRouter eventRouter;
 
-    public SecretEventListener(Clock clock, EventRouter eventRouter) {
-        this.clock = clock;
+    public SecretEventListener(EventRouter eventRouter) {
         this.eventRouter = eventRouter;
     }
 
@@ -43,7 +37,7 @@ public class SecretEventListener implements SecretListener {
                 .secretId(secret.getId())
                 .build();
 
-        publish(event);
+        eventRouter.publish(event);
     }
 
     @Override
@@ -52,7 +46,7 @@ public class SecretEventListener implements SecretListener {
                 .secretId(secret.getId())
                 .build();
 
-        publish(event);
+        eventRouter.publish(event);
     }
 
     @Override
@@ -61,14 +55,7 @@ public class SecretEventListener implements SecretListener {
                 .secretId(secret.getId())
                 .build();
 
-        publish(event);
+        eventRouter.publish(event);
     }
 
-    private void publish(SecretEvent event) {
-        var envelope = EventEnvelope.Builder.newInstance()
-                .payload(event)
-                .at(clock.millis())
-                .build();
-        eventRouter.publish(envelope);
-    }
 }

--- a/core/control-plane/control-plane-contract/src/main/java/org/eclipse/edc/connector/controlplane/contract/ContractCoreExtension.java
+++ b/core/control-plane/control-plane-contract/src/main/java/org/eclipse/edc/connector/controlplane/contract/ContractCoreExtension.java
@@ -198,7 +198,7 @@ public class ContractCoreExtension implements ServiceExtension {
             providerWaitStrategy = getWaitStrategy(context, providerStateMachineConfiguration.iterationWaitExponentialWaitStrategy());
         }
 
-        observable.registerListener(new ContractNegotiationEventListener(eventRouter, clock));
+        observable.registerListener(new ContractNegotiationEventListener(eventRouter));
 
         consumerNegotiationManager = ConsumerContractNegotiationManagerImpl.Builder.newInstance()
                 .participantId(participantId)

--- a/core/control-plane/control-plane-contract/src/main/java/org/eclipse/edc/connector/controlplane/contract/listener/ContractNegotiationEventListener.java
+++ b/core/control-plane/control-plane-contract/src/main/java/org/eclipse/edc/connector/controlplane/contract/listener/ContractNegotiationEventListener.java
@@ -25,60 +25,55 @@ import org.eclipse.edc.connector.controlplane.contract.spi.event.contractnegotia
 import org.eclipse.edc.connector.controlplane.contract.spi.event.contractnegotiation.ContractNegotiationVerified;
 import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.observe.ContractNegotiationListener;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
-import org.eclipse.edc.spi.event.EventEnvelope;
 import org.eclipse.edc.spi.event.EventRouter;
-
-import java.time.Clock;
 
 public class ContractNegotiationEventListener implements ContractNegotiationListener {
     private final EventRouter eventRouter;
-    private final Clock clock;
 
-    public ContractNegotiationEventListener(EventRouter eventRouter, Clock clock) {
+    public ContractNegotiationEventListener(EventRouter eventRouter) {
         this.eventRouter = eventRouter;
-        this.clock = clock;
     }
 
     @Override
     public void initiated(ContractNegotiation negotiation) {
         var event = baseBuilder(ContractNegotiationInitiated.Builder.newInstance(), negotiation).build();
-        publish(event);
+        eventRouter.publish(event);
     }
 
     @Override
     public void requested(ContractNegotiation negotiation) {
         var event = baseBuilder(ContractNegotiationRequested.Builder.newInstance(), negotiation).build();
-        publish(event);
+        eventRouter.publish(event);
     }
 
     @Override
     public void offered(ContractNegotiation negotiation) {
         var event = baseBuilder(ContractNegotiationOffered.Builder.newInstance(), negotiation).build();
-        publish(event);
+        eventRouter.publish(event);
     }
 
     @Override
     public void accepted(ContractNegotiation negotiation) {
         var event = baseBuilder(ContractNegotiationAccepted.Builder.newInstance(), negotiation).build();
-        publish(event);
+        eventRouter.publish(event);
     }
 
     @Override
     public void terminated(ContractNegotiation negotiation) {
         var event = baseBuilder(ContractNegotiationTerminated.Builder.newInstance(), negotiation).build();
-        publish(event);
+        eventRouter.publish(event);
     }
 
     @Override
     public void agreed(ContractNegotiation negotiation) {
         var event = baseBuilder(ContractNegotiationAgreed.Builder.newInstance(), negotiation).build();
-        publish(event);
+        eventRouter.publish(event);
     }
 
     @Override
     public void verified(ContractNegotiation negotiation) {
         var event = baseBuilder(ContractNegotiationVerified.Builder.newInstance(), negotiation).build();
-        publish(event);
+        eventRouter.publish(event);
     }
 
     @Override
@@ -86,7 +81,7 @@ public class ContractNegotiationEventListener implements ContractNegotiationList
         var event = baseBuilder(ContractNegotiationFinalized.Builder.newInstance(), negotiation)
                 .contractAgreement(negotiation.getContractAgreement())
                 .build();
-        publish(event);
+        eventRouter.publish(event);
     }
 
     private <T extends ContractNegotiationEvent, B extends ContractNegotiationEvent.Builder<T, B>> B baseBuilder(B builder, ContractNegotiation negotiation) {
@@ -98,11 +93,4 @@ public class ContractNegotiationEventListener implements ContractNegotiationList
                 .protocol(negotiation.getProtocol());
     }
 
-    private void publish(ContractNegotiationEvent event) {
-        var envelope = EventEnvelope.Builder.newInstance()
-                .payload(event)
-                .at(clock.millis())
-                .build();
-        eventRouter.publish(envelope);
-    }
 }

--- a/core/control-plane/control-plane-contract/src/test/java/org/eclipse/edc/connector/controlplane/contract/listener/ContractNegotiationEventListenerTest.java
+++ b/core/control-plane/control-plane-contract/src/test/java/org/eclipse/edc/connector/controlplane/contract/listener/ContractNegotiationEventListenerTest.java
@@ -26,37 +26,25 @@ import org.eclipse.edc.connector.controlplane.contract.spi.event.contractnegotia
 import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.policy.model.Policy;
-import org.eclipse.edc.spi.event.EventEnvelope;
 import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-import java.time.Clock;
 import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class ContractNegotiationEventListenerTest {
 
-    private final EventRouter router = mock(EventRouter.class);
-
-    private final Clock clock = mock(Clock.class);
-
-
-    @BeforeEach
-    void setup() {
-        when(clock.millis()).thenAnswer(i -> System.currentTimeMillis());
-    }
+    private final EventRouter router = mock();
+    private final ContractNegotiationEventListener listener = new ContractNegotiationEventListener(router);
 
     @Test
     void initiated_shouldDispatchEvent() {
-        var listener = new ContractNegotiationEventListener(router, clock);
         var negotiation = getNegotiation("id");
 
         listener.initiated(negotiation);
@@ -74,7 +62,6 @@ public class ContractNegotiationEventListenerTest {
 
     @Test
     void requested_shouldDispatchEvent() {
-        var listener = new ContractNegotiationEventListener(router, clock);
         var negotiation = getNegotiation("id");
 
         listener.requested(negotiation);
@@ -93,7 +80,6 @@ public class ContractNegotiationEventListenerTest {
 
     @Test
     void offered_shouldDispatchEvent() {
-        var listener = new ContractNegotiationEventListener(router, clock);
         var negotiation = getNegotiation("id");
 
         listener.offered(negotiation);
@@ -107,12 +93,10 @@ public class ContractNegotiationEventListenerTest {
                 .build();
 
         assertEvent(eventPayload);
-
     }
 
     @Test
     void accepted_shouldDispatchEvent() {
-        var listener = new ContractNegotiationEventListener(router, clock);
         var negotiation = getNegotiation("id");
 
         listener.accepted(negotiation);
@@ -131,7 +115,6 @@ public class ContractNegotiationEventListenerTest {
 
     @Test
     void terminated_shouldDispatchEvent() {
-        var listener = new ContractNegotiationEventListener(router, clock);
         var negotiation = getNegotiation("id");
 
         listener.terminated(negotiation);
@@ -150,7 +133,6 @@ public class ContractNegotiationEventListenerTest {
 
     @Test
     void agreed_shouldDispatchEvent() {
-        var listener = new ContractNegotiationEventListener(router, clock);
         var negotiation = getNegotiation("id");
 
         listener.agreed(negotiation);
@@ -169,7 +151,6 @@ public class ContractNegotiationEventListenerTest {
 
     @Test
     void verified_shouldDispatchEvent() {
-        var listener = new ContractNegotiationEventListener(router, clock);
         var negotiation = getNegotiation("id");
 
         listener.verified(negotiation);
@@ -188,7 +169,6 @@ public class ContractNegotiationEventListenerTest {
 
     @Test
     void finalized_shouldDispatchEvent() {
-        var listener = new ContractNegotiationEventListener(router, clock);
         var agreement = ContractAgreement.Builder.newInstance()
                 .id("id")
                 .policy(Policy.Builder.newInstance().build())
@@ -234,21 +214,8 @@ public class ContractNegotiationEventListenerTest {
     }
 
     private void assertEvent(ContractNegotiationEvent eventPayload) {
-        @SuppressWarnings("unchecked")
-        ArgumentCaptor<EventEnvelope<ContractNegotiationEvent>> eventCaptor = ArgumentCaptor.forClass(EventEnvelope.class);
-
+        var eventCaptor = ArgumentCaptor.forClass(ContractNegotiationEvent.class);
         verify(router).publish(eventCaptor.capture());
-
-        var event = eventCaptor.getValue();
-
-        var targetEnvelope = EventEnvelope.Builder.newInstance()
-                .at(event.getAt())
-                .id(event.getId())
-                .payload(eventPayload)
-                .build();
-
-        assertThat(event).usingRecursiveComparison().isEqualTo(targetEnvelope);
-
-        assertThat(event.getPayload().getClass()).isEqualTo(eventPayload.getClass());
+        assertThat(eventCaptor.getValue()).usingRecursiveComparison().isEqualTo(eventPayload);
     }
 }

--- a/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/TransferCoreExtension.java
+++ b/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/TransferCoreExtension.java
@@ -138,7 +138,7 @@ public class TransferCoreExtension implements ServiceExtension {
 
         typeTransformerRegistry.register(new DataAddressToEndpointDataReferenceTransformer());
 
-        observable.registerListener(new TransferProcessEventListener(eventRouter, clock));
+        observable.registerListener(new TransferProcessEventListener(eventRouter));
 
         var entityRetryProcessConfiguration = stateMachineConfiguration.entityRetryProcessConfiguration();
         var provisionResponsesHandler = new ProvisionResponsesHandler(observable, monitor, vault, typeManager);

--- a/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/listener/TransferProcessEventListener.java
+++ b/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/listener/TransferProcessEventListener.java
@@ -28,21 +28,16 @@ import org.eclipse.edc.connector.controlplane.transfer.spi.event.TransferProcess
 import org.eclipse.edc.connector.controlplane.transfer.spi.observe.TransferProcessListener;
 import org.eclipse.edc.connector.controlplane.transfer.spi.observe.TransferProcessStartedData;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
-import org.eclipse.edc.spi.event.EventEnvelope;
 import org.eclipse.edc.spi.event.EventRouter;
-
-import java.time.Clock;
 
 /**
  * Listener responsible for creating and publishing events regarding TransferProcess state changes
  */
 public class TransferProcessEventListener implements TransferProcessListener {
     private final EventRouter eventRouter;
-    private final Clock clock;
 
-    public TransferProcessEventListener(EventRouter eventRouter, Clock clock) {
+    public TransferProcessEventListener(EventRouter eventRouter) {
         this.eventRouter = eventRouter;
-        this.clock = clock;
     }
 
     @Override
@@ -50,7 +45,7 @@ public class TransferProcessEventListener implements TransferProcessListener {
         var event = withBaseProperties(TransferProcessInitiated.Builder.newInstance(), process)
                 .build();
 
-        publish(event);
+        eventRouter.publish(event);
     }
 
     @Override
@@ -58,7 +53,7 @@ public class TransferProcessEventListener implements TransferProcessListener {
         var event = withBaseProperties(TransferProcessProvisioningRequested.Builder.newInstance(), process)
                 .build();
 
-        publish(event);
+        eventRouter.publish(event);
     }
 
     @Override
@@ -66,7 +61,7 @@ public class TransferProcessEventListener implements TransferProcessListener {
         var event = withBaseProperties(TransferProcessProvisioned.Builder.newInstance(), process)
                 .build();
 
-        publish(event);
+        eventRouter.publish(event);
     }
 
     @Override
@@ -74,7 +69,7 @@ public class TransferProcessEventListener implements TransferProcessListener {
         var event = withBaseProperties(TransferProcessRequested.Builder.newInstance(), process)
                 .build();
 
-        publish(event);
+        eventRouter.publish(event);
     }
 
     @Override
@@ -83,7 +78,7 @@ public class TransferProcessEventListener implements TransferProcessListener {
                 .dataAddress(additionalData.getDataAddress())
                 .build();
 
-        publish(event);
+        eventRouter.publish(event);
     }
 
     @Override
@@ -91,7 +86,7 @@ public class TransferProcessEventListener implements TransferProcessListener {
         var event = withBaseProperties(TransferProcessCompleted.Builder.newInstance(), process)
                 .build();
 
-        publish(event);
+        eventRouter.publish(event);
     }
 
     @Override
@@ -100,7 +95,7 @@ public class TransferProcessEventListener implements TransferProcessListener {
                 .reason(process.getErrorDetail())
                 .build();
 
-        publish(event);
+        eventRouter.publish(event);
     }
 
     @Override
@@ -109,7 +104,7 @@ public class TransferProcessEventListener implements TransferProcessListener {
                 .reason(process.getErrorDetail())
                 .build();
 
-        publish(event);
+        eventRouter.publish(event);
     }
 
     @Override
@@ -117,7 +112,7 @@ public class TransferProcessEventListener implements TransferProcessListener {
         var event = withBaseProperties(TransferProcessDeprovisioningRequested.Builder.newInstance(), process)
                 .build();
 
-        publish(event);
+        eventRouter.publish(event);
     }
 
     @Override
@@ -125,7 +120,7 @@ public class TransferProcessEventListener implements TransferProcessListener {
         var event = withBaseProperties(TransferProcessDeprovisioned.Builder.newInstance(), process)
                 .build();
 
-        publish(event);
+        eventRouter.publish(event);
     }
 
     private <T extends TransferProcessEvent, B extends TransferProcessEvent.Builder<T, B>> B withBaseProperties(B builder, TransferProcess process) {
@@ -136,13 +131,4 @@ public class TransferProcessEventListener implements TransferProcessListener {
                 .callbackAddresses(process.getCallbackAddresses());
     }
 
-    @SuppressWarnings("unchecked")
-    private void publish(TransferProcessEvent event) {
-        var envelope = EventEnvelope.Builder.newInstance()
-                .payload(event)
-                .at(clock.millis())
-                .build();
-
-        eventRouter.publish(envelope);
-    }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/EventRouter.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/EventRouter.java
@@ -44,5 +44,12 @@ public interface EventRouter {
      *
      * @param event the event to be published
      */
-    <E extends Event> void publish(EventEnvelope<E> event);
+    <E extends Event> void publish(E event);
+
+    /**
+     * Publish an eventEnvelope to all the subscribers
+     *
+     * @param eventEnvelope the eventEnvelope to be published
+     */
+    <E extends Event> void publish(EventEnvelope<E> eventEnvelope);
 }


### PR DESCRIPTION
## What this PR changes/adds

Adds a `<E extends Event> void publish(E event)` to the `EventRouter`, that will permit to publish events without having to care about `EventEnvelope` and its attributes (`id`, `at`).

the `<E extends Event> void publish(EventEnvelope<E> eventEnvelope)` will be kept to permit eventual customization of the envelope, but the common case is to have a central envelope definition.

## Why it does that

refactoring, usability

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5069

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
