### PR TITLE
feat: data-plane provision resource sql persistence

### DIFF
--- a/core/common/lib/sql-lib/src/main/java/org/eclipse/edc/sql/store/AbstractSqlStore.java
+++ b/core/common/lib/sql-lib/src/main/java/org/eclipse/edc/sql/store/AbstractSqlStore.java
@@ -16,7 +16,10 @@ package org.eclipse.edc.sql.store;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.CollectionType;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 import org.eclipse.edc.spi.persistence.EdcPersistenceException;
 import org.eclipse.edc.sql.QueryExecutor;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
@@ -25,6 +28,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.List;
 import java.util.Objects;
 import javax.sql.DataSource;
 
@@ -72,27 +76,26 @@ public abstract class AbstractSqlStore {
     }
 
     protected <T> T fromJson(String json, TypeReference<T> typeReference) {
-        if (json == null) {
-            return null;
-        }
-        try {
-            return objectMapper.readValue(json, typeReference);
-        } catch (JsonProcessingException e) {
-            throw new EdcPersistenceException(e);
-        }
+        return fromJson(json, objectMapper.constructType(typeReference));
     }
 
     protected <T> T fromJson(String json, Class<T> type) {
+        return fromJson(json, objectMapper.constructType(type));
+    }
 
+    protected <T> T fromJson(String json, JavaType type) {
         if (json == null) {
             return null;
         }
-
         try {
             return objectMapper.readValue(json, type);
         } catch (JsonProcessingException e) {
             throw new EdcPersistenceException(e);
         }
+    }
+
+    protected <T> CollectionType listOf(Class<T> clazz) {
+        return TypeFactory.defaultInstance().constructCollectionType(List.class, clazz);
     }
 
     @NotNull

--- a/extensions/data-plane/data-plane-iam/src/main/java/org/eclipse/edc/connector/dataplane/iam/service/DataPlaneAuthorizationServiceImpl.java
+++ b/extensions/data-plane/data-plane-iam/src/main/java/org/eclipse/edc/connector/dataplane/iam/service/DataPlaneAuthorizationServiceImpl.java
@@ -69,7 +69,7 @@ public class DataPlaneAuthorizationServiceImpl implements DataPlaneAuthorization
         additionalProperties.put(PROPERTY_FLOW_TYPE, dataFlow.getTransferType().flowType().toString());
         additionalProperties.put(PROPERTY_PARTICIPANT_ID, dataFlow.getParticipantId());
         var tokenParams = createTokenParams(dataFlow);
-        var sourceDataAddress = dataFlow.getSource();
+        var sourceDataAddress = dataFlow.getActualSource();
 
 
         // create the "front-channel" data address

--- a/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/SqlDataPlaneStore.java
+++ b/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/SqlDataPlaneStore.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.dataplane.store.sql;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.edc.connector.dataplane.spi.DataFlow;
+import org.eclipse.edc.connector.dataplane.spi.provision.ProvisionResource;
 import org.eclipse.edc.connector.dataplane.spi.store.DataPlaneStore;
 import org.eclipse.edc.connector.dataplane.store.sql.schema.DataFlowStatements;
 import org.eclipse.edc.spi.persistence.EdcPersistenceException;
@@ -139,7 +140,8 @@ public class SqlDataPlaneStore extends AbstractSqlStore implements DataPlaneStor
                         toJson(entity.getProperties()),
                         entity.getTransferType().flowType().toString(),
                         entity.getTransferType().destinationType(),
-                        entity.getRuntimeId()
+                        entity.getRuntimeId(),
+                        toJson(entity.getResourceDefinitions())
                 );
 
                 leaseContext.by(leaseHolderName).withConnection(connection).breakLease(entity.getId());
@@ -168,6 +170,7 @@ public class SqlDataPlaneStore extends AbstractSqlStore implements DataPlaneStor
                         FlowType.valueOf(resultSet.getString(statements.getFlowTypeColumn()))
                 ))
                 .runtimeId(resultSet.getString(statements.getRuntimeIdColumn()))
+                .resourceDefinitions(fromJson(resultSet.getString(statements.getResourceDefinitionsColumn()), listOf(ProvisionResource.class)))
                 .build();
     }
 

--- a/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/schema/BaseSqlDataFlowStatements.java
+++ b/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/schema/BaseSqlDataFlowStatements.java
@@ -47,6 +47,7 @@ public class BaseSqlDataFlowStatements implements DataFlowStatements {
                 .column(getFlowTypeColumn())
                 .column(getTransferTypeDestinationColumn())
                 .column(getRuntimeIdColumn())
+                .jsonColumn(getResourceDefinitionsColumn())
                 .upsertInto(getDataPlaneTable(), getIdColumn());
     }
 

--- a/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/schema/DataFlowStatements.java
+++ b/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/schema/DataFlowStatements.java
@@ -60,6 +60,10 @@ public interface DataFlowStatements extends StatefulEntityStatements, LeaseState
         return "runtime_id";
     }
 
+    default String getResourceDefinitionsColumn() {
+        return "resource_definitions";
+    }
+
     String getUpsertTemplate();
 
     String getSelectTemplate();

--- a/extensions/data-plane/store/sql/data-plane-store-sql/src/main/resources/dataplane-schema.sql
+++ b/extensions/data-plane/store/sql/data-plane-store-sql/src/main/resources/dataplane-schema.sql
@@ -33,7 +33,8 @@ CREATE TABLE IF NOT EXISTS edc_data_plane
     properties           JSON,
     flow_type            VARCHAR,
     transfer_type_destination VARCHAR,
-    runtime_id           VARCHAR
+    runtime_id           VARCHAR,
+    resource_definitions JSON DEFAULT '[]'
 );
 
 COMMENT ON COLUMN edc_data_plane.trace_context IS 'Java Map serialized as JSON';

--- a/extensions/data-plane/store/sql/data-plane-store-sql/src/test/java/org/eclipse/edc/connector/dataplane/store/sql/PostgresDataPlaneStoreTest.java
+++ b/extensions/data-plane/store/sql/data-plane-store-sql/src/test/java/org/eclipse/edc/connector/dataplane/store/sql/PostgresDataPlaneStoreTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.io.IOException;
 import java.time.Clock;
 import java.time.Duration;
 
@@ -42,8 +41,7 @@ public class PostgresDataPlaneStoreTest extends DataPlaneStoreTestBase {
     private SqlDataPlaneStore store;
 
     @BeforeEach
-    void setUp(PostgresqlStoreSetupExtension extension, QueryExecutor queryExecutor) throws IOException {
-
+    void setUp(PostgresqlStoreSetupExtension extension, QueryExecutor queryExecutor) {
         var typeManager = new JacksonTypeManager();
 
         var clock = Clock.systemUTC();

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/DataFlow.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/DataFlow.java
@@ -88,6 +88,16 @@ public class DataFlow extends StatefulEntity<DataFlow> {
     }
 
     public DataAddress getSource() {
+        return source;
+    }
+
+    /**
+     * Returns the actual source address that it could have been provisioned and being different from the original sent
+     * by the control-plane
+     *
+     * @return the actual data source.
+     */
+    public DataAddress getActualSource() {
         var provisioned = provisionedDataAddress();
         if (provisioned != null) {
             return provisioned;
@@ -119,7 +129,7 @@ public class DataFlow extends StatefulEntity<DataFlow> {
     public DataFlowStartMessage toRequest() {
         return DataFlowStartMessage.Builder.newInstance()
                 .id(getId())
-                .sourceDataAddress(getSource())
+                .sourceDataAddress(getActualSource())
                 .destinationDataAddress(getDestination())
                 .processId(getId())
                 .callbackAddress(getCallbackAddress())
@@ -249,6 +259,7 @@ public class DataFlow extends StatefulEntity<DataFlow> {
     public DataAddress provisionedDataAddress() {
         return resourceDefinitions.stream()
                 .map(ProvisionResource::getProvisionedResource)
+                .filter(Objects::nonNull)
                 .map(ProvisionedResource::getDataAddress)
                 .filter(Objects::nonNull)
                 .findFirst().orElse(null);

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/provision/ProvisionResource.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/provision/ProvisionResource.java
@@ -14,6 +14,9 @@
 
 package org.eclipse.edc.connector.dataplane.spi.provision;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.eclipse.edc.spi.entity.StatefulEntity;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 
@@ -31,6 +34,7 @@ import static org.eclipse.edc.connector.dataplane.spi.provision.ProvisionResourc
 /**
  * Resource that needs to be provisioned to support a data flow.
  */
+@JsonDeserialize(builder = ProvisionResource.Builder.class)
 public class ProvisionResource extends StatefulEntity<ProvisionResource> {
 
     private String flowId;
@@ -54,6 +58,10 @@ public class ProvisionResource extends StatefulEntity<ProvisionResource> {
 
     public Object getProperty(String key) {
         return properties.get(key);
+    }
+
+    public Map<String, Object> getProperties() {
+        return properties;
     }
 
     @Override
@@ -83,6 +91,10 @@ public class ProvisionResource extends StatefulEntity<ProvisionResource> {
 
     public ProvisionedResource getProvisionedResource() {
         return provisionedResource;
+    }
+
+    public DeprovisionedResource getDeprovisionedResource() {
+        return deprovisionedResource;
     }
 
     public void transitionDeprovisioned(DeprovisionedResource deprovisionedResource) {
@@ -118,8 +130,10 @@ public class ProvisionResource extends StatefulEntity<ProvisionResource> {
         return state == DEPROVISIONED.code();
     }
 
+    @JsonPOJOBuilder(withPrefix = "")
     public static class Builder extends StatefulEntity.Builder<ProvisionResource, Builder> {
 
+        @JsonCreator
         public static Builder newInstance() {
             return new Builder(new ProvisionResource());
         }
@@ -168,6 +182,16 @@ public class ProvisionResource extends StatefulEntity<ProvisionResource> {
 
         public Builder properties(Map<String, Object> properties) {
             entity.properties.putAll(properties);
+            return this;
+        }
+
+        public Builder provisionedResource(ProvisionedResource provisionedResource) {
+            entity.provisionedResource = provisionedResource;
+            return this;
+        }
+
+        public Builder deprovisionedResource(DeprovisionedResource deprovisionedResource) {
+            entity.deprovisionedResource = deprovisionedResource;
             return this;
         }
     }

--- a/spi/data-plane/data-plane-spi/src/test/java/org/eclipse/edc/connector/dataplane/spi/provision/ProvisionResourceTest.java
+++ b/spi/data-plane/data-plane-spi/src/test/java/org/eclipse/edc/connector/dataplane/spi/provision/ProvisionResourceTest.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Contributors to the Eclipse Foundation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.dataplane.spi.provision;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.eclipse.edc.json.JacksonTypeManager;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProvisionResourceTest {
+
+    private final JacksonTypeManager typeManager = new JacksonTypeManager();
+
+    @Test
+    void serdes() throws JsonProcessingException {
+        var resource = ProvisionResource.Builder.newInstance()
+                .flowId(UUID.randomUUID().toString())
+                .dataAddress(DataAddress.Builder.newInstance().type("any").build())
+                .property("any", "any")
+                .build();
+
+        resource.transitionProvisioned(ProvisionedResource.Builder.from(resource).pending(true).dataAddress(DataAddress.Builder.newInstance().type(UUID.randomUUID().toString()).build()).build());
+        resource.transitionDeprovisioned(DeprovisionedResource.Builder.from(resource).pending(true).build());
+
+        var json = typeManager.getMapper().writeValueAsString(resource);
+        var deserialized = typeManager.getMapper().readValue(json, ProvisionResource.class);
+
+        assertThat(deserialized).usingRecursiveComparison().isEqualTo(resource);
+    }
+}

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/provision/ProvisioningTransferConsumerEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/provision/ProvisioningTransferConsumerEndToEndTest.java
@@ -37,11 +37,13 @@ import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.sql.testfixtures.PostgresqlEndToEndExtension;
 import org.eclipse.edc.test.e2e.Runtimes;
 import org.eclipse.edc.test.e2e.TransferEndToEndParticipant;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockserver.integration.ClientAndServer;
 
@@ -128,6 +130,59 @@ public class ProvisioningTransferConsumerEndToEndTest {
         private final RuntimeExtension providerDataPlane = new RuntimePerMethodExtension(
                 Runtimes.IN_MEMORY_DATA_PLANE.create("provider-data-plane")
                         .configurationProvider(PROVIDER::dataPlaneConfig)
+        );
+
+        @Override
+        protected DataPlaneStore consumerDataPlaneStore() {
+            return consumerDataPlane.getService(DataPlaneStore.class);
+        }
+    }
+
+    @Nested
+    class Postgres extends Tests {
+
+        @RegisterExtension
+        @Order(0)
+        static final PostgresqlEndToEndExtension POSTGRESQL_EXTENSION = new PostgresqlEndToEndExtension();
+
+        @Order(1)
+        @RegisterExtension
+        static final BeforeAllCallback CREATE_DATABASES = context -> {
+            POSTGRESQL_EXTENSION.createDatabase(CONSUMER.getName());
+            POSTGRESQL_EXTENSION.createDatabase(PROVIDER.getName());
+        };
+
+        @RegisterExtension
+        @Order(1)
+        private final RuntimeExtension consumerControlPlane = new RuntimePerMethodExtension(
+                Runtimes.POSTGRES_CONTROL_PLANE.create("consumer-control-plane")
+                        .configurationProvider(CONSUMER::controlPlaneConfig)
+                        .configurationProvider(() -> POSTGRESQL_EXTENSION.configFor(CONSUMER.getName()))
+        );
+
+        @RegisterExtension
+        @Order(2)
+        private final RuntimeExtension consumerDataPlane = new RuntimePerMethodExtension(
+                Runtimes.POSTGRES_DATA_PLANE.create("consumer-data-plane")
+                        .configurationProvider(CONSUMER::dataPlaneConfig)
+                        .configurationProvider(() -> POSTGRESQL_EXTENSION.configFor(CONSUMER.getName()))
+                        .registerSystemExtension(ServiceExtension.class, new TestConsumerProvisionerExtension())
+        );
+
+        @RegisterExtension
+        @Order(1)
+        private final RuntimeExtension providerControlPlane = new RuntimePerMethodExtension(
+                Runtimes.POSTGRES_CONTROL_PLANE.create("provider-control-plane")
+                        .configurationProvider(PROVIDER::controlPlaneConfig)
+                        .configurationProvider(() -> POSTGRESQL_EXTENSION.configFor(PROVIDER.getName()))
+        );
+
+        @RegisterExtension
+        @Order(2)
+        private final RuntimeExtension providerDataPlane = new RuntimePerMethodExtension(
+                Runtimes.POSTGRES_DATA_PLANE.create("provider-data-plane")
+                        .configurationProvider(PROVIDER::dataPlaneConfig)
+                        .configurationProvider(() -> POSTGRESQL_EXTENSION.configFor(PROVIDER.getName()))
         );
 
         @Override
@@ -260,7 +315,7 @@ public class ProvisioningTransferConsumerEndToEndTest {
 
         }
 
-        private static class AddHeaderResourceGenerator implements ResourceDefinitionGenerator {
+    private static class AddHeaderResourceGenerator implements ResourceDefinitionGenerator {
 
             @Override
             public String supportedType() {


### PR DESCRIPTION
## What this PR changes/adds

Persists `ProvisionResource` in `DataFlow` into sql database

**BREAKING CHANGE**: a migration on the `dataplane-schema.sql` is required: a new `resource_definitions JSON DEFAULT '[]'` column has been added

## Why it does that

move provisioning into data-plane

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Part of #4793 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
