### PR TITLE
refactor: use DataFlow instead of StartMessage where possible

### DIFF
--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImpl.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImpl.java
@@ -493,7 +493,7 @@ public class DataPlaneManagerImpl extends AbstractStateEntityManager<DataFlow, D
 
     private boolean processCompleted(DataFlow dataFlow) {
         return entityRetryProcessFactory.retryProcessor(dataFlow)
-                .doProcess(Process.result("Complete data flow", (d, v) -> transferProcessClient.completed(dataFlow.toRequest())))
+                .doProcess(Process.result("Complete data flow", (d, v) -> transferProcessClient.completed(dataFlow)))
                 .onSuccess((d, v) -> {
                     if (dataFlow.resourcesToBeDeprovisioned().isEmpty()) {
                         dataFlow.transitionToNotified();
@@ -515,7 +515,7 @@ public class DataPlaneManagerImpl extends AbstractStateEntityManager<DataFlow, D
 
     private boolean processFailed(DataFlow dataFlow) {
         return entityRetryProcessFactory.retryProcessor(dataFlow)
-                .doProcess(Process.result("Fail data flow", (d, v) -> transferProcessClient.failed(dataFlow.toRequest(), dataFlow.getErrorDetail())))
+                .doProcess(Process.result("Fail data flow", (d, v) -> transferProcessClient.failed(dataFlow, dataFlow.getErrorDetail())))
                 .onSuccess((d, v) -> {
                     dataFlow.transitionToNotified();
                     update(dataFlow);

--- a/extensions/control-plane/api/control-plane-api-client/src/main/java/org/eclipse/edc/connector/controlplane/api/client/transferprocess/EmbeddedTransferProcessHttpClient.java
+++ b/extensions/control-plane/api/control-plane-api-client/src/main/java/org/eclipse/edc/connector/controlplane/api/client/transferprocess/EmbeddedTransferProcessHttpClient.java
@@ -21,7 +21,6 @@ import org.eclipse.edc.connector.dataplane.spi.DataFlow;
 import org.eclipse.edc.connector.dataplane.spi.port.TransferProcessApiClient;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.result.ServiceResult;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 
 import java.util.function.Function;
 
@@ -37,14 +36,14 @@ public class EmbeddedTransferProcessHttpClient implements TransferProcessApiClie
     }
 
     @Override
-    public StatusResult<Void> completed(DataFlowStartMessage request) {
-        return transferProcessService.complete(request.getProcessId())
+    public StatusResult<Void> completed(DataFlow dataFlow) {
+        return transferProcessService.complete(dataFlow.getId())
                 .flatMap(toStatusResult());
     }
 
     @Override
-    public StatusResult<Void> failed(DataFlowStartMessage request, String reason) {
-        return transferProcessService.terminate(new TerminateTransferCommand(request.getProcessId(), reason))
+    public StatusResult<Void> failed(DataFlow dataFlow, String reason) {
+        return transferProcessService.terminate(new TerminateTransferCommand(dataFlow.getId(), reason))
                 .flatMap(toStatusResult());
     }
 

--- a/extensions/control-plane/api/control-plane-api-client/src/main/java/org/eclipse/edc/connector/controlplane/api/client/transferprocess/TransferProcessHttpClient.java
+++ b/extensions/control-plane/api/control-plane-api-client/src/main/java/org/eclipse/edc/connector/controlplane/api/client/transferprocess/TransferProcessHttpClient.java
@@ -25,7 +25,6 @@ import org.eclipse.edc.connector.dataplane.spi.port.TransferProcessApiClient;
 import org.eclipse.edc.http.spi.ControlApiHttpClient;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.response.StatusResult;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.jetbrains.annotations.NotNull;
 
 import static org.eclipse.edc.spi.response.ResponseStatus.ERROR_RETRY;
@@ -48,14 +47,14 @@ public class TransferProcessHttpClient implements TransferProcessApiClient {
     }
 
     @Override
-    public StatusResult<Void> completed(DataFlowStartMessage dataFlowStartMessage) {
-        var url = dataFlowStartMessage.getCallbackAddress() + "/transferprocess/" + dataFlowStartMessage.getProcessId() + "/complete";
+    public StatusResult<Void> completed(DataFlow dataFlow) {
+        var url = dataFlow.getCallbackAddress() + "/transferprocess/" + dataFlow.getId() + "/complete";
         return sendRequest(url, null);
     }
 
     @Override
-    public StatusResult<Void> failed(DataFlowStartMessage dataFlowStartMessage, String reason) {
-        var url = dataFlowStartMessage.getCallbackAddress() + "/transferprocess/" + dataFlowStartMessage.getProcessId() + "/fail";
+    public StatusResult<Void> failed(DataFlow dataFlow, String reason) {
+        var url = dataFlow.getCallbackAddress() + "/transferprocess/" + dataFlow.getId() + "/fail";
         var body = TransferProcessFailRequest.Builder.newInstance().errorMessage(reason).build();
         return sendRequest(url, body);
     }

--- a/extensions/control-plane/api/control-plane-api-client/src/test/java/org/eclipse/edc/connector/controlplane/api/client/transferprocess/EmbeddedTransferProcessHttpClientTest.java
+++ b/extensions/control-plane/api/control-plane-api-client/src/test/java/org/eclipse/edc/connector/controlplane/api/client/transferprocess/EmbeddedTransferProcessHttpClientTest.java
@@ -18,7 +18,6 @@ import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.Trans
 import org.eclipse.edc.connector.dataplane.spi.DataFlow;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -39,8 +38,8 @@ class EmbeddedTransferProcessHttpClientTest {
         void shouldCallService() {
             var serviceResult = ServiceResult.<Void>success();
             when(service.complete(any())).thenReturn(serviceResult);
-            var message = DataFlowStartMessage.Builder.newInstance().processId("any")
-                    .sourceDataAddress(DataAddress.Builder.newInstance().type("any").build()).build();
+            var message = DataFlow.Builder.newInstance().id("any")
+                    .source(DataAddress.Builder.newInstance().type("any").build()).build();
 
             var result = client.completed(message);
 
@@ -55,8 +54,8 @@ class EmbeddedTransferProcessHttpClientTest {
         void shouldCallService() {
             var serviceResult = ServiceResult.<Void>success();
             when(service.terminate(any())).thenReturn(serviceResult);
-            var message = DataFlowStartMessage.Builder.newInstance().processId("any")
-                    .sourceDataAddress(DataAddress.Builder.newInstance().type("any").build()).build();
+            var message = DataFlow.Builder.newInstance().id("any")
+                    .source(DataAddress.Builder.newInstance().type("any").build()).build();
 
             var result = client.failed(message, "any");
 

--- a/extensions/control-plane/api/control-plane-api-client/src/test/java/org/eclipse/edc/connector/controlplane/api/client/transferprocess/TransferProcessHttpClientTest.java
+++ b/extensions/control-plane/api/control-plane-api-client/src/test/java/org/eclipse/edc/connector/controlplane/api/client/transferprocess/TransferProcessHttpClientTest.java
@@ -24,7 +24,6 @@ import org.eclipse.edc.http.client.ControlApiHttpClientImpl;
 import org.eclipse.edc.http.spi.ControlApiHttpClient;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
@@ -53,7 +52,7 @@ public class TransferProcessHttpClientTest {
 
     @Test
     void complete() throws IOException {
-        var req = createRequest().callbackAddress(URI.create("http://localhost:8080/test")).build();
+        var req = createFlow().callbackAddress(URI.create("http://localhost:8080/test")).build();
         when(interceptor.intercept(any()))
                 .thenAnswer(invocation -> createResponse(204, invocation));
 
@@ -65,7 +64,7 @@ public class TransferProcessHttpClientTest {
 
     @Test
     void complete_shouldSucceed_withRetry() throws IOException {
-        var req = createRequest().callbackAddress(URI.create("http://localhost:8080/test")).build();
+        var req = createFlow().callbackAddress(URI.create("http://localhost:8080/test")).build();
         when(interceptor.intercept(any()))
                 .thenAnswer(invocation -> createResponse(400, invocation))
                 .thenAnswer(invocation -> createResponse(204, invocation));
@@ -79,7 +78,7 @@ public class TransferProcessHttpClientTest {
 
     @Test
     void complete_shouldFail_withMaxRetryExceeded() throws IOException {
-        var req = createRequest().callbackAddress(URI.create("http://localhost:8080/test")).build();
+        var req = createFlow().callbackAddress(URI.create("http://localhost:8080/test")).build();
         when(interceptor.intercept(any()))
                 .thenAnswer(invocation -> createResponse(400, invocation))
                 .thenAnswer(invocation -> createResponse(400, invocation))
@@ -94,7 +93,7 @@ public class TransferProcessHttpClientTest {
 
     @Test
     void fail() throws IOException {
-        var req = createRequest().callbackAddress(URI.create("http://localhost:8080/test")).build();
+        var req = createFlow().callbackAddress(URI.create("http://localhost:8080/test")).build();
         when(interceptor.intercept(any()))
                 .thenAnswer(invocation -> createResponse(204, invocation));
 
@@ -154,12 +153,11 @@ public class TransferProcessHttpClientTest {
         }
     }
 
-    private DataFlowStartMessage.Builder createRequest() {
-        return DataFlowStartMessage.Builder.newInstance()
+    private DataFlow.Builder createFlow() {
+        return DataFlow.Builder.newInstance()
                 .id("1")
-                .processId("1")
-                .sourceDataAddress(DataAddress.Builder.newInstance().type("type").build())
-                .destinationDataAddress(DataAddress.Builder.newInstance().type("type").build());
+                .source(DataAddress.Builder.newInstance().type("type").build())
+                .destination(DataAddress.Builder.newInstance().type("type").build());
     }
 
     private Response createResponse(int code, InvocationOnMock invocation) {

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/port/TransferProcessApiClient.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/port/TransferProcessApiClient.java
@@ -18,7 +18,6 @@ package org.eclipse.edc.connector.dataplane.spi.port;
 import org.eclipse.edc.connector.dataplane.spi.DataFlow;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import org.eclipse.edc.spi.response.StatusResult;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 
 /**
  * {@link TransferProcessApiClient} is an abstraction for talking with Control Plane, in this case for signaling back
@@ -30,20 +29,20 @@ import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 public interface TransferProcessApiClient {
 
     /**
-     * Mark the TransferProcess referenced by {@link DataFlowStartMessage#getProcessId()} as completed
+     * Mark the TransferProcess referenced by {@link DataFlow#getId()} as completed
      *
-     * @param request The completed {@link DataFlowStartMessage}
+     * @param dataFlow The completed {@link DataFlow}
      * @return the result.
      */
-    StatusResult<Void> completed(DataFlowStartMessage request);
+    StatusResult<Void> completed(DataFlow dataFlow);
 
     /**
-     * Mark the TransferProcess referenced by {@link DataFlowStartMessage#getProcessId()} as failed
+     * Mark the TransferProcess referenced by {@link DataFlow#getId()} as failed
      *
-     * @param request The failed {@link DataFlowStartMessage}
+     * @param dataFlow The failed {@link DataFlow}
      * @return the result.
      */
-    StatusResult<Void> failed(DataFlowStartMessage request, String reason);
+    StatusResult<Void> failed(DataFlow dataFlow, String reason);
 
     /**
      * Mark the TransferProcess as provisioned.


### PR DESCRIPTION
## What this PR changes/adds

Make `TransferProcessClient` accept `DataFlow` instead of `DataFlowStartMessage`

## Why it does that

For some reasons we are using the signaling message representation all around, when it should be bound to the communication between control-plane and data-plane.

## Further notes
- the usages of the `DataFlow.toRequest()` methods are still there, because the way we are validating/starting transfers both from signaling api and from data plane manager is a little tangled. some further refactoring could come.


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Part of #4793

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
