### PR TITLE
feat: add dsp tck with pg under test

### DIFF
--- a/system-tests/dsp-compatibility-tests/compatibility-test-runner/build.gradle.kts
+++ b/system-tests/dsp-compatibility-tests/compatibility-test-runner/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     testRuntimeOnly(libs.dsp.tck.transferprocess)
     testRuntimeOnly(libs.dsp.tck.contractnegotiation)
     testImplementation(libs.junit.platform.launcher)
+    testImplementation(testFixtures(project(":extensions:common:sql:sql-test-fixtures")))
     runtimeOnly(libs.parsson)
 }
 

--- a/system-tests/dsp-compatibility-tests/compatibility-test-runner/src/test/java/org/eclipse/edc/tck/dsp/PostgresEdcCompatibilityDockerTest.java
+++ b/system-tests/dsp-compatibility-tests/compatibility-test-runner/src/test/java/org/eclipse/edc/tck/dsp/PostgresEdcCompatibilityDockerTest.java
@@ -1,0 +1,129 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.tck.dsp;
+
+import org.eclipse.edc.junit.annotations.NightlyTest;
+import org.eclipse.edc.junit.extensions.EmbeddedRuntime;
+import org.eclipse.edc.junit.extensions.RuntimeExtension;
+import org.eclipse.edc.junit.extensions.RuntimePerClassExtension;
+import org.eclipse.edc.junit.testfixtures.TestUtils;
+import org.eclipse.edc.spi.monitor.ConsoleMonitor;
+import org.eclipse.edc.spi.system.configuration.Config;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+import org.eclipse.edc.sql.testfixtures.PostgresqlEndToEndExtension;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.SelinuxContext;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.HashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.eclipse.edc.tck.dsp.CompatibilityTests.ALLOWED_FAILURES;
+import static org.eclipse.edc.util.io.Ports.getFreePort;
+
+@NightlyTest
+@Testcontainers
+public class PostgresEdcCompatibilityDockerTest {
+
+    @Order(0)
+    @RegisterExtension
+    static final PostgresqlEndToEndExtension POSTGRESQL_EXTENSION = new PostgresqlEndToEndExtension();
+    private static final String CONNECTOR_UNDER_TEST = "CUT";
+
+    @Order(1)
+    @RegisterExtension
+    static final BeforeAllCallback CREATE_DATABASES = context -> {
+        POSTGRESQL_EXTENSION.createDatabase(CONNECTOR_UNDER_TEST.toLowerCase());
+    };
+
+    private static final GenericContainer<?> TCK_CONTAINER = new TckContainer<>("eclipsedataspacetck/dsp-tck-runtime:1.0.0-RC4");
+    @RegisterExtension
+    protected static RuntimeExtension runtime = new RuntimePerClassExtension(new EmbeddedRuntime(CONNECTOR_UNDER_TEST,
+            ":system-tests:dsp-compatibility-tests:connector-under-test",
+            ":dist:bom:controlplane-feature-sql-bom"
+    ).configurationProvider(PostgresEdcCompatibilityDockerTest::runtimeConfiguration)
+            .configurationProvider(() -> POSTGRESQL_EXTENSION.configFor(CONNECTOR_UNDER_TEST.toLowerCase())));
+
+
+    private static Config runtimeConfiguration() {
+        return ConfigFactory.fromMap(new HashMap<>() {
+            {
+                put("edc.participant.id", "CONNECTOR_UNDER_TEST");
+                put("web.http.port", "8080");
+                put("web.http.path", "/api");
+                put("web.http.version.port", String.valueOf(getFreePort()));
+                put("web.http.version.path", "/api/version");
+                put("web.http.control.port", String.valueOf(getFreePort()));
+                put("web.http.control.path", "/api/control");
+                put("web.http.management.port", "8081");
+                put("web.http.management.path", "/api/management");
+                put("web.http.protocol.port", "8282"); // this must match the configured connector url in resources/docker.tck.properties
+                put("web.http.protocol.path", "/api/dsp"); // this must match the configured connector url in resources/docker.tck.properties
+                put("web.api.auth.key", "password");
+                put("edc.dsp.callback.address", "http://host.docker.internal:8282/api/dsp"); // host.docker.internal is required by the container to communicate with the host
+                put("edc.management.context.enabled", "true");
+                put("edc.hostname", "host.docker.internal");
+                put("edc.component.id", "DSP-compatibility-test");
+                put("edc.transfer.proxy.token.signer.privatekey.alias", "private-key");
+                put("edc.transfer.proxy.token.verifier.publickey.alias", "public-key");
+            }
+        });
+    }
+
+    private static String resourceConfig(String resource) {
+        return Path.of(TestUtils.getResource(resource)).toString();
+    }
+
+    @Timeout(300)
+    @Test
+    void assertDspCompatibility() {
+
+
+        // pipe the docker container's log to this console at the INFO level
+        var monitor = new ConsoleMonitor(">>> TCK Runtime (Docker)", ConsoleMonitor.Level.INFO, true);
+        var reporter = new TckTestReporter();
+
+        TCK_CONTAINER.addFileSystemBind(resourceConfig("docker.tck.properties"), "/etc/tck/config.properties", BindMode.READ_ONLY, SelinuxContext.SINGLE);
+        TCK_CONTAINER.addFileSystemBind(resourceConfig("dspace-edc-context-v1.jsonld"), "/etc/tck/dspace-edc-context-v1.jsonld", BindMode.READ_ONLY, SelinuxContext.SINGLE);
+        TCK_CONTAINER.withExtraHost("host.docker.internal", "host-gateway");
+        TCK_CONTAINER.withLogConsumer(outputFrame -> monitor.info(outputFrame.getUtf8String()));
+        TCK_CONTAINER.withLogConsumer(reporter);
+        TCK_CONTAINER.waitingFor(new LogMessageWaitStrategy().withRegEx(".*Test run complete.*").withStartupTimeout(Duration.ofSeconds(300)));
+        TCK_CONTAINER.start();
+
+        var failures = reporter.failures();
+
+        assertThat(failures).containsAll(ALLOWED_FAILURES);
+
+        failures.removeAll(ALLOWED_FAILURES);
+
+        if (!failures.isEmpty()) {
+            fail(failures.size() + " TCK test cases failed:\n" + String.join("\n", failures));
+        }
+    }
+
+
+}
+

--- a/system-tests/protocol-tck/tck-extension/build.gradle.kts
+++ b/system-tests/protocol-tck/tck-extension/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
 
 dependencies {
     implementation(project(":spi:common:core-spi"))
+    implementation(project(":spi:common:transaction-spi"))
     implementation(project(":spi:control-plane:contract-spi"))
     implementation(project(":spi:control-plane:asset-spi"))
     implementation(project(":spi:control-plane:control-plane-spi"))

--- a/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/guard/TckGuardExtension.java
+++ b/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/guard/TckGuardExtension.java
@@ -24,6 +24,7 @@ import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.transaction.spi.TransactionContext;
 
 import static org.eclipse.edc.tck.dsp.data.DataAssembly.createNegotiationRecorder;
 import static org.eclipse.edc.tck.dsp.data.DataAssembly.createNegotiationTriggers;
@@ -47,6 +48,9 @@ public class TckGuardExtension implements ServiceExtension {
     private TransferProcessStore transferProcessStore;
 
     @Inject
+    private TransactionContext transactionContext;
+
+    @Inject
     private EventRouter router;
 
     @Override
@@ -58,7 +62,7 @@ public class TckGuardExtension implements ServiceExtension {
     public ContractNegotiationPendingGuard negotiationGuard() {
         var recorder = createNegotiationRecorder();
 
-        var registry = new ContractNegotiationTriggerSubscriber(store);
+        var registry = new ContractNegotiationTriggerSubscriber(store, transactionContext);
         createNegotiationTriggers().forEach(registry::register);
         router.register(ContractNegotiationEvent.class, registry);
 

--- a/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/guard/TransferProcessTriggerSubscriber.java
+++ b/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/guard/TransferProcessTriggerSubscriber.java
@@ -23,6 +23,7 @@ import org.eclipse.edc.spi.persistence.StateEntityStore;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Fires triggers based on transfer events.
@@ -42,6 +43,11 @@ public class TransferProcessTriggerSubscriber implements EventSubscriber, Transf
 
     @Override
     public <E extends Event> void on(EventEnvelope<E> envelope) {
+        try {
+            TimeUnit.MILLISECONDS.sleep(100);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
         triggers.stream()
                 .filter(trigger -> trigger.predicate().test(envelope.getPayload()))
                 .forEach(trigger -> {


### PR DESCRIPTION
## What this PR changes/adds

Adds dsp-tck testing using postgres persistence instead of memory

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5119 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
