### PR TITLE
docs: embed data-plane-selector DR

### DIFF
--- a/docs/developer/decision-records/2025-07-09-embed-data-plane-selector/README.md
+++ b/docs/developer/decision-records/2025-07-09-embed-data-plane-selector/README.md
@@ -1,0 +1,22 @@
+# Embed `data-plane-selector` into `control-plane`
+
+## Decision
+
+`data-plane-selector` "select" functionality will only be available embedded in the `control-plane`.
+
+## Rationale
+
+At the moment we are maintaining the http communication layer for `data-plane` selection between the `control-plane` and
+a potentially independently deployed `data-plane-selector`.
+There's no actual demonstration of the usefulness of this separation and all the project we know are actually deploying
+them together.
+Nothing will stop us in the future to re-think the boundaries again, but at the moment this is a simplification that will
+reduce maintenance burden.
+
+## Approach
+
+The implementation of the `select` method in the `RemoteDataPlaneSelectorService` will always return a failed result.
+The `/select` endpoint in the `DataplaneSelectorControlApiController` will be removed.
+In the `DataPlaneSelectorService` only the `select(@Nullable String selectionStrategy, Predicate<DataPlaneInstance> filter)`
+method will remain, the other `select(DataAddress source, String transferType, @Nullable String selectionStrategy)` will
+be removed as less flexible and all it's usages can be easily replaced with the first one.

--- a/docs/developer/decision-records/README.md
+++ b/docs/developer/decision-records/README.md
@@ -81,3 +81,4 @@
 - [2025-04-30 Finalize phase](./2025-04-30-finalize-phase)
 - [2025-06-11 Dataspace Profile Context](2025-05-28-dataspace-profile-context)
 - [2025-06-20 Listeners "pre" methods](./2025-06-20-listeners-pre-methods)
+- [2025-07-09 Embed data-plane-selector in control-plane](2025-07-09-embed-data-plane-selector)


### PR DESCRIPTION
## What this PR changes/adds

DR about removing the remote "select" capabilities from data-plane-selector 

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Part of #4793 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
