### PR TITLE
fix: adds copy before returning the entity in findByIdAndLease method

### DIFF
--- a/core/common/lib/store-lib/src/main/java/org/eclipse/edc/store/InMemoryStatefulEntityStore.java
+++ b/core/common/lib/store-lib/src/main/java/org/eclipse/edc/store/InMemoryStatefulEntityStore.java
@@ -48,13 +48,13 @@ import static java.util.stream.Collectors.toList;
  */
 public class InMemoryStatefulEntityStore<T extends StatefulEntity<T>> implements StateEntityStore<T> {
     private static final Duration DEFAULT_LEASE_TIME = Duration.ofSeconds(60);
+    protected final CriterionOperatorRegistry criterionOperatorRegistry;
     private final Map<String, T> entitiesById = new ConcurrentHashMap<>();
     private final QueryResolver<T> queryResolver;
     private final LockManager lockManager = new LockManager(new ReentrantReadWriteLock());
     private final String lockId;
     private final Clock clock;
     private final Map<String, Lease> leases = new HashMap<>();
-    protected final CriterionOperatorRegistry criterionOperatorRegistry;
 
     public InMemoryStatefulEntityStore(Class<T> clazz, String lockId, Clock clock, CriterionOperatorRegistry criterionOperatorRegistry, StateResolver stateResolver) {
         this.queryResolver = new ReflectionBasedQueryResolver<>(clazz, new StatefulEntityCriteriaToPredicate<>(criterionOperatorRegistry, stateResolver));
@@ -97,7 +97,7 @@ public class InMemoryStatefulEntityStore<T extends StatefulEntity<T>> implements
 
             try {
                 acquireLease(id);
-                return StoreResult.success(entity);
+                return StoreResult.success(entity.copy());
             } catch (IllegalStateException e) {
                 return StoreResult.alreadyLeased(format("Entity %s is already leased: %s", id, e.getMessage()));
             }


### PR DESCRIPTION
## What this PR changes/adds

Adds copy before returning the entity in `findByIdAndLease` method

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5102 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
