### PR TITLE
feat: limit distributions for datasets with response channels

### DIFF
--- a/core/common/lib/transform-lib/src/main/java/org/eclipse/edc/transform/transformer/edc/from/JsonObjectFromDataAddressTransformer.java
+++ b/core/common/lib/transform-lib/src/main/java/org/eclipse/edc/transform/transformer/edc/from/JsonObjectFromDataAddressTransformer.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.transform.transformer.edc.from;
 
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.spi.types.domain.DataAddress;
@@ -23,8 +24,11 @@ import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.function.BiFunction;
+
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+import static org.eclipse.edc.spi.types.domain.DataAddress.EDC_DATA_ADDRESS_RESPONSE_CHANNEL;
 
 public class JsonObjectFromDataAddressTransformer extends AbstractJsonLdTransformer<DataAddress, JsonObject> {
 
@@ -45,7 +49,14 @@ public class JsonObjectFromDataAddressTransformer extends AbstractJsonLdTransfor
 
         builder.add(TYPE, EDC_NAMESPACE + "DataAddress");
 
-        transformProperties(dataAddress.getProperties(), builder, typeManager.getMapper(typeContext), context);
+        BiFunction<String, Object, JsonValue> func = (k, v) -> {
+            if (k.equals(EDC_DATA_ADDRESS_RESPONSE_CHANNEL)) {
+                return context.transform(v, JsonObject.class);
+            }
+            return typeManager.getMapper(typeContext).convertValue(v, JsonValue.class);
+        };
+
+        transformProperties(dataAddress.getProperties(), builder, func, context);
 
         return builder.build();
     }

--- a/core/common/lib/transform-lib/src/main/java/org/eclipse/edc/transform/transformer/edc/to/JsonObjectToDataAddressTransformer.java
+++ b/core/common/lib/transform-lib/src/main/java/org/eclipse/edc/transform/transformer/edc/to/JsonObjectToDataAddressTransformer.java
@@ -49,6 +49,9 @@ public class JsonObjectToDataAddressTransformer extends AbstractJsonLdTransforme
 
         if (firstValue != null && key.equals(PROPERTIES_KEY)) {
             visitProperties(firstValue, (k, val) -> transformProperties(k, val, builder, context));
+        } else if (firstValue != null && key.equals(DataAddress.EDC_DATA_ADDRESS_RESPONSE_CHANNEL)) {
+            builder.responseChannel(transformObject(firstValue, DataAddress.class, context));
+
         } else {
             builder.property(key, transformGenericProperty(jsonValue, context));
         }

--- a/core/common/lib/transform-lib/src/test/java/org/eclipse/edc/transform/transformer/edc/to/JsonObjectToDataAddressTransformerTest.java
+++ b/core/common/lib/transform-lib/src/test/java/org/eclipse/edc/transform/transformer/edc/to/JsonObjectToDataAddressTransformerTest.java
@@ -173,6 +173,32 @@ class JsonObjectToDataAddressTransformerTest {
         verify(transformerContext, never()).reportProblem(any());
     }
 
+    @Test
+    void transform_withResponseChannel() {
+        var innerDataAddress = createObjectBuilder()
+                .add(TYPE, EDC_NAMESPACE + "DataAddress")
+                .add(DataAddress.EDC_DATA_ADDRESS_TYPE_PROPERTY, "innerType")
+                .build();
+
+        var json = createDataAddress()
+                .add(EDC_NAMESPACE + "properties", createObjectBuilder()
+                        .add(DataAddress.EDC_DATA_ADDRESS_RESPONSE_CHANNEL, innerDataAddress)
+                        .build())
+                .build();
+
+        when(transformerContext.transform(any(), eq(DataAddress.class)))
+                .thenReturn(DataAddress.Builder.newInstance()
+                        .type("innerType")
+                        .build());
+
+        var dataAddress = transformer.transform(expand(json), transformerContext);
+
+        assertThat(dataAddress).isNotNull();
+        assertThat(dataAddress.getResponseChannel()).isNotNull();
+        assertThat(dataAddress.getResponseChannel().getType()).isEqualTo("innerType");
+        verify(transformerContext, never()).reportProblem(any());
+    }
+
     private JsonObjectBuilder createDataAddress() {
         return createObjectBuilder()
                 .add(CONTEXT, createContextBuilder().build())

--- a/data-protocols/dsp/dsp-lib/dsp-transfer-process-lib/dsp-transfer-process-transform-lib/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/from/JsonObjectFromDataAddressTransformerTest.java
+++ b/data-protocols/dsp/dsp-lib/dsp-transfer-process-lib/dsp-transfer-process-transform-lib/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/from/JsonObjectFromDataAddressTransformerTest.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.protocol.dsp.transferprocess.transform.from;
 import jakarta.json.Json;
 import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
 import org.eclipse.edc.jsonld.util.JacksonJsonLd;
 import org.eclipse.edc.spi.types.TypeManager;
@@ -35,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 import static org.eclipse.edc.spi.types.domain.DataAddress.EDC_DATA_ADDRESS_KEY_NAME;
+import static org.eclipse.edc.spi.types.domain.DataAddress.EDC_DATA_ADDRESS_RESPONSE_CHANNEL;
 import static org.eclipse.edc.spi.types.domain.DataAddress.EDC_DATA_ADDRESS_TYPE_PROPERTY;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
@@ -72,7 +74,6 @@ class JsonObjectFromDataAddressTransformerTest {
                 .property("string", "test")
                 .property("integer", 123)
                 .property("whatAboutDouble", 123.456)
-                .property("nestedDataAddress", innerDataAddress)
                 .property("nestedJsonObject", Map.of("key", Map.of("testKey", "testValue")))
                 .property("jsonArray", List.of("string1", "string2"))
                 .property("arrayOfObjects", List.of(
@@ -81,7 +82,14 @@ class JsonObjectFromDataAddressTransformerTest {
                 .property("nestedJsonObjectWithArray", Map.of(
                         "key", List.of("value1", "value2"),
                         "anotherKey", List.of("value3", "value4")))
+                .responseChannel(innerDataAddress)
                 .build();
+
+        when(context.transform(innerDataAddress, JsonObject.class))
+                .thenReturn(
+                        jsonObject()
+                                .add(TYPE, EDC_NAMESPACE + "DataAddress")
+                                .add(EDC_DATA_ADDRESS_TYPE_PROPERTY, "type").build());
 
         var expectedJson = jsonObject()
                 .add(TYPE, EDC_NAMESPACE + "DataAddress")
@@ -90,9 +98,10 @@ class JsonObjectFromDataAddressTransformerTest {
                 .add("string", "test")
                 .add("integer", 123)
                 .add("whatAboutDouble", 123.456)
-                .add("nestedDataAddress",
+                .add(EDC_DATA_ADDRESS_RESPONSE_CHANNEL,
                         jsonObject()
-                                .add("properties", jsonObject().add(EDC_DATA_ADDRESS_TYPE_PROPERTY, "type")))
+                                .add(TYPE, EDC_NAMESPACE + "DataAddress")
+                                .add(EDC_DATA_ADDRESS_TYPE_PROPERTY, "type"))
                 .add("nestedJsonObject",
                         jsonObject()
                                 .add("key", jsonObject().add("testKey", "testValue")))

--- a/extensions/control-plane/transfer/transfer-data-plane-signaling/src/test/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/flow/DataPlaneSignalingFlowControllerTest.java
+++ b/extensions/control-plane/transfer/transfer-data-plane-signaling/src/test/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/flow/DataPlaneSignalingFlowControllerTest.java
@@ -42,11 +42,13 @@ import org.mockito.ArgumentCaptor;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.spi.types.domain.DataAddress.EDC_DATA_ADDRESS_RESPONSE_CHANNEL;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -340,7 +342,8 @@ public class DataPlaneSignalingFlowControllerTest {
             assertThat(result).isFailed().detail().contains("Failed to select the data plane for terminating the transfer process");
         }
 
-        @Test // a null dataPlaneId means that the flow has not been started so it can be considered as already terminated
+        @Test
+            // a null dataPlaneId means that the flow has not been started so it can be considered as already terminated
         void shouldReturnSuccess_whenDataPlaneIdIsNull() {
             var transferProcess = transferProcessBuilder()
                     .id("transferProcessId")
@@ -413,9 +416,13 @@ public class DataPlaneSignalingFlowControllerTest {
 
         @Test
         void transferTypes_shouldReturnTypesForSpecifiedAsset() {
+            when(transferTypeParser.parse(any()))
+                    .thenReturn(Result.success(new TransferType("any", FlowType.PUSH)))
+                    .thenReturn(Result.success(new TransferType("any", FlowType.PULL)))
+                    .thenReturn(Result.success(new TransferType("any", FlowType.PULL, "Response")));
             when(selectorService.getAll()).thenReturn(ServiceResult.success(List.of(
                     dataPlaneInstanceBuilder().allowedTransferType("Custom-PUSH").allowedSourceType("TargetSrc").allowedDestType("TargetDest").build(),
-                    dataPlaneInstanceBuilder().allowedTransferType("Custom-PULL").allowedSourceType("TargetSrc").allowedDestType("AnotherTargetDest").build(),
+                    dataPlaneInstanceBuilder().allowedTransferType(Set.of("Custom-PULL", "Custom-PULL-Response")).allowedSourceType("TargetSrc").allowedDestType("AnotherTargetDest").build(),
                     dataPlaneInstanceBuilder().allowedSourceType("AnotherSrc").allowedDestType("ThisWontBeListed").build()
             )));
             var asset = Asset.Builder.newInstance().dataAddress(DataAddress.Builder.newInstance().type("TargetSrc").build()).build();
@@ -423,6 +430,31 @@ public class DataPlaneSignalingFlowControllerTest {
             var transferTypes = flowController.transferTypesFor(asset);
 
             assertThat(transferTypes).containsExactly("Custom-PUSH", "Custom-PULL");
+        }
+
+        @Test
+        void transferTypes_shouldFilterTypesForSpecifiedAssetWithResponseChannel() {
+            when(transferTypeParser.parse(any()))
+                    .thenReturn(Result.success(new TransferType("any", FlowType.PUSH)))
+                    .thenReturn(Result.success(new TransferType("any", FlowType.PUSH)))
+                    .thenReturn(Result.success(new TransferType("any", FlowType.PULL, "Response")))
+                    .thenReturn(Result.success(new TransferType("any", FlowType.PULL)))
+                    .thenReturn(Result.success(new TransferType("any", FlowType.PUSH, "Response")));
+            when(selectorService.getAll()).thenReturn(ServiceResult.success(List.of(
+                    dataPlaneInstanceBuilder().allowedTransferType("Custom-PUSH").allowedSourceType("TargetSrc").build(),
+                    dataPlaneInstanceBuilder().allowedTransferType("Response-PUSH").allowedSourceType("TargetSrc").build(),
+                    dataPlaneInstanceBuilder().allowedTransferType("Custom-PULL-Response").allowedTransferType("Custom-PULL").allowedSourceType("TargetSrc").build(),
+                    dataPlaneInstanceBuilder().allowedTransferType("Custom-PUSH-Response").allowedSourceType("AnotherSrc").build(),
+                    dataPlaneInstanceBuilder().allowedSourceType("AnotherSrc").build()
+            )));
+            var asset = Asset.Builder.newInstance().dataAddress(DataAddress.Builder.newInstance()
+                    .type("TargetSrc")
+                    .property(EDC_DATA_ADDRESS_RESPONSE_CHANNEL, buildResponseChannel())
+                    .build()).build();
+
+            var transferTypes = flowController.transferTypesFor(asset);
+
+            assertThat(transferTypes).containsExactly("Custom-PULL-Response");
         }
 
         @Test
@@ -462,6 +494,10 @@ public class DataPlaneSignalingFlowControllerTest {
 
     private Policy.Builder policyBuilder() {
         return Policy.Builder.newInstance();
+    }
+
+    private DataAddress buildResponseChannel() {
+        return DataAddress.Builder.newInstance().type("Response").build();
     }
 
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/DataAddress.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/DataAddress.java
@@ -46,6 +46,7 @@ public class DataAddress {
     public static final String EDC_DATA_ADDRESS_TYPE_PROPERTY = EDC_NAMESPACE + SIMPLE_TYPE;
     public static final String EDC_DATA_ADDRESS_KEY_NAME = EDC_NAMESPACE + SIMPLE_KEY_NAME;
     public static final String EDC_DATA_ADDRESS_SECRET = EDC_NAMESPACE + "secret";
+    public static final String EDC_DATA_ADDRESS_RESPONSE_CHANNEL = EDC_NAMESPACE + "responseChannel";
 
     protected final Map<String, Object> properties = new HashMap<>();
 
@@ -91,6 +92,11 @@ public class DataAddress {
     }
 
     @JsonIgnore
+    public DataAddress getResponseChannel() {
+        return (DataAddress) getProperty(EDC_DATA_ADDRESS_RESPONSE_CHANNEL);
+    }
+
+    @JsonIgnore
     public void setKeyName(String keyName) {
         Objects.requireNonNull(keyName);
         properties.put(EDC_DATA_ADDRESS_KEY_NAME, keyName);
@@ -130,6 +136,7 @@ public class DataAddress {
             switch (key) {
                 case SIMPLE_TYPE -> address.properties.put(EDC_DATA_ADDRESS_TYPE_PROPERTY, value);
                 case SIMPLE_KEY_NAME -> address.properties.put(EDC_DATA_ADDRESS_KEY_NAME, value);
+                case EDC_DATA_ADDRESS_RESPONSE_CHANNEL -> responseChannel(value);
                 default -> address.properties.put(key, value);
             }
             return self();
@@ -142,6 +149,26 @@ public class DataAddress {
 
         public B keyName(String keyName) {
             address.getProperties().put(EDC_DATA_ADDRESS_KEY_NAME, Objects.requireNonNull(keyName));
+            return self();
+        }
+
+        @JsonIgnore
+        @SuppressWarnings("unchecked")
+        public B responseChannel(Object rc) {
+            Objects.requireNonNull(rc, "Response channel cannot be null.");
+            if (rc instanceof DataAddress) {
+                address.properties.put(EDC_DATA_ADDRESS_RESPONSE_CHANNEL, rc);
+            } else if (rc instanceof Map) {
+                var builder = DataAddress.Builder.newInstance();
+                var rcMap = (Map<String, Object>) rc;
+                var props = rcMap.get("properties");
+                if (props != null) {
+                    builder.properties((Map<String, Object>) props);
+                } else {
+                    builder.properties(rcMap);
+                }
+                address.properties.put(EDC_DATA_ADDRESS_RESPONSE_CHANNEL, builder.build());
+            }
             return self();
         }
 

--- a/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/transformer/AbstractJsonLdTransformer.java
+++ b/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/transformer/AbstractJsonLdTransformer.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -154,12 +155,18 @@ public abstract class AbstractJsonLdTransformer<INPUT, OUTPUT> implements JsonLd
      * @param context    the transformer context
      */
     protected void transformProperties(Map<String, ?> properties, JsonObjectBuilder builder, ObjectMapper mapper, TransformerContext context) {
+        BiFunction<String, Object, JsonValue> func = (k, v) -> mapper.convertValue(v, JsonValue.class);
+
+        transformProperties(properties, builder, func, context);
+    }
+
+    protected void transformProperties(Map<String, ?> properties, JsonObjectBuilder builder, BiFunction<String, Object, JsonValue> consumer, TransformerContext context) {
         if (properties == null) {
             return;
         }
         properties.forEach((k, v) -> {
             try {
-                builder.add(k, mapper.convertValue(v, JsonValue.class));
+                builder.add(k, consumer.apply(k, v));
             } catch (IllegalArgumentException e) {
                 context.problem()
                         .invalidProperty()

--- a/system-tests/management-api/management-api-test-runner/build.gradle.kts
+++ b/system-tests/management-api/management-api-test-runner/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     testImplementation(project(":extensions:control-plane:api:management-api:policy-definition-api"))
     testImplementation(project(":extensions:control-plane:api:management-api:transfer-process-api"))
     testImplementation(project(":extensions:control-plane:api:management-api:secrets-api"))
+    testImplementation(project(":extensions:control-plane:transfer:transfer-data-plane-signaling"))
     testImplementation(project(":extensions:control-plane:api:management-api:edr-cache-api"))
     testImplementation(project(":extensions:data-plane-selector:data-plane-selector-api"))
 }


### PR DESCRIPTION
## What this PR changes/adds

When an Dataset contains a response channel, only distributions that contain that response channel should be included in the catalog.

## Why it does that

Whenever a data provider defines a dataset with a response channel, the use of that response channel should be enforced.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

@ndr-brt ?
@jimmarino ? 


## Linked Issue(s)

Closes #4987 

